### PR TITLE
Add the Slack invitation badge

### DIFF
--- a/src/site/sphinx/_static/overrides.css
+++ b/src/site/sphinx/_static/overrides.css
@@ -44,6 +44,17 @@ body {
   padding: 0;
 }
 
+.wy-menu.wy-menu-vertical .slack-invitation {
+  padding: 0.4em 1.45em;
+  display: block;
+  position: relative;
+}
+
+/* Make sure the invitation dialog appears on top of the menu whose z-index is 200. */
+.__slackin {
+  z-index: 1000;
+}
+
 h1, h2, h3, h4, h5, h6 {
   font-weight: inherit;
 }

--- a/src/site/sphinx/_templates/versions.html
+++ b/src/site/sphinx/_templates/versions.html
@@ -3,3 +3,24 @@
     <a href="https://github.com/line/armeria">Fork me on GitHub</a>
   </div>
 </div>
+<!-- Append the Slack invitation at the end of the menu. -->
+<script type="text/javascript">
+var menus = document.getElementsByClassName("wy-menu wy-menu-vertical");
+if (menus.length > 0) {
+  var menu = menus[0];
+  var lists = menu.getElementsByTagName('ul');
+  if (lists.length > 0) {
+    var li = document.createElement('li');
+    li.className = 'toctree-l1';
+    var div = document.createElement('div');
+    div.className = 'slack-invitation';
+    var script = document.createElement('script');
+    script.type = 'text/javascript';
+    script.src = 'https://slackin-line-armeria.herokuapp.com/slackin.js';
+    div.appendChild(script);
+    li.appendChild(div);
+    lists[0].appendChild(li);
+  }
+}
+</script>
+


### PR DESCRIPTION
We recently create a public Slack group:

- https://line-armeria.slack.com/

We also deployed Slackin at Heroku for simpler signup:

- https://slackin-line-armeria.herokuapp.com/

This commit adds the Slack invitation badge that publishes our public
Slack group in our web site.