### PR TITLE
Use daemon threads for the default RemoteInvokerFactory

### DIFF
--- a/src/main/java/com/linecorp/armeria/server/Server.java
+++ b/src/main/java/com/linecorp/armeria/server/Server.java
@@ -355,6 +355,9 @@ public final class Server implements AutoCloseable {
     }
 
     private Future<Void> stop1(Promise<Void> promise, EventLoopGroup bossGroup) {
+        // FIXME(trustin): Shutdown and terminate the blockingTaskExecutor.
+        //                 Could be fixed while fixing https://github.com/line/armeria/issues/46
+
         final Future<?> bossShutdownFuture;
         if (bossGroup != null) {
             bossShutdownFuture = bossGroup.shutdownGracefully();


### PR DESCRIPTION
.. because there's no way for a user to close the default RemoteInvokerFactory