### PR TITLE
Reduce the amount of log messages while testing

### DIFF
--- a/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -632,8 +632,11 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter {
             req.headers().remove(HttpHeaderNames.UPGRADE);
             req.headers().remove(Http2CodecUtil.HTTP_UPGRADE_SETTINGS_HEADER);
 
-            logger.debug("{} Handling the pre-upgrade request ({}): {}",
-                         ctx.channel(), ((UpgradeEvent) evt).protocol(), req);
+            if (logger.isDebugEnabled()) {
+                logger.debug("{} Handling the pre-upgrade request ({}): {} {} {} ({}B)",
+                             ctx.channel(), ((UpgradeEvent) evt).protocol(),
+                             req.method(), req.uri(), req.protocolVersion(), req.content().readableBytes());
+            }
 
             // Set the stream ID of the pre-upgrade request, which is always 1.
             req.headers().set(STREAM_ID, "1");

--- a/src/test/java/com/linecorp/armeria/client/circuitbreaker/NonBlockingCircuitBreakerTest.java
+++ b/src/test/java/com/linecorp/armeria/client/circuitbreaker/NonBlockingCircuitBreakerTest.java
@@ -29,6 +29,8 @@ import org.junit.Test;
 
 import com.google.common.testing.FakeTicker;
 
+import com.linecorp.armeria.common.util.Exceptions;
+
 public class NonBlockingCircuitBreakerTest {
 
     private static final String remoteServiceName = "testservice";
@@ -189,7 +191,9 @@ public class NonBlockingCircuitBreakerTest {
     @Test
     public void testFailureOfExceptionFilter() {
         NonBlockingCircuitBreaker cb = (NonBlockingCircuitBreaker) new CircuitBreakerBuilder()
-                .exceptionFilter(cause -> {throw new Exception();})
+                .exceptionFilter(cause -> {
+                    throw Exceptions.clearTrace(new Exception("exception filter failed"));
+                })
                 .ticker(ticker)
                 .build();
         cb.onFailure(new Exception());

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -23,6 +23,7 @@
   </appender>
 
   <logger name="com.linecorp.armeria" level="DEBUG" />
+  <logger name="com.linecorp.armeria.common.http.Http2GoAwayListener" level="INFO" />
   <logger name="armeria" level="DEBUG" />
 
   <root level="WARN">


### PR DESCRIPTION
Motivation:

We log too much when running tests and Travis truncates the log file
when browsing it online. We can download the full raw log file, but it's
not as convenient as before

Modifications:

- Disable LoggingClient/Service, KeyedChannelPoolLoggingHandler by
  default
- Simplify pre-upgrade request logging
- Clear stack trace of an expected exceptions in tests

Result:

Significantly reduced log file size