### PR TITLE
Fix side nav logo in Firefox

### DIFF
--- a/src/site/sphinx/_static/overrides.css
+++ b/src/site/sphinx/_static/overrides.css
@@ -34,6 +34,7 @@ body {
 
 .wy-side-nav-search > a {
   margin: 0;
+  display: block;
 }
 
 .wy-side-nav-search > a img.logo {


### PR DESCRIPTION
Documentation layout was strange in Firefox. (tested on Mac Firefox 42)

<img width="339" alt="armeria-doc-ff" src="https://cloud.githubusercontent.com/assets/2622/11205300/f563e7ba-8d49-11e5-8534-31d299a31252.png">
