### PR TITLE
Support unexpected exceptions that don't have a cause string.

### DIFF
--- a/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -470,7 +470,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter {
             return;
         }
 
-        if (IGNORABLE_ERROR_MESSAGE.matcher(cause.getMessage()).find()) {
+        if (cause.getMessage() != null && IGNORABLE_ERROR_MESSAGE.matcher(cause.getMessage()).find()) {
             return;
         }
 


### PR DESCRIPTION
Fixes

```
java.lang.NullPointerException: null
	at java.util.regex.Matcher.getTextLength(Matcher.java:1283) ~[na:1.8.0_60]
	at java.util.regex.Matcher.reset(Matcher.java:309) ~[na:1.8.0_60]
	at java.util.regex.Matcher.<init>(Matcher.java:229) ~[na:1.8.0_60]
	at java.util.regex.Pattern.matcher(Pattern.java:1093) ~[na:1.8.0_60]
	at com.linecorp.armeria.server.HttpServerHandler.logUnexpectedException(HttpServerHandler.java:473) [armeria-0.6.2.Final.jar!/:na]
```