### PR TITLE
Add doc strings to DocService's json output

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,7 @@
     <thrift.generated.test>${project.build.directory}/generated-test-sources</thrift.generated.test>
     <brave.version>3.5.0</brave.version>
     <guava.version>19.0</guava.version>
+    <reflections.version>0.9.10</reflections.version>
   </properties>
 
   <dependencies>
@@ -211,6 +212,13 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <version>${jackson.version}</version>
+    </dependency>
+
+    <!-- reflections -->
+    <dependency>
+      <groupId>org.reflections</groupId>
+      <artifactId>reflections</artifactId>
+      <version>${reflections.version}</version>
     </dependency>
 
     <!-- Metrics -->

--- a/src/main/java/com/linecorp/armeria/server/docs/ClassInfo.java
+++ b/src/main/java/com/linecorp/armeria/server/docs/ClassInfo.java
@@ -39,4 +39,7 @@ interface ClassInfo {
 
     @JsonProperty
     List<Object> constants();
+
+    @JsonProperty
+    String docString();
 }

--- a/src/main/java/com/linecorp/armeria/server/docs/EnumInfo.java
+++ b/src/main/java/com/linecorp/armeria/server/docs/EnumInfo.java
@@ -22,6 +22,7 @@ import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import org.apache.thrift.meta_data.EnumMetaData;
@@ -30,6 +31,10 @@ import org.apache.thrift.protocol.TType;
 class EnumInfo extends TypeInfo implements ClassInfo {
 
     static EnumInfo of(EnumMetaData enumMetaData) {
+        return of(enumMetaData, Collections.emptyMap());
+    }
+
+    static EnumInfo of(EnumMetaData enumMetaData, Map<String, String> docStrings) {
         requireNonNull(enumMetaData, "enumMetaData");
 
         final Class<?> enumClass = enumMetaData.enumClass;
@@ -47,21 +52,28 @@ class EnumInfo extends TypeInfo implements ClassInfo {
             }
         }
 
-        return new EnumInfo(enumClass.getName(), constants);
+        final String name = enumClass.getName();
+        return new EnumInfo(name, constants, docStrings.get(name));
     }
 
     static EnumInfo of(String name, List<Object> constants) {
-        return new EnumInfo(name, constants);
+        return of(name, constants, Collections.emptyMap());
+    }
+
+    static EnumInfo of(String name, List<Object> constants, Map<String, String> docStrings) {
+        return new EnumInfo(name, constants, docStrings.get(name));
     }
 
     private final String name;
     private final List<Object> constants;
+    private final String docString;
 
