### PR TITLE
Set remoteHost/Addr/Port and localName/Addr/Port of Coyote request

### DIFF
--- a/src/main/java/com/linecorp/armeria/common/ServiceInvocationContext.java
+++ b/src/main/java/com/linecorp/armeria/common/ServiceInvocationContext.java
@@ -351,6 +351,13 @@ public abstract class ServiceInvocationContext extends DefaultAttributeMap {
     }
 
     /**
+     * Returns the local address of this invocation.
+     */
+    public final SocketAddress localAddress() {
+        return ch.localAddress();
+    }
+
+    /**
      * Returns the ID of this invocation. Note that the ID returned by this method is only for debugging
      * purposes and thus is never guaranteed to be unique.
      */

--- a/src/test/java/com/linecorp/armeria/server/http/tomcat/TomcatServiceTest.java
+++ b/src/test/java/com/linecorp/armeria/server/http/tomcat/TomcatServiceTest.java
@@ -18,9 +18,9 @@ package com.linecorp.armeria.server.http.tomcat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.regex.Pattern;
 
@@ -108,6 +108,29 @@ public class TomcatServiceTest extends AbstractServerTest {
                         "<html><body>" +
                         "<p>foo is 3</p>" +
                         "<p>bar is 4</p>" +
+                        "</body></html>"));
+            }
+        }
+    }
+
+    @Test
+    public void testAddressesAndPorts() throws Exception {
+        try (CloseableHttpClient hc = HttpClients.createMinimal()) {
+            try (CloseableHttpResponse res = hc.execute(new HttpGet(uri("/tc/addrs_and_ports.jsp")))) {
+                assertThat(res.getStatusLine().toString(), is("HTTP/1.1 200 OK"));
+                assertThat(res.getFirstHeader(HttpHeaderNames.CONTENT_TYPE.toString()).getValue(),
+                           startsWith("text/html"));
+                final String actualContent = CR_OR_LF.matcher(EntityUtils.toString(res.getEntity()))
+                                                     .replaceAll("");
+
+                assertTrue(actualContent, actualContent.matches(
+                        "<html><body>" +
+                        "<p>RemoteAddr: 127\\.0\\.0\\.1</p>" +
+                        "<p>RemoteHost: 127\\.0\\.0\\.1</p>" +
+                        "<p>RemotePort: [1-9][0-9]+</p>" +
+                        "<p>LocalAddr: (?!null)[^<]+</p>" +
+                        "<p>LocalName: localhost</p>" +
+                        "<p>LocalPort: " + server().activePort().get().localAddress().getPort() + "</p>" +
                         "</body></html>"));
             }
         }

--- a/src/test/resources/tomcat_service/addrs_and_ports.jsp
+++ b/src/test/resources/tomcat_service/addrs_and_ports.jsp
@@ -1,0 +1,11 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
+<html>
+<body>
+<p>RemoteAddr: <%= request.getRemoteAddr() %></p>
+<p>RemoteHost: <%= request.getRemoteHost() %></p>
+<p>RemotePort: <%= request.getRemotePort() %></p>
+<p>LocalAddr: <%= request.getLocalAddr() %></p>
+<p>LocalName: <%= request.getLocalName() %></p>
+<p>LocalPort: <%= request.getLocalPort() %></p>
+</body>
+</html>

--- a/src/test/resources/tomcat_service/index.jsp
+++ b/src/test/resources/tomcat_service/index.jsp
@@ -1,5 +1,5 @@
 <%@ page import="io.netty.buffer.ByteBuf" %>
-<%@ page contentType="text/html; ISO-8859-1" %>
+<%@ page contentType="text/html; charset=UTF-8" %>
 <html>
 <body>
 <%-- Attempt to access the class that exists only in WEB-INF/lib/hello.jar --%>

--- a/src/test/resources/tomcat_service/query_string.jsp
+++ b/src/test/resources/tomcat_service/query_string.jsp
@@ -1,4 +1,4 @@
-<%@ page contentType="text/html; ISO-8859-1" %>
+<%@ page contentType="text/html; charset=UTF-8" %>
 <html>
 <body>
 <p>foo is <%= request.getParameter("foo") %></p>


### PR DESCRIPTION
Related: #81

Motivation:

When TomcatServiceInvocationHandler converts a Netty HTTP request to a
Coyote request, it should set the remoteAddr() and remoteHost() property
of the Coyote request.

Modifications:

- Fill remoteAddr/remoteHost/remotePort/localAddr/localName/localPort of
  Coyote request
- Add ServiceInvocationContext.localAddress() to get the local address
  and port
- Fix the content-type of the test JSP pages

Result:

Fixes #81
