### PR TITLE
Fix a bad call cycle when closing active HTTP/2 streams

### DIFF
--- a/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
+++ b/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
@@ -22,9 +22,13 @@ import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.Queue;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.ServiceInvocationContext;
 import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.util.Exceptions;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
@@ -48,6 +52,9 @@ import io.netty.util.collection.IntObjectMap;
 import io.netty.util.concurrent.Promise;
 
 class HttpSessionHandler extends ChannelDuplexHandler {
+
+    private static final Logger logger = LoggerFactory.getLogger(HttpSessionHandler.class);
+
     private static final String ARMERIA_USER_AGENT = "armeria client";
 
     static boolean isActive(Channel ch) {
@@ -139,6 +146,15 @@ class HttpSessionHandler extends ChannelDuplexHandler {
     public void channelInactive(ChannelHandlerContext ctx) throws Exception {
         failPendingResponses(ClosedSessionException.INSTANCE);
         ctx.fireChannelInactive();
+    }
+
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        Exceptions.log(logger, ctx.channel(), cause);
+        if (ctx.channel().isActive()) {
+            ctx.close();
+        }
     }
 
     void deactivateSession() {

--- a/src/main/java/com/linecorp/armeria/common/http/AbstractHttpToHttp2ConnectionHandler.java
+++ b/src/main/java/com/linecorp/armeria/common/http/AbstractHttpToHttp2ConnectionHandler.java
@@ -55,6 +55,7 @@ public abstract class AbstractHttpToHttp2ConnectionHandler extends HttpToHttp2Co
     };
 
     private boolean closing;
+    private boolean handlingConnectionError;
 
     protected AbstractHttpToHttp2ConnectionHandler(Http2ConnectionDecoder decoder, Http2ConnectionEncoder encoder,
                                                    Http2Settings initialSettings, boolean validateHeaders) {
@@ -63,6 +64,16 @@ public abstract class AbstractHttpToHttp2ConnectionHandler extends HttpToHttp2Co
 
     public boolean isClosing() {
         return closing;
+    }
+
+    @Override
+    protected void onConnectionError(ChannelHandlerContext ctx, Throwable cause, Http2Exception http2Ex) {
+        if (handlingConnectionError) {
+            return;
+        }
+
+        handlingConnectionError = true;
+        super.onConnectionError(ctx, cause, http2Ex);
     }
 
     @Override

--- a/src/main/java/com/linecorp/armeria/common/http/AbstractHttpToHttp2ConnectionHandler.java
+++ b/src/main/java/com/linecorp/armeria/common/http/AbstractHttpToHttp2ConnectionHandler.java
@@ -54,13 +54,21 @@ public abstract class AbstractHttpToHttp2ConnectionHandler extends HttpToHttp2Co
         return true;
     };
 
+    private boolean closing;
+
     protected AbstractHttpToHttp2ConnectionHandler(Http2ConnectionDecoder decoder, Http2ConnectionEncoder encoder,
                                                    Http2Settings initialSettings, boolean validateHeaders) {
         super(decoder, encoder, initialSettings, validateHeaders);
     }
 
+    public boolean isClosing() {
+        return closing;
+    }
+
     @Override
     public void close(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+        closing = true;
+
         // TODO(trustin): Remove this line once https://github.com/netty/netty/issues/4210 is fixed.
         connection().forEachActiveStream(closeAllStreams);
 

--- a/src/main/java/com/linecorp/armeria/common/util/Exceptions.java
+++ b/src/main/java/com/linecorp/armeria/common/util/Exceptions.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.util;
+
+import java.io.IOException;
+import java.nio.channels.ClosedChannelException;
+import java.util.regex.Pattern;
+
+import org.slf4j.Logger;
+
+import com.linecorp.armeria.client.ClosedSessionException;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelException;
+import io.netty.handler.codec.http2.Http2Exception;
+
+public final class Exceptions {
+
+    private static final Pattern IGNORABLE_SOCKET_ERROR_MESSAGE = Pattern.compile(
+            "(?:connection.*(?:reset|closed|abort|broken)|broken.*pipe)", Pattern.CASE_INSENSITIVE);
+
+    private static final Pattern IGNORABLE_HTTP2_ERROR_MESSAGE = Pattern.compile(
+            "(?:stream closed)", Pattern.CASE_INSENSITIVE);
+
+
+    public static void log(Logger logger, Channel ch, Throwable cause) {
+        if (!logger.isWarnEnabled()) {
+            return;
+        }
+
+        if (needsAttention(cause)) {
+            logger.warn("{} Unexpected exception:", ch, cause);
+        }
+    }
+
+    public static boolean needsAttention(Throwable cause) {
+        // We do not need to log every exception because some exceptions are expected to occur.
+
+        if (cause instanceof ClosedChannelException || cause instanceof ClosedSessionException) {
+            // Can happen when attempting to write to a closed channel.
+            return false;
+        }
+
+        final String msg = cause.getMessage();
+        if (msg != null) {
+            if ((cause instanceof IOException || cause instanceof ChannelException) &&
+                IGNORABLE_SOCKET_ERROR_MESSAGE.matcher(msg).find()) {
+                // Can happen when socket error occurs.
+                return false;
+            }
+
+            if (cause instanceof Http2Exception && IGNORABLE_HTTP2_ERROR_MESSAGE.matcher(msg).find()) {
+                // Can happen when disconnected prematurely.
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private Exceptions() {}
+}


### PR DESCRIPTION
Motivation:

An HTTP/2 connection closed with pending writes can cause a bad cycle:

1. Channel.close() triggers AbstractHttpToHttp2ConnectionHandler.close().
2. AbstractHttpToHttp2ConnectionHandler.close() triggers Http2Stream.close().
3. Http2Stream.close() fails the promise of its pending writes.
4. The failed promise notifies HttpServerHandler.CLOSE_ON_FAILURE.
5. HttpServerHandler.CLOSE_ON_FAILURE calls Channel.close().
6. Repeat from the step 1.

More the pending writes, longer the stack trace.

Modifications:

- Do not call Channel.close() if HttpToHttp2Connection.close() has been
  invoked already or the Channel has been closed already

Result:

The bad cycle is gone.