### PR TITLE
Fix backward compatibility with old Armeria servers

### DIFF
--- a/src/main/java/com/linecorp/armeria/client/HttpRemoteInvoker.java
+++ b/src/main/java/com/linecorp/armeria/client/HttpRemoteInvoker.java
@@ -53,6 +53,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.EventLoop;
+import io.netty.channel.pool.ChannelHealthChecker;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.Future;
@@ -66,6 +67,10 @@ final class HttpRemoteInvoker implements RemoteInvoker {
 
     private static final KeyedChannelPoolHandlerAdapter<PoolKey> NOOP_POOL_HANDLER =
             new KeyedChannelPoolHandlerAdapter<>();
+
+    private static final ChannelHealthChecker POOL_HEALTH_CHECKER =
+            ch -> ch.eventLoop().newSucceededFuture(HttpSessionHandler.get(ch).isActive());
+
 
     static final Set<SessionProtocol> HTTP_PROTOCOLS = EnumSet.of(H1, H1C, H2, H2C, HTTPS, HTTP);
 
@@ -136,7 +141,7 @@ final class HttpRemoteInvoker implements RemoteInvoker {
 
             //TODO(inch772) handle options.maxConcurrency();
             return new DefaultKeyedChannelPool<>(eventLoop, factory,
-                                                 HttpSessionChannelFactory.HEALTH_CHECKER, handler, true);
+                                                 POOL_HEALTH_CHECKER, handler, true);
         });
     }
 

--- a/src/main/java/com/linecorp/armeria/client/HttpSession.java
+++ b/src/main/java/com/linecorp/armeria/client/HttpSession.java
@@ -37,11 +37,17 @@ interface HttpSession {
         }
 
         @Override
+        public void retryWithH1C() {
+            throw new IllegalStateException();
+        }
+
+        @Override
         public void deactivate() {}
     };
 
     SessionProtocol protocol();
     boolean isActive();
     boolean onRequestSent();
+    void retryWithH1C();
     void deactivate();
 }

--- a/src/main/java/com/linecorp/armeria/client/HttpSessionChannelFactory.java
+++ b/src/main/java/com/linecorp/armeria/client/HttpSessionChannelFactory.java
@@ -42,11 +42,6 @@ import io.netty.util.internal.OneTimeTask;
 
 class HttpSessionChannelFactory implements Function<PoolKey, Future<Channel>> {
 
-    static final Object RETRY_WITH_H1C = new Object();
-
-    static final ChannelHealthChecker HEALTH_CHECKER =
-            ch -> ch.eventLoop().newSucceededFuture(HttpSessionHandler.get(ch).isActive());
-
     private final Bootstrap baseBootstrap;
     private final EventLoop eventLoop;
     private final Map<SessionProtocol, Bootstrap> bootstrapMap;

--- a/src/main/java/com/linecorp/armeria/client/RemoteInvokerOptions.java
+++ b/src/main/java/com/linecorp/armeria/client/RemoteInvokerOptions.java
@@ -56,7 +56,7 @@ public class RemoteInvokerOptions extends AbstractOptions {
     private static final int DEFAULT_MAX_FRAME_LENGTH = 10 * 1024 * 1024; // 10 MB
     private static final Integer DEFAULT_MAX_CONCURRENCY = Integer.MAX_VALUE;
     private static final Boolean DEFAULT_USE_HTTP2_PREFACE =
-            !"false".equals(System.getProperty("com.linecorp.armeria.defaultUseHttp2Preface", "true"));
+            "true".equals(System.getProperty("com.linecorp.armeria.defaultUseHttp2Preface", "false"));
 
     static {
         logger.info("defaultUseHttp2Preface: {}", DEFAULT_USE_HTTP2_PREFACE);


### PR DESCRIPTION
Motivation:

1)

The old Armeria server does not handle an HTTP request whose path is '*'
correctly. As a result, sending an HTTP/2 connection preface string will
make the server close the connection immediately.

HttpConfigurator.DowngradeHandler does not handle the case where the
connection is closed before the first 4 bytes are received, and thus it
fails to downgrade to H1C.

2)

Armeria server raises an unexpected exception when the path of an HTTP
request is not an absolute path rather than responding with 400 Bad
Request.

Also, it doesn't handle 'OPTIONS * HTTP/1.1' requests because of the
same reason.

Modifications:

- Make sure DowngradeHandler switches to H1C when less than 4 bytes were
  received before disconnection.
- Use 'HEAD / HTTP/1.1' again as the default upgrade mechanism for
  backward compatibility
- Respond with a '400 Bad Request' response when a request does not have
  an absolute path
- Handle 'OPTIONS * HTTP/1.1' specially
- Miscellaneous:
  - Move HttpSessionChannelFactory.HEALTH_CHECKER to HttpRemoteInvoker
    because it's used only there
  - Add documentation for HttpSessionHandler fields

Result:

- Armeria client works fine with the old Armeria servers again.
- No more IllegalArgumentException on non-absolute path requests
- Armeria server handles 'OPTIONS *' correctly
