### PR TITLE
Expose service path and formats in DocService

### DIFF
--- a/src/main/java/com/linecorp/armeria/common/MimeTypeParams.java
+++ b/src/main/java/com/linecorp/armeria/common/MimeTypeParams.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2015 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common;
+
+final class MimeTypeParams {
+
+    static String find(String params, String name) {
+        if (params == null) {
+            return null;
+        }
+
+        final int length = params.length();
+        if (length - 2 < name.length()) {
+            return null;
+        }
+
+        int i = 0;
+        for (;;) {
+            // Skip whitespace characters.
+            i = skipWhitespace(params, i);
+            if (i >= length) {
+                return null;
+            }
+
+            // Expect a semicolon.
+            if (params.charAt(i) != ';') {
+                return null;
+            }
+
+            // Skip whitespace characters.
+            i = skipWhitespace(params, i + 1);
+            if (i >= length) {
+                return null;
+            }
+
+            // Find the last index of the name part.
+            int lastIndex;
+            for (lastIndex = i; i < length && isTokenChar(params.charAt(i)); i ++) {
+                continue;
+            }
+
+            // Get the name part.
+            final boolean found = params.substring(lastIndex, i).equals(name);
+
+            // Skip whitespace characters.
+            i = skipWhitespace(params, i);
+            if (i >= length) {
+                return null;
+            }
+
+            // Expect an equal sign.
+            if (params.charAt(i) != '=') {
+                return null;
+            }
+
+            // Skip whitespace characters.
+            i = skipWhitespace(params, i + 1);
+            if(i >= length) {
+                return null;
+            }
+
+            // Parse a value (unquoted or quoted)
+            char c = params.charAt(i);
+            if (c != '"') { // Parse a unquoted value.
+                if (!isTokenChar(c)) {
+                    // Not a token character
+                    return null;
+                }
+
+                for (lastIndex = i; i < length && isTokenChar(params.charAt(i)); i++) {
+                    continue;
+                }
+
+                if (found) {
+                    return params.substring(lastIndex, i);
+                }
+            } else { // Parse a quoted value.
+                // Skip the opening quote.
+                i ++;
+                if (i >= length) {
+                    // Met the end of string right after the opening quote.
+                    return null;
+                }
+
+                // Find the closing quote.
+                for (lastIndex = i; i < length; i++) {
+                    c = params.charAt(i);
+                    if (c == '"') {
+                        break;
+                    }
+
+                    if (c == '\\') {
+                        i++;
+                    }
+                }
+
+                if (c != '"') {
+                    // Couldn't find the closing quote.
+                    return null;
+                }
+
+                if (found) {
+                    return unquote(params.substring(lastIndex, i));
+                }
+
+                // Skip the closing quote.
+                i++;
+            }
+        }
+    }
+
+    private static int skipWhitespace(String str, int i) {
+        final int length = str.length();
+        for (; i < length && Character.isWhitespace(str.charAt(i)); i ++) {
+            continue;
+        }
+
+        return i;
+    }
+
+    private static boolean isTokenChar(char c) {
+        return c > 32 && c < 127 && "()<>@,;:/[]?=\\\"".indexOf(c) < 0;
+    }
+
+    private static String unquote(String value) {
+        final int length = value.length();
+        final StringBuilder buf = new StringBuilder(length);
+
+        boolean escaped = false;
+        for(int i = 0; i < length; i++) {
+            final char c = value.charAt(i);
+            if (escaped) {
+                buf.append(c);
+                escaped = false;
+            } else if (c != '\\') {
+                buf.append(c);
+            } else {
+                escaped = true;
+            }
+        }
+
+        return buf.toString();
+    }
+
+    private MimeTypeParams() {}
+}

