### PR TITLE
Give full control over the metric name of Dropwizard Metrics integration

### DIFF
--- a/src/main/java/com/linecorp/armeria/client/metrics/MetricCollectingClient.java
+++ b/src/main/java/com/linecorp/armeria/client/metrics/MetricCollectingClient.java
@@ -15,26 +15,27 @@ public final class MetricCollectingClient extends DecoratingClient {
      * A {@link Client} decorator that tracks request stats using the Dropwizard metrics library.
      * To use, simply prepare a {@link MetricRegistry} and add this decorator to a client.
      *
-     * @param serviceName a name to describe this service. Metrics will all be logged with name
-     *     client.serviceName.method.metricName.
      * @param metricRegistry the {@link MetricRegistry} to store metrics into.
+     * @param metricNamePrefix the prefix of the names of the metrics created by the returned decorator.
      *
      * <p>Example:
      * <pre>{@code
      * MetricRegistry metricRegistry = new MetricRegistry();
      * MyService.Iface client = new ClientBuilder(uri)
-     *     .decorate(MetricCollectingClient.newDropwizardDecorator("MyService", metricRegistry))
-     *     .build(MyService.Iface.class);
+     *         .decorate(MetricCollectingClient.newDropwizardDecorator(
+     *                 metricRegistry, MetricRegistry.name("clients", "myService")))
+     *         .build(MyService.Iface.class);
      * }
      * </pre>
      * <p>It is generally recommended to define your own name for the service instead of using something like
      * the Java class to make sure otherwise safe changes like renames don't break metrics.
      */
-    public static Function<Client, Client> newDropwizardDecorator(
-            String serviceName, MetricRegistry metricRegistry) {
+    public static Function<Client, Client> newDropwizardDecorator(MetricRegistry metricRegistry,
+                                                                  String metricNamePrefix) {
+
         return client -> new MetricCollectingClient(
                 client,
-                new DropwizardMetricConsumer("client", serviceName, metricRegistry));
+                new DropwizardMetricConsumer(metricRegistry, metricNamePrefix));
     }
 
 

--- a/src/main/java/com/linecorp/armeria/server/metrics/MetricCollectingService.java
+++ b/src/main/java/com/linecorp/armeria/server/metrics/MetricCollectingService.java
@@ -35,25 +35,28 @@ public class MetricCollectingService extends DecoratingService {
      * A {@link Service} decorator that tracks request stats using the Dropwizard metrics library.
      * To use, simply prepare a {@link MetricRegistry} and add this decorator to a service specification.
      *
-     * @param serviceName a name to describe this service. Metrics will all be logged with name
-     *     server.serviceName.method.metricName.
      * @param metricRegistry the {@link MetricRegistry} to store metrics into.
+     * @param metricNamePrefix the prefix of the names of the metrics created by the returned decorator.
      *
      * <p>Example:
      * <pre>{@code
      * MetricRegistry metricRegistry = new MetricRegistry();
-     * serverBuilder.serviceAt("/service", ThriftService.of(handler)
-     *     .decorate(MetricCollectingService.newDropwizardDecorator("MyService", metricRegistry)));
+     * serverBuilder.serviceAt(
+     *         "/service",
+     *         ThriftService.of(handler).decorate(
+     *                 MetricCollectingService.newDropwizardDecorator(
+     *                         metricRegistry, MetricRegister.name("services", "myService"))));
      * }
      * </pre>
      * <p>It is generally recommended to define your own name for the service instead of using something like
      * the Java class to make sure otherwise safe changes like renames don't break metrics.
      */
-    public static Function<Service, Service> newDropwizardDecorator(
-            String serviceName, MetricRegistry metricRegistry) {
+    public static Function<Service, Service> newDropwizardDecorator(MetricRegistry metricRegistry,
+                                                                    String metricNamePrefix) {
+
         return service -> new MetricCollectingService(
                 service,
-                new DropwizardMetricConsumer("server", serviceName, metricRegistry));
+                new DropwizardMetricConsumer(metricRegistry, metricNamePrefix));
     }
 
     public MetricCollectingService(Service service, MetricConsumer consumer) {


### PR DESCRIPTION
Motivation:

There's no way for a user to create a metric entry with different prefix
than 'client' or 'server' when using the newDropwizardDecorator()
methods in MetricCollectingClient/Service.

Modifications:

- Remove the hard-coded 'client' and 'server' prefix.
- Rename the parameter 'serviceName' to 'metricName' and let users use
  MetricRegistry.name()

Result:

More control to the users