### PR TITLE
Un-blacklist 'Content-Type' and 'Accept' from ClientOption.HTTP_HEADERS

### DIFF
--- a/src/main/java/com/linecorp/armeria/client/ClientOptions.java
+++ b/src/main/java/com/linecorp/armeria/client/ClientOptions.java
@@ -34,11 +34,14 @@ import java.util.Optional;
 import java.util.function.Function;
 
 import com.linecorp.armeria.common.TimeoutPolicy;
+import com.linecorp.armeria.common.http.ImmutableHttpHeaders;
 import com.linecorp.armeria.common.util.AbstractOptions;
 
+import io.netty.handler.codec.http.DefaultHttpHeaders;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http2.HttpConversionUtil.ExtensionHeaderNames;
+import io.netty.util.AsciiString;
 
 /**
  * A set of {@link ClientOption}s and their respective values.
@@ -61,19 +64,20 @@ public final class ClientOptions extends AbstractOptions {
     public static final ClientOptions DEFAULT = new ClientOptions(DEFAULT_OPTIONS);
 
     @SuppressWarnings("deprecation")
-    private static final Collection<CharSequence> BLACKLISTED_HEADER_NAMES = Collections.unmodifiableCollection(
-                                        Arrays.asList(HttpHeaderNames.HOST,
-                                                      HttpHeaderNames.USER_AGENT,
-                                                      HttpHeaderNames.CONNECTION,
-                                                      HttpHeaderNames.CONTENT_TYPE,
-                                                      HttpHeaderNames.ACCEPT,
-                                                      HttpHeaderNames.KEEP_ALIVE,
-                                                      HttpHeaderNames.PROXY_CONNECTION,
-                                                      HttpHeaderNames.TRANSFER_ENCODING,
-                                                      HttpHeaderNames.UPGRADE,
-                                                      ExtensionHeaderNames.SCHEME.text(),
-                                                      ExtensionHeaderNames.PATH.text(),
-                                                      ExtensionHeaderNames.STREAM_ID.text()));
+    private static final Collection<AsciiString> BLACKLISTED_HEADER_NAMES =
+            Collections.unmodifiableCollection(Arrays.asList(
+                    HttpHeaderNames.CONNECTION,
+                    HttpHeaderNames.HOST,
+                    HttpHeaderNames.KEEP_ALIVE,
+                    HttpHeaderNames.PROXY_CONNECTION,
+                    HttpHeaderNames.TRANSFER_ENCODING,
+                    HttpHeaderNames.UPGRADE,
+                    HttpHeaderNames.USER_AGENT,
+                    ExtensionHeaderNames.PATH.text(),
+                    ExtensionHeaderNames.SCHEME.text(),
+                    ExtensionHeaderNames.STREAM_DEPENDENCY_ID.text(),
+                    ExtensionHeaderNames.STREAM_ID.text(),
+                    ExtensionHeaderNames.STREAM_PROMISE_ID.text()));
 
     /**
      * Returns the {@link ClientOptions} with the specified {@link ClientOptionValue}s.
@@ -106,16 +110,24 @@ public final class ClientOptions extends AbstractOptions {
         T value = optionValue.value();
 
         if (option == HTTP_HEADERS) {
-            validateHttpHeaders((HttpHeaders) value);
+            @SuppressWarnings("unchecked")
+            ClientOption<HttpHeaders> castOption = (ClientOption<HttpHeaders>) option;
+            @SuppressWarnings("unchecked")
+            ClientOptionValue<T> castOptionValue =
+                    (ClientOptionValue<T>) castOption.newValue(validateHttpHeaders((HttpHeaders) value));
+            optionValue = castOptionValue;
         }
         return optionValue;
     }
 
-    private static void validateHttpHeaders(HttpHeaders headers) {
+    private static HttpHeaders validateHttpHeaders(HttpHeaders headers) {
         requireNonNull(headers, "headers");
         BLACKLISTED_HEADER_NAMES.stream().filter(headers::contains).anyMatch(h -> {
             throw new IllegalArgumentException("unallowed header name: " + h);
         });
+
+        // Create an immutable copy to prevent further modification.
+        return new ImmutableHttpHeaders(new DefaultHttpHeaders(false).add(headers));
     }
 
     private ClientOptions(ClientOptionValue<?>... options) {

--- a/src/main/java/com/linecorp/armeria/client/http/SimpleHttpRequest.java
+++ b/src/main/java/com/linecorp/armeria/client/http/SimpleHttpRequest.java
@@ -18,6 +18,8 @@ package com.linecorp.armeria.client.http;
 
 import java.net.URI;
 
+import com.linecorp.armeria.common.http.ImmutableHttpHeaders;
+
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;

--- a/src/main/java/com/linecorp/armeria/common/http/ImmutableHttpHeaders.java
+++ b/src/main/java/com/linecorp/armeria/common/http/ImmutableHttpHeaders.java
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-package com.linecorp.armeria.client.http;
+package com.linecorp.armeria.common.http;
 
 import java.util.Iterator;
 import java.util.List;
@@ -24,14 +24,14 @@ import java.util.Set;
 import io.netty.handler.codec.http.HttpHeaders;
 
 /**
- * A container for HTTP headers that cannot be mutated. Just delegates read
- * operations to an underlying {@link HttpHeaders} object.
+ * A container for HTTP headers that cannot be mutated. Just delegates read operations to an underlying
+ * {@link HttpHeaders} object.
  */
-final class ImmutableHttpHeaders extends HttpHeaders {
+public final class ImmutableHttpHeaders extends HttpHeaders {
 
     private final HttpHeaders delegate;
 
-    ImmutableHttpHeaders(HttpHeaders delegate) {
+    public ImmutableHttpHeaders(HttpHeaders delegate) {
         this.delegate = delegate;
     }
 
@@ -165,6 +165,7 @@ final class ImmutableHttpHeaders extends HttpHeaders {
     }
 
     @Override
+    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
     public boolean equals(Object other) {
         return delegate.equals(other);
     }


### PR DESCRIPTION
Motivation:

Sometimes a user need to override the default `Content-Type` and
`Accept` header values set by invoker/codec implementation. For example,
a user might want to add a parameter to the MIME type:

  Content-Type: application/x-thrift; protocol=tbinary schema=v3

Modification:

- Remove `Content-Type` and `Accept` from the blacklist
- Sort the blacklisted header name list
- Make a defensive immutable copy when building a value of
  ClientOptions.HTTP_HEADERS

Result:

More freedom to users