### PR TITLE
Advanced routing method

### DIFF
--- a/src/main/java/com/linecorp/armeria/server/AbstractPathMapping.java
+++ b/src/main/java/com/linecorp/armeria/server/AbstractPathMapping.java
@@ -20,6 +20,10 @@ import static java.util.Objects.requireNonNull;
 
 import com.linecorp.armeria.common.ServiceInvocationContext;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
 /**
  * A skeletal {@link PathMapping} implementation. Implement {@link #doApply(String)}.
  */
@@ -65,4 +69,105 @@ public abstract class AbstractPathMapping implements PathMapping {
      *         {@code null} if the specified {@code path} does not match this mapping.
      */
     protected abstract String doApply(String path);
+
+
+
+    /**
+     * A helper method which maps the variable symbols on {@code routingRule} with the values from {@code path}.
+     * Supports 'variable symbol' and '*' rules, mostly inspired from http://www.sinatrarb.com/intro.html#Routes
+     *
+     * @param routingRule a routing rule that might contains some variables
+     * @param path a requested URI path
+     * @return a {@link HashMap} which maps the variable symbol and the value
+     *         {@code null} if the given {@code path} is not suitable for the given {@code routingRule}
+     */
+    protected final HashMap<String, List<String>> getRoutingVariables(String routingRule, String path) {
+        /**
+         * Calculate the mapping validity between {@code routingRule} and {@code path} by dynamic programming
+         * {@code isValid[i1][i2]} is true if {@code routingRule[i1:]} is matched with {@code path[i2:]}
+         */
+        int rlen = routingRule.length(), plen = path.length();
+        boolean[][] isValid = new boolean[rlen + 1][plen + 1];
+        int[][][] transition = new int[rlen + 1][plen + 1][2];
+
+        isValid[rlen][plen] = true;
+        for (int ruleIndex = rlen - 1; ruleIndex >= 0; ruleIndex--) {
+            for (int pathIndex = plen - 1; pathIndex >= 0; pathIndex--) {
+                char currentRule = routingRule.charAt(ruleIndex);
+                char currentPath = path.charAt(pathIndex);
+                String currentTwoRule = "";
+                if (ruleIndex + 2 <= rlen) {
+                    currentTwoRule = routingRule.substring(ruleIndex, ruleIndex + 2);
+                }
+
+                if (currentTwoRule.equals("/:")) {  // rule for 'variable symbol'
+                    if (currentPath != '/') continue;
+                    if (ruleIndex + 2 >= rlen) continue;
+                    if (pathIndex + 1 == plen) continue;
+
+                    char nextRule = routingRule.charAt(ruleIndex + 2);
+                    char nextPath = path.charAt(pathIndex + 1);
+                    if (nextRule == '/' || nextRule == '*' || nextRule == ':') continue;
+                    if (nextPath == '/') continue;
+
+                    int nextRuleIndex = ruleIndex + 2;
+                    while (nextRuleIndex < rlen && routingRule.charAt(nextRuleIndex) != '/') {
+                        nextRuleIndex++;
+                    }
+                    int nextPathIndex = pathIndex + 1;
+                    while (nextPathIndex < plen && path.charAt(nextPathIndex) != '/') {
+                        nextPathIndex++;
+                    }
+
+                    isValid[ruleIndex][pathIndex] = isValid[nextRuleIndex][nextPathIndex];
+                    transition[ruleIndex][pathIndex][0] = nextRuleIndex;
+                    transition[ruleIndex][pathIndex][1] = nextPathIndex;
+                } else if (currentRule == '*') {    // rule for '*'
+                    for (int nextPathIndex = pathIndex; nextPathIndex <= plen; nextPathIndex++) {
+                        if (isValid[ruleIndex + 1][nextPathIndex]) {
+                            isValid[ruleIndex][pathIndex] = true;
+                            transition[ruleIndex][pathIndex][0] = ruleIndex + 1;
+                            transition[ruleIndex][pathIndex][1] = nextPathIndex;
+                            break;
+                        }
+                    }
+                } else if (currentRule == currentPath) {    // rule for exact matching
+                    isValid[ruleIndex][pathIndex] = isValid[ruleIndex + 1][pathIndex + 1];
+                    transition[ruleIndex][pathIndex][0] = ruleIndex + 1;
+                    transition[ruleIndex][pathIndex][1] = pathIndex + 1;
+                }
+            }
+        }
+
+        if(!isValid[0][0]) {
+            return null;
+        }
+
+        // only glob may have multiple variables, e.g. "/foo/*/bar/*/hello"
+        HashMap<String, List<String>> ret = new HashMap<>();
+        ret.put("*", new ArrayList<>());
+
+        int ruleIndex = 0, pathIndex = 0;
+        while (ruleIndex < rlen) {
+            int nextRuleIndex = transition[ruleIndex][pathIndex][0];
+            int nextPathIndex = transition[ruleIndex][pathIndex][1];
+
+            boolean isVariable = ruleIndex + 2 < rlen && routingRule.substring(ruleIndex, ruleIndex + 2).equals("/:");
+            boolean isGlob = routingRule.charAt(ruleIndex) == '*';
+            if (isVariable) {
+                String symbol = routingRule.substring(ruleIndex + 2, nextRuleIndex);
+                String value = path.substring(pathIndex + 1, nextPathIndex);
+                ArrayList<String> values = new ArrayList<>();
+                values.add(value);
+                ret.put(symbol, values);
+            } else if (isGlob) {
+                ret.get("*").add(path.substring(pathIndex, nextPathIndex));
+            }
+
+            ruleIndex = nextRuleIndex;
+            pathIndex = nextPathIndex;
+        }
+
+        return ret;
+    }
 }

--- a/src/main/java/com/linecorp/armeria/server/ExactPathMapping.java
+++ b/src/main/java/com/linecorp/armeria/server/ExactPathMapping.java
@@ -18,6 +18,8 @@ package com.linecorp.armeria.server;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.HashMap;
+import java.util.List;
 import java.util.Optional;
 
 final class ExactPathMapping extends AbstractPathMapping {
@@ -41,12 +43,17 @@ final class ExactPathMapping extends AbstractPathMapping {
 
     @Override
     protected String doApply(String path) {
-        return exactPath.equals(path) ? path : null;
+        return getRoutingVariables(path).equals(Optional.empty()) ? null : path;
     }
 
     @Override
     public Optional<String> exactPath() {
         return exactPathOpt;
+    }
+
+    @Override
+    public Optional<HashMap<String, List<String>>> getRoutingVariables(String uri) {
+        return Optional.ofNullable(getRoutingVariables(exactPath, uri));
     }
 
     @Override

--- a/src/main/java/com/linecorp/armeria/server/PathMapping.java
+++ b/src/main/java/com/linecorp/armeria/server/PathMapping.java
@@ -17,6 +17,8 @@ package com.linecorp.armeria.server;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.HashMap;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.regex.Pattern;
@@ -210,5 +212,13 @@ public interface PathMapping extends Function<String, String> {
         }
 
         return new Prepend(this, pathPrefix);
+    }
+
+    /**
+     * Returns a map which contains routing variable symbols and values if the certain path mapping class supports
+     * variable symbols, {@link Optional#empty} otherwise
+     */
+    default Optional<HashMap<String, List<String>>> getRoutingVariables(String uri) {
+        return Optional.empty();
     }
 }

--- a/src/main/java/com/linecorp/armeria/server/http/HttpServiceCodec.java
+++ b/src/main/java/com/linecorp/armeria/server/http/HttpServiceCodec.java
@@ -53,7 +53,8 @@ final class HttpServiceCodec implements ServiceCodec {
 
         return new HttpServiceInvocationContext(
                 ch, Scheme.of(SerializationFormat.NONE, sessionProtocol),
-                hostname, path, mappedPath, cfg.loggerName(), (FullHttpRequest) originalRequest);
+                hostname, path, mappedPath, cfg.loggerName(), (FullHttpRequest) originalRequest,
+                cfg.pathMapping().getRoutingVariables(path));
     }
 
     @Override

--- a/src/test/java/com/linecorp/armeria/server/ExactPathMappingTest.java
+++ b/src/test/java/com/linecorp/armeria/server/ExactPathMappingTest.java
@@ -22,6 +22,10 @@ import static org.junit.Assert.assertThat;
 
 import org.junit.Test;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+
 public class ExactPathMappingTest {
 
     @Test
@@ -32,5 +36,39 @@ public class ExactPathMappingTest {
     @Test
     public void shouldReturnExactPathOnMatch() {
         assertThat(new ExactPathMapping("/find/me").apply("/find/me"), is("/find/me"));
+    }
+
+    @Test
+    public void routingVariableMappingTest() {
+        Optional<HashMap<String, List<String>>> dict =
+                new ExactPathMapping("/hello/:variable").getRoutingVariables("/hello/world");
+        assert(!dict.equals(Optional.empty()));
+        assertThat(dict.get().size(), is(2));
+        assertThat(dict.get().containsKey("variable"), is(true));
+        assertThat(dict.get().get("variable").size(), is(1));
+        assertThat(dict.get().get("variable").get(0), is("world"));
+        assertThat(dict.get().containsKey("*"), is(true));
+
+        dict = new ExactPathMapping("/:variable/world").getRoutingVariables("/hello/world");
+        assert(!dict.equals(Optional.empty()));
+        assertThat(dict.get().size(), is(2));
+        assertThat(dict.get().containsKey("variable"), is(true));
+        assertThat(dict.get().get("variable").size(), is(1));
+        assertThat(dict.get().get("variable").get(0), is("hello"));
+        assertThat(dict.get().containsKey("*"), is(true));
+
+        dict = new ExactPathMapping("/p1/*/:variable/p2/*").getRoutingVariables("/p1/foo/bar/value/p2/tail");
+        assert(!dict.equals(Optional.empty()));
+        assertThat(dict.get().size(), is(2));
+        assertThat(dict.get().containsKey("variable"), is(true));
+        assertThat(dict.get().get("variable").size(), is(1));
+        assertThat(dict.get().get("variable").get(0), is("value"));
+        assertThat(dict.get().containsKey("*"), is(true));
+        assertThat(dict.get().get("*").size(), is(2));
+        assertThat(dict.get().get("*").get(0), is("foo/bar"));
+        assertThat(dict.get().get("*").get(1), is("tail"));
+
+        dict = new ExactPathMapping("/:variable/p1").getRoutingVariables("/hello/world/p1");
+        assertThat(dict, is(Optional.empty()));
     }
 }


### PR DESCRIPTION
Related to issue #150 
- Implemented a simple mapping method on HTTP request
  - Inspired from http://www.sinatrarb.com/intro.html#Routes
  - Currently supports symbol-value mapping and \* mapping as a starter, which are most likely helpful in my opinion.
- Only `ExactPathMapping`'s mapping logic is swapped to the new routing method as a tester.
  - Going to apply on `PrefixPathMapping` and `GlobPathMapping` also after some feedback
- Mapped variables can be accessed via `HttpServiceInvocationContext`
- If I understood correctly on what @taicki mentioned at #150, limiting HTTP methods to certain routing can be done independently after this variable mapping work by assigning more properties on routing or so, therefore they're not considered on this pull request.

Since I'm not familiar with Armeria, I'm still feeling very cautious on deciding the overall architecture.
Please let me have some feedback from anywhere, anything which looks weird.

Thank you. :)
