### PR TITLE
fix Invalid assert on HttpClientIdleTimeoutHandlerTest

### DIFF
--- a/src/test/java/com/linecorp/armeria/client/HttpClientIdleTimeoutHandlerTest.java
+++ b/src/test/java/com/linecorp/armeria/client/HttpClientIdleTimeoutHandlerTest.java
@@ -96,7 +96,7 @@ public class HttpClientIdleTimeoutHandlerTest {
 
     private void readResponse() {
         ch.writeInbound(httpResponse);
-        assertThat(ch.readInbound(), equalTo(httpRequest));
+        assertThat(ch.readInbound(), equalTo(httpResponse));
     }
 
     private void writeRequest() {


### PR DESCRIPTION
Motivation
@trustin reported  ``HttpClientIdleTimeoutHandlerTest `` test case failed when change to netty 4.1.0.BETA8
I caused by incorrect assert.

Exceptions
Pass Test Case 