### PR TITLE
Add {VirtualHost, Server}.defaultHostname()

### DIFF
--- a/src/main/java/com/linecorp/armeria/server/Server.java
+++ b/src/main/java/com/linecorp/armeria/server/Server.java
@@ -147,6 +147,14 @@ public final class Server implements AutoCloseable {
     }
 
     /**
+     * Returns the hostname of the default {@link VirtualHost}, which is the hostname of the machine unless
+     * configured explicitly via {@link ServerBuilder#defaultVirtualHost(VirtualHost)}.
+     */
+    public String defaultHostname() {
+        return config().defaultVirtualHost().defaultHostname();
+    }
+
+    /**
      * Returns all {@link ServerPort}s that this {@link Server} is listening to.
      *
      * @return a {@link Map} whose key is the bind address and value is {@link ServerPort}.

--- a/src/main/java/com/linecorp/armeria/server/ServerConfig.java
+++ b/src/main/java/com/linecorp/armeria/server/ServerConfig.java
@@ -206,7 +206,7 @@ public final class ServerConfig {
         }
 
         return new VirtualHost(
-                "*", sslCtx,
+                h.defaultHostname(), "*", sslCtx,
                 h.serviceConfigs().stream().map(
                         e -> new ServiceConfig(e.pathMapping(), e.service(), e.loggerNameWithoutPrefix()))
                  .collect(Collectors.toList()));
@@ -423,18 +423,22 @@ public final class ServerConfig {
         buf.append(" virtualHosts: [");
         if (!virtualHosts.isEmpty()) {
             virtualHosts.forEach(c -> {
-                buf.append(VirtualHost.toString(null, c.hostnamePattern(), c.sslContext(), c.serviceConfigs()));
+                buf.append(VirtualHost.toString(null, c.defaultHostname(), c.hostnamePattern(),
+                                                c.sslContext(), c.serviceConfigs()));
                 buf.append(", ");
             });
 
             if (defaultVirtualHost != null) {
-                buf.append(VirtualHost.toString(null, "*", defaultVirtualHost.sslContext(),
+                buf.append(VirtualHost.toString(null, defaultVirtualHost.defaultHostname(), "*",
+                                                defaultVirtualHost.sslContext(),
                                                 defaultVirtualHost.serviceConfigs()));
             } else {
                 buf.setLength(buf.length() - 2);
             }
         } else if (defaultVirtualHost != null) {
-            buf.append(VirtualHost.toString(null, "*", defaultVirtualHost.sslContext(), defaultVirtualHost.serviceConfigs()));
+            buf.append(VirtualHost.toString(null, defaultVirtualHost.defaultHostname(), "*",
+                                            defaultVirtualHost.sslContext(),
+                                            defaultVirtualHost.serviceConfigs()));
         }
 
         buf.append("], numWorkers: ");

--- a/src/main/java/com/linecorp/armeria/server/http/jetty/ArmeriaThreadPool.java
+++ b/src/main/java/com/linecorp/armeria/server/http/jetty/ArmeriaThreadPool.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.http.jetty;
+
+import java.util.concurrent.ExecutorService;
+
+import org.eclipse.jetty.util.thread.ThreadPool;
+
+final class ArmeriaThreadPool implements ThreadPool {
+    private final ExecutorService blockingTaskExecutor;
+
+    ArmeriaThreadPool(ExecutorService blockingTaskExecutor) {
+        this.blockingTaskExecutor = blockingTaskExecutor;
+    }
+
+    @Override
+    public void join() {}
+
+    @Override
+    public int getThreads() {
+        return -1;
+    }
+
+    @Override
+    public int getIdleThreads() {
+        return -1;
+    }
+
+    @Override
+    public boolean isLowOnThreads() {
+        return false;
+    }
+
+    @Override
+    public void execute(Runnable command) {
+        blockingTaskExecutor.execute(command);
+    }
+}

--- a/src/main/java/com/linecorp/armeria/server/http/jetty/JettyServiceBuilder.java
+++ b/src/main/java/com/linecorp/armeria/server/http/jetty/JettyServiceBuilder.java
@@ -28,6 +28,7 @@ import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.RequestLog;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.SessionIdManager;
+import org.eclipse.jetty.server.handler.HandlerWrapper;
 import org.eclipse.jetty.util.component.Container;
 import org.eclipse.jetty.util.component.LifeCycle;
 
@@ -41,11 +42,12 @@ public final class JettyServiceBuilder {
 
     private final Map<String, Object> attrs = new LinkedHashMap<>();
     private final List<Bean> beans = new ArrayList<>();
+    private final List<HandlerWrapper> handlerWrappers = new ArrayList<>();
     private final List<Container.Listener> eventListeners = new ArrayList<>();
     private final List<LifeCycle.Listener> lifeCycleListeners = new ArrayList<>();
     private final List<Consumer<? super Server>> configurators = new ArrayList<>();
 
-    private String hostname = "localhost";
+    private String hostname;
     private Boolean dumpAfterStart;
     private Boolean dumpBeforeStop;
     private Handler handler;
@@ -122,6 +124,16 @@ public final class JettyServiceBuilder {
     }
 
     /**
+     * Adds the specified {@link HandlerWrapper} to the Jetty {@link Server}.
+     *
+     * @see Server#insertHandler(HandlerWrapper)
+     */
+    public JettyServiceBuilder handlerWrapper(HandlerWrapper handlerWrapper) {
+        handlerWrappers.add(requireNonNull(handlerWrapper, "handlerWrapper"));
+        return this;
+    }
+
+    /**
      * Sets the {@link RequestLog} of the Jetty {@link Server}.
      *
      * @see Server#setRequestLog(RequestLog)
@@ -182,13 +194,15 @@ public final class JettyServiceBuilder {
     public JettyService build() {
         return JettyService.forConfig(new JettyServiceConfig(
                 hostname, dumpAfterStart, dumpBeforeStop, stopTimeoutMillis, handler, requestLog,
-                sessionIdManager, attrs, beans, eventListeners, lifeCycleListeners, configurators));
+                sessionIdManager, attrs, beans, handlerWrappers, eventListeners, lifeCycleListeners,
+                configurators));
     }
 
     @Override
     public String toString() {
         return JettyServiceConfig.toString(
-                this, hostname, dumpAfterStart, dumpBeforeStop, stopTimeoutMillis, handler,
-                requestLog, sessionIdManager, attrs, beans, eventListeners, lifeCycleListeners, configurators);
+                this, hostname, dumpAfterStart, dumpBeforeStop, stopTimeoutMillis, handler, requestLog,
+                sessionIdManager, attrs, beans, handlerWrappers, eventListeners, lifeCycleListeners,
+                configurators);
     }
 }

--- a/src/main/java/com/linecorp/armeria/server/http/jetty/JettyServiceConfig.java
+++ b/src/main/java/com/linecorp/armeria/server/http/jetty/JettyServiceConfig.java
@@ -28,7 +28,9 @@ import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.RequestLog;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.SessionIdManager;
+import org.eclipse.jetty.server.handler.HandlerWrapper;
 import org.eclipse.jetty.util.component.Container;
+import org.eclipse.jetty.util.component.Container.Listener;
 import org.eclipse.jetty.util.component.LifeCycle;
 
 final class JettyServiceConfig {
@@ -42,6 +44,7 @@ final class JettyServiceConfig {
     private final SessionIdManager sessionIdManager;
     private final Map<String, Object> attrs;
     private final List<Bean> beans;
+    private final List<HandlerWrapper> handlerWrappers;
     private final List<Container.Listener> eventListeners;
     private final List<LifeCycle.Listener> lifeCycleListeners;
     private final List<Consumer<? super Server>> configurators;
@@ -49,8 +52,8 @@ final class JettyServiceConfig {
     JettyServiceConfig(String hostname,
                        Boolean dumpAfterStart, Boolean dumpBeforeStop, Long stopTimeoutMillis,
                        Handler handler, RequestLog requestLog, SessionIdManager sessionIdManager,
-                       Map<String, Object> attrs, List<Bean> beans,
-                       List<Container.Listener> eventListeners, List<LifeCycle.Listener> lifeCycleListeners,
+                       Map<String, Object> attrs, List<Bean> beans, List<HandlerWrapper> handlerWrappers,
+                       List<Listener> eventListeners, List<LifeCycle.Listener> lifeCycleListeners,
                        List<Consumer<? super Server>> configurators) {
 
         this.hostname = hostname;
@@ -62,13 +65,14 @@ final class JettyServiceConfig {
         this.sessionIdManager = sessionIdManager;
         this.attrs = Collections.unmodifiableMap(attrs);
         this.beans = Collections.unmodifiableList(beans);
+        this.handlerWrappers = Collections.unmodifiableList(handlerWrappers);
         this.eventListeners = Collections.unmodifiableList(eventListeners);
         this.lifeCycleListeners = Collections.unmodifiableList(lifeCycleListeners);
         this.configurators = Collections.unmodifiableList(configurators);
     }
 
-    String hostname() {
-        return hostname;
+    Optional<String> hostname() {
+        return Optional.ofNullable(hostname);
     }
 
     Optional<Boolean> dumpAfterStart() {
@@ -103,6 +107,10 @@ final class JettyServiceConfig {
         return beans;
     }
 
+    List<HandlerWrapper> handlerWrappers() {
+        return handlerWrappers;
+    }
+
     List<Container.Listener> eventListeners() {
         return eventListeners;
     }
@@ -118,15 +126,16 @@ final class JettyServiceConfig {
     @Override
     public String toString() {
         return toString(
-                this, hostname, dumpAfterStart, dumpBeforeStop, stopTimeoutMillis, handler,
-                requestLog, sessionIdManager, attrs, beans, eventListeners, lifeCycleListeners, configurators);
+                this, hostname, dumpAfterStart, dumpBeforeStop, stopTimeoutMillis, handler, requestLog,
+                sessionIdManager, attrs, beans, handlerWrappers, eventListeners, lifeCycleListeners,
+                configurators);
     }
 
     static String toString(
-            Object holder, String hostname, Boolean dumpAfterStart, Boolean dumpBeforeStop,
-            Long stopTimeout, Handler handler, RequestLog requestLog,
-            SessionIdManager sessionIdManager, Map<String, Object> attrs, List<Bean> beans,
-            List<Container.Listener> eventListeners, List<LifeCycle.Listener> lifeCycleListeners,
+            Object holder, String hostname, Boolean dumpAfterStart, Boolean dumpBeforeStop, Long stopTimeout,
+            Handler handler, RequestLog requestLog, SessionIdManager sessionIdManager,
+            Map<String, Object> attrs, List<Bean> beans, List<HandlerWrapper> handlerWrappers,
+            List<Listener> eventListeners, List<LifeCycle.Listener> lifeCycleListeners,
             List<Consumer<? super Server>> configurators) {
 
         final StringBuilder buf = new StringBuilder(256);
@@ -149,6 +158,8 @@ final class JettyServiceConfig {
         buf.append(attrs);
         buf.append(", beans: ");
         buf.append(beans);
+        buf.append(", handlerWrappers: ");
+        buf.append(handlerWrappers);
         buf.append(", eventListeners: ");
         buf.append(eventListeners);
         buf.append(", lifeCycleListeners: ");

--- a/src/main/java/com/linecorp/armeria/server/http/tomcat/TomcatServiceBuilder.java
+++ b/src/main/java/com/linecorp/armeria/server/http/tomcat/TomcatServiceBuilder.java
@@ -54,7 +54,6 @@ public final class TomcatServiceBuilder {
 
     // From Tomcat conf/server.xml
     private static final String DEFAULT_SERVICE_NAME = "Catalina";
-    private static final String DEFAULT_ENGINE_NAME = DEFAULT_SERVICE_NAME;
 
     /**
      * Creates a new {@link TomcatServiceBuilder} with the web application at the root directory inside the
@@ -179,10 +178,10 @@ public final class TomcatServiceBuilder {
     private final List<Consumer<? super StandardServer>> configurators = new ArrayList<>();
 
     private String serviceName = DEFAULT_SERVICE_NAME;
-    private String engineName = DEFAULT_ENGINE_NAME;
+    private String engineName;
     private Path baseDir;
     private Realm realm = NULL_REALM;
-    private String hostname = "localhost";
+    private String hostname;
 
     private TomcatServiceBuilder(Path docBase, String jarRoot) {
         this.docBase = validateDocBase(docBase);
@@ -228,7 +227,8 @@ public final class TomcatServiceBuilder {
     }
 
     /**
-     * Sets the name of the {@link StandardService} of an embedded Tomcat.
+     * Sets the name of the {@link StandardService} of an embedded Tomcat. The default serviceName is
+     * {@code "Catalina"}.
      */
     public TomcatServiceBuilder serviceName(String serviceName) {
         this.serviceName = requireNonNull(serviceName, "serviceName");
@@ -236,7 +236,8 @@ public final class TomcatServiceBuilder {
     }
 
     /**
-     * Sets the name of the {@link StandardEngine} of an embedded Tomcat.
+     * Sets the name of the {@link StandardEngine} of an embedded Tomcat. {@link #serviceName(String)} will be
+     * used instead if not set.
      */
     public TomcatServiceBuilder engineName(String engineName) {
         this.engineName = requireNonNull(engineName, "engineName");
@@ -321,7 +322,7 @@ public final class TomcatServiceBuilder {
             }
         }
 
-        return new TomcatService(new TomcatServiceConfig(
+        return TomcatService.forConfig(new TomcatServiceConfig(
                 serviceName, engineName, baseDir, realm, hostname, docBase, jarRoot,
                 Collections.unmodifiableList(configurators)));
     }

--- a/src/main/java/com/linecorp/armeria/server/http/tomcat/TomcatServiceConfig.java
+++ b/src/main/java/com/linecorp/armeria/server/http/tomcat/TomcatServiceConfig.java
@@ -65,7 +65,7 @@ final class TomcatServiceConfig {
      * Returns the name of the {@link StandardEngine} of an embedded Tomcat.
      */
     String engineName() {
-        return engineName;
+        return engineName != null ? engineName : serviceName;
     }
 
     /**
@@ -85,8 +85,8 @@ final class TomcatServiceConfig {
     /**
      * Returns the hostname of an embedded Tomcat.
      */
-    String hostname() {
-        return hostname;
+    Optional<String> hostname() {
+        return Optional.ofNullable(hostname);
     }
 
     /**
@@ -115,7 +115,7 @@ final class TomcatServiceConfig {
 
     @Override
     public String toString() {
-        return toString(this, serviceName(), engineName(), baseDir(), realm(), hostname(),
+        return toString(this, serviceName(), engineName(), baseDir(), realm(), hostname().orElse(null),
                         docBase(), jarRoot().orElse(null));
     }
 

--- a/src/test/java/com/linecorp/armeria/server/VirtualHostBuilderTest.java
+++ b/src/test/java/com/linecorp/armeria/server/VirtualHostBuilderTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+import org.junit.Test;
+
+public class VirtualHostBuilderTest {
+
+    @Test
+    public void defaultVirtualHost() {
+        final VirtualHost h = new VirtualHostBuilder().build();
+        assertThat(h.hostnamePattern(), is("*"));
+        assertThat(h.defaultHostname(), is(not("*")));
+    }
+
+    @Test
+    public void defaultVirtualHostWithExplicitAsterisk() {
+        final VirtualHost h = new VirtualHostBuilder("*").build();
+        assertThat(h.hostnamePattern(), is("*"));
+        assertThat(h.defaultHostname(), is(not("*")));
+    }
+
+    @Test
+    public void defaultVirtualHostWithExplicitAsterisk2() {
+        final VirtualHost h = new VirtualHostBuilder("foo", "*").build();
+        assertThat(h.hostnamePattern(), is("*"));
+        assertThat(h.defaultHostname(), is("foo"));
+    }
+
+    @Test
+    public void virtualHostWithoutPattern() {
+        final VirtualHost h = new VirtualHostBuilder("foo.com", "foo.com").build();
+        assertThat(h.hostnamePattern(), is("foo.com"));
+        assertThat(h.defaultHostname(), is("foo.com"));
+    }
+
+    @Test
+    public void virtualHostWithPattern() {
+        final VirtualHost h = new VirtualHostBuilder("bar.foo.com", "*.foo.com").build();
+        assertThat(h.hostnamePattern(), is("*.foo.com"));
+        assertThat(h.defaultHostname(), is("bar.foo.com"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void virtualHostWithMismatch() {
+        new VirtualHostBuilder("bar.com", "foo.com").build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void virtualHostWithMismatch2() {
+        new VirtualHostBuilder("bar.com", "*.foo.com").build();
+    }
+}

--- a/src/test/java/com/linecorp/armeria/server/http/WebAppContainerTest.java
+++ b/src/test/java/com/linecorp/armeria/server/http/WebAppContainerTest.java
@@ -121,7 +121,7 @@ public abstract class WebAppContainerTest extends AbstractServerTest {
                         "<p>RemoteHost: 127\\.0\\.0\\.1</p>" +
                         "<p>RemotePort: [1-9][0-9]+</p>" +
                         "<p>LocalAddr: (?!null)[^<]+</p>" +
-                        "<p>LocalName: localhost</p>" +
+                        "<p>LocalName: " + server().defaultHostname() + "</p>" +
                         "<p>LocalPort: " + server().activePort().get().localAddress().getPort() + "</p>" +
                         "</body></html>"));
             }

--- a/src/test/java/com/linecorp/armeria/server/http/jetty/JettyServiceTest.java
+++ b/src/test/java/com/linecorp/armeria/server/http/jetty/JettyServiceTest.java
@@ -39,7 +39,7 @@ import org.eclipse.jetty.apache.jsp.JettyJasperInitializer;
 import org.eclipse.jetty.plus.annotation.ContainerInitializer;
 import org.eclipse.jetty.server.handler.DefaultHandler;
 import org.eclipse.jetty.util.resource.Resource;
-import org.eclipse.jetty.util.thread.ExecutorThreadPool;
+import org.eclipse.jetty.util.thread.ThreadPool;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.junit.Test;
 
@@ -59,9 +59,7 @@ public class JettyServiceTest extends WebAppContainerTest {
                 "/jsp/",
                 new JettyServiceBuilder()
                         .handler(newWebAppContext())
-                        .configurator(s -> {
-                            jettyBeans.addAll(s.getBeans());
-                        })
+                        .configurator(s -> jettyBeans.addAll(s.getBeans()))
                         .build()
                         .decorate(LoggingService::new));
 
@@ -89,7 +87,7 @@ public class JettyServiceTest extends WebAppContainerTest {
 
     @Test
     public void testConfigurator() throws Exception {
-        assertThat(jettyBeans, hasItems(instanceOf(ExecutorThreadPool.class),
+        assertThat(jettyBeans, hasItems(instanceOf(ThreadPool.class),
                                         instanceOf(WebAppContext.class)));
     }
 

--- a/src/test/java/com/linecorp/armeria/server/http/jetty/UnmanagedJettyServiceTest.java
+++ b/src/test/java/com/linecorp/armeria/server/http/jetty/UnmanagedJettyServiceTest.java
@@ -36,14 +36,14 @@ public class UnmanagedJettyServiceTest extends WebAppContainerTest {
         jetty = new Server(0);
         jetty.setHandler(JettyServiceTest.newWebAppContext());
         jetty.start();
-
         sb.serviceUnder(
                 "/jsp/",
-                JettyService.forServer("localhost", jetty).decorate(LoggingService::new));
+                JettyService.forServer(jetty).decorate(LoggingService::new));
     }
 
     @AfterClass
     public static void stopJetty() throws Exception {
         jetty.stop();
+        jetty.destroy();
     }
 }

--- a/src/test/java/com/linecorp/armeria/server/http/tomcat/TomcatServiceTest.java
+++ b/src/test/java/com/linecorp/armeria/server/http/tomcat/TomcatServiceTest.java
@@ -19,26 +19,18 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.regex.Pattern;
 
 import org.apache.catalina.Service;
-import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPost;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
-import org.apache.http.message.BasicNameValuePair;
-import org.apache.http.util.EntityUtils;
 import org.junit.Test;
 
-import com.linecorp.armeria.server.AbstractServerTest;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.http.WebAppContainerTest;
 import com.linecorp.armeria.server.logging.LoggingService;
@@ -64,12 +56,17 @@ public class TomcatServiceTest extends WebAppContainerTest {
 
         sb.serviceUnder(
                 "/jar/",
-                TomcatService.forClassPath(Future.class).decorate(LoggingService::new));
+                TomcatServiceBuilder.forClassPath(Future.class)
+                                    .serviceName("TomcatServiceTest-JAR")
+                                    .build()
+                                    .decorate(LoggingService::new));
 
         sb.serviceUnder(
                 "/jar_altroot/",
-                TomcatService.forClassPath(Future.class, "/io/netty/util/concurrent")
-                             .decorate(LoggingService::new));
+                TomcatServiceBuilder.forClassPath(Future.class, "/io/netty/util/concurrent")
+                                    .serviceName("TomcatServiceTest-JAR-AltRoot")
+                                    .build()
+                                    .decorate(LoggingService::new));
     }
 
     @Test


### PR DESCRIPTION
- Add VirtualHost.defaultHostname
  - Unless specified, it is determined from the user-specified hostname
    pattern or the current machine's hostname
- Add Server.defaultHostname() which is a shortcut to
  config().defaultVirtualHost().defaultHostname()
- Use Server.defaultHostname() if a user does not specify hostname when
  creating JettyService or TomcatService

- Add missing configuration options to JettyServiceBuilder
- Merge TomcatServiceInvocationHandler and
  ManagedTomcatServiceInvocationHandler
  - Move the part related with the managed one to
    ManagedConnectorFactory
- Call Tomcat/Jetty Server.destroy() when it is managed and stopped.
- Fix UnsupportedOperationException in ThreadPoolExecutor.stop() when
  embedded Jetty is stopped
  - Add ArmeriaThreadPool
- Fix Tomcat LifeCycleExceptions while stopping Tomcats in
  TomcatServiceTest due to duplicate engine names
- Determine Tomcat engine name from service name when engine name was
  not specified