### PR TITLE
Add more configuration properties to TomcatService

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     <jackson.version>2.6.3</jackson.version>
     <netty.version>4.1.0.Beta8</netty.version>
     <slf4j.version>1.7.13</slf4j.version>
-    <tomcat.version>8.0.28</tomcat.version>
+    <tomcat.version>8.0.30</tomcat.version>
     <jetty.alpnAgent.version>1.0.0.Final</jetty.alpnAgent.version>
     <jetty.alpnAgent.path>${settings.localRepository}/kr/motd/javaagent/jetty-alpn-agent/${jetty.alpnAgent.version}/jetty-alpn-agent-${jetty.alpnAgent.version}.jar</jetty.alpnAgent.path>
     <argLine.alpnAgent>-javaagent:${jetty.alpnAgent.path}</argLine.alpnAgent>

--- a/src/main/java/com/linecorp/armeria/server/http/tomcat/TomcatService.java
+++ b/src/main/java/com/linecorp/armeria/server/http/tomcat/TomcatService.java
@@ -23,7 +23,7 @@ import com.linecorp.armeria.server.http.HttpService;
 /**
  * An {@link HttpService} that dispatches its requests to a web application running in an embedded Tomcat.
  */
-public class TomcatService extends HttpService {
+public final class TomcatService extends HttpService {
 
     /**
      * Creates a new {@link TomcatService} with the web application at the root directory inside the

--- a/src/main/java/com/linecorp/armeria/server/http/tomcat/TomcatServiceConfig.java
+++ b/src/main/java/com/linecorp/armeria/server/http/tomcat/TomcatServiceConfig.java
@@ -17,25 +17,51 @@
 package com.linecorp.armeria.server.http.tomcat;
 
 import java.nio.file.Path;
+import java.util.List;
+import java.util.function.Consumer;
 
 import org.apache.catalina.Realm;
+import org.apache.catalina.core.StandardEngine;
+import org.apache.catalina.core.StandardServer;
+import org.apache.catalina.core.StandardService;
 
 /**
  * {@link TomcatService} configuration.
  */
 public class TomcatServiceConfig {
 
+    private final String serviceName;
+    private final String engineName;
     private final Path baseDir;
     private final Realm realm;
     private final String hostname;
     private final Path docBase;
+    private final List<Consumer<? super StandardServer>> configurators;
 
-    TomcatServiceConfig(Path baseDir, Realm realm, String hostname, Path docBase) {
+    TomcatServiceConfig(String serviceName, String engineName, Path baseDir, Realm realm,
+                        String hostname, Path docBase, List<Consumer<? super StandardServer>> configurators) {
 
+        this.engineName = engineName;
+        this.serviceName = serviceName;
         this.baseDir = baseDir;
         this.realm = realm;
         this.hostname = hostname;
         this.docBase = docBase;
+        this.configurators = configurators;
+    }
+
+    /**
+     * Returns the name of the {@link StandardService} of an embedded Tomcat.
+     */
+    public String serviceName() {
+        return serviceName;
+    }
+
+    /**
+     * Returns the name of the {@link StandardEngine} of an embedded Tomcat.
+     */
+    public String engineName() {
+        return engineName;
     }
 
     /**
@@ -66,15 +92,26 @@ public class TomcatServiceConfig {
         return docBase;
     }
 
-    @Override
-    public String toString() {
-        return toString(this, baseDir(), realm(), hostname(), docBase());
+    /**
+     * Returns the {@link Consumer}s that performs additional configuration operations against
+     * the Tomcat {@link StandardServer} created by a {@link TomcatService}.
+     */
+    public List<Consumer<? super StandardServer>> configurators() {
+        return configurators;
     }
 
-    static String toString(Object holder, Path baseDir, Realm realm, String hostname, Path docBase) {
+    @Override
+    public String toString() {
+        return toString(this, serviceName(), engineName(), baseDir(), realm(), hostname(), docBase());
+    }
+
+    static String toString(Object holder, String serviceName, String engineName,
+                           Path baseDir, Realm realm, String hostname, Path docBase) {
 
         return holder.getClass().getSimpleName() +
-               "(baseDir: " + baseDir +
+               "(serviceName: " + serviceName +
+               ", engineName: " + engineName +
+               ", baseDir: " + baseDir +
                ", realm: " + realm.getClass().getSimpleName() +
                ", hostname: " + hostname +
                ", docBase: " + docBase + ')';


### PR DESCRIPTION
Related: #83

Motivation:

Tomcat registers JMX MBeans using the configured service name, which is
often 'Catalina' as written in the default Tomcat server.xml file.
TomcatService currently does not use 'Catalina' but
'Tomcat-over-Armeria' as the default service name. It makes the legacy
JMX clients confused because they assume a Tomcat MBean always has the
name 'Catalina'.

Also, a user might want to set some additional properties of Tomcat
which might not be used by an ordinary web applications. e.g.
Service.addExecutor().

Modifications:

- Add serviceName() and engineName() property
- Change the default service/engine name to 'Catalina' which is the
  default in conf/server.xml
- Add configurator() builder operation so that a user can configure the
  server more freely
- Miscellaneous
  - Upgrade Tomcat to 8.0.30

Result:

- A user has pretty much full control over the embedded Tomcat
  configuration