--- a/src/main/java/com/linecorp/armeria/common/SerializationFormat.java
+++ b/src/main/java/com/linecorp/armeria/common/SerializationFormat.java
@@ -113,12 +113,7 @@ public enum SerializationFormat {
 
     private static Optional<SerializationFormat> fromThriftMimeType(String params) {
         final String protocol = MimeTypeParams.find(params, "protocol");
-        if (protocol == null) {
-            return Optional.empty();
-        }
-
-        final Optional<SerializationFormat> serFmt = PROTOCOL_TO_THRIFT_FORMATS.get(protocol);
-        return serFmt != null ? serFmt : Optional.empty();
+        return PROTOCOL_TO_THRIFT_FORMATS.getOrDefault(protocol, Optional.empty());
     }
 
     private final String uriText;

--- a/src/main/java/com/linecorp/armeria/common/SerializationFormat.java
+++ b/src/main/java/com/linecorp/armeria/common/SerializationFormat.java
@@ -18,13 +18,11 @@ package com.linecorp.armeria.common;
 
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Function;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
 
@@ -60,19 +58,18 @@ public enum SerializationFormat {
      */
     THRIFT_TEXT("ttext", "application/x-thrift; protocol=TTEXT");
 
-    private static final Pattern WHITESPACE = Pattern.compile("\\s");
-
-    private static final Function<String, String> MIME_TYPE_NORMALIZER =
-            s -> WHITESPACE.matcher(s.toLowerCase()).replaceAll("");
-
-    private static final Set<SerializationFormat> THRIFT_FORMAT = Collections.unmodifiableSet(
+    private static final Set<SerializationFormat> THRIFT_FORMATS = Collections.unmodifiableSet(
             EnumSet.of(THRIFT_BINARY, THRIFT_COMPACT, THRIFT_JSON, THRIFT_TEXT));
 
-    private static final Map<String, SerializationFormat> MIME_TYPE_TO_FORMAT =
-            Collections.unmodifiableMap(
-                    Stream.of(SerializationFormat.values()).collect(
-                            Collectors.toMap(f -> MIME_TYPE_NORMALIZER.apply(f.mimeType),
-                                             Function.identity())));
+    private static final Map<String, Optional<SerializationFormat>> PROTOCOL_TO_THRIFT_FORMATS;
+
+    static {
+        Map<String, Optional<SerializationFormat>> protocolToThriftFormats = new HashMap<>();
+        for (SerializationFormat f : THRIFT_FORMATS) {
+            protocolToThriftFormats.put(f.uriText(), Optional.of(f));
+        }
+        PROTOCOL_TO_THRIFT_FORMATS = Collections.unmodifiableMap(protocolToThriftFormats);
+    }
 
     /**
      * Returns the set of all known Thrift serialization formats. This method is useful when determining if a
@@ -80,7 +77,7 @@ public enum SerializationFormat {
      * e.g. {@code if (SerializationFormat.ofThrift().contains(serFmt)) { ... }}
      */
     public static Set<SerializationFormat> ofThrift() {
-        return THRIFT_FORMAT;
+        return THRIFT_FORMATS;
     }
 
     /**
@@ -89,12 +86,41 @@ public enum SerializationFormat {
      * mimetype.
      */
     public static Optional<SerializationFormat> fromMimeType(@Nullable String mimeType) {
-        if (mimeType == null) {
+        if (mimeType == null || mimeType.isEmpty()) {
             return Optional.empty();
         }
-        return Optional.ofNullable(MIME_TYPE_TO_FORMAT.get(MIME_TYPE_NORMALIZER.apply(mimeType)));
+
+        final int semicolonIdx = mimeType.indexOf(';');
+        final String paramPart;
+        if (semicolonIdx >= 0) {
+            paramPart = mimeType.substring(semicolonIdx).toLowerCase(Locale.US);
+            mimeType = mimeType.substring(0, semicolonIdx).toLowerCase(Locale.US).trim();
+        } else {
+            paramPart = null;
+            mimeType = mimeType.toLowerCase(Locale.US).trim();
+        }
+
+        if ("application/x-thrift".equals(mimeType)) {
+            return fromThriftMimeType(paramPart);
+        }
+
+        if (NONE.mimeType().equals(mimeType)) {
+            return Optional.of(NONE);
+        }
+
+        return Optional.empty();
     }
-    
+
+    private static Optional<SerializationFormat> fromThriftMimeType(String params) {
+        final String protocol = MimeTypeParams.find(params, "protocol");
+        if (protocol == null) {
+            return Optional.empty();
+        }
+
+        final Optional<SerializationFormat> serFmt = PROTOCOL_TO_THRIFT_FORMATS.get(protocol);
+        return serFmt != null ? serFmt : Optional.empty();
+    }
+
     private final String uriText;
     private final String mimeType;
 

--- a/src/main/java/com/linecorp/armeria/server/docs/EndpointInfo.java
+++ b/src/main/java/com/linecorp/armeria/server/docs/EndpointInfo.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2015 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.docs;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.linecorp.armeria.common.SerializationFormat;
+
+class EndpointInfo {
+
+    static EndpointInfo of(String hostnamePattern, String path,
+                           SerializationFormat defaultFormat, Set<SerializationFormat> formats) {
+        return new EndpointInfo(hostnamePattern, path, defaultFormat, formats);
+    }
+
+    private final String hostnamePattern;
+    private final String path;
+    private final String defaultMimeType;
+    private final Set<String> availableMimeTypes;
+
+    EndpointInfo(String hostnamePattern, String path,
+                 SerializationFormat defaultFormat, Set<SerializationFormat> availableFormats) {
+        this.hostnamePattern = requireNonNull(hostnamePattern, "hostnamePattern");
+        this.path = requireNonNull(path, "path");
+        defaultMimeType = requireNonNull(defaultFormat, "defaultFormat").mimeType();
+        availableMimeTypes = Collections.unmodifiableSet(
+                availableFormats.stream().map(SerializationFormat::mimeType)
+                                .collect(Collectors.toCollection(TreeSet::new)));
+    }
+
+    @JsonProperty
+    String hostnamePattern() {
+        return hostnamePattern;
+    }
+
+    @JsonProperty
+    String path() {
+        return path;
+    }
+
+    @JsonProperty
+    String defaultMimeType() {
+        return defaultMimeType;
+    }
+
+    @JsonProperty
+    Set<String> availableMimeTypes() {
+        return availableMimeTypes;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(hostnamePattern, path);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof EndpointInfo)) {
+            return false;
+        }
+
+        if (this == obj) {
+            return true;
+        }
+
+        final EndpointInfo that = (EndpointInfo) obj;
+        return hostnamePattern.equals(that.hostnamePattern) &&
+               path.equals(that.path) &&
+               defaultMimeType.equals(that.defaultMimeType) &&
+               availableMimeTypes.equals(that.availableMimeTypes);
+    }
+
+    @Override
+    public String toString() {
+        return "EndpointInfo{" +
+               "hostnamePattern=" + hostnamePattern +
+               ", path=" + path +
+               ", defaultMimeType=" + defaultMimeType +
+               ", availableMimeTypes=" + availableMimeTypes +
+               '}';
+    }
+}

--- a/src/main/java/com/linecorp/armeria/server/thrift/ThriftService.java
+++ b/src/main/java/com/linecorp/armeria/server/thrift/ThriftService.java
@@ -100,7 +100,7 @@ public class ThriftService extends SimpleService {
      */
     public static ThriftService ofFormats(Object thriftService, SerializationFormat defaultSerializationFormat,
                                           Iterable<SerializationFormat> otherAllowedSerializationFormats) {
-        requireNonNull(otherAllowedSerializationFormats, "allowedSerializationFormats");
+        requireNonNull(otherAllowedSerializationFormats, "otherAllowedSerializationFormats");
         EnumSet<SerializationFormat> allowedSerializationFormatsSet = EnumSet.of(defaultSerializationFormat);
         otherAllowedSerializationFormats.forEach(allowedSerializationFormatsSet::add);
         return new ThriftService(

--- a/src/main/resources/com/linecorp/armeria/server/docs/assets/css/armeria.css
+++ b/src/main/resources/com/linecorp/armeria/server/docs/assets/css/armeria.css
@@ -36,6 +36,10 @@ h2 {
   font-size: 125%;
 }
 
+label {
+  font-weight: inherit;
+}
+
 /*
  * Top navigation
  * Hide default border to remove 1px line.
@@ -114,6 +118,11 @@ h2 {
   font-size: 60%;
 }
 
+.main td ul {
+  list-style-type: none;
+  padding-left: 0;
+}
+
 .main h2 ~ .table-responsive {
   /* Remove the spacing between a heading and its first table */
   margin-top: -0.75em;
@@ -148,4 +157,15 @@ h2 {
 
 .debug-textarea {
   width: 100%;
+  max-width: 100%;
+  font-size: 90%;
+  min-height: 256px;
+}
+
+.debug-submit {
+  margin-top: 8px;
+}
+
+.debug-response {
+  min-height: 256px;
 }

--- a/src/main/resources/com/linecorp/armeria/server/docs/assets/fonts/fonts.css
+++ b/src/main/resources/com/linecorp/armeria/server/docs/assets/fonts/fonts.css
@@ -105,7 +105,7 @@ body {
                'Helvetica', 'Arial', sans-serif;
 }
 
-pre, code, kbd, var, samp, tt {
+pre, code, kbd, var, samp, tt, .code {
   font-family: 'Source Code Pro', 'Consolas', 'Menlo', 'Monaco', 'Lucida Console', 'Liberation Mono',
                'DejaVu Sans Mono', monospace;
 }

--- a/src/main/resources/com/linecorp/armeria/server/docs/index.html
+++ b/src/main/resources/com/linecorp/armeria/server/docs/index.html
@@ -128,13 +128,54 @@
           </div>
           {{/if}}
 
+          {{#if serviceEndpoints.length}}
+          <h2 class="sub-header">Endpoints</h2>
+          <div class="table-responsive">
+            <table class="table table-striped table-condensed">
+              <thead>
+              <tr>
+                <th>Hostname</th>
+                <th>Path</th>
+                <th>MIME types</th>
+              </tr>
+              </thead>
+              <tbody>
+              {{#each serviceEndpoints}}
+              <tr>
+                <td><code>{{{hostnamePattern}}}</code></td>
+                <td><code>{{{path}}}</code></td>
+                <td>
+                  <ul>
+                  {{#each availableMimeTypes}}
+                    <li>{{{.}}}</li>
+                  {{/each}}
+                  </ul>
+                </td>
+              </tr>
+              {{/each}}
+              </tbody>
+            </table>
+          </div>
+          {{/if}}
+
           {{#if serviceDebugPath}}
+          <h2 class="sub-header">Debug</h2>
           <div class="row">
             <div class="col-sm-6">
-              <div><textarea class="debug-textarea" rows="20"></textarea></div>
-              <div><button class="debug-submit btn btn-primary">Submit</button></div>
+              <div>
+                <label>
+                  Arguments as a
+                  <a href="https://github.com/line/armeria/blob/13b0510205a84e1a3cd17509e7d39116d050b6b3/src/main/java/com/linecorp/armeria/common/thrift/text/TTextProtocol.java">TText</a>
+                  JSON object:
+                </label>
+                <textarea class="debug-textarea form-control code">{&#10;&#32;&#32;"": ""&#10;}&#10;</textarea>
+              </div>
+              <div>
+                <button class="debug-submit btn btn-primary">Submit to: <code>{{{serviceDebugPath}}}</code></button>
+              </div>
             </div>
             <div class="col-sm-6">
+              <label >Result:</label>
               <pre class="debug-response json"><code></code></pre>
             </div>
           </div>

--- a/src/test/java/com/linecorp/armeria/common/SerializationFormatTest.java
+++ b/src/test/java/com/linecorp/armeria/common/SerializationFormatTest.java
@@ -1,7 +1,7 @@
 package com.linecorp.armeria.common;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
 
 import org.junit.Test;
 
@@ -10,16 +10,20 @@ public class SerializationFormatTest {
     @Test
     public void fromMimeType_exactMatch() {
         for (SerializationFormat format : SerializationFormat.values()) {
-            assertEquals(format, SerializationFormat.fromMimeType(format.mimeType()).get());
+            assertSame(format, SerializationFormat.fromMimeType(format.mimeType()).get());
         }
     }
 
     @Test
     public void fromMimeType_normalizes() {
-        assertEquals(SerializationFormat.THRIFT_BINARY,
-                     SerializationFormat.fromMimeType("application/x-thrift; protocol=tbinary").get());
-        assertEquals(SerializationFormat.THRIFT_COMPACT,
-                     SerializationFormat.fromMimeType("application/x-thrift;protocol=TCompact").get());
+        assertSame(SerializationFormat.THRIFT_BINARY,
+                   SerializationFormat.fromMimeType("application/x-thrift; protocol=tbinary").get());
+        assertSame(SerializationFormat.THRIFT_COMPACT,
+                   SerializationFormat.fromMimeType("application/x-thrift;protocol=TCompact").get());
+        assertSame(SerializationFormat.THRIFT_JSON,
+                   SerializationFormat.fromMimeType("application/x-thrift ; protocol=\"TjSoN\"").get());
+        assertSame(SerializationFormat.THRIFT_TEXT,
+                   SerializationFormat.fromMimeType("application/x-thrift ; version=3;protocol=ttext").get());
     }
 
     @Test

--- a/src/test/java/com/linecorp/armeria/common/thrift/text/TTextProtocolTest.java
+++ b/src/test/java/com/linecorp/armeria/common/thrift/text/TTextProtocolTest.java
@@ -117,14 +117,14 @@ public class TTextProtocolTest {
                 ))
                 .setF(true)
                 .setG((byte) 12)
-                .setH(ImmutableMap.<Integer, Long>of(
+                .setH(ImmutableMap.of(
                         1, 2L,
                         3, 4L,
                         5, 6L
                 ))
                 .setJ(ImmutableMap.<Short,List<Boolean>>of(
-                        (short) 1, ImmutableList.<Boolean>of(true, true, false, true),
-                        (short) 5, ImmutableList.<Boolean>of(false)
+                        (short) 1, ImmutableList.of(true, true, false, true),
+                        (short) 5, ImmutableList.of(false)
                 ))
                 .setK(ImmutableSet.of(true, false, false, false, true))
                 .setL(base64Encoder.decode("SGVsbG8gV29ybGQ="))
@@ -132,17 +132,17 @@ public class TTextProtocolTest {
                 .setN((short) 678)
                 .setP(Letter.CHARLIE)
                 .setQ(EnumSet.allOf(Letter.class))
-                .setR(ImmutableMap.<Sub, Long>of(sub(1, 2), 100L))
+                .setR(ImmutableMap.of(sub(1, 2), 100L))
                 .setS(ImmutableMap.<Map<Map<Long, Long>, Long> ,Long>of(
                         ImmutableMap.<Map<Long, Long>, Long>of(
-                                ImmutableMap.<Long, Long>of(200L, 400L), 300L
+                                ImmutableMap.of(200L, 400L), 300L
                         ), 100L
                 ))
                 ;
 
     }
 
-    private Sub sub(int s, int x) {
+    private static Sub sub(int s, int x) {
         return new Sub(s, new SubSub(x));
     }
 
@@ -166,9 +166,9 @@ public class TTextProtocolTest {
                 "  \"u\" : {\n" +
                 "    \"f2\" : 2\n" +
                 "  }\n" +
-                "}";
+                '}';
 
-        assertEquals(expectedMsg, baos.toString());
+        assertJsonEquals(expectedMsg, baos.toString());
     }
 
     @Test
@@ -186,7 +186,7 @@ public class TTextProtocolTest {
                 "      \"detailsArg2\" : 100\n" +
                 "    }\n" +
                 "  }\n" +
-                "}";
+                '}';
 
         TTextProtocol prot = new TTextProtocol(
                 new TIOStreamTransport(new ByteArrayInputStream(request.getBytes())));
@@ -227,7 +227,7 @@ public class TTextProtocolTest {
                 "      \"detailsArg2\" : 100\n" +
                 "    }\n" +
                 "  }\n" +
-                "}";
+                '}';
 
         TTextProtocol prot = new TTextProtocol(
                 new TIOStreamTransport(new ByteArrayInputStream(request.getBytes())));
@@ -256,7 +256,7 @@ public class TTextProtocolTest {
                 "      \"detailsArg2\" : 100\n" +
                 "    }\n" +
                 "  }\n" +
-                "}";
+                '}';
 
         TTextProtocol prot = new TTextProtocol(
                 new TIOStreamTransport(new ByteArrayInputStream(request.getBytes())));
@@ -295,7 +295,7 @@ public class TTextProtocolTest {
                 "      \"response\" : \"Nice response\"\n" +
                 "    }\n" +
                 "  }\n" +
-                "}";
+                '}';
 
         TTextProtocol prot = new TTextProtocol(
                 new TIOStreamTransport(new ByteArrayInputStream(request.getBytes())));
@@ -331,7 +331,7 @@ public class TTextProtocolTest {
                 "      \"reason\" : \"Bad rpc\"\n" +
                 "    }\n" +
                 "  }\n" +
-                "}";
+                '}';
 
         TTextProtocol prot = new TTextProtocol(
                 new TIOStreamTransport(new ByteArrayInputStream(request.getBytes())));
@@ -368,7 +368,7 @@ public class TTextProtocolTest {
                 "      \"detailsArg2\" : 100\n" +
                 "    }\n" +
                 "  }\n" +
-                "}";
+                '}';
         TTextProtocol prot = new TTextProtocol(
                 new TIOStreamTransport(new ByteArrayInputStream(request.getBytes())));
         prot.readMessageBegin();
@@ -387,7 +387,7 @@ public class TTextProtocolTest {
                 "      \"detailsArg2\" : 100\n" +
                 "    }\n" +
                 "  }\n" +
-                "}";
+                '}';
         TTextProtocol prot = new TTextProtocol(
                 new TIOStreamTransport(new ByteArrayInputStream(request.getBytes())));
         prot.readMessageBegin();
@@ -399,7 +399,7 @@ public class TTextProtocolTest {
                 "{\n" +
                 "  \"method\" : \"doDebug\"\n" +
                 "  \"type\" : \"CALL\",\n" +
-                "}";
+                '}';
         TTextProtocol prot = new TTextProtocol(
                 new TIOStreamTransport(new ByteArrayInputStream(request.getBytes())));
         prot.readMessageBegin();
@@ -411,7 +411,7 @@ public class TTextProtocolTest {
                 "{\n" +
                 "  \"method\" : \"doDebug\",\n" +
                 "  \"args\" : 100\n" +
-                "}";
+                '}';
         TTextProtocol prot = new TTextProtocol(
                 new TIOStreamTransport(new ByteArrayInputStream(request.getBytes())));
         prot.readMessageBegin();

--- a/src/test/java/com/linecorp/armeria/server/docs/SpecificationTest.java
+++ b/src/test/java/com/linecorp/armeria/server/docs/SpecificationTest.java
@@ -16,12 +16,15 @@
 
 package com.linecorp.armeria.server.docs;
 
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.Map;
 
 import org.junit.Test;
@@ -47,13 +50,19 @@ public class SpecificationTest {
                                 new VirtualHostBuilder().build(),
                                 PathMapping.ofExact("/foo"),
                                 ThriftService.ofFormats(mock(FooService.AsyncIface.class),
-                                                  SerializationFormat.THRIFT_BINARY))));
+                                                  SerializationFormat.THRIFT_COMPACT))));
 
         final Map<String, ServiceInfo> services = specification.services();
         assertThat(services.size(), is(2));
+
         assertThat(services.containsKey(HelloService.class.getName()), is(true));
-        assertThat(services.get(HelloService.class.getName()).debugPath(), is("/hello"));
+        assertThat(services.get(HelloService.class.getName()).endpoints(),
+                   contains(EndpointInfo.of("*", "/hello", SerializationFormat.THRIFT_BINARY,
+                                            SerializationFormat.ofThrift())));
+
         assertThat(services.containsKey(FooService.class.getName()), is(true));
-        assertThat(services.get(FooService.class.getName()).debugPath(), nullValue());
+        assertThat(services.get(FooService.class.getName()).endpoints(),
+                   contains(EndpointInfo.of("*", "/foo", SerializationFormat.THRIFT_COMPACT,
+                                            EnumSet.of(SerializationFormat.THRIFT_COMPACT))));
     }
 }

--- a/src/test/java/com/linecorp/armeria/server/thrift/ThriftSerializationFormatsTest.java
+++ b/src/test/java/com/linecorp/armeria/server/thrift/ThriftSerializationFormatsTest.java
@@ -86,7 +86,7 @@ public class ThriftSerializationFormatsTest extends AbstractServerTest {
                                   HelloService.Iface.class,
                                   ClientOption.HTTP_HEADERS.newValue(headers));
         thrown.expect(InvalidResponseException.class);
-        thrown.expectMessage("HTTP Response code: 415 Unsupported Media Type");
+        thrown.expectMessage("HTTP Response code: 406 Not Acceptable");
         client.hello("Trustin");
     }
 


### PR DESCRIPTION
- Add EndpointInfo to represent:
  - hostname(pattern) and path of a Service
  - default MIME type
  - available MIME types
- Replace ServiceInfo.debugPath() with endpoints()
- ServiceInfo exposes all available path information
  - We exposed TTEXT paths only previously.
- Fix a bug where submitting in a debug form fails with Not Acceptable
- Fix a bug where StructContext fails to encode TApplicationException
- Update the frontend
  - Add a section for rendering PathInfo
  - Better error handling
  - Overall style cleanup

Misc:
- Parse MIME type parameter properly
- Fix a test failure on Windows