### PR TITLE
Add Content-Type header for TomcatService

### DIFF
--- a/src/main/java/com/linecorp/armeria/server/http/tomcat/TomcatServiceInvocationHandler.java
+++ b/src/main/java/com/linecorp/armeria/server/http/tomcat/TomcatServiceInvocationHandler.java
@@ -51,6 +51,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
@@ -260,6 +261,12 @@ final class TomcatServiceInvocationHandler implements ServiceInvocationHandler {
                 HttpVersion.HTTP_1_1, HttpResponseStatus.valueOf(coyoteRes.getStatus()), content);
 
         final HttpHeaders headers = res.headers();
+
+        final String contentType = coyoteRes.getContentType();
+        if (contentType != null && !contentType.isEmpty()) {
+            headers.set(HttpHeaderNames.CONTENT_TYPE, contentType);
+        }
+
         final MimeHeaders cheaders = coyoteRes.getMimeHeaders();
         final int numHeaders = cheaders.size();
         for (int i = 0; i < numHeaders; i ++) {

--- a/src/test/java/com/linecorp/armeria/server/http/tomcat/TomcatServiceTest.java
+++ b/src/test/java/com/linecorp/armeria/server/http/tomcat/TomcatServiceTest.java
@@ -16,6 +16,7 @@
 package com.linecorp.armeria.server.http.tomcat;
 
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertThat;
 
 import java.util.regex.Pattern;
@@ -31,6 +32,8 @@ import com.linecorp.armeria.server.AbstractServerTest;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.VirtualHostBuilder;
 import com.linecorp.armeria.server.logging.LoggingService;
+
+import io.netty.handler.codec.http.HttpHeaderNames;
 
 public class TomcatServiceTest extends AbstractServerTest {
 
@@ -52,7 +55,10 @@ public class TomcatServiceTest extends AbstractServerTest {
         try (CloseableHttpClient hc = HttpClients.createMinimal()) {
             try (CloseableHttpResponse res = hc.execute(new HttpGet(uri("/tc/")))) {
                 assertThat(res.getStatusLine().toString(), is("HTTP/1.1 200 OK"));
-                final String actualContent = CR_OR_LF.matcher(EntityUtils.toString(res.getEntity())).replaceAll("");
+                assertThat(res.getFirstHeader(HttpHeaderNames.CONTENT_TYPE.toString()).getValue(),
+                           startsWith("text/html"));
+                final String actualContent = CR_OR_LF.matcher(EntityUtils.toString(res.getEntity()))
+                                                     .replaceAll("");
                 assertThat(actualContent, is(
                         "<html><body>" +
                         "<p>Hello, Armerian World!</p>" +


### PR DESCRIPTION
Motivation:

`Content-Type` header is missing in `TomcatServiceInvocationHandler.convertResponse`.

Modification:

Add `Content-Type` header if it is possible

Result:

Correct `Content-Type` header value