### PR TITLE
More efficient and correct H1C-to-H2C upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     <netty.version>4.1.0.CR1</netty.version>
     <slf4j.version>1.7.13</slf4j.version>
     <tomcat.version>8.0.30</tomcat.version>
-    <jetty.alpnAgent.version>1.0.0.Final</jetty.alpnAgent.version>
+    <jetty.alpnAgent.version>1.0.1.Final</jetty.alpnAgent.version>
     <jetty.alpnAgent.path>${settings.localRepository}/kr/motd/javaagent/jetty-alpn-agent/${jetty.alpnAgent.version}/jetty-alpn-agent-${jetty.alpnAgent.version}.jar</jetty.alpnAgent.path>
     <argLine.alpnAgent>-javaagent:${jetty.alpnAgent.path}</argLine.alpnAgent>
     <argLine.leak>-D_</argLine.leak> <!-- Overridden when 'leak' profile is active -->

--- a/src/main/java/com/linecorp/armeria/client/DefaultHostsFileEntriesResolver.java
+++ b/src/main/java/com/linecorp/armeria/client/DefaultHostsFileEntriesResolver.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client;
+
+import java.net.InetAddress;
+import java.util.Map;
+
+import io.netty.resolver.HostsFileEntriesResolver;
+
+/**
+ * Default {@link HostsFileEntriesResolver} that resolves hosts file entries only once.
+ */
+final class DefaultHostsFileEntriesResolver implements HostsFileEntriesResolver {
+    // TODO(trustin): Remove this fork once Netty 4.1.0.CR2 is out.
+    private final Map<String, InetAddress> entries = HostsFileParser.parseSilently();
+
+    @Override
+    public InetAddress address(String inetHost) {
+        return entries.get(inetHost);
+    }
+}

