### PR TITLE
Force travis to update jdk in its build environment to fix compilatio…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,14 @@
 language: java
 sudo: false
 
+# Force update Java in our build since Travis default is 1.8.0_31,
+# which sometimes can't compile correct Java8 code.
+# https://github.com/travis-ci/travis-ci/issues/3259
+addons:
+  apt:
+    packages:
+      - oracle-java8-installer
+
 jdk:
   - oraclejdk8
 


### PR DESCRIPTION
…n of java8 features. Currently it seems to install 1.8.0_66 but I think it'll be whatever version is in the Java repo Travis uses at the time.

From https://github.com/travis-ci/travis-ci/issues/3259

For example, #58 fails to compile on the default java of 1.8.0_31. According to the thread, any version under _40 is susceptible to failure compiling certain lambdas.