### PR TITLE
Fix broken interface discovery for Thrift services in DocService

### DIFF
--- a/src/main/java/com/linecorp/armeria/server/thrift/ThriftService.java
+++ b/src/main/java/com/linecorp/armeria/server/thrift/ThriftService.java
@@ -114,8 +114,16 @@ public class ThriftService extends SimpleService {
     /**
      * Returns the Thrift service object that implements {@code *.Iface} or {@code *.AsyncIface}.
      */
-    public Object thriftService() {
-        return ((ThriftServiceCodec) codec()).thriftService();
+    public Object implementation() {
+        return ((ThriftServiceCodec) codec()).implementation();
+    }
+
+    /**
+     * Returns the Thrift service interfaces ({@code *.Iface} or {@code *.AsyncIface}) the Thrift service
+     * object implements.
+     */
+    public Set<Class<?>> interfaces() {
+        return ((ThriftServiceCodec) codec()).interfaces();
     }
 
     /**


### PR DESCRIPTION
Motivation:

A Thrift service implementation may not implement .Iface/.AsyncIface
interfaces directly when the service implementation implements another
interface or abstract class that extends or implements
.Iface/.AsyncIface. For example:

    public abstract class AbstractMyService implements Service.Iface {}
    public class MyService extends AbstractMyService { ... }

Trying to get the list of implemented interfaces via
MyService.class.getInterfaces() will not return Service.Iface, leading
DocService to think MyService is not a Thrift service implementation.

This issue has been fixed in 665e6415b98dc3f7a1a34f2fb90b64e5653478cc
for ThriftService previously, but the fix did not cover DocService.

Modifications:

- Add ThriftService.interfaces() that returns all .Iface/.AsyncIface
  interfaces a service implementation impleents
- Make Specification uses ThriftService.interfaces() to get the list of
  implemented interfaces
- Rename ThriftService.thriftService() to implementation() because
  ThriftService.thriftService() sounds redundant and confusing.

Result:

DocService works for Thrift service implementations with non-trivial
type hierarchy