### PR TITLE
Upgrade the dependencies to their latest stable versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,14 +81,14 @@
     <maven.compiler.showWarnings>true</maven.compiler.showWarnings>
 
     <!-- Dependency versions -->
-    <jackson.version>2.7.3</jackson.version>
-    <jetty.version>9.3.8.v20160314</jetty.version>
+    <jackson.version>2.7.5</jackson.version>
+    <jetty.version>9.3.10.v20160621</jetty.version>
     <logback.version>1.1.7</logback.version>
     <metrics.version>3.1.2</metrics.version>
-    <netty.version>4.1.0.CR7</netty.version>
+    <netty.version>4.1.2.Final</netty.version>
     <slf4j.version>1.7.21</slf4j.version>
-    <tomcat.version>8.0.33</tomcat.version>
-    <jetty.alpnAgent.version>2.0.1</jetty.alpnAgent.version>
+    <tomcat.version>8.0.36</tomcat.version>
+    <jetty.alpnAgent.version>2.0.3</jetty.alpnAgent.version>
     <jetty.alpnAgent.path>${settings.localRepository}/org/mortbay/jetty/alpn/jetty-alpn-agent/${jetty.alpnAgent.version}/jetty-alpn-agent-${jetty.alpnAgent.version}.jar</jetty.alpnAgent.path>
     <argLine.alpnAgent>-javaagent:${jetty.alpnAgent.path}</argLine.alpnAgent>
     <argLine.leak>-D_</argLine.leak> <!-- Overridden when 'leak' profile is active -->
@@ -97,7 +97,7 @@
     <thrift.source.test>${project.basedir}/src/test/thrift</thrift.source.test>
     <thrift.generated.main>${project.build.directory}/generated-sources</thrift.generated.main>
     <thrift.generated.test>${project.build.directory}/generated-test-sources</thrift.generated.test>
-    <brave.version>3.5.0</brave.version>
+    <brave.version>3.9.0</brave.version>
     <guava.version>19.0</guava.version>
     <reflections.version>0.9.10</reflections.version>
   </properties>
@@ -136,7 +136,7 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative-boringssl-static</artifactId>
-      <version>1.1.33.Fork17</version>
+      <version>1.1.33.Fork18</version>
     </dependency>
 
     <!-- ALPN -->
@@ -347,12 +347,12 @@
 
     <!-- distributed tracing -->
     <dependency>
-      <groupId>com.github.kristofa</groupId>
+      <groupId>io.zipkin.brave</groupId>
       <artifactId>brave-core</artifactId>
       <version>${brave.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.github.kristofa</groupId>
+      <groupId>io.zipkin.brave</groupId>
       <artifactId>brave-http</artifactId>
       <version>${brave.version}</version>
     </dependency>

--- a/src/main/java/com/linecorp/armeria/client/HttpRemoteInvoker.java
+++ b/src/main/java/com/linecorp/armeria/client/HttpRemoteInvoker.java
@@ -59,7 +59,6 @@ import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
 import io.netty.util.concurrent.Promise;
-import io.netty.util.internal.OneTimeTask;
 
 final class HttpRemoteInvoker implements RemoteInvoker {
 
@@ -83,7 +82,7 @@ final class HttpRemoteInvoker implements RemoteInvoker {
         this.baseBootstrap = requireNonNull(baseBootstrap, "baseBootstrap");
         this.options = requireNonNull(options, "options");
 
-        assert baseBootstrap.group() == null;
+        assert baseBootstrap.config().group() == null;
     }
 
     @Override
@@ -245,7 +244,7 @@ final class HttpRemoteInvoker implements RemoteInvoker {
         });
     }
 
