### PR TITLE
Add TestCases for HttpClientIdleTimeoutHandler and HttpServerIdleTimeoutHandlerTest

### DIFF
--- a/src/test/java/com/linecorp/armeria/client/thrift/ThriftOverHttpClientTest.java
+++ b/src/test/java/com/linecorp/armeria/client/thrift/ThriftOverHttpClientTest.java
@@ -299,7 +299,7 @@ public class ThriftOverHttpClientTest {
         }
     }
 
-    @Test(timeout = 1000)
+    @Test(timeout = 10000)
     public void testDevNullServiceSync() throws Exception {
         DevNullService.Iface client =
                 Clients.newClient(remoteInvokerFactory, getURI(Handlers.DEVNULL), Handlers.DEVNULL.Iface(),
@@ -310,7 +310,7 @@ public class ThriftOverHttpClientTest {
         assertEquals("kukuman2", serverReceivedNames.take());
     }
 
-    @Test(timeout = 1000)
+    @Test(timeout = 10000)
     public void testODevNullServiceAsync() throws Exception {
         DevNullService.AsyncIface client =
                 Clients.newClient(remoteInvokerFactory, getURI(Handlers.DEVNULL),
@@ -328,7 +328,7 @@ public class ThriftOverHttpClientTest {
         }
     }
 
-    @Test(timeout = 1000)
+    @Test(timeout = 10000)
     public void testTimeServiceSync() throws Exception {
         TimeService.Iface client =
                 Clients.newClient(remoteInvokerFactory, getURI(Handlers.TIME), Handlers.TIME.Iface(),
@@ -338,7 +338,7 @@ public class ThriftOverHttpClientTest {
         assertThat(serverTime, lessThanOrEqualTo(System.currentTimeMillis()));
     }
 
-    @Test(timeout = 1000)
+    @Test(timeout = 10000)
     public void testTimeServiceAsync() throws Exception {
         TimeService.AsyncIface client =
                 Clients.newClient(remoteInvokerFactory, getURI(Handlers.TIME), Handlers.TIME.AsyncIface(),
@@ -359,7 +359,7 @@ public class ThriftOverHttpClientTest {
         client.create("test");
     }
 
-    @Test(timeout = 1000)
+    @Test(timeout = 10000)
     public void testFileServiceAsync() throws Exception {
         FileService.AsyncIface client =
                 Clients.newClient(remoteInvokerFactory, getURI(Handlers.FILE), Handlers.FILE.AsyncIface(),


### PR DESCRIPTION
Motivation:
 I add test case consider case of #14

Modifications:
 * add test-case of idle timeout event throws twice by ``IdleStateHandler``  on `HttpClientIdleTimeoutHandler``
 * add test-case of ``HttpServerIdleTimeoutHandler``
 * Increase Timeout of ThriftOverHttpClientTest (1sec -> 10sec)

result
proof HttpClientIdleTimeoutHandler and HttpServerIdleTimeoutHandlerTest has no problem about   https://github.com/line/armeria/issues/14