### PR TITLE
Reduce the unnecessarily noisy/long exceptions

### DIFF
--- a/src/main/java/com/linecorp/armeria/common/ServiceInvocationContext.java
+++ b/src/main/java/com/linecorp/armeria/common/ServiceInvocationContext.java
@@ -31,6 +31,8 @@ import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.linecorp.armeria.common.util.Exceptions;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.Channel;
@@ -429,7 +431,7 @@ public abstract class ServiceInvocationContext extends DefaultAttributeMap {
         try {
             if (!(promise.cause() instanceof TimeoutException)) {
                 // Log resolve failure unless it is due to a timeout.
-                logger().warn("Failed to resolve a promise ({}) with {}", promise, result);
+                logger().warn("Failed to resolve a completed promise ({}) with {}", promise, result);
             }
         } finally {
             ReferenceCountUtil.safeRelease(result);
@@ -459,10 +461,19 @@ public abstract class ServiceInvocationContext extends DefaultAttributeMap {
             return;
         }
 
-        if (!(promise.cause() instanceof TimeoutException)) {
-            // Log reject failure unless it is due to a timeout.
-            logger().warn("Failed to reject a promise ({}) with {}", promise, cause, cause);
+        final Throwable firstCause = promise.cause();
+        if (firstCause instanceof TimeoutException) {
+            // Timed out already.
+            return;
         }
+
+        if (Exceptions.isExpected(cause)) {
+            // The exception that was thrown after firstCause (often a transport-layer exception)
+            // was a usual expected exception, not an error.
+            return;
+        }
+
+        logger().warn("Failed to reject a completed promise ({}) with {}", promise, cause, cause);
     }
 
     @Override

--- a/src/main/java/com/linecorp/armeria/common/http/AbstractHttpToHttp2ConnectionHandler.java
+++ b/src/main/java/com/linecorp/armeria/common/http/AbstractHttpToHttp2ConnectionHandler.java
@@ -54,13 +54,32 @@ public abstract class AbstractHttpToHttp2ConnectionHandler extends HttpToHttp2Co
         return true;
     };
 
+    private boolean closing;
+    private boolean handlingConnectionError;
+
     protected AbstractHttpToHttp2ConnectionHandler(Http2ConnectionDecoder decoder, Http2ConnectionEncoder encoder,
                                                    Http2Settings initialSettings, boolean validateHeaders) {
         super(decoder, encoder, initialSettings, validateHeaders);
     }
 
+    public boolean isClosing() {
+        return closing;
+    }
+
+    @Override
+    protected void onConnectionError(ChannelHandlerContext ctx, Throwable cause, Http2Exception http2Ex) {
+        if (handlingConnectionError) {
+            return;
+        }
+
+        handlingConnectionError = true;
+        super.onConnectionError(ctx, cause, http2Ex);
+    }
+
     @Override
     public void close(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+        closing = true;
+
         // TODO(trustin): Remove this line once https://github.com/netty/netty/issues/4210 is fixed.
         connection().forEachActiveStream(closeAllStreams);
 

--- a/src/main/java/com/linecorp/armeria/common/util/Exceptions.java
+++ b/src/main/java/com/linecorp/armeria/common/util/Exceptions.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.util;
+
+import java.io.IOException;
+import java.nio.channels.ClosedChannelException;
+import java.util.regex.Pattern;
+
+import org.slf4j.Logger;
+
+import com.linecorp.armeria.client.ClosedSessionException;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelException;
+import io.netty.handler.codec.http2.Http2Exception;
+
+/**
+ * Provides the methods that are useful for handling exceptions.
+ */
+public final class Exceptions {
+
+    private static final Pattern IGNORABLE_SOCKET_ERROR_MESSAGE = Pattern.compile(
+            "(?:connection.*(?:reset|closed|abort|broken)|broken.*pipe)", Pattern.CASE_INSENSITIVE);
+
+    private static final Pattern IGNORABLE_HTTP2_ERROR_MESSAGE = Pattern.compile(
+            "(?:stream closed)", Pattern.CASE_INSENSITIVE);
+
+    /**
+     * Logs the specified exception if it is {@linkplain #isExpected(Throwable)} unexpected}.
+     */
+    public static void logIfUnexpected(Logger logger, Channel ch, Throwable cause) {
+        if (!logger.isWarnEnabled() || !isExpected(cause)) {
+            return;
+        }
+
+        logger.warn("{} Unexpected exception:", ch, cause);
+    }
+
+    /**
+     * Returns {@code true} if the specified exception is expected to occur in well-known circumstances.
+     * <ul>
+     *   <li>{@link ClosedChannelException}</li>
+     *   <li>{@link ClosedSessionException}</li>
+     *   <li>{@link IOException} - 'Connection reset/closed/aborted by peer'</li>
+     *   <li>'Broken pipe'</li>
+     *   <li>{@link Http2Exception} - 'Stream closed'</li>
+     * </ul>
+     */
+    public static boolean isExpected(Throwable cause) {
+        // We do not need to log every exception because some exceptions are expected to occur.
+
+        if (cause instanceof ClosedChannelException || cause instanceof ClosedSessionException) {
+            // Can happen when attempting to write to a channel closed by the other end.
+            return true;
+        }
+
+        final String msg = cause.getMessage();
+        if (msg != null) {
+            if ((cause instanceof IOException || cause instanceof ChannelException) &&
+                IGNORABLE_SOCKET_ERROR_MESSAGE.matcher(msg).find()) {
+                // Can happen when socket error occurs.
+                return true;
+            }
+
+            if (cause instanceof Http2Exception && IGNORABLE_HTTP2_ERROR_MESSAGE.matcher(msg).find()) {
+                // Can happen when disconnected prematurely.
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private Exceptions() {}
+}


### PR DESCRIPTION
Motivation:

When Armeria is under heavy load that it cannot keep up with, exceptions
will be triggered, and some of them do not really need logging.

Here's the list of the exceptions which are triggered very usually in
case of socket disconnection due to timeout / connection reset by peer
errors:

- IOException: connection reset by peer / broken pipe
- Http2Exception$StreamException: Stream closed
- ClosedChannelException
- ClosedSessionException

Also, an attempt to close a HTTP/2 connection with pending writes can
cause unnecessarily long stack trace because of the following steps they
involve:

1. Channel.close() triggers AbstractHttpToHttp2ConnectionHandler.close().
2. AbstractHttpToHttp2ConnectionHandler.close() triggers Http2Stream.close().
3. Http2Stream.close() fails the promise of its pending writes.
4. The failed promise notifies HttpServerHandler.CLOSE_ON_FAILURE.
5. HttpServerHandler.CLOSE_ON_FAILURE calls Channel.close().
6. Repeat from the step 1.

More the pending writes, longer the stack trace.

Modifications:

- Add Exceptions, a utility class that filters out the exceptions
  mentioned above
  - Use Exceptions in ServiceInvocationContext and ChannelHandler
    implementations to reduce the amount of noisy log messages
- Do not call Channel.close() if HttpToHttp2Connection.close() has been
  invoked already or the Channel has been closed already

Result:

- Much less noise when Armeria server is overloaded
- The bad call cycle that was cause unnecessarily long stack trace is gone.