### PR TITLE
Add test cases for SNI support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -287,7 +287,7 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>4.5.1</version>
+      <version>4.5.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/com/linecorp/armeria/client/RemoteInvokerFactory.java
+++ b/src/main/java/com/linecorp/armeria/client/RemoteInvokerFactory.java
@@ -34,7 +34,6 @@ import com.linecorp.armeria.common.util.NativeLibraries;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
-import io.netty.channel.epoll.Epoll;
 import io.netty.channel.epoll.EpollDatagramChannel;
 import io.netty.channel.epoll.EpollEventLoopGroup;
 import io.netty.channel.epoll.EpollSocketChannel;
@@ -138,8 +137,10 @@ public final class RemoteInvokerFactory implements AutoCloseable {
         final Bootstrap baseBootstrap = new Bootstrap();
 
         baseBootstrap.channel(channelType());
-        baseBootstrap.resolver(new DnsAddressResolverGroup(datagramChannelType(),
-                                                           DnsServerAddresses.defaultAddresses()));
+        baseBootstrap.resolver(
+                options.addressResolverGroup()
+                       .orElseGet(() -> new DnsAddressResolverGroup(
+                               datagramChannelType(), DnsServerAddresses.defaultAddresses())));
 
         baseBootstrap.option(ChannelOption.CONNECT_TIMEOUT_MILLIS,
                              ConvertUtils.safeLongToInt(options.connectTimeoutMillis()));

--- a/src/main/java/com/linecorp/armeria/client/RemoteInvokerOption.java
+++ b/src/main/java/com/linecorp/armeria/client/RemoteInvokerOption.java
@@ -17,6 +17,7 @@ package com.linecorp.armeria.client;
 
 import static java.util.Objects.requireNonNull;
 
+import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.function.Function;
 
@@ -28,6 +29,7 @@ import com.linecorp.armeria.common.util.AbstractOption;
 
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
+import io.netty.resolver.AddressResolverGroup;
 import io.netty.util.ConstantPool;
 
 /**
@@ -70,6 +72,12 @@ public class RemoteInvokerOption<T> extends AbstractOption<T> {
      */
     public static final RemoteInvokerOption<TrustManagerFactory> TRUST_MANAGER_FACTORY =
             valueOf("TRUST_MANAGER_FACTORY");
+
+    /**
+     * The {@link AddressResolverGroup} to use to resolve remote addresses into {@link InetSocketAddress}es.
+     */
+    public static final RemoteInvokerOption<AddressResolverGroup<? extends InetSocketAddress>>
+            ADDRESS_RESOLVER_GROUP = valueOf("ADDRESS_RESOLVER_GROUP");
 
     /**
      * The {@link EventLoopGroup} that will provide the {@link EventLoop} for I/O and asynchronous invocations.

--- a/src/main/java/com/linecorp/armeria/client/RemoteInvokerOptions.java
+++ b/src/main/java/com/linecorp/armeria/client/RemoteInvokerOptions.java
@@ -15,6 +15,7 @@
  */
 package com.linecorp.armeria.client;
 
+import static com.linecorp.armeria.client.RemoteInvokerOption.ADDRESS_RESOLVER_GROUP;
 import static com.linecorp.armeria.client.RemoteInvokerOption.CONNECT_TIMEOUT;
 import static com.linecorp.armeria.client.RemoteInvokerOption.EVENT_LOOP_GROUP;
 import static com.linecorp.armeria.client.RemoteInvokerOption.IDLE_TIMEOUT;
@@ -24,6 +25,7 @@ import static com.linecorp.armeria.client.RemoteInvokerOption.POOL_HANDLER_DECOR
 import static com.linecorp.armeria.client.RemoteInvokerOption.TRUST_MANAGER_FACTORY;
 import static java.util.Objects.requireNonNull;
 
+import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
@@ -36,6 +38,7 @@ import com.linecorp.armeria.client.pool.PoolKey;
 import com.linecorp.armeria.common.util.AbstractOptions;
 
 import io.netty.channel.EventLoopGroup;
+import io.netty.resolver.AddressResolverGroup;
 
 /**
  * A set of {@link RemoteInvokerOption}s and their respective values.
@@ -179,6 +182,16 @@ public class RemoteInvokerOptions extends AbstractOptions {
 
     public Optional<TrustManagerFactory> trustManagerFactory() {
         return get(TRUST_MANAGER_FACTORY);
+    }
+
+    public Optional<AddressResolverGroup<InetSocketAddress>> addressResolverGroup() {
+        final Optional<AddressResolverGroup<? extends InetSocketAddress>> value = get(ADDRESS_RESOLVER_GROUP);
+
+        @SuppressWarnings("unchecked")
+        final Optional<AddressResolverGroup<InetSocketAddress>> castValue =
+                (Optional<AddressResolverGroup<InetSocketAddress>>) (Optional<?>) value;
+
+        return castValue;
     }
 
     public Duration idleTimeout() {

--- a/src/test/java/com/linecorp/armeria/client/http/SimpleHttpClientIntegrationTest.java
+++ b/src/test/java/com/linecorp/armeria/client/http/SimpleHttpClientIntegrationTest.java
@@ -38,7 +38,6 @@ import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
-import io.netty.handler.ssl.util.SelfSignedCertificate;
 
 public class SimpleHttpClientIntegrationTest {
 
@@ -48,14 +47,10 @@ public class SimpleHttpClientIntegrationTest {
     private static RemoteInvokerFactory remoteInvokerFactory;
 
     static {
-        final SelfSignedCertificate ssc;
         final ServerBuilder sb = new ServerBuilder();
 
         try {
             sb.port(0, SessionProtocol.HTTP);
-
-            ssc = new SelfSignedCertificate("127.0.0.1");
-            sb.sslContext(SessionProtocol.HTTPS, ssc.certificate(), ssc.privateKey());
 
             sb.serviceAt("/httptestbody", new HttpService(
                     (ctx, executor, promise) -> {

--- a/src/test/java/com/linecorp/armeria/client/http/SimpleHttpClientSniTest.java
+++ b/src/test/java/com/linecorp/armeria/client/http/SimpleHttpClientSniTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.http;
+
+import static org.junit.Assert.assertEquals;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.linecorp.armeria.client.Clients;
+import com.linecorp.armeria.client.RemoteInvokerFactory;
+import com.linecorp.armeria.client.RemoteInvokerOption;
+import com.linecorp.armeria.client.RemoteInvokerOptions;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.VirtualHostBuilder;
+import com.linecorp.armeria.server.http.HttpService;
+
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import io.netty.handler.ssl.util.SelfSignedCertificate;
+import io.netty.resolver.AddressResolver;
+import io.netty.resolver.AddressResolverGroup;
+import io.netty.resolver.InetNameResolver;
+import io.netty.resolver.InetSocketAddressResolver;
+import io.netty.util.NetUtil;
+import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.concurrent.Promise;
+
+public class SimpleHttpClientSniTest {
+
+    private static final Server server;
+
+    private static int httpsPort;
+    private static RemoteInvokerFactory remoteInvokerFactory;
+    private static final SelfSignedCertificate sscA;
+    private static final SelfSignedCertificate sscB;
+
+    static {
+        final ServerBuilder sb = new ServerBuilder();
+
+        try {
+            sscA = new SelfSignedCertificate("a.com");
+            sscB = new SelfSignedCertificate("b.com");
+
+            sb.port(0, SessionProtocol.HTTPS);
+
+            final VirtualHostBuilder a = new VirtualHostBuilder("a.com");
+            final VirtualHostBuilder b = new VirtualHostBuilder("b.com");
+
+            a.serviceAt("/", new HttpService(
+                    (ctx, blockingTaskExecutor, promise) ->
+                            ctx.resolvePromise(promise, new DefaultFullHttpResponse(
+                                    HttpVersion.HTTP_1_1, HttpResponseStatus.OK,
+                                    Unpooled.copiedBuffer("a.com", StandardCharsets.UTF_8)))));
+
+            b.serviceAt("/", new HttpService(
+                    (ctx, blockingTaskExecutor, promise) ->
+                            ctx.resolvePromise(promise, new DefaultFullHttpResponse(
+                                    HttpVersion.HTTP_1_1, HttpResponseStatus.OK,
+                                    Unpooled.copiedBuffer("b.com", StandardCharsets.UTF_8)))));
+
+            a.sslContext(SessionProtocol.HTTPS, sscA.certificate(), sscA.privateKey());
+            b.sslContext(SessionProtocol.HTTPS, sscB.certificate(), sscB.privateKey());
+
+            sb.virtualHost(a.build());
+            sb.defaultVirtualHost(b.build());
+        } catch (Exception e) {
+            throw new Error(e);
+        }
+        server = sb.build();
+    }
+
+    @BeforeClass
+    public static void init() throws Exception {
+        server.start().sync();
+        httpsPort = server.activePorts().values().stream()
+                          .filter(p -> p.protocol() == SessionProtocol.HTTPS).findAny().get().localAddress()
+                          .getPort();
+        remoteInvokerFactory = new RemoteInvokerFactory(RemoteInvokerOptions.of(
+                RemoteInvokerOption.TRUST_MANAGER_FACTORY.newValue(InsecureTrustManagerFactory.INSTANCE),
+                RemoteInvokerOption.ADDRESS_RESOLVER_GROUP.newValue(new DummyAddressResolverGroup())));
+    }
+
+    @AfterClass
+    public static void destroy() throws Exception {
+        remoteInvokerFactory.close();
+        server.stop();
+        sscA.delete();
+        sscB.delete();
+    }
+
+    @Test
+    public void testMatch() throws Exception {
+        testMatch("a.com");
+        testMatch("b.com");
+    }
+
+    private static void testMatch(String fqdn) throws Exception {
+        assertEquals(fqdn, get(fqdn));
+    }
+
+    @Test
+    public void testMismatch() throws Exception {
+        testMismatch("127.0.0.1");
+        testMismatch("mismatch.com");
+    }
+
+    private static void testMismatch(String fqdn) throws Exception {
+        assertEquals("b.com", get(fqdn));
+    }
+
+    private static String get(String fqdn) throws Exception {
+        SimpleHttpClient client = Clients.newClient(
+                remoteInvokerFactory, "none+https://" + fqdn + ':' + httpsPort,
+                SimpleHttpClient.class);
+
+        SimpleHttpRequest request = SimpleHttpRequestBuilder.forGet("/").build();
+        SimpleHttpResponse response = client.execute(request).get();
+        assertEquals(HttpResponseStatus.OK, response.status());
+        return new String(response.content(), StandardCharsets.UTF_8);
+    }
+
+    private static class DummyAddressResolverGroup extends AddressResolverGroup<InetSocketAddress> {
+        @Override
+        protected AddressResolver<InetSocketAddress> newResolver(EventExecutor eventExecutor) {
+            return new InetSocketAddressResolver(eventExecutor, new InetNameResolver(eventExecutor) {
+                @Override
+                protected void doResolve(String hostname, Promise<InetAddress> promise) {
+                    promise.setSuccess(NetUtil.LOCALHOST4);
+                }
+
+                @Override
+                protected void doResolveAll(String hostname, Promise<List<InetAddress>> promise) {
+                    promise.setSuccess(Collections.singletonList(NetUtil.LOCALHOST4));
+                }
+            });
+        }
+    }
+}

--- a/src/test/java/com/linecorp/armeria/server/SniServerTest.java
+++ b/src/test/java/com/linecorp/armeria/server/SniServerTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.nio.charset.StandardCharsets;
+
+import javax.net.ssl.SSLContext;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.conn.InMemoryDnsResolver;
+import org.apache.http.ssl.SSLContextBuilder;
+import org.apache.http.util.EntityUtils;
+import org.junit.AfterClass;
+import org.junit.Test;
+
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.server.http.HttpService;
+
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.ssl.util.SelfSignedCertificate;
+import io.netty.util.NetUtil;
+
+public class SniServerTest extends AbstractServerTest {
+
+    private static SelfSignedCertificate sscA;
+    private static SelfSignedCertificate sscB;
+    private static SelfSignedCertificate sscC;
+
+    private static InMemoryDnsResolver dnsResolver;
+
+    @Override
+    protected void configureServer(ServerBuilder sb) throws Exception {
+        dnsResolver = new InMemoryDnsResolver();
+        dnsResolver.add("a.com", NetUtil.LOCALHOST4);
+        dnsResolver.add("b.com", NetUtil.LOCALHOST4);
+        dnsResolver.add("c.com", NetUtil.LOCALHOST4);
+        dnsResolver.add("mismatch.com", NetUtil.LOCALHOST4);
+        dnsResolver.add("127.0.0.1", NetUtil.LOCALHOST4);
+
+        sscA = new SelfSignedCertificate("a.com");
+        sscB = new SelfSignedCertificate("b.com");
+        sscC = new SelfSignedCertificate("c.com");
+
+        final VirtualHostBuilder a = new VirtualHostBuilder("a.com");
+        final VirtualHostBuilder b = new VirtualHostBuilder("b.com");
+        final VirtualHostBuilder c = new VirtualHostBuilder("c.com");
+
+        a.serviceAt("/", new HttpService(
+                (ctx, blockingTaskExecutor, promise) ->
+                        ctx.resolvePromise(promise, new DefaultFullHttpResponse(
+                                HttpVersion.HTTP_1_1, HttpResponseStatus.OK,
+                                Unpooled.copiedBuffer("a.com", StandardCharsets.UTF_8)))));
+
+        b.serviceAt("/", new HttpService(
+                (ctx, blockingTaskExecutor, promise) ->
+                        ctx.resolvePromise(promise, new DefaultFullHttpResponse(
+                                HttpVersion.HTTP_1_1, HttpResponseStatus.OK,
+                                Unpooled.copiedBuffer("b.com", StandardCharsets.UTF_8)))));
+
+        c.serviceAt("/", new HttpService(
+                (ctx, blockingTaskExecutor, promise) ->
+                        ctx.resolvePromise(promise, new DefaultFullHttpResponse(
+                                HttpVersion.HTTP_1_1, HttpResponseStatus.OK,
+                                Unpooled.copiedBuffer("c.com", StandardCharsets.UTF_8)))));
+
+        a.sslContext(SessionProtocol.HTTPS, sscA.certificate(), sscA.privateKey());
+        b.sslContext(SessionProtocol.HTTPS, sscB.certificate(), sscB.privateKey());
+        c.sslContext(SessionProtocol.HTTPS, sscC.certificate(), sscC.privateKey());
+
+        sb.virtualHost(a.build());
+        sb.virtualHost(b.build());
+        sb.defaultVirtualHost(c.build());
+
+        sb.port(0, SessionProtocol.HTTPS);
+    }
+
+    @AfterClass
+    public static void deleteSelfSignedCertificated() {
+        sscA.delete();
+        sscB.delete();
+        sscC.delete();
+    }
+
+    @Test
+    public void testSniMatch() throws Exception {
+        try (CloseableHttpClient hc = newHttpClient()) {
+            try (CloseableHttpResponse res = hc.execute(new HttpGet("https://a.com:" + httpsPort()))) {
+                assertThat(res.getStatusLine().toString(), is("HTTP/1.1 200 OK"));
+                assertThat(EntityUtils.toString(res.getEntity()), is("a.com"));
+            }
+
+            try (CloseableHttpResponse res = hc.execute(new HttpGet("https://b.com:" + httpsPort()))) {
+                assertThat(res.getStatusLine().toString(), is("HTTP/1.1 200 OK"));
+                assertThat(EntityUtils.toString(res.getEntity()), is("b.com"));
+            }
+
+            try (CloseableHttpResponse res = hc.execute(new HttpGet("https://c.com:" + httpsPort()))) {
+                assertThat(res.getStatusLine().toString(), is("HTTP/1.1 200 OK"));
+                assertThat(EntityUtils.toString(res.getEntity()), is("c.com"));
+            }
+        }
+    }
+
+    @Test
+    public void testSniMismatch() throws Exception {
+        try (CloseableHttpClient hc = newHttpClient()) {
+            try (CloseableHttpResponse res = hc.execute(new HttpGet("https://mismatch.com:" + httpsPort()))) {
+                assertThat(res.getStatusLine().toString(), is("HTTP/1.1 200 OK"));
+                assertThat(EntityUtils.toString(res.getEntity()), is("c.com"));
+            }
+
+            try (CloseableHttpResponse res = hc.execute(new HttpGet(httpsUri("/")))) {
+                assertThat(res.getStatusLine().toString(), is("HTTP/1.1 200 OK"));
+                assertThat(EntityUtils.toString(res.getEntity()), is("c.com"));
+            }
+        }
+    }
+
+    public CloseableHttpClient newHttpClient() throws Exception {
+        final SSLContext sslCtx =
+                new SSLContextBuilder().loadTrustMaterial(null, (chain, authType) -> true).build();
+
+        return HttpClients.custom()
+                          .setDnsResolver(dnsResolver)
+                          .setSSLHostnameVerifier(NoopHostnameVerifier.INSTANCE)
+                          .setSSLContext(sslCtx)
+                          .build();
+    }
+}


### PR DESCRIPTION
- Add SniServerTest and SimpleHttpClientSniTest to test Armeria's SNI
  support
- Improve HTTPS support of AbstractServerTest by adding a few more
  utility methods
- Add RemoteInvokerOption.ADDRESS_RESOLVER_GROUP so that we don't need
  to query DNS servers to test client-side SNI support
- Upgrade Apache HttpClient to 4.5.2 to use setSSLNameVerifier()