--- a/src/main/java/com/linecorp/armeria/client/HostsFileParser.java
+++ b/src/main/java/com/linecorp/armeria/client/HostsFileParser.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client;
+
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.Reader;
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import io.netty.util.NetUtil;
+import io.netty.util.internal.PlatformDependent;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+
+/**
+ * A parser for hosts files.
+ */
+final class HostsFileParser {
+    // TODO(trustin): Remove this fork once Netty 4.1.0.CR2 is out.
+    private static final String WINDOWS_DEFAULT_SYSTEM_ROOT = "C:\\Windows";
+    private static final String WINDOWS_HOSTS_FILE_RELATIVE_PATH = "\\system32\\drivers\\etc\\hosts";
+    private static final String X_PLATFORMS_HOSTS_FILE_PATH = "/etc/hosts";
+
+    private static final Pattern WHITESPACES = Pattern.compile("[ \t]+");
+
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(HostsFileParser.class);
+
+    private static File locateHostsFile() {
+        File hostsFile;
+        if (PlatformDependent.isWindows()) {
+            hostsFile = new File(System.getenv("SystemRoot") + WINDOWS_HOSTS_FILE_RELATIVE_PATH);
+            if (!hostsFile.exists()) {
+                hostsFile = new File(WINDOWS_DEFAULT_SYSTEM_ROOT + WINDOWS_HOSTS_FILE_RELATIVE_PATH);
+            }
+        } else {
+            hostsFile = new File(X_PLATFORMS_HOSTS_FILE_PATH);
+        }
+        return hostsFile;
+    }
+
+    /**
+     * Parse hosts file at standard OS location.
+     *
+     * @return a map of hostname or alias to {@link InetAddress}
+     */
+    static Map<String, InetAddress> parseSilently() {
+        File hostsFile = locateHostsFile();
+        try {
+            return parse(hostsFile);
+        } catch (IOException e) {
+            logger.warn("Failed to load and parse hosts file at " + hostsFile.getPath(), e);
+            return Collections.emptyMap();
+        }
+    }
+
+    /**
+     * Parse hosts file at standard OS location.
+     *
+     * @return a map of hostname or alias to {@link InetAddress}
+     * @throws IOException file could not be read
+     */
+    static Map<String, InetAddress> parse() throws IOException {
+        return parse(locateHostsFile());
+    }
+
+    /**
+     * Parse a hosts file.
+     *
+     * @param file the file to be parsed
+     * @return a map of hostname or alias to {@link InetAddress}
+     * @throws IOException file could not be read
+     */
+    static Map<String, InetAddress> parse(File file) throws IOException {
+        checkNotNull(file, "file");
+        if (file.exists() && file.isFile()) {
+            return parse(new BufferedReader(new FileReader(file)));
+        } else {
+            return Collections.emptyMap();
+        }
+    }
+
+    /**
+     * Parse a reader of hosts file format.
+     *
+     * @param reader the file to be parsed
+     * @return a map of hostname or alias to {@link InetAddress}
+     * @throws IOException file could not be read
+     */
+    static Map<String, InetAddress> parse(Reader reader) throws IOException {
+        checkNotNull(reader, "reader");
+        BufferedReader buff = new BufferedReader(reader);
+        try {
+            Map<String, InetAddress> entries = new HashMap<>();
+            String line;
+            while ((line = buff.readLine()) != null) {
+                // remove comment
+                int commentPosition = line.indexOf('#');
+                if (commentPosition != -1) {
+                    line = line.substring(0, commentPosition);
+                }
+                // skip empty lines
+                line = line.trim();
+                if (line.isEmpty()) {
+                    continue;
+                }
+
+                // split
+                List<String> lineParts = new ArrayList<>();
+                for (String s: WHITESPACES.split(line)) {
+                    if (!s.isEmpty()) {
+                        lineParts.add(s);
+                    }
+                }
+
+                // a valid line should be [IP, hostname, alias*]
+                if (lineParts.size() < 2) {
+                    // skip invalid line
+                    continue;
+                }
+
+                byte[] ipBytes = NetUtil.createByteArrayFromIpAddressString(lineParts.get(0));
+
+                if (ipBytes == null) {
+                    // skip invalid IP
+                    continue;
+                }
+
+                // loop over hostname and aliases
+                for (int i = 1; i < lineParts.size(); i ++) {
+                    String hostname = lineParts.get(i);
+                    if (!entries.containsKey(hostname)) {
+                        // trying to map a host to multiple IPs is wrong
+                        // only the first entry is honored
+                        entries.put(hostname, InetAddress.getByAddress(hostname, ipBytes));
+                    }
+                }
+            }
+            return entries;
+        } finally {
+            try {
+                buff.close();
+            } catch (IOException e) {
+                logger.warn("Failed to close a reader", e);
+            }
+        }
+    }
+
+    /**
+     * Can't be instantiated.
+     */
+    private HostsFileParser() {}
+}

