### PR TITLE
Handle HTTP/2 upgrade response from the stream 1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
   <groupId>com.linecorp.armeria</groupId>
   <artifactId>armeria</artifactId>
-  <version>0.7.0.Final-SNAPSHOT</version>
+  <version>0.6.1.Final-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Armeria</name>
   <description>


### PR DESCRIPTION
Motivation:

Once an upgrade to HTTP/2 is finished in a cleartext connection, the
server sends the response for the upgrade request to the client via the
stream 1. Armeria client currently does not handle it explicitly,
causing the response to reach at the end of the pipeline. This is not
necessarily harmful, but it will pollute our DEBUG log level because
Netty will log any messages that reach at the end of the pipeline.

Modifications:

- Make UpgradeHandler handle the upgrade response so that Netty does not
  complain
- Change the next version to 0.6.1.Final

Result:

Less noisy log messages