### PR TITLE
Record each API's processing requests as a metric for monitoring

### DIFF
--- a/src/main/java/com/linecorp/armeria/client/metrics/MetricCollectingClientCodec.java
+++ b/src/main/java/com/linecorp/armeria/client/metrics/MetricCollectingClientCodec.java
@@ -46,6 +46,8 @@ class MetricCollectingClientCodec extends DecoratingClientCodec {
         if (result.isSuccess()) {
             ServiceInvocationContext context = result.invocationContext();
             context.attr(METRICS).set(new MetricsData(getRequestSize(result.content()), startTime));
+            metricConsumer.invocationStarted(
+                    context.scheme(), context.host(), context.path(), Optional.of(context.method()));
         } else {
             metricConsumer.invocationComplete(
                     result.encodedScheme().orElse(Scheme.of(SerializationFormat.UNKNOWN, sessionProtocol)),
@@ -53,7 +55,8 @@ class MetricCollectingClientCodec extends DecoratingClientCodec {
                     System.nanoTime() - startTime, 0, 0,
                     result.encodedHost().orElse("__unknown_host__"),
                     result.encodedPath().orElse("__unknown_path__"),
-                    Optional.empty());
+                    Optional.empty(),
+                    false);
         }
         return result;
     }
@@ -64,7 +67,7 @@ class MetricCollectingClientCodec extends DecoratingClientCodec {
         metricConsumer.invocationComplete(
                 ctx.scheme(), status.code(), System.nanoTime() - metricsData.startTimeNanos,
                 metricsData.requestSizeBytes, responseSizeBytes, ctx.host(), ctx.path(),
-                Optional.of(ctx.method()));
+                Optional.of(ctx.method()), true);
     }
 
     @Override

--- a/src/main/java/com/linecorp/armeria/common/metrics/DropwizardRequestMetrics.java
+++ b/src/main/java/com/linecorp/armeria/common/metrics/DropwizardRequestMetrics.java
@@ -2,6 +2,7 @@ package com.linecorp.armeria.common.metrics;
 
 import java.util.concurrent.TimeUnit;
 
+import com.codahale.metrics.Counter;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.Metric;
 import com.codahale.metrics.Timer;
@@ -18,15 +19,18 @@ public final class DropwizardRequestMetrics {
     private final Timer timer;
     private final Meter successes;
     private final Meter failures;
+    private final Counter activeRequests;
     private final Meter requestBytes;
     private final Meter responseBytes;
 
     public DropwizardRequestMetrics(String name, Timer timer, Meter successes, Meter failures,
+                                    Counter activeRequests,
                                     Meter requestBytes, Meter responseBytes) {
         this.name = name;
         this.timer = timer;
         this.successes = successes;
         this.failures = failures;
+        this.activeRequests = activeRequests;
         this.requestBytes = requestBytes;
         this.responseBytes = responseBytes;
     }
@@ -47,6 +51,14 @@ public final class DropwizardRequestMetrics {
         failures.mark();
     }
 
+    public void markStart() {
+        activeRequests.inc();
+    }
+
+    public void markComplete() {
+        activeRequests.dec();
+    }
+
     public void requestBytes(int requestBytes) {
         this.requestBytes.mark(requestBytes);
     }
@@ -61,6 +73,7 @@ public final class DropwizardRequestMetrics {
                "  requests: " + timer.getCount() + '\n' +
                "  successes: " + successes.getCount() + '\n' +
                "  failures: " + failures.getCount() + '\n' +
+               "  activeRequests: " + activeRequests.getCount() + '\n' +
                "  requestBytes: " + requestBytes.getCount() + '\n' +
                "  responseBytes: " + responseBytes.getCount() + "\n>";
     }

--- a/src/test/java/com/linecorp/armeria/server/metrics/MetricConsumerTest.java
+++ b/src/test/java/com/linecorp/armeria/server/metrics/MetricConsumerTest.java
@@ -20,24 +20,45 @@ import static org.junit.Assert.assertEquals;
 
 import java.util.Optional;
 
-import com.linecorp.armeria.common.Scheme;
-import com.linecorp.armeria.common.SerializationFormat;
 import org.junit.Test;
 
+import com.linecorp.armeria.common.Scheme;
+import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.metrics.MetricConsumer;
 
 public class MetricConsumerTest {
     @Test
     public void testInfiniteRecursion() throws Exception {
-        final int[] executeCounter = { 0 };
+        // Given
+        final int[] executeCounters = { 0,   // for invocationStarted
+                                        0 }; // for invocationComplete
 
-        MetricConsumer consumer = (a, b, c, d, e, f, g, h) -> executeCounter[0] += 1;
-        consumer.andThen(consumer).invocationComplete(
+        MetricConsumer consumer = new MetricConsumer() {
+            @Override
+            public void invocationStarted(Scheme scheme, String hostname, String path, Optional<String> method) {
+                executeCounters[0] += 1;
+            }
+
+            @Override
+            public void invocationComplete(Scheme scheme, int code, long processTimeNanos, int requestSize,
+                                           int responseSize, String hostname, String path,
+                                           Optional<String> method, boolean started) {
+                executeCounters[1] += 1;
+            }
+        };
+        MetricConsumer finalConsumer = consumer.andThen(consumer).andThen(consumer);
+
+        // When
+        finalConsumer.invocationStarted(
+                Scheme.of(SerializationFormat.NONE, SessionProtocol.HTTP), "", "", Optional.empty());
+        finalConsumer.invocationComplete(
                 Scheme.of(SerializationFormat.NONE, SessionProtocol.HTTP), 200, 0, 0, 0, "", "",
-                Optional.of(""));
+                Optional.of(""), true);
 
-        assertEquals("invocationComplete should be executed twice", 2, executeCounter[0]);
+        // Then
+        assertEquals("invocationStarted should be executed twice", 3, executeCounters[0]);
+        assertEquals("invocationComplete should be executed twice", 3, executeCounters[1]);
     }
 }
 


### PR DESCRIPTION
Motivation:

Currently there are metrics like success and failures, but it is important to
monitor how many requests are in progress to figure out each API's status.

Modifications:

- Add MetricConsumer.invocationStart() to record requests' starting point
- Use the method on Client and Service codecs

Result:

Users can monitor each API's processingRequests counter to check its current
status.