--- a/src/main/java/com/linecorp/armeria/client/SessionProtocolNegotiationCache.java
+++ b/src/main/java/com/linecorp/armeria/client/SessionProtocolNegotiationCache.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import static java.util.Objects.requireNonNull;
+
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.locks.StampedLock;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.util.LruMap;
+
+/**
+ * Keeps the recent {@link SessionProtocol} negotiation failures. It is a LRU cache which keeps at most
+ * 64k 'host name + port' pairs.
+ */
+public final class SessionProtocolNegotiationCache {
+
+    private static final Logger logger = LoggerFactory.getLogger(SessionProtocolNegotiationCache.class);
+
+    private static final StampedLock lock = new StampedLock();
+    private static final Map<String, CacheEntry> cache = new LruMap<String, CacheEntry>(65536) {
+        private static final long serialVersionUID = -2506868886873712772L;
+
+        @Override
+        protected boolean removeEldestEntry(Entry<String, CacheEntry> eldest) {
+            final boolean remove = super.removeEldestEntry(eldest);
+            if (remove) {
+                logger.debug("Evicted: '{}' does not support ", eldest.getKey(), eldest.getValue());
+            }
+
+            return remove;
+        }
+    };
+
+    /**
+     * Returns {@code true} if the specified {@code remoteAddress} is known to have no support for
+     * the specified {@link SessionProtocol}.
+     */
+    public static boolean isUnsupported(SocketAddress remoteAddress, SessionProtocol protocol) {
+        final String key = key(remoteAddress);
+        final CacheEntry e;
+        final long stamp = lock.readLock();
+        try {
+            e = cache.get(key);
+        } finally {
+            lock.unlockRead(stamp);
+        }
+
+        if (e == null) {
+            // Can't tell if it's unsupported
+            return false;
+        }
+
+        return e.isUnsupported(protocol);
+    }
+
+    /**
+     * Updates the cache with the information that the specified {@code remoteAddress} does not support
+     * the specified {@link SessionProtocol}.
+     */
+    public static void setUnsupported(SocketAddress remoteAddress, SessionProtocol protocol) {
+        final String key = key(remoteAddress);
+        final CacheEntry e = getOrCreate(key);
+
+        if (e.addUnsupported(protocol)) {
+            logger.debug("Updated: '{}' does not support {}", key, e);
+        }
+    }
+
+    /**
+     * Clears the cache.
+     */
+    public static void clear() {
+        int size;
+        long stamp = lock.readLock();
+        try {
+            size = cache.size();
+            if (size == 0) {
+                return;
+            }
+
+            stamp = convertToWriteLock(stamp);
+            size = cache.size();
+            cache.clear();
+        } finally {
+            lock.unlock(stamp);
+        }
+
+        if (size != 0 && logger.isDebugEnabled()) {
+            if (size != 1) {
+                logger.debug("Cleared: {} entries", size);
+            } else {
+                logger.debug("Cleared: 1 entry");
+            }
+        }
+    }
+
+    private static CacheEntry getOrCreate(String key) {
+        long stamp = lock.readLock();
+        try {
+            final CacheEntry entry = cache.get(key);
+            if (entry != null) {
+                return entry;
+            }
+
+            stamp = convertToWriteLock(stamp);
+
+            return cache.computeIfAbsent(key, CacheEntry::new);
+        } finally {
+            lock.unlock(stamp);
+        }
+    }
+
+    private static String key(SocketAddress remoteAddress) {
+        requireNonNull(remoteAddress, "remoteAddress");
+        if (!(remoteAddress instanceof InetSocketAddress)) {
+            throw new IllegalArgumentException(
+                    "remoteAddress: " + remoteAddress +
+                    " (expected: an " + InetSocketAddress.class.getSimpleName() + ')');
+        }
+
+        final InetSocketAddress raddr = (InetSocketAddress) remoteAddress;
+        final String host = raddr.getHostString();
+
+        return new StringBuilder(host.length() + 6)
+                .append(host)
+                .append(':')
+                .append(raddr.getPort())
+                .toString();
+    }
+
+    private static long convertToWriteLock(long stamp) {
+        final long writeStamp = lock.tryConvertToWriteLock(stamp);
+        if (writeStamp == 0L) {
+            lock.unlockRead(stamp);
+            stamp = lock.writeLock();
+        } else {
+            stamp = writeStamp;
+        }
+        return stamp;
+    }
+
+    private static final class CacheEntry {
+        private volatile EnumSet<SessionProtocol> unsupported = EnumSet.noneOf(SessionProtocol.class);
+
+        CacheEntry(String key) {
+            // Key is unused. It's just here to simplify the Map.computeIfAbsent() call in getOrCreate().
+        }
+
+        boolean addUnsupported(SessionProtocol protocol) {
+            EnumSet<SessionProtocol> unsupported = this.unsupported;
+            if (unsupported.contains(protocol)) {
+                return false;
+            }
+
+            final EnumSet<SessionProtocol> copy = EnumSet.copyOf(unsupported);
+            copy.add(protocol);
+
+            this.unsupported = copy;
+            return true;
+        }
+
+        boolean isUnsupported(SessionProtocol protocol) {
+            requireNonNull(protocol, "protocol");
+            return unsupported.contains(protocol);
+        }
+
+        @Override
+        public String toString() {
+            return unsupported.toString();
+        }
+    }
+
+    private SessionProtocolNegotiationCache() {}
+}

