### PR TITLE
Upgrade to Netty 4.1.0.Beta8 / Interop with Jetty and cURL

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -61,6 +61,22 @@ by Adobe Systems Incorporated:
   * Homepage: http://adobe-fonts.github.io/source-sans-pro/
               http://adobe-fonts.github.io/source-code-pro/
 
+
+Modified redistributions
+========================
+
+This product contains a modified part of Netty, distributed by Netty.io:
+
+  * License: licenses/LICENSE.netty.al20.txt (Apache License v2.0)
+  * Homepage: http://netty.io/
+
+This product contains a modified part of Twitter Commons, distributed by Twitter,
+Inc:
+
+  * License: license/LICENSE.twitter.al20.txt (Apache License v2.0)
+  * Homepage: http://twitter.github.io/commons/
+
+
 Dependencies
 ============
 

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
 
     <!-- Dependency versions -->
     <jackson.version>2.6.3</jackson.version>
-    <netty.version>4.1.0.Beta7</netty.version>
+    <netty.version>4.1.0.Beta8</netty.version>
     <slf4j.version>1.7.13</slf4j.version>
     <tomcat.version>8.0.28</tomcat.version>
     <jetty.alpn.version.latest>8.1.6.v20151105</jetty.alpn.version.latest>
@@ -282,6 +282,20 @@
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
       <version>4.5.1</version>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- Jetty, for verifying integration with official thrift library's TServlet -->
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-servlet</artifactId>
+      <version>9.3.6.v20151106</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.http2</groupId>
+      <artifactId>http2-server</artifactId>
+      <version>9.3.6.v20151106</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -573,8 +587,8 @@
           <!-- Enable all lints except the missing tag warnings -->
           <additionalparam>-Xdoclint:all -Xdoclint:-missing</additionalparam>
 
-          <!-- Exclude the machine-generate code -->
-          <excludePackageNames>*.thrift.v1</excludePackageNames>
+          <!-- Exclude the machine-generate code and the internal-only classes -->
+          <excludePackageNames>*.thrift.v1,*.common.http</excludePackageNames>
 
           <groups>
             <group>

--- a/src/main/java/com/linecorp/armeria/client/ClientCodec.java
+++ b/src/main/java/com/linecorp/armeria/client/ClientCodec.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 
 import com.linecorp.armeria.common.Scheme;
 import com.linecorp.armeria.common.ServiceInvocationContext;
