### PR TITLE
Fix a leak in an HTTP/2 connection

### DIFF
--- a/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
+++ b/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
@@ -17,8 +17,8 @@ package com.linecorp.armeria.client;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.ArrayDeque;
 import java.util.Collection;
-import java.util.LinkedList;
 import java.util.Queue;
 
 import com.linecorp.armeria.common.SerializationFormat;
@@ -180,7 +180,7 @@ class HttpSessionHandler extends ChannelDuplexHandler {
         private final Queue<Promise<FullHttpResponse>> requestExpectQueue;
 
         SequentialWaitsHolder() {
-            requestExpectQueue = new LinkedList<>();
+            requestExpectQueue = new ArrayDeque<>();
         }
 
         @Override
@@ -216,7 +216,7 @@ class HttpSessionHandler extends ChannelDuplexHandler {
         @Override
         public Promise<FullHttpResponse> poll(FullHttpResponse response) {
             int streamID = response.headers().getInt(ExtensionHeaderNames.STREAM_ID.text(), 0);
-            return resultExpectMap.get(streamID);
+            return resultExpectMap.remove(streamID);
         }
 
         @Override


### PR DESCRIPTION
HttpSessionHandler.MultiplexWaitsHolder.poll() does not remove the polled request, causing a leak.

Also, replaced LinkedList with ArrayDeque for better performance and memory usage