--- a/src/main/java/com/linecorp/armeria/client/SessionProtocolNegotiationException.java
+++ b/src/main/java/com/linecorp/armeria/client/SessionProtocolNegotiationException.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Optional;
+
+import javax.annotation.Nullable;
+
+import com.linecorp.armeria.common.SessionProtocol;
+
+/**
+ * An exception triggered when failed to negotiate the desired {@link SessionProtocol} with a server.
+ */
+public final class SessionProtocolNegotiationException extends RuntimeException {
+
+    private static final long serialVersionUID = 5788454584691399858L;
+
+    private final SessionProtocol expected;
+    private final SessionProtocol actual;
+
+    /**
+     * Creates a new instance with the specified expected {@link SessionProtocol}.
+     */
+    public SessionProtocolNegotiationException(SessionProtocol expected, @Nullable String reason) {
+        super("expected: " + requireNonNull(expected, "expected"));
+        this.expected = expected;
+        actual = null;
+    }
+
+    /**
+     * Creates a new instance with the specified expected and actual {@link SessionProtocol}s.
+     */
+    public SessionProtocolNegotiationException(SessionProtocol expected,
+                                               @Nullable SessionProtocol actual, @Nullable String reason) {
+
+        super("expected: " + requireNonNull(expected, "expected") +
+              ", actual: " + requireNonNull(actual, "actual"));
+        this.expected = expected;
+        this.actual = actual;
+    }
+
+    private static String message(SessionProtocol expected, SessionProtocol actual, String reason) {
+        requireNonNull(expected, "expected");
+
+        final StringBuilder buf;
+
+        if (reason != null) {
+            buf = new StringBuilder(reason.length() + 32);
+
+            buf.append(reason);
+            buf.append(" (expected: ");
+            buf.append(expected);
+            if (actual != null) {
+                buf.append(", actual: ");
+                buf.append(actual);
+            }
+            buf.append(')');
+        } else {
+            buf = new StringBuilder(32);
+
+            buf.append("expected: ");
+            buf.append(expected);
+            if (actual != null) {
+                buf.append(", actual: ");
+                buf.append(actual);
+            }
+        }
+
+        return buf.toString();
+    }
+
+    /**
+     * Returns the expected {@link SessionProtocol}.
+     */
+    public SessionProtocol expected() {
+        return expected;
+    }
+
+    /**
+     * Returns the actual {@link SessionProtocol}.
+     */
+    public Optional<SessionProtocol> actual() {
+        return Optional.ofNullable(actual);
+    }
+
+    @Override
+    public Throwable fillInStackTrace() {
+        return this;
+    }
+}

--- a/src/main/java/com/linecorp/armeria/common/util/Exceptions.java
+++ b/src/main/java/com/linecorp/armeria/common/util/Exceptions.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.common.util;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.IOException;
 import java.nio.channels.ClosedChannelException;
 import java.util.regex.Pattern;
@@ -27,6 +29,7 @@ import com.linecorp.armeria.client.ClosedSessionException;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelException;
 import io.netty.handler.codec.http2.Http2Exception;
+import io.netty.util.internal.EmptyArrays;
 
 /**
  * Provides the methods that are useful for handling exceptions.
@@ -48,6 +51,17 @@ public final class Exceptions {
         }
 
         logger.warn("{} Unexpected exception:", ch, cause);
+    }
+
+    /**
+     * Logs the specified exception if it is {@linkplain #isExpected(Throwable)} unexpected}.
+     */
+    public static void logIfUnexpected(Logger logger, Channel ch, String debugData, Throwable cause) {
+        if (!logger.isWarnEnabled() || !isExpected(cause)) {
+            return;
+        }
+
+        logger.warn("{} Unexpected exception: {}", ch, debugData, cause);
     }
 
     /**
@@ -83,6 +97,15 @@ public final class Exceptions {
         }
 
         return false;
+    }
+
+    /**
+     * Empties the stack trace of the specified {@code exception}.
+     */
+    public static <T extends Throwable> T clearTrace(T exception) {
+        requireNonNull(exception, "exception");
+        exception.setStackTrace(EmptyArrays.EMPTY_STACK_TRACE);
+        return exception;
     }
 
     private Exceptions() {}

--- a/src/main/java/com/linecorp/armeria/server/ServerPort.java
+++ b/src/main/java/com/linecorp/armeria/server/ServerPort.java
@@ -60,8 +60,16 @@ public final class ServerPort implements Comparable<ServerPort> {
             }
         }
 
+        requireNonNull(protocol, "protocol");
+
+        if (protocol != SessionProtocol.HTTP && protocol != SessionProtocol.HTTPS) {
+            throw new IllegalArgumentException(
+                    "protocol: " + protocol +
+                    " (expected: " + SessionProtocol.HTTP + " or " + SessionProtocol.HTTPS + ')');
+        }
+
         this.localAddress = localAddress;
-        this.protocol = requireNonNull(protocol, "protocol");
+        this.protocol = protocol;
 
         localAddressString = localAddress.getAddress().getHostAddress() + ':' + localAddress.getPort();
     }

--- a/src/test/java/com/linecorp/armeria/server/ServerTest.java
+++ b/src/test/java/com/linecorp/armeria/server/ServerTest.java
@@ -41,6 +41,7 @@ import com.linecorp.armeria.common.Scheme;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.ServiceInvocationContext;
 import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.server.logging.LoggingService;
 
 import io.netty.buffer.ByteBuf;
@@ -81,7 +82,7 @@ public class ServerTest extends AbstractServerTest {
         }).decorate(LoggingService::new);
 
         final Service buggy = new ByteBufService((ctx, exec, promise) -> {
-            throw new Exception("bug!");
+            throw Exceptions.clearTrace(new Exception("bug!"));
         }).decorate(LoggingService::new);
 
         sb.serviceAt("/", immediateResponseOnIoThread)


### PR DESCRIPTION
Motivation:

The current HTTP/1-to-2 upgrade has the following slightly inter-related
issues:

1. When a user specifies an explicit session protocol (H1C/H1/H2C/H2)
instead of HTTP/HTTPS, the session creation must fail when the
negotiated protocol does not match exactly. For example, when a user
specified H2C, a rejected upgrade request should fail session creation.
2. When connecting to a host whose name is registered in /etc/hosts, the
'Host' header of the HEAD upgrade request is not set to the host name
but the host address.
3. When a user specifies HTTP/HTTPS as session protocol and the remote
host does not support H2C/H2, the client currently keeps sending the
HEAD upgrade request. We could cache the list of the hosts with no
HTTP/2 support, so we do not send upgrade requests unnecessarily.
4. Some servers send 'Connection: close' header when rejecting a upgrade
request, resulting disconnection. When this happens and a user specified
HTTP as session protocol, the client should retry the connection attempt
silently, so that a user does not notice the upgrade failure, because
it's not really a failure.

Modifications:

- (2) Fork DefaultHostsFileEntryResolver and HostsFileParser so that
  they do not omit the host name in the resolved InetAddress, where
  the host name is picked up from by Armeria
- (1) Add SessionProtocolNegotiationException
  - Mark the session creation as failure when protocol upgrade fails or
    the protocol is different from what user expected
    - See HttpConfigurator and HttpSessionChannelFactory
- (3) Add SessionProtocolNegotiationCache
  - Update the cache when protocol upgrade is rejected by remote host in
    HttpConfigurator
- (4) HttpSessionChannelFactory now retries the connection attempt when
  HttpConfigurator finds the upgrade response contains 'Connection:
  close' header.
- Add the test cases for (1, 3, 4) to ThriftOverHttpClientTServletIntegrationTest
- Miscellaneous:
  - When HTTP codec fails to decode a response, use the cause of the
    decoder failure as the invocation result, which is much more
    informative.
  - Add another variant of Exceptions.logIfUnexpected()
  - Add Exceptions.clearTrace() to remove the stack trace of an
    exception easily
  - Fix a bug where HttpServerHandler sends content in a response to a
    HEAD request. A response content of a HEAD request must be empty.

Result:

- Invocation now fails when the negotiated protocol does not match the
  desired protocol.
- The 'Host' header in a upgrade request now contains host name even if
  the host address was resolved via the /etc/hosts file
- HTTP/1-to-2 upgrade request is sent only when necessary.
- Http/1-to-2 upgrade deals better with 'Connection: close' headers.
