### PR TITLE
Add JettyService

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,7 @@
 
     <!-- Dependency versions -->
     <jackson.version>2.7.3</jackson.version>
+    <jetty.version>9.3.8.v20160314</jetty.version>
     <logback.version>1.1.7</logback.version>
     <metrics.version>3.1.2</metrics.version>
     <netty.version>4.1.0.CR7</netty.version>
@@ -196,6 +197,14 @@
       <optional>true</optional>
     </dependency>
 
+    <!-- Jetty (optional) -->
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-server</artifactId>
+      <version>${jetty.version}</version>
+      <optional>true</optional>
+    </dependency>
+
     <!-- Jackson -->
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -300,14 +309,32 @@
     <!-- Jetty, for verifying integration with official thrift library's TServlet -->
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-servlet</artifactId>
-      <version>9.3.6.v20151106</version>
+      <artifactId>jetty-webapp</artifactId>
+      <version>${jetty.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-annotations</artifactId>
+      <version>${jetty.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>apache-jsp</artifactId>
+      <version>${jetty.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>apache-jstl</artifactId>
+      <version>${jetty.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.http2</groupId>
       <artifactId>http2-server</artifactId>
-      <version>9.3.6.v20151106</version>
+      <version>${jetty.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/src/main/java/com/linecorp/armeria/server/ExecutorBasedExecutorService.java
+++ b/src/main/java/com/linecorp/armeria/server/ExecutorBasedExecutorService.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import java.util.List;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+
+final class ExecutorBasedExecutorService extends AbstractExecutorService {
+
+    private final Executor executor;
+
+    ExecutorBasedExecutorService(Executor executor) {
+        this.executor = executor;
+    }
+
+    @Override
+    public void shutdown() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return false;
+    }
+
+    @Override
+    public boolean isTerminated() {
+        return false;
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        Thread.sleep(unit.toMillis(timeout));
+        return false;
+    }
+
+    @Override
+    public void execute(Runnable command) {
+        executor.execute(command);
+    }
+
+    @Override
+    public String toString() {
+        return executor.toString();
+    }
+}

--- a/src/main/java/com/linecorp/armeria/server/InterminableExecutorService.java
+++ b/src/main/java/com/linecorp/armeria/server/InterminableExecutorService.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+final class InterminableExecutorService implements ExecutorService {
+
+    private final ExecutorService executor;
+
+    InterminableExecutorService(ExecutorService executor) {
+        this.executor = executor;
+    }
+
+    @Override
+    public void shutdown() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return executor.isShutdown();
+    }
+
+    @Override
+    public boolean isTerminated() {
+        return executor.isTerminated();
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit)
+            throws InterruptedException {
+        return executor.awaitTermination(timeout, unit);
+    }
+
+    @Override
+    public void execute(Runnable command) {
+        executor.execute(command);
+    }
+
+    @Override
+    public <T> Future<T> submit(Callable<T> task) {
+        return executor.submit(task);
+    }
+
+    @Override
+    public <T> Future<T> submit(Runnable task, T result) {
+        return executor.submit(task, result);
+    }
+
+    @Override
+    public Future<?> submit(Runnable task) {
+        return executor.submit(task);
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks)
+            throws InterruptedException {
+        return executor.invokeAll(tasks);
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout,
+                                         TimeUnit unit) throws InterruptedException {
+        return executor.invokeAll(tasks, timeout, unit);
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks)
+            throws InterruptedException, ExecutionException {
+        return executor.invokeAny(tasks);
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+            throws InterruptedException, ExecutionException, TimeoutException {
+        return executor.invokeAny(tasks, timeout, unit);
+    }
+
+    @Override
+    public String toString() {
+        return executor.toString();
+    }
+}

--- a/src/main/java/com/linecorp/armeria/server/http/jetty/ArmeriaConnector.java
+++ b/src/main/java/com/linecorp/armeria/server/http/jetty/ArmeriaConnector.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.http.jetty;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Future;
+
+import org.eclipse.jetty.io.ArrayByteBufferPool;
+import org.eclipse.jetty.io.ByteBufferPool;
+import org.eclipse.jetty.io.Connection;
+import org.eclipse.jetty.io.EndPoint;
+import org.eclipse.jetty.server.ConnectionFactory;
+import org.eclipse.jetty.server.Connector;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.util.component.ContainerLifeCycle;
+import org.eclipse.jetty.util.thread.ScheduledExecutorScheduler;
+import org.eclipse.jetty.util.thread.Scheduler;
+
+import io.netty.util.concurrent.GlobalEventExecutor;
+
+final class ArmeriaConnector extends ContainerLifeCycle implements Connector {
+
+    private static final String PROTOCOL_NAME = "armeria";
+    private static final List<String> PROTOCOL_NAMES = Collections.singletonList(PROTOCOL_NAME);
+
+    private final Server server;
+    private final HttpConfiguration httpConfig;
+    private final Executor executor;
+    private final Scheduler scheduler;
+    private final ByteBufferPool byteBufferPool;
+    private final ArmeriaConnectionFactory connectionFactory;
+    private final Collection<ConnectionFactory> connectionFactories;
+
+    ArmeriaConnector(Server server) {
+        this.server = server;
+        executor = server.getThreadPool();
+
+        final HttpConfiguration httpConfig = server.getBean(HttpConfiguration.class);
+        this.httpConfig = httpConfig != null ? httpConfig : new HttpConfiguration();
+
+        final Scheduler scheduler = server.getBean(Scheduler.class);
+        this.scheduler = scheduler != null ? scheduler : new ScheduledExecutorScheduler();
+
+        final ByteBufferPool byteBufferPool = server.getBean(ByteBufferPool.class);
+        this.byteBufferPool = byteBufferPool != null ? byteBufferPool : new ArrayByteBufferPool();
+
+        addBean(server, false);
+        addBean(executor);
+        unmanage(executor);
+        addBean(this.httpConfig);
+        addBean(this.scheduler);
+        addBean(this.byteBufferPool);
+
+        connectionFactory = new ArmeriaConnectionFactory();
+        connectionFactories = Collections.singleton(connectionFactory);
+    }
+
+    @Override
+    public Object getTransport() {
+        return this;
+    }
+
+    @Override
+    public Server getServer() {
+        return server;
+    }
+
+    public HttpConfiguration getHttpConfiguration() {
+        return httpConfig;
+    }
+
+    @Override
+    public Executor getExecutor() {
+        return executor;
+    }
+
+    @Override
+    public Scheduler getScheduler() {
+        return scheduler;
+    }
+
+    @Override
+    public ByteBufferPool getByteBufferPool() {
+        return byteBufferPool;
+    }
+
+    @Override
+    public ConnectionFactory getConnectionFactory(String nextProtocol) {
+        return PROTOCOL_NAME.equals(nextProtocol) ? connectionFactory : null;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T getConnectionFactory(Class<T> factoryType) {
+        return factoryType == ArmeriaConnectionFactory.class ? (T) connectionFactory : null;
+    }
+
+    @Override
+    public ConnectionFactory getDefaultConnectionFactory() {
+        return connectionFactory;
+    }
+
+    @Override
+    public Collection<ConnectionFactory> getConnectionFactories() {
+        return connectionFactories;
+    }
+
+    @Override
+    public List<String> getProtocols() {
+        return PROTOCOL_NAMES;
+    }
+
+    @Override
+    public long getIdleTimeout() {
+        return 0;
+    }
+
+    @Override
+    public Collection<EndPoint> getConnectedEndPoints() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public String getName() {
+        return "armeria";
+    }
+
+    @Override
+    public Future<Void> shutdown() {
+        return GlobalEventExecutor.INSTANCE.newSucceededFuture(null);
+    }
+
+    private static final class ArmeriaConnectionFactory implements ConnectionFactory {
+        @Override
+        public String getProtocol() {
+            return PROTOCOL_NAME;
+        }
+
+        @Override
+        public List<String> getProtocols() {
+            return PROTOCOL_NAMES;
+        }
+
+        @Override
+        public Connection newConnection(Connector connector, EndPoint endPoint) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/src/main/java/com/linecorp/armeria/server/http/jetty/JettyService.java
+++ b/src/main/java/com/linecorp/armeria/server/http/jetty/JettyService.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.http.jetty;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.concurrent.ExecutorService;
+import java.util.function.Function;
+
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.util.thread.ExecutorThreadPool;
+
+import com.linecorp.armeria.server.http.HttpService;
+
+/**
+ * An {@link HttpService} that dispatches its requests to a web application running in an embedded
+ * <a href="http://www.eclipse.org/jetty/">Jetty</a>.
+ *
+ * @see JettyServiceBuilder
+ */
+public class JettyService extends HttpService {
+
+    /**
+     * Creates a new {@link JettyService} from an existing Jetty {@link Server}.
+     *
+     * @param hostname the default hostname
+     * @param jettyServer the Jetty {@link Server}
+     */
+    public static JettyService forServer(String hostname, Server jettyServer) {
+        requireNonNull(hostname, "hostname");
+        requireNonNull(jettyServer, "jettyServer");
+        return new JettyService(hostname, blockingTaskExecutor -> jettyServer);
+    }
+
+    static JettyService forConfig(JettyServiceConfig config) {
+        final Function<ExecutorService, Server> serverFactory = blockingTaskExecutor -> {
+            final Server server = new Server(new ExecutorThreadPool(blockingTaskExecutor));
+
+            config.dumpAfterStart().ifPresent(server::setDumpAfterStart);
+            config.dumpBeforeStop().ifPresent(server::setDumpBeforeStop);
+            config.handler().ifPresent(server::setHandler);
+            config.requestLog().ifPresent(server::setRequestLog);
+            config.sessionIdManager().ifPresent(server::setSessionIdManager);
+            config.stopTimeoutMillis().ifPresent(server::setStopTimeout);
+
+            config.attrs().forEach(server::setAttribute);
+            config.beans().forEach(bean -> {
+                final Boolean managed = bean.isManaged();
+                if (managed == null) {
+                    server.addBean(bean.bean());
+                } else {
+                    server.addBean(bean.bean(), managed);
+                }
+            });
+
+            config.eventListeners().forEach(server::addEventListener);
+            config.lifeCycleListeners().forEach(server::addLifeCycleListener);
+
+            config.configurators().forEach(c -> c.accept(server));
+
+            return server;
+        };
+
+        return new JettyService(config.hostname(), serverFactory);
+    }
+
+    private JettyService(String hostname, Function<ExecutorService, Server> serverSupplier) {
+        super(new JettyServiceInvocationHandler(hostname, serverSupplier));
+    }
+}

--- a/src/main/java/com/linecorp/armeria/server/http/jetty/JettyServiceBuilder.java
+++ b/src/main/java/com/linecorp/armeria/server/http/jetty/JettyServiceBuilder.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.http.jetty;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.RequestLog;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.SessionIdManager;
+import org.eclipse.jetty.util.component.Container;
+import org.eclipse.jetty.util.component.LifeCycle;
+
+import com.linecorp.armeria.server.http.jetty.JettyServiceConfig.Bean;
+
+/**
+ * Builds a {@link JettyService}. Use {@link JettyService#forServer(String, Server)} if you have a configured
+ * Jetty {@link Server} instance.
+ */
+public final class JettyServiceBuilder {
+
+    private final Map<String, Object> attrs = new LinkedHashMap<>();
+    private final List<Bean> beans = new ArrayList<>();
+    private final List<Container.Listener> eventListeners = new ArrayList<>();
+    private final List<LifeCycle.Listener> lifeCycleListeners = new ArrayList<>();
+    private final List<Consumer<? super Server>> configurators = new ArrayList<>();
+
+    private String hostname = "localhost";
+    private Boolean dumpAfterStart;
+    private Boolean dumpBeforeStop;
+    private Handler handler;
+    private RequestLog requestLog;
+    private SessionIdManager sessionIdManager;
+    private Long stopTimeoutMillis;
+
+    /**
+     * Sets the default hostname of the Jetty {@link Server}.
+     */
+    public JettyServiceBuilder hostname(String hostname) {
+        this.hostname = requireNonNull(hostname, "hostname");
+        return this;
+    }
+
+    /**
+     * Puts the specified attribute into the Jetty {@link Server}.
+     *
+     * @see Server#setAttribute(String, Object)
+     */
+    public JettyServiceBuilder attr(String name, Object attribute) {
+        attrs.put(requireNonNull(name, "name"), requireNonNull(attribute, "attribute"));
+        return this;
+    }
+
+    /**
+     * Adds the specified bean to the Jetty {@link Server}.
+     *
+     * @see Server#addBean(Object)
+     */
+    public JettyServiceBuilder bean(Object bean) {
+        beans.add(new Bean(bean, null));
+        return this;
+    }
+
+    /**
+     * Adds the specified bean to the Jetty {@link Server}.
+     *
+     * @see Server#addBean(Object, boolean)
+     */
+    public JettyServiceBuilder bean(Object bean, boolean managed) {
+        beans.add(new Bean(bean, managed));
+        return this;
+    }
+
+    /**
+     * Sets whether the Jetty {@link Server} needs to dump its configuration after it started up.
+     *
+     * @see Server#setDumpAfterStart(boolean)
+     */
+    public JettyServiceBuilder dumpAfterStart(boolean dumpAfterStart) {
+        this.dumpAfterStart = dumpAfterStart;
+        return this;
+    }
+
+    /**
+     * Sets whether the Jetty {@link Server} needs to dump its configuration before it shuts down.
+     *
+     * @see Server#setDumpBeforeStop(boolean)
+     */
+    public JettyServiceBuilder dumpBeforeStop(boolean dumpBeforeStop) {
+        this.dumpBeforeStop = dumpBeforeStop;
+        return this;
+    }
+
+    /**
+     * Sets the {@link Handler} of the Jetty {@link Server}.
+     *
+     * @see Server#setHandler(Handler)
+     */
+    public JettyServiceBuilder handler(Handler handler) {
+        this.handler = requireNonNull(handler, "handler");
+        return this;
+    }
+
+    /**
+     * Sets the {@link RequestLog} of the Jetty {@link Server}.
+     *
+     * @see Server#setRequestLog(RequestLog)
+     */
+    public JettyServiceBuilder requestLog(RequestLog requestLog) {
+        this.requestLog = requireNonNull(requestLog, "requestLog");
+        return this;
+    }
+
+    /**
+     * Sets the {@link SessionIdManager} of the Jetty {@link Server}.
+     *
+     * @see Server#setSessionIdManager(SessionIdManager)
+     */
+    public JettyServiceBuilder sessionIdManager(SessionIdManager sessionIdManager) {
+        this.sessionIdManager = requireNonNull(sessionIdManager, "sessionIdManager");
+        return this;
+    }
+
+    /**
+     * Sets the graceful stop time of the {@link Server#stop()} in milliseconds.
+     *
+     * @see Server#setStopTimeout(long)
+     */
+    public JettyServiceBuilder stopTimeoutMillis(long stopTimeoutMillis) {
+        this.stopTimeoutMillis = stopTimeoutMillis;
+        return this;
+    }
+
+    /**
+     * Adds the specified event listener to the Jetty {@link Server}.
+     */
+    public JettyServiceBuilder eventListener(Container.Listener eventListener) {
+        eventListeners.add(requireNonNull(eventListener, "eventListener"));
+        return this;
+    }
+
+    /**
+     * Adds the specified life cycle listener to the Jetty {@link Server}.
+     */
+    public JettyServiceBuilder lifeCycleListener(LifeCycle.Listener lifeCycleListener) {
+        lifeCycleListeners.add(requireNonNull(lifeCycleListener, "lifeCycleListener"));
+        return this;
+    }
+
+    /**
+     * Adds a {@link Consumer} that performs additional configuration operations against
+     * the Jetty {@link Server} created by a {@link JettyService}.
+     */
+    public JettyServiceBuilder configurator(Consumer<? super Server> configurator) {
+        configurators.add(requireNonNull(configurator, "configurator"));
+        return this;
+    }
+
+    /**
+     * Creates a new {@link JettyService}.
+     */
+    public JettyService build() {
+        return JettyService.forConfig(new JettyServiceConfig(
+                hostname, dumpAfterStart, dumpBeforeStop, stopTimeoutMillis, handler, requestLog,
+                sessionIdManager, attrs, beans, eventListeners, lifeCycleListeners, configurators));
+    }
+
+    @Override
+    public String toString() {
+        return JettyServiceConfig.toString(
+                this, hostname, dumpAfterStart, dumpBeforeStop, stopTimeoutMillis, handler,
+                requestLog, sessionIdManager, attrs, beans, eventListeners, lifeCycleListeners, configurators);
+    }
+}

--- a/src/main/java/com/linecorp/armeria/server/http/jetty/JettyServiceConfig.java
+++ b/src/main/java/com/linecorp/armeria/server/http/jetty/JettyServiceConfig.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.http.jetty;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.RequestLog;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.SessionIdManager;
+import org.eclipse.jetty.util.component.Container;
+import org.eclipse.jetty.util.component.LifeCycle;
+
+final class JettyServiceConfig {
+
+    private final String hostname;
+    private final Boolean dumpAfterStart;
+    private final Boolean dumpBeforeStop;
+    private final Long stopTimeoutMillis;
+    private final Handler handler;
+    private final RequestLog requestLog;
+    private final SessionIdManager sessionIdManager;
+    private final Map<String, Object> attrs;
+    private final List<Bean> beans;
+    private final List<Container.Listener> eventListeners;
+    private final List<LifeCycle.Listener> lifeCycleListeners;
+    private final List<Consumer<? super Server>> configurators;
+
+    JettyServiceConfig(String hostname,
+                       Boolean dumpAfterStart, Boolean dumpBeforeStop, Long stopTimeoutMillis,
+                       Handler handler, RequestLog requestLog, SessionIdManager sessionIdManager,
+                       Map<String, Object> attrs, List<Bean> beans,
+                       List<Container.Listener> eventListeners, List<LifeCycle.Listener> lifeCycleListeners,
+                       List<Consumer<? super Server>> configurators) {
+
+        this.hostname = hostname;
+        this.dumpAfterStart = dumpAfterStart;
+        this.dumpBeforeStop = dumpBeforeStop;
+        this.stopTimeoutMillis = stopTimeoutMillis;
+        this.handler = handler;
+        this.requestLog = requestLog;
+        this.sessionIdManager = sessionIdManager;
+        this.attrs = Collections.unmodifiableMap(attrs);
+        this.beans = Collections.unmodifiableList(beans);
+        this.eventListeners = Collections.unmodifiableList(eventListeners);
+        this.lifeCycleListeners = Collections.unmodifiableList(lifeCycleListeners);
+        this.configurators = Collections.unmodifiableList(configurators);
+    }
+
+    String hostname() {
+        return hostname;
+    }
+
+    Optional<Boolean> dumpAfterStart() {
+        return Optional.ofNullable(dumpAfterStart);
+    }
+
+    Optional<Boolean> dumpBeforeStop() {
+        return Optional.ofNullable(dumpBeforeStop);
+    }
+
+    Optional<Long> stopTimeoutMillis() {
+        return Optional.ofNullable(stopTimeoutMillis);
+    }
+
+    Optional<Handler> handler() {
+        return Optional.ofNullable(handler);
+    }
+
+    Optional<RequestLog> requestLog() {
+        return Optional.ofNullable(requestLog);
+    }
+
+    Optional<SessionIdManager> sessionIdManager() {
+        return Optional.ofNullable(sessionIdManager);
+    }
+
+    Map<String, Object> attrs() {
+        return attrs;
+    }
+
+    List<Bean> beans() {
+        return beans;
+    }
+
+    List<Container.Listener> eventListeners() {
+        return eventListeners;
+    }
+
+    List<LifeCycle.Listener> lifeCycleListeners() {
+        return lifeCycleListeners;
+    }
+
+    List<Consumer<? super Server>> configurators() {
+        return configurators;
+    }
+
+    @Override
+    public String toString() {
+        return toString(
+                this, hostname, dumpAfterStart, dumpBeforeStop, stopTimeoutMillis, handler,
+                requestLog, sessionIdManager, attrs, beans, eventListeners, lifeCycleListeners, configurators);
+    }
+
+    static String toString(
+            Object holder, String hostname, Boolean dumpAfterStart, Boolean dumpBeforeStop,
+            Long stopTimeout, Handler handler, RequestLog requestLog,
+            SessionIdManager sessionIdManager, Map<String, Object> attrs, List<Bean> beans,
+            List<Container.Listener> eventListeners, List<LifeCycle.Listener> lifeCycleListeners,
+            List<Consumer<? super Server>> configurators) {
+
+        final StringBuilder buf = new StringBuilder(256);
+        buf.append(holder.getClass().getSimpleName());
+        buf.append("(hostname: ");
+        buf.append(hostname);
+        buf.append(", dumpAfterStart: ");
+        buf.append(dumpAfterStart);
+        buf.append(", dumpBeforeStop: ");
+        buf.append(dumpBeforeStop);
+        buf.append(", stopTimeoutMillis: ");
+        buf.append(stopTimeout);
+        buf.append(", handler: ");
+        buf.append(handler);
+        buf.append(", requestLog: ");
+        buf.append(requestLog);
+        buf.append(", sessionIdManager: ");
+        buf.append(sessionIdManager);
+        buf.append(", attrs: ");
+        buf.append(attrs);
+        buf.append(", beans: ");
+        buf.append(beans);
+        buf.append(", eventListeners: ");
+        buf.append(eventListeners);
+        buf.append(", lifeCycleListeners: ");
+        buf.append(lifeCycleListeners);
+        buf.append(", configurators: ");
+        buf.append(configurators);
+        buf.append(')');
+        return buf.toString();
+    }
+
+    static final class Bean {
+
+        private final Object bean;
+        private final Boolean managed;
+
+        Bean(Object bean, Boolean managed) {
+            this.bean = requireNonNull(bean, "bean");
+            this.managed = managed;
+        }
+
+        Object bean() {
+            return bean;
+        }
+
+        Boolean isManaged() {
+            return managed;
+        }
+
+        @Override
+        public String toString() {
+            final String mode = managed != null ? managed ? "managed" : "unmanaged"
+                                                : "auto";
+            return "(" + bean + ", " + mode + ')';
+        }
+    }
+}

--- a/src/main/java/com/linecorp/armeria/server/http/jetty/JettyServiceInvocationHandler.java
+++ b/src/main/java/com/linecorp/armeria/server/http/jetty/JettyServiceInvocationHandler.java
@@ -1,0 +1,344 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.http.jetty;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.net.UnknownHostException;
+import java.nio.ByteBuffer;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.function.Function;
+
+import javax.servlet.DispatcherType;
+
+import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http.HttpURI;
+import org.eclipse.jetty.http.HttpVersion;
+import org.eclipse.jetty.http.MetaData;
+import org.eclipse.jetty.io.AbstractEndPoint;
+import org.eclipse.jetty.server.HttpChannel;
+import org.eclipse.jetty.server.HttpInput.Content;
+import org.eclipse.jetty.server.HttpTransport;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.thread.Scheduler;
+
+import com.linecorp.armeria.common.ServiceInvocationContext;
+import com.linecorp.armeria.server.ServerListenerAdapter;
+import com.linecorp.armeria.server.ServiceConfig;
+import com.linecorp.armeria.server.ServiceInvocationHandler;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.util.concurrent.Promise;
+
+final class JettyServiceInvocationHandler implements ServiceInvocationHandler {
+
+    private final String hostname;
+    private final Function<ExecutorService, Server> serverFactory;
+    private final Configurator configurator = new Configurator();
+    private Server server;
+    private ArmeriaConnector connector;
+    private com.linecorp.armeria.server.Server armeriaServer;
+    private boolean startedServer;
+
+    JettyServiceInvocationHandler(String hostname, Function<ExecutorService, Server> serverFactory) {
+        this.hostname = hostname;
+        this.serverFactory = serverFactory;
+    }
+
+    @Override
+    public void handlerAdded(ServiceConfig cfg) throws Exception {
+        if (armeriaServer != null) {
+            if (armeriaServer != cfg.server()) {
+                throw new IllegalStateException("cannot be added to more than one server");
+            } else {
+                return;
+            }
+        }
+
+        armeriaServer = cfg.server();
+        armeriaServer.addListener(configurator);
+    }
+
+    void start() throws Exception {
+        boolean success = false;
+        try {
+            server = serverFactory.apply(armeriaServer.config().blockingTaskExecutor());
+            connector = new ArmeriaConnector(server);
+            server.addConnector(connector);
+
+            if (!server.isStarted()) {
+                server.start();
+                startedServer = true;
+            } else {
+                startedServer = false;
+            }
+            success = true;
+        } finally {
+            if (!success) {
+                server = null;
+                connector = null;
+            }
+        }
+    }
+
+    void stop() throws Exception {
+        if (server == null) {
+            return;
+        }
+
+        if (startedServer) {
+            try {
+                server.stop();
+            } finally {
+                server = null;
+                connector = null;
+            }
+        }
+    }
+
+    @Override
+    public void invoke(ServiceInvocationContext ctx, Executor blockingTaskExecutor,
+                       Promise<Object> promise) throws Exception {
+
+        final ArmeriaConnector connector = this.connector;
+        final FullHttpRequest aReq = ctx.originalRequest();
+        final ByteBuf out = ctx.alloc().ioBuffer();
+
+        boolean submitted = false;
+        try {
+            final ArmeriaHttpTransport transport = new ArmeriaHttpTransport(out);
+            final HttpChannel httpChannel = new HttpChannel(
+                    connector,
+                    connector.getHttpConfiguration(),
+                    new ArmeriaEndPoint(hostname, connector.getScheduler(),
+                                        ctx.localAddress(), ctx.remoteAddress()),
+                    transport);
+
+            fillRequest(ctx, aReq, httpChannel.getRequest());
+
+            blockingTaskExecutor.execute(() -> invoke(ctx, promise, transport, httpChannel));
+            submitted = true;
+        } catch (Throwable t) {
+            ctx.rejectPromise(promise, t);
+        } finally {
+            if (!submitted) {
+                out.release();
+            }
+        }
+    }
+
+    private void invoke(ServiceInvocationContext ctx, Promise<Object> promise,
+                        ArmeriaHttpTransport transport, HttpChannel httpChannel) {
+
+        final ByteBuf out = transport.out;
+        boolean success = false;
+        try {
+            server.handle(httpChannel);
+            httpChannel.getResponse().getHttpOutput().flush();
+
+            final Throwable cause = transport.cause;
+            if (cause == null) {
+                ctx.resolvePromise(promise, toFullHttpResponse(transport, out));
+                success = true;
+            } else {
+                ctx.rejectPromise(promise, cause);
+            }
+        } catch (Throwable t) {
+            ctx.rejectPromise(promise, t);
+        } finally {
+            if (!success) {
+                out.release();
+            }
+        }
+    }
+
+    private static void fillRequest(
+            ServiceInvocationContext ctx, FullHttpRequest aReq, Request jReq) {
+
+        jReq.setDispatcherType(DispatcherType.REQUEST);
+        jReq.setAsyncSupported(true, "armeria");
+        jReq.setSecure(ctx.scheme().sessionProtocol().isTls());
+        jReq.setMetaData(toRequestMetadata(ctx, aReq));
+
+        if (aReq.content().isReadable()) {
+            jReq.getHttpInput().addContent(new Content(aReq.content().nioBuffer()));
+        }
+        jReq.getHttpInput().eof();
+    }
+
+    private static MetaData.Request toRequestMetadata(ServiceInvocationContext ctx, FullHttpRequest aReq) {
+        // Construct the HttpURI
+        final StringBuilder uriBuf = new StringBuilder();
+        uriBuf.append(ctx.scheme().sessionProtocol().isTls() ? "https" : "http");
+        uriBuf.append("://");
+        uriBuf.append(ctx.host());
+        uriBuf.append(':');
+        uriBuf.append(((InetSocketAddress) ctx.localAddress()).getPort());
+        uriBuf.append(aReq.uri());
+
+        final HttpURI uri = new HttpURI(uriBuf.toString());
+        uri.setPath(ctx.mappedPath());
+
+        // Convert HttpHeaders to HttpFields
+        final HttpFields headers = new HttpFields(aReq.headers().size());
+        aReq.headers().forEach(e -> headers.add(e.getKey(), e.getValue()));
+
+        return new MetaData.Request(
+                ctx.method(), uri, HttpVersion.HTTP_1_1, headers, aReq.content().readableBytes());
+    }
+
+    private static FullHttpResponse toFullHttpResponse(ArmeriaHttpTransport transport, ByteBuf content) {
+        final MetaData.Response info = transport.info;
+        if (info == null) {
+            throw new IllegalStateException("response metadata unavailable");
+        }
+
+        final FullHttpResponse res = new DefaultFullHttpResponse(
+                io.netty.handler.codec.http.HttpVersion.HTTP_1_1,
+                HttpResponseStatus.valueOf(info.getStatus()),
+                content, false);
+
+        info.getFields().forEach(e -> res.headers().add(e.getName(), e.getValue()));
+
+        return res;
+    }
+
+    private static final class ArmeriaHttpTransport implements HttpTransport {
+
+        final ByteBuf out;
+        MetaData.Response info;
+        Throwable cause;
+
+        ArmeriaHttpTransport(ByteBuf out) {
+            this.out = out;
+        }
+
+        @Override
+        public void send(MetaData.Response info, boolean head,
+                         ByteBuffer content, boolean lastContent, Callback callback) {
+
+            if (info != null) {
+                this.info = info;
+            }
+
+            out.writeBytes(content);
+            callback.succeeded();
+        }
+
+        @Override
+        public boolean isPushSupported() {
+            return false;
+        }
+
+        @Override
+        public void push(MetaData.Request request) {}
+
+        @Override
+        public void onCompleted() {}
+
+        @Override
+        public void abort(Throwable failure) {
+            cause = failure;
+        }
+
+        @Override
+        public boolean isOptimizedForDirectBuffers() {
+            return false;
+        }
+    }
+
+    private static final class ArmeriaEndPoint extends AbstractEndPoint {
+        ArmeriaEndPoint(String hostname, Scheduler scheduler, SocketAddress local, SocketAddress remote) {
+            super(scheduler, addHostname((InetSocketAddress) local, hostname), (InetSocketAddress) remote);
+
+            setIdleTimeout(getIdleTimeout());
+        }
+
+        /**
+         * Adds the hostname string to the specified {@link InetSocketAddress} so that
+         * Jetty's {@code ServletRequest.getLocalName()} implementation returns the configured hostname.
+         */
+        private static InetSocketAddress addHostname(InetSocketAddress address, String hostname) {
+            try {
+                return new InetSocketAddress(InetAddress.getByAddress(
+                        hostname, address.getAddress().getAddress()), address.getPort());
+            } catch (UnknownHostException e) {
+                throw new Error(e); // Should never happen
+            }
+        }
+
+
+        @Override
+        protected void onIncompleteFlush() {}
+
+        @Override
+        protected void needsFillInterest() {}
+
+        @Override
+        public void shutdownOutput() {}
+
+        @Override
+        public boolean isOutputShutdown() {
+            return false;
+        }
+
+        @Override
+        public boolean isInputShutdown() {
+            return false;
+        }
+
+        @Override
+        public int fill(ByteBuffer buffer) {
+            return 0;
+        }
+
+        @Override
+        public boolean flush(ByteBuffer... buffer) {
+            return true;
+        }
+
+        @Override
+        public Object getTransport() {
+            return null;
+        }
+
+        @Override
+        public boolean isOpen() {
+            return true;
+        }
+    }
+
+    private final class Configurator extends ServerListenerAdapter {
+        @Override
+        public void serverStarting(com.linecorp.armeria.server.Server server) throws Exception {
+            start();
+        }
+
+        @Override
+        public void serverStopped(com.linecorp.armeria.server.Server server) throws Exception {
+            stop();
+        }
+    }
+}

--- a/src/main/java/com/linecorp/armeria/server/http/jetty/package-info.java
+++ b/src/main/java/com/linecorp/armeria/server/http/jetty/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -15,6 +15,6 @@
  */
 
 /**
- * Embedded <a href="http://tomcat.apache.org/">Tomcat</a> service.
+ * Embedded <a href="http://www.eclipse.org/jetty/">Jetty</a> service.
  */
-package com.linecorp.armeria.server.http.tomcat;
+package com.linecorp.armeria.server.http.jetty;

--- a/src/main/java/com/linecorp/armeria/server/http/tomcat/TomcatServiceBuilder.java
+++ b/src/main/java/com/linecorp/armeria/server/http/tomcat/TomcatServiceBuilder.java
@@ -35,16 +35,18 @@ import java.util.List;
 import java.util.function.Consumer;
 
 import org.apache.catalina.Realm;
+import org.apache.catalina.connector.Connector;
 import org.apache.catalina.core.StandardEngine;
 import org.apache.catalina.core.StandardServer;
 import org.apache.catalina.core.StandardService;
 import org.apache.catalina.realm.NullRealm;
+import org.apache.catalina.startup.Tomcat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Builds a {@link TomcatService} and its {@link TomcatServiceConfig}. Use the factory methods in
- * {@link TomcatService} if you do not override the default settings.
+ * Builds a {@link TomcatService}. Use the factory methods in {@link TomcatService} if you do not override
+ * the default settings or you have a configured {@link Tomcat} or {@link Connector} instance.
  */
 public final class TomcatServiceBuilder {
 
@@ -287,9 +289,8 @@ public final class TomcatServiceBuilder {
     }
 
     /**
-     * Sets a {@link Consumer} that performs additional configuration operations against
-     * the Tomcat {@link StandardServer} created by a {@link TomcatService}. This method can be invoked
-     * multiple times to add multiple {@code configurator}s.
+     * Adds a {@link Consumer} that performs additional configuration operations against
+     * the Tomcat {@link StandardServer} created by a {@link TomcatService}.
      */
     public TomcatServiceBuilder configurator(Consumer<? super StandardServer> configurator) {
         configurators.add(requireNonNull(configurator, "configurator"));

--- a/src/main/java/com/linecorp/armeria/server/http/tomcat/TomcatServiceConfig.java
+++ b/src/main/java/com/linecorp/armeria/server/http/tomcat/TomcatServiceConfig.java
@@ -29,7 +29,7 @@ import org.apache.catalina.core.StandardService;
 /**
  * {@link TomcatService} configuration.
  */
-public class TomcatServiceConfig {
+final class TomcatServiceConfig {
 
     private final String serviceName;
     private final String engineName;
@@ -57,42 +57,42 @@ public class TomcatServiceConfig {
     /**
      * Returns the name of the {@link StandardService} of an embedded Tomcat.
      */
-    public String serviceName() {
+    String serviceName() {
         return serviceName;
     }
 
     /**
      * Returns the name of the {@link StandardEngine} of an embedded Tomcat.
      */
-    public String engineName() {
+    String engineName() {
         return engineName;
     }
 
     /**
      * Returns the base directory of an embedded Tomcat.
      */
-    public Path baseDir() {
+    Path baseDir() {
         return baseDir;
     }
 
     /**
      * Returns the {@link Realm} of an embedded Tomcat.
      */
-    public Realm realm() {
+    Realm realm() {
         return realm;
     }
 
     /**
      * Returns the hostname of an embedded Tomcat.
      */
-    public String hostname() {
+    String hostname() {
         return hostname;
     }
 
     /**
      * Returns the document base directory of a web application.
      */
-    public Path docBase() {
+    Path docBase() {
         return docBase;
     }
 
@@ -101,7 +101,7 @@ public class TomcatServiceConfig {
      *
      * @return {@link Optional#empty()} if {@link #docBase()} is not a JAR/WAR file
      */
-    public Optional<String> jarRoot() {
+    Optional<String> jarRoot() {
         return Optional.ofNullable(jarRoot);
     }
 
@@ -109,7 +109,7 @@ public class TomcatServiceConfig {
      * Returns the {@link Consumer}s that performs additional configuration operations against
      * the Tomcat {@link StandardServer} created by a {@link TomcatService}.
      */
-    public List<Consumer<? super StandardServer>> configurators() {
+    List<Consumer<? super StandardServer>> configurators() {
         return configurators;
     }
 

--- a/src/main/java/com/linecorp/armeria/server/http/tomcat/TomcatServiceInvocationHandler.java
+++ b/src/main/java/com/linecorp/armeria/server/http/tomcat/TomcatServiceInvocationHandler.java
@@ -52,8 +52,6 @@ import io.netty.util.concurrent.Promise;
 
 class TomcatServiceInvocationHandler implements ServiceInvocationHandler {
 
-    private static final Logger logger = LoggerFactory.getLogger(TomcatServiceInvocationHandler.class);
-
     private final String hostname;
 
     private final Connector connector;

--- a/src/test/java/com/linecorp/armeria/server/http/WebAppContainerTest.java
+++ b/src/test/java/com/linecorp/armeria/server/http/WebAppContainerTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.http;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.regex.Pattern;
+
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.util.EntityUtils;
+import org.junit.Test;
+
+import com.linecorp.armeria.server.AbstractServerTest;
+
+import io.netty.handler.codec.http.HttpHeaderNames;
+
+public abstract class WebAppContainerTest extends AbstractServerTest {
+
+    private static final Pattern CR_OR_LF = Pattern.compile("[\\r\\n]");
+
+    @Test
+    public void testJsp() throws Exception {
+        try (CloseableHttpClient hc = HttpClients.createMinimal()) {
+            try (CloseableHttpResponse res = hc.execute(new HttpGet(uri("/jsp/index.jsp")))) {
+                assertThat(res.getStatusLine().toString(), is("HTTP/1.1 200 OK"));
+                assertThat(res.getFirstHeader(HttpHeaderNames.CONTENT_TYPE.toString()).getValue(),
+                           startsWith("text/html"));
+                final String actualContent = CR_OR_LF.matcher(EntityUtils.toString(res.getEntity()))
+                                                     .replaceAll("");
+                assertThat(actualContent, is(
+                        "<html><body>" +
+                        "<p>Hello, Armerian World!</p>" +
+                        "<p>Have you heard about the class 'io.netty.buffer.ByteBuf'?</p>" +
+                        "<p>Context path: </p>" + // ROOT context path
+                        "<p>Request URI: /index.jsp</p>" +
+                        "</body></html>"));
+            }
+        }
+    }
+
+    @Test
+    public void testGetQueryString() throws Exception {
+        try (CloseableHttpClient hc = HttpClients.createMinimal()) {
+            try (CloseableHttpResponse res = hc.execute(
+                    new HttpGet(uri("/jsp/query_string.jsp?foo=%31&bar=%32")))) {
+
+                assertThat(res.getStatusLine().toString(), is("HTTP/1.1 200 OK"));
+                assertThat(res.getFirstHeader(HttpHeaderNames.CONTENT_TYPE.toString()).getValue(),
+                           startsWith("text/html"));
+                final String actualContent = CR_OR_LF.matcher(EntityUtils.toString(res.getEntity()))
+                                                     .replaceAll("");
+                assertThat(actualContent, is(
+                        "<html><body>" +
+                        "<p>foo is 1</p>" +
+                        "<p>bar is 2</p>" +
+                        "</body></html>"));
+            }
+        }
+    }
+
+    @Test
+    public void testPostQueryString() throws Exception {
+        try (CloseableHttpClient hc = HttpClients.createMinimal()) {
+            final HttpPost post = new HttpPost(uri("/jsp/query_string.jsp?foo=3"));
+            post.setEntity(new UrlEncodedFormEntity(
+                    Collections.singletonList(new BasicNameValuePair("bar", "4")), StandardCharsets.UTF_8));
+
+            try (CloseableHttpResponse res = hc.execute(post)) {
+                assertThat(res.getStatusLine().toString(), is("HTTP/1.1 200 OK"));
+                assertThat(res.getFirstHeader(HttpHeaderNames.CONTENT_TYPE.toString()).getValue(),
+                           startsWith("text/html"));
+                final String actualContent = CR_OR_LF.matcher(EntityUtils.toString(res.getEntity()))
+                                                     .replaceAll("");
+                assertThat(actualContent, is(
+                        "<html><body>" +
+                        "<p>foo is 3</p>" +
+                        "<p>bar is 4</p>" +
+                        "</body></html>"));
+            }
+        }
+    }
+
+    @Test
+    public void testAddressesAndPorts() throws Exception {
+        try (CloseableHttpClient hc = HttpClients.createMinimal()) {
+            try (CloseableHttpResponse res = hc.execute(new HttpGet(uri("/jsp/addrs_and_ports.jsp")))) {
+                assertThat(res.getStatusLine().toString(), is("HTTP/1.1 200 OK"));
+                assertThat(res.getFirstHeader(HttpHeaderNames.CONTENT_TYPE.toString()).getValue(),
+                           startsWith("text/html"));
+                final String actualContent = CR_OR_LF.matcher(EntityUtils.toString(res.getEntity()))
+                                                     .replaceAll("");
+
+                assertTrue(actualContent, actualContent.matches(
+                        "<html><body>" +
+                        "<p>RemoteAddr: 127\\.0\\.0\\.1</p>" +
+                        "<p>RemoteHost: 127\\.0\\.0\\.1</p>" +
+                        "<p>RemotePort: [1-9][0-9]+</p>" +
+                        "<p>LocalAddr: (?!null)[^<]+</p>" +
+                        "<p>LocalName: localhost</p>" +
+                        "<p>LocalPort: " + server().activePort().get().localAddress().getPort() + "</p>" +
+                        "</body></html>"));
+            }
+        }
+    }
+}

--- a/src/test/java/com/linecorp/armeria/server/http/jetty/JettyServiceTest.java
+++ b/src/test/java/com/linecorp/armeria/server/http/jetty/JettyServiceTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.http.jetty;
+
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertThat;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.eclipse.jetty.annotations.ServletContainerInitializersStarter;
+import org.eclipse.jetty.apache.jsp.JettyJasperInitializer;
+import org.eclipse.jetty.plus.annotation.ContainerInitializer;
+import org.eclipse.jetty.server.handler.DefaultHandler;
+import org.eclipse.jetty.util.resource.Resource;
+import org.eclipse.jetty.util.thread.ExecutorThreadPool;
+import org.eclipse.jetty.webapp.WebAppContext;
+import org.junit.Test;
+
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.http.WebAppContainerTest;
+import com.linecorp.armeria.server.logging.LoggingService;
+
+import io.netty.handler.codec.http.HttpHeaderNames;
+
+public class JettyServiceTest extends WebAppContainerTest {
+
+    private final List<Object> jettyBeans = new ArrayList<>();
+
+    @Override
+    protected void configureServer(ServerBuilder sb) throws Exception {
+        sb.serviceUnder(
+                "/jsp/",
+                new JettyServiceBuilder()
+                        .handler(newWebAppContext())
+                        .configurator(s -> {
+                            jettyBeans.addAll(s.getBeans());
+                        })
+                        .build()
+                        .decorate(LoggingService::new));
+
+        sb.serviceUnder(
+                "/default/",
+                new JettyServiceBuilder().handler(new DefaultHandler()).build());
+    }
+
+    static WebAppContext newWebAppContext() throws MalformedURLException {
+        final WebAppContext handler = new WebAppContext();
+        handler.setContextPath("/");
+        handler.setBaseResource(Resource.newClassPathResource("/tomcat_service"));
+        handler.setClassLoader(new URLClassLoader(
+                new URL[] {
+                        Resource.newClassPathResource("/tomcat_service/WEB-INF/lib/hello.jar").getURI().toURL()
+                },
+                JettyService.class.getClassLoader()));
+
+        handler.addBean(new ServletContainerInitializersStarter(handler), true);
+        handler.setAttribute(
+                "org.eclipse.jetty.containerInitializers",
+                Collections.singletonList(new ContainerInitializer(new JettyJasperInitializer(), null)));
+        return handler;
+    }
+
+    @Test
+    public void testConfigurator() throws Exception {
+        assertThat(jettyBeans, hasItems(instanceOf(ExecutorThreadPool.class),
+                                        instanceOf(WebAppContext.class)));
+    }
+
+    @Test
+    public void testDefaultHandlerFavicon() throws Exception {
+        try (CloseableHttpClient hc = HttpClients.createMinimal()) {
+            try (CloseableHttpResponse res = hc.execute(
+                    new HttpGet(uri("/default/favicon.ico")))) {
+                assertThat(res.getStatusLine().toString(), is("HTTP/1.1 200 OK"));
+                assertThat(res.getFirstHeader(HttpHeaderNames.CONTENT_TYPE.toString()).getValue(),
+                           startsWith("image/x-icon"));
+                assertThat(EntityUtils.toByteArray(res.getEntity()).length, is(greaterThan(0)));
+            }
+        }
+    }
+}

--- a/src/test/java/com/linecorp/armeria/server/http/jetty/UnmanagedJettyServiceTest.java
+++ b/src/test/java/com/linecorp/armeria/server/http/jetty/UnmanagedJettyServiceTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.http.jetty;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jetty.server.Server;
+import org.junit.AfterClass;
+
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.http.WebAppContainerTest;
+import com.linecorp.armeria.server.logging.LoggingService;
+
+public class UnmanagedJettyServiceTest extends WebAppContainerTest {
+
+    private final List<Object> jettyBeans = new ArrayList<>();
+    private static Server jetty;
+
+    @Override
+    protected void configureServer(ServerBuilder sb) throws Exception {
+        jetty = new Server(0);
+        jetty.setHandler(JettyServiceTest.newWebAppContext());
+        jetty.start();
+
+        sb.serviceUnder(
+                "/jsp/",
+                JettyService.forServer("localhost", jetty).decorate(LoggingService::new));
+    }
+
+    @AfterClass
+    public static void stopJetty() throws Exception {
+        jetty.stop();
+    }
+}


### PR DESCRIPTION
- Add JettyService and its builder
- Add WebAppContainerTest and make TomcatServiceTest and
  JettyServiceTest extend it
- Make ServerConfig.blockingTaskExecutor() return ExecutorService
  instead of Executor, because many components including Jetty requires
  an ExecutorService which provides more useful operations such as
  submit()
  - Add ExecutorBasedExecutorService
  - Add InterminableExecutorService