### PR TITLE
Remove mime-type validation. At least browser clients don't seem to s…

### DIFF
--- a/src/main/java/com/linecorp/armeria/server/thrift/ThriftServiceCodec.java
+++ b/src/main/java/com/linecorp/armeria/server/thrift/ThriftServiceCodec.java
@@ -70,9 +70,6 @@ final class ThriftServiceCodec implements ServiceCodec {
     private static final Exception HTTP_METHOD_NOT_ALLOWED_EXCEPTION =
             new IllegalArgumentException("HTTP method not allowed");
     @SuppressWarnings("ThrowableInstanceNeverThrown")
-    private static final Exception MIME_TYPE_MUST_BE_THRIFT =
-            new IllegalArgumentException("MIME type must be application/x-thrift");
-    @SuppressWarnings("ThrowableInstanceNeverThrown")
     private static final Exception THRIFT_PROTOCOL_NOT_SUPPORTED =
             new IllegalArgumentException("Specified Thrift protocol not supported");
     @SuppressWarnings("ThrowableInstanceNeverThrown")
@@ -443,7 +440,6 @@ final class ThriftServiceCodec implements ServiceCodec {
 
         final String contentTypeHeader = httpRequest.headers().get(HttpHeaderNames.CONTENT_TYPE);
         if (contentTypeHeader != null) {
-            validateContentType(contentTypeHeader);
             serializationFormat = SerializationFormat.fromMimeType(contentTypeHeader)
                     .orElse(defaultSerializationFormat);
             if (!allowedSerializationFormats.contains(serializationFormat)) {
@@ -456,7 +452,6 @@ final class ThriftServiceCodec implements ServiceCodec {
 
         final String acceptHeader = httpRequest.headers().get(HttpHeaderNames.ACCEPT);
         if (acceptHeader != null) {
-            validateAccept(acceptHeader);
             // If accept header is present, make sure it is sane. Currently, we do not support accept
             // headers with a different format than the content type header.
             SerializationFormat outputSerializationFormat =
@@ -467,24 +462,6 @@ final class ThriftServiceCodec implements ServiceCodec {
             }
         }
         return serializationFormat;
-    }
-
-    private static void validateContentType(String contentType) throws InvalidHttpRequestException {
-        if (!contentType.contains("application/x-thrift")) {
-            throw new InvalidHttpRequestException(HttpResponseStatus.UNSUPPORTED_MEDIA_TYPE,
-                                                  MIME_TYPE_MUST_BE_THRIFT);
-        }
-    }
-
-    private static void validateAccept(String accept) throws InvalidHttpRequestException {
-        if (accept.contains("application/x-thrift") ||
-            accept.contains("*/*") ||
-            accept.contains("application/*")) {
-            return;
-        }
-
-        throw new InvalidHttpRequestException(HttpResponseStatus.NOT_ACCEPTABLE,
-                                              MIME_TYPE_MUST_BE_THRIFT);
     }
 
     private static String typeString(byte typeValue) {

--- a/src/test/java/com/linecorp/armeria/server/thrift/ThriftSerializationFormatsTest.java
+++ b/src/test/java/com/linecorp/armeria/server/thrift/ThriftSerializationFormatsTest.java
@@ -66,28 +66,15 @@ public class ThriftSerializationFormatsTest extends AbstractServerTest {
 
     @Test
     public void contentTypeNotThrift() throws Exception {
+        // Browser clients often send a non-thrift content type.
         HttpHeaders headers = new DefaultHttpHeaders().set(HttpHeaderNames.CONTENT_TYPE,
-                                                           "text/html; protocol=TBINARY");
+                                                           "text/plain; charset=utf-8");
         HelloService.Iface client =
-                Clients.newClient("ttext+" + uri("/hello"),
+                Clients.newClient("tbinary+" + uri("/hello"),
                                   HelloService.Iface.class,
                                   ClientOption.HTTP_HEADERS.newValue(headers));
-        thrown.expect(InvalidResponseException.class);
-        thrown.expectMessage("HTTP Response code: 415 Unsupported Media Type");
-        client.hello("Trustin");
-    }
-
-    @Test
-    public void acceptNotThrift() throws Exception {
-        HttpHeaders headers = new DefaultHttpHeaders().set(HttpHeaderNames.ACCEPT,
-                                                           "text/html; protocol=TBINARY");
-        HelloService.Iface client =
-                Clients.newClient("ttext+" + uri("/hello"),
-                                  HelloService.Iface.class,
-                                  ClientOption.HTTP_HEADERS.newValue(headers));
-        thrown.expect(InvalidResponseException.class);
-        thrown.expectMessage("HTTP Response code: 406 Not Acceptable");
-        client.hello("Trustin");
+        String res = client.hello("Trustin");
+        assertEquals("Hello, Trustin!", res);
     }
 
     @Test


### PR DESCRIPTION
…et this in a very predictable way, meaning currently browsers cannot use a TJSON endpoint.

It should be reasonable to assume that server/client set their default serialization format appropriately when mime-types are not recognizable and otherwise there'll be decode/encode errors which can clue into the mismatch (this was the behavior before we added content-type detection).