### PR TITLE
Add connector based TomcatServiceInvocationHandler

### DIFF
--- a/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -383,7 +383,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter {
     }
 
     private static HttpResponseStatus toHttpResponseStatus(Throwable cause) {
-        if (cause instanceof RequestTimeoutException) {
+        if (cause instanceof RequestTimeoutException || cause instanceof ServiceUnavailableException) {
             return HttpResponseStatus.SERVICE_UNAVAILABLE;
         }
 

--- a/src/main/java/com/linecorp/armeria/server/ServiceUnavailableException.java
+++ b/src/main/java/com/linecorp/armeria/server/ServiceUnavailableException.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2015 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+/**
+ * A {@link RuntimeException} that is raised when a requested invocation cannot be served.
+ */
+public class ServiceUnavailableException extends RuntimeException {
+
+    private static final long serialVersionUID = -9092895165959388396L;
+
+    /**
+     * Creates a new exception.
+     */
+    public ServiceUnavailableException() {}
+
+    /**
+     * Creates a new instance with the specified {@code message}.
+     */
+    public ServiceUnavailableException(String message) {
+        super(message);
+    }
+
+    /**
+     * Creates a new instance with the specified {@code message} and {@code cause}.
+     */
+    public ServiceUnavailableException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Creates a new instance with the specified {@code cause}.
+     */
+    public ServiceUnavailableException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Creates a new instance with the specified {@code message}, {@code cause}, suppression enabled or
+     * disabled, and writable stack trace enabled or disabled.
+     */
+    protected ServiceUnavailableException(String message, Throwable cause, boolean enableSuppression,
+                                          boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+
+    @Override
+    public Throwable fillInStackTrace() {
+        return this;
+    }
+}

--- a/src/main/java/com/linecorp/armeria/server/http/tomcat/ManagedTomcatServiceInvocationHandler.java
+++ b/src/main/java/com/linecorp/armeria/server/http/tomcat/ManagedTomcatServiceInvocationHandler.java
@@ -1,0 +1,283 @@
+/*
+ * Copyright 2015 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.http.tomcat;
+
+import static java.util.Objects.requireNonNull;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Objects;
+
+import org.apache.catalina.Container;
+import org.apache.catalina.Context;
+import org.apache.catalina.Engine;
+import org.apache.catalina.LifecycleException;
+import org.apache.catalina.Service;
+import org.apache.catalina.connector.Connector;
+import org.apache.catalina.core.StandardEngine;
+import org.apache.catalina.core.StandardHost;
+import org.apache.catalina.core.StandardServer;
+import org.apache.catalina.core.StandardService;
+import org.apache.catalina.startup.ContextConfig;
+import org.apache.coyote.ProtocolHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.ServerListener;
+import com.linecorp.armeria.server.ServerListenerAdapter;
+import com.linecorp.armeria.server.ServiceConfig;
+
+final class ManagedTomcatServiceInvocationHandler extends TomcatServiceInvocationHandler {
+
+    private static final Logger logger = LoggerFactory.getLogger(ManagedTomcatServiceInvocationHandler.class);
+
+    private static final String ROOT_CONTEXT_PATH = "";
+
+    /**
+     * See {@link StandardServer#await()} for more information about this magic number (-2),
+     * which is used for an embedded Tomcat server that manages its life cycle manually.
+     */
+    private static final int EMBEDDED_TOMCAT_PORT = -2;
+
+    static {
+        // Disable JNDI naming provided by Tomcat by default.
+        System.setProperty("catalina.useNaming", "false");
+    }
+
+    private final TomcatServiceConfig config;
+    private final ServerListener configurator = new Configurator();
+
+    private volatile StandardServer server;
+
+    private Server armeriaServer;
+
+    ManagedTomcatServiceInvocationHandler(TomcatServiceConfig config) {
+        super(config.hostname(), new Connector(TomcatProtocolHandler.class.getName()));
+        this.config = requireNonNull(config, "config");
+    }
+
+    TomcatServiceConfig config() {
+        return config;
+    }
+
+    @Override
+    public void handlerAdded(ServiceConfig cfg) throws Exception {
+        if (armeriaServer != null) {
+            if (armeriaServer != cfg.server()) {
+                throw new IllegalStateException("cannot be added to more than one server");
+            } else {
+                return;
+            }
+        }
+
+        armeriaServer = cfg.server();
+        armeriaServer.addListener(configurator);
+    }
+
+    void start() {
+        logger.info("Starting an embedded Tomcat: {}", config());
+
+        assert server == null;
+
+        // Create the connector with our protocol handler. Tomcat will call ProtocolHandler.setAdapter()
+        // on its startup with the Coyote Adapter which gives an access to Tomcat's HTTP service pipeline.
+        final Connector connector = connector();
+        connector.setPort(0); // We do not really open a port - just trying to stop the Connector from complaining.
+        final ProtocolHandler protocolHandler = connector.getProtocolHandler();
+
+        server = newServer(connector, config());
+
+        // Retrieve the components configured by newServer(), so we can use it in checkConfiguration().
+        final Service service = server.findServices()[0];
+        @SuppressWarnings("deprecation")
+        final Engine engine = (Engine) service.getContainer();
+        final StandardHost host = (StandardHost) engine.findChildren()[0];
+        final Context context = (Context) host.findChildren()[0];
+
+        // Apply custom configurators set via TomcatServiceBuilder.configurator()
+        try {
+            config().configurators().forEach(c -> c.accept(server));
+        } catch (Throwable t) {
+            throw new TomcatServiceException("failed to configure an embedded Tomcat", t);
+        }
+
+        // Make sure the configurators did not ruin what we have configured in this method.
+        checkConfiguration(service, connector, engine, host, context);
+
+        // Start the server finally.
+        try {
+            server.start();
+        } catch (LifecycleException e) {
+            throw new TomcatServiceException("failed to start an embedded Tomcat", e);
+        }
+    }
+
+    void stop() {
+        StandardServer server = this.server;
+        this.server = null;
+
+        if (server != null) {
+            logger.info("Stopping an embedded Tomcat: {}", config());
+            server.stopAwait();
+        }
+    }
+
+    private StandardServer newServer(Connector connector, TomcatServiceConfig config) {
+        //
+        // server <------ services <------ engines <------ realm
+        //                                         <------ hosts <------ contexts
+        //                         <------ connectors
+        //                         <------ executors
+        //
+
+        final StandardEngine engine = new StandardEngine();
+        engine.setName(config.engineName());
+        engine.setDefaultHost(config.hostname());
+        engine.setRealm(config.realm());
+
+        final StandardService service = new StandardService();
+        service.setName(config.serviceName());
+        service.setContainer(engine);
+
+        service.addConnector(connector);
+
+        final StandardServer server = new StandardServer();
+
+        final File baseDir = config.baseDir().toFile();
+        server.setCatalinaBase(baseDir);
+        server.setCatalinaHome(baseDir);
+        server.setPort(EMBEDDED_TOMCAT_PORT);
+
+        server.addService(service);
+
+        // Add the web application context.
+        // Get or create a host.
+        StandardHost host = (StandardHost) engine.findChild(config.hostname());
+        if (host == null) {
+            host = new StandardHost();
+            host.setName(config.hostname());
+            engine.addChild(host);
+        }
+
+        // Create a new context and add it to the host.
+        final Context ctx;
+        try {
+            ctx = (Context) Class.forName(host.getContextClass(), true, getClass().getClassLoader()).newInstance();
+        } catch (Exception e) {
+            throw new TomcatServiceException("failed to create a new context: " + config, e);
+        }
+
+        ctx.setPath(ROOT_CONTEXT_PATH);
+        ctx.setDocBase(config.docBase().toString());
+        ctx.addLifecycleListener(TomcatUtil.getDefaultWebXmlListener());
+        ctx.setConfigFile(TomcatUtil.getWebAppConfigFile(ROOT_CONTEXT_PATH, config.docBase()));
+
+        final ContextConfig ctxCfg = new ContextConfig();
+        ctxCfg.setDefaultWebXml(TomcatUtil.noDefaultWebXmlPath());
+        ctx.addLifecycleListener(ctxCfg);
+
+        host.addChild(ctx);
+
+        return server;
+    }
+
+    private void checkConfiguration(Service expectedService, Connector expectedConnector,
+                                    Engine expectedEngine, StandardHost expectedHost, Context expectedContext) {
+
+
+        // Check if Catalina base and home directories have not been changed.
+        final File expectedBaseDir = config.baseDir().toFile();
+        if (!Objects.equals(server.getCatalinaBase(), expectedBaseDir) ||
+            !Objects.equals(server.getCatalinaHome(), expectedBaseDir)) {
+            throw new TomcatServiceException("A configurator should never change the Catalina base and home.");
+        }
+
+        // Check if the server's port has not been changed.
+        if (server.getPort() != EMBEDDED_TOMCAT_PORT) {
+            throw new TomcatServiceException("A configurator should never change the port of the server.");
+        }
+
+        // Check if the default service has not been removed and a new service has not been added.
+        final Service[] services = server.findServices();
+        if (services == null || services.length != 1 || services[0] != expectedService) {
+            throw new TomcatServiceException(
+                    "A configurator should never remove the default service or add a new service.");
+        }
+
+        // Check if the name of the default service has not been changed.
+        if (!config().serviceName().equals(expectedService.getName())) {
+            throw new TomcatServiceException(
+                    "A configurator should never change the name of the default service.");
+        }
+
+        // Check if the default connector has not been removed
+        final Connector[] connectors = expectedService.findConnectors();
+        if (connectors == null || Arrays.stream(connectors).noneMatch(c -> c == expectedConnector)) {
+            throw new TomcatServiceException("A configurator should never remove the default connector.");
+        }
+
+        // Check if the engine has not been changed.
+        @SuppressWarnings("deprecation")
+        final Container actualEngine = expectedService.getContainer();
+        if (actualEngine != expectedEngine) {
+            throw new TomcatServiceException(
+                    "A configurator should never change the engine of the default service.");
+        }
+
+        // Check if the engine's name has not been changed.
+        if (!config().engineName().equals(expectedEngine.getName())) {
+            throw new TomcatServiceException(
+                    "A configurator should never change the name of the default engine.");
+        }
+
+        // Check if the default realm has not been changed.
+        if (expectedEngine.getRealm() != config().realm()) {
+            throw new TomcatServiceException("A configurator should never change the default realm.");
+        }
+
+        // Check if the default host has not been removed.
+        final Container[] engineChildren = expectedEngine.findChildren();
+        if (engineChildren == null || Arrays.stream(engineChildren).noneMatch(c -> c == expectedHost)) {
+            throw new TomcatServiceException("A configurator should never remove the default host.");
+        }
+
+        // Check if the default context has not been removed.
+        final Container[] contextChildren = expectedHost.findChildren();
+        if (contextChildren == null || Arrays.stream(contextChildren).noneMatch(c -> c == expectedContext)) {
+            throw new TomcatServiceException("A configurator should never remove the default context.");
+        }
+
+        // Check if the docBase of the default context has not been changed.
+        if (!config.docBase().toString().equals(expectedContext.getDocBase())) {
+            throw new TomcatServiceException(
+                    "A configurator should never change the docBase of the default context.");
+        }
+    }
+
+    private final class Configurator extends ServerListenerAdapter {
+        @Override
+        public void serverStarting(Server server) {
+            start();
+        }
+
+        @Override
+        public void serverStopped(Server server) {
+            stop();
+        }
+    }
+}

--- a/src/main/java/com/linecorp/armeria/server/http/tomcat/TomcatServiceInvocationHandler.java
+++ b/src/main/java/com/linecorp/armeria/server/http/tomcat/TomcatServiceInvocationHandler.java
@@ -16,32 +16,16 @@
 
 package com.linecorp.armeria.server.http.tomcat;
 
-import static java.util.Objects.requireNonNull;
-
-import java.io.File;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Map.Entry;
-import java.util.Objects;
 import java.util.concurrent.Executor;
 
-import org.apache.catalina.Container;
-import org.apache.catalina.Context;
-import org.apache.catalina.Engine;
-import org.apache.catalina.LifecycleException;
-import org.apache.catalina.Service;
 import org.apache.catalina.connector.Connector;
-import org.apache.catalina.core.StandardEngine;
-import org.apache.catalina.core.StandardHost;
-import org.apache.catalina.core.StandardServer;
-import org.apache.catalina.core.StandardService;
-import org.apache.catalina.startup.ContextConfig;
 import org.apache.coyote.Adapter;
 import org.apache.coyote.InputBuffer;
 import org.apache.coyote.OutputBuffer;
-import org.apache.coyote.ProtocolHandler;
 import org.apache.coyote.Request;
 import org.apache.coyote.Response;
 import org.apache.tomcat.util.buf.ByteChunk;
@@ -51,10 +35,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.linecorp.armeria.common.ServiceInvocationContext;
-import com.linecorp.armeria.server.Server;
-import com.linecorp.armeria.server.ServerListener;
-import com.linecorp.armeria.server.ServerListenerAdapter;
-import com.linecorp.armeria.server.ServiceConfig;
+import com.linecorp.armeria.server.ServiceUnavailableException;
 import com.linecorp.armeria.server.ServiceInvocationHandler;
 
 import io.netty.buffer.ByteBuf;
@@ -69,241 +50,32 @@ import io.netty.handler.codec.http.HttpVersion;
 import io.netty.util.AsciiString;
 import io.netty.util.concurrent.Promise;
 
-final class TomcatServiceInvocationHandler implements ServiceInvocationHandler {
+class TomcatServiceInvocationHandler implements ServiceInvocationHandler {
 
     private static final Logger logger = LoggerFactory.getLogger(TomcatServiceInvocationHandler.class);
 
-    private static final String ROOT_CONTEXT_PATH = "";
+    private final String hostname;
 
-    /**
-     * See {@link StandardServer#await()} for more information about this magic number (-2),
-     * which is used for an embedded Tomcat server that manages its life cycle manually.
-     */
-    private static final int EMBEDDED_TOMCAT_PORT = -2;
+    private final Connector connector;
 
-    static {
-        // Disable JNDI naming provided by Tomcat by default.
-        System.setProperty("catalina.useNaming", "false");
+    TomcatServiceInvocationHandler(String hostname, Connector connector) {
+        this.hostname = hostname;
+        this.connector = connector;
     }
 
-    private final TomcatServiceConfig config;
-    private final ServerListener configurator = new Configurator();
-
-    private volatile StandardServer server;
-    private volatile Adapter coyoteAdapter;
-
-    private Server armeriaServer;
-
-    TomcatServiceInvocationHandler(TomcatServiceConfig config) {
-        this.config = requireNonNull(config, "config");
-    }
-
-    TomcatServiceConfig config() {
-        return config;
-    }
-
-    @Override
-    public void handlerAdded(ServiceConfig cfg) throws Exception {
-        if (armeriaServer != null) {
-            if (armeriaServer != cfg.server()) {
-                throw new IllegalStateException("cannot be added to more than one server");
-            } else {
-                return;
-            }
-        }
-
-        armeriaServer = cfg.server();
-        armeriaServer.addListener(configurator);
-    }
-
-    void start() {
-        logger.info("Starting an embedded Tomcat: {}", config());
-
-        assert server == null;
-        assert coyoteAdapter == null;
-
-        // Create the connector with our protocol handler. Tomcat will call ProtocolHandler.setAdapter()
-        // on its startup with the Coyote Adapter which gives an access to Tomcat's HTTP service pipeline.
-        final Connector connector = new Connector(TomcatProtocolHandler.class.getName());
-        connector.setPort(0); // We do not really open a port - just trying to stop the Connector from complaining.
-        final ProtocolHandler protocolHandler = connector.getProtocolHandler();
-
-        server = newServer(connector, config());
-
-        // Retrieve the components configured by newServer(), so we can use it in checkConfiguration().
-        final Service service = server.findServices()[0];
-        @SuppressWarnings("deprecation")
-        final Engine engine = (Engine) service.getContainer();
-        final StandardHost host = (StandardHost) engine.findChildren()[0];
-        final Context context = (Context) host.findChildren()[0];
-
-
-        // Apply custom configurators set via TomcatServiceBuilder.configurator()
-        try {
-            config().configurators().forEach(c -> c.accept(server));
-        } catch (Throwable t) {
-            throw new TomcatServiceException("failed to configure an embedded Tomcat", t);
-        }
-
-        // Make sure the configurators did not ruin what we have configured in this method.
-        checkConfiguration(service, connector, engine, host, context);
-
-        // Start the server finally.
-        try {
-            server.start();
-        } catch (LifecycleException e) {
-            throw new TomcatServiceException("failed to start an embedded Tomcat", e);
-        }
-
-        coyoteAdapter = protocolHandler.getAdapter();
-    }
-
-    void stop() {
-        StandardServer server = this.server;
-        this.server = null;
-        coyoteAdapter = null;
-
-        if (server != null) {
-            logger.info("Stopping an embedded Tomcat: {}", config());
-            server.stopAwait();
-        }
-    }
-
-    private StandardServer newServer(Connector connector, TomcatServiceConfig config) {
-        //
-        // server <------ services <------ engines <------ realm
-        //                                         <------ hosts <------ contexts
-        //                         <------ connectors
-        //                         <------ executors
-        //
-
-        final StandardEngine engine = new StandardEngine();
-        engine.setName(config.engineName());
-        engine.setDefaultHost(config.hostname());
-        engine.setRealm(config.realm());
-
-        final StandardService service = new StandardService();
-        service.setName(config.serviceName());
-        service.setContainer(engine);
-
-        service.addConnector(connector);
-
-        final StandardServer server = new StandardServer();
-
-        final File baseDir = config.baseDir().toFile();
-        server.setCatalinaBase(baseDir);
-        server.setCatalinaHome(baseDir);
-        server.setPort(EMBEDDED_TOMCAT_PORT);
-
-        server.addService(service);
-
-        // Add the web application context.
-        // Get or create a host.
-        StandardHost host = (StandardHost) engine.findChild(config.hostname());
-        if (host == null) {
-            host = new StandardHost();
-            host.setName(config.hostname());
-            engine.addChild(host);
-        }
-
-        // Create a new context and add it to the host.
-        final Context ctx;
-        try {
-            ctx = (Context) Class.forName(host.getContextClass(), true, getClass().getClassLoader()).newInstance();
-        } catch (Exception e) {
-            throw new TomcatServiceException("failed to create a new context: " + config, e);
-        }
-
-        ctx.setPath(ROOT_CONTEXT_PATH);
-        ctx.setDocBase(config.docBase().toString());
-        ctx.addLifecycleListener(TomcatUtil.getDefaultWebXmlListener());
-        ctx.setConfigFile(TomcatUtil.getWebAppConfigFile(ROOT_CONTEXT_PATH, config.docBase()));
-
-        final ContextConfig ctxCfg = new ContextConfig();
-        ctxCfg.setDefaultWebXml(TomcatUtil.noDefaultWebXmlPath());
-        ctx.addLifecycleListener(ctxCfg);
-
-        host.addChild(ctx);
-
-        return server;
-    }
-
-    private void checkConfiguration(Service expectedService, Connector expectedConnector,
-                                    Engine expectedEngine, StandardHost expectedHost, Context expectedContext) {
-
-
-        // Check if Catalina base and home directories have not been changed.
-        final File expectedBaseDir = config.baseDir().toFile();
-        if (!Objects.equals(server.getCatalinaBase(), expectedBaseDir) ||
-            !Objects.equals(server.getCatalinaHome(), expectedBaseDir)) {
-            throw new TomcatServiceException("A configurator should never change the Catalina base and home.");
-        }
-
-        // Check if the server's port has not been changed.
-        if (server.getPort() != EMBEDDED_TOMCAT_PORT) {
-            throw new TomcatServiceException("A configurator should never change the port of the server.");
-        }
-
-        // Check if the default service has not been removed and a new service has not been added.
-        final Service[] services = server.findServices();
-        if (services == null || services.length != 1 || services[0] != expectedService) {
-            throw new TomcatServiceException(
-                    "A configurator should never remove the default service or add a new service.");
-        }
-
-        // Check if the name of the default service has not been changed.
-        if (!config().serviceName().equals(expectedService.getName())) {
-            throw new TomcatServiceException(
-                    "A configurator should never change the name of the default service.");
-        }
-
-        // Check if the default connector has not been removed
-        final Connector[] connectors = expectedService.findConnectors();
-        if (connectors == null || Arrays.stream(connectors).noneMatch(c -> c == expectedConnector)) {
-            throw new TomcatServiceException("A configurator should never remove the default connector.");
-        }
-
-        // Check if the engine has not been changed.
-        @SuppressWarnings("deprecation")
-        final Container actualEngine = expectedService.getContainer();
-        if (actualEngine != expectedEngine) {
-            throw new TomcatServiceException(
-                    "A configurator should never change the engine of the default service.");
-        }
-
-        // Check if the engine's name has not been changed.
-        if (!config().engineName().equals(expectedEngine.getName())) {
-            throw new TomcatServiceException(
-                    "A configurator should never change the name of the default engine.");
-        }
-
-        // Check if the default realm has not been changed.
-        if (expectedEngine.getRealm() != config().realm()) {
-            throw new TomcatServiceException("A configurator should never change the default realm.");
-        }
-
-        // Check if the default host has not been removed.
-        final Container[] engineChildren = expectedEngine.findChildren();
-        if (engineChildren == null || Arrays.stream(engineChildren).noneMatch(c -> c == expectedHost)) {
-            throw new TomcatServiceException("A configurator should never remove the default host.");
-        }
-
-        // Check if the default context has not been removed.
-        final Container[] contextChildren = expectedHost.findChildren();
-        if (contextChildren == null || Arrays.stream(contextChildren).noneMatch(c -> c == expectedContext)) {
-            throw new TomcatServiceException("A configurator should never remove the default context.");
-        }
-
-        // Check if the docBase of the default context has not been changed.
-        if (!config.docBase().toString().equals(expectedContext.getDocBase())) {
-            throw new TomcatServiceException(
-                    "A configurator should never change the docBase of the default context.");
-        }
+    Connector connector() {
+        return connector;
     }
 
     @Override
     public void invoke(ServiceInvocationContext ctx,
                        Executor blockingTaskExecutor, Promise<Object> promise) throws Exception {
+        final Adapter coyoteAdapter = connector.getProtocolHandler().getAdapter();
+        if (coyoteAdapter == null) {
+            // Tomcat is not configured / stopped.
+            promise.tryFailure(new ServiceUnavailableException());
+            return;
+        }
 
         final Request coyoteReq = convertRequest(ctx);
         final Response coyoteRes = new Response();
@@ -360,7 +132,7 @@ final class TomcatServiceInvocationHandler implements ServiceInvocationHandler {
         // Set the local host/address.
         final InetSocketAddress localAddr = (InetSocketAddress) ctx.localAddress();
         coyoteReq.localAddr().setString(localAddr.getAddress().getHostAddress());
-        coyoteReq.localName().setString(config().hostname());
+        coyoteReq.localName().setString(hostname);
         coyoteReq.setLocalPort(localAddr.getPort());
 
         // Set the method.
@@ -476,17 +248,5 @@ final class TomcatServiceInvocationHandler implements ServiceInvocationHandler {
 
         final ByteChunk chunk = value.getByteChunk();
         return new AsciiString(chunk.getBuffer(), chunk.getOffset(), chunk.getLength(), false);
-    }
-
-    private final class Configurator extends ServerListenerAdapter {
-        @Override
-        public void serverStarting(Server server) {
-            start();
-        }
-
-        @Override
-        public void serverStopped(Server server) {
-            stop();
-        }
     }
 }

--- a/src/test/java/com/linecorp/armeria/server/http/tomcat/UnmanagedTomcatServiceTest.java
+++ b/src/test/java/com/linecorp/armeria/server/http/tomcat/UnmanagedTomcatServiceTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2015 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.http.tomcat;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.apache.catalina.LifecycleException;
+import org.apache.catalina.connector.Connector;
+import org.apache.catalina.startup.Tomcat;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.linecorp.armeria.server.AbstractServerTest;
+import com.linecorp.armeria.server.ServerBuilder;
+
+public class UnmanagedTomcatServiceTest extends AbstractServerTest {
+    private static Tomcat tomcat;
+
+    @BeforeClass
+    public static void createTomcat() {
+        tomcat = new Tomcat();
+    }
+
+    @Override
+    protected void configureServer(ServerBuilder sb) throws LifecycleException {
+        tomcat.start();
+        Connector configuredConnector = tomcat.getConnector();
+
+        sb.serviceUnder("/empty/", TomcatService.forConnector("somehost", new Connector()))
+          .serviceUnder("/some/", TomcatService.forConnector("somehost", configuredConnector));
+    }
+
+    @Test
+    public void testUnavailableStatus() throws Exception {
+        try (CloseableHttpClient hc = HttpClients.createMinimal()) {
+            try (CloseableHttpResponse res = hc.execute(new HttpGet(uri("/empty/")))) {
+                // as connector is not configured, TomcatServiceInvocationHandler will throw.
+                assertThat(res.getStatusLine().toString(), is("HTTP/1.1 503 Service Unavailable"));
+            }
+        }
+    }
+
+    @Test
+    public void testSomeStatus() throws Exception {
+        try (CloseableHttpClient hc = HttpClients.createMinimal()) {
+            try (CloseableHttpResponse res = hc.execute(new HttpGet(uri("/some/")))) {
+                // as no webapp is configured inside tomcat, 500 will be thrown.
+                assertThat(res.getStatusLine().toString(), is("HTTP/1.1 500 Internal Server Error"));
+            }
+        }
+    }
+
+    @After
+    public void stopTomcat() throws LifecycleException {
+        tomcat.stop();
+    }
+
+    @AfterClass
+    public static void destroyTomcat() throws LifecycleException {
+        tomcat.destroy();
+    }
+}


### PR DESCRIPTION
Beware: this PR is still in POC state, don't merge this as is.

Motivation:

Introduce a way to setup TomcatService using existing Embedded Tomcat
instance.  possible usage can be found at [HERE](https://github.com/blmarket/spring-boot-armeria-demo/blob/master/src/main/java/com/linecorp/DemoApplication.java)

Modification:

Split TomcatServiceInvocationHandler into two classes,
introduced class is instantiated using configured hostname and
Connector, and provides ServiceInvocationHandler interface using those
values.

(TBD) I've left TomcatServiceInvocationHandler for
backward-compatibility. But as this class is not public, roles of the
class can be migrated into `TomcatServiceBuilder`, with little logical
changes.

(TBD) name of introduced class is not yet determined.

Result:

Easier TomcatService integration with other framework like spring