### PR TITLE
Pass through error-code http responses for raw http clients. Allows c…

### DIFF
--- a/src/test/java/com/linecorp/armeria/client/http/SimpleHttpClientIntegrationTest.java
+++ b/src/test/java/com/linecorp/armeria/client/http/SimpleHttpClientIntegrationTest.java
@@ -82,6 +82,11 @@ public class SimpleHttpClientIntegrationTest {
                         response.headers().set(HttpHeaderNames.CACHE_CONTROL, "alwayscache");
                         promise.setSuccess(response);
                     }));
+            sb.serviceAt("/not200", new HttpService((ctx, executor, promise) -> {
+                DefaultFullHttpResponse response =
+                        new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.NOT_FOUND);
+                promise.setSuccess(response);
+            }));
         } catch (Exception e) {
             throw new Error(e);
         }
@@ -130,5 +135,14 @@ public class SimpleHttpClientIntegrationTest {
         assertEquals("alwayscache", response.headers().get(HttpHeaderNames.CACHE_CONTROL));
         assertEquals("METHOD: POST|ACCEPT: utf-8|BODY: requestbody日本語",
                      new String(response.content(), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void testNot200() throws Exception {
+        SimpleHttpClient client = Clients.newClient(remoteInvokerFactory, "none+http://127.0.0.1:" + httpPort,
+                                                    SimpleHttpClient.class);
+        SimpleHttpRequest request = SimpleHttpRequestBuilder.forGet("/not200").build();
+        SimpleHttpResponse response = client.execute(request).get();
+        assertEquals(HttpResponseStatus.NOT_FOUND, response.status());
     }
 }


### PR DESCRIPTION
…lient code to check the status / headers to deal with it appropriately and is expected for an http client.

- Stores invocation objects will waiting instead of only the promise.
- Checks the invocation's serialization format before dispatching an HTTP error response