### PR TITLE
Allow registering callbacks when propagating a ServiceInvocationConte…

### DIFF
--- a/src/main/java/com/linecorp/armeria/server/tracing/ServerTracingInterceptor.java
+++ b/src/main/java/com/linecorp/armeria/server/tracing/ServerTracingInterceptor.java
@@ -53,6 +53,10 @@ class ServerTracingInterceptor {
         return spanThreadBinder.getCurrentServerSpan();
     }
 
+    void setSpan(ServerSpan span) {
+        spanThreadBinder.setCurrentSpan(span);
+    }
+
     void closeSpan(ServerSpan span, ServerResponseAdapter adapter) {
         spanThreadBinder.setCurrentSpan(span);
         responseInterceptor.handle(adapter);

--- a/src/main/java/com/linecorp/armeria/server/tracing/TracingServiceInvocationHandler.java
+++ b/src/main/java/com/linecorp/armeria/server/tracing/TracingServiceInvocationHandler.java
@@ -61,6 +61,8 @@ public abstract class TracingServiceInvocationHandler extends DecoratingServiceI
 
         final ServerSpan span = serverInterceptor.openSpan(requestAdapter);
         if (span != null && span.getSample()) {
+            ctx.onEnter(() -> serverInterceptor.setSpan(span))
+               .onExit(serverInterceptor::clearSpan);
             promise.addListener(future -> {
                 serverInterceptor.closeSpan(span, createResponseAdapter(ctx, future));
             });

--- a/src/test/java/com/linecorp/armeria/server/tracing/TracingServiceInvocationHandlerTest.java
+++ b/src/test/java/com/linecorp/armeria/server/tracing/TracingServiceInvocationHandlerTest.java
@@ -35,6 +35,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 import org.junit.Test;
+import org.mockito.Matchers;
 
 import com.github.kristofa.brave.Brave;
 import com.github.kristofa.brave.KeyValueAnnotation;
@@ -108,6 +109,8 @@ public class TracingServiceInvocationHandlerTest extends TracingTestBase {
 
         ServiceInvocationContext ctx = mock(ServiceInvocationContext.class);
         when(ctx.method()).thenReturn(TEST_SPAN);
+        when(ctx.onEnter(Matchers.isA(Runnable.class))).thenReturn(ctx);
+        when(ctx.onExit(Matchers.isA(Runnable.class))).thenReturn(ctx);
         Executor executor = mock(Executor.class);
         Promise<Object> promise = mockPromise();
 


### PR DESCRIPTION
…xt and set them for tracing.

In fully asynchronous servers, it is common to jump in and out of the execution thread, and we need to restore ThreadLocal state every time this happens. We have the makeContextAware family of methods to restore ServiceInvocationContext, but for tracing we also need to restore the ServerSpan.