### PR TITLE
Remove build warnings

### DIFF
--- a/src/test/java/com/linecorp/armeria/server/docs/StructInfoTest.java
+++ b/src/test/java/com/linecorp/armeria/server/docs/StructInfoTest.java
@@ -48,7 +48,6 @@ public class StructInfoTest {
         fields.add(FieldInfo.of("doubleVal", RequirementType.DEFAULT, TypeInfo.of(ValueType.DOUBLE, false)));
         fields.add(FieldInfo.of("stringVal", RequirementType.DEFAULT, string));
         fields.add(FieldInfo.of("binaryVal", RequirementType.DEFAULT, TypeInfo.of(ValueType.STRING, true)));
-        fields.add(FieldInfo.of("slistVal", RequirementType.DEFAULT, string));
         fields.add(FieldInfo.of("enumVal", RequirementType.DEFAULT, fooEnum));
         fields.add(FieldInfo.of("unionVal", RequirementType.DEFAULT, union));
         fields.add(FieldInfo.of("mapVal", RequirementType.DEFAULT, MapInfo.of(string, fooEnum)));

--- a/src/test/thrift/main.thrift
+++ b/src/test/thrift/main.thrift
@@ -70,7 +70,7 @@ struct FooStruct {
     6: double doubleVal,
     7: string stringVal,
     8: binary binaryVal,
-    9: slist slistVal,
+    /* 9: slist slistVal, */
     10: FooEnum enumVal,
     11: FooUnion unionVal,
     12: map<string, FooEnum> mapVal,
@@ -82,6 +82,6 @@ service FooService {
     void bar1() throws (1: FooServiceException e),
     string bar2() throws (1: FooServiceException e),
     FooStruct bar3(1: i32 intVal, 2: FooStruct foo) throws (1: FooServiceException e),
-    list<FooStruct> bar4(list<FooStruct> foos) throws (1: FooServiceException e),
-    map<string, FooStruct> bar5(map<string, FooStruct> foos) throws (1: FooServiceException e)
+    list<FooStruct> bar4(1: list<FooStruct> foos) throws (1: FooServiceException e),
+    map<string, FooStruct> bar5(1: map<string, FooStruct> foos) throws (1: FooServiceException e)
 }


### PR DESCRIPTION
Motivation:

```
[WARNING:src/test/thrift/main.thrift:73]
"slist" is deprecated and will be removed in a future compiler version.
This type should be replaced with "string".
[WARNING:src/test/thrift/main.thrift:85]
No field key specified for foos, resulting protocol may have conflicts
or not be backwards compatible!
[WARNING:src/test/thrift/main.thrift:86]
No field key specified for foos, resulting protocol may have conflicts
or not be backwards compatible!
```

- `slist` is deprecated. https://issues.apache.org/jira/browse/THRIFT-1994

Modification:

- Remove `slist` fields
- Add field keys for the missing

Result:

No more build warnings :smile: