### PR TITLE
Use singleton list instead of array list for SimpleHttpInvocation#par…

### DIFF
--- a/src/main/java/com/linecorp/armeria/client/http/SimpleHttpInvocation.java
+++ b/src/main/java/com/linecorp/armeria/client/http/SimpleHttpInvocation.java
@@ -16,7 +16,6 @@
 
 package com.linecorp.armeria.client.http;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -77,7 +76,7 @@ class SimpleHttpInvocation extends ServiceInvocationContext implements EncodeRes
 
     @Override
     public List<Object> params() {
-        return Arrays.asList(originalRequest());
+        return Collections.singletonList(originalRequest());
     }
 
     @Override


### PR DESCRIPTION
…ams. Arrays.asList is a varargs method and attempts to cast the single request object into Object[] instead of Object, causing ClassCastException.