+import com.linecorp.armeria.common.SessionProtocol;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
@@ -38,7 +39,7 @@ public interface ClientCodec {
     /**
      * Encodes a Java method invocation into a {@link ServiceInvocationContext}.
      */
-    EncodeResult encodeRequest(Channel channel, Method method, Object[] args);
+    EncodeResult encodeRequest(Channel channel, SessionProtocol sessionProtocol, Method method, Object[] args);
 
     /**
      * Decodes the response bytes into a Java object.
@@ -52,7 +53,7 @@ public interface ClientCodec {
     boolean isAsyncClient();
 
     /**
-     * The result of {@link #encodeRequest(Channel, Method, Object[]) ClientCodec.encodeRequest()}.
+     * The result of {@link #encodeRequest(Channel, SessionProtocol, Method, Object[]) ClientCodec.encodeRequest()}.
      */
     interface EncodeResult {
         /**

--- a/src/main/java/com/linecorp/armeria/client/ClosedSessionException.java
+++ b/src/main/java/com/linecorp/armeria/client/ClosedSessionException.java
@@ -15,12 +15,21 @@
  */
 package com.linecorp.armeria.client;
 
+import io.netty.util.internal.EmptyArrays;
+
 /**
  * A {@link RuntimeException} raised when the connection to the server has been closed unexpectedly.
  */
 public class ClosedSessionException extends RuntimeException {
 
     private static final long serialVersionUID = -78487475521731580L;
+
+    @SuppressWarnings("ThrowableInstanceNeverThrown")
+    static final ClosedSessionException INSTANCE = new ClosedSessionException();
+
+    static {
+        INSTANCE.setStackTrace(EmptyArrays.EMPTY_STACK_TRACE);
+    }
 
     /**
      * Creates a new instance.

--- a/src/main/java/com/linecorp/armeria/client/DecoratingClientCodec.java
+++ b/src/main/java/com/linecorp/armeria/client/DecoratingClientCodec.java
@@ -21,6 +21,7 @@ import static java.util.Objects.requireNonNull;
 import java.lang.reflect.Method;
 
 import com.linecorp.armeria.common.ServiceInvocationContext;
+import com.linecorp.armeria.common.SessionProtocol;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
@@ -35,6 +36,9 @@ public abstract class DecoratingClientCodec implements ClientCodec {
 
     private final ClientCodec delegate;
 
+    /**
+     * Creates a new instance that decorates the specified {@link ClientCodec}.
+     */
     protected DecoratingClientCodec(ClientCodec delegate) {
         this.delegate = requireNonNull(delegate, "delegate");
     }
@@ -54,9 +58,9 @@ public abstract class DecoratingClientCodec implements ClientCodec {
     }
 
     @Override
-    public EncodeResult encodeRequest(Channel channel, Method method,
+    public EncodeResult encodeRequest(Channel channel, SessionProtocol sessionProtocol, Method method,
                                       Object[] args) {
-        return delegate().encodeRequest(channel, method, args);
+        return delegate().encodeRequest(channel, sessionProtocol, method, args);
     }
 
     @Override

--- a/src/main/java/com/linecorp/armeria/client/DecoratingInvocationHandler.java
+++ b/src/main/java/com/linecorp/armeria/client/DecoratingInvocationHandler.java
@@ -28,9 +28,12 @@ import java.lang.reflect.Method;
  */
 public abstract class DecoratingInvocationHandler implements InvocationHandler {
 
-    private final RemoteInvoker delegate;
+    private final InvocationHandler delegate;
 
-    protected DecoratingInvocationHandler(RemoteInvoker delegate) {
+    /**
+     * Creates a new instance that decorates the specified {@link InvocationHandler}.
+     */
+    protected DecoratingInvocationHandler(InvocationHandler delegate) {
         this.delegate = requireNonNull(delegate, "delegate");
     }
 

--- a/src/main/java/com/linecorp/armeria/client/DecoratingRemoteInvoker.java
+++ b/src/main/java/com/linecorp/armeria/client/DecoratingRemoteInvoker.java
@@ -32,6 +32,9 @@ public abstract class DecoratingRemoteInvoker implements RemoteInvoker {
 
     private final RemoteInvoker delegate;
 
+    /**
+     * Creates a new instance that decorates the specified {@link RemoteInvoker}.
+     */
     protected DecoratingRemoteInvoker(RemoteInvoker delegate) {
         this.delegate = requireNonNull(delegate, "delegate");
     }

--- a/src/main/java/com/linecorp/armeria/client/Http2ClientIdleTimeoutHandler.java
+++ b/src/main/java/com/linecorp/armeria/client/Http2ClientIdleTimeoutHandler.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2015 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import java.util.concurrent.TimeUnit;
+
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpMessage;
+import io.netty.handler.codec.http2.HttpConversionUtil.ExtensionHeaderNames;
+
+/**
+ * A {@link HttpClientIdleTimeoutHandler} that ignores the responses received from the upgrade stream.
+ */
+class Http2ClientIdleTimeoutHandler extends HttpClientIdleTimeoutHandler {
+
+    Http2ClientIdleTimeoutHandler(long idleTimeoutMillis) {
+        super(idleTimeoutMillis);
+    }
+
+    Http2ClientIdleTimeoutHandler(long idleTimeout, TimeUnit timeUnit) {
+        super(idleTimeout, timeUnit);
+    }
+
+    @Override
+    boolean isResponseEnd(Object msg) {
+        if (!(msg instanceof FullHttpResponse)) {
+            return false;
+        }
+
+        return !"1".equals(((HttpMessage) msg).headers().get(ExtensionHeaderNames.STREAM_ID.text()));
+    }
+}

--- a/src/main/java/com/linecorp/armeria/client/http/SimpleHttpClientCodec.java
+++ b/src/main/java/com/linecorp/armeria/client/http/SimpleHttpClientCodec.java
@@ -20,7 +20,9 @@ import java.lang.reflect.Method;
 
 import com.linecorp.armeria.client.ClientCodec;
 import com.linecorp.armeria.common.Scheme;
+import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.ServiceInvocationContext;
+import com.linecorp.armeria.common.SessionProtocol;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
@@ -39,14 +41,12 @@ public class SimpleHttpClientCodec implements ClientCodec {
     private static final byte[] EMPTY = new byte[0];
 
     private final String host;
-    private final Scheme scheme;
 
     /**
      * Creates a new codec with the specified {@link Scheme} and {@code host}.
      */
-    public SimpleHttpClientCodec(Scheme scheme, String host) {
+    public SimpleHttpClientCodec(String host) {
         this.host = host;
-        this.scheme = scheme;
     }
 
     @Override
@@ -55,10 +55,12 @@ public class SimpleHttpClientCodec implements ClientCodec {
     }
 
     @Override
-    public EncodeResult encodeRequest(Channel channel, Method method, Object[] args) {
+    public EncodeResult encodeRequest(
+            Channel channel, SessionProtocol sessionProtocol, Method method, Object[] args) {
         @SuppressWarnings("unchecked")  // Guaranteed by SimpleHttpClient interface.
         SimpleHttpRequest request = (SimpleHttpRequest) args[0];
         FullHttpRequest fullHttpRequest = convertToFullHttpRequest(request, channel);
+        Scheme scheme = Scheme.of(SerializationFormat.NONE, sessionProtocol);
         return new SimpleHttpInvocation(channel, scheme, host, request.uri().getPath(),
                                         fullHttpRequest, request);
     }

--- a/src/main/java/com/linecorp/armeria/client/logging/LoggingClientCodec.java
+++ b/src/main/java/com/linecorp/armeria/client/logging/LoggingClientCodec.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 import com.linecorp.armeria.client.ClientCodec;
 import com.linecorp.armeria.common.Scheme;
 import com.linecorp.armeria.common.ServiceInvocationContext;
+import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.util.Ticker;
 import com.linecorp.armeria.common.util.UnitFormatter;
 
@@ -72,8 +73,10 @@ public class LoggingClientCodec implements ClientCodec {
     }
 
     @Override
-    public EncodeResult encodeRequest(Channel channel, Method method, Object[] args) {
-        final EncodeResult result = c.encodeRequest(channel, method, args);
+    public EncodeResult encodeRequest(
+            Channel channel, SessionProtocol sessionProtocol, Method method, Object[] args) {
+
+        final EncodeResult result = c.encodeRequest(channel, sessionProtocol, method, args);
         if (result.isSuccess()) {
             final ServiceInvocationContext ctx = result.invocationContext();
             final Logger logger = ctx.logger();

--- a/src/main/java/com/linecorp/armeria/common/http/AbstractHttpToHttp2ConnectionHandler.java
+++ b/src/main/java/com/linecorp/armeria/common/http/AbstractHttpToHttp2ConnectionHandler.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2015 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.http;
+
+import static io.netty.handler.codec.http2.Http2CodecUtil.HTTP_UPGRADE_STREAM_ID;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import io.netty.handler.codec.http2.Http2ConnectionDecoder;
+import io.netty.handler.codec.http2.Http2ConnectionEncoder;
+import io.netty.handler.codec.http2.Http2ConnectionHandler;
+import io.netty.handler.codec.http2.Http2Error;
+import io.netty.handler.codec.http2.Http2Exception;
+import io.netty.handler.codec.http2.Http2Exception.StreamException;
+import io.netty.handler.codec.http2.Http2Settings;
+import io.netty.handler.codec.http2.Http2Stream.State;
+import io.netty.handler.codec.http2.Http2StreamVisitor;
+import io.netty.handler.codec.http2.HttpToHttp2ConnectionHandler;
+import io.netty.util.internal.EmptyArrays;
+
+public abstract class AbstractHttpToHttp2ConnectionHandler extends HttpToHttp2ConnectionHandler {
+
+    private static final StreamException REFUSED_STREAM_EXCEPTION =
+            (StreamException) Http2Exception.streamError(
+                    HTTP_UPGRADE_STREAM_ID, Http2Error.REFUSED_STREAM,
+                    "The request sent with the upgrade request has been refused; try again.");
+
+    static {
+        REFUSED_STREAM_EXCEPTION.setStackTrace(EmptyArrays.EMPTY_STACK_TRACE);
+    }
+
+    /**
+     * XXX(trustin): Don't know why, but {@link Http2ConnectionHandler} does not close the last stream
+     *               on a cleartext connection, so we make sure all streams are closed.
+     */
+    private static final Http2StreamVisitor closeAllStreams = stream -> {
+        if (stream.state() != State.CLOSED) {
+            stream.close();
+        }
+        return true;
+    };
+
+    protected AbstractHttpToHttp2ConnectionHandler(Http2ConnectionDecoder decoder, Http2ConnectionEncoder encoder,
+                                                   Http2Settings initialSettings, boolean validateHeaders) {
+        super(decoder, encoder, initialSettings, validateHeaders);
+    }
+
+    @Override
+    public void close(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+        // TODO(trustin): Remove this line once https://github.com/netty/netty/issues/4210 is fixed.
+        connection().forEachActiveStream(closeAllStreams);
+
+        onCloseRequest(ctx);
+        super.close(ctx, promise);
+    }
+
+    protected abstract void onCloseRequest(ChannelHandlerContext ctx) throws Exception;
+}

--- a/src/main/java/com/linecorp/armeria/common/http/Http1ClientCodec.java
+++ b/src/main/java/com/linecorp/armeria/common/http/Http1ClientCodec.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright 2015 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common.http;
+
+import java.util.ArrayDeque;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.atomic.AtomicLong;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerAppender;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.ChannelPromise;
+import io.netty.handler.codec.PrematureChannelClosureException;
+import io.netty.handler.codec.http.HttpClientCodec;
+import io.netty.handler.codec.http.HttpClientUpgradeHandler;
+import io.netty.handler.codec.http.HttpMessage;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpRequestEncoder;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseDecoder;
+import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.util.internal.OneTimeTask;
+
+/**
+ * A fork of {@link HttpClientCodec} that fixes
+ * <a href="https://github.com/netty/netty/issues/4504">netty/netty#4504</a>.
+ */
+public class Http1ClientCodec extends ChannelHandlerAppender implements HttpClientUpgradeHandler.SourceCodec {
+
+    /** A queue that is used for correlating a request and a response. */
+    private final Queue<HttpMethod> queue = new ArrayDeque<>();
+
+    /** If true, decoding stops (i.e. pass-through) */
+    private boolean done;
+
+    private final AtomicLong requestResponseCounter = new AtomicLong();
+    private final boolean failOnMissingResponse;
+
+    /**
+     * Creates a new instance with the default decoder options
+     * ({@code maxInitialLineLength (4096}}, {@code maxHeaderSize (8192)}, and
+     * {@code maxChunkSize (8192)}).
+     */
+    public Http1ClientCodec() {
+        this(4096, 8192, 8192, false);
+    }
+
+    /**
+     * Creates a new instance with the specified decoder options.
+     */
+    public Http1ClientCodec(int maxInitialLineLength, int maxHeaderSize, int maxChunkSize) {
+        this(maxInitialLineLength, maxHeaderSize, maxChunkSize, false);
+    }
+
+    /**
+     * Creates a new instance with the specified decoder options.
+     */
+    public Http1ClientCodec(
+            int maxInitialLineLength, int maxHeaderSize, int maxChunkSize, boolean failOnMissingResponse) {
+        this(maxInitialLineLength, maxHeaderSize, maxChunkSize, failOnMissingResponse, true);
+    }
+
+    /**
+     * Creates a new instance with the specified decoder options.
+     */
+    public Http1ClientCodec(
+            int maxInitialLineLength, int maxHeaderSize, int maxChunkSize, boolean failOnMissingResponse,
+            boolean validateHeaders) {
+        add(new Decoder(maxInitialLineLength, maxHeaderSize, maxChunkSize, validateHeaders));
+        add(new Encoder());
+        this.failOnMissingResponse = failOnMissingResponse;
+    }
+
+    /**
+     * Upgrades to another protocol from HTTP. Removes the {@link Decoder} and {@link Encoder} from
+     * the pipeline.
+     */
+    @Override
+    public void upgradeFrom(ChannelHandlerContext ctx) {
+        final ChannelPipeline p = ctx.pipeline();
+        p.remove(Encoder.class);
+        ctx.executor().execute(new OneTimeTask() {
+            @Override
+            public void run() {
+                p.remove(Decoder.class);
+            }
+        });
+    }
+
+    /**
+     * Returns the encoder of this codec.
+     */
+    public HttpRequestEncoder encoder() {
+        return handlerAt(1);
+    }
+
+    /**
+     * Returns the decoder of this codec.
+     */
+    public HttpResponseDecoder decoder() {
+        return handlerAt(0);
+    }
+
+    public void setSingleDecode(boolean singleDecode) {
+        decoder().setSingleDecode(singleDecode);
+    }
+
+    public boolean isSingleDecode() {
+        return decoder().isSingleDecode();
+    }
+
+    protected void onCloseRequest(ChannelHandlerContext ctx) throws Exception {}
+
+    private final class Encoder extends HttpRequestEncoder {
+
+        @Override
+        protected void encode(
+                ChannelHandlerContext ctx, Object msg, List<Object> out) throws Exception {
+            if (msg instanceof HttpRequest && !done) {
+                queue.offer(((HttpRequest) msg).method());
+            }
+
+            super.encode(ctx, msg, out);
+
+            if (failOnMissingResponse) {
+                // check if the request is chunked if so do not increment
+                if (msg instanceof LastHttpContent) {
+                    // increment as its the last chunk
+                    requestResponseCounter.incrementAndGet();
+                }
+            }
+        }
+
+        @Override
+        public void close(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+            onCloseRequest(ctx);
+            super.close(ctx, promise);
+        }
+    }
+
+    private final class Decoder extends HttpResponseDecoder {
+        Decoder(int maxInitialLineLength, int maxHeaderSize, int maxChunkSize, boolean validateHeaders) {
+            super(maxInitialLineLength, maxHeaderSize, maxChunkSize, validateHeaders);
+        }
+
+        @Override
+        protected void decode(
+                ChannelHandlerContext ctx, ByteBuf buffer, List<Object> out) throws Exception {
+            if (done) {
+                int readable = actualReadableBytes();
+                if (readable == 0) {
+                    // if non is readable just return null
+                    // https://github.com/netty/netty/issues/1159
+                    return;
+                }
+                out.add(buffer.readBytes(readable));
+            } else {
+                int oldSize = out.size();
+                super.decode(ctx, buffer, out);
+                if (failOnMissingResponse) {
+                    int size = out.size();
+                    for (int i = oldSize; i < size; i++) {
+                        decrement(out.get(i));
+                    }
+                }
+            }
+        }
+
+        private void decrement(Object msg) {
+            if (msg == null) {
+                return;
+            }
+
+            // check if it's an Header and its transfer encoding is not chunked.
+            if (msg instanceof LastHttpContent) {
+                requestResponseCounter.decrementAndGet();
+            }
+        }
+
+        @Override
+        protected boolean isContentAlwaysEmpty(HttpMessage msg) {
+            final int statusCode = ((HttpResponse) msg).status().code();
+            if (statusCode == 100) {
+                // 100-continue response should be excluded from paired comparison.
+                return true;
+            }
+
+            // Get the getMethod of the HTTP request that corresponds to the
+            // current response.
+            HttpMethod method = queue.poll();
+
+            char firstChar = method.name().charAt(0);
+            switch (firstChar) {
+            case 'H':
+                // According to 4.3, RFC2616:
+                // All responses to the HEAD request getMethod MUST NOT include a
+                // message-body, even though the presence of entity-header fields
+                // might lead one to believe they do.
+                if (HttpMethod.HEAD.equals(method)) {
+                    return true;
+
+                    // The following code was inserted to work around the servers
+                    // that behave incorrectly.  It has been commented out
+                    // because it does not work with well behaving servers.
+                    // Please note, even if the 'Transfer-Encoding: chunked'
+                    // header exists in the HEAD response, the response should
+                    // have absolutely no content.
+                    //
+                    //// Interesting edge case:
+                    //// Some poorly implemented servers will send a zero-byte
+                    //// chunk if Transfer-Encoding of the response is 'chunked'.
+                    ////
+                    //// return !msg.isChunked();
+                }
+                break;
+            case 'C':
+                // Successful CONNECT request results in a response with empty body.
+                if (statusCode == 200) {
+                    if (HttpMethod.CONNECT.equals(method)) {
+                        // Proxy connection established - Not HTTP anymore.
+                        done = true;
+                        queue.clear();
+                        return true;
+                    }
+                }
+                break;
+            }
+
+            return super.isContentAlwaysEmpty(msg);
+        }
+
+        @Override
+        public void channelInactive(ChannelHandlerContext ctx)
+                throws Exception {
+            super.channelInactive(ctx);
+
+            if (failOnMissingResponse) {
+                long missingResponses = requestResponseCounter.get();
+                if (missingResponses > 0) {
+                    ctx.fireExceptionCaught(new PrematureChannelClosureException(
+                            "channel gone inactive with " + missingResponses +
+                            " missing response(s)"));
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/linecorp/armeria/common/http/package-info.java
+++ b/src/main/java/com/linecorp/armeria/common/http/package-info.java
@@ -14,14 +14,7 @@
  * under the License.
  */
 
-package com.linecorp.armeria.client;
-
-import com.linecorp.armeria.common.SessionProtocol;
-
-import io.netty.channel.ChannelHandlerContext;
-
-interface SessionListener {
-    void sessionActivated(ChannelHandlerContext ctx, SessionProtocol sessionProtocol);
-
-    void sessionDeactivated(ChannelHandlerContext ctx);
-}
+/**
+ * HTTP1/2-related classes used internally.
+ */
+package com.linecorp.armeria.common.http;

--- a/src/main/java/com/linecorp/armeria/server/DecoratingServiceCodec.java
+++ b/src/main/java/com/linecorp/armeria/server/DecoratingServiceCodec.java
@@ -39,13 +39,13 @@ import io.netty.util.concurrent.Promise;
  */
 public abstract class DecoratingServiceCodec implements ServiceCodec {
 
-    private final ServiceCodec codec;
+    private final ServiceCodec delegate;
 
     /**
      * Creates a new instance that decorates the specified {@link ServiceCodec}.
      */
-    protected DecoratingServiceCodec(ServiceCodec codec) {
-        this.codec = requireNonNull(codec, "codec");
+    protected DecoratingServiceCodec(ServiceCodec delegate) {
+        this.delegate = requireNonNull(delegate, "delegate");
     }
 
     /**
@@ -53,7 +53,7 @@ public abstract class DecoratingServiceCodec implements ServiceCodec {
      */
     @SuppressWarnings("unchecked")
     protected final <T extends ServiceCodec> T delegate() {
-        return (T) codec;
+        return (T) delegate;
     }
 
     @Override

--- a/src/main/java/com/linecorp/armeria/server/HttpServerIdleTimeoutHandler.java
+++ b/src/main/java/com/linecorp/armeria/server/HttpServerIdleTimeoutHandler.java
@@ -23,8 +23,11 @@ import org.slf4j.LoggerFactory;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpMessage;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.handler.codec.http2.HttpConversionUtil.ExtensionHeaderNames;
 import io.netty.handler.timeout.IdleStateEvent;
 import io.netty.handler.timeout.IdleStateHandler;
 
@@ -49,6 +52,10 @@ class HttpServerIdleTimeoutHandler extends IdleStateHandler {
     }
 
     boolean isResponseEnd(Object msg) {
+        if (msg instanceof FullHttpResponse) {
+            return !"1".equals(((HttpMessage) msg).headers().get(ExtensionHeaderNames.STREAM_ID.text()));
+        }
+
         return msg instanceof LastHttpContent;
     }
 

--- a/src/test/java/com/linecorp/armeria/client/HttpClientIdleTimeoutHandlerTest.java
+++ b/src/test/java/com/linecorp/armeria/client/HttpClientIdleTimeoutHandlerTest.java
@@ -80,12 +80,12 @@ public class HttpClientIdleTimeoutHandlerTest {
     public void testIdleTimeoutOccuredTwice() throws Exception {
         writeRequest();
         waitUntilTimeout();
-        //padding request count is 1
+        //pending request count is 1
         assertTrue(ch.isOpen());
 
         readResponse();
         waitUntilTimeout();
-        //padding request count turns to 0
+        //pending request count turns to 0
         assertFalse(ch.isOpen());
     }
 

--- a/src/test/java/com/linecorp/armeria/client/http/SimpleHttpClientCodecTest.java
+++ b/src/test/java/com/linecorp/armeria/client/http/SimpleHttpClientCodecTest.java
@@ -72,7 +72,7 @@ public class SimpleHttpClientCodecTest {
 
     @Before
     public void setUp() {
-        codec = new SimpleHttpClientCodec(SCHEME, "www.github.com");
+        codec = new SimpleHttpClientCodec("www.github.com");
         when(channel.alloc()).thenReturn(ByteBufAllocator.DEFAULT);
     }
 
@@ -81,7 +81,7 @@ public class SimpleHttpClientCodecTest {
         SimpleHttpRequest request = SimpleHttpRequestBuilder.forGet("/foo")
                 .header(HttpHeaderNames.ORIGIN, "localhost")
                 .build();
-        EncodeResult result = codec.encodeRequest(channel, EXECUTE_METHOD, new Object[]{ request });
+        EncodeResult result = codec.encodeRequest(channel, SCHEME.sessionProtocol(), EXECUTE_METHOD, new Object[]{ request });
         assertTrue(result.isSuccess());
         assertEquals(SCHEME, result.encodedScheme().get());
         assertEquals("/foo", result.encodedPath().get());
@@ -99,7 +99,7 @@ public class SimpleHttpClientCodecTest {
                 .content("lorem ipsum foo bar", StandardCharsets.UTF_8)
                 .header(HttpHeaderNames.ORIGIN, "localhost")
                 .build();
-        EncodeResult result = codec.encodeRequest(channel, EXECUTE_METHOD, new Object[]{ request });
+        EncodeResult result = codec.encodeRequest(channel, SCHEME.sessionProtocol(), EXECUTE_METHOD, new Object[]{ request });
         assertTrue(result.isSuccess());
         assertEquals(SCHEME, result.encodedScheme().get());
         assertEquals("/foo", result.encodedPath().get());

--- a/src/test/java/com/linecorp/armeria/client/thrift/ThriftOverHttpClientTServletIntegrationTest.java
+++ b/src/test/java/com/linecorp/armeria/client/thrift/ThriftOverHttpClientTServletIntegrationTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2015 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client.thrift;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.servlet.Servlet;
+
+import org.apache.thrift.server.TServlet;
+import org.eclipse.jetty.http2.server.HTTP2CServerConnectionFactory;
+import org.eclipse.jetty.server.ConnectionFactory;
+import org.eclipse.jetty.server.Connector;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.HttpConnectionFactory;
+import org.eclipse.jetty.server.NetworkConnector;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.servlet.ServletHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.linecorp.armeria.client.ClientCodec;
+import com.linecorp.armeria.client.ClientOption;
+import com.linecorp.armeria.client.Clients;
+import com.linecorp.armeria.client.DecoratingClientCodec;
+import com.linecorp.armeria.common.Scheme;
+import com.linecorp.armeria.common.ServiceInvocationContext;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.thrift.ThriftProtocolFactories;
+import com.linecorp.armeria.service.test.thrift.main.HelloService;
+
+import io.netty.buffer.ByteBuf;
+
+/**
+ * Test to verify interaction between armeria client and official thrift
+ * library's {@link TServlet}.
+ */
+public class ThriftOverHttpClientTServletIntegrationTest {
+
+    private static final HelloService.Iface helloHandler = name -> "Hello, " + name + '!';
+
+    private static Servlet servlet;
+    private static Server http1server;
+    private static Server http2server;
+
+    @BeforeClass
+    public static void createServer() throws Exception {
+        servlet = new TServlet(new HelloService.Processor(helloHandler), ThriftProtocolFactories.BINARY);
+
+        http1server = startHttp1();
+        http2server = startHttp2();
+    }
+
+    private static Server startHttp1() throws Exception {
+        Server server = new Server(0);
+        ServletHandler handler = new ServletHandler();
+        handler.addServletWithMapping(new ServletHolder(servlet), "/thrift");
+        server.setHandler(handler);
+
+        for (Connector c : server.getConnectors()) {
+            for (ConnectionFactory f : c.getConnectionFactories()) {
+                for (String p : f.getProtocols()) {
+                    if (p.startsWith("h2c")) {
+                        fail("Attempted to create a Jetty server without HTTP/2 support, but failed: " +
+                             f.getProtocols());
+                    }
+                }
+            }
+        }
+
+        server.start();
+        return server;
+    }
+
+    private static Server startHttp2() throws Exception {
+        Server server = new Server();
+        // Common HTTP configuration.
+        HttpConfiguration config = new HttpConfiguration();
+
+        // HTTP/1.1 support.
+        HttpConnectionFactory http1 = new HttpConnectionFactory(config);
+
+        // HTTP/2 cleartext support.
+        HTTP2CServerConnectionFactory http2c = new HTTP2CServerConnectionFactory(config);
+
+        // Add the connector.
+        ServerConnector connector = new ServerConnector(server, http1, http2c);
+        connector.setPort(0);
+        server.addConnector(connector);
+
+        // Add the servlet.
+        ServletHandler handler = new ServletHandler();
+        handler.addServletWithMapping(new ServletHolder(servlet), "/thrift");
+        server.setHandler(handler);
+
+        // Start the server.
+        server.start();
+        return server;
+    }
+
+    @AfterClass
+    public static void destroyServer() throws Exception {
+        if (http1server != null) {
+            http1server.stop();
+        }
+        if (http2server != null) {
+            http2server.stop();
+        }
+    }
+
+    @Test
+    public void sendHelloViaHttp1() throws Exception {
+        AtomicReference<Scheme> scheme = new AtomicReference<>();
+        HelloService.Iface client = Clients.newClient(
+                http1uri("/thrift"), HelloService.Iface.class,
+                ClientOption.CLIENT_CODEC_DECORATOR.newValue(c -> new SchemeCapturer(c, scheme)));
+
+        assertEquals("Hello, old world!", client.hello("old world"));
+        assertThat(scheme.get().sessionProtocol(), is(SessionProtocol.H1C));
+    }
+
+    @Test
+    public void sendHelloViaHttp2() throws Exception {
+        AtomicReference<Scheme> scheme = new AtomicReference<>();
+        HelloService.Iface client = Clients.newClient(
+                http2uri("/thrift"), HelloService.Iface.class,
+                ClientOption.CLIENT_CODEC_DECORATOR.newValue(c -> new SchemeCapturer(c, scheme)));
+
+        assertEquals("Hello, new world!", client.hello("new world"));
+        assertThat(scheme.get().sessionProtocol(), is(SessionProtocol.H2C));
+    }
+
+    private static String http1uri(String path) {
+        int port = ((NetworkConnector) http1server.getConnectors()[0]).getLocalPort();
+        return "tbinary+http://127.0.0.1:" + port + path;
+    }
+
+    private static String http2uri(String path) {
+        int port = ((NetworkConnector) http2server.getConnectors()[0]).getLocalPort();
+        return "tbinary+http://127.0.0.1:" + port + path;
+    }
+
+    private static class SchemeCapturer extends DecoratingClientCodec {
+
+        private final AtomicReference<Scheme> scheme;
+
+        SchemeCapturer(ClientCodec delegate, AtomicReference<Scheme> scheme) {
+            super(delegate);
+            this.scheme = scheme;
+        }
+
+        @Override
+        public <T> T decodeResponse(ServiceInvocationContext ctx,
+                                    ByteBuf content, Object originalResponse) throws Exception {
+            if (!scheme.compareAndSet(null, ctx.scheme())) {
+                throw new IllegalStateException("decoded more than one response");
+            }
+
+            return super.decodeResponse(ctx, content, originalResponse);
+        }
+    }
+}

--- a/src/test/java/com/linecorp/armeria/server/HttpServerIdleTimeoutHandlerTest.java
+++ b/src/test/java/com/linecorp/armeria/server/HttpServerIdleTimeoutHandlerTest.java
@@ -81,11 +81,11 @@ public class HttpServerIdleTimeoutHandlerTest {
     public void testIdleTimeoutOccuredTwice() throws Exception {
         readRequest();
         waitUntilTimeout();
-        //padding request count is 2
+        //pending request count is 2
         Assert.assertTrue(ch.isOpen());
 
         writeResponse();
-        //padding request count turns to 0
+        //pending request count turns to 0
         waitUntilTimeout();
         assertFalse(ch.isOpen());
 

--- a/src/test/java/com/linecorp/armeria/server/thrift/ThriftOverHttp1Test.java
+++ b/src/test/java/com/linecorp/armeria/server/thrift/ThriftOverHttp1Test.java
@@ -50,11 +50,12 @@ public class ThriftOverHttp1Test extends AbstractThriftOverHttpTest {
             SSLContext sslCtx =
                     SSLContextBuilder.create().loadTrustMaterial(TrustSelfSignedStrategy.INSTANCE).build();
 
-            httpClient = HttpClientBuilder.create().setSslcontext(sslCtx).build();
+            httpClient = HttpClientBuilder.create().setSSLContext(sslCtx).build();
         } catch (Exception e) {
             throw new Error(e);
         }
     }
+
     @Override
     protected TTransport newTransport(String uri) throws TTransportException {
         return new THttpClient(uri, httpClient);


### PR DESCRIPTION
Changes related with Netty 4.1.0.Beta8 upgrade:

- Add common.http.Http1ClientCodec to:
  - work around the bug in Netty HttpClientCodec
    netty/netty#4504 for more info
  - add onCloseRequest() as an extension point
- Add common.http.AbstractHttpToHttp2ConnectionHandler to
  - remove the code duplication in HttpConfigurator and
    ServerInitializer
- Avoid using the builder pattern for building Http2ConnectionHandler,
  because it doesn't really simplify construction a lot
- Reorganize the client-side pipeline construction
  - HttpConfigurator.finishConfiguration() now adds most of the common
    handlers
- Remove HttpSessionChannelFactory.SESSION_ACTIVE and SessionListener
  - Change the way how the activeness of a session is determined
    - Active if and only if the pipeline contains HttpSessionHandler
  - Move the logic related with the determination of the session
    activeness to HttpSessionHandler

Changes related with Jetty HTTP/1&2 interoperability

- Fix #4
- Add SessionProtocol to ClientCodec.encodeRequest() as a parameter
  - so that the session layer can provide more specific session protocol
  - HttpRemoteInvoker.invoke0() now retrieves the current session
    protocol from HttpSessionHandler.
- Add ThriftOverHttpClientTServletIntegrationTest
  - Originally written by @anuraaga
- Add WorkaroundHandler that works around the issues related with
  h1c-to-h2c upgrade
- Add jetty-serlvet and http2-server to the test dependencies

Changes related with cURL interoperability

- HttpServerHandler now handles the upgrade request after the upgrade is
  done successfully.

Miscellaneous:

- Fix #5
- Fix typo: padding -> pending
- Send 'HEAD / HTTP/1.1' instead of 'GET / HTTP/1.1' as recommended by
  the HTTP/2 official FAQ
- Translate ClosedChannelException to ClosedSessionException in
  ClientBuilder
  - Replace HttpSessionHandler.CLOSED_SESSION_EXCEPTION with
    ClosedSessionException.INSTANCE