### PR TITLE
Add service metrics decorator

### DIFF
--- a/src/main/java/com/linecorp/armeria/common/SerializationFormat.java
+++ b/src/main/java/com/linecorp/armeria/common/SerializationFormat.java
@@ -32,10 +32,15 @@ import javax.annotation.Nullable;
 public enum SerializationFormat {
 
     /**
-     * No serialization format. Used when no serialization/deserialization is desired or when the server
-     * failed to determine the serialization format.
+     * No serialization format. Used when no serialization/deserialization is desired.
      */
-    NONE("none", "none/none"),
+    NONE("none", "application/x-none"),
+
+    /**
+     * Unknown serialization format. Used when some serialization format is desired but the server
+     * failed to understand/recognize it.
+     */
+    UNKNOWN("unknown", "application/x-unknown"),
 
     /**
      * Thrift TBinary serialization format

--- a/src/main/java/com/linecorp/armeria/server/ServiceCodec.java
+++ b/src/main/java/com/linecorp/armeria/server/ServiceCodec.java
@@ -161,7 +161,7 @@ public interface ServiceCodec {
         /**
          * Returns the serialization format of the invocation.
          */
-        Optional<SerializationFormat> decodedSerializationFormat();
+        SerializationFormat decodedSerializationFormat();
 
         /**
          * Returns the ID of the invocation.
@@ -246,8 +246,8 @@ public interface ServiceCodec {
         }
 
         @Override
-        public Optional<SerializationFormat> decodedSerializationFormat() {
-            return Optional.empty();
+        public SerializationFormat decodedSerializationFormat() {
+            return SerializationFormat.UNKNOWN;
         }
 
         @Override

--- a/src/main/java/com/linecorp/armeria/server/http/HttpServiceInvocationContext.java
+++ b/src/main/java/com/linecorp/armeria/server/http/HttpServiceInvocationContext.java
@@ -102,8 +102,8 @@ final class HttpServiceInvocationContext extends ServiceInvocationContext implem
     }
 
     @Override
-    public Optional<SerializationFormat> decodedSerializationFormat() {
-        return Optional.of(scheme().serializationFormat());
+    public SerializationFormat decodedSerializationFormat() {
+        return scheme().serializationFormat();
     }
 
     @Override

--- a/src/main/java/com/linecorp/armeria/server/logging/LoggingServiceCodec.java
+++ b/src/main/java/com/linecorp/armeria/server/logging/LoggingServiceCodec.java
@@ -69,11 +69,11 @@ final class LoggingServiceCodec extends DecoratingServiceCodec {
         }
         case FAILURE:
             // Failed decode
-            final Optional<SerializationFormat> serFmt = result.decodedSerializationFormat();
+            final SerializationFormat serFmt = result.decodedSerializationFormat();
 
             logger.warn("{}[{}+{}://{}{}#{}][{}] Rejected due to protocol violation:",
                         ch,
-                        serFmt.isPresent() ? serFmt.get().uriText() : "unknown",
+                        serFmt.uriText(),
                         sessionProtocol.uriText(),
                         hostname,
                         path,

--- a/src/main/java/com/linecorp/armeria/server/metrics/MetricCollectingService.java
+++ b/src/main/java/com/linecorp/armeria/server/metrics/MetricCollectingService.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2015 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.metrics;
+
+import java.util.function.Function;
+
+import com.linecorp.armeria.server.DecoratingService;
+import com.linecorp.armeria.server.Service;
+
+/**
+ * A decorator {@link Service} that collects metrics for every requests
+ * Currently only HTTP-based session protocols are supported.
+ */
+public class MetricCollectingService extends DecoratingService {
+    public MetricCollectingService(Service service, ServiceMetricConsumer consumer) {
+        super(service, x -> new MetricCollectingServiceCodec(x, consumer), Function.identity());
+    }
+}

--- a/src/main/java/com/linecorp/armeria/server/metrics/MetricCollectingServiceCodec.java
+++ b/src/main/java/com/linecorp/armeria/server/metrics/MetricCollectingServiceCodec.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2015 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.metrics;
+
+import java.util.Optional;
+import java.util.function.LongSupplier;
+
+import com.linecorp.armeria.common.Scheme;
+import com.linecorp.armeria.common.SerializationFormat;
+import com.linecorp.armeria.common.ServiceInvocationContext;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.server.DecoratingServiceCodec;
+import com.linecorp.armeria.server.RequestTimeoutException;
+import com.linecorp.armeria.server.ServiceCodec;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.Channel;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.util.AttributeKey;
+import io.netty.util.concurrent.Promise;
+
+/**
+ * Decorator to collect service metrics.
+ *
+ * This class is expected to be used with other {@link ServiceMetricConsumer}
+ */
+final class MetricCollectingServiceCodec extends DecoratingServiceCodec {
+    private static final AttributeKey<Metrics> METRICS =
+            AttributeKey.valueOf(MetricCollectingServiceCodec.class, "METRICS");
+
+    private final ServiceMetricConsumer metricConsumer;
+
+    /**
+     * Creates a new instance that decorates the specified {@link ServiceCodec} with
+     * the specified {@link ServiceMetricConsumer}.
+     */
+    public MetricCollectingServiceCodec(ServiceCodec codec, ServiceMetricConsumer consumer) {
+        super(codec);
+        metricConsumer = consumer;
+    }
+
+    @Override
+    public DecodeResult decodeRequest(Channel ch, SessionProtocol sessionProtocol, String hostname, String path,
+                                      String mappedPath, ByteBuf in, Object originalRequest,
+                                      Promise<Object> promise) throws Exception {
+        final long startTime = System.nanoTime();
+        final int requestSize = in.readableBytes();
+
+        DecodeResult decodeResult = delegate().decodeRequest(
+                ch, sessionProtocol, hostname, path, mappedPath, in, originalRequest, promise);
+
+        LongSupplier lazyElapsedTime = () -> System.nanoTime() - startTime;
+
+        switch (decodeResult.type()) {
+        case SUCCESS: {
+            ServiceInvocationContext context = decodeResult.invocationContext();
+            context.attr(METRICS).set(new Metrics(requestSize, startTime));
+
+            promise.addListener(future -> {
+                if (!future.isSuccess()) {
+                    // encodeFailureResponse will process this case.
+                    return;
+                }
+                Object result = future.getNow();
+
+                if (result instanceof FullHttpResponse) {
+                    FullHttpResponse httpResponse = (FullHttpResponse) result;
+                    metricConsumer.invocationComplete(
+                            context.scheme(), httpResponse.status().code(),
+                            lazyElapsedTime.getAsLong(), requestSize, httpResponse.content().readableBytes(),
+                            hostname, path, decodeResult.decodedMethod());
+                }
+                // encodeResponse will process this case.
+            });
+            break;
+        }
+        case FAILURE: {
+            final Object errorResponse = decodeResult.errorResponse();
+            if (errorResponse instanceof FullHttpResponse) {
+                FullHttpResponse httpResponse = (FullHttpResponse) errorResponse;
+                metricConsumer.invocationComplete(
+                        Scheme.of(decodeResult.decodedSerializationFormat(), sessionProtocol),
+                        httpResponse.status().code(), lazyElapsedTime.getAsLong(), requestSize,
+                        httpResponse.content().readableBytes(), hostname, path, decodeResult.decodedMethod());
+            } else {
+                metricConsumer.invocationComplete(
+                        Scheme.of(decodeResult.decodedSerializationFormat(), sessionProtocol),
+                        HttpResponseStatus.BAD_REQUEST.code(), lazyElapsedTime.getAsLong(), requestSize, 0, hostname,
+                        path, decodeResult.decodedMethod());
+            }
+            break;
+        }
+        case NOT_FOUND:
+            metricConsumer.invocationComplete(
+                    Scheme.of(decodeResult.decodedSerializationFormat(), sessionProtocol),
+                    HttpResponseStatus.NOT_FOUND.code(), lazyElapsedTime.getAsLong(), requestSize, 0, hostname, path,
+                    decodeResult.decodedMethod());
+            break;
+        }
+
+        return decodeResult;
+    }
+
+    private void invokeComplete(ServiceInvocationContext ctx, HttpResponseStatus status, ByteBuf buf)
+            throws Exception {
+        Metrics metrics = ctx.attr(METRICS).get();
+        long elapsedTime = System.nanoTime() - metrics.startTime;
+        metricConsumer.invocationComplete(
+                ctx.scheme(), status.code(), elapsedTime, metrics.requestSize,
+                buf.readableBytes(), ctx.host(), ctx.path(), Optional.of(ctx.method()));
+    }
+
+    @Override
+    public ByteBuf encodeFailureResponse(ServiceInvocationContext ctx, Throwable cause) throws Exception {
+        ByteBuf buf = delegate().encodeFailureResponse(ctx, cause);
+        if (cause instanceof RequestTimeoutException) {
+            invokeComplete(ctx, HttpResponseStatus.SERVICE_UNAVAILABLE, buf);
+        } else {
+            invokeComplete(ctx, HttpResponseStatus.INTERNAL_SERVER_ERROR, buf);
+        }
+        return buf;
+    }
+
+    @Override
+    public ByteBuf encodeResponse(ServiceInvocationContext ctx, Object response) throws Exception {
+        ByteBuf buf = delegate().encodeResponse(ctx, response);
+        invokeComplete(ctx, HttpResponseStatus.OK, buf);
+        return buf;
+    }
+
+    /**
+     * internal container for metric data
+     */
+    static class Metrics {
+        final int requestSize;
+        final long startTime;
+
+        Metrics(int requestSize, long startTime) {
+            this.requestSize = requestSize;
+            this.startTime = startTime;
+        }
+    }
+}

--- a/src/main/java/com/linecorp/armeria/server/metrics/ServiceMetricConsumer.java
+++ b/src/main/java/com/linecorp/armeria/server/metrics/ServiceMetricConsumer.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2015 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.metrics;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import com.linecorp.armeria.common.Scheme;
+import org.slf4j.LoggerFactory;
+import com.linecorp.armeria.common.SessionProtocol;
+
+@FunctionalInterface
+public interface ServiceMetricConsumer {
+    /**
+     * Invoked for each request that has been processed
+     *
+     * @param scheme the {@link Scheme} which the invocation has been performed on.
+     * @param code the {@link SessionProtocol}-specific status code that signifies the result of the
+     *             invocation. e.g. HTTP response status code
+     * @param processTimeNanos elapsed nano time processing request
+     * @param requestSize number of bytes in request if possible, otherwise it will be 0
+     * @param responseSize number of bytes in response if possible, otherwise it will be 0
+     */
+    void invocationComplete(Scheme scheme, int code, long processTimeNanos, int requestSize,
+                            int responseSize, String hostname, String path, Optional<String> method);
+
+    default ServiceMetricConsumer andThen(ServiceMetricConsumer other) {
+        Objects.requireNonNull(other, "other");
+        return (scheme, code, processNanoTime, requestSize, responseSize, hostname, path,
+                mappedPath) -> {
+            try {
+                invocationComplete(scheme, code, processNanoTime, requestSize, responseSize,
+                                   hostname, path, mappedPath);
+            } catch (Throwable e) {
+                LoggerFactory.getLogger(ServiceMetricConsumer.class).warn(
+                        "invocationComplete() failed with an exception: {}", e);
+            }
+            other.invocationComplete(scheme, code, processNanoTime, requestSize, responseSize,
+                                     hostname, path, mappedPath);
+        };
+    }
+}
+

--- a/src/main/java/com/linecorp/armeria/server/metrics/package-info.java
+++ b/src/main/java/com/linecorp/armeria/server/metrics/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2015 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Metrics service.
+ */
+package com.linecorp.armeria.server.metrics;

--- a/src/main/java/com/linecorp/armeria/server/thrift/ThriftServiceCodec.java
+++ b/src/main/java/com/linecorp/armeria/server/thrift/ThriftServiceCodec.java
@@ -511,8 +511,8 @@ final class ThriftServiceCodec implements ServiceCodec {
         }
 
         @Override
-        public Optional<SerializationFormat> decodedSerializationFormat() {
-            return Optional.of(serializationFormat);
+        public SerializationFormat decodedSerializationFormat() {
+            return serializationFormat;
         }
 
         @Override

--- a/src/main/java/com/linecorp/armeria/server/thrift/ThriftServiceInvocationContext.java
+++ b/src/main/java/com/linecorp/armeria/server/thrift/ThriftServiceInvocationContext.java
@@ -107,8 +107,8 @@ final class ThriftServiceInvocationContext extends ServiceInvocationContext impl
     }
 
     @Override
-    public Optional<SerializationFormat> decodedSerializationFormat() {
-        return Optional.of(scheme().serializationFormat());
+    public SerializationFormat decodedSerializationFormat() {
+        return scheme().serializationFormat();
     }
 
     @Override

--- a/src/test/java/com/linecorp/armeria/common/SerializationFormatTest.java
+++ b/src/test/java/com/linecorp/armeria/common/SerializationFormatTest.java
@@ -10,6 +10,9 @@ public class SerializationFormatTest {
     @Test
     public void fromMimeType_exactMatch() {
         for (SerializationFormat format : SerializationFormat.values()) {
+            if (format == SerializationFormat.UNKNOWN) {
+                continue;
+            }
             assertSame(format, SerializationFormat.fromMimeType(format.mimeType()).get());
         }
     }

--- a/src/test/java/com/linecorp/armeria/server/metrics/MetricCollectingServiceCodecTest.java
+++ b/src/test/java/com/linecorp/armeria/server/metrics/MetricCollectingServiceCodecTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2015 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.metrics;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+
+import java.nio.charset.StandardCharsets;
+
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+
+import com.linecorp.armeria.common.ServiceInvocationContext;
+import com.linecorp.armeria.server.AbstractServerTest;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.Service;
+import com.linecorp.armeria.server.ServiceCodec;
+import com.linecorp.armeria.server.ServiceCodec.DecodeResult;
+import com.linecorp.armeria.server.ServiceCodec.DecodeResultType;
+import com.linecorp.armeria.server.ServiceInvocationHandler;
+import com.linecorp.armeria.server.VirtualHostBuilder;
+
+import io.netty.buffer.ByteBufHolder;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.util.AttributeKey;
+import io.netty.util.DefaultAttributeMap;
+
+@RunWith(Enclosed.class)
+public class MetricCollectingServiceCodecTest {
+    @SuppressWarnings("unchecked")
+    protected static void setupServer(
+            ServerBuilder sb, ServiceInvocationHandler handler, final ServiceMetricConsumer consumer) {
+        ServiceCodec codec = Mockito.mock(ServiceCodec.class);
+        DecodeResult decodeResult = Mockito.mock(DecodeResult.class);
+        DefaultAttributeMap defaultAttributeMap = new DefaultAttributeMap();
+        ServiceInvocationContext invocationContext = Mockito.mock(ServiceInvocationContext.class);
+
+        try {
+            when(decodeResult.type()).thenReturn(DecodeResultType.SUCCESS);
+            when(decodeResult.invocationContext()).thenReturn(invocationContext);
+            when(invocationContext.attr(any())).then(x -> {
+                return defaultAttributeMap.attr(AttributeKey.valueOf("TEST"));
+            });
+            when(invocationContext.method()).thenReturn("someMethod");
+
+            when(codec.decodeRequest(any(), any(), any(), any(), any(), any(), any(), any()))
+                    .thenReturn(decodeResult);
+
+            when(codec.encodeResponse(any(), any())).thenReturn(Unpooled.EMPTY_BUFFER);
+            when(codec.encodeFailureResponse(any(), any())).thenReturn(Unpooled.EMPTY_BUFFER);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        Service service = Service.of(new MetricCollectingServiceCodec(codec, consumer), handler);
+
+        sb.defaultVirtualHost(new VirtualHostBuilder().serviceAt("/", service).build());
+    }
+
+    abstract static class ExecutionCheckingTest extends AbstractServerTest {
+        private int executed = 0;
+
+        protected ServiceMetricConsumer defaultConsumer = (a, b, c, d, e, f, g, h) -> executed += 1;
+
+        @Test
+        public void test() throws Exception {
+            try (CloseableHttpClient hc = HttpClients.createMinimal()) {
+                final HttpPost req = new HttpPost(uri("/"));
+                req.setEntity(new StringEntity("Hello, world!", StandardCharsets.UTF_8));
+
+                hc.execute(req);
+
+                assertEquals(1, executed);
+            }
+        }
+    }
+
+    public static class NormalResponseTest extends ExecutionCheckingTest {
+        @Override
+        protected void configureServer(ServerBuilder sb) {
+            setupServer(sb, (ctx, blockingTaskExecutor, promise) -> promise.trySuccess("Hello World"),
+                        defaultConsumer);
+        }
+    }
+
+    public static class TypedResponseTest extends ExecutionCheckingTest {
+        @Override
+        protected void configureServer(ServerBuilder sb) {
+            ByteBufHolder response = Mockito.mock(ByteBufHolder.class);
+            when(response.content()).thenReturn(Unpooled.EMPTY_BUFFER);
+            setupServer(sb, (ctx, blockingTaskExecutor, promise) -> promise.trySuccess(response),
+                        defaultConsumer);
+        }
+    }
+
+    public static class HttpResponseTest extends ExecutionCheckingTest {
+        @Override
+        protected void configureServer(ServerBuilder sb) {
+            setupServer(
+                    sb, (ctx, blockingTaskExecutor, promise) -> promise.trySuccess(
+                            new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK)),
+                    defaultConsumer);
+        }
+    }
+
+    public static class ExceptionResponseTest extends ExecutionCheckingTest {
+        @Override
+        protected void configureServer(ServerBuilder sb) {
+            setupServer(sb, (ctx, blockingTaskExecutor, promise) -> promise.tryFailure(new RuntimeException()),
+                        defaultConsumer);
+        }
+    }
+}

--- a/src/test/java/com/linecorp/armeria/server/metrics/ServiceMetricConsumerTest.java
+++ b/src/test/java/com/linecorp/armeria/server/metrics/ServiceMetricConsumerTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2015 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.metrics;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Optional;
+
+import com.linecorp.armeria.common.Scheme;
+import com.linecorp.armeria.common.SerializationFormat;
+import org.junit.Test;
+
+import com.linecorp.armeria.common.SessionProtocol;
+
+public class ServiceMetricConsumerTest {
+    @Test
+    public void testInfiniteRecursion() throws Exception {
+        final int[] executeCounter = { 0 };
+
+        ServiceMetricConsumer consumer = (a, b, c, d, e, f, g, h) -> executeCounter[0] += 1;
+        consumer.andThen(consumer).invocationComplete(
+                Scheme.of(SerializationFormat.NONE, SessionProtocol.HTTP), 200, 0, 0, 0, "", "",
+                Optional.of(""));
+
+        assertEquals("invocationComplete should be executed twice", 2, executeCounter[0]);
+    }
+}
+


### PR DESCRIPTION
Introduced classes are expected to be used with proper consumers which
can be implemented for own purposes. (integrate with dropwizard metrics,
or other in-house metric utilities)