### PR TITLE
Fix LifecycleException when stopping Tomcat

### DIFF
--- a/src/main/java/com/linecorp/armeria/server/http/tomcat/TomcatServiceBuilder.java
+++ b/src/main/java/com/linecorp/armeria/server/http/tomcat/TomcatServiceBuilder.java
@@ -171,8 +171,6 @@ public final class TomcatServiceBuilder {
         return new TomcatServiceBuilder(docBase, null);
     }
 
-    private static final Realm NULL_REALM = new NullRealm();
-
     private final Path docBase;
     private final String jarRoot;
     private final List<Consumer<? super StandardServer>> configurators = new ArrayList<>();
@@ -180,7 +178,7 @@ public final class TomcatServiceBuilder {
     private String serviceName = DEFAULT_SERVICE_NAME;
     private String engineName;
     private Path baseDir;
-    private Realm realm = NULL_REALM;
+    private Realm realm;
     private String hostname;
 
     private TomcatServiceBuilder(Path docBase, String jarRoot) {
@@ -320,6 +318,12 @@ public final class TomcatServiceBuilder {
             } catch (IOException e) {
                 throw new TomcatServiceException("failed to secure a temporary directory", e);
             }
+        }
+
+        // Use a NullRealm if no Realm was specified.
+        Realm realm = this.realm;
+        if (realm == null) {
+            realm = new NullRealm();
         }
 
         return TomcatService.forConfig(new TomcatServiceConfig(

--- a/src/main/java/com/linecorp/armeria/server/http/tomcat/TomcatServiceConfig.java
+++ b/src/main/java/com/linecorp/armeria/server/http/tomcat/TomcatServiceConfig.java
@@ -126,7 +126,7 @@ final class TomcatServiceConfig {
                "(serviceName: " + serviceName +
                ", engineName: " + engineName +
                ", baseDir: " + baseDir +
-               ", realm: " + realm.getClass().getSimpleName() +
+               ", realm: " + (realm != null ? realm.getClass().getSimpleName() : "null") +
                ", hostname: " + hostname +
                ", docBase: " + docBase +
                (jarRoot != null ? ", jarRoot: " + jarRoot : "") +


### PR DESCRIPTION
Motivation:

A LifecycleException can occur while stopping a TomcatService if:

- a user bound more than one TomcatService built by TomcatServiceBuilder
- and used the default Realm (NullRealm)

When a TomcatService stops, the NullRealm will be stopped and destroyed.
After then, when another TomcatService stops, it will attempt to stop
the same NullRealm, which will fail with LifecycleException because it
has been destroyed by the first TomcatService.

Modifications:

Create a new NullRealm instead of using a singleton

Result:

No more LifecycleException

Related stack trace:

    Caused by: org.apache.catalina.LifecycleException: Failed to stop component [StandardService[TomcatServiceTest-JAR]]
        at org.apache.catalina.util.LifecycleBase.stop(LifecycleBase.java:228)
        at org.apache.catalina.core.StandardServer.stopInternal(StandardServer.java:808)
        at org.apache.catalina.util.LifecycleBase.stop(LifecycleBase.java:224)
        ... 16 common frames omitted
    Caused by: org.apache.catalina.LifecycleException: Failed to stop component [StandardEngine[TomcatServiceTest-JAR]]
        at org.apache.catalina.util.LifecycleBase.stop(LifecycleBase.java:228)
        at org.apache.catalina.core.StandardService.stopInternal(StandardService.java:502)
        at org.apache.catalina.util.LifecycleBase.stop(LifecycleBase.java:224)
        ... 18 common frames omitted
    Caused by: org.apache.catalina.LifecycleException: An invalid Lifecycle transition was attempted ([before_stop]) for component [Realm[NullRealm]] in state [DESTROYED]
        at org.apache.catalina.util.LifecycleBase.invalidTransition(LifecycleBase.java:401)
        at org.apache.catalina.util.LifecycleBase.stop(LifecycleBase.java:211)
        at org.apache.catalina.core.ContainerBase.stopInternal(ContainerBase.java:986)
        at org.apache.catalina.util.LifecycleBase.stop(LifecycleBase.java:224)
        ... 20 common frames omitted