### PR TITLE
Don't set content type and accept specially when serialization format…

### DIFF
--- a/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
+++ b/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.LinkedList;
 import java.util.Queue;
 
+import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.ServiceInvocationContext;
 import com.linecorp.armeria.common.SessionProtocol;
 
@@ -273,13 +274,15 @@ class HttpSessionHandler extends ChannelDuplexHandler {
         }
 
         invocation.options().get(ClientOption.HTTP_HEADERS).ifPresent(headers::add);
-        //we allow a user can set content type and accept headers
-        String mimeType = ctx.scheme().serializationFormat().mimeType();
-        if (!headers.contains(HttpHeaderNames.CONTENT_TYPE)) {
-            headers.set(HttpHeaderNames.CONTENT_TYPE, mimeType);
-        }
-        if (!headers.contains(HttpHeaderNames.ACCEPT)) {
-            headers.set(HttpHeaderNames.ACCEPT, mimeType);
+        if (ctx.scheme().serializationFormat() != SerializationFormat.NONE) {
+            //we allow a user can set content type and accept headers
+            String mimeType = ctx.scheme().serializationFormat().mimeType();
+            if (!headers.contains(HttpHeaderNames.CONTENT_TYPE)) {
+                headers.set(HttpHeaderNames.CONTENT_TYPE, mimeType);
+            }
+            if (!headers.contains(HttpHeaderNames.ACCEPT)) {
+                headers.set(HttpHeaderNames.ACCEPT, mimeType);
+            }
         }
 
         return request;

--- a/src/test/java/com/linecorp/armeria/client/http/SimpleHttpClientIntegrationTest.java
+++ b/src/test/java/com/linecorp/armeria/client/http/SimpleHttpClientIntegrationTest.java
@@ -61,6 +61,14 @@ public class SimpleHttpClientIntegrationTest {
             vhBuilder.serviceAt("/httptestbody", new HttpService(
                     (ctx, executor, promise) -> {
                         FullHttpRequest request = ctx.originalRequest();
+                        if (request.headers().get(HttpHeaderNames.CONTENT_TYPE) != null) {
+                            throw new IllegalArgumentException(
+                                    "Serialization format is none, so content type should not be set!");
+                        }
+                        if (!"utf-8".equals(request.headers().get(HttpHeaderNames.ACCEPT))) {
+                            throw new IllegalArgumentException(
+                                    "Serialization format is none, so accept should be set to netty default!");
+                        }
                         ByteBuf content = ctx.alloc().ioBuffer();
                         byte[] body = ByteBufUtil.getBytes(request.content());
                         content.writeBytes(String.format("METHOD: %s|ACCEPT: %s|BODY: %s",


### PR DESCRIPTION
… is NONE. Lack of a serialization format means the library should treat the request opaquely. If a user needs to set the header for their service they will.