### PR TITLE
Do not attempt to send a response to a closed connection/stream

### DIFF
--- a/src/main/java/com/linecorp/armeria/server/ServiceConfig.java
+++ b/src/main/java/com/linecorp/armeria/server/ServiceConfig.java
@@ -115,6 +115,9 @@ public final class ServiceConfig {
                         buf.append(ch);
                     } else {
                         buf.append('_');
+                        if (Character.isJavaIdentifierPart(ch)) {
+                            buf.append(ch);
+                        }
                     }
                 } else {
                     if (Character.isJavaIdentifierPart(ch)) {


### PR DESCRIPTION
Motivation:

An HTTP/2 stream can be closed by various reasons, such as RST_STREAM
and GOAWAY frame. If Armeria server attempts to write a response to a
closed connection or a closed HTTP/2 stream, Netty's Http2Connection
will reject it with an unexpected exception, such as:

    Http2Exception: Cannot create stream 1 since this endpoint has
                    received a GOAWAY frame with last stream id 0

    Http2Exception: Request stream N is not correct for server
                    connection

    Http2Exception: Request stream ODD_N is not correct for server
                    connection

Modifications:

- Make sure that the connection is still active and the HTTP/2 stream
  associated with the response is still not closed
- Replace useHeadOfBlocking flag with http2conn field which becomes
  non-null when upgraded to HTTP/2
- Miscellaneous:
  - Remove redundant Future.isDone() check
  - Set the 'content-length' even if the current protocol is HTTP/1 and
    the response being written is the last response, to work around
    overly strict clients

Result:

Less mysterious yet noisy exceptions in the log