### PR TITLE
Disconnect before HTTP/2 stream ID overflows

### DIFF
--- a/src/main/java/com/linecorp/armeria/client/HttpConfigurator.java
+++ b/src/main/java/com/linecorp/armeria/client/HttpConfigurator.java
@@ -465,7 +465,7 @@ class HttpConfigurator extends ChannelDuplexHandler {
         return new Http1ClientCodec() {
             @Override
             public void close(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
-                HttpSessionHandler.deactivate(ctx.channel());
+                HttpSessionHandler.get(ctx.channel()).deactivate();
                 super.close(ctx, promise);
             }
         };
@@ -480,7 +480,7 @@ class HttpConfigurator extends ChannelDuplexHandler {
 
         @Override
         protected void onCloseRequest(ChannelHandlerContext ctx) throws Exception {
-            HttpSessionHandler.deactivate(ctx.channel());
+            HttpSessionHandler.get(ctx.channel()).deactivate();
         }
     }
 

--- a/src/main/java/com/linecorp/armeria/client/HttpSession.java
+++ b/src/main/java/com/linecorp/armeria/client/HttpSession.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import com.linecorp.armeria.common.SessionProtocol;
+
+interface HttpSession {
+
+    HttpSession INACTIVE = new HttpSession() {
+        @Override
+        public SessionProtocol protocol() {
+            return null;
+        }
+
+        @Override
+        public boolean isActive() {
+            return false;
+        }
+
+        @Override
+        public boolean onRequestSent() {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public void deactivate() {}
+    };
+
+    SessionProtocol protocol();
+    boolean isActive();
+    boolean onRequestSent();
+    void deactivate();
+}

--- a/src/main/java/com/linecorp/armeria/client/HttpSessionChannelFactory.java
+++ b/src/main/java/com/linecorp/armeria/client/HttpSessionChannelFactory.java
@@ -48,7 +48,7 @@ class HttpSessionChannelFactory implements Function<PoolKey, Future<Channel>> {
     static final Object RETRY_WITH_H1C = new Object();
 
     static final ChannelHealthChecker HEALTH_CHECKER =
-            ch -> ch.eventLoop().newSucceededFuture(HttpSessionHandler.isActive(ch));
+            ch -> ch.eventLoop().newSucceededFuture(HttpSessionHandler.get(ch).isActive());
 
     private final Bootstrap baseBootstrap;
     private final EventLoop eventLoop;
@@ -137,7 +137,7 @@ class HttpSessionChannelFactory implements Function<PoolKey, Future<Channel>> {
     private void watchSessionActive0(final Channel ch, Promise<Channel> sessionPromise) {
         assert ch.eventLoop().inEventLoop();
 
-        if (HttpSessionHandler.isActive(ch)) {
+        if (HttpSessionHandler.get(ch).isActive()) {
             sessionPromise.setSuccess(ch);
             return;
         }


### PR DESCRIPTION
Related issue: #69

Motivation:

When we keep an HTTP/2 connection long enough to handle more than 1G
requests, the stream ID will exceed Integer.MAX_VALUE. It's probably a
good idea for an Armeria client to close the connection before hitting
the limit.

Modifications:

- Add HttpSession that provides the operations related with session
  management
- Replace the static methods in HttpSessionHandler with get() which
  returns HttpSession that provides everything needed
- Do not return the channel to the pool if the number of the sent
  requests exceeds a threshold
- Close the channel if the number of the sent requests exceeds a
  threshold and there are no requests that await responses

Result:

- Fixes #69