### PR TITLE
Make sure not to send a bogus request object when JSON fails to parse…

### DIFF
--- a/src/main/resources/com/linecorp/armeria/server/docs/assets/js/armeria.js
+++ b/src/main/resources/com/linecorp/armeria/server/docs/assets/js/armeria.js
@@ -90,7 +90,8 @@ $(function () {
       try {
         args = JSON.parse(debugText.val());
       } catch (e) {
-        debugResponse.text("Failed to parse a JSON object:\n" + e);
+        debugResponse.text("Failed to parse a JSON object, please check your request:\n" + e);
+        return false;
       }
       var request = {
         method: functionInfo.name,


### PR DESCRIPTION
…, and also make the error message a bit more clear.

The effect of the bad behaviour is we get back an empty response from the server which overwrites the more useful error message.