### PR TITLE
Make Tomcat allow a .JAR file that contains a webapp

### DIFF
--- a/src/main/java/com/linecorp/armeria/server/Server.java
+++ b/src/main/java/com/linecorp/armeria/server/Server.java
@@ -47,7 +47,6 @@ import io.netty.channel.epoll.EpollEventLoopGroup;
 import io.netty.channel.epoll.EpollServerSocketChannel;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
-import io.netty.handler.ssl.OpenSsl;
 import io.netty.handler.ssl.SslContext;
 import io.netty.util.DomainMappingBuilder;
 import io.netty.util.DomainNameMapping;

--- a/src/main/java/com/linecorp/armeria/server/http/tomcat/ArmeriaWebResourceRoot.java
+++ b/src/main/java/com/linecorp/armeria/server/http/tomcat/ArmeriaWebResourceRoot.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.http.tomcat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import org.apache.catalina.Context;
+import org.apache.catalina.WebResourceSet;
+import org.apache.catalina.webresources.DirResourceSet;
+import org.apache.catalina.webresources.JarResourceSet;
+import org.apache.catalina.webresources.StandardRoot;
+
+/**
+ * A {@link StandardRoot} that accepts any ZIP-based archive files.
+ */
+final class ArmeriaWebResourceRoot extends StandardRoot {
+
+    private final TomcatServiceConfig config;
+
+    ArmeriaWebResourceRoot(Context context, TomcatServiceConfig config) {
+        super(context);
+        this.config = config;
+    }
+
+    @Override
+    protected WebResourceSet createMainResourceSet() {
+        final Path docBase = config.docBase();
+        final String docBaseStr = docBase.toString();
+
+        assert docBase.isAbsolute();
+        assert docBaseStr.equals(getContext().getDocBase());
+
+        if (Files.isDirectory(docBase)) {
+            return new DirResourceSet(this, "/", docBaseStr, "/");
+        }
+
+        final Optional<String> jarRootOpt = config.jarRoot();
+        if (jarRootOpt.isPresent()) { // If docBase is a JAR file
+            final String jarRoot = jarRootOpt.get();
+            if ("/".equals(jarRoot)) {
+                return new JarResourceSet(this, "/", docBaseStr, "/");
+            } else {
+                return new JarSubsetResourceSet(this, "/", docBaseStr, "/", jarRoot);
+            }
+        }
+
+        throw new IllegalArgumentException(sm.getString("standardRoot.startInvalidMain", docBaseStr));
+    }
+}

--- a/src/main/java/com/linecorp/armeria/server/http/tomcat/JarSubsetResourceSet.java
+++ b/src/main/java/com/linecorp/armeria/server/http/tomcat/JarSubsetResourceSet.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linecorp.armeria.server.http.tomcat;
+
+import java.io.IOException;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+import org.apache.catalina.WebResourceRoot;
+import org.apache.catalina.webresources.JarResourceSet;
+
+final class JarSubsetResourceSet extends JarResourceSet {
+
+    private final String prefix;
+
+    JarSubsetResourceSet(WebResourceRoot root, String webAppMount, String base, String internalPath,
+                         String jarRoot) {
+        super(root, webAppMount, base, internalPath);
+
+        // Should be normalized by TomcatServiceBuilder.
+        assert !"/".equals(jarRoot) : "JarResourceSet should be used instead.";
+        assert jarRoot.startsWith("/") : "jarRoot must be absolute.";
+        assert !jarRoot.endsWith("/") : "jarRoot must not end with '/'.";
+
+        prefix = jarRoot.substring(1) + '/';
+    }
+
+    @Override
+    protected HashMap<String,JarEntry> getArchiveEntries(boolean single) {
+        synchronized (archiveLock) {
+            if (archiveEntries == null && !single) {
+                JarFile jarFile = null;
+                archiveEntries = new HashMap<>();
+                try {
+                    jarFile = openJarFile();
+                    Enumeration<JarEntry> entries = jarFile.entries();
+                    while (entries.hasMoreElements()) {
+                        final JarEntry entry = entries.nextElement();
+                        final String name = entry.getName();
+                        if (!name.startsWith(prefix)) {
+                            continue;
+                        }
+
+                        archiveEntries.put(name.substring(prefix.length()), entry);
+                    }
+                } catch (IOException ioe) {
+                    // Should never happen
+                    archiveEntries = null;
+                    throw new IllegalStateException(ioe);
+                } finally {
+                    if (jarFile != null) {
+                        closeJarFile();
+                    }
+                }
+            }
+            return archiveEntries;
+        }
+    }
+
+    @Override
+    protected JarEntry getArchiveEntry(String pathInArchive) {
+        JarFile jarFile = null;
+        try {
+            jarFile = openJarFile();
+            return jarFile.getJarEntry(prefix + pathInArchive);
+        } catch (IOException ioe) {
+            // Should never happen
+            throw new IllegalStateException(ioe);
+        } finally {
+            if (jarFile != null) {
+                closeJarFile();
+            }
+        }
+    }
+}

--- a/src/main/java/com/linecorp/armeria/server/http/tomcat/ManagedTomcatServiceInvocationHandler.java
+++ b/src/main/java/com/linecorp/armeria/server/http/tomcat/ManagedTomcatServiceInvocationHandler.java
@@ -33,7 +33,6 @@ import org.apache.catalina.core.StandardHost;
 import org.apache.catalina.core.StandardServer;
 import org.apache.catalina.core.StandardService;
 import org.apache.catalina.startup.ContextConfig;
-import org.apache.coyote.ProtocolHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -98,7 +97,6 @@ final class ManagedTomcatServiceInvocationHandler extends TomcatServiceInvocatio
         // on its startup with the Coyote Adapter which gives an access to Tomcat's HTTP service pipeline.
         final Connector connector = connector();
         connector.setPort(0); // We do not really open a port - just trying to stop the Connector from complaining.
-        final ProtocolHandler protocolHandler = connector.getProtocolHandler();
 
         server = newServer(connector, config());
 
@@ -181,6 +179,10 @@ final class ManagedTomcatServiceInvocationHandler extends TomcatServiceInvocatio
         } catch (Exception e) {
             throw new TomcatServiceException("failed to create a new context: " + config, e);
         }
+
+        // Use our own WebResourceRoot implementation so that we can load a ZIP/JAR file
+        // whose extention is not '.war'.
+        ctx.setResources(new ArmeriaWebResourceRoot(ctx, config));
 
         ctx.setPath(ROOT_CONTEXT_PATH);
         ctx.setDocBase(config.docBase().toString());

--- a/src/main/java/com/linecorp/armeria/server/http/tomcat/TomcatServiceConfig.java
+++ b/src/main/java/com/linecorp/armeria/server/http/tomcat/TomcatServiceConfig.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.server.http.tomcat;
 
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Consumer;
 
 import org.apache.catalina.Realm;
@@ -36,10 +37,12 @@ public class TomcatServiceConfig {
     private final Realm realm;
     private final String hostname;
     private final Path docBase;
+    private final String jarRoot;
     private final List<Consumer<? super StandardServer>> configurators;
 
     TomcatServiceConfig(String serviceName, String engineName, Path baseDir, Realm realm,
-                        String hostname, Path docBase, List<Consumer<? super StandardServer>> configurators) {
+                        String hostname, Path docBase, String jarRoot,
+                        List<Consumer<? super StandardServer>> configurators) {
 
         this.engineName = engineName;
         this.serviceName = serviceName;
@@ -47,6 +50,7 @@ public class TomcatServiceConfig {
         this.realm = realm;
         this.hostname = hostname;
         this.docBase = docBase;
+        this.jarRoot = jarRoot;
         this.configurators = configurators;
     }
 
@@ -86,10 +90,19 @@ public class TomcatServiceConfig {
     }
 
     /**
-     * Returns the document base directory of an web application.
+     * Returns the document base directory of a web application.
      */
     public Path docBase() {
         return docBase;
+    }
+
+    /**
+     * Returns the path to the root directory of a web application inside a JAR/WAR.
+     *
+     * @return {@link Optional#empty()} if {@link #docBase()} is not a JAR/WAR file
+     */
+    public Optional<String> jarRoot() {
+        return Optional.ofNullable(jarRoot);
     }
 
     /**
@@ -102,11 +115,12 @@ public class TomcatServiceConfig {
 
     @Override
     public String toString() {
-        return toString(this, serviceName(), engineName(), baseDir(), realm(), hostname(), docBase());
+        return toString(this, serviceName(), engineName(), baseDir(), realm(), hostname(),
+                        docBase(), jarRoot().orElse(null));
     }
 
     static String toString(Object holder, String serviceName, String engineName,
-                           Path baseDir, Realm realm, String hostname, Path docBase) {
+                           Path baseDir, Realm realm, String hostname, Path docBase, String jarRoot) {
 
         return holder.getClass().getSimpleName() +
                "(serviceName: " + serviceName +
@@ -114,6 +128,8 @@ public class TomcatServiceConfig {
                ", baseDir: " + baseDir +
                ", realm: " + realm.getClass().getSimpleName() +
                ", hostname: " + hostname +
-               ", docBase: " + docBase + ')';
+               ", docBase: " + docBase +
+               (jarRoot != null ? ", jarRoot: " + jarRoot : "") +
+               ')';
     }
 }

--- a/src/main/java/com/linecorp/armeria/server/http/tomcat/TomcatUtil.java
+++ b/src/main/java/com/linecorp/armeria/server/http/tomcat/TomcatUtil.java
@@ -16,10 +16,13 @@
 
 package com.linecorp.armeria.server.http.tomcat;
 
+import java.io.IOException;
 import java.net.URL;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.zip.ZipFile;
 
 import org.apache.catalina.LifecycleListener;
 import org.apache.catalina.startup.Constants;
@@ -58,6 +61,19 @@ final class TomcatUtil {
         // - The anonymous SecurityManager
         final Class<?>[] classContext = classContextRef.get();
         return Arrays.copyOfRange(classContext, 2, classContext.length);
+    }
+
+    static boolean isZip(Path path) {
+        if (!Files.isRegularFile(path)) {
+            return false;
+        }
+
+        try (ZipFile ignored = new ZipFile(path.toFile())) {
+            return true;
+        } catch (IOException ignored) {
+            // Probably not a JAR file.
+            return false;
+        }
     }
 
     private TomcatUtil() {}


### PR DESCRIPTION
Motivation:

1) Tomcat does not allow us to use a JAR file whose extention is not
'.war' as a web application:

- https://github.com/apache/tomcat/blob/4166a2b96f482f8bf7b0024836dab53d3594710e/java/org/apache/catalina/webresources/StandardRoot.java#L722

2) When TomcatService is created via forClassPath(Class, String), the
service construction fails if the specified class is packaged in a .JAR
file. forClassPath(Class, String) currently requires the specified class
to exist in a directory, which is not always true.

Modifications:

- Replace Tomcat's StandardRoot with ArmeriaWebResourceRoot to accept
  any JAR files
- Add JarSubsetResourceSet which allows a user to specify non-root web
  application path in a JAR file
  - Note that the upstream JarResourceSet is used unless specified
    explicitly.
- Add TomcatConfig.jarRoot()
- Add TomcatUtil.isJar() to determine if the specified path is really a
  JAR-compatible archive file
- Add the tests for the issue (2) in the Motivations section

Result:

A user can use TomcatService.forClassPath(Class, String) even when the
specified class is packaged in a JAR file.