### PR TITLE
Upgrade to Netty 4.1.0.CR5 / Use epoll and BoringSSL when running on linux-x86_64

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     <jackson.version>2.6.5</jackson.version>
     <logback.version>1.1.5</logback.version>
     <metrics.version>3.1.2</metrics.version>
-    <netty.version>4.1.0.CR3</netty.version>
+    <netty.version>4.1.0.CR5</netty.version>
     <slf4j.version>1.7.16</slf4j.version>
     <tomcat.version>8.0.30</tomcat.version>
     <jetty.alpnAgent.version>1.0.1.Final</jetty.alpnAgent.version>
@@ -110,6 +110,7 @@
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-native-epoll</artifactId>
       <version>${netty.version}</version>
+      <classifier>linux-x86_64</classifier>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
@@ -127,6 +128,13 @@
       <artifactId>javassist</artifactId>
       <version>3.20.0-GA</version>
       <scope>runtime</scope>
+    </dependency>
+    <!-- BoringSSL support -->
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-tcnative-boringssl-static</artifactId>
+      <version>1.1.33.Fork15</version>
+      <classifier>linux-x86_64</classifier>
     </dependency>
 
     <!-- ALPN -->

--- a/src/main/java/com/linecorp/armeria/common/ServiceInvocationContextAwareFuture.java
+++ b/src/main/java/com/linecorp/armeria/common/ServiceInvocationContextAwareFuture.java
@@ -54,7 +54,8 @@ final class ServiceInvocationContextAwareFuture<T> implements Future<T> {
     }
 
     @Override
-    public Future<T> removeListeners(
+    @SafeVarargs
+    public final Future<T> removeListeners(
             GenericFutureListener<? extends Future<? super T>>... listeners) {
         return delegate.removeListeners(listeners);
     }

--- a/src/main/java/com/linecorp/armeria/common/util/NativeLibraries.java
+++ b/src/main/java/com/linecorp/armeria/common/util/NativeLibraries.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.util;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.netty.channel.epoll.Epoll;
+import io.netty.handler.ssl.OpenSsl;
+
+/**
+ * Reports the availability of the native libraries used by Armeria
+ */
+public final class NativeLibraries {
+
+    private static final Logger logger = LoggerFactory.getLogger(NativeLibraries.class);
+    private static final AtomicBoolean reported = new AtomicBoolean();
+
+    /**
+     * Logs the availability of the native libraries used by Armeria. This method does nothing if it was
+     * called once before.
+     */
+    public static void report() {
+        if (!reported.compareAndSet(false, true)) {
+            return;
+        }
+
+        logger.info("/dev/epoll: " +
+                    (Epoll.isAvailable() ? "yes"
+                                         : "no (" + filterCause(Epoll.unavailabilityCause()) + ')'));
+
+        logger.info("OpenSSL: " +
+                    (OpenSsl.isAvailable() ? "yes (" + OpenSsl.versionString() + ", " +
+                                             OpenSsl.version() + ')'
+                                           : "no (" + filterCause(OpenSsl.unavailabilityCause()) + ')'));
+    }
+
+    private static Throwable filterCause(Throwable cause) {
+        if (cause instanceof ExceptionInInitializerError) {
+            return cause.getCause();
+        }
+
+        return cause;
+    }
+
+    private NativeLibraries() {}
+}


### PR DESCRIPTION
- Upgrade to Netty 4.1.0.CR5
- Use epoll when running on linux-x86_64
- Use BoringSSL for SSL when running on linux-x86_64
- Use different event loop names for different transport types
- Use different event loop names for bosses and workers
- Log the availability of epoll and BoringSSL