### PR TITLE
Upgrade tcnative-boringssl to the latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,8 +136,7 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative-boringssl-static</artifactId>
-      <version>1.1.33.Fork16</version>
-      <classifier>linux-x86_64</classifier>
+      <version>1.1.33.Fork17</version>
     </dependency>
 
     <!-- ALPN -->


### PR DESCRIPTION
.. and remove dependency classifier which includes Windows and macOS
binaries.