### PR TITLE
Add methods to ServiceInvocationContext for propagating context into callback invocations.

### DIFF
--- a/src/main/java/com/linecorp/armeria/common/ServiceInvocationContextAwareEventLoop.java
+++ b/src/main/java/com/linecorp/armeria/common/ServiceInvocationContextAwareEventLoop.java
@@ -1,0 +1,231 @@
+package com.linecorp.armeria.common;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerInvoker;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.EventLoop;
+import io.netty.channel.EventLoopGroup;
+import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.ProgressivePromise;
+import io.netty.util.concurrent.Promise;
+import io.netty.util.concurrent.ScheduledFuture;
+
+/**
+ * A delegating {@link EventExecutor} that makes sure all submitted tasks are
+ * executed within the {@link ServiceInvocationContext}.
+ */
+final class ServiceInvocationContextAwareEventLoop implements EventLoop {
+
+    private final ServiceInvocationContext context;
+    private final EventLoop delegate;
+
+    ServiceInvocationContextAwareEventLoop(ServiceInvocationContext context,
+                                           EventLoop delegate) {
+
+        this.context = context;
+        this.delegate = delegate;
+    }
+
+    @Override
+    public EventLoop next() {
+        return delegate.next();
+    }
+
+    @Override
+    public <E extends EventExecutor> Set<E> children() {
+        return delegate.children();
+    }
+
+    @Override
+    public EventLoopGroup parent() {
+        return delegate.parent();
+    }
+
+    @Override
+    public boolean inEventLoop() {
+        return delegate.inEventLoop();
+    }
+
+    @Override
+    public boolean inEventLoop(Thread thread) {
+        return delegate.inEventLoop(thread);
+    }
+
+    @Override
+    public <V> Promise<V> newPromise() {
+        return new ServiceInvocationContextAwarePromise<>(context, delegate.newPromise());
+    }
+
+    @Override
+    public <V> ProgressivePromise<V> newProgressivePromise() {
+        return new ServiceInvocationContextProgressivePromise<>(context, delegate.newProgressivePromise());
+    }
+
+    @Override
+    public <V> Future<V> newSucceededFuture(V result) {
+        return new ServiceInvocationContextAwareFuture<>(context, delegate.newSucceededFuture(result));
+    }
+
+    @Override
+    public <V> Future<V> newFailedFuture(Throwable cause) {
+        return new ServiceInvocationContextAwareFuture<>(context, delegate.newFailedFuture(cause));
+    }
+
+    @Override
+    public boolean isShuttingDown() {
+        return delegate.isShuttingDown();
+    }
+
+    @Override
+    public Future<?> shutdownGracefully() {
+        return delegate.shutdownGracefully();
+    }
+
+    @Override
+    public Future<?> shutdownGracefully(long quietPeriod, long timeout,
+                                        TimeUnit unit) {
+        return delegate.shutdownGracefully(quietPeriod, timeout, unit);
+    }
+
+    @Override
+    public Future<?> terminationFuture() {
+        return delegate.terminationFuture();
+    }
+
+    @Override
+    @Deprecated
+    public void shutdown() {
+        delegate.shutdown();
+    }
+
+    @Override
+    @Deprecated
+    public List<Runnable> shutdownNow() {
+        return delegate.shutdownNow();
+    }
+
+    @Override
+    @Deprecated
+    public Iterator<EventExecutor> iterator() {
+        return delegate.iterator();
+    }
+
+    @Override
+    public Future<?> submit(Runnable task) {
+        return delegate.submit(context.makeContextAware(task));
+    }
+
+    @Override
+    public <T> Future<T> submit(Runnable task, T result) {
+        return delegate.submit(context.makeContextAware(task), result);
+    }
+
+    @Override
+    public <T> Future<T> submit(Callable<T> task) {
+        return delegate.submit(context.makeContextAware(task));
+    }
+
+    @Override
+    public ScheduledFuture<?> schedule(Runnable command, long delay,
+                                       TimeUnit unit) {
+        return delegate.schedule(context.makeContextAware(command), delay, unit);
+    }
+
+    @Override
+    public <V> ScheduledFuture<V> schedule(Callable<V> callable,
+                                           long delay, TimeUnit unit) {
+        return delegate.schedule(context.makeContextAware(callable), delay, unit);
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay,
+                                                  long period,
+                                                  TimeUnit unit) {
+        return delegate.scheduleAtFixedRate(context.makeContextAware(command), initialDelay, period, unit);
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay,
+                                                     long delay,
+                                                     TimeUnit unit) {
+        return delegate.scheduleWithFixedDelay(context.makeContextAware(command), initialDelay, delay, unit);
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return delegate.isShutdown();
+    }
+
+    @Override
+    public boolean isTerminated() {
+        return delegate.isTerminated();
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        return delegate.awaitTermination(timeout, unit);
+    }
+
+    @Override
+    public <T> List<java.util.concurrent.Future<T>> invokeAll(
+            Collection<? extends Callable<T>> tasks) throws InterruptedException {
+        return delegate.invokeAll(makeContextAware(tasks));
+    }
+
+    @Override
+    public <T> List<java.util.concurrent.Future<T>> invokeAll(
+            Collection<? extends Callable<T>> tasks, long timeout,
+            TimeUnit unit) throws InterruptedException {
+        return delegate.invokeAll(makeContextAware(tasks), timeout, unit);
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks)
+            throws InterruptedException, ExecutionException {
+        return delegate.invokeAny(makeContextAware(tasks));
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout,
+                           TimeUnit unit) throws InterruptedException, ExecutionException,
+                                                 java.util.concurrent.TimeoutException {
+        return delegate.invokeAny(makeContextAware(tasks), timeout, unit);
+    }
+
+    @Override
+    public void execute(Runnable command) {
+        delegate.execute(context.makeContextAware(command));
+    }
+
+    private <T> Collection<? extends Callable<T>> makeContextAware(
+            Collection<? extends Callable<T>> tasks) {
+        return tasks.stream().map(context::makeContextAware).collect(Collectors.toList());
+    }
+
+    @Override
+    public ChannelFuture register(Channel channel) {
+        return delegate.register(channel);
+    }
+
+    @Override
+    public ChannelFuture register(Channel channel,
+                                  ChannelPromise channelPromise) {
+        return delegate.register(channel, channelPromise);
+    }
+
+    @Override
+    public ChannelHandlerInvoker asInvoker() {
+        return delegate.asInvoker();
+    }
+}

--- a/src/main/java/com/linecorp/armeria/common/ServiceInvocationContextAwareFuture.java
+++ b/src/main/java/com/linecorp/armeria/common/ServiceInvocationContextAwareFuture.java
@@ -1,0 +1,132 @@
+package com.linecorp.armeria.common;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.GenericFutureListener;
+
+final class ServiceInvocationContextAwareFuture<T> implements Future<T> {
+
+    private final ServiceInvocationContext context;
+    private final Future<T> delegate;
+
+    ServiceInvocationContextAwareFuture(ServiceInvocationContext context, Future<T> delegate) {
+        this.context = context;
+        this.delegate = delegate;
+    }
+
+    @Override
+    public boolean isSuccess() {
+        return delegate.isSuccess();
+    }
+
+    @Override
+    public boolean isCancellable() {
+        return delegate.isCancellable();
+    }
+
+    @Override
+    public Throwable cause() {
+        return delegate.cause();
+    }
+
+    @Override
+    public Future<T> addListener(
+            GenericFutureListener<? extends Future<? super T>> listener) {
+        return delegate.addListener(context.makeContextAware(listener));
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @Override
+    public Future<T> addListeners(
+            GenericFutureListener<? extends Future<? super T>>... listeners) {
+        return delegate.addListeners(Stream.of(listeners)
+                                           .map(context::makeContextAware)
+                                           .toArray(GenericFutureListener[]::new));
+    }
+
+    @Override
+    public Future<T> removeListener(
+            GenericFutureListener<? extends Future<? super T>> listener) {
+        return delegate.removeListener(listener);
+    }
+
+    @Override
+    public Future<T> removeListeners(
+            GenericFutureListener<? extends Future<? super T>>... listeners) {
+        return delegate.removeListeners(listeners);
+    }
+
+    @Override
+    public Future<T> sync() throws InterruptedException {
+        return delegate.sync();
+    }
+
+    @Override
+    public Future<T> syncUninterruptibly() {
+        return delegate.syncUninterruptibly();
+    }
+
+    @Override
+    public Future<T> await() throws InterruptedException {
+        return delegate.await();
+    }
+
+    @Override
+    public Future<T> awaitUninterruptibly() {
+        return delegate.awaitUninterruptibly();
+    }
+
+    @Override
+    public boolean await(long timeout, TimeUnit unit) throws InterruptedException {
+        return delegate.await(timeout, unit);
+    }
+
+    @Override
+    public boolean await(long timeoutMillis) throws InterruptedException {
+        return delegate.await(timeoutMillis);
+    }
+
+    @Override
+    public boolean awaitUninterruptibly(long timeout, TimeUnit unit) {
+        return delegate.awaitUninterruptibly(timeout, unit);
+    }
+
+    @Override
+    public boolean awaitUninterruptibly(long timeoutMillis) {
+        return delegate.awaitUninterruptibly(timeoutMillis);
+    }
+
+    @Override
+    public T getNow() {
+        return delegate.getNow();
+    }
+
+    @Override
+    public boolean cancel(boolean mayInterruptIfRunning) {
+        return delegate.cancel(mayInterruptIfRunning);
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return delegate.isCancelled();
+    }
+
+    @Override
+    public boolean isDone() {
+        return delegate.isDone();
+    }
+
+    @Override
+    public T get() throws InterruptedException, ExecutionException {
+        return delegate.get();
+    }
+
+    @Override
+    public T get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException,
+                                                     java.util.concurrent.TimeoutException {
+        return delegate.get(timeout, unit);
+    }
+}

--- a/src/main/java/com/linecorp/armeria/common/ServiceInvocationContextAwarePromise.java
+++ b/src/main/java/com/linecorp/armeria/common/ServiceInvocationContextAwarePromise.java
@@ -1,0 +1,159 @@
+package com.linecorp.armeria.common;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.GenericFutureListener;
+import io.netty.util.concurrent.Promise;
+
+final class ServiceInvocationContextAwarePromise<T> implements Promise<T> {
+
+    private final ServiceInvocationContext context;
+    private final Promise<T> delegate;
+
+    ServiceInvocationContextAwarePromise(ServiceInvocationContext context, Promise<T> delegate) {
+        this.context = context;
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Promise<T> setSuccess(T result) {
+        return delegate.setSuccess(result);
+    }
+
+    @Override
+    public boolean trySuccess(T result) {
+        return delegate.trySuccess(result);
+    }
+
+    @Override
+    public Promise<T> setFailure(Throwable cause) {
+        return delegate.setFailure(cause);
+    }
+
+    @Override
+    public boolean tryFailure(Throwable cause) {
+        return delegate.tryFailure(cause);
+    }
+
+    @Override
+    public boolean setUncancellable() {
+        return delegate.setUncancellable();
+    }
+
+    @Override
+    public Promise<T> addListener(
+            GenericFutureListener<? extends Future<? super T>> listener) {
+        return delegate.addListener(context.makeContextAware(listener));
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @Override
+    public Promise<T> addListeners(
+            GenericFutureListener<? extends Future<? super T>>... listeners) {
+        return delegate.addListeners(
+                Stream.of(listeners)
+                      .map(context::makeContextAware)
+                      .toArray(GenericFutureListener[]::new));
+    }
+
+    @Override
+    public Promise<T> removeListener(
+            GenericFutureListener<? extends Future<? super T>> listener) {
+        return delegate.removeListener(listener);
+    }
+
+    @Override
+    public Promise<T> removeListeners(
+            GenericFutureListener<? extends Future<? super T>>... listeners) {
+        return delegate.removeListeners(listeners);
+    }
+
+    @Override
+    public Promise<T> await() throws InterruptedException {
+        return delegate.await();
+    }
+
+    @Override
+    public Promise<T> awaitUninterruptibly() {
+        return delegate.awaitUninterruptibly();
+    }
+
+    @Override
+    public Promise<T> sync() throws InterruptedException {
+        return delegate.sync();
+    }
+
+    @Override
+    public Promise<T> syncUninterruptibly() {
+        return delegate.syncUninterruptibly();
+    }
+
+    @Override
+    public boolean isSuccess() {
+        return delegate.isSuccess();
+    }
+
+    @Override
+    public boolean isCancellable() {
+        return delegate.isCancellable();
+    }
+
+    @Override
+    public Throwable cause() {
+        return delegate.cause();
+    }
+
+    @Override
+    public boolean await(long timeout, TimeUnit unit) throws InterruptedException {
+        return delegate.await(timeout, unit);
+    }
+
+    @Override
+    public boolean await(long timeoutMillis) throws InterruptedException {
+        return delegate.await(timeoutMillis);
+    }
+
+    @Override
+    public boolean awaitUninterruptibly(long timeout, TimeUnit unit) {
+        return delegate.awaitUninterruptibly(timeout, unit);
+    }
+
+    @Override
+    public boolean awaitUninterruptibly(long timeoutMillis) {
+        return delegate.awaitUninterruptibly(timeoutMillis);
+    }
+
+    @Override
+    public T getNow() {
+        return delegate.getNow();
+    }
+
+    @Override
+    public boolean cancel(boolean mayInterruptIfRunning) {
+        return delegate.cancel(mayInterruptIfRunning);
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return delegate.isCancelled();
+    }
+
+    @Override
+    public boolean isDone() {
+        return delegate.isDone();
+    }
+
+    @Override
+    public T get() throws InterruptedException, ExecutionException {
+        return delegate.get();
+    }
+
+    @Override
+    public T get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException,
+                                                     java.util.concurrent.TimeoutException {
+        return delegate.get(timeout, unit);
+    }
+}

--- a/src/main/java/com/linecorp/armeria/common/ServiceInvocationContextProgressivePromise.java
+++ b/src/main/java/com/linecorp/armeria/common/ServiceInvocationContextProgressivePromise.java
@@ -1,0 +1,169 @@
+package com.linecorp.armeria.common;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.GenericFutureListener;
+import io.netty.util.concurrent.ProgressivePromise;
+
+final class ServiceInvocationContextProgressivePromise<T> implements ProgressivePromise<T> {
+
+    private final ServiceInvocationContext context;
+    private final ProgressivePromise<T> delegate;
+
+    ServiceInvocationContextProgressivePromise(ServiceInvocationContext context,
+                                               ProgressivePromise<T> delegate) {
+        this.context = context;
+        this.delegate = delegate;
+    }
+
+    @Override
+    public ProgressivePromise<T> setProgress(long progress, long total) {
+        return delegate.setProgress(progress, total);
+    }
+
+    @Override
+    public boolean tryProgress(long progress, long total) {
+        return delegate.tryProgress(progress, total);
+    }
+
+    @Override
+    public ProgressivePromise<T> setSuccess(T result) {
+        return delegate.setSuccess(result);
+    }
+
+    @Override
+    public ProgressivePromise<T> setFailure(Throwable cause) {
+        return delegate.setFailure(cause);
+    }
+
+    @Override
+    public ProgressivePromise<T> addListener(
+            GenericFutureListener<? extends Future<? super T>> listener) {
+        return delegate.addListener(context.makeContextAware(listener));
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @Override
+    public ProgressivePromise<T> addListeners(
+            GenericFutureListener<? extends Future<? super T>>... listeners) {
+        return delegate.addListeners(Stream.of(listeners)
+                                           .map(context::makeContextAware)
+                                           .toArray(GenericFutureListener[]::new));
+    }
+
+    @Override
+    public ProgressivePromise<T> removeListener(
+            GenericFutureListener<? extends Future<? super T>> listener) {
+        return delegate.removeListener(listener);
+    }
+
+    @Override
+    public ProgressivePromise<T> removeListeners(
+            GenericFutureListener<? extends Future<? super T>>... listeners) {
+        return delegate.removeListeners(listeners);
+    }
+
+    @Override
+    public ProgressivePromise<T> await() throws InterruptedException {
+        return delegate.await();
+    }
+
+    @Override
+    public ProgressivePromise<T> awaitUninterruptibly() {
+        return delegate.awaitUninterruptibly();
+    }
+
+    @Override
+    public ProgressivePromise<T> sync() throws InterruptedException {
+        return delegate.sync();
+    }
+
+    @Override
+    public ProgressivePromise<T> syncUninterruptibly() {
+        return delegate.syncUninterruptibly();
+    }
+
+    @Override
+    public boolean trySuccess(T result) {
+        return delegate.trySuccess(result);
+    }
+
+    @Override
+    public boolean tryFailure(Throwable cause) {
+        return delegate.tryFailure(cause);
+    }
+
+    @Override
+    public boolean setUncancellable() {
+        return delegate.setUncancellable();
+    }
+
+    @Override
+    public boolean isSuccess() {
+        return delegate.isSuccess();
+    }
+
+    @Override
+    public boolean isCancellable() {
+        return delegate.isCancellable();
+    }
+
+    @Override
+    public Throwable cause() {
+        return delegate.cause();
+    }
+
+    @Override
+    public boolean await(long timeout, TimeUnit unit) throws InterruptedException {
+        return delegate.await(timeout, unit);
+    }
+
+    @Override
+    public boolean await(long timeoutMillis) throws InterruptedException {
+        return delegate.await(timeoutMillis);
+    }
+
+    @Override
+    public boolean awaitUninterruptibly(long timeout, TimeUnit unit) {
+        return delegate.awaitUninterruptibly(timeout, unit);
+    }
+
+    @Override
+    public boolean awaitUninterruptibly(long timeoutMillis) {
+        return delegate.awaitUninterruptibly(timeoutMillis);
+    }
+
+    @Override
+    public T getNow() {
+        return delegate.getNow();
+    }
+
+    @Override
+    public boolean cancel(boolean mayInterruptIfRunning) {
+        return delegate.cancel(mayInterruptIfRunning);
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return delegate.isCancelled();
+    }
+
+    @Override
+    public boolean isDone() {
+        return delegate.isDone();
+    }
+
+    @Override
+    public T get() throws InterruptedException, ExecutionException {
+        return delegate.get();
+    }
+
+    @Override
+    public T get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException,
+                                                     java.util.concurrent.TimeoutException {
+        return delegate.get(timeout, unit);
+    }
+}

--- a/src/test/java/com/linecorp/armeria/common/ServiceInvocationContextTest.java
+++ b/src/test/java/com/linecorp/armeria/common/ServiceInvocationContextTest.java
@@ -1,0 +1,187 @@
+package com.linecorp.armeria.common;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.eclipse.jetty.util.ConcurrentHashSet;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import com.google.common.util.concurrent.MoreExecutors;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.DefaultChannelPromise;
+import io.netty.channel.DefaultEventLoop;
+import io.netty.channel.EventLoop;
+import io.netty.util.concurrent.DefaultPromise;
+import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.concurrent.FutureListener;
+import io.netty.util.concurrent.ImmediateEventExecutor;
+import io.netty.util.concurrent.ProgressivePromise;
+import io.netty.util.concurrent.Promise;
+
+public class ServiceInvocationContextTest {
+
+    @Rule
+    public MockitoRule mocks = MockitoJUnit.rule();
+
+    @Mock
+    private Channel channel;
+
+    @Test
+    public void contextAwareEventExecutor() throws Exception {
+        EventLoop eventLoop = new DefaultEventLoop();
+        when(channel.eventLoop()).thenReturn(eventLoop);
+        ServiceInvocationContext context = createContext();
+        Set<Integer> callbacksCalled = new ConcurrentHashSet<>();
+        EventExecutor executor = context.contextAwareEventLoop();
+        CountDownLatch latch = new CountDownLatch(18);
+        executor.execute(() -> checkCallback(1, context, callbacksCalled, latch));
+        executor.schedule(() -> checkCallback(2, context, callbacksCalled, latch), 0, TimeUnit.SECONDS);
+        executor.schedule(() -> {
+            checkCallback(2, context, callbacksCalled, latch);
+            return "success";
+        }, 0, TimeUnit.SECONDS);
+        executor.scheduleAtFixedRate(() -> checkCallback(3, context, callbacksCalled, latch), 0, 1000,
+                                     TimeUnit.SECONDS);
+        executor.scheduleWithFixedDelay(() -> checkCallback(4, context, callbacksCalled, latch), 0, 1000,
+                                        TimeUnit.SECONDS);
+        executor.submit(() -> checkCallback(5, context, callbacksCalled, latch));
+        executor.submit(() -> checkCallback(6, context, callbacksCalled, latch), "success");
+        executor.submit(() -> {
+            checkCallback(7, context, callbacksCalled, latch);
+            return "success";
+        });
+        executor.invokeAll(makeTaskList(8, 10, context, callbacksCalled, latch));
+        executor.invokeAll(makeTaskList(11, 12, context, callbacksCalled, latch), 10000, TimeUnit.SECONDS);
+        executor.invokeAny(makeTaskList(13, 13, context, callbacksCalled, latch));
+        executor.invokeAny(makeTaskList(14, 14, context, callbacksCalled, latch), 10000, TimeUnit.SECONDS);
+        Promise<String> promise = executor.newPromise();
+        promise.addListener(f -> checkCallback(15, context, callbacksCalled, latch));
+        promise.setSuccess("success");
+        executor.newSucceededFuture("success")
+                .addListener(f -> checkCallback(16, context, callbacksCalled, latch));
+        executor.newFailedFuture(new IllegalArgumentException())
+                .addListener(f -> checkCallback(17, context, callbacksCalled, latch));
+        ProgressivePromise<String> progressivePromise = executor.newProgressivePromise();
+        progressivePromise.addListener(f -> checkCallback(18, context, callbacksCalled, latch));
+        progressivePromise.setSuccess("success");
+        latch.await();
+        eventLoop.shutdownGracefully().sync();
+        assertEquals(IntStream.rangeClosed(1, 18).boxed().collect(Collectors.toSet()), callbacksCalled);
+    }
+
+    @Test
+    public void makeContextAwareExecutor() {
+        ServiceInvocationContext context = createContext();
+        Executor executor = context.makeContextAware(MoreExecutors.directExecutor());
+        AtomicBoolean callbackCalled = new AtomicBoolean(false);
+        executor.execute(() -> {
+            assertEquals(context, ServiceInvocationContext.current());
+            callbackCalled.set(true);
+        });
+        assertTrue(callbackCalled.get());
+    }
+
+    @Test
+    public void makeContextAwareCallable() throws Exception {
+        ServiceInvocationContext context = createContext();
+        context.makeContextAware(() -> {
+            assertEquals(context, ServiceInvocationContext.current());
+            return "success";
+        }).call();
+    }
+
+    @Test
+    public void makeContextAwareRunnable() {
+        ServiceInvocationContext context = createContext();
+        context.makeContextAware(() -> {
+            assertEquals(context, ServiceInvocationContext.current());
+        }).run();
+    }
+
+    @Test
+    public void makeContextAwareFutureListener() {
+        ServiceInvocationContext context = createContext();
+        Promise<String> promise = new DefaultPromise<>(ImmediateEventExecutor.INSTANCE);
+        promise.addListener(context.makeContextAware((FutureListener<String>) f ->
+                assertEquals(context, ServiceInvocationContext.current())));
+        promise.setSuccess("success");
+    }
+
+    @Test
+    public void makeContextAwareChannelFutureListener() {
+        ServiceInvocationContext context = createContext();
+        ChannelPromise promise = new DefaultChannelPromise(channel, ImmediateEventExecutor.INSTANCE);
+        promise.addListener(context.makeContextAware((ChannelFutureListener) f ->
+                assertEquals(context, ServiceInvocationContext.current())));
+        promise.setSuccess(null);
+    }
+
+    private static List<Callable<String>> makeTaskList(int startId,
+                                                       int endId,
+                                                       ServiceInvocationContext context,
+                                                       Set<Integer> callbacksCalled,
+                                                       CountDownLatch latch) {
+        return IntStream.rangeClosed(startId, endId).boxed().map(id -> (Callable<String>) () -> {
+            checkCallback(id, context, callbacksCalled, latch);
+            return "success";
+        }).collect(Collectors.toList());
+    }
+
+    private static void checkCallback(int id, ServiceInvocationContext context, Set<Integer> callbacksCalled,
+                                      CountDownLatch latch) {
+        assertEquals(context, ServiceInvocationContext.current());
+        if (!callbacksCalled.contains(id)) {
+            callbacksCalled.add(id);
+            latch.countDown();
+        }
+    }
+
+    private ServiceInvocationContext createContext() {
+        return new ServiceInvocationContext(channel, Scheme.parse("http+none"), "localhost", "/path", "/path",
+                                            "logger", null) {
+            @Override
+            public String invocationId() {
+                return null;
+            }
+
+            @Override
+            public String method() {
+                return null;
+            }
+
+            @Override
+            public List<Class<?>> paramTypes() {
+                return null;
+            }
+
+            @Override
+            public Class<?> returnType() {
+                return null;
+            }
+
+            @Override
+            public List<Object> params() {
+                return null;
+            }
+        };
+    }
+
+}


### PR DESCRIPTION
Currently, when writing an asynchronous service that does multiple RPCs, the RPC callbacks will likely be called with no ServiceInvocationContext.current() set. This is because the initial invocation removes the context right away to allow processing another event from the event loop, here

https://github.com/line/armeria/blob/master/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java#L264

We need a mechanism for propagating the invocation context to when the RPC callbacks fire (and may trigger additional RPCs, callbacks, etc), otherwise context-dependent features (think zipkin) will not work.

This PR adds methods for propagating context into callback methods, including an executor that will do it automatically for any subitted tasks. In general, service code will want to to use this executor in calls like CompletableFuture.whenCompleteAsync. They probably already are using ServiceInvocationContext.eventLoop to make sure callbacks are called on the same thread, and this would replace that so they're on the same thread with the correct context.
