### PR TITLE
Add a way for specifying sample requests to prepopulate debug forms i…

### DIFF
--- a/src/main/java/com/linecorp/armeria/server/docs/ServiceInfo.java
+++ b/src/main/java/com/linecorp/armeria/server/docs/ServiceInfo.java
@@ -29,12 +29,15 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 
+import org.apache.thrift.TBase;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 class ServiceInfo {
 
     static ServiceInfo of(
-            Class<?> serviceClass, Iterable<EndpointInfo> endpoints) throws ClassNotFoundException {
+            Class<?> serviceClass, Iterable<EndpointInfo> endpoints,
+            Map<Class<?>, ? extends TBase<?, ?>> sampleRequests) throws ClassNotFoundException {
 
         requireNonNull(serviceClass, "serviceClass");
 
@@ -46,7 +49,7 @@ class ServiceInfo {
         final List<FunctionInfo> functions = new ArrayList<>(methods.length);
         final Set<ClassInfo> classes = new LinkedHashSet<>();
         for (Method method : methods) {
-            final FunctionInfo function = FunctionInfo.of(method);
+            final FunctionInfo function = FunctionInfo.of(method, sampleRequests);
             functions.add(function);
 
             addClassIfPossible(classes, function.returnType());

--- a/src/main/java/com/linecorp/armeria/server/docs/Specification.java
+++ b/src/main/java/com/linecorp/armeria/server/docs/Specification.java
@@ -29,6 +29,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 
+import org.apache.thrift.TBase;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.linecorp.armeria.server.Service;
@@ -37,7 +39,8 @@ import com.linecorp.armeria.server.thrift.ThriftService;
 
 class Specification {
 
-    static Specification forServiceEntries(Iterable<ServiceEntry> services) {
+    static Specification forServiceEntries(Iterable<ServiceEntry> services,
+                                           Map<Class<?>, ? extends TBase<?, ?>> sampleRequests) {
         final Map<Class<?>, Iterable<EndpointInfo>> map = new LinkedHashMap<>();
 
         for (ServiceEntry serviceEntry : services) {
@@ -66,17 +69,18 @@ class Specification {
             }
         }
 
-        return forServiceClasses(map);
+        return forServiceClasses(map, sampleRequests);
     }
 
-    static Specification forServiceClasses(Map<Class<?>, Iterable<EndpointInfo>> map) {
+    static Specification forServiceClasses(Map<Class<?>, Iterable<EndpointInfo>> map,
+                                           Map<Class<?>, ? extends TBase<?, ?>> sampleRequests) {
         requireNonNull(map, "map");
 
         final List<ServiceInfo> services = new ArrayList<>(map.size());
         final Set<ClassInfo> classes = new HashSet<>();
         map.forEach((serviceClass, endpoints) -> {
             try {
-                final ServiceInfo service = ServiceInfo.of(serviceClass, endpoints);
+                final ServiceInfo service = ServiceInfo.of(serviceClass, endpoints, sampleRequests);
                 services.add(service);
                 classes.addAll(service.classes().values());
             } catch (ClassNotFoundException e) {

--- a/src/main/resources/com/linecorp/armeria/server/docs/assets/js/armeria.js
+++ b/src/main/resources/com/linecorp/armeria/server/docs/assets/js/armeria.js
@@ -94,7 +94,7 @@ $(function () {
       'function': functionInfo
     }));
 
-    var debugText = functionContainer.find('.debug-textarea');
+    var debugText = functionContainer.find('.debug-textarea').val(functionInfo.sampleJsonRequest);
     var debugResponse = functionContainer.find('.debug-response code');
 
     var submitDebugRequest = function () {

--- a/src/test/java/com/linecorp/armeria/server/docs/SpecificationTest.java
+++ b/src/test/java/com/linecorp/armeria/server/docs/SpecificationTest.java
@@ -17,13 +17,12 @@
 package com.linecorp.armeria.server.docs;
 
 import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Map;
 
@@ -38,6 +37,7 @@ import com.linecorp.armeria.service.test.thrift.main.FooService;
 import com.linecorp.armeria.service.test.thrift.main.HelloService;
 
 public class SpecificationTest {
+
     @Test
     public void servicesTest() throws Exception {
         final Specification specification =
@@ -50,7 +50,8 @@ public class SpecificationTest {
                                 new VirtualHostBuilder().build(),
                                 PathMapping.ofExact("/foo"),
                                 ThriftService.ofFormats(mock(FooService.AsyncIface.class),
-                                                  SerializationFormat.THRIFT_COMPACT))));
+                                                        SerializationFormat.THRIFT_COMPACT))),
+                                                Collections.emptyMap());
 
         final Map<String, ServiceInfo> services = specification.services();
         assertThat(services.size(), is(2));


### PR DESCRIPTION
…n the doc service. Users provide a list of _args objects to DocService which will be used for matching methods.

```java
List<? extends TBase<?, ?>> sampleRequests = Arrays.asList(
  new hello_args().setName("world"),
  new monster_args().setFood("cookies").setColor("blue"));
...
virtualHostBuilder.serviceUnder("/docs", new DocService(sampleRequests))
```

For #47