### PR TITLE
Fix incomplete TTextProtocol.reset()

### DIFF
--- a/src/main/java/com/linecorp/armeria/common/thrift/text/TTextProtocol.java
+++ b/src/main/java/com/linecorp/armeria/common/thrift/text/TTextProtocol.java
@@ -117,13 +117,8 @@ public class TTextProtocol extends TProtocol {
         super(trans);
 
         writers = new Stack<>();
-
-        ByteArrayOutputStream mybaos = new TTransportOutputStream();
-        pushWriter(mybaos);
-
-        reset();
         contextStack = new Stack<>();
-        contextStack.push(new BaseContext());
+        reset();
     }
 
     @Override
@@ -134,6 +129,12 @@ public class TTextProtocol extends TProtocol {
     @Override
     public final void reset() {
         root = null;
+
+        writers.clear();
+        pushWriter(new TTransportOutputStream());
+
+        contextStack.clear();
+        contextStack.push(new BaseContext());
     }
 
     /**


### PR DESCRIPTION
Motivation:

ThriftServiceCodec keeps the TProtocol implementations in a thread-local
cache to avoid repetitive instantiation of TProtocol instances.

TTextProtocol.reset() does not re-initializes its writer and context
stack, which makes it possible for a previously failed call corrupts the
state of TTextProtocol.

Modifications:

TTextProtocol.reset() now clears the writer and context stack and adds
the initial stack elements.

Result:

A previously failed TText Thrift call does not corrupt the state of the
codec