### PR TITLE
Fix sidebar to be collapsed in mobile view

### DIFF
--- a/src/main/resources/com/linecorp/armeria/server/docs/assets/js/armeria.js
+++ b/src/main/resources/com/linecorp/armeria/server/docs/assets/js/armeria.js
@@ -46,6 +46,7 @@ $(function () {
   function resetClasses() {
     $('li.active').removeClass('active');
     $('.main .content').addClass('hidden');
+    $('.collapse.in').collapse('hide');
   }
 
   function renderNav() {

--- a/src/main/resources/com/linecorp/armeria/server/docs/index.html
+++ b/src/main/resources/com/linecorp/armeria/server/docs/index.html
@@ -51,7 +51,9 @@
         <h2><code title="{{name}}">{{simpleName}}</code></h2>
         <ul class="nav nav-sidebar">
           {{#each functions}}
-          <li id="nav-{{../name}}.{{name}}"><a href="#function/{{../name}}/{{name}}"><code>{{name}}()</code></a></li>
+          <li id="nav-{{../name}}.{{name}}">
+            <a href="#function/{{../name}}/{{name}}"><code>{{name}}()</code></a>
+          </li>
           {{/each}}
         </ul>
         {{/each}}


### PR DESCRIPTION
Motivation:

The sidebar is hidden by default in mobile view, and it is able to toggle the visibility.
The problem is that it is not hidden again when a user clicks a link in the sidebar. A user has to close it all the time, and it is definitely bad user experience.

Modification:

Collapse the sidebar when clicking a link in the sidebar in mobile view

Result:

Better user experience for mobile doc service