### PR TITLE
Fix missing query string conversion in TomcatService

### DIFF
--- a/src/test/resources/tomcat_service/query_string.jsp
+++ b/src/test/resources/tomcat_service/query_string.jsp
@@ -1,0 +1,7 @@
+<%@ page contentType="text/html; ISO-8859-1" %>
+<html>
+<body>
+<p>foo is <%= request.getParameter("foo") %></p>
+<p>bar is <%= request.getParameter("bar") %></p>
+</body>
+</html>


### PR DESCRIPTION
Motivation:

TomcatServiceInvocationHandler does not set the 'queryString' property
of Coyote Request object during the conversion.

Modifications:

- Call Request.queryString().setString() if HttpRequest.uri() has a
  query string
- Add the test cases for GET and POST with query parameters

Result:

Web application gets query parameters correctly.