### PR TITLE
Fix StackOverflowError in ServerConfig.toString()

### DIFF
--- a/src/main/java/com/linecorp/armeria/server/ServiceEntry.java
+++ b/src/main/java/com/linecorp/armeria/server/ServiceEntry.java
@@ -62,6 +62,6 @@ public final class ServiceEntry {
 
     @Override
     public String toString() {
-        return "{ " + virtualHost + ", " + pathMapping + ", " + service + " }";
+        return "{ " + virtualHost.hostnamePattern() + ", " + pathMapping + ", " + service + " }";
     }
 }


### PR DESCRIPTION
Motivation:

ServerConfig.toString() triggers a StackOverflowError because of the cyclic
dependency between VirtualHost and ServiceEntry.

ServerConfig.toString() calls VirtualHost.toString(), VirtualHost.toString()
calls ServiceEntry.toString(), ServiceEntry.toString() calls
VirtualHost.toString(), and so on.

Modification:

Change ServiceEntry.toString() so that it does not call
VirtualHost.toString() but just call VirtualHost.hostnamePattern(),
which should be enough for the stringification of ServiceEntry.

Result:

ServerConfig.toString() works fine.