### PR TITLE
Use the same default maxFrameLength for both sides

### DIFF
--- a/src/main/java/com/linecorp/armeria/client/RemoteInvokerOptions.java
+++ b/src/main/java/com/linecorp/armeria/client/RemoteInvokerOptions.java
@@ -44,7 +44,7 @@ public class RemoteInvokerOptions extends AbstractOptions {
 
     private static final Duration DEFAULT_CONNECTION_TIMEOUT = Duration.ofMillis(3200);
     private static final Duration DEFAULT_IDLE_TIMEOUT = Duration.ofSeconds(10);
-    private static final int DEFAULT_MAX_FRAME_LENGTH = 10485760; //10 MB
+    private static final int DEFAULT_MAX_FRAME_LENGTH = 10 * 1024 * 1024; // 10 MB
     private static final Integer DEFAULT_MAX_CONCURRENCY = Integer.MAX_VALUE;
 
     private static final RemoteInvokerOptionValue<?>[] DEFAULT_OPTION_VALUES = {

--- a/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -65,7 +65,7 @@ public final class ServerBuilder {
     private static final TimeoutPolicy DEFAULT_REQUEST_TIMEOUT_POLICY =
             TimeoutPolicy.ofFixed(Duration.ofSeconds(10));
     private static final long DEFAULT_IDLE_TIMEOUT_MILLIS = Duration.ofSeconds(10).toMillis();
-    private static final int DEFAULT_MAX_FRAME_LENGTH = 1048576;
+    private static final int DEFAULT_MAX_FRAME_LENGTH = 10 * 1024 * 1024; // 10 MB
     // Defaults to no graceful shutdown.
     private static final Duration DEFAULT_GRACEFUL_SHUTDOWN_QUIET_PERIOD = Duration.ZERO;
     private static final Duration DEFAULT_GRACEFUL_SHUTDOWN_TIMEOUT = Duration.ZERO;


### PR DESCRIPTION
Motivation:

The current default maxFrameLength values for client and server are 10
MB and 1 MB respectively. Having different default values gives a user
surprises.

Modifications:

Use the same default maxFrameLength value (10 MB) for client and server

Result:

Fixes #118