-    private static class TimeoutTask extends OneTimeTask {
+    private static class TimeoutTask implements Runnable {
 
         private final Promise<?> promise;
         private final long timeoutMillis;

--- a/src/main/java/com/linecorp/armeria/client/tracing/HttpTracingRemoteInvoker.java
+++ b/src/main/java/com/linecorp/armeria/client/tracing/HttpTracingRemoteInvoker.java
@@ -52,11 +52,11 @@ class HttpTracingRemoteInvoker extends TracingRemoteInvoker {
             headers.add(BraveHttpHeaders.Sampled.getName(), "0");
         } else {
             headers.add(BraveHttpHeaders.Sampled.getName(), "1");
-            headers.add(BraveHttpHeaders.TraceId.getName(), IdConversion.convertToString(spanId.getTraceId()));
-            headers.add(BraveHttpHeaders.SpanId.getName(), IdConversion.convertToString(spanId.getSpanId()));
-            if (spanId.getParentSpanId() != null) {
+            headers.add(BraveHttpHeaders.TraceId.getName(), IdConversion.convertToString(spanId.traceId));
+            headers.add(BraveHttpHeaders.SpanId.getName(), IdConversion.convertToString(spanId.spanId));
+            if (!spanId.root()) {
                 headers.add(BraveHttpHeaders.ParentSpanId.getName(),
-                            IdConversion.convertToString(spanId.getParentSpanId()));
+                            IdConversion.convertToString(spanId.parentId));
             }
         }
 

--- a/src/main/java/com/linecorp/armeria/common/ServiceInvocationContextAwareEventLoop.java
+++ b/src/main/java/com/linecorp/armeria/common/ServiceInvocationContextAwareEventLoop.java
@@ -3,7 +3,6 @@ package com.linecorp.armeria.common;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -11,7 +10,6 @@ import java.util.stream.Collectors;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelHandlerInvoker;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
@@ -40,11 +38,6 @@ final class ServiceInvocationContextAwareEventLoop implements EventLoop {
     @Override
     public EventLoop next() {
         return delegate.next();
-    }
-
-    @Override
-    public <E extends EventExecutor> Set<E> children() {
-        return delegate.children();
     }
 
     @Override
@@ -219,13 +212,14 @@ final class ServiceInvocationContextAwareEventLoop implements EventLoop {
     }
 
     @Override
-    public ChannelFuture register(Channel channel,
-                                  ChannelPromise channelPromise) {
-        return delegate.register(channel, channelPromise);
+    public ChannelFuture register(ChannelPromise channelPromise) {
+        return delegate.register(channelPromise);
     }
 
     @Override
-    public ChannelHandlerInvoker asInvoker() {
-        return delegate.asInvoker();
+    @Deprecated
+    public ChannelFuture register(Channel channel,
+                                  ChannelPromise channelPromise) {
+        return delegate.register(channel, channelPromise);
     }
 }

--- a/src/main/java/com/linecorp/armeria/server/Server.java
+++ b/src/main/java/com/linecorp/armeria/server/Server.java
@@ -48,8 +48,8 @@ import io.netty.channel.epoll.EpollServerSocketChannel;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.handler.ssl.SslContext;
-import io.netty.util.DomainMappingBuilder;
 import io.netty.util.DomainNameMapping;
+import io.netty.util.DomainNameMappingBuilder;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GlobalEventExecutor;
@@ -114,7 +114,8 @@ public final class Server implements AutoCloseable {
                 }
             }
         } else {
-            final DomainMappingBuilder<SslContext> mappingBuilder = new DomainMappingBuilder<>(lastSslContext);
+            final DomainNameMappingBuilder<SslContext>
+                    mappingBuilder = new DomainNameMappingBuilder<>(lastSslContext);
             for (VirtualHost h : config.virtualHosts()) {
                 final SslContext sslCtx = h.sslContext();
                 if (sslCtx != null) {

--- a/src/main/java/com/linecorp/armeria/server/ServerConfig.java
+++ b/src/main/java/com/linecorp/armeria/server/ServerConfig.java
@@ -31,8 +31,8 @@ import com.linecorp.armeria.common.ServiceInvocationContext;
 import com.linecorp.armeria.common.TimeoutPolicy;
 
 import io.netty.handler.ssl.SslContext;
-import io.netty.util.DomainMappingBuilder;
 import io.netty.util.DomainNameMapping;
+import io.netty.util.DomainNameMappingBuilder;
 import io.netty.util.concurrent.Promise;
 
 /**
@@ -118,7 +118,8 @@ public final class ServerConfig {
 
         // Set virtual host definitions and initialize their domain name mapping.
         defaultVirtualHost = normalizeDefaultVirtualHost(defaultVirtualHost, portsCopy);
-        final DomainMappingBuilder<VirtualHost> mappingBuilder = new DomainMappingBuilder<>(defaultVirtualHost);
+        final DomainNameMappingBuilder<VirtualHost> mappingBuilder =
+                new DomainNameMappingBuilder<>(defaultVirtualHost);
         final List<VirtualHost> virtualHostsCopy = new ArrayList<>();
         for (VirtualHost h : virtualHosts) {
             if (h == null) {

--- a/src/main/java/com/linecorp/armeria/server/VirtualHost.java
+++ b/src/main/java/com/linecorp/armeria/server/VirtualHost.java
@@ -26,8 +26,8 @@ import java.util.Locale;
 import java.util.regex.Pattern;
 
 import io.netty.handler.ssl.SslContext;
-import io.netty.util.DomainMappingBuilder;
 import io.netty.util.DomainNameMapping;
+import io.netty.util.DomainNameMappingBuilder;
 
 /**
  * A <a href="https://en.wikipedia.org/wiki/Virtual_hosting#Name-based">name-based virtual host</a>.
@@ -127,7 +127,7 @@ public final class VirtualHost {
         // Pretty convoluted way to validate but it's done only once and
         // we don't need to duplicate the pattern matching logic.
         final DomainNameMapping<Boolean> mapping =
-                new DomainMappingBuilder<>(Boolean.FALSE).add(hostnamePattern, Boolean.TRUE).build();
+                new DomainNameMappingBuilder<>(Boolean.FALSE).add(hostnamePattern, Boolean.TRUE).build();
 
         if (!mapping.map(defaultHostname)) {
             throw new IllegalArgumentException(

--- a/src/test/java/com/linecorp/armeria/common/tracing/HttpTracingTestBase.java
+++ b/src/test/java/com/linecorp/armeria/common/tracing/HttpTracingTestBase.java
@@ -8,7 +8,7 @@ import io.netty.handler.codec.http.HttpHeaders;
 
 public abstract class HttpTracingTestBase {
 
-    public static final SpanId testSpanId = SpanId.create(1, 2, 3L);
+    public static final SpanId testSpanId = SpanId.builder().traceId(1).spanId(2).parentId(3L).build();
 
     public static HttpHeaders traceHeaders() {
         HttpHeaders httpHeader = new DefaultHttpHeaders();

--- a/src/test/java/com/linecorp/armeria/server/tracing/TracingServiceInvocationHandlerTest.java
+++ b/src/test/java/com/linecorp/armeria/server/tracing/TracingServiceInvocationHandlerTest.java
@@ -102,7 +102,10 @@ public class TracingServiceInvocationHandlerTest extends TracingTestBase {
 
         ServiceInvocationHandler serviceInvocationHandler = mock(ServiceInvocationHandler.class);
 
-        TraceData traceData = TraceData.builder().sample(sampled).spanId(SpanId.create(1, 2, 3L)).build();
+        TraceData traceData = TraceData.builder()
+                                       .sample(sampled)
+                                       .spanId(SpanId.builder().traceId(1).spanId(2).parentId(3L).build())
+                                       .build();
 
         TracingServiceInvocationHandlerImpl stub = new TracingServiceInvocationHandlerImpl(
                 serviceInvocationHandler, brave, traceData);


### PR DESCRIPTION
- Brave 3.9.0
- Jackson 2.7.5
- Jetty 9.3.10
- Jetty ALPN agent 2.0.3
- Netty 4.1.2.Final
- Netty TCNative (BoringSSL-static) 1.1.33.Fork18
- Tomcat 8.0.36
- Related changes:
  - Remove the references to the deprecated/removed APIs