### PR TITLE
Add a way to create a derived client

### DIFF
--- a/src/test/thrift/main.thrift
+++ b/src/test/thrift/main.thrift
@@ -46,6 +46,7 @@ service SleepService {
     i64 sleep(1:i64 delay)
 }
 
+// Tests DocService
 exception FooServiceException {
     1: string stringVal,
 }
@@ -84,4 +85,9 @@ service FooService {
     FooStruct bar3(1: i32 intVal, 2: FooStruct foo) throws (1: FooServiceException e),
     list<FooStruct> bar4(1: list<FooStruct> foos) throws (1: FooServiceException e),
     map<string, FooStruct> bar5(1: map<string, FooStruct> foos) throws (1: FooServiceException e)
+}
+
+// Tests Clients.newDerivedClient()
+service HeaderService {
+    string header(1: string name)
 }


### PR DESCRIPTION
Related: #95

Motivation:

Given that the creation of a new client is relatively an expensive
operation, a user might want to create a client that reuses the
RemoteInvoker and ClientCodec of an existing client while using an
alternative ClientOptions.

A good example is writing an API proxy that forwards a certain set of
HTTP headers such as access tokens, as explained in #95.

Modifications:

- Add Clients.newDerivedClient() that creates a derived client from an
  existing client created by ClientBuilder or Clients.newClient()
- Add a test case for Clients.newDerivedClient() to
  ThriftOverHttpClientTest
  - Add HeaderService to assert that the derived client sends an
    expected header
- Simplify the method comparison of ClientInvocationHandler. It doesn't
  really need to use Method.equals() that performs rigorous comparison
  because Object has no overloaded methods.

Result:

A user can create a derived client at much lower cost, which makes it
easy to implement an API proxy-ish server.