### PR TITLE
Make EventLoop available to RemoteInvoker.invoke()

### DIFF
--- a/src/main/java/com/linecorp/armeria/client/ClientBuilder.java
+++ b/src/main/java/com/linecorp/armeria/client/ClientBuilder.java
@@ -236,10 +236,10 @@ public final class ClientBuilder {
 
         final ClientOptions options = ClientOptions.of(this.options.values());
 
-        final Client decoratable = options.decorator().apply(newClient(interfaceClass));
+        final Client client = options.decorator().apply(newClient(interfaceClass));
 
         final InvocationHandler handler = new ClientInvocationHandler(
-                uri, interfaceClass, decoratable.invoker(), decoratable.codec(), options);
+                remoteInvokerFactory.eventLoopGroup(), uri, interfaceClass, client, options);
 
         return (T) Proxy.newProxyInstance(interfaceClass.getClassLoader(),
                                           new Class[] { interfaceClass },

--- a/src/main/java/com/linecorp/armeria/client/Clients.java
+++ b/src/main/java/com/linecorp/armeria/client/Clients.java
@@ -183,7 +183,8 @@ public final class Clients {
         final T derived = (T) Proxy.newProxyInstance(
                 interfaceClass.getClassLoader(),
                 new Class[] { interfaceClass },
-                new ClientInvocationHandler(parent.uri(), interfaceClass, parent.invoker(), parent.codec(),
+                new ClientInvocationHandler(parent.eventLoopGroup(),
+                                            parent.uri(), interfaceClass, parent.client(),
                                             optionFactory.apply(parent.options())));
 
         return derived;

--- a/src/main/java/com/linecorp/armeria/client/DecoratingRemoteInvoker.java
+++ b/src/main/java/com/linecorp/armeria/client/DecoratingRemoteInvoker.java
@@ -21,6 +21,7 @@ import static java.util.Objects.requireNonNull;
 import java.lang.reflect.Method;
 import java.net.URI;
 
+import io.netty.channel.EventLoop;
 import io.netty.util.concurrent.Future;
 
 /**
@@ -48,12 +49,12 @@ public abstract class DecoratingRemoteInvoker implements RemoteInvoker {
     }
 
     @Override
-    public <T> Future<T> invoke(URI uri,
+    public <T> Future<T> invoke(EventLoop eventLoop, URI uri,
                                 ClientOptions options,
                                 ClientCodec codec, Method method,
                                 Object[] args) throws Exception {
 
-        return delegate().invoke(uri, options, codec, method, args);
+        return delegate().invoke(eventLoop, uri, options, codec, method, args);
     }
 
     @Override

--- a/src/main/java/com/linecorp/armeria/client/RemoteInvoker.java
+++ b/src/main/java/com/linecorp/armeria/client/RemoteInvoker.java
@@ -19,6 +19,7 @@ package com.linecorp.armeria.client;
 import java.lang.reflect.Method;
 import java.net.URI;
 
+import io.netty.channel.EventLoop;
 import io.netty.util.concurrent.Future;
 
 /**
@@ -29,6 +30,7 @@ public interface RemoteInvoker extends AutoCloseable {
     /**
      * Performs a remote invocation to the specified {@link URI}.
      *
+     * @param eventLoop the {@link EventLoop} to perform the invocation
      * @param uri the {@link URI} of the server endpoint
      * @param options the {@link ClientOptions}
      * @param codec the {@link ClientCodec}
@@ -37,8 +39,8 @@ public interface RemoteInvoker extends AutoCloseable {
      *
      * @return the {@link Future} that notifies the result of the remote invocation.
      */
-    <T> Future<T> invoke(URI uri, ClientOptions options, ClientCodec codec, Method method, Object[] args)
-            throws Exception;
+    <T> Future<T> invoke(EventLoop eventLoop, URI uri, ClientOptions options, ClientCodec codec,
+                         Method method, Object[] args) throws Exception;
 
     /**
      * Closes the underlying socket connection and releases its associated resources.

--- a/src/main/java/com/linecorp/armeria/client/RemoteInvokerFactory.java
+++ b/src/main/java/com/linecorp/armeria/client/RemoteInvokerFactory.java
@@ -126,7 +126,7 @@ public final class RemoteInvokerFactory implements AutoCloseable {
         }
 
         final EnumMap<SessionProtocol, RemoteInvoker> remoteInvokers = new EnumMap<>(SessionProtocol.class);
-        final HttpRemoteInvoker remoteInvoker = new HttpRemoteInvoker(eventLoopGroup, baseBootstrap, options);
+        final HttpRemoteInvoker remoteInvoker = new HttpRemoteInvoker(baseBootstrap, options);
 
         SessionProtocol.ofHttp().stream().forEach(
                 protocol -> remoteInvokers.put(protocol, remoteInvoker));


### PR DESCRIPTION
Motivation:

EventLoop to perform the actual invocation is determined at the
HttpRemoteInvoker.invoke() method, which is the last moment right before
the invocation.

It means decorating RemoteInvokers does not have an access to the
EventLoop, nevertheless the EventLoop can be determined from the
beginning of the invocation.

A decorating RemoteInvoker with an access to an EventLoop could create
Future/Promise and schedule a task, which will be useful when building
an advanced decorator such as a circuit breaker.

Modifications:

- Add EventLoop parameter to RemoteInvoker.invoke()
- Determine the EventLoop to perform the invocation in
  ClientInvocationHandler instead of in HttpRemoteInvoker
  - Move HttpRemoteInvoker.eventLoop() to ClientInvocationHandler
- Reorder the methods in HttpRemoteInvoker for readability

Result:

A decorating RemoteInvoker now has an access to the EventLoop which will
perform the actual invocation.