### PR TITLE
Fix wrong call depth in TomcatService.forCurrentClassPath()

### DIFF
--- a/src/main/java/com/linecorp/armeria/server/http/tomcat/TomcatService.java
+++ b/src/main/java/com/linecorp/armeria/server/http/tomcat/TomcatService.java
@@ -30,7 +30,7 @@ public class TomcatService extends HttpService {
      * JAR/WAR/directory where the caller class is located at.
      */
     public static TomcatService forCurrentClassPath() {
-        return TomcatServiceBuilder.forCurrentClassPath(2).build();
+        return TomcatServiceBuilder.forCurrentClassPath(3).build();
     }
 
     /**
@@ -38,7 +38,7 @@ public class TomcatService extends HttpService {
      * inside the JAR/WAR/directory where the caller class is located at.
      */
     public static TomcatService forCurrentClassPath(String docBase) {
-        return TomcatServiceBuilder.forCurrentClassPath(docBase, 2).build();
+        return TomcatServiceBuilder.forCurrentClassPath(docBase, 3).build();
     }
 
     /**


### PR DESCRIPTION
Motivation:

When a user calls TomcatService.forCurrentClassPath(), the caller class
is determined to be TomcatService instead of the actual caller class.

Modification:

Increase the call depth parameter from 2 to 3

Result:

TomcatService.forCurrentClassPath() works as expected.