### PR TITLE
More robust resolution/rejection of a promise

### DIFF
--- a/src/main/java/com/linecorp/armeria/common/TimeoutException.java
+++ b/src/main/java/com/linecorp/armeria/common/TimeoutException.java
@@ -56,4 +56,9 @@ public class TimeoutException extends RuntimeException {
                                boolean writableStackTrace) {
         super(message, cause, enableSuppression, writableStackTrace);
     }
+
+    @Override
+    public Throwable fillInStackTrace() {
+        return this;
+    }
 }

--- a/src/main/java/com/linecorp/armeria/server/http/HttpService.java
+++ b/src/main/java/com/linecorp/armeria/server/http/HttpService.java
@@ -125,7 +125,7 @@ public class HttpService implements Service {
 
             if (!subFuture.isSuccess()) {
                 // sub-handler failed with an exception.
-                promise.tryFailure(subFuture.cause());
+                ctx.rejectPromise(promise, subFuture.cause());
                 return;
             }
 
@@ -140,9 +140,7 @@ public class HttpService implements Service {
             }
 
             // The current sub-handler returned non-404 or it is the last resort.
-            if (!promise.trySuccess(res)) {
-                res.release();
-            }
+            ctx.resolvePromise(promise, res);
         }
     }
 }

--- a/src/main/java/com/linecorp/armeria/server/http/healthcheck/HttpHealthCheckService.java
+++ b/src/main/java/com/linecorp/armeria/server/http/healthcheck/HttpHealthCheckService.java
@@ -160,7 +160,8 @@ public class HttpHealthCheckService extends HttpService {
             } else {
                 response = newUnhealthyResponse(ctx);
             }
-            promise.setSuccess(response);
+
+            ctx.resolvePromise(promise, response);
         }
 
         private boolean isHealthy() {

--- a/src/main/java/com/linecorp/armeria/server/http/tomcat/TomcatServiceInvocationHandler.java
+++ b/src/main/java/com/linecorp/armeria/server/http/tomcat/TomcatServiceInvocationHandler.java
@@ -236,11 +236,9 @@ final class TomcatServiceInvocationHandler implements ServiceInvocationHandler {
             ServiceInvocationContext.setCurrent(ctx);
             try {
                 coyoteAdapter.service(coyoteReq, coyoteRes);
-                promise.trySuccess(convertResponse(coyoteRes, resContent));
+                ctx.resolvePromise(promise, convertResponse(coyoteRes, resContent));
             } catch (Throwable t) {
-                if (!promise.tryFailure(t)) {
-                    ctx.logger().warn("Failed to mark a promise as a failure: {}", promise, t);
-                }
+                ctx.rejectPromise(promise, t);
             } finally {
                 ServiceInvocationContext.removeCurrent();
             }

--- a/src/test/java/com/linecorp/armeria/server/http/healthcheck/HttpHealthCheckServiceTest.java
+++ b/src/test/java/com/linecorp/armeria/server/http/healthcheck/HttpHealthCheckServiceTest.java
@@ -17,6 +17,9 @@
 package com.linecorp.armeria.server.http.healthcheck;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 
 import java.nio.charset.StandardCharsets;
@@ -61,6 +64,17 @@ public class HttpHealthCheckServiceTest {
     public void setUp() {
         service = new HttpHealthCheckService(health1, health2, health3);
         service.serverHealth.setHealthy(true);
+
+        doAnswer(invocation -> {
+            final Object[] args = invocation.getArguments();
+
+            @SuppressWarnings("unchecked")
+            final Promise<Object> promise = (Promise<Object>) args[0];
+            final FullHttpResponse response = (FullHttpResponse) args[1];
+
+            promise.setSuccess(response);
+            return null;
+        }).when(context).resolvePromise(any(), any());
     }
 
     @Test


### PR DESCRIPTION
Motivation:

When a client does not receive a response or a server fails to process a
request within time limit, an invocation promise is rejected regardless
the final outcome of the invocation.

In such a case, a ServiceInvocationHandler or a remote invoker
implementation might attempt to resolve or reject the promise which is
already rejected with TimeoutException. Handling this sort of situations
is very common, and thus we should provide it as part of Armeria.

Modifications:

- Add ServiceInvocationContext.resolvePromise() and rejectPromise() to
  provide a simple and robust way to resolve or reject a promise in a
  ServiceInvocationHandler
- Use resolvePromise() and rejectPromise() wherever possible.
- Miscellaneous:
  - Fix a bug where WriteTimeoutException is raised rather than
    ResponseTimeoutException
  - Fix a bug where HttpSessionHandler.failPendingResponses() does not
    fail anything at all
  - Make TimeoutException traceless to reduce its instantiation overhead

Result:

- Robustness
  - Fixes potential issues when attempting to resolve a rejected promise.
  - Late responses are now silently discarded to avoid log message
    flooding