### PR TITLE
Use the HTTP/2 preface string for H1C-to-H2C upgrade

### DIFF
--- a/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
+++ b/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
@@ -34,6 +34,7 @@ import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.util.Exceptions;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
@@ -182,7 +183,13 @@ class HttpSessionHandler extends ChannelDuplexHandler implements HttpSession {
             }
         } else {
             try {
-                throw new IllegalStateException("unexpected message type: " + msg);
+                final String typeInfo;
+                if (msg instanceof ByteBuf) {
+                    typeInfo = msg + " HexDump: " + ByteBufUtil.hexDump((ByteBuf) msg);
+                } else {
+                    typeInfo = String.valueOf(msg);
+                }
+                throw new IllegalStateException("unexpected message type: " + typeInfo);
             } finally {
                 ReferenceCountUtil.release(msg);
             }

--- a/src/main/java/com/linecorp/armeria/client/RemoteInvokerOption.java
+++ b/src/main/java/com/linecorp/armeria/client/RemoteInvokerOption.java
@@ -92,6 +92,12 @@ public class RemoteInvokerOption<T> extends AbstractOption<T> {
             KeyedChannelPoolHandler<PoolKey>>> POOL_HANDLER_DECORATOR = valueOf("POOL_HANDLER_DECORATOR");
 
     /**
+     * Whether to send an HTTP/2 preface string instead of an HTTP/1 upgrade request to negotiate the protocol
+     * version of a cleartext HTTP connection.
+     */
+    public static final RemoteInvokerOption<Boolean> USE_HTTP2_PREFACE = valueOf("USE_HTTP2_PREFACE");
+
+    /**
      * Returns the {@link RemoteInvokerOption} of the specified name.
      */
     @SuppressWarnings("unchecked")

--- a/src/main/java/com/linecorp/armeria/client/RemoteInvokerOptions.java
+++ b/src/main/java/com/linecorp/armeria/client/RemoteInvokerOptions.java
@@ -23,6 +23,7 @@ import static com.linecorp.armeria.client.RemoteInvokerOption.MAX_CONCURRENCY;
 import static com.linecorp.armeria.client.RemoteInvokerOption.MAX_FRAME_LENGTH;
 import static com.linecorp.armeria.client.RemoteInvokerOption.POOL_HANDLER_DECORATOR;
 import static com.linecorp.armeria.client.RemoteInvokerOption.TRUST_MANAGER_FACTORY;
+import static com.linecorp.armeria.client.RemoteInvokerOption.USE_HTTP2_PREFACE;
 import static java.util.Objects.requireNonNull;
 
 import java.net.InetSocketAddress;
@@ -32,6 +33,9 @@ import java.util.Optional;
 import java.util.function.Function;
 
 import javax.net.ssl.TrustManagerFactory;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.linecorp.armeria.client.pool.KeyedChannelPoolHandler;
 import com.linecorp.armeria.client.pool.PoolKey;
@@ -45,16 +49,25 @@ import io.netty.resolver.AddressResolverGroup;
  */
 public class RemoteInvokerOptions extends AbstractOptions {
 
+    private static final Logger logger = LoggerFactory.getLogger(RemoteInvokerOptions.class);
+
     private static final Duration DEFAULT_CONNECTION_TIMEOUT = Duration.ofMillis(3200);
     private static final Duration DEFAULT_IDLE_TIMEOUT = Duration.ofSeconds(10);
     private static final int DEFAULT_MAX_FRAME_LENGTH = 10 * 1024 * 1024; // 10 MB
     private static final Integer DEFAULT_MAX_CONCURRENCY = Integer.MAX_VALUE;
+    private static final Boolean DEFAULT_USE_HTTP2_PREFACE =
+            !"false".equals(System.getProperty("com.linecorp.armeria.defaultUseHttp2Preface", "true"));
+
+    static {
+        logger.info("defaultUseHttp2Preface: {}", DEFAULT_USE_HTTP2_PREFACE);
+    }
 
     private static final RemoteInvokerOptionValue<?>[] DEFAULT_OPTION_VALUES = {
             CONNECT_TIMEOUT.newValue(DEFAULT_CONNECTION_TIMEOUT),
             IDLE_TIMEOUT.newValue(DEFAULT_IDLE_TIMEOUT),
             MAX_FRAME_LENGTH.newValue(DEFAULT_MAX_FRAME_LENGTH),
-            MAX_CONCURRENCY.newValue(DEFAULT_MAX_CONCURRENCY)
+            MAX_CONCURRENCY.newValue(DEFAULT_MAX_CONCURRENCY),
+            USE_HTTP2_PREFACE.newValue(DEFAULT_USE_HTTP2_PREFACE)
     };
 
     /**
@@ -212,5 +225,9 @@ public class RemoteInvokerOptions extends AbstractOptions {
 
     public Function<KeyedChannelPoolHandler<PoolKey>, KeyedChannelPoolHandler<PoolKey>> poolHandlerDecorator() {
         return getOrElse(POOL_HANDLER_DECORATOR, Function.identity());
+    }
+
+    public boolean useHttp2Preface() {
+        return getOrElse(USE_HTTP2_PREFACE, DEFAULT_USE_HTTP2_PREFACE);
     }
 }


### PR DESCRIPTION
Related: #142

Motivation:

Armeria client currently sends a 'HEAD / HTTP/1.1' request to issue a
protocol upgrade, as recommended by the RFC, but it can cause heavy load
on the server side if the service bound at / does not implement HEAD
method optimally. When many Armeria clients creates a lot of connections
concurrently, the server might not respond to the upgrade request in a
timely manner.

Modifications:

- Add RemoteInvokerOption.USE_HTTP2_PREFACE which is true by default
  - When set to true, Armeria client uses 'PRI * HTTP/2.0' preface
    string instead of the old 'HEAD / HTTP/1.1' request to upgrade from
    H1C to H2C.
  - A user can specify a system property to change the default value of
    the USE_HTTP2_PREFACE option.
- Implement the H1C-to-H2C upgrade that uses the HTTP/2 preface string,
  while retaining the old behavior when USE_HTTP2_PREFACE is set to
  false

Result:

- Fixes #142
- Armeria client does not produce load on the server accidentally.
- HTTP/2 clients have more upgrade options.