### PR TITLE
Do not propagate IdleStateEvent to suppress misleading 'unexpected user event' message

### DIFF
--- a/src/main/java/com/linecorp/armeria/client/HttpClientIdleTimeoutHandler.java
+++ b/src/main/java/com/linecorp/armeria/client/HttpClientIdleTimeoutHandler.java
@@ -74,9 +74,6 @@ class HttpClientIdleTimeoutHandler extends IdleStateHandler {
         if (pendingResCount == 0 && evt.isFirst()) {
             logger.debug("{} Closing due to idleness", ctx.channel());
             ctx.close();
-            return;
         }
-
-        ctx.fireUserEventTriggered(evt);
     }
 }

--- a/src/main/java/com/linecorp/armeria/server/HttpServerIdleTimeoutHandler.java
+++ b/src/main/java/com/linecorp/armeria/server/HttpServerIdleTimeoutHandler.java
@@ -80,9 +80,6 @@ class HttpServerIdleTimeoutHandler extends IdleStateHandler {
         if (pendingResCount == 0 && evt.isFirst()) {
             logger.debug("{} Closing due to idleness", ctx.channel());
             ctx.close();
-            return;
         }
-
-        ctx.fireUserEventTriggered(evt);
     }
 }


### PR DESCRIPTION
Motivation:

HttpClient/ServerIdleTimeoutHandler currently propagates an
IdleStateEvent unless it triggers a request/response timeout.

However, there's no handler in Armeria that has interest in an
IdleStateEvent.

Also, HttpServerHandler logs an IdleStateEvent as an unexpected user
event, which is misleading.

Modifications:

- HttpClient/ServerIdleTimeoutHandler does not propagate an
  IdleStateEvent anymore

Result:

No more misleading 'unexpected user event' message