### PR TITLE
Add more debug information to HTTP/2 GOAWAY frame

### DIFF
--- a/src/main/java/com/linecorp/armeria/common/http/Http2GoAwayListener.java
+++ b/src/main/java/com/linecorp/armeria/common/http/Http2GoAwayListener.java
@@ -70,7 +70,7 @@ public class Http2GoAwayListener extends Http2ConnectionAdapter {
                             ByteBufUtil.hexDump(debugData));
             }
         } else {
-            if (logger.isInfoEnabled()) {
+            if (logger.isDebugEnabled()) {
                 logger.debug("{} {} a GOAWAY frame: lastStreamId={}, errorCode=NO_ERROR",
                              ch, sentOrReceived, lastStreamId);
             }

--- a/src/main/java/com/linecorp/armeria/common/util/Exceptions.java
+++ b/src/main/java/com/linecorp/armeria/common/util/Exceptions.java
@@ -19,6 +19,8 @@ package com.linecorp.armeria.common.util;
 import static java.util.Objects.requireNonNull;
 
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.nio.channels.ClosedChannelException;
 import java.util.regex.Pattern;
 
@@ -116,6 +118,18 @@ public final class Exceptions {
         requireNonNull(exception, "exception");
         exception.setStackTrace(EMPTY_STACK_TRACE);
         return exception;
+    }
+
+    /**
+     * Returns the stack trace of the specified {@code exception} as a {@link String}.
+     */
+    public static String traceText(Throwable exception) {
+        requireNonNull(exception, "exception");
+        final StringWriter out = new StringWriter(256);
+        final PrintWriter pout = new PrintWriter(out);
+        exception.printStackTrace(pout);
+        pout.flush();
+        return out.toString();
     }
 
     private Exceptions() {}


### PR DESCRIPTION
Motivation:

An HTTP/2 GOAWAY frame with non-zero error code sometimes gives an empty
debugData, making it hard to determine the root cause of the error.

Modifications:

- Add the following information to debugData:
  - the exact type of Http2Exception
  - the original message of Http2Exception
  - the exact type, message and stack trace of the cause of Http2Exception
- Add Exceptions.traceText() to stringify the stack trace of an
  exception
- Fix incorrect Logger level check

Result:

We will have more information when we get an error GOAWAY frame.