### PR TITLE
Log meaningful identifier of embedded Tomcat

### DIFF
--- a/src/main/java/com/linecorp/armeria/server/http/tomcat/TomcatService.java
+++ b/src/main/java/com/linecorp/armeria/server/http/tomcat/TomcatService.java
@@ -24,6 +24,7 @@ import java.util.function.Function;
 
 import org.apache.catalina.LifecycleState;
 import org.apache.catalina.Server;
+import org.apache.catalina.Service;
 import org.apache.catalina.connector.Connector;
 import org.apache.catalina.startup.Tomcat;
 import org.slf4j.Logger;
@@ -137,15 +138,29 @@ public final class TomcatService extends HttpService {
             final Server server = connector.getService().getServer();
             if (server.getState() == LifecycleState.STOPPED) {
                 try {
-                    logger.info("Destroying an embedded Tomcat: {}", server);
+                    logger.info("Destroying an embedded Tomcat: {}", toString(server));
                     server.destroy();
                 } catch (Exception e) {
-                    logger.warn("Failed to destroy an embedded Tomcat: {}", server, e);
+                    logger.warn("Failed to destroy an embedded Tomcat: {}", toString(server), e);
                 }
             }
         };
 
         return new TomcatService(null, new ManagedConnectorFactory(config), postStopTask);
+    }
+
+    static String toString(Server server) {
+        requireNonNull(server, "server");
+
+        final Service[] services = server.findServices();
+        final String serviceName;
+        if (services.length == 0) {
+            serviceName = "<unknown>";
+        } else {
+            serviceName = services[0].getName();
+        }
+
+        return "(serviceName: " + serviceName + ", catalinaBase: " + server.getCatalinaBase() + ')';
     }
 
     private TomcatService(String hostname, Function<String, Connector> connectorFactory) {

--- a/src/main/java/com/linecorp/armeria/server/http/tomcat/TomcatServiceInvocationHandler.java
+++ b/src/main/java/com/linecorp/armeria/server/http/tomcat/TomcatServiceInvocationHandler.java
@@ -142,7 +142,7 @@ class TomcatServiceInvocationHandler implements ServiceInvocationHandler {
         server = service.getServer();
 
         if (server.getState() != LifecycleState.STARTED) {
-            logger.info("Starting an embedded Tomcat: {}", server);
+            logger.info("Starting an embedded Tomcat: {}", TomcatService.toString(server));
             server.start();
             started = true;
         }
@@ -167,10 +167,10 @@ class TomcatServiceInvocationHandler implements ServiceInvocationHandler {
         }
 
         try {
-            logger.info("Stopping an embedded Tomcat: {}", server);
+            logger.info("Stopping an embedded Tomcat: {}", TomcatService.toString(server));
             server.stop();
         } catch (Exception e) {
-            logger.warn("Failed to stop an embedded Tomcat: {}", server, e);
+            logger.warn("Failed to stop an embedded Tomcat: {}", TomcatService.toString(server), e);
         }
 
         postStopTask.accept(connector);


### PR DESCRIPTION
Motivation:

TomcatService(InvocationHandler) logs the following (or similar) message
when starting, stopping and destroying embedded Tomcat:

    Starting an embedded Tomcat: Server[-2]

.. which is not useful to identify the Server instances when a user is
using more than one Servers.

Modifications:

- Add TomcatService.toString(Server) and use it wherever a Server is
  stringified

Result:

Better-looking log message:

    Starting an embedded Tomcat: (serviceName: TomcatServiceTest,
    catalinaBase: /tmp/tomcat-armeria.7377474203691902870)