### PR TITLE
Do not create 'tomcat.8080' directory under project root directory

### DIFF
--- a/src/test/java/com/linecorp/armeria/server/http/tomcat/UnmanagedTomcatServiceTest.java
+++ b/src/test/java/com/linecorp/armeria/server/http/tomcat/UnmanagedTomcatServiceTest.java
@@ -18,6 +18,8 @@ package com.linecorp.armeria.server.http.tomcat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
+import java.io.File;
+
 import org.apache.catalina.LifecycleException;
 import org.apache.catalina.connector.Connector;
 import org.apache.catalina.startup.Tomcat;
@@ -39,6 +41,8 @@ public class UnmanagedTomcatServiceTest extends AbstractServerTest {
     @BeforeClass
     public static void createTomcat() {
         tomcat = new Tomcat();
+        tomcat.setBaseDir("target" + File.separatorChar +
+                          "tomcat-" + UnmanagedTomcatServiceTest.class.getSimpleName());
     }
 
     @Override


### PR DESCRIPTION
Motivation:

UnmanagedTomcatServiceTest does not specify the base directory of the
Tomcat, which makes the Tomcat create an empty 'tomcat.8080' directory
under the project root directory. It could be created somewhere under
'/target' instead for less distraction.

Modifications:

- Set the baseDir of Tomcat explicitly

Result:

Cleaner build