### PR TITLE
Fix delayed notification of session creation failure and log GOAWAY frames

### DIFF
--- a/src/main/java/com/linecorp/armeria/client/HttpClientIdleTimeoutHandler.java
+++ b/src/main/java/com/linecorp/armeria/client/HttpClientIdleTimeoutHandler.java
@@ -74,6 +74,7 @@ class HttpClientIdleTimeoutHandler extends IdleStateHandler {
         if (pendingResCount == 0 && evt.isFirst()) {
             logger.debug("{} Closing due to idleness", ctx.channel());
             ctx.close();
+            return;
         }
 
         ctx.fireUserEventTriggered(evt);

--- a/src/main/java/com/linecorp/armeria/common/http/Http2GoAwayListener.java
+++ b/src/main/java/com/linecorp/armeria/common/http/Http2GoAwayListener.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.http;
+
+import java.nio.charset.StandardCharsets;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.channel.Channel;
+import io.netty.handler.codec.http2.Http2Connection;
+import io.netty.handler.codec.http2.Http2ConnectionAdapter;
+import io.netty.handler.codec.http2.Http2Error;
+import io.netty.handler.codec.http2.Http2Stream;
+
+/**
+ * A {@link Http2Connection.Listener} that logs the received GOAWAY frames and makes sure disconnection.
+ */
+public class Http2GoAwayListener extends Http2ConnectionAdapter {
+
+    private static final Logger logger = LoggerFactory.getLogger(Http2GoAwayListener.class);
+
+    private final Channel ch;
+    private boolean goAwaySent;
+
+    public Http2GoAwayListener(Channel ch) {
+        this.ch = ch;
+    }
+
+    @Override
+    public void onGoAwaySent(int lastStreamId, long errorCode, ByteBuf debugData) {
+        goAwaySent = true;
+        onGoAway("Sent", lastStreamId, errorCode, debugData);
+    }
+
+    @Override
+    public void onGoAwayReceived(int lastStreamId, long errorCode, ByteBuf debugData) {
+        onGoAway("Received", lastStreamId, errorCode, debugData);
+
+        // Send a GOAWAY back to the peer and close the connection gracefully if we did not send GOAWAY yet.
+        // This will make sure that the connection is always closed after receiving GOAWAY,
+        // because otherwise we have to wait until the peer who sent GOAWAY to us closes the connection.
+        if (!goAwaySent) {
+            ch.close();
+        }
+    }
+
+    private void onGoAway(String sentOrReceived, int lastStreamId, long errorCode, ByteBuf debugData) {
+        if (errorCode != Http2Error.NO_ERROR.code()) {
+            if (logger.isWarnEnabled()) {
+                logger.warn("{} {} a GOAWAY frame: lastStreamId={}, errorCode={}, debugData=\"{}\" (Hex: {})",
+                            ch, sentOrReceived, lastStreamId, errorStr(errorCode),
+                            debugData.toString(StandardCharsets.UTF_8),
+                            ByteBufUtil.hexDump(debugData));
+            }
+        } else {
+            if (logger.isInfoEnabled()) {
+                logger.debug("{} {} a GOAWAY frame: lastStreamId={}, errorCode=NO_ERROR",
+                             ch, sentOrReceived, lastStreamId);
+            }
+        }
+    }
+
+    private static String errorStr(long errorCode) {
+        final Http2Error error = Http2Error.valueOf(errorCode);
+        return error != null ? error.toString() + '(' + errorCode + ')'
+                             : "UNKNOWN(" + errorCode + ')';
+    }
+
+    @Override
+    public void onStreamRemoved(Http2Stream stream) {
+        if (stream.id() == 1) {
+            logger.debug("{} HTTP/2 upgrade stream removed: {}", ch, stream.state());
+        }
+    }
+}

--- a/src/main/java/com/linecorp/armeria/common/util/Exceptions.java
+++ b/src/main/java/com/linecorp/armeria/common/util/Exceptions.java
@@ -25,6 +25,7 @@ import java.util.regex.Pattern;
 import org.slf4j.Logger;
 
 import com.linecorp.armeria.client.ClosedSessionException;
+import com.linecorp.armeria.common.SessionProtocol;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelException;
@@ -46,23 +47,31 @@ public final class Exceptions {
     /**
      * Logs the specified exception if it is {@linkplain #isExpected(Throwable)} unexpected}.
      */
-    public static void logIfUnexpected(Logger logger, Channel ch, Throwable cause) {
+    public static void logIfUnexpected(Logger logger, Channel ch, SessionProtocol protocol, Throwable cause) {
         if (!logger.isWarnEnabled() || isExpected(cause)) {
             return;
         }
 
-        logger.warn("{} Unexpected exception:", ch, cause);
+        logger.warn("{}[{}] Unexpected exception:",
+                    ch, protocolName(protocol), cause);
     }
 
     /**
      * Logs the specified exception if it is {@linkplain #isExpected(Throwable)} unexpected}.
      */
-    public static void logIfUnexpected(Logger logger, Channel ch, String debugData, Throwable cause) {
+    public static void logIfUnexpected(Logger logger, Channel ch, SessionProtocol protocol,
+                                       String debugData, Throwable cause) {
+
         if (!logger.isWarnEnabled() || isExpected(cause)) {
             return;
         }
 
-        logger.warn("{} Unexpected exception: {}", ch, debugData, cause);
+        logger.warn("{}[{}] Unexpected exception: {}",
+                    ch, protocolName(protocol), debugData, cause);
+    }
+
+    private static String protocolName(SessionProtocol protocol) {
+        return protocol != null ? protocol.uriText() : "<unknown>";
     }
 
     /**

--- a/src/main/java/com/linecorp/armeria/server/HttpServerIdleTimeoutHandler.java
+++ b/src/main/java/com/linecorp/armeria/server/HttpServerIdleTimeoutHandler.java
@@ -80,6 +80,7 @@ class HttpServerIdleTimeoutHandler extends IdleStateHandler {
         if (pendingResCount == 0 && evt.isFirst()) {
             logger.debug("{} Closing due to idleness", ctx.channel());
             ctx.close();
+            return;
         }
 
         ctx.fireUserEventTriggered(evt);

--- a/src/main/java/com/linecorp/armeria/server/ServerInitializer.java
+++ b/src/main/java/com/linecorp/armeria/server/ServerInitializer.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.http.AbstractHttpToHttp2ConnectionHandler;
+import com.linecorp.armeria.common.http.Http2GoAwayListener;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
@@ -45,6 +46,7 @@ import io.netty.handler.codec.http2.Http2ConnectionEncoder;
 import io.netty.handler.codec.http2.Http2ConnectionHandler;
 import io.netty.handler.codec.http2.Http2Exception;
 import io.netty.handler.codec.http2.Http2FrameListener;
+import io.netty.handler.codec.http2.Http2FrameListenerDecorator;
 import io.netty.handler.codec.http2.Http2FrameReader;
 import io.netty.handler.codec.http2.Http2FrameWriter;
 import io.netty.handler.codec.http2.Http2ServerUpgradeCodec;
@@ -142,6 +144,8 @@ final class ServerInitializer extends ChannelInitializer<Channel> {
     private Http2ConnectionHandler createHttp2ConnectionHandler(ChannelPipeline pipeline, ChannelHandler... toRemove) {
         final boolean validateHeaders = true;
         final Http2Connection conn = new DefaultHttp2Connection(true);
+        conn.addListener(new Http2GoAwayListener(pipeline.channel()));
+
         final Http2FrameListener listener = new InboundHttp2ToHttpAdapterBuilder(conn)
                 .propagateSettings(true).validateHttpHeaders(validateHeaders)
                 .maxContentLength(config.maxFrameLength()).build();


### PR DESCRIPTION
Motivation:

When a connection is closed before session protocol negotiation succeeds
or fails, the Promise of session creation is not notified immediately
but only after the session creation timeout. As a result, the
notification of session creation due to an unexpected disconnection can
take up to as long as connection timeout (3.2 seconds by default)

Also, we need to log more:

- the information about GOAWAY frames we sent and received
- the current session protocol when an unexpected exception occurred

Modifications:

- Try to reject the session creation promise when a connection has been
  closed.
- Add Http2GoAwayListener and add it to both client and server
  connections so that we have more information about GOAWAY frames we
  send and receive.
- Log the current session protocol when logging an unexpected exception
- Log the pre-upgrade request and the removal of the upgrade stream to
  see if there's a case where the upgrade stream is removed before
  sending the first response
- Miscellaneous:
  - Do not propagate IdleStateEvent in Http*IdleTimeoutHandler.

Result:

- Session creation failure is notified much sooner in the situation
  described above.
- We will have more information about GOAWAY frames and unexpected
  behaviors related with session protocol negotiation