### PR TITLE
Add DocService's docString to html view

### DIFF
--- a/src/main/resources/com/linecorp/armeria/server/docs/assets/css/armeria.css
+++ b/src/main/resources/com/linecorp/armeria/server/docs/assets/css/armeria.css
@@ -118,6 +118,11 @@ label {
   font-size: 60%;
 }
 
+.main div.description, .main td.description {
+  font-size: 100%;
+  text-align: justify;
+}
+
 .main td ul {
   list-style-type: none;
   padding-left: 0;

--- a/src/main/resources/com/linecorp/armeria/server/docs/assets/js/armeria.js
+++ b/src/main/resources/com/linecorp/armeria/server/docs/assets/js/armeria.js
@@ -14,7 +14,7 @@ $(function () {
   var previousFragmentPath = null;
 
   $.getJSON('specification.json', function (data) {
-    specification = data;
+    specification = escapeDocString(updateDocString(data));
 
     renderNav();
     $(window).trigger('hashchange');
@@ -23,6 +23,85 @@ $(function () {
   $(window).on('hashchange', function () {
     render(URI(window.location.href));
   });
+
+  function parseParametersDocString(docString) {
+    var parameters = {};
+    if (docString != null) {
+      var pattern = /@param\s+(\w+)[\s\.]+(({@|[^@])*)(?=(@[\w]+|$|\s))/gm;
+      var match = pattern.exec(docString);
+      while (match != null) {
+        parameters[match[1]] = match[2];
+        match = pattern.exec(docString);
+      }
+    }
+    return parameters;
+  }
+
+  function removeParamDocString(docString) {
+    if (docString == null) {
+      return null;
+    }
+    return docString.replace(/@param .*[\n\r]*/mig, '');
+  }
+
+  function updateDocString(specification) {
+    // hierachy
+    // services.SERVICE_NAME.functions.FUNCTION_NAME.docString
+    // services.SERVICE_NAME.functions.FUNCTION_NAME.parameters[i].name (simple_string)
+    // services.SERVICE_NAME.functions.FUNCTION_NAME.parameters[i].docString
+    // classes.CLASS_NAME.docString
+    // classes.CLASS_NAME.fields[i].name (simple_name)
+    // classes.CLASS_NAME.fields[i].docString
+
+    var services = specification.services;
+    var classes = specification.classes;
+
+    for (var serviceName in services) {
+      var svc = services[serviceName];
+      for (var functionName in svc.functions) {
+        var func = svc.functions[functionName];
+        var childDocStrings = parseParametersDocString(func.docString);
+        func.docString = removeParamDocString(func.docString);
+        for (var idx in func.parameters) {
+          var param = func.parameters[idx];
+          if (param.name in childDocStrings) {
+            param.docString = childDocStrings[param.name];
+          }
+        }
+      }
+    }
+
+    for (var className in classes) {
+      var cls = classes[className];
+      var childDocStrings = parseParametersDocString(cls.docString);
+      cls.docString = removeParamDocString(cls.docString);
+      for (var idx in cls.fields) {
+        var field = cls.fields[idx];
+        if (field.name in childDocStrings) {
+          field.docString = childDocStrings[field.name];
+        }
+      }
+    }
+
+    return specification;
+  }
+
+  function escapeDocString(node) {
+    if (node instanceof Array) {
+      for (var idx in node) {
+        escapeDocString(node[idx]);
+      }
+    } else if (node instanceof Object) {
+      var docString = node['docString'];
+      if (docString && typeof docString === 'string') {
+        node['docString'] = escapeHtml(docString).replace(/\n/g, '<br>');
+      }
+      for (var key in node) {
+        escapeDocString(node[key]);
+      }
+    }
+    return node;
+  }
 
   function render(uri) {
     var fragmentUri = uri.fragment(true);
@@ -187,6 +266,20 @@ $(function () {
                    return '<a href="#!class/' + encodeURIComponent(className) + '" title="' + className + '">' +
                           classInfo.simpleName + '</a>';
                  });
+  }
+
+  function escapeHtml(string) {
+    var htmlEscapes = {
+      '&': '&amp;',
+      '<': '&lt;',
+      '>': '&gt;',
+      '"': '&quot;',
+      "'": '&#39;',
+      '/': '&#x2F;',
+      '`': '&#x60;',
+      '=': '&#x3D;'
+    };
+    return string.replace(/[&<>"'`=\/]/g, function(s) { return htmlEscapes[s]; });
   }
 
   function escapeTag(value) {

--- a/src/main/resources/com/linecorp/armeria/server/docs/index.html
+++ b/src/main/resources/com/linecorp/armeria/server/docs/index.html
@@ -80,6 +80,8 @@
         <script id="function-template" type="text/x-handlebars-template">
           <h1 class="page-header"><code title="{{serviceName}}.{{function.name}}()">{{serviceSimpleName}}.{{function.name}}()</code></h1>
 
+          <div class="description">{{{function.docString}}}</div>
+
           <h2 class="sub-header">Parameters</h2>
           <div class="table-responsive">
             <table class="table table-striped table-condensed">
@@ -88,6 +90,7 @@
                 <th>Name</th>
                 <th>Required</th>
                 <th>Type</th>
+                <th>Description</th>
               </tr>
               </thead>
               <tbody>
@@ -96,6 +99,7 @@
                 <td><code>{{name}}</code></td>
                 <td>{{requirementType}}</td>
                 <td><code>{{{type.typeStr}}}</code></td>
+                <td class="description">{{{docString}}}</td>
               </tr>
               {{else}}
               <tr>
@@ -190,6 +194,8 @@
             <code class="package-name">{{class.packageName}}</code>
           </h1>
 
+          <div class="description">{{{class.docString}}}</div>
+
           {{#if class.fields.length}}
           <h2 class="sub-header">Fields</h2>
           <div class="table-responsive">
@@ -199,6 +205,7 @@
                 <th>Name</th>
                 <th>Required</th>
                 <th>Type</th>
+                <th>Description</th>
               </tr>
               </thead>
               <tbody>
@@ -207,6 +214,7 @@
                 <td><code>{{name}}</code></td>
                 <td>{{requirementType}}</td>
                 <td><code>{{{type.typeStr}}}</code></td>
+                <td class="description">{{{docString}}}</td>
               </tr>
               {{/each}}
               </tbody>

--- a/src/test/resources/META-INF/armeria/thrift/cassandra.json
+++ b/src/test/resources/META-INF/armeria/thrift/cassandra.json
@@ -1545,7 +1545,7 @@
             "valueTypeId": "i32"
           },
           "oneway": false,
-          "doc": "Perform a get_count in parallel on the given list<binary> keys. The return value maps keys to the count found.\n",
+          "doc": "Perform a get_count in parallel on the given list<binary> keys. The return value maps keys to the count found.\n@param keys. this is test doc string.",
           "arguments": [
             {
               "key": 1,


### PR DESCRIPTION
Motivation:

Current DocService's html view doesn't contain JavaDoc string.
This is second part of adding docstring to DocService.

Modifications:

Render DocString to html view if it exists.

Result:

DocService's html output contains DocString.