-    private EnumInfo(String name, List<Object> constants) {
+    private EnumInfo(String name, List<Object> constants, String docString) {
         super(ValueType.ENUM, false);
 
         this.name = requireNonNull(name, "name");
         this.constants = Collections.unmodifiableList(requireNonNull(constants, "constants"));
+        this.docString = docString;
     }
 
     @Override
@@ -77,6 +89,11 @@ class EnumInfo extends TypeInfo implements ClassInfo {
     @Override
     public List<Object> constants() {
         return constants;
+    }
+
+    @Override
+    public String docString() {
+        return docString;
     }
 
     @Override

--- a/src/main/java/com/linecorp/armeria/server/docs/FieldInfo.java
+++ b/src/main/java/com/linecorp/armeria/server/docs/FieldInfo.java
@@ -18,7 +18,11 @@ package com.linecorp.armeria.server.docs;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Collections;
+import java.util.Map;
 import java.util.Objects;
+
+import javax.annotation.Nullable;
 
 import org.apache.thrift.meta_data.FieldMetaData;
 
@@ -27,24 +31,39 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 class FieldInfo {
 
     static FieldInfo of(FieldMetaData fieldMetaData) {
-        requireNonNull(fieldMetaData, "fieldMetaData");
+        return of(fieldMetaData, null, Collections.emptyMap());
+    }
 
-        return new FieldInfo(fieldMetaData.fieldName, RequirementType.of(fieldMetaData.requirementType),
-                             TypeInfo.of(fieldMetaData.valueMetaData));
+    static FieldInfo of(FieldMetaData fieldMetaData, @Nullable String namespace,
+                        Map<String, String> docStrings) {
+        requireNonNull(fieldMetaData, "fieldMetaData");
+        final String docStringKey = ThriftDocString.key(namespace, fieldMetaData.fieldName);
+        return new FieldInfo(fieldMetaData.fieldName,
+                             RequirementType.of(fieldMetaData.requirementType),
+                             TypeInfo.of(fieldMetaData.valueMetaData, namespace, docStrings),
+                             docStrings.get(docStringKey));
     }
 
     static FieldInfo of(String name, RequirementType requirementType, TypeInfo type) {
-        return new FieldInfo(name, requirementType, type);
+        return of(name, requirementType, type, null, Collections.emptyMap());
+    }
+
+    static FieldInfo of(String name, RequirementType requirementType, TypeInfo type,
+                        @Nullable String namespace, Map<String, String> docStrings) {
+        final String docStringKey = ThriftDocString.key(namespace, name);
+        return new FieldInfo(name, requirementType, type, docStrings.get(docStringKey));
     }
 
     private final String name;
     private final RequirementType requirementType;
     private final TypeInfo type;
+    private final String docString;
 
-    private FieldInfo(String name, RequirementType requirementType, TypeInfo type) {
+    private FieldInfo(String name, RequirementType requirementType, TypeInfo type, @Nullable String docString) {
         this.name = requireNonNull(name, "name");
         this.requirementType = requireNonNull(requirementType, "requirementType");
         this.type = requireNonNull(type, "type");
+        this.docString = docString;
     }
 
     @JsonProperty
@@ -60,6 +79,11 @@ class FieldInfo {
     @JsonProperty
     public TypeInfo type() {
         return type;
+    }
+
+    @JsonProperty
+    public String docString() {
+        return docString;
     }
 
     @Override

--- a/src/main/java/com/linecorp/armeria/server/docs/ListInfo.java
+++ b/src/main/java/com/linecorp/armeria/server/docs/ListInfo.java
@@ -18,7 +18,11 @@ package com.linecorp.armeria.server.docs;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Collections;
+import java.util.Map;
 import java.util.Objects;
+
+import javax.annotation.Nullable;
 
 import org.apache.thrift.meta_data.ListMetaData;
 import org.apache.thrift.protocol.TType;
@@ -26,12 +30,16 @@ import org.apache.thrift.protocol.TType;
 class ListInfo extends TypeInfo implements CollectionInfo {
 
     static ListInfo of(ListMetaData listMetaData) {
+        return of(listMetaData, null, Collections.emptyMap());
+    }
+
+    static ListInfo of(ListMetaData listMetaData, @Nullable String namespace, Map<String, String> docStrings) {
         requireNonNull(listMetaData, "listMetaData");
 
         assert listMetaData.type == TType.LIST;
         assert !listMetaData.isBinary();
 
-        return new ListInfo(of(listMetaData.elemMetaData));
+        return new ListInfo(of(listMetaData.elemMetaData, namespace, docStrings));
     }
 
     static ListInfo of(TypeInfo elementType) {

--- a/src/main/java/com/linecorp/armeria/server/docs/MapInfo.java
+++ b/src/main/java/com/linecorp/armeria/server/docs/MapInfo.java
@@ -18,7 +18,11 @@ package com.linecorp.armeria.server.docs;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Collections;
+import java.util.Map;
 import java.util.Objects;
+
+import javax.annotation.Nullable;
 
 import org.apache.thrift.meta_data.MapMetaData;
 import org.apache.thrift.protocol.TType;
@@ -28,12 +32,17 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 class MapInfo extends TypeInfo {
 
     static MapInfo of(MapMetaData mapMetaData) {
+        return of(mapMetaData, null, Collections.emptyMap());
+    }
+
+    static MapInfo of(MapMetaData mapMetaData, @Nullable String namespace, Map<String, String> docStrings) {
         requireNonNull(mapMetaData, "mapMetaData");
 
         assert mapMetaData.type == TType.MAP;
         assert !mapMetaData.isBinary();
 
-        return new MapInfo(TypeInfo.of(mapMetaData.keyMetaData), TypeInfo.of(mapMetaData.valueMetaData));
+        return new MapInfo(TypeInfo.of(mapMetaData.keyMetaData, namespace, docStrings),
+                           TypeInfo.of(mapMetaData.valueMetaData, namespace, docStrings));
     }
 
     static MapInfo of(TypeInfo keyType, TypeInfo valueType) {

--- a/src/main/java/com/linecorp/armeria/server/docs/SetInfo.java
+++ b/src/main/java/com/linecorp/armeria/server/docs/SetInfo.java
@@ -18,7 +18,11 @@ package com.linecorp.armeria.server.docs;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Collections;
+import java.util.Map;
 import java.util.Objects;
+
+import javax.annotation.Nullable;
 
 import org.apache.thrift.meta_data.SetMetaData;
 import org.apache.thrift.protocol.TType;
@@ -26,12 +30,16 @@ import org.apache.thrift.protocol.TType;
 class SetInfo extends TypeInfo implements CollectionInfo {
 
     static SetInfo of(SetMetaData setMetaData) {
+        return of(setMetaData, null, Collections.emptyMap());
+    }
+
+    static SetInfo of(SetMetaData setMetaData, @Nullable String namespace, Map<String, String> docStrings) {
         requireNonNull(setMetaData, "setMetaData");
 
         assert setMetaData.type == TType.SET;
         assert !setMetaData.isBinary();
 
-        return new SetInfo(of(setMetaData.elemMetaData));
+        return new SetInfo(of(setMetaData.elemMetaData, namespace, docStrings));
     }
 
     static SetInfo of(TypeInfo elementType) {

--- a/src/main/java/com/linecorp/armeria/server/docs/ThriftDocString.java
+++ b/src/main/java/com/linecorp/armeria/server/docs/ThriftDocString.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.docs;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.reflections.Reflections;
+import org.reflections.scanners.ResourcesScanner;
+import org.reflections.util.ClasspathHelper;
+import org.reflections.util.ConfigurationBuilder;
+import org.reflections.util.FilterBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * {@link ThriftDocString} is a DocString extractor for Thrift IDL JSON.
+ *
+ * To include docstrings in {@link DocService} pages, use a recent development version of the Thrift compiler
+ * (0.9.3 will not work) and compile your thrift files with 'json' code generation and
+ * include the resulting json files in the classpath location META-INF/armeria/thrift.
+ * The classpath location can be changed by setting the armeria.thrift.json.dir system property.
+ */
+final class ThriftDocString {
+
+    private static final Logger logger = LoggerFactory.getLogger(ThriftDocString.class);
+
+    private static final String THRIFT_JSON_PATH;
+
+    private static final TypeReference JSON_VALUE_TYPE = new TypeReference<HashMap<String, Object>>() {};
+
+    private static final String FQCN_DELIM = ".";
+
+    private static final String DELIM = "#";
+
+    private static Map<ClassLoader, Map<String, String>> cached = new ConcurrentHashMap<>();
+
+    static {
+        final String propertyName = "com.linecorp.armeria.thrift.jsonDir";
+        String dir = System.getProperty(propertyName, "META-INF/armeria/thrift");
+        if (dir.startsWith("/") || dir.startsWith("\\")) {
+            dir = dir.substring(1);
+        }
+        if (dir.endsWith("/") || dir.endsWith("\\")) {
+            dir = dir.substring(0, dir.length() - 1);
+        }
+        logger.info("{}: {}", propertyName, dir);
+        THRIFT_JSON_PATH = dir;
+    }
+
+    private ThriftDocString() {
+    }
+
+    /**
+     * Extracts all DocStrings from all Thrift IDL JSON Resources.
+     * @return a map with key is FQCN and value is document string.
+     */
+    static Map<String, String> getAllDocStrings(ClassLoader classLoader) {
+        return cached.computeIfAbsent(classLoader, loader -> parseDocStrings(loader, getAllThriftJsons(loader)));
+    }
+
+    /**
+     * Parses DocStrings from input Thrift IDL JSON Resources.
+     * @return a map with key is FQCN and value is document string.
+     */
+    static Map<String, String> parseDocStrings(ClassLoader classLoader, Iterable<String> jsonPaths) {
+        final ImmutableMap.Builder<String, String> docStrings = ImmutableMap.builder();
+        for (String jsonPath : jsonPaths) {
+            docStrings.putAll(getDocStringsFromJsonResource(classLoader, jsonPath));
+        }
+        return docStrings.build();
+    }
+
+    static Iterable<String> getAllThriftJsons(ClassLoader classLoader) {
+        final Reflections reflections = new Reflections(
+                new ConfigurationBuilder()
+                        .filterInputsBy(new FilterBuilder().includePackage(THRIFT_JSON_PATH))
+                        .setUrls(ClasspathHelper.forPackage(THRIFT_JSON_PATH))
+                        .addClassLoader(classLoader)
+                        .addScanners(new ResourcesScanner()));
+        return reflections.getResources(filename -> filename.endsWith(".json"));
+    }
+
+    /**
+     * Gets the namespace key of names.
+     * @param names name list.
+     * @return merged key.
+     */
+    static String key(String... names) {
+        return Stream.of(names).filter(s -> !Strings.isNullOrEmpty(s)).collect(Collectors.joining(DELIM));
+    }
+
+    @VisibleForTesting
+    static Map<String, String> getDocStringsFromJsonResource(ClassLoader classLoader, String jsonResourcePath) {
+        ImmutableMap.Builder<String, String> docStrings = ImmutableMap.builder();
+        try (InputStream in = classLoader.getResourceAsStream(jsonResourcePath)) {
+            if (in == null) {
+                throw new IllegalStateException("not found: " + jsonResourcePath);
+            }
+
+            final Map<String, Object> json = new ObjectMapper().readValue(in, JSON_VALUE_TYPE);
+            @SuppressWarnings("unchecked")
+            final Map<String, Object> namespaces = (Map<String, Object>) json.getOrDefault("namespaces",
+                                                                                           ImmutableMap.of());
+            final String packageName = (String) namespaces.get("java");
+            json.forEach((key, children) -> {
+                if (children instanceof Collection) {
+                    ((Collection) children).forEach(grandChild -> {
+                        traverseChildren(docStrings, packageName, FQCN_DELIM, grandChild);
+                    });
+                }
+            });
+
+            return docStrings.build();
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static void traverseChildren(ImmutableMap.Builder<String, String> docStrings, String prefix,
+                                         String delimiter, Object node) {
+        if (node instanceof Map) {
+            @SuppressWarnings("unchecked")
+            final Map<String, Object> map = (Map<String, Object>) node;
+            final String name = (String) map.get("name");
+            final String doc = (String) map.get("doc");
+            String childPrefix;
+            if (name != null) {
+                childPrefix = (prefix != null ? prefix : "") + delimiter + name;
+                if (doc != null) {
+                    docStrings.put(childPrefix, doc);
+                }
+            } else {
+                childPrefix = prefix;
+            }
+            map.forEach((key, value) -> traverseChildren(docStrings, childPrefix, DELIM, value));
+        } else if (node instanceof Iterable) {
+            @SuppressWarnings("unchecked")
+            final Iterable<Object> children = (Iterable<Object>) node;
+            children.forEach(child -> traverseChildren(docStrings, prefix, DELIM, child));
+        }
+    }
+}

--- a/src/main/java/com/linecorp/armeria/server/docs/TypeInfo.java
+++ b/src/main/java/com/linecorp/armeria/server/docs/TypeInfo.java
@@ -18,7 +18,10 @@ package com.linecorp.armeria.server.docs;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Map;
 import java.util.Objects;
+
+import javax.annotation.Nullable;
 
 import org.apache.thrift.meta_data.EnumMetaData;
 import org.apache.thrift.meta_data.FieldValueMetaData;
@@ -32,25 +35,26 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 class TypeInfo {
     static final TypeInfo VOID = new TypeInfo(ValueType.VOID, false);
 
-    static TypeInfo of(FieldValueMetaData fieldValueMetaData) {
+    static TypeInfo of(FieldValueMetaData fieldValueMetaData, @Nullable String namespace,
+                       Map<String, String> docStrings) {
         if (fieldValueMetaData instanceof StructMetaData) {
-            return StructInfo.of((StructMetaData) fieldValueMetaData);
+            return StructInfo.of((StructMetaData) fieldValueMetaData, namespace, docStrings);
         }
 
         if (fieldValueMetaData instanceof EnumMetaData) {
-            return EnumInfo.of((EnumMetaData) fieldValueMetaData);
+            return EnumInfo.of((EnumMetaData) fieldValueMetaData, docStrings);
         }
 
         if (fieldValueMetaData instanceof ListMetaData) {
-            return ListInfo.of((ListMetaData) fieldValueMetaData);
+            return ListInfo.of((ListMetaData) fieldValueMetaData, namespace, docStrings);
         }
 
         if (fieldValueMetaData instanceof SetMetaData) {
-            return SetInfo.of((SetMetaData) fieldValueMetaData);
+            return SetInfo.of((SetMetaData) fieldValueMetaData, namespace, docStrings);
         }
 
         if (fieldValueMetaData instanceof MapMetaData) {
-            return MapInfo.of((MapMetaData) fieldValueMetaData);
+            return MapInfo.of((MapMetaData) fieldValueMetaData, namespace, docStrings);
         }
 
         return new TypeInfo(ValueType.of(fieldValueMetaData.type), fieldValueMetaData.isBinary());

--- a/src/test/java/com/linecorp/armeria/server/docs/ThriftDocStringTest.java
+++ b/src/test/java/com/linecorp/armeria/server/docs/ThriftDocStringTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2015 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.docs;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.junit.Test;
+
+/**
+ * Tests {@link ThriftDocString}.
+ */
+public class ThriftDocStringTest {
+    @Test
+    public void testThriftTestJson() {
+        Map<String, String> docStrings = ThriftDocString.getDocStringsFromJsonResource(
+                getClass().getClassLoader(),
+                "META-INF/armeria/thrift/ThriftTest.json");
+        assertThat(docStrings.get("thrift.test.Numberz"), is("Docstring!\n"));
+        assertThat(docStrings.get("thrift.test.ThriftTest#testVoid"),
+                   is("Prints \"testVoid()\" and returns nothing.\n"));
+    }
+
+    @Test
+    public void testCassandraJson() {
+        Map<String, String> docStrings = ThriftDocString.getDocStringsFromJsonResource(
+                getClass().getClassLoader(),
+                "META-INF/armeria/thrift/cassandra.json");
+        assertThat(docStrings.get("com.linecorp.armeria.service.test.thrift.cassandra.Compression"),
+                   is("CQL query compression\n"));
+        assertThat(docStrings.get("com.linecorp.armeria.service.test.thrift.cassandra.CqlResultType"),
+                   is(nullValue()));
+    }
+
+    @Test
+    public void testGetAllDocStrings() throws IOException {
+        Map<String, String> docStrings = ThriftDocString.getAllDocStrings(getClass().getClassLoader());
+        assertThat(docStrings.containsKey("thrift.test.Numberz"), is(true));
+        assertThat(docStrings.containsKey("com.linecorp.armeria.service.test.thrift.cassandra.Compression"),
+                   is(true));
+    }
+}

--- a/src/test/resources/META-INF/armeria/thrift/ThriftTest.json
+++ b/src/test/resources/META-INF/armeria/thrift/ThriftTest.json
@@ -1,0 +1,1425 @@
+{
+  "name": "ThriftTest",
+  "namespaces": {
+    "*": "thrift.test",
+    "c_glib": "TTest",
+    "cocoa": "ThriftTest",
+    "cpp": "thrift.test",
+    "cpp.noexist": "ThriftTest",
+    "csharp": "Thrift.Test",
+    "delphi": "Thrift.Test",
+    "go": "thrifttest",
+    "java": "thrift.test",
+    "js": "ThriftTest",
+    "lua": "ThriftTest",
+    "noexist": "ThriftTest",
+    "perl": "ThriftTest",
+    "php": "ThriftTest",
+    "py": "ThriftTest",
+    "py.twisted": "ThriftTest",
+    "rb": "Thrift.Test",
+    "st": "ThriftTest",
+    "xsd": "test"
+  },
+  "includes": [
+  ],
+  "enums": [
+    {
+      "name": "Numberz",
+      "doc": "Docstring!\n",
+      "members": [
+        {
+          "name": "ONE",
+          "value": 1
+        },
+        {
+          "name": "TWO",
+          "value": 2
+        },
+        {
+          "name": "THREE",
+          "value": 3
+        },
+        {
+          "name": "FIVE",
+          "value": 5
+        },
+        {
+          "name": "SIX",
+          "value": 6
+        },
+        {
+          "name": "EIGHT",
+          "value": 8
+        }
+      ]
+    }
+  ],
+  "typedefs": [
+    {
+      "name": "UserId",
+      "typeId": "i64"
+    },
+    {
+      "name": "MapType",
+      "typeId": "map",
+      "type": {
+        "typeId": "map",
+        "keyTypeId": "string",
+        "valueTypeId": "struct",
+        "valueType": {
+          "typeId": "struct",
+          "class": "Bonk"
+        }
+      }
+    }
+  ],
+  "structs": [
+    {
+      "name": "Bonk",
+      "isException": false,
+      "isUnion": false,
+      "fields": [
+        {
+          "key": 1,
+          "name": "message",
+          "typeId": "string",
+          "required": "req_out"
+        },
+        {
+          "key": 2,
+          "name": "type",
+          "typeId": "i32",
+          "required": "req_out"
+        }
+      ]
+    },
+    {
+      "name": "Bools",
+      "isException": false,
+      "isUnion": false,
+      "fields": [
+        {
+          "key": 1,
+          "name": "im_true",
+          "typeId": "bool",
+          "required": "req_out"
+        },
+        {
+          "key": 2,
+          "name": "im_false",
+          "typeId": "bool",
+          "required": "req_out"
+        }
+      ]
+    },
+    {
+      "name": "Xtruct",
+      "isException": false,
+      "isUnion": false,
+      "fields": [
+        {
+          "key": 1,
+          "name": "string_thing",
+          "typeId": "string",
+          "required": "req_out"
+        },
+        {
+          "key": 4,
+          "name": "byte_thing",
+          "typeId": "i8",
+          "required": "req_out"
+        },
+        {
+          "key": 9,
+          "name": "i32_thing",
+          "typeId": "i32",
+          "required": "req_out"
+        },
+        {
+          "key": 11,
+          "name": "i64_thing",
+          "typeId": "i64",
+          "required": "req_out"
+        }
+      ]
+    },
+    {
+      "name": "Xtruct2",
+      "isException": false,
+      "isUnion": false,
+      "fields": [
+        {
+          "key": 1,
+          "name": "byte_thing",
+          "typeId": "i8",
+          "required": "req_out"
+        },
+        {
+          "key": 2,
+          "name": "struct_thing",
+          "typeId": "struct",
+          "type": {
+            "typeId": "struct",
+            "class": "Xtruct"
+          },
+          "required": "req_out"
+        },
+        {
+          "key": 3,
+          "name": "i32_thing",
+          "typeId": "i32",
+          "required": "req_out"
+        }
+      ]
+    },
+    {
+      "name": "Xtruct3",
+      "isException": false,
+      "isUnion": false,
+      "fields": [
+        {
+          "key": 1,
+          "name": "string_thing",
+          "typeId": "string",
+          "required": "req_out"
+        },
+        {
+          "key": 4,
+          "name": "changed",
+          "typeId": "i32",
+          "required": "req_out"
+        },
+        {
+          "key": 9,
+          "name": "i32_thing",
+          "typeId": "i32",
+          "required": "req_out"
+        },
+        {
+          "key": 11,
+          "name": "i64_thing",
+          "typeId": "i64",
+          "required": "req_out"
+        }
+      ]
+    },
+    {
+      "name": "Insanity",
+      "isException": false,
+      "isUnion": false,
+      "fields": [
+        {
+          "key": 1,
+          "name": "userMap",
+          "typeId": "map",
+          "type": {
+            "typeId": "map",
+            "keyTypeId": "i32",
+            "valueTypeId": "i64"
+          },
+          "required": "req_out"
+        },
+        {
+          "key": 2,
+          "name": "xtructs",
+          "typeId": "list",
+          "type": {
+            "typeId": "list",
+            "elemTypeId": "struct",
+            "elemType": {
+              "typeId": "struct",
+              "class": "Xtruct"
+            }
+          },
+          "required": "req_out"
+        }
+      ]
+    },
+    {
+      "name": "CrazyNesting",
+      "isException": false,
+      "isUnion": false,
+      "fields": [
+        {
+          "key": 1,
+          "name": "string_field",
+          "typeId": "string",
+          "required": "req_out"
+        },
+        {
+          "key": 2,
+          "name": "set_field",
+          "typeId": "set",
+          "type": {
+            "typeId": "set",
+            "elemTypeId": "struct",
+            "elemType": {
+              "typeId": "struct",
+              "class": "Insanity"
+            }
+          },
+          "required": "optional"
+        },
+        {
+          "key": 3,
+          "name": "list_field",
+          "typeId": "list",
+          "type": {
+            "typeId": "list",
+            "elemTypeId": "map",
+            "elemType": {
+              "typeId": "map",
+              "keyTypeId": "set",
+              "valueTypeId": "map",
+              "keyType": {
+                "typeId": "set",
+                "elemTypeId": "i32"
+              },
+              "valueType": {
+                "typeId": "map",
+                "keyTypeId": "i32",
+                "valueTypeId": "set",
+                "valueType": {
+                  "typeId": "set",
+                  "elemTypeId": "list",
+                  "elemType": {
+                    "typeId": "list",
+                    "elemTypeId": "map",
+                    "elemType": {
+                      "typeId": "map",
+                      "keyTypeId": "struct",
+                      "valueTypeId": "string",
+                      "keyType": {
+                        "typeId": "struct",
+                        "class": "Insanity"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "required": "required"
+        },
+        {
+          "key": 4,
+          "name": "binary_field",
+          "typeId": "binary",
+          "required": "req_out"
+        }
+      ]
+    },
+    {
+      "name": "Xception",
+      "isException": true,
+      "isUnion": false,
+      "fields": [
+        {
+          "key": 1,
+          "name": "errorCode",
+          "typeId": "i32",
+          "required": "req_out"
+        },
+        {
+          "key": 2,
+          "name": "message",
+          "typeId": "string",
+          "required": "req_out"
+        }
+      ]
+    },
+    {
+      "name": "Xception2",
+      "isException": true,
+      "isUnion": false,
+      "fields": [
+        {
+          "key": 1,
+          "name": "errorCode",
+          "typeId": "i32",
+          "required": "req_out"
+        },
+        {
+          "key": 2,
+          "name": "struct_thing",
+          "typeId": "struct",
+          "type": {
+            "typeId": "struct",
+            "class": "Xtruct"
+          },
+          "required": "req_out"
+        }
+      ]
+    },
+    {
+      "name": "EmptyStruct",
+      "isException": false,
+      "isUnion": false,
+      "fields": [
+      ]
+    },
+    {
+      "name": "OneField",
+      "isException": false,
+      "isUnion": false,
+      "fields": [
+        {
+          "key": 1,
+          "name": "field",
+          "typeId": "struct",
+          "type": {
+            "typeId": "struct",
+            "class": "EmptyStruct"
+          },
+          "required": "req_out"
+        }
+      ]
+    },
+    {
+      "name": "VersioningTestV1",
+      "isException": false,
+      "isUnion": false,
+      "fields": [
+        {
+          "key": 1,
+          "name": "begin_in_both",
+          "typeId": "i32",
+          "required": "req_out"
+        },
+        {
+          "key": 3,
+          "name": "old_string",
+          "typeId": "string",
+          "required": "req_out"
+        },
+        {
+          "key": 12,
+          "name": "end_in_both",
+          "typeId": "i32",
+          "required": "req_out"
+        }
+      ]
+    },
+    {
+      "name": "VersioningTestV2",
+      "isException": false,
+      "isUnion": false,
+      "fields": [
+        {
+          "key": 1,
+          "name": "begin_in_both",
+          "typeId": "i32",
+          "required": "req_out"
+        },
+        {
+          "key": 2,
+          "name": "newint",
+          "typeId": "i32",
+          "required": "req_out"
+        },
+        {
+          "key": 3,
+          "name": "newbyte",
+          "typeId": "i8",
+          "required": "req_out"
+        },
+        {
+          "key": 4,
+          "name": "newshort",
+          "typeId": "i16",
+          "required": "req_out"
+        },
+        {
+          "key": 5,
+          "name": "newlong",
+          "typeId": "i64",
+          "required": "req_out"
+        },
+        {
+          "key": 6,
+          "name": "newdouble",
+          "typeId": "double",
+          "required": "req_out"
+        },
+        {
+          "key": 7,
+          "name": "newstruct",
+          "typeId": "struct",
+          "type": {
+            "typeId": "struct",
+            "class": "Bonk"
+          },
+          "required": "req_out"
+        },
+        {
+          "key": 8,
+          "name": "newlist",
+          "typeId": "list",
+          "type": {
+            "typeId": "list",
+            "elemTypeId": "i32"
+          },
+          "required": "req_out"
+        },
+        {
+          "key": 9,
+          "name": "newset",
+          "typeId": "set",
+          "type": {
+            "typeId": "set",
+            "elemTypeId": "i32"
+          },
+          "required": "req_out"
+        },
+        {
+          "key": 10,
+          "name": "newmap",
+          "typeId": "map",
+          "type": {
+            "typeId": "map",
+            "keyTypeId": "i32",
+            "valueTypeId": "i32"
+          },
+          "required": "req_out"
+        },
+        {
+          "key": 11,
+          "name": "newstring",
+          "typeId": "string",
+          "required": "req_out"
+        },
+        {
+          "key": 12,
+          "name": "end_in_both",
+          "typeId": "i32",
+          "required": "req_out"
+        }
+      ]
+    },
+    {
+      "name": "ListTypeVersioningV1",
+      "isException": false,
+      "isUnion": false,
+      "fields": [
+        {
+          "key": 1,
+          "name": "myints",
+          "typeId": "list",
+          "type": {
+            "typeId": "list",
+            "elemTypeId": "i32"
+          },
+          "required": "req_out"
+        },
+        {
+          "key": 2,
+          "name": "hello",
+          "typeId": "string",
+          "required": "req_out"
+        }
+      ]
+    },
+    {
+      "name": "ListTypeVersioningV2",
+      "isException": false,
+      "isUnion": false,
+      "fields": [
+        {
+          "key": 1,
+          "name": "strings",
+          "typeId": "list",
+          "type": {
+            "typeId": "list",
+            "elemTypeId": "string"
+          },
+          "required": "req_out"
+        },
+        {
+          "key": 2,
+          "name": "hello",
+          "typeId": "string",
+          "required": "req_out"
+        }
+      ]
+    },
+    {
+      "name": "GuessProtocolStruct",
+      "isException": false,
+      "isUnion": false,
+      "fields": [
+        {
+          "key": 7,
+          "name": "map_field",
+          "typeId": "map",
+          "type": {
+            "typeId": "map",
+            "keyTypeId": "string",
+            "valueTypeId": "string"
+          },
+          "required": "req_out"
+        }
+      ]
+    },
+    {
+      "name": "LargeDeltas",
+      "isException": false,
+      "isUnion": false,
+      "fields": [
+        {
+          "key": 1,
+          "name": "b1",
+          "typeId": "struct",
+          "type": {
+            "typeId": "struct",
+            "class": "Bools"
+          },
+          "required": "req_out"
+        },
+        {
+          "key": 10,
+          "name": "b10",
+          "typeId": "struct",
+          "type": {
+            "typeId": "struct",
+            "class": "Bools"
+          },
+          "required": "req_out"
+        },
+        {
+          "key": 100,
+          "name": "b100",
+          "typeId": "struct",
+          "type": {
+            "typeId": "struct",
+            "class": "Bools"
+          },
+          "required": "req_out"
+        },
+        {
+          "key": 500,
+          "name": "check_true",
+          "typeId": "bool",
+          "required": "req_out"
+        },
+        {
+          "key": 1000,
+          "name": "b1000",
+          "typeId": "struct",
+          "type": {
+            "typeId": "struct",
+            "class": "Bools"
+          },
+          "required": "req_out"
+        },
+        {
+          "key": 1500,
+          "name": "check_false",
+          "typeId": "bool",
+          "required": "req_out"
+        },
+        {
+          "key": 2000,
+          "name": "vertwo2000",
+          "typeId": "struct",
+          "type": {
+            "typeId": "struct",
+            "class": "VersioningTestV2"
+          },
+          "required": "req_out"
+        },
+        {
+          "key": 2500,
+          "name": "a_set2500",
+          "typeId": "set",
+          "type": {
+            "typeId": "set",
+            "elemTypeId": "string"
+          },
+          "required": "req_out"
+        },
+        {
+          "key": 3000,
+          "name": "vertwo3000",
+          "typeId": "struct",
+          "type": {
+            "typeId": "struct",
+            "class": "VersioningTestV2"
+          },
+          "required": "req_out"
+        },
+        {
+          "key": 4000,
+          "name": "big_numbers",
+          "typeId": "list",
+          "type": {
+            "typeId": "list",
+            "elemTypeId": "i32"
+          },
+          "required": "req_out"
+        }
+      ]
+    },
+    {
+      "name": "NestedListsI32x2",
+      "isException": false,
+      "isUnion": false,
+      "fields": [
+        {
+          "key": 1,
+          "name": "integerlist",
+          "typeId": "list",
+          "type": {
+            "typeId": "list",
+            "elemTypeId": "list",
+            "elemType": {
+              "typeId": "list",
+              "elemTypeId": "i32"
+            }
+          },
+          "required": "req_out"
+        }
+      ]
+    },
+    {
+      "name": "NestedListsI32x3",
+      "isException": false,
+      "isUnion": false,
+      "fields": [
+        {
+          "key": 1,
+          "name": "integerlist",
+          "typeId": "list",
+          "type": {
+            "typeId": "list",
+            "elemTypeId": "list",
+            "elemType": {
+              "typeId": "list",
+              "elemTypeId": "list",
+              "elemType": {
+                "typeId": "list",
+                "elemTypeId": "i32"
+              }
+            }
+          },
+          "required": "req_out"
+        }
+      ]
+    },
+    {
+      "name": "NestedMixedx2",
+      "isException": false,
+      "isUnion": false,
+      "fields": [
+        {
+          "key": 1,
+          "name": "int_set_list",
+          "typeId": "list",
+          "type": {
+            "typeId": "list",
+            "elemTypeId": "set",
+            "elemType": {
+              "typeId": "set",
+              "elemTypeId": "i32"
+            }
+          },
+          "required": "req_out"
+        },
+        {
+          "key": 2,
+          "name": "map_int_strset",
+          "typeId": "map",
+          "type": {
+            "typeId": "map",
+            "keyTypeId": "i32",
+            "valueTypeId": "set",
+            "valueType": {
+              "typeId": "set",
+              "elemTypeId": "string"
+            }
+          },
+          "required": "req_out"
+        },
+        {
+          "key": 3,
+          "name": "map_int_strset_list",
+          "typeId": "list",
+          "type": {
+            "typeId": "list",
+            "elemTypeId": "map",
+            "elemType": {
+              "typeId": "map",
+              "keyTypeId": "i32",
+              "valueTypeId": "set",
+              "valueType": {
+                "typeId": "set",
+                "elemTypeId": "string"
+              }
+            }
+          },
+          "required": "req_out"
+        }
+      ]
+    },
+    {
+      "name": "ListBonks",
+      "isException": false,
+      "isUnion": false,
+      "fields": [
+        {
+          "key": 1,
+          "name": "bonk",
+          "typeId": "list",
+          "type": {
+            "typeId": "list",
+            "elemTypeId": "struct",
+            "elemType": {
+              "typeId": "struct",
+              "class": "Bonk"
+            }
+          },
+          "required": "req_out"
+        }
+      ]
+    },
+    {
+      "name": "NestedListsBonk",
+      "isException": false,
+      "isUnion": false,
+      "fields": [
+        {
+          "key": 1,
+          "name": "bonk",
+          "typeId": "list",
+          "type": {
+            "typeId": "list",
+            "elemTypeId": "list",
+            "elemType": {
+              "typeId": "list",
+              "elemTypeId": "list",
+              "elemType": {
+                "typeId": "list",
+                "elemTypeId": "struct",
+                "elemType": {
+                  "typeId": "struct",
+                  "class": "Bonk"
+                }
+              }
+            }
+          },
+          "required": "req_out"
+        }
+      ]
+    },
+    {
+      "name": "BoolTest",
+      "isException": false,
+      "isUnion": false,
+      "fields": [
+        {
+          "key": 1,
+          "name": "b",
+          "typeId": "bool",
+          "required": "optional",
+          "default": 1
+        },
+        {
+          "key": 2,
+          "name": "s",
+          "typeId": "string",
+          "required": "optional",
+          "default": "true"
+        }
+      ]
+    },
+    {
+      "name": "StructA",
+      "isException": false,
+      "isUnion": false,
+      "fields": [
+        {
+          "key": 1,
+          "name": "s",
+          "typeId": "string",
+          "required": "required"
+        }
+      ]
+    },
+    {
+      "name": "StructB",
+      "isException": false,
+      "isUnion": false,
+      "fields": [
+        {
+          "key": 1,
+          "name": "aa",
+          "typeId": "struct",
+          "type": {
+            "typeId": "struct",
+            "class": "StructA"
+          },
+          "required": "optional"
+        },
+        {
+          "key": 2,
+          "name": "ab",
+          "typeId": "struct",
+          "type": {
+            "typeId": "struct",
+            "class": "StructA"
+          },
+          "required": "required"
+        }
+      ]
+    }
+  ],
+  "constants": [
+    {
+      "name": "myNumberz",
+      "typeId": "i32",
+      "value": 1
+    }
+  ],
+  "services": [
+    {
+      "name": "ThriftTest",
+      "functions": [
+        {
+          "name": "testVoid",
+          "returnTypeId": "void",
+          "oneway": false,
+          "doc": "Prints \"testVoid()\" and returns nothing.\n",
+          "arguments": [
+          ],
+          "exceptions": [
+          ]
+        },
+        {
+          "name": "testString",
+          "returnTypeId": "string",
+          "oneway": false,
+          "doc": "Prints 'testString(\"%s\")' with thing as '%s'\n@param string thing - the string to print\n@return string - returns the string 'thing'\n",
+          "arguments": [
+            {
+              "key": 1,
+              "name": "thing",
+              "typeId": "string",
+              "required": "req_out"
+            }
+          ],
+          "exceptions": [
+          ]
+        },
+        {
+          "name": "testBool",
+          "returnTypeId": "bool",
+          "oneway": false,
+          "doc": "Prints 'testBool(\"%s\")' where '%s' with thing as 'true' or 'false'\n@param bool  thing - the bool data to print\n@return bool  - returns the bool 'thing'\n",
+          "arguments": [
+            {
+              "key": 1,
+              "name": "thing",
+              "typeId": "bool",
+              "required": "req_out"
+            }
+          ],
+          "exceptions": [
+          ]
+        },
+        {
+          "name": "testByte",
+          "returnTypeId": "i8",
+          "oneway": false,
+          "doc": "Prints 'testByte(\"%d\")' with thing as '%d'\nThe types i8 and byte are synonyms, use of i8 is encouraged, byte still exists for the sake of compatibility.\n@param byte thing - the i8\/byte to print\n@return i8 - returns the i8\/byte 'thing'\n",
+          "arguments": [
+            {
+              "key": 1,
+              "name": "thing",
+              "typeId": "i8",
+              "required": "req_out"
+            }
+          ],
+          "exceptions": [
+          ]
+        },
+        {
+          "name": "testI32",
+          "returnTypeId": "i32",
+          "oneway": false,
+          "doc": "Prints 'testI32(\"%d\")' with thing as '%d'\n@param i32 thing - the i32 to print\n@return i32 - returns the i32 'thing'\n",
+          "arguments": [
+            {
+              "key": 1,
+              "name": "thing",
+              "typeId": "i32",
+              "required": "req_out"
+            }
+          ],
+          "exceptions": [
+          ]
+        },
+        {
+          "name": "testI64",
+          "returnTypeId": "i64",
+          "oneway": false,
+          "doc": "Prints 'testI64(\"%d\")' with thing as '%d'\n@param i64 thing - the i64 to print\n@return i64 - returns the i64 'thing'\n",
+          "arguments": [
+            {
+              "key": 1,
+              "name": "thing",
+              "typeId": "i64",
+              "required": "req_out"
+            }
+          ],
+          "exceptions": [
+          ]
+        },
+        {
+          "name": "testDouble",
+          "returnTypeId": "double",
+          "oneway": false,
+          "doc": "Prints 'testDouble(\"%f\")' with thing as '%f'\n@param double thing - the double to print\n@return double - returns the double 'thing'\n",
+          "arguments": [
+            {
+              "key": 1,
+              "name": "thing",
+              "typeId": "double",
+              "required": "req_out"
+            }
+          ],
+          "exceptions": [
+          ]
+        },
+        {
+          "name": "testBinary",
+          "returnTypeId": "binary",
+          "oneway": false,
+          "doc": "Prints 'testBinary(\"%s\")' where '%s' is a hex-formatted string of thing's data\n@param binary  thing - the binary data to print\n@return binary  - returns the binary 'thing'\n",
+          "arguments": [
+            {
+              "key": 1,
+              "name": "thing",
+              "typeId": "binary",
+              "required": "req_out"
+            }
+          ],
+          "exceptions": [
+          ]
+        },
+        {
+          "name": "testStruct",
+          "returnTypeId": "struct",
+          "returnType": {
+            "typeId": "struct",
+            "class": "Xtruct"
+          },
+          "oneway": false,
+          "doc": "Prints 'testStruct(\"{%s}\")' where thing has been formatted into a string of comma separated values\n@param Xtruct thing - the Xtruct to print\n@return Xtruct - returns the Xtruct 'thing'\n",
+          "arguments": [
+            {
+              "key": 1,
+              "name": "thing",
+              "typeId": "struct",
+              "type": {
+                "typeId": "struct",
+                "class": "Xtruct"
+              },
+              "required": "req_out"
+            }
+          ],
+          "exceptions": [
+          ]
+        },
+        {
+          "name": "testNest",
+          "returnTypeId": "struct",
+          "returnType": {
+            "typeId": "struct",
+            "class": "Xtruct2"
+          },
+          "oneway": false,
+          "doc": "Prints 'testNest(\"{%s}\")' where thing has been formatted into a string of the nested struct\n@param Xtruct2 thing - the Xtruct2 to print\n@return Xtruct2 - returns the Xtruct2 'thing'\n",
+          "arguments": [
+            {
+              "key": 1,
+              "name": "thing",
+              "typeId": "struct",
+              "type": {
+                "typeId": "struct",
+                "class": "Xtruct2"
+              },
+              "required": "req_out"
+            }
+          ],
+          "exceptions": [
+          ]
+        },
+        {
+          "name": "testMap",
+          "returnTypeId": "map",
+          "returnType": {
+            "typeId": "map",
+            "keyTypeId": "i32",
+            "valueTypeId": "i32"
+          },
+          "oneway": false,
+          "doc": "Prints 'testMap(\"{%s\")' where thing has been formatted into a string of  'key => value' pairs\n separated by commas and new lines\n@param map<i32,i32> thing - the map<i32,i32> to print\n@return map<i32,i32> - returns the map<i32,i32> 'thing'\n",
+          "arguments": [
+            {
+              "key": 1,
+              "name": "thing",
+              "typeId": "map",
+              "type": {
+                "typeId": "map",
+                "keyTypeId": "i32",
+                "valueTypeId": "i32"
+              },
+              "required": "req_out"
+            }
+          ],
+          "exceptions": [
+          ]
+        },
+        {
+          "name": "testStringMap",
+          "returnTypeId": "map",
+          "returnType": {
+            "typeId": "map",
+            "keyTypeId": "string",
+            "valueTypeId": "string"
+          },
+          "oneway": false,
+          "doc": "Prints 'testStringMap(\"{%s}\")' where thing has been formatted into a string of  'key => value' pairs\n separated by commas and new lines\n@param map<string,string> thing - the map<string,string> to print\n@return map<string,string> - returns the map<string,string> 'thing'\n",
+          "arguments": [
+            {
+              "key": 1,
+              "name": "thing",
+              "typeId": "map",
+              "type": {
+                "typeId": "map",
+                "keyTypeId": "string",
+                "valueTypeId": "string"
+              },
+              "required": "req_out"
+            }
+          ],
+          "exceptions": [
+          ]
+        },
+        {
+          "name": "testSet",
+          "returnTypeId": "set",
+          "returnType": {
+            "typeId": "set",
+            "elemTypeId": "i32"
+          },
+          "oneway": false,
+          "doc": "Prints 'testSet(\"{%s}\")' where thing has been formatted into a string of  values\n separated by commas and new lines\n@param set<i32> thing - the set<i32> to print\n@return set<i32> - returns the set<i32> 'thing'\n",
+          "arguments": [
+            {
+              "key": 1,
+              "name": "thing",
+              "typeId": "set",
+              "type": {
+                "typeId": "set",
+                "elemTypeId": "i32"
+              },
+              "required": "req_out"
+            }
+          ],
+          "exceptions": [
+          ]
+        },
+        {
+          "name": "testList",
+          "returnTypeId": "list",
+          "returnType": {
+            "typeId": "list",
+            "elemTypeId": "i32"
+          },
+          "oneway": false,
+          "doc": "Prints 'testList(\"{%s}\")' where thing has been formatted into a string of  values\n separated by commas and new lines\n@param list<i32> thing - the list<i32> to print\n@return list<i32> - returns the list<i32> 'thing'\n",
+          "arguments": [
+            {
+              "key": 1,
+              "name": "thing",
+              "typeId": "list",
+              "type": {
+                "typeId": "list",
+                "elemTypeId": "i32"
+              },
+              "required": "req_out"
+            }
+          ],
+          "exceptions": [
+          ]
+        },
+        {
+          "name": "testEnum",
+          "returnTypeId": "i32",
+          "oneway": false,
+          "doc": "Prints 'testEnum(\"%d\")' where thing has been formatted into it's numeric value\n@param Numberz thing - the Numberz to print\n@return Numberz - returns the Numberz 'thing'\n",
+          "arguments": [
+            {
+              "key": 1,
+              "name": "thing",
+              "typeId": "i32",
+              "required": "req_out"
+            }
+          ],
+          "exceptions": [
+          ]
+        },
+        {
+          "name": "testTypedef",
+          "returnTypeId": "i64",
+          "oneway": false,
+          "doc": "Prints 'testTypedef(\"%d\")' with thing as '%d'\n@param UserId thing - the UserId to print\n@return UserId - returns the UserId 'thing'\n",
+          "arguments": [
+            {
+              "key": 1,
+              "name": "thing",
+              "typeId": "i64",
+              "required": "req_out"
+            }
+          ],
+          "exceptions": [
+          ]
+        },
+        {
+          "name": "testMapMap",
+          "returnTypeId": "map",
+          "returnType": {
+            "typeId": "map",
+            "keyTypeId": "i32",
+            "valueTypeId": "map",
+            "valueType": {
+              "typeId": "map",
+              "keyTypeId": "i32",
+              "valueTypeId": "i32"
+            }
+          },
+          "oneway": false,
+          "doc": "Prints 'testMapMap(\"%d\")' with hello as '%d'\n@param i32 hello - the i32 to print\n@return map<i32,map<i32,i32>> - returns a dictionary with these values:\n  {-4 => {-4 => -4, -3 => -3, -2 => -2, -1 => -1, }, 4 => {1 => 1, 2 => 2, 3 => 3, 4 => 4, }, }\n",
+          "arguments": [
+            {
+              "key": 1,
+              "name": "hello",
+              "typeId": "i32",
+              "required": "req_out"
+            }
+          ],
+          "exceptions": [
+          ]
+        },
+        {
+          "name": "testInsanity",
+          "returnTypeId": "map",
+          "returnType": {
+            "typeId": "map",
+            "keyTypeId": "i64",
+            "valueTypeId": "map",
+            "valueType": {
+              "typeId": "map",
+              "keyTypeId": "i32",
+              "valueTypeId": "struct",
+              "valueType": {
+                "typeId": "struct",
+                "class": "Insanity"
+              }
+            }
+          },
+          "oneway": false,
+          "doc": "So you think you've got this all worked, out eh?\n\nCreates a the returned map with these values and prints it out:\n  { 1 => { 2 => argument,\n           3 => argument,\n         },\n    2 => { 6 => <empty Insanity struct>, },\n  }\n@return map<UserId, map<Numberz,Insanity>> - a map with the above values\n",
+          "arguments": [
+            {
+              "key": 1,
+              "name": "argument",
+              "typeId": "struct",
+              "type": {
+                "typeId": "struct",
+                "class": "Insanity"
+              },
+              "required": "req_out"
+            }
+          ],
+          "exceptions": [
+          ]
+        },
+        {
+          "name": "testMulti",
+          "returnTypeId": "struct",
+          "returnType": {
+            "typeId": "struct",
+            "class": "Xtruct"
+          },
+          "oneway": false,
+          "doc": "Prints 'testMulti()'\n@param i8 arg0 -\n@param i32 arg1 -\n@param i64 arg2 -\n@param map<i16, string> arg3 -\n@param Numberz arg4 -\n@param UserId arg5 -\n@return Xtruct - returns an Xtruct with string_thing = \"Hello2, byte_thing = arg0, i32_thing = arg1\n   and i64_thing = arg2\n",
+          "arguments": [
+            {
+              "key": 1,
+              "name": "arg0",
+              "typeId": "i8",
+              "required": "req_out"
+            },
+            {
+              "key": 2,
+              "name": "arg1",
+              "typeId": "i32",
+              "required": "req_out"
+            },
+            {
+              "key": 3,
+              "name": "arg2",
+              "typeId": "i64",
+              "required": "req_out"
+            },
+            {
+              "key": 4,
+              "name": "arg3",
+              "typeId": "map",
+              "type": {
+                "typeId": "map",
+                "keyTypeId": "i16",
+                "valueTypeId": "string"
+              },
+              "required": "req_out"
+            },
+            {
+              "key": 5,
+              "name": "arg4",
+              "typeId": "i32",
+              "required": "req_out"
+            },
+            {
+              "key": 6,
+              "name": "arg5",
+              "typeId": "i64",
+              "required": "req_out"
+            }
+          ],
+          "exceptions": [
+          ]
+        },
+        {
+          "name": "testException",
+          "returnTypeId": "void",
+          "oneway": false,
+          "doc": "Print 'testException(%s)' with arg as '%s'\n@param string arg - a string indication what type of exception to throw\nif arg == \"Xception\" throw Xception with errorCode = 1001 and message = arg\nelsen if arg == \"TException\" throw TException\nelse do not throw anything\n",
+          "arguments": [
+            {
+              "key": 1,
+              "name": "arg",
+              "typeId": "string",
+              "required": "req_out"
+            }
+          ],
+          "exceptions": [
+            {
+              "key": 1,
+              "name": "err1",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "Xception"
+              },
+              "required": "req_out"
+            }
+          ]
+        },
+        {
+          "name": "testMultiException",
+          "returnTypeId": "struct",
+          "returnType": {
+            "typeId": "struct",
+            "class": "Xtruct"
+          },
+          "oneway": false,
+          "doc": "Print 'testMultiException(%s, %s)' with arg0 as '%s' and arg1 as '%s'\n@param string arg - a string indication what type of exception to throw\nif arg0 == \"Xception\" throw Xception with errorCode = 1001 and message = \"This is an Xception\"\nelsen if arg0 == \"Xception2\" throw Xception2 with errorCode = 2002 and struct_thing.string_thing = \"This is an Xception2\"\nelse do not throw anything\n@return Xtruct - an Xtruct with string_thing = arg1\n",
+          "arguments": [
+            {
+              "key": 1,
+              "name": "arg0",
+              "typeId": "string",
+              "required": "req_out"
+            },
+            {
+              "key": 2,
+              "name": "arg1",
+              "typeId": "string",
+              "required": "req_out"
+            }
+          ],
+          "exceptions": [
+            {
+              "key": 1,
+              "name": "err1",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "Xception"
+              },
+              "required": "req_out"
+            },
+            {
+              "key": 2,
+              "name": "err2",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "Xception2"
+              },
+              "required": "req_out"
+            }
+          ]
+        },
+        {
+          "name": "testOneway",
+          "returnTypeId": "void",
+          "oneway": true,
+          "doc": "Print 'testOneway(%d): Sleeping...' with secondsToSleep as '%d'\nsleep 'secondsToSleep'\nPrint 'testOneway(%d): done sleeping!' with secondsToSleep as '%d'\n@param i32 secondsToSleep - the number of seconds to sleep\n",
+          "arguments": [
+            {
+              "key": 1,
+              "name": "secondsToSleep",
+              "typeId": "i32",
+              "required": "req_out"
+            }
+          ],
+          "exceptions": [
+          ]
+        }
+      ]
+    },
+    {
+      "name": "SecondService",
+      "functions": [
+        {
+          "name": "blahBlah",
+          "returnTypeId": "void",
+          "oneway": false,
+          "arguments": [
+          ],
+          "exceptions": [
+          ]
+        },
+        {
+          "name": "secondtestString",
+          "returnTypeId": "string",
+          "oneway": false,
+          "doc": "Prints 'testString(\"%s\")' with thing as '%s'\n@param string thing - the string to print\n@return string - returns the string 'thing'\n",
+          "arguments": [
+            {
+              "key": 1,
+              "name": "thing",
+              "typeId": "string",
+              "required": "req_out"
+            }
+          ],
+          "exceptions": [
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/META-INF/armeria/thrift/ThriftTest.thrift
+++ b/src/test/resources/META-INF/armeria/thrift/ThriftTest.thrift
@@ -1,0 +1,403 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * Contains some contributions under the Thrift Software License.
+ * Please see doc/old-thrift-license.txt in the Thrift distribution for
+ * details.
+ */
+
+namespace c_glib TTest
+namespace java thrift.test
+namespace cpp thrift.test
+namespace rb Thrift.Test
+namespace perl ThriftTest
+namespace csharp Thrift.Test
+namespace js ThriftTest
+namespace st ThriftTest
+namespace py ThriftTest
+namespace py.twisted ThriftTest
+namespace go thrifttest
+namespace php ThriftTest
+namespace delphi Thrift.Test
+namespace cocoa ThriftTest
+namespace lua ThriftTest
+namespace xsd test (uri = 'http://thrift.apache.org/ns/ThriftTest')
+
+// Presence of namespaces and sub-namespaces for which there is
+// no generator should compile with warnings only
+namespace noexist ThriftTest
+namespace cpp.noexist ThriftTest
+
+namespace * thrift.test
+
+/**
+ * Docstring!
+ */
+enum Numberz
+{
+  ONE = 1,
+  TWO,
+  THREE,
+  FIVE = 5,
+  SIX,
+  EIGHT = 8
+}
+
+const Numberz myNumberz = Numberz.ONE;
+// the following is expected to fail:
+// const Numberz urNumberz = ONE;
+
+typedef i64 UserId
+
+struct Bonk
+{
+  1: string message,
+  2: i32 type
+}
+
+typedef map<string,Bonk> MapType
+
+struct Bools {
+  1: bool im_true,
+  2: bool im_false,
+}
+
+struct Xtruct
+{
+  1:  string string_thing,
+  4:  i8     byte_thing,
+  9:  i32    i32_thing,
+  11: i64    i64_thing
+}
+
+struct Xtruct2
+{
+  1: i8     byte_thing,  // used to be byte, hence the name
+  2: Xtruct struct_thing,
+  3: i32    i32_thing
+}
+
+struct Xtruct3
+{
+  1:  string string_thing,
+  4:  i32    changed,
+  9:  i32    i32_thing,
+  11: i64    i64_thing
+}
+
+
+struct Insanity
+{
+  1: map<Numberz, UserId> userMap,
+  2: list<Xtruct> xtructs
+} (python.immutable= "")
+
+struct CrazyNesting {
+  1: string string_field,
+  2: optional set<Insanity> set_field,
+  // Do not insert line break as test/go/Makefile.am is removing this line with pattern match
+  3: required list<map<set<i32> (python.immutable = ""), map<i32,set<list<map<Insanity,string>(python.immutable = "")> (python.immutable = "")>>>> list_field,
+  4: binary binary_field
+}
+
+exception Xception {
+  1: i32 errorCode,
+  2: string message
+}
+
+exception Xception2 {
+  1: i32 errorCode,
+  2: Xtruct struct_thing
+}
+
+struct EmptyStruct {}
+
+struct OneField {
+  1: EmptyStruct field
+}
+
+service ThriftTest
+{
+  /**
+   * Prints "testVoid()" and returns nothing.
+   */
+  void         testVoid(),
+
+  /**
+   * Prints 'testString("%s")' with thing as '%s'
+   * @param string thing - the string to print
+   * @return string - returns the string 'thing'
+   */
+  string       testString(1: string thing),
+
+  /**
+   * Prints 'testBool("%s")' where '%s' with thing as 'true' or 'false'
+   * @param bool  thing - the bool data to print
+   * @return bool  - returns the bool 'thing'
+   */
+  bool         testBool(1: bool thing),
+
+  /**
+   * Prints 'testByte("%d")' with thing as '%d'
+   * The types i8 and byte are synonyms, use of i8 is encouraged, byte still exists for the sake of compatibility.
+   * @param byte thing - the i8/byte to print
+   * @return i8 - returns the i8/byte 'thing'
+   */
+  i8           testByte(1: i8 thing),
+
+  /**
+   * Prints 'testI32("%d")' with thing as '%d'
+   * @param i32 thing - the i32 to print
+   * @return i32 - returns the i32 'thing'
+   */
+  i32          testI32(1: i32 thing),
+
+  /**
+   * Prints 'testI64("%d")' with thing as '%d'
+   * @param i64 thing - the i64 to print
+   * @return i64 - returns the i64 'thing'
+   */
+  i64          testI64(1: i64 thing),
+
+  /**
+   * Prints 'testDouble("%f")' with thing as '%f'
+   * @param double thing - the double to print
+   * @return double - returns the double 'thing'
+   */
+  double       testDouble(1: double thing),
+
+  /**
+   * Prints 'testBinary("%s")' where '%s' is a hex-formatted string of thing's data
+   * @param binary  thing - the binary data to print
+   * @return binary  - returns the binary 'thing'
+   */
+  binary       testBinary(1: binary thing),
+
+  /**
+   * Prints 'testStruct("{%s}")' where thing has been formatted into a string of comma separated values
+   * @param Xtruct thing - the Xtruct to print
+   * @return Xtruct - returns the Xtruct 'thing'
+   */
+  Xtruct       testStruct(1: Xtruct thing),
+
+  /**
+   * Prints 'testNest("{%s}")' where thing has been formatted into a string of the nested struct
+   * @param Xtruct2 thing - the Xtruct2 to print
+   * @return Xtruct2 - returns the Xtruct2 'thing'
+   */
+  Xtruct2      testNest(1: Xtruct2 thing),
+
+  /**
+   * Prints 'testMap("{%s")' where thing has been formatted into a string of  'key => value' pairs
+   *  separated by commas and new lines
+   * @param map<i32,i32> thing - the map<i32,i32> to print
+   * @return map<i32,i32> - returns the map<i32,i32> 'thing'
+   */
+  map<i32,i32> testMap(1: map<i32,i32> thing),
+
+  /**
+   * Prints 'testStringMap("{%s}")' where thing has been formatted into a string of  'key => value' pairs
+   *  separated by commas and new lines
+   * @param map<string,string> thing - the map<string,string> to print
+   * @return map<string,string> - returns the map<string,string> 'thing'
+   */
+  map<string,string> testStringMap(1: map<string,string> thing),
+
+  /**
+   * Prints 'testSet("{%s}")' where thing has been formatted into a string of  values
+   *  separated by commas and new lines
+   * @param set<i32> thing - the set<i32> to print
+   * @return set<i32> - returns the set<i32> 'thing'
+   */
+  set<i32>     testSet(1: set<i32> thing),
+
+  /**
+   * Prints 'testList("{%s}")' where thing has been formatted into a string of  values
+   *  separated by commas and new lines
+   * @param list<i32> thing - the list<i32> to print
+   * @return list<i32> - returns the list<i32> 'thing'
+   */
+  list<i32>    testList(1: list<i32> thing),
+
+  /**
+   * Prints 'testEnum("%d")' where thing has been formatted into it's numeric value
+   * @param Numberz thing - the Numberz to print
+   * @return Numberz - returns the Numberz 'thing'
+   */
+  Numberz      testEnum(1: Numberz thing),
+
+  /**
+   * Prints 'testTypedef("%d")' with thing as '%d'
+   * @param UserId thing - the UserId to print
+   * @return UserId - returns the UserId 'thing'
+   */
+  UserId       testTypedef(1: UserId thing),
+
+  /**
+   * Prints 'testMapMap("%d")' with hello as '%d'
+   * @param i32 hello - the i32 to print
+   * @return map<i32,map<i32,i32>> - returns a dictionary with these values:
+   *   {-4 => {-4 => -4, -3 => -3, -2 => -2, -1 => -1, }, 4 => {1 => 1, 2 => 2, 3 => 3, 4 => 4, }, }
+   */
+  map<i32,map<i32,i32>> testMapMap(1: i32 hello),
+
+  /**
+   * So you think you've got this all worked, out eh?
+   *
+   * Creates a the returned map with these values and prints it out:
+   *   { 1 => { 2 => argument,
+   *            3 => argument,
+   *          },
+   *     2 => { 6 => <empty Insanity struct>, },
+   *   }
+   * @return map<UserId, map<Numberz,Insanity>> - a map with the above values
+   */
+  map<UserId, map<Numberz,Insanity>> testInsanity(1: Insanity argument),
+
+  /**
+   * Prints 'testMulti()'
+   * @param i8 arg0 -
+   * @param i32 arg1 -
+   * @param i64 arg2 -
+   * @param map<i16, string> arg3 -
+   * @param Numberz arg4 -
+   * @param UserId arg5 -
+   * @return Xtruct - returns an Xtruct with string_thing = "Hello2, byte_thing = arg0, i32_thing = arg1
+   *    and i64_thing = arg2
+   */
+  Xtruct testMulti(1: i8 arg0, 2: i32 arg1, 3: i64 arg2, 4: map<i16, string> arg3, 5: Numberz arg4, 6: UserId arg5),
+
+  /**
+   * Print 'testException(%s)' with arg as '%s'
+   * @param string arg - a string indication what type of exception to throw
+   * if arg == "Xception" throw Xception with errorCode = 1001 and message = arg
+   * elsen if arg == "TException" throw TException
+   * else do not throw anything
+   */
+  void testException(1: string arg) throws(1: Xception err1),
+
+  /**
+   * Print 'testMultiException(%s, %s)' with arg0 as '%s' and arg1 as '%s'
+   * @param string arg - a string indication what type of exception to throw
+   * if arg0 == "Xception" throw Xception with errorCode = 1001 and message = "This is an Xception"
+   * elsen if arg0 == "Xception2" throw Xception2 with errorCode = 2002 and struct_thing.string_thing = "This is an Xception2"
+   * else do not throw anything
+   * @return Xtruct - an Xtruct with string_thing = arg1
+   */
+  Xtruct testMultiException(1: string arg0, 2: string arg1) throws(1: Xception err1, 2: Xception2 err2)
+
+  /**
+   * Print 'testOneway(%d): Sleeping...' with secondsToSleep as '%d'
+   * sleep 'secondsToSleep'
+   * Print 'testOneway(%d): done sleeping!' with secondsToSleep as '%d'
+   * @param i32 secondsToSleep - the number of seconds to sleep
+   */
+  oneway void testOneway(1:i32 secondsToSleep)
+}
+
+service SecondService
+{
+  void blahBlah()
+  /**
+   * Prints 'testString("%s")' with thing as '%s'
+   * @param string thing - the string to print
+   * @return string - returns the string 'thing'
+   */
+  string       secondtestString(1: string thing),
+}
+
+struct VersioningTestV1 {
+       1: i32 begin_in_both,
+       3: string old_string,
+       12: i32 end_in_both
+}
+
+struct VersioningTestV2 {
+       1: i32 begin_in_both,
+
+       2: i32 newint,
+       3: i8 newbyte,
+       4: i16 newshort,
+       5: i64 newlong,
+       6: double newdouble
+       7: Bonk newstruct,
+       8: list<i32> newlist,
+       9: set<i32> newset,
+       10: map<i32, i32> newmap,
+       11: string newstring,
+       12: i32 end_in_both
+}
+
+struct ListTypeVersioningV1 {
+       1: list<i32> myints;
+       2: string hello;
+}
+
+struct ListTypeVersioningV2 {
+       1: list<string> strings;
+       2: string hello;
+}
+
+struct GuessProtocolStruct {
+  7: map<string,string> map_field,
+}
+
+struct LargeDeltas {
+  1: Bools b1,
+  10: Bools b10,
+  100: Bools b100,
+  500: bool check_true,
+  1000: Bools b1000,
+  1500: bool check_false,
+  2000: VersioningTestV2 vertwo2000,
+  2500: set<string> a_set2500,
+  3000: VersioningTestV2 vertwo3000,
+  4000: list<i32> big_numbers
+}
+
+struct NestedListsI32x2 {
+  1: list<list<i32>> integerlist
+}
+struct NestedListsI32x3 {
+  1: list<list<list<i32>>> integerlist
+}
+struct NestedMixedx2 {
+  1: list<set<i32>> int_set_list
+  2: map<i32,set<string>> map_int_strset
+  3: list<map<i32,set<string>>> map_int_strset_list
+}
+struct ListBonks {
+  1: list<Bonk> bonk
+}
+struct NestedListsBonk {
+  1: list<list<list<Bonk>>> bonk
+}
+
+struct BoolTest {
+  1: optional bool b = true;
+  2: optional string s = "true";
+}
+
+struct StructA {
+  1: required string s;
+}
+
+struct StructB {
+  1: optional StructA aa;
+  2: required StructA ab;
+}

--- a/src/test/resources/META-INF/armeria/thrift/cassandra.json
+++ b/src/test/resources/META-INF/armeria/thrift/cassandra.json
@@ -1,0 +1,2812 @@
+{
+  "name": "cassandra",
+  "namespaces": {
+    "java": "com.linecorp.armeria.service.test.thrift.cassandra"
+  },
+  "includes": [
+  ],
+  "enums": [
+    {
+      "name": "ConsistencyLevel",
+      "doc": "The ConsistencyLevel is an enum that controls both read and write\nbehavior based on the ReplicationFactor of the keyspace.  The\ndifferent consistency levels have different meanings, depending on\nif you're doing a write or read operation.\n\nIf W + R > ReplicationFactor, where W is the number of nodes to\nblock for on write, and R the number to block for on reads, you\nwill have strongly consistent behavior; that is, readers will\nalways see the most recent write. Of these, the most interesting is\nto do QUORUM reads and writes, which gives you consistency while\nstill allowing availability in the face of node failures up to half\nof <ReplicationFactor>. Of course if latency is more important than\nconsistency then you can use lower values for either or both.\n\nSome ConsistencyLevels (ONE, TWO, THREE) refer to a specific number\nof replicas rather than a logical concept that adjusts\nautomatically with the replication factor.  Of these, only ONE is\ncommonly used; TWO and (even more rarely) THREE are only useful\nwhen you care more about guaranteeing a certain level of\ndurability, than consistency.\n\nWrite consistency levels make the following guarantees before reporting success to the client:\n  ANY          Ensure that the write has been written once somewhere, including possibly being hinted in a non-target node.\n  ONE          Ensure that the write has been written to at least 1 node's commit log and memory table\n  TWO          Ensure that the write has been written to at least 2 node's commit log and memory table\n  THREE        Ensure that the write has been written to at least 3 node's commit log and memory table\n  QUORUM       Ensure that the write has been written to <ReplicationFactor> \/ 2 + 1 nodes\n  LOCAL_QUORUM Ensure that the write has been written to <ReplicationFactor> \/ 2 + 1 nodes, within the local datacenter (requires NetworkTopologyStrategy)\n  EACH_QUORUM  Ensure that the write has been written to <ReplicationFactor> \/ 2 + 1 nodes in each datacenter (requires NetworkTopologyStrategy)\n  ALL          Ensure that the write is written to <code>&lt;ReplicationFactor&gt;<\/code> nodes before responding to the client.\n\nRead consistency levels make the following guarantees before returning successful results to the client:\n  ANY          Not supported. You probably want ONE instead.\n  ONE          Returns the record obtained from a single replica.\n  TWO          Returns the record with the most recent timestamp once two replicas have replied.\n  THREE        Returns the record with the most recent timestamp once three replicas have replied.\n  QUORUM       Returns the record with the most recent timestamp once a majority of replicas have replied.\n  LOCAL_QUORUM Returns the record with the most recent timestamp once a majority of replicas within the local datacenter have replied.\n  EACH_QUORUM  Returns the record with the most recent timestamp once a majority of replicas within each datacenter have replied.\n  ALL          Returns the record with the most recent timestamp once all replicas have replied (implies no replica may be down)..\n",
+      "members": [
+        {
+          "name": "ONE",
+          "value": 1
+        },
+        {
+          "name": "QUORUM",
+          "value": 2
+        },
+        {
+          "name": "LOCAL_QUORUM",
+          "value": 3
+        },
+        {
+          "name": "EACH_QUORUM",
+          "value": 4
+        },
+        {
+          "name": "ALL",
+          "value": 5
+        },
+        {
+          "name": "ANY",
+          "value": 6
+        },
+        {
+          "name": "TWO",
+          "value": 7
+        },
+        {
+          "name": "THREE",
+          "value": 8
+        }
+      ]
+    },
+    {
+      "name": "IndexOperator",
+      "members": [
+        {
+          "name": "EQ",
+          "value": 0
+        },
+        {
+          "name": "GTE",
+          "value": 1
+        },
+        {
+          "name": "GT",
+          "value": 2
+        },
+        {
+          "name": "LTE",
+          "value": 3
+        },
+        {
+          "name": "LT",
+          "value": 4
+        }
+      ]
+    },
+    {
+      "name": "IndexType",
+      "members": [
+        {
+          "name": "KEYS",
+          "value": 0
+        },
+        {
+          "name": "CUSTOM",
+          "value": 1
+        }
+      ]
+    },
+    {
+      "name": "Compression",
+      "doc": "CQL query compression\n",
+      "members": [
+        {
+          "name": "GZIP",
+          "value": 1
+        },
+        {
+          "name": "NONE",
+          "value": 2
+        }
+      ]
+    },
+    {
+      "name": "CqlResultType",
+      "members": [
+        {
+          "name": "ROWS",
+          "value": 1
+        },
+        {
+          "name": "VOID",
+          "value": 2
+        },
+        {
+          "name": "INT",
+          "value": 3
+        }
+      ]
+    }
+  ],
+  "typedefs": [
+  ],
+  "structs": [
+    {
+      "name": "Column",
+      "doc": "Basic unit of data within a ColumnFamily.\n@param name, the name by which this column is set and retrieved.  Maximum 64KB long.\n@param value. The data associated with the name.  Maximum 2GB long, but in practice you should limit it to small numbers of MB (since Thrift must read the full value into memory to operate on it).\n@param timestamp. The timestamp is used for conflict detection\/resolution when two columns with same name need to be compared.\n@param ttl. An optional, positive delay (in seconds) after which the column will be automatically deleted.\n",
+      "isException": false,
+      "isUnion": false,
+      "fields": [
+        {
+          "key": 1,
+          "name": "name",
+          "typeId": "binary",
+          "required": "required"
+        },
+        {
+          "key": 2,
+          "name": "value",
+          "typeId": "binary",
+          "required": "optional"
+        },
+        {
+          "key": 3,
+          "name": "timestamp",
+          "typeId": "i64",
+          "required": "optional"
+        },
+        {
+          "key": 4,
+          "name": "ttl",
+          "typeId": "i32",
+          "required": "optional"
+        }
+      ]
+    },
+    {
+      "name": "SuperColumn",
+      "doc": "A named list of columns.\n@param name. see Column.name.\n@param columns. A collection of standard Columns.  The columns within a super column are defined in an adhoc manner.\n                Columns within a super column do not have to have matching structures (similarly named child columns).\n",
+      "isException": false,
+      "isUnion": false,
+      "fields": [
+        {
+          "key": 1,
+          "name": "name",
+          "typeId": "binary",
+          "required": "required"
+        },
+        {
+          "key": 2,
+          "name": "columns",
+          "typeId": "list",
+          "type": {
+            "typeId": "list",
+            "elemTypeId": "struct",
+            "elemType": {
+              "typeId": "struct",
+              "class": "Column"
+            }
+          },
+          "required": "required"
+        }
+      ]
+    },
+    {
+      "name": "CounterColumn",
+      "isException": false,
+      "isUnion": false,
+      "fields": [
+        {
+          "key": 1,
+          "name": "name",
+          "typeId": "binary",
+          "required": "required"
+        },
+        {
+          "key": 2,
+          "name": "value",
+          "typeId": "i64",
+          "required": "required"
+        }
+      ]
+    },
+    {
+      "name": "CounterSuperColumn",
+      "isException": false,
+      "isUnion": false,
+      "fields": [
+        {
+          "key": 1,
+          "name": "name",
+          "typeId": "binary",
+          "required": "required"
+        },
+        {
+          "key": 2,
+          "name": "columns",
+          "typeId": "list",
+          "type": {
+            "typeId": "list",
+            "elemTypeId": "struct",
+            "elemType": {
+              "typeId": "struct",
+              "class": "CounterColumn"
+            }
+          },
+          "required": "required"
+        }
+      ]
+    },
+    {
+      "name": "ColumnOrSuperColumn",
+      "doc": "Methods for fetching rows\/records from Cassandra will return either a single instance of ColumnOrSuperColumn or a list\nof ColumnOrSuperColumns (get_slice()). If you're looking up a SuperColumn (or list of SuperColumns) then the resulting\ninstances of ColumnOrSuperColumn will have the requested SuperColumn in the attribute super_column. For queries resulting\nin Columns, those values will be in the attribute column. This change was made between 0.3 and 0.4 to standardize on\nsingle query methods that may return either a SuperColumn or Column.\n\nIf the query was on a counter column family, you will either get a counter_column (instead of a column) or a\ncounter_super_column (instead of a super_column)\n\n@param column. The Column returned by get() or get_slice().\n@param super_column. The SuperColumn returned by get() or get_slice().\n@param counter_column. The Counterolumn returned by get() or get_slice().\n@param counter_super_column. The CounterSuperColumn returned by get() or get_slice().\n",
+      "isException": false,
+      "isUnion": false,
+      "fields": [
+        {
+          "key": 1,
+          "name": "column",
+          "typeId": "struct",
+          "type": {
+            "typeId": "struct",
+            "class": "Column"
+          },
+          "required": "optional"
+        },
+        {
+          "key": 2,
+          "name": "super_column",
+          "typeId": "struct",
+          "type": {
+            "typeId": "struct",
+            "class": "SuperColumn"
+          },
+          "required": "optional"
+        },
+        {
+          "key": 3,
+          "name": "counter_column",
+          "typeId": "struct",
+          "type": {
+            "typeId": "struct",
+            "class": "CounterColumn"
+          },
+          "required": "optional"
+        },
+        {
+          "key": 4,
+          "name": "counter_super_column",
+          "typeId": "struct",
+          "type": {
+            "typeId": "struct",
+            "class": "CounterSuperColumn"
+          },
+          "required": "optional"
+        }
+      ]
+    },
+    {
+      "name": "NotFoundException",
+      "doc": "A specific column was requested that does not exist.\n",
+      "isException": true,
+      "isUnion": false,
+      "fields": [
+      ]
+    },
+    {
+      "name": "InvalidRequestException",
+      "doc": "Invalid request could mean keyspace or column family does not exist, required parameters are missing, or a parameter is malformed.\nwhy contains an associated error message.\n",
+      "isException": true,
+      "isUnion": false,
+      "fields": [
+        {
+          "key": 1,
+          "name": "why",
+          "typeId": "string",
+          "required": "required"
+        }
+      ]
+    },
+    {
+      "name": "UnavailableException",
+      "doc": "Not all the replicas required could be created and\/or read.\n",
+      "isException": true,
+      "isUnion": false,
+      "fields": [
+      ]
+    },
+    {
+      "name": "TimedOutException",
+      "doc": "RPC timeout was exceeded.  either a node failed mid-operation, or load was too high, or the requested op was too large.\n",
+      "isException": true,
+      "isUnion": false,
+      "fields": [
+      ]
+    },
+    {
+      "name": "AuthenticationException",
+      "doc": "invalid authentication request (invalid keyspace, user does not exist, or credentials invalid)\n",
+      "isException": true,
+      "isUnion": false,
+      "fields": [
+        {
+          "key": 1,
+          "name": "why",
+          "typeId": "string",
+          "required": "required"
+        }
+      ]
+    },
+    {
+      "name": "AuthorizationException",
+      "doc": "invalid authorization request (user does not have access to keyspace)\n",
+      "isException": true,
+      "isUnion": false,
+      "fields": [
+        {
+          "key": 1,
+          "name": "why",
+          "typeId": "string",
+          "required": "required"
+        }
+      ]
+    },
+    {
+      "name": "SchemaDisagreementException",
+      "doc": "schemas are not in agreement across all nodes\n",
+      "isException": true,
+      "isUnion": false,
+      "fields": [
+      ]
+    },
+    {
+      "name": "ColumnParent",
+      "doc": "ColumnParent is used when selecting groups of columns from the same ColumnFamily. In directory structure terms, imagine\nColumnParent as ColumnPath + '\/..\/'.\n\nSee also <a href=\"cassandra.html#Struct_ColumnPath\">ColumnPath<\/a>\n",
+      "isException": false,
+      "isUnion": false,
+      "fields": [
+        {
+          "key": 3,
+          "name": "column_family",
+          "typeId": "string",
+          "required": "required"
+        },
+        {
+          "key": 4,
+          "name": "super_column",
+          "typeId": "binary",
+          "required": "optional"
+        }
+      ]
+    },
+    {
+      "name": "ColumnPath",
+      "doc": "The ColumnPath is the path to a single column in Cassandra. It might make sense to think of ColumnPath and\nColumnParent in terms of a directory structure.\n\nColumnPath is used to looking up a single column.\n\n@param column_family. The name of the CF of the column being looked up.\n@param super_column. The super column name.\n@param column. The column name.\n",
+      "isException": false,
+      "isUnion": false,
+      "fields": [
+        {
+          "key": 3,
+          "name": "column_family",
+          "typeId": "string",
+          "required": "required"
+        },
+        {
+          "key": 4,
+          "name": "super_column",
+          "typeId": "binary",
+          "required": "optional"
+        },
+        {
+          "key": 5,
+          "name": "column",
+          "typeId": "binary",
+          "required": "optional"
+        }
+      ]
+    },
+    {
+      "name": "SliceRange",
+      "doc": "A slice range is a structure that stores basic range, ordering and limit information for a query that will return\nmultiple columns. It could be thought of as Cassandra's version of LIMIT and ORDER BY\n\n@param start. The column name to start the slice with. This attribute is not required, though there is no default value,\n              and can be safely set to '', i.e., an empty byte array, to start with the first column name. Otherwise, it\n              must a valid value under the rules of the Comparator defined for the given ColumnFamily.\n@param finish. The column name to stop the slice at. This attribute is not required, though there is no default value,\n               and can be safely set to an empty byte array to not stop until 'count' results are seen. Otherwise, it\n               must also be a valid value to the ColumnFamily Comparator.\n@param reversed. Whether the results should be ordered in reversed order. Similar to ORDER BY blah DESC in SQL.\n@param count. How many columns to return. Similar to LIMIT in SQL. May be arbitrarily large, but Thrift will\n              materialize the whole result into memory before returning it to the client, so be aware that you may\n              be better served by iterating through slices by passing the last value of one call in as the 'start'\n              of the next instead of increasing 'count' arbitrarily large.\n",
+      "isException": false,
+      "isUnion": false,
+      "fields": [
+        {
+          "key": 1,
+          "name": "start",
+          "typeId": "binary",
+          "required": "required"
+        },
+        {
+          "key": 2,
+          "name": "finish",
+          "typeId": "binary",
+          "required": "required"
+        },
+        {
+          "key": 3,
+          "name": "reversed",
+          "typeId": "bool",
+          "required": "required",
+          "default": 0
+        },
+        {
+          "key": 4,
+          "name": "count",
+          "typeId": "i32",
+          "required": "required",
+          "default": 100
+        }
+      ]
+    },
+    {
+      "name": "SlicePredicate",
+      "doc": "A SlicePredicate is similar to a mathematic predicate (see http:\/\/en.wikipedia.org\/wiki\/Predicate_(mathematical_logic)),\nwhich is described as \"a property that the elements of a set have in common.\"\n\nSlicePredicate's in Cassandra are described with either a list of column_names or a SliceRange.  If column_names is\nspecified, slice_range is ignored.\n\n@param column_name. A list of column names to retrieve. This can be used similar to Memcached's \"multi-get\" feature\n                    to fetch N known column names. For instance, if you know you wish to fetch columns 'Joe', 'Jack',\n                    and 'Jim' you can pass those column names as a list to fetch all three at once.\n@param slice_range. A SliceRange describing how to range, order, and\/or limit the slice.\n",
+      "isException": false,
+      "isUnion": false,
+      "fields": [
+        {
+          "key": 1,
+          "name": "column_names",
+          "typeId": "list",
+          "type": {
+            "typeId": "list",
+            "elemTypeId": "binary"
+          },
+          "required": "optional"
+        },
+        {
+          "key": 2,
+          "name": "slice_range",
+          "typeId": "struct",
+          "type": {
+            "typeId": "struct",
+            "class": "SliceRange"
+          },
+          "required": "optional"
+        }
+      ]
+    },
+    {
+      "name": "IndexExpression",
+      "isException": false,
+      "isUnion": false,
+      "fields": [
+        {
+          "key": 1,
+          "name": "column_name",
+          "typeId": "binary",
+          "required": "required"
+        },
+        {
+          "key": 2,
+          "name": "op",
+          "typeId": "i32",
+          "required": "required"
+        },
+        {
+          "key": 3,
+          "name": "value",
+          "typeId": "binary",
+          "required": "required"
+        }
+      ]
+    },
+    {
+      "name": "IndexClause",
+      "isException": false,
+      "isUnion": false,
+      "fields": [
+        {
+          "key": 1,
+          "name": "expressions",
+          "typeId": "list",
+          "type": {
+            "typeId": "list",
+            "elemTypeId": "struct",
+            "elemType": {
+              "typeId": "struct",
+              "class": "IndexExpression"
+            }
+          },
+          "required": "required"
+        },
+        {
+          "key": 2,
+          "name": "start_key",
+          "typeId": "binary",
+          "required": "required"
+        },
+        {
+          "key": 3,
+          "name": "count",
+          "typeId": "i32",
+          "required": "required",
+          "default": 100
+        }
+      ]
+    },
+    {
+      "name": "KeyRange",
+      "doc": "The semantics of start keys and tokens are slightly different.\nKeys are start-inclusive; tokens are start-exclusive.  Token\nranges may also wrap -- that is, the end token may be less\nthan the start one.  Thus, a range from keyX to keyX is a\none-element range, but a range from tokenY to tokenY is the\nfull ring.\n",
+      "isException": false,
+      "isUnion": false,
+      "fields": [
+        {
+          "key": 1,
+          "name": "start_key",
+          "typeId": "binary",
+          "required": "optional"
+        },
+        {
+          "key": 2,
+          "name": "end_key",
+          "typeId": "binary",
+          "required": "optional"
+        },
+        {
+          "key": 3,
+          "name": "start_token",
+          "typeId": "string",
+          "required": "optional"
+        },
+        {
+          "key": 4,
+          "name": "end_token",
+          "typeId": "string",
+          "required": "optional"
+        },
+        {
+          "key": 5,
+          "name": "count",
+          "typeId": "i32",
+          "required": "required",
+          "default": 100
+        }
+      ]
+    },
+    {
+      "name": "KeySlice",
+      "doc": "A KeySlice is key followed by the data it maps to. A collection of KeySlice is returned by the get_range_slice operation.\n\n@param key. a row key\n@param columns. List of data represented by the key. Typically, the list is pared down to only the columns specified by\n                a SlicePredicate.\n",
+      "isException": false,
+      "isUnion": false,
+      "fields": [
+        {
+          "key": 1,
+          "name": "key",
+          "typeId": "binary",
+          "required": "required"
+        },
+        {
+          "key": 2,
+          "name": "columns",
+          "typeId": "list",
+          "type": {
+            "typeId": "list",
+            "elemTypeId": "struct",
+            "elemType": {
+              "typeId": "struct",
+              "class": "ColumnOrSuperColumn"
+            }
+          },
+          "required": "required"
+        }
+      ]
+    },
+    {
+      "name": "KeyCount",
+      "isException": false,
+      "isUnion": false,
+      "fields": [
+        {
+          "key": 1,
+          "name": "key",
+          "typeId": "binary",
+          "required": "required"
+        },
+        {
+          "key": 2,
+          "name": "count",
+          "typeId": "i32",
+          "required": "required"
+        }
+      ]
+    },
+    {
+      "name": "Deletion",
+      "doc": "Note that the timestamp is only optional in case of counter deletion.\n",
+      "isException": false,
+      "isUnion": false,
+      "fields": [
+        {
+          "key": 1,
+          "name": "timestamp",
+          "typeId": "i64",
+          "required": "optional"
+        },
+        {
+          "key": 2,
+          "name": "super_column",
+          "typeId": "binary",
+          "required": "optional"
+        },
+        {
+          "key": 3,
+          "name": "predicate",
+          "typeId": "struct",
+          "type": {
+            "typeId": "struct",
+            "class": "SlicePredicate"
+          },
+          "required": "optional"
+        }
+      ]
+    },
+    {
+      "name": "Mutation",
+      "doc": "A Mutation is either an insert (represented by filling column_or_supercolumn) or a deletion (represented by filling the deletion attribute).\n@param column_or_supercolumn. An insert to a column or supercolumn (possibly counter column or supercolumn)\n@param deletion. A deletion of a column or supercolumn\n",
+      "isException": false,
+      "isUnion": false,
+      "fields": [
+        {
+          "key": 1,
+          "name": "column_or_supercolumn",
+          "typeId": "struct",
+          "type": {
+            "typeId": "struct",
+            "class": "ColumnOrSuperColumn"
+          },
+          "required": "optional"
+        },
+        {
+          "key": 2,
+          "name": "deletion",
+          "typeId": "struct",
+          "type": {
+            "typeId": "struct",
+            "class": "Deletion"
+          },
+          "required": "optional"
+        }
+      ]
+    },
+    {
+      "name": "EndpointDetails",
+      "isException": false,
+      "isUnion": false,
+      "fields": [
+        {
+          "key": 1,
+          "name": "host",
+          "typeId": "string",
+          "required": "req_out"
+        },
+        {
+          "key": 2,
+          "name": "datacenter",
+          "typeId": "string",
+          "required": "req_out"
+        },
+        {
+          "key": 3,
+          "name": "rack",
+          "typeId": "string",
+          "required": "optional"
+        }
+      ]
+    },
+    {
+      "name": "TokenRange",
+      "doc": "A TokenRange describes part of the Cassandra ring, it is a mapping from a range to\nendpoints responsible for that range.\n@param start_token The first token in the range\n@param end_token The last token in the range\n@param endpoints The endpoints responsible for the range (listed by their configured listen_address)\n@param rpc_endpoints The endpoints responsible for the range (listed by their configured rpc_address)\n",
+      "isException": false,
+      "isUnion": false,
+      "fields": [
+        {
+          "key": 1,
+          "name": "start_token",
+          "typeId": "string",
+          "required": "required"
+        },
+        {
+          "key": 2,
+          "name": "end_token",
+          "typeId": "string",
+          "required": "required"
+        },
+        {
+          "key": 3,
+          "name": "endpoints",
+          "typeId": "list",
+          "type": {
+            "typeId": "list",
+            "elemTypeId": "string"
+          },
+          "required": "required"
+        },
+        {
+          "key": 4,
+          "name": "rpc_endpoints",
+          "typeId": "list",
+          "type": {
+            "typeId": "list",
+            "elemTypeId": "string"
+          },
+          "required": "optional"
+        },
+        {
+          "key": 5,
+          "name": "endpoint_details",
+          "typeId": "list",
+          "type": {
+            "typeId": "list",
+            "elemTypeId": "struct",
+            "elemType": {
+              "typeId": "struct",
+              "class": "EndpointDetails"
+            }
+          },
+          "required": "optional"
+        }
+      ]
+    },
+    {
+      "name": "AuthenticationRequest",
+      "doc": "Authentication requests can contain any data, dependent on the IAuthenticator used\n",
+      "isException": false,
+      "isUnion": false,
+      "fields": [
+        {
+          "key": 1,
+          "name": "credentials",
+          "typeId": "map",
+          "type": {
+            "typeId": "map",
+            "keyTypeId": "string",
+            "valueTypeId": "string"
+          },
+          "required": "required"
+        }
+      ]
+    },
+    {
+      "name": "ColumnDef",
+      "isException": false,
+      "isUnion": false,
+      "fields": [
+        {
+          "key": 1,
+          "name": "name",
+          "typeId": "binary",
+          "required": "required"
+        },
+        {
+          "key": 2,
+          "name": "validation_class",
+          "typeId": "string",
+          "required": "required"
+        },
+        {
+          "key": 3,
+          "name": "index_type",
+          "typeId": "i32",
+          "required": "optional"
+        },
+        {
+          "key": 4,
+          "name": "index_name",
+          "typeId": "string",
+          "required": "optional"
+        },
+        {
+          "key": 5,
+          "name": "index_options",
+          "typeId": "map",
+          "type": {
+            "typeId": "map",
+            "keyTypeId": "string",
+            "valueTypeId": "string"
+          },
+          "required": "optional"
+        }
+      ]
+    },
+    {
+      "name": "CfDef",
+      "isException": false,
+      "isUnion": false,
+      "fields": [
+        {
+          "key": 1,
+          "name": "keyspace",
+          "typeId": "string",
+          "required": "required"
+        },
+        {
+          "key": 2,
+          "name": "name",
+          "typeId": "string",
+          "required": "required"
+        },
+        {
+          "key": 3,
+          "name": "column_type",
+          "typeId": "string",
+          "required": "optional",
+          "default": "Standard"
+        },
+        {
+          "key": 5,
+          "name": "comparator_type",
+          "typeId": "string",
+          "required": "optional",
+          "default": "BytesType"
+        },
+        {
+          "key": 6,
+          "name": "subcomparator_type",
+          "typeId": "string",
+          "required": "optional"
+        },
+        {
+          "key": 8,
+          "name": "comment",
+          "typeId": "string",
+          "required": "optional"
+        },
+        {
+          "key": 12,
+          "name": "read_repair_chance",
+          "typeId": "double",
+          "required": "optional",
+          "default": 1
+        },
+        {
+          "key": 13,
+          "name": "column_metadata",
+          "typeId": "list",
+          "type": {
+            "typeId": "list",
+            "elemTypeId": "struct",
+            "elemType": {
+              "typeId": "struct",
+              "class": "ColumnDef"
+            }
+          },
+          "required": "optional"
+        },
+        {
+          "key": 14,
+          "name": "gc_grace_seconds",
+          "typeId": "i32",
+          "required": "optional"
+        },
+        {
+          "key": 15,
+          "name": "default_validation_class",
+          "typeId": "string",
+          "required": "optional"
+        },
+        {
+          "key": 16,
+          "name": "id",
+          "typeId": "i32",
+          "required": "optional"
+        },
+        {
+          "key": 17,
+          "name": "min_compaction_threshold",
+          "typeId": "i32",
+          "required": "optional"
+        },
+        {
+          "key": 18,
+          "name": "max_compaction_threshold",
+          "typeId": "i32",
+          "required": "optional"
+        },
+        {
+          "key": 24,
+          "name": "replicate_on_write",
+          "typeId": "bool",
+          "required": "optional"
+        },
+        {
+          "key": 25,
+          "name": "merge_shards_chance",
+          "typeId": "double",
+          "required": "optional"
+        },
+        {
+          "key": 26,
+          "name": "key_validation_class",
+          "typeId": "string",
+          "required": "optional"
+        },
+        {
+          "key": 28,
+          "name": "key_alias",
+          "typeId": "binary",
+          "required": "optional"
+        },
+        {
+          "key": 29,
+          "name": "compaction_strategy",
+          "typeId": "string",
+          "required": "optional"
+        },
+        {
+          "key": 30,
+          "name": "compaction_strategy_options",
+          "typeId": "map",
+          "type": {
+            "typeId": "map",
+            "keyTypeId": "string",
+            "valueTypeId": "string"
+          },
+          "required": "optional"
+        },
+        {
+          "key": 32,
+          "name": "compression_options",
+          "typeId": "map",
+          "type": {
+            "typeId": "map",
+            "keyTypeId": "string",
+            "valueTypeId": "string"
+          },
+          "required": "optional"
+        },
+        {
+          "key": 33,
+          "name": "bloom_filter_fp_chance",
+          "typeId": "double",
+          "required": "optional"
+        }
+      ]
+    },
+    {
+      "name": "KsDef",
+      "isException": false,
+      "isUnion": false,
+      "fields": [
+        {
+          "key": 1,
+          "name": "name",
+          "typeId": "string",
+          "required": "required"
+        },
+        {
+          "key": 2,
+          "name": "strategy_class",
+          "typeId": "string",
+          "required": "required"
+        },
+        {
+          "key": 3,
+          "name": "strategy_options",
+          "typeId": "map",
+          "type": {
+            "typeId": "map",
+            "keyTypeId": "string",
+            "valueTypeId": "string"
+          },
+          "required": "optional"
+        },
+        {
+          "key": 4,
+          "name": "replication_factor",
+          "typeId": "i32",
+          "doc": "@deprecated\n",
+          "required": "optional"
+        },
+        {
+          "key": 5,
+          "name": "cf_defs",
+          "typeId": "list",
+          "type": {
+            "typeId": "list",
+            "elemTypeId": "struct",
+            "elemType": {
+              "typeId": "struct",
+              "class": "CfDef"
+            }
+          },
+          "required": "required"
+        },
+        {
+          "key": 6,
+          "name": "durable_writes",
+          "typeId": "bool",
+          "required": "optional",
+          "default": 1
+        }
+      ]
+    },
+    {
+      "name": "CqlRow",
+      "doc": "Row returned from a CQL query\n",
+      "isException": false,
+      "isUnion": false,
+      "fields": [
+        {
+          "key": 1,
+          "name": "key",
+          "typeId": "binary",
+          "required": "required"
+        },
+        {
+          "key": 2,
+          "name": "columns",
+          "typeId": "list",
+          "type": {
+            "typeId": "list",
+            "elemTypeId": "struct",
+            "elemType": {
+              "typeId": "struct",
+              "class": "Column"
+            }
+          },
+          "required": "required"
+        }
+      ]
+    },
+    {
+      "name": "CqlMetadata",
+      "isException": false,
+      "isUnion": false,
+      "fields": [
+        {
+          "key": 1,
+          "name": "name_types",
+          "typeId": "map",
+          "type": {
+            "typeId": "map",
+            "keyTypeId": "binary",
+            "valueTypeId": "string"
+          },
+          "required": "required"
+        },
+        {
+          "key": 2,
+          "name": "value_types",
+          "typeId": "map",
+          "type": {
+            "typeId": "map",
+            "keyTypeId": "binary",
+            "valueTypeId": "string"
+          },
+          "required": "required"
+        },
+        {
+          "key": 3,
+          "name": "default_name_type",
+          "typeId": "string",
+          "required": "required"
+        },
+        {
+          "key": 4,
+          "name": "default_value_type",
+          "typeId": "string",
+          "required": "required"
+        }
+      ]
+    },
+    {
+      "name": "CqlResult",
+      "isException": false,
+      "isUnion": false,
+      "fields": [
+        {
+          "key": 1,
+          "name": "type",
+          "typeId": "i32",
+          "required": "required"
+        },
+        {
+          "key": 2,
+          "name": "rows",
+          "typeId": "list",
+          "type": {
+            "typeId": "list",
+            "elemTypeId": "struct",
+            "elemType": {
+              "typeId": "struct",
+              "class": "CqlRow"
+            }
+          },
+          "required": "optional"
+        },
+        {
+          "key": 3,
+          "name": "num",
+          "typeId": "i32",
+          "required": "optional"
+        },
+        {
+          "key": 4,
+          "name": "schema",
+          "typeId": "struct",
+          "type": {
+            "typeId": "struct",
+            "class": "CqlMetadata"
+          },
+          "required": "optional"
+        }
+      ]
+    },
+    {
+      "name": "CqlPreparedResult",
+      "isException": false,
+      "isUnion": false,
+      "fields": [
+        {
+          "key": 1,
+          "name": "itemId",
+          "typeId": "i32",
+          "required": "required"
+        },
+        {
+          "key": 2,
+          "name": "count",
+          "typeId": "i32",
+          "required": "required"
+        }
+      ]
+    }
+  ],
+  "constants": [
+    {
+      "name": "VERSION",
+      "typeId": "string",
+      "value": "19.24.0"
+    }
+  ],
+  "services": [
+    {
+      "name": "Cassandra",
+      "functions": [
+        {
+          "name": "login",
+          "returnTypeId": "void",
+          "oneway": false,
+          "arguments": [
+            {
+              "key": 1,
+              "name": "auth_request",
+              "typeId": "struct",
+              "type": {
+                "typeId": "struct",
+                "class": "AuthenticationRequest"
+              },
+              "required": "required"
+            }
+          ],
+          "exceptions": [
+            {
+              "key": 1,
+              "name": "authnx",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "AuthenticationException"
+              },
+              "required": "req_out"
+            },
+            {
+              "key": 2,
+              "name": "authzx",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "AuthorizationException"
+              },
+              "required": "req_out"
+            }
+          ]
+        },
+        {
+          "name": "set_keyspace",
+          "returnTypeId": "void",
+          "oneway": false,
+          "arguments": [
+            {
+              "key": 1,
+              "name": "keyspace",
+              "typeId": "string",
+              "required": "required"
+            }
+          ],
+          "exceptions": [
+            {
+              "key": 1,
+              "name": "ire",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "InvalidRequestException"
+              },
+              "required": "req_out"
+            }
+          ]
+        },
+        {
+          "name": "get",
+          "returnTypeId": "struct",
+          "returnType": {
+            "typeId": "struct",
+            "class": "ColumnOrSuperColumn"
+          },
+          "oneway": false,
+          "doc": "Get the Column or SuperColumn at the given column_path. If no value is present, NotFoundException is thrown. (This is\nthe only method that can throw an exception under non-failure conditions.)\n",
+          "arguments": [
+            {
+              "key": 1,
+              "name": "key",
+              "typeId": "binary",
+              "required": "required"
+            },
+            {
+              "key": 2,
+              "name": "column_path",
+              "typeId": "struct",
+              "type": {
+                "typeId": "struct",
+                "class": "ColumnPath"
+              },
+              "required": "required"
+            },
+            {
+              "key": 3,
+              "name": "consistency_level",
+              "typeId": "i32",
+              "required": "required",
+              "default": 1
+            }
+          ],
+          "exceptions": [
+            {
+              "key": 1,
+              "name": "ire",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "InvalidRequestException"
+              },
+              "required": "req_out"
+            },
+            {
+              "key": 2,
+              "name": "nfe",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "NotFoundException"
+              },
+              "required": "req_out"
+            },
+            {
+              "key": 3,
+              "name": "ue",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "UnavailableException"
+              },
+              "required": "req_out"
+            },
+            {
+              "key": 4,
+              "name": "te",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "TimedOutException"
+              },
+              "required": "req_out"
+            }
+          ]
+        },
+        {
+          "name": "get_slice",
+          "returnTypeId": "list",
+          "returnType": {
+            "typeId": "list",
+            "elemTypeId": "struct",
+            "elemType": {
+              "typeId": "struct",
+              "class": "ColumnOrSuperColumn"
+            }
+          },
+          "oneway": false,
+          "doc": "Get the group of columns contained by column_parent (either a ColumnFamily name or a ColumnFamily\/SuperColumn name\npair) specified by the given SlicePredicate. If no matching values are found, an empty list is returned.\n",
+          "arguments": [
+            {
+              "key": 1,
+              "name": "key",
+              "typeId": "binary",
+              "required": "required"
+            },
+            {
+              "key": 2,
+              "name": "column_parent",
+              "typeId": "struct",
+              "type": {
+                "typeId": "struct",
+                "class": "ColumnParent"
+              },
+              "required": "required"
+            },
+            {
+              "key": 3,
+              "name": "predicate",
+              "typeId": "struct",
+              "type": {
+                "typeId": "struct",
+                "class": "SlicePredicate"
+              },
+              "required": "required"
+            },
+            {
+              "key": 4,
+              "name": "consistency_level",
+              "typeId": "i32",
+              "required": "required",
+              "default": 1
+            }
+          ],
+          "exceptions": [
+            {
+              "key": 1,
+              "name": "ire",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "InvalidRequestException"
+              },
+              "required": "req_out"
+            },
+            {
+              "key": 2,
+              "name": "ue",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "UnavailableException"
+              },
+              "required": "req_out"
+            },
+            {
+              "key": 3,
+              "name": "te",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "TimedOutException"
+              },
+              "required": "req_out"
+            }
+          ]
+        },
+        {
+          "name": "get_count",
+          "returnTypeId": "i32",
+          "oneway": false,
+          "doc": "returns the number of columns matching <code>predicate<\/code> for a particular <code>key<\/code>,\n<code>ColumnFamily<\/code> and optionally <code>SuperColumn<\/code>.\n",
+          "arguments": [
+            {
+              "key": 1,
+              "name": "key",
+              "typeId": "binary",
+              "required": "required"
+            },
+            {
+              "key": 2,
+              "name": "column_parent",
+              "typeId": "struct",
+              "type": {
+                "typeId": "struct",
+                "class": "ColumnParent"
+              },
+              "required": "required"
+            },
+            {
+              "key": 3,
+              "name": "predicate",
+              "typeId": "struct",
+              "type": {
+                "typeId": "struct",
+                "class": "SlicePredicate"
+              },
+              "required": "required"
+            },
+            {
+              "key": 4,
+              "name": "consistency_level",
+              "typeId": "i32",
+              "required": "required",
+              "default": 1
+            }
+          ],
+          "exceptions": [
+            {
+              "key": 1,
+              "name": "ire",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "InvalidRequestException"
+              },
+              "required": "req_out"
+            },
+            {
+              "key": 2,
+              "name": "ue",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "UnavailableException"
+              },
+              "required": "req_out"
+            },
+            {
+              "key": 3,
+              "name": "te",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "TimedOutException"
+              },
+              "required": "req_out"
+            }
+          ]
+        },
+        {
+          "name": "multiget_slice",
+          "returnTypeId": "map",
+          "returnType": {
+            "typeId": "map",
+            "keyTypeId": "binary",
+            "valueTypeId": "list",
+            "valueType": {
+              "typeId": "list",
+              "elemTypeId": "struct",
+              "elemType": {
+                "typeId": "struct",
+                "class": "ColumnOrSuperColumn"
+              }
+            }
+          },
+          "oneway": false,
+          "doc": "Performs a get_slice for column_parent and predicate for the given keys in parallel.\n",
+          "arguments": [
+            {
+              "key": 1,
+              "name": "keys",
+              "typeId": "list",
+              "type": {
+                "typeId": "list",
+                "elemTypeId": "binary"
+              },
+              "required": "required"
+            },
+            {
+              "key": 2,
+              "name": "column_parent",
+              "typeId": "struct",
+              "type": {
+                "typeId": "struct",
+                "class": "ColumnParent"
+              },
+              "required": "required"
+            },
+            {
+              "key": 3,
+              "name": "predicate",
+              "typeId": "struct",
+              "type": {
+                "typeId": "struct",
+                "class": "SlicePredicate"
+              },
+              "required": "required"
+            },
+            {
+              "key": 4,
+              "name": "consistency_level",
+              "typeId": "i32",
+              "required": "required",
+              "default": 1
+            }
+          ],
+          "exceptions": [
+            {
+              "key": 1,
+              "name": "ire",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "InvalidRequestException"
+              },
+              "required": "req_out"
+            },
+            {
+              "key": 2,
+              "name": "ue",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "UnavailableException"
+              },
+              "required": "req_out"
+            },
+            {
+              "key": 3,
+              "name": "te",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "TimedOutException"
+              },
+              "required": "req_out"
+            }
+          ]
+        },
+        {
+          "name": "multiget_count",
+          "returnTypeId": "map",
+          "returnType": {
+            "typeId": "map",
+            "keyTypeId": "binary",
+            "valueTypeId": "i32"
+          },
+          "oneway": false,
+          "doc": "Perform a get_count in parallel on the given list<binary> keys. The return value maps keys to the count found.\n",
+          "arguments": [
+            {
+              "key": 1,
+              "name": "keys",
+              "typeId": "list",
+              "type": {
+                "typeId": "list",
+                "elemTypeId": "binary"
+              },
+              "required": "required"
+            },
+            {
+              "key": 2,
+              "name": "column_parent",
+              "typeId": "struct",
+              "type": {
+                "typeId": "struct",
+                "class": "ColumnParent"
+              },
+              "required": "required"
+            },
+            {
+              "key": 3,
+              "name": "predicate",
+              "typeId": "struct",
+              "type": {
+                "typeId": "struct",
+                "class": "SlicePredicate"
+              },
+              "required": "required"
+            },
+            {
+              "key": 4,
+              "name": "consistency_level",
+              "typeId": "i32",
+              "required": "required",
+              "default": 1
+            }
+          ],
+          "exceptions": [
+            {
+              "key": 1,
+              "name": "ire",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "InvalidRequestException"
+              },
+              "required": "req_out"
+            },
+            {
+              "key": 2,
+              "name": "ue",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "UnavailableException"
+              },
+              "required": "req_out"
+            },
+            {
+              "key": 3,
+              "name": "te",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "TimedOutException"
+              },
+              "required": "req_out"
+            }
+          ]
+        },
+        {
+          "name": "get_range_slices",
+          "returnTypeId": "list",
+          "returnType": {
+            "typeId": "list",
+            "elemTypeId": "struct",
+            "elemType": {
+              "typeId": "struct",
+              "class": "KeySlice"
+            }
+          },
+          "oneway": false,
+          "doc": "returns a subset of columns for a contiguous range of keys.\n",
+          "arguments": [
+            {
+              "key": 1,
+              "name": "column_parent",
+              "typeId": "struct",
+              "type": {
+                "typeId": "struct",
+                "class": "ColumnParent"
+              },
+              "required": "required"
+            },
+            {
+              "key": 2,
+              "name": "predicate",
+              "typeId": "struct",
+              "type": {
+                "typeId": "struct",
+                "class": "SlicePredicate"
+              },
+              "required": "required"
+            },
+            {
+              "key": 3,
+              "name": "range",
+              "typeId": "struct",
+              "type": {
+                "typeId": "struct",
+                "class": "KeyRange"
+              },
+              "required": "required"
+            },
+            {
+              "key": 4,
+              "name": "consistency_level",
+              "typeId": "i32",
+              "required": "required",
+              "default": 1
+            }
+          ],
+          "exceptions": [
+            {
+              "key": 1,
+              "name": "ire",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "InvalidRequestException"
+              },
+              "required": "req_out"
+            },
+            {
+              "key": 2,
+              "name": "ue",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "UnavailableException"
+              },
+              "required": "req_out"
+            },
+            {
+              "key": 3,
+              "name": "te",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "TimedOutException"
+              },
+              "required": "req_out"
+            }
+          ]
+        },
+        {
+          "name": "get_indexed_slices",
+          "returnTypeId": "list",
+          "returnType": {
+            "typeId": "list",
+            "elemTypeId": "struct",
+            "elemType": {
+              "typeId": "struct",
+              "class": "KeySlice"
+            }
+          },
+          "oneway": false,
+          "doc": "Returns the subset of columns specified in SlicePredicate for the rows matching the IndexClause\n",
+          "arguments": [
+            {
+              "key": 1,
+              "name": "column_parent",
+              "typeId": "struct",
+              "type": {
+                "typeId": "struct",
+                "class": "ColumnParent"
+              },
+              "required": "required"
+            },
+            {
+              "key": 2,
+              "name": "index_clause",
+              "typeId": "struct",
+              "type": {
+                "typeId": "struct",
+                "class": "IndexClause"
+              },
+              "required": "required"
+            },
+            {
+              "key": 3,
+              "name": "column_predicate",
+              "typeId": "struct",
+              "type": {
+                "typeId": "struct",
+                "class": "SlicePredicate"
+              },
+              "required": "required"
+            },
+            {
+              "key": 4,
+              "name": "consistency_level",
+              "typeId": "i32",
+              "required": "required",
+              "default": 1
+            }
+          ],
+          "exceptions": [
+            {
+              "key": 1,
+              "name": "ire",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "InvalidRequestException"
+              },
+              "required": "req_out"
+            },
+            {
+              "key": 2,
+              "name": "ue",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "UnavailableException"
+              },
+              "required": "req_out"
+            },
+            {
+              "key": 3,
+              "name": "te",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "TimedOutException"
+              },
+              "required": "req_out"
+            }
+          ]
+        },
+        {
+          "name": "insert",
+          "returnTypeId": "void",
+          "oneway": false,
+          "doc": "Insert a Column at the given column_parent.column_family and optional column_parent.super_column.\n",
+          "arguments": [
+            {
+              "key": 1,
+              "name": "key",
+              "typeId": "binary",
+              "required": "required"
+            },
+            {
+              "key": 2,
+              "name": "column_parent",
+              "typeId": "struct",
+              "type": {
+                "typeId": "struct",
+                "class": "ColumnParent"
+              },
+              "required": "required"
+            },
+            {
+              "key": 3,
+              "name": "column",
+              "typeId": "struct",
+              "type": {
+                "typeId": "struct",
+                "class": "Column"
+              },
+              "required": "required"
+            },
+            {
+              "key": 4,
+              "name": "consistency_level",
+              "typeId": "i32",
+              "required": "required",
+              "default": 1
+            }
+          ],
+          "exceptions": [
+            {
+              "key": 1,
+              "name": "ire",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "InvalidRequestException"
+              },
+              "required": "req_out"
+            },
+            {
+              "key": 2,
+              "name": "ue",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "UnavailableException"
+              },
+              "required": "req_out"
+            },
+            {
+              "key": 3,
+              "name": "te",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "TimedOutException"
+              },
+              "required": "req_out"
+            }
+          ]
+        },
+        {
+          "name": "add",
+          "returnTypeId": "void",
+          "oneway": false,
+          "doc": "Increment or decrement a counter.\n",
+          "arguments": [
+            {
+              "key": 1,
+              "name": "key",
+              "typeId": "binary",
+              "required": "required"
+            },
+            {
+              "key": 2,
+              "name": "column_parent",
+              "typeId": "struct",
+              "type": {
+                "typeId": "struct",
+                "class": "ColumnParent"
+              },
+              "required": "required"
+            },
+            {
+              "key": 3,
+              "name": "column",
+              "typeId": "struct",
+              "type": {
+                "typeId": "struct",
+                "class": "CounterColumn"
+              },
+              "required": "required"
+            },
+            {
+              "key": 4,
+              "name": "consistency_level",
+              "typeId": "i32",
+              "required": "required",
+              "default": 1
+            }
+          ],
+          "exceptions": [
+            {
+              "key": 1,
+              "name": "ire",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "InvalidRequestException"
+              },
+              "required": "req_out"
+            },
+            {
+              "key": 2,
+              "name": "ue",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "UnavailableException"
+              },
+              "required": "req_out"
+            },
+            {
+              "key": 3,
+              "name": "te",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "TimedOutException"
+              },
+              "required": "req_out"
+            }
+          ]
+        },
+        {
+          "name": "remove",
+          "returnTypeId": "void",
+          "oneway": false,
+          "doc": "Remove data from the row specified by key at the granularity specified by column_path, and the given timestamp. Note\nthat all the values in column_path besides column_path.column_family are truly optional: you can remove the entire\nrow by just specifying the ColumnFamily, or you can remove a SuperColumn or a single Column by specifying those levels too.\n",
+          "arguments": [
+            {
+              "key": 1,
+              "name": "key",
+              "typeId": "binary",
+              "required": "required"
+            },
+            {
+              "key": 2,
+              "name": "column_path",
+              "typeId": "struct",
+              "type": {
+                "typeId": "struct",
+                "class": "ColumnPath"
+              },
+              "required": "required"
+            },
+            {
+              "key": 3,
+              "name": "timestamp",
+              "typeId": "i64",
+              "required": "required"
+            },
+            {
+              "key": 4,
+              "name": "consistency_level",
+              "typeId": "i32",
+              "required": "req_out",
+              "default": 1
+            }
+          ],
+          "exceptions": [
+            {
+              "key": 1,
+              "name": "ire",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "InvalidRequestException"
+              },
+              "required": "req_out"
+            },
+            {
+              "key": 2,
+              "name": "ue",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "UnavailableException"
+              },
+              "required": "req_out"
+            },
+            {
+              "key": 3,
+              "name": "te",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "TimedOutException"
+              },
+              "required": "req_out"
+            }
+          ]
+        },
+        {
+          "name": "remove_counter",
+          "returnTypeId": "void",
+          "oneway": false,
+          "doc": "Remove a counter at the specified location.\nNote that counters have limited support for deletes: if you remove a counter, you must wait to issue any following update\nuntil the delete has reached all the nodes and all of them have been fully compacted.\n",
+          "arguments": [
+            {
+              "key": 1,
+              "name": "key",
+              "typeId": "binary",
+              "required": "required"
+            },
+            {
+              "key": 2,
+              "name": "path",
+              "typeId": "struct",
+              "type": {
+                "typeId": "struct",
+                "class": "ColumnPath"
+              },
+              "required": "required"
+            },
+            {
+              "key": 3,
+              "name": "consistency_level",
+              "typeId": "i32",
+              "required": "required",
+              "default": 1
+            }
+          ],
+          "exceptions": [
+            {
+              "key": 1,
+              "name": "ire",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "InvalidRequestException"
+              },
+              "required": "req_out"
+            },
+            {
+              "key": 2,
+              "name": "ue",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "UnavailableException"
+              },
+              "required": "req_out"
+            },
+            {
+              "key": 3,
+              "name": "te",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "TimedOutException"
+              },
+              "required": "req_out"
+            }
+          ]
+        },
+        {
+          "name": "batch_mutate",
+          "returnTypeId": "void",
+          "oneway": false,
+          "doc": "  Mutate many columns or super columns for many row keys. See also: Mutation.\n\n  mutation_map maps key to column family to a list of Mutation objects to take place at that scope.\n*\n",
+          "arguments": [
+            {
+              "key": 1,
+              "name": "mutation_map",
+              "typeId": "map",
+              "type": {
+                "typeId": "map",
+                "keyTypeId": "binary",
+                "valueTypeId": "map",
+                "valueType": {
+                  "typeId": "map",
+                  "keyTypeId": "string",
+                  "valueTypeId": "list",
+                  "valueType": {
+                    "typeId": "list",
+                    "elemTypeId": "struct",
+                    "elemType": {
+                      "typeId": "struct",
+                      "class": "Mutation"
+                    }
+                  }
+                }
+              },
+              "required": "required"
+            },
+            {
+              "key": 2,
+              "name": "consistency_level",
+              "typeId": "i32",
+              "required": "required",
+              "default": 1
+            }
+          ],
+          "exceptions": [
+            {
+              "key": 1,
+              "name": "ire",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "InvalidRequestException"
+              },
+              "required": "req_out"
+            },
+            {
+              "key": 2,
+              "name": "ue",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "UnavailableException"
+              },
+              "required": "req_out"
+            },
+            {
+              "key": 3,
+              "name": "te",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "TimedOutException"
+              },
+              "required": "req_out"
+            }
+          ]
+        },
+        {
+          "name": "truncate",
+          "returnTypeId": "void",
+          "oneway": false,
+          "doc": "Truncate will mark and entire column family as deleted.\nFrom the user's perspective a successful call to truncate will result complete data deletion from cfname.\nInternally, however, disk space will not be immediatily released, as with all deletes in cassandra, this one\nonly marks the data as deleted.\nThe operation succeeds only if all hosts in the cluster at available and will throw an UnavailableException if\nsome hosts are down.\n",
+          "arguments": [
+            {
+              "key": 1,
+              "name": "cfname",
+              "typeId": "string",
+              "required": "required"
+            }
+          ],
+          "exceptions": [
+            {
+              "key": 1,
+              "name": "ire",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "InvalidRequestException"
+              },
+              "required": "req_out"
+            },
+            {
+              "key": 2,
+              "name": "ue",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "UnavailableException"
+              },
+              "required": "req_out"
+            },
+            {
+              "key": 3,
+              "name": "te",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "TimedOutException"
+              },
+              "required": "req_out"
+            }
+          ]
+        },
+        {
+          "name": "describe_schema_versions",
+          "returnTypeId": "map",
+          "returnType": {
+            "typeId": "map",
+            "keyTypeId": "string",
+            "valueTypeId": "list",
+            "valueType": {
+              "typeId": "list",
+              "elemTypeId": "string"
+            }
+          },
+          "oneway": false,
+          "doc": "for each schema version present in the cluster, returns a list of nodes at that version.\nhosts that do not respond will be under the key DatabaseDescriptor.INITIAL_VERSION.\nthe cluster is all on the same version if the size of the map is 1.\n",
+          "arguments": [
+          ],
+          "exceptions": [
+            {
+              "key": 1,
+              "name": "ire",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "InvalidRequestException"
+              },
+              "required": "req_out"
+            }
+          ]
+        },
+        {
+          "name": "describe_keyspaces",
+          "returnTypeId": "list",
+          "returnType": {
+            "typeId": "list",
+            "elemTypeId": "struct",
+            "elemType": {
+              "typeId": "struct",
+              "class": "KsDef"
+            }
+          },
+          "oneway": false,
+          "doc": "list the defined keyspaces in this cluster\n",
+          "arguments": [
+          ],
+          "exceptions": [
+            {
+              "key": 1,
+              "name": "ire",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "InvalidRequestException"
+              },
+              "required": "req_out"
+            }
+          ]
+        },
+        {
+          "name": "describe_cluster_name",
+          "returnTypeId": "string",
+          "oneway": false,
+          "doc": "get the cluster name\n",
+          "arguments": [
+          ],
+          "exceptions": [
+          ]
+        },
+        {
+          "name": "describe_version",
+          "returnTypeId": "string",
+          "oneway": false,
+          "doc": "get the thrift api version\n",
+          "arguments": [
+          ],
+          "exceptions": [
+          ]
+        },
+        {
+          "name": "describe_ring",
+          "returnTypeId": "list",
+          "returnType": {
+            "typeId": "list",
+            "elemTypeId": "struct",
+            "elemType": {
+              "typeId": "struct",
+              "class": "TokenRange"
+            }
+          },
+          "oneway": false,
+          "doc": "get the token ring: a map of ranges to host addresses,\nrepresented as a set of TokenRange instead of a map from range\nto list of endpoints, because you can't use Thrift structs as\nmap keys:\nhttps:\/\/issues.apache.org\/jira\/browse\/THRIFT-162\n\nfor the same reason, we can't return a set here, even though\norder is neither important nor predictable.\n",
+          "arguments": [
+            {
+              "key": 1,
+              "name": "keyspace",
+              "typeId": "string",
+              "required": "required"
+            }
+          ],
+          "exceptions": [
+            {
+              "key": 1,
+              "name": "ire",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "InvalidRequestException"
+              },
+              "required": "req_out"
+            }
+          ]
+        },
+        {
+          "name": "describe_partitioner",
+          "returnTypeId": "string",
+          "oneway": false,
+          "doc": "returns the partitioner used by this cluster\n",
+          "arguments": [
+          ],
+          "exceptions": [
+          ]
+        },
+        {
+          "name": "describe_snitch",
+          "returnTypeId": "string",
+          "oneway": false,
+          "doc": "returns the snitch used by this cluster\n",
+          "arguments": [
+          ],
+          "exceptions": [
+          ]
+        },
+        {
+          "name": "describe_keyspace",
+          "returnTypeId": "struct",
+          "returnType": {
+            "typeId": "struct",
+            "class": "KsDef"
+          },
+          "oneway": false,
+          "doc": "describe specified keyspace\n",
+          "arguments": [
+            {
+              "key": 1,
+              "name": "keyspace",
+              "typeId": "string",
+              "required": "required"
+            }
+          ],
+          "exceptions": [
+            {
+              "key": 1,
+              "name": "nfe",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "NotFoundException"
+              },
+              "required": "req_out"
+            },
+            {
+              "key": 2,
+              "name": "ire",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "InvalidRequestException"
+              },
+              "required": "req_out"
+            }
+          ]
+        },
+        {
+          "name": "describe_splits",
+          "returnTypeId": "list",
+          "returnType": {
+            "typeId": "list",
+            "elemTypeId": "string"
+          },
+          "oneway": false,
+          "doc": "experimental API for hadoop\/parallel query support.\nmay change violently and without warning.\n\nreturns list of token strings such that first subrange is (list[0], list[1]],\nnext is (list[1], list[2]], etc.\n",
+          "arguments": [
+            {
+              "key": 1,
+              "name": "cfName",
+              "typeId": "string",
+              "required": "required"
+            },
+            {
+              "key": 2,
+              "name": "start_token",
+              "typeId": "string",
+              "required": "required"
+            },
+            {
+              "key": 3,
+              "name": "end_token",
+              "typeId": "string",
+              "required": "required"
+            },
+            {
+              "key": 4,
+              "name": "keys_per_split",
+              "typeId": "i32",
+              "required": "required"
+            }
+          ],
+          "exceptions": [
+            {
+              "key": 1,
+              "name": "ire",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "InvalidRequestException"
+              },
+              "required": "req_out"
+            }
+          ]
+        },
+        {
+          "name": "system_add_column_family",
+          "returnTypeId": "string",
+          "oneway": false,
+          "doc": "adds a column family. returns the new schema id.\n",
+          "arguments": [
+            {
+              "key": 1,
+              "name": "cf_def",
+              "typeId": "struct",
+              "type": {
+                "typeId": "struct",
+                "class": "CfDef"
+              },
+              "required": "required"
+            }
+          ],
+          "exceptions": [
+            {
+              "key": 1,
+              "name": "ire",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "InvalidRequestException"
+              },
+              "required": "req_out"
+            },
+            {
+              "key": 2,
+              "name": "sde",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "SchemaDisagreementException"
+              },
+              "required": "req_out"
+            }
+          ]
+        },
+        {
+          "name": "system_drop_column_family",
+          "returnTypeId": "string",
+          "oneway": false,
+          "doc": "drops a column family. returns the new schema id.\n",
+          "arguments": [
+            {
+              "key": 1,
+              "name": "column_family",
+              "typeId": "string",
+              "required": "required"
+            }
+          ],
+          "exceptions": [
+            {
+              "key": 1,
+              "name": "ire",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "InvalidRequestException"
+              },
+              "required": "req_out"
+            },
+            {
+              "key": 2,
+              "name": "sde",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "SchemaDisagreementException"
+              },
+              "required": "req_out"
+            }
+          ]
+        },
+        {
+          "name": "system_add_keyspace",
+          "returnTypeId": "string",
+          "oneway": false,
+          "doc": "adds a keyspace and any column families that are part of it. returns the new schema id.\n",
+          "arguments": [
+            {
+              "key": 1,
+              "name": "ks_def",
+              "typeId": "struct",
+              "type": {
+                "typeId": "struct",
+                "class": "KsDef"
+              },
+              "required": "required"
+            }
+          ],
+          "exceptions": [
+            {
+              "key": 1,
+              "name": "ire",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "InvalidRequestException"
+              },
+              "required": "req_out"
+            },
+            {
+              "key": 2,
+              "name": "sde",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "SchemaDisagreementException"
+              },
+              "required": "req_out"
+            }
+          ]
+        },
+        {
+          "name": "system_drop_keyspace",
+          "returnTypeId": "string",
+          "oneway": false,
+          "doc": "drops a keyspace and any column families that are part of it. returns the new schema id.\n",
+          "arguments": [
+            {
+              "key": 1,
+              "name": "keyspace",
+              "typeId": "string",
+              "required": "required"
+            }
+          ],
+          "exceptions": [
+            {
+              "key": 1,
+              "name": "ire",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "InvalidRequestException"
+              },
+              "required": "req_out"
+            },
+            {
+              "key": 2,
+              "name": "sde",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "SchemaDisagreementException"
+              },
+              "required": "req_out"
+            }
+          ]
+        },
+        {
+          "name": "system_update_keyspace",
+          "returnTypeId": "string",
+          "oneway": false,
+          "doc": "updates properties of a keyspace. returns the new schema id.\n",
+          "arguments": [
+            {
+              "key": 1,
+              "name": "ks_def",
+              "typeId": "struct",
+              "type": {
+                "typeId": "struct",
+                "class": "KsDef"
+              },
+              "required": "required"
+            }
+          ],
+          "exceptions": [
+            {
+              "key": 1,
+              "name": "ire",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "InvalidRequestException"
+              },
+              "required": "req_out"
+            },
+            {
+              "key": 2,
+              "name": "sde",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "SchemaDisagreementException"
+              },
+              "required": "req_out"
+            }
+          ]
+        },
+        {
+          "name": "system_update_column_family",
+          "returnTypeId": "string",
+          "oneway": false,
+          "doc": "updates properties of a column family. returns the new schema id.\n",
+          "arguments": [
+            {
+              "key": 1,
+              "name": "cf_def",
+              "typeId": "struct",
+              "type": {
+                "typeId": "struct",
+                "class": "CfDef"
+              },
+              "required": "required"
+            }
+          ],
+          "exceptions": [
+            {
+              "key": 1,
+              "name": "ire",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "InvalidRequestException"
+              },
+              "required": "req_out"
+            },
+            {
+              "key": 2,
+              "name": "sde",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "SchemaDisagreementException"
+              },
+              "required": "req_out"
+            }
+          ]
+        },
+        {
+          "name": "execute_cql_query",
+          "returnTypeId": "struct",
+          "returnType": {
+            "typeId": "struct",
+            "class": "CqlResult"
+          },
+          "oneway": false,
+          "doc": "Executes a CQL (Cassandra Query Language) statement and returns a\nCqlResult containing the results.\n",
+          "arguments": [
+            {
+              "key": 1,
+              "name": "query",
+              "typeId": "binary",
+              "required": "required"
+            },
+            {
+              "key": 2,
+              "name": "compression",
+              "typeId": "i32",
+              "required": "required"
+            }
+          ],
+          "exceptions": [
+            {
+              "key": 1,
+              "name": "ire",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "InvalidRequestException"
+              },
+              "required": "req_out"
+            },
+            {
+              "key": 2,
+              "name": "ue",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "UnavailableException"
+              },
+              "required": "req_out"
+            },
+            {
+              "key": 3,
+              "name": "te",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "TimedOutException"
+              },
+              "required": "req_out"
+            },
+            {
+              "key": 4,
+              "name": "sde",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "SchemaDisagreementException"
+              },
+              "required": "req_out"
+            }
+          ]
+        },
+        {
+          "name": "prepare_cql_query",
+          "returnTypeId": "struct",
+          "returnType": {
+            "typeId": "struct",
+            "class": "CqlPreparedResult"
+          },
+          "oneway": false,
+          "doc": "Prepare a CQL (Cassandra Query Language) statement by compiling and returning\n- the type of CQL statement\n- an id token of the compiled CQL stored on the server side.\n- a count of the discovered bound markers in the statement\n",
+          "arguments": [
+            {
+              "key": 1,
+              "name": "query",
+              "typeId": "binary",
+              "required": "required"
+            },
+            {
+              "key": 2,
+              "name": "compression",
+              "typeId": "i32",
+              "required": "required"
+            }
+          ],
+          "exceptions": [
+            {
+              "key": 1,
+              "name": "ire",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "InvalidRequestException"
+              },
+              "required": "req_out"
+            }
+          ]
+        },
+        {
+          "name": "execute_prepared_cql_query",
+          "returnTypeId": "struct",
+          "returnType": {
+            "typeId": "struct",
+            "class": "CqlResult"
+          },
+          "oneway": false,
+          "doc": "Executes a prepared CQL (Cassandra Query Language) statement by passing an id token and  a list of variables\nto bind and returns a CqlResult containing the results.\n",
+          "arguments": [
+            {
+              "key": 1,
+              "name": "itemId",
+              "typeId": "i32",
+              "required": "required"
+            },
+            {
+              "key": 2,
+              "name": "values",
+              "typeId": "list",
+              "type": {
+                "typeId": "list",
+                "elemTypeId": "string"
+              },
+              "required": "required"
+            }
+          ],
+          "exceptions": [
+            {
+              "key": 1,
+              "name": "ire",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "InvalidRequestException"
+              },
+              "required": "req_out"
+            },
+            {
+              "key": 2,
+              "name": "ue",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "UnavailableException"
+              },
+              "required": "req_out"
+            },
+            {
+              "key": 3,
+              "name": "te",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "TimedOutException"
+              },
+              "required": "req_out"
+            },
+            {
+              "key": 4,
+              "name": "sde",
+              "typeId": "exception",
+              "type": {
+                "typeId": "exception",
+                "class": "SchemaDisagreementException"
+              },
+              "required": "req_out"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Motivation:

Current DocService's json output doesn't contain JavaDoc string.
And, the latest Thrift compiler support `--gen json` option and it contains doc strings.
So, we can merge doc strings to DocService's output using json.
This commit is first part of adding docstring to DocService.

Modifications:

Read JSONs generated by Thrift if exists and build `*Info` models.

Result:

DocService's JSON output contains doc strings.