### PR TITLE
Fix the broken links for classes in DocService

### DIFF
--- a/src/main/resources/com/linecorp/armeria/server/docs/assets/js/armeria.js
+++ b/src/main/resources/com/linecorp/armeria/server/docs/assets/js/armeria.js
@@ -184,7 +184,7 @@ $(function () {
                      return className;
                    }
 
-                   return '<a href="#class/' + encodeURIComponent(className) + '" title="' + className + '">' +
+                   return '<a href="#!class/' + encodeURIComponent(className) + '" title="' + className + '">' +
                           classInfo.simpleName + '</a>';
                  });
   }


### PR DESCRIPTION
Should use #! instead of #