### PR TITLE
Simplify exception handling in ClientInvocationHandler

### DIFF
--- a/src/main/java/com/linecorp/armeria/client/ClosedSessionException.java
+++ b/src/main/java/com/linecorp/armeria/client/ClosedSessionException.java
@@ -15,7 +15,7 @@
  */
 package com.linecorp.armeria.client;
 
-import io.netty.util.internal.EmptyArrays;
+import com.linecorp.armeria.common.util.Exceptions;
 
 /**
  * A {@link RuntimeException} raised when the connection to the server has been closed unexpectedly.
@@ -24,12 +24,7 @@ public class ClosedSessionException extends RuntimeException {
 
     private static final long serialVersionUID = -78487475521731580L;
 
-    @SuppressWarnings("ThrowableInstanceNeverThrown")
-    static final ClosedSessionException INSTANCE = new ClosedSessionException();
-
-    static {
-        INSTANCE.setStackTrace(EmptyArrays.EMPTY_STACK_TRACE);
-    }
+    static final ClosedSessionException INSTANCE = Exceptions.clearTrace(new ClosedSessionException());
 
     /**
      * Creates a new instance.

--- a/src/main/java/com/linecorp/armeria/client/HttpRemoteInvoker.java
+++ b/src/main/java/com/linecorp/armeria/client/HttpRemoteInvoker.java
@@ -28,6 +28,7 @@ import java.net.InetSocketAddress;
 import java.net.URI;
 import java.util.EnumSet;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -58,7 +59,6 @@ import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.internal.OneTimeTask;
-import io.netty.util.internal.PlatformDependent;
 
 final class HttpRemoteInvoker implements RemoteInvoker {
 
@@ -69,7 +69,7 @@ final class HttpRemoteInvoker implements RemoteInvoker {
 
     static final Set<SessionProtocol> HTTP_PROTOCOLS = EnumSet.of(H1, H1C, H2, H2C, HTTPS, HTTP);
 
-    final ConcurrentMap<EventLoop, KeyedChannelPool<PoolKey>> map = PlatformDependent.newConcurrentHashMap();
+    final ConcurrentMap<EventLoop, KeyedChannelPool<PoolKey>> map = new ConcurrentHashMap<>();
 
     private final Bootstrap baseBootstrap;
     private final RemoteInvokerOptions options;

--- a/src/main/java/com/linecorp/armeria/common/http/AbstractHttpToHttp2ConnectionHandler.java
+++ b/src/main/java/com/linecorp/armeria/common/http/AbstractHttpToHttp2ConnectionHandler.java
@@ -16,32 +16,18 @@
 
 package com.linecorp.armeria.common.http;
 
-import static io.netty.handler.codec.http2.Http2CodecUtil.HTTP_UPGRADE_STREAM_ID;
-
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http2.Http2ConnectionDecoder;
 import io.netty.handler.codec.http2.Http2ConnectionEncoder;
 import io.netty.handler.codec.http2.Http2ConnectionHandler;
-import io.netty.handler.codec.http2.Http2Error;
 import io.netty.handler.codec.http2.Http2Exception;
-import io.netty.handler.codec.http2.Http2Exception.StreamException;
 import io.netty.handler.codec.http2.Http2Settings;
 import io.netty.handler.codec.http2.Http2Stream.State;
 import io.netty.handler.codec.http2.Http2StreamVisitor;
 import io.netty.handler.codec.http2.HttpToHttp2ConnectionHandler;
-import io.netty.util.internal.EmptyArrays;
 
 public abstract class AbstractHttpToHttp2ConnectionHandler extends HttpToHttp2ConnectionHandler {
-
-    private static final StreamException REFUSED_STREAM_EXCEPTION =
-            (StreamException) Http2Exception.streamError(
-                    HTTP_UPGRADE_STREAM_ID, Http2Error.REFUSED_STREAM,
-                    "The request sent with the upgrade request has been refused; try again.");
-
-    static {
-        REFUSED_STREAM_EXCEPTION.setStackTrace(EmptyArrays.EMPTY_STACK_TRACE);
-    }
 
     /**
      * XXX(trustin): Don't know why, but {@link Http2ConnectionHandler} does not close the last stream

--- a/src/main/java/com/linecorp/armeria/common/util/Exceptions.java
+++ b/src/main/java/com/linecorp/armeria/common/util/Exceptions.java
@@ -29,7 +29,6 @@ import com.linecorp.armeria.client.ClosedSessionException;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelException;
 import io.netty.handler.codec.http2.Http2Exception;
-import io.netty.util.internal.EmptyArrays;
 
 /**
  * Provides the methods that are useful for handling exceptions.
@@ -41,6 +40,8 @@ public final class Exceptions {
 
     private static final Pattern IGNORABLE_HTTP2_ERROR_MESSAGE = Pattern.compile(
             "(?:stream closed)", Pattern.CASE_INSENSITIVE);
+
+    private static final StackTraceElement[] EMPTY_STACK_TRACE = new StackTraceElement[0];
 
     /**
      * Logs the specified exception if it is {@linkplain #isExpected(Throwable)} unexpected}.
@@ -104,7 +105,7 @@ public final class Exceptions {
      */
     public static <T extends Throwable> T clearTrace(T exception) {
         requireNonNull(exception, "exception");
-        exception.setStackTrace(EmptyArrays.EMPTY_STACK_TRACE);
+        exception.setStackTrace(EMPTY_STACK_TRACE);
         return exception;
     }
 

--- a/src/main/java/com/linecorp/armeria/server/Server.java
+++ b/src/main/java/com/linecorp/armeria/server/Server.java
@@ -51,7 +51,6 @@ import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GlobalEventExecutor;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 import io.netty.util.concurrent.Promise;
-import io.netty.util.internal.PlatformDependent;
 
 /**
  * Listens to {@link ServerPort}s and delegates client requests to {@link Service}s.
@@ -407,15 +406,11 @@ public final class Server implements AutoCloseable {
     }
 
     /**
-     * A shortcut to {@link #stop() stop().sync()}.
+     * A shortcut to {@link #stop() stop().syncUninterruptibly()}.
      */
     @Override
     public void close() {
-        try {
-            stop().sync();
-        } catch (Exception e) {
-            PlatformDependent.throwException(e);
-        }
+        stop().syncUninterruptibly();
     }
 
     enum StateType {

--- a/src/main/java/com/linecorp/armeria/server/thrift/ThriftServiceCodec.java
+++ b/src/main/java/com/linecorp/armeria/server/thrift/ThriftServiceCodec.java
@@ -50,6 +50,7 @@ import com.linecorp.armeria.common.ServiceInvocationContext;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.thrift.ThriftProtocolFactories;
 import com.linecorp.armeria.common.thrift.ThriftUtil;
+import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.server.ServiceCodec;
 import com.linecorp.armeria.server.ServiceConfig;
 
@@ -63,24 +64,19 @@ import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.util.concurrent.Promise;
-import io.netty.util.internal.EmptyArrays;
 
 final class ThriftServiceCodec implements ServiceCodec {
 
-    @SuppressWarnings("ThrowableInstanceNeverThrown")
     private static final Exception HTTP_METHOD_NOT_ALLOWED_EXCEPTION =
-            new IllegalArgumentException("HTTP method not allowed");
-    @SuppressWarnings("ThrowableInstanceNeverThrown")
-    private static final Exception THRIFT_PROTOCOL_NOT_SUPPORTED =
-            new IllegalArgumentException("Specified Thrift protocol not supported");
-    @SuppressWarnings("ThrowableInstanceNeverThrown")
-    private static final Exception ACCEPT_THRIFT_PROTOCOL_MUST_MATCH_CONTENT_TYPE =
-            new IllegalArgumentException("Thrift protocol specified in Accept header must match the one " +
-                                         "specified in Content-Type header");
+            Exceptions.clearTrace(new IllegalArgumentException("HTTP method not allowed"));
 
-    static {
-        HTTP_METHOD_NOT_ALLOWED_EXCEPTION.setStackTrace(EmptyArrays.EMPTY_STACK_TRACE);
-    }
+    private static final Exception THRIFT_PROTOCOL_NOT_SUPPORTED =
+            Exceptions.clearTrace(new IllegalArgumentException("Specified Thrift protocol not supported"));
+
+    private static final Exception ACCEPT_THRIFT_PROTOCOL_MUST_MATCH_CONTENT_TYPE =
+            Exceptions.clearTrace(new IllegalArgumentException(
+                    "Thrift protocol specified in Accept header must match the one specified " +
+                    "in Content-Type header"));
 
     private static final Logger logger = LoggerFactory.getLogger(ThriftServiceCodec.class);
 


### PR DESCRIPTION
Motivation:

ClientInvocationHandler wraps an exception raised by
RemoteInvoker.invoke() with UndeclaredThrowableException if it is a
checked exception that's not listed in the method's 'throws' clause.

However, this behavioe is redundant because Java's proxy generator
(sun.misc.ProxyGenerator) already does that for us:

Modifications:

- Simplify exception handling code
- Miscellaneous:
  - Refrain from using PlatformDependent wherever possible

Result:

Less code