### PR TITLE
Use the newer Oracle JDK in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,6 @@
 language: java
 sudo: false
 
-# Force update Java in our build since Travis default is 1.8.0_31,
-# which sometimes can't compile correct Java8 code.
-# https://github.com/travis-ci/travis-ci/issues/3259
-addons:
-  apt:
-    packages:
-      - oracle-java8-installer
-
-jdk:
-  - oraclejdk8
-
 os:
   - linux
 
@@ -26,7 +15,20 @@ notifications:
 cache:
   directories:
     - $HOME/.m2
+    - $HOME/.jdk
 
-install: true
-script: mvn -B test site
+env:
+  global:
+    - JAVA_HOME=$HOME/.jdk/default
+    - PATH=$JAVA_HOME/bin:$PATH
+
+before_install:
+  - .travis/install-jdk.sh
+  - .travis/clean-m2-repo.sh
+
+install:
+  - true
+
+script:
+  - mvn -B test site
 

--- a/.travis/clean-m2-repo.sh
+++ b/.travis/clean-m2-repo.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+rm -fr "$HOME/.m2/repository/com/linecorp/armeria"
+

--- a/.travis/install-jdk.sh
+++ b/.travis/install-jdk.sh
@@ -1,0 +1,28 @@
+#!/bin/bash -e
+JDK_VERSION='jdk1.8.0_92'
+JDK_DOWNLOAD_URL='http://download.oracle.com/otn-pub/java/jdk/8u92-b14/jdk-8u92-linux-x64.tar.gz'
+
+JDK_HOME="$HOME/.jdk/$JDK_VERSION"
+JDK_TARBALL="$HOME/.jdk/${JDK_VERSION}.tar.gz"
+
+function install_symlink() {
+  local DEFAULT_JDK_HOME="$HOME/.jdk/default"
+  ln -sf "$JDK_HOME" "$DEFAULT_JDK_HOME"
+  "$DEFAULT_JDK_HOME/bin/java" -version
+}
+
+if [[ ! -x "$JDK_HOME/bin/java" ]]; then
+  mkdir -p "$HOME/.jdk"
+  wget --no-cookies --no-check-certificate \
+       --header='Cookie: gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie' \
+       --output-document="$JDK_TARBALL" \
+       "$JDK_DOWNLOAD_URL"
+
+  rm -fr "$JDK_HOME"
+  mkdir "$JDK_HOME"
+  tar zxf "$JDK_TARBALL" -C "$HOME/.jdk"
+  rm -f "$JDK_TARBALL"
+fi
+
+install_symlink
+


### PR DESCRIPTION
- Download the Oracle JDK 8u92 from the official site
- Untar the downloaded JDK tarball into `~/.jdk/<version>`
- Create a symlink at `~/.jdk/default` for the untar'd directory
- Cache `~/.jdk` if everything worked as expected