### PR TITLE
Make ServiceInvocationContent.current() return non-Optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -221,6 +221,14 @@
       <scope>test</scope>
     </dependency>
 
+    <!-- JSR305 -->
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <version>3.0.1</version>
+      <optional>true</optional>
+    </dependency>
+
     <!-- Test-time dependencies -->
     <dependency>
       <groupId>junit</groupId>

--- a/src/main/java/com/linecorp/armeria/client/HttpRemoteInvoker.java
+++ b/src/main/java/com/linecorp/armeria/client/HttpRemoteInvoker.java
@@ -143,13 +143,7 @@ final class HttpRemoteInvoker implements RemoteInvoker {
     }
 
     private EventLoop eventLoop() {
-        final ServiceInvocationContext currentServerContext = ServiceInvocationContext.current().orElse(null);
-        if (currentServerContext != null) {
-            // Use the current server-side event loop if possible.
-            return currentServerContext.eventLoop();
-        } else {
-            return eventLoopGroup.next();
-        }
+        return ServiceInvocationContext.mapCurrent(ServiceInvocationContext::eventLoop, eventLoopGroup::next);
     }
 
     static <T> void invoke0(SessionProtocol sessionProtocol, ClientCodec codec, Channel channel,

--- a/src/test/java/com/linecorp/armeria/server/GracefulShutdownIntegrationTest.java
+++ b/src/test/java/com/linecorp/armeria/server/GracefulShutdownIntegrationTest.java
@@ -43,7 +43,7 @@ public class GracefulShutdownIntegrationTest extends AbstractServerTest {
 
         defaultVirtualHost.serviceAt("/sleep", new ThriftService(
                 (AsyncIface) (milliseconds, resultHandler) ->
-                        ServiceInvocationContext.current().get().eventLoop().schedule(
+                        ServiceInvocationContext.current().eventLoop().schedule(
                                 () -> resultHandler.onComplete(milliseconds),
                                 milliseconds, TimeUnit.MILLISECONDS)).decorate(LoggingService::new));
 


### PR DESCRIPTION
Related: #21

Motivation:

Given that ServiceInvocationContext is almost always available in the
server-side thread, it is inconvenient to call Optional.get() to get the
current thread's ServiceInvocationContext.

Modifications:

- Make ServiceInvocationContext.current() return
  ServiceInvocationContext instead of Optional and throw
  IllegalStateException when the context is unavailable
- Add ServiceInvocationContext.mapCurrent() for a caller who does not
  expect an exception when the context is unavailable
- Add jsr305 as an optional dependency to use the `@Nullable` annotation

Result:

More user-friendly API