### PR TITLE
Do not produce an empty response when ServiceCodec raises an exception

### DIFF
--- a/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -251,9 +251,17 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter {
             final Service service = serviceCfg.service();
             final ServiceCodec codec = service.codec();
             final Promise<Object> promise = ctx.executor().newPromise();
-            final DecodeResult decodeResult = codec.decodeRequest(
-                    serviceCfg, ctx.channel(), protocol,
-                    hostname, path, mappedPath, req.content(), req, promise);
+
+            final DecodeResult decodeResult;
+            try {
+                decodeResult = codec.decodeRequest(
+                        serviceCfg, ctx.channel(), protocol,
+                        hostname, path, mappedPath, req.content(), req, promise);
+            } catch (Exception e) {
+                logger.warn("{} Unexpected exception from a decoder:", ctx.channel(), e);
+                respond(ctx, reqSeq, req, HttpResponseStatus.BAD_REQUEST, e);
+                return;
+            }
 
             switch (decodeResult.type()) {
             case SUCCESS: {


### PR DESCRIPTION
Motivation:

When a ServiceCodec.decodeRequest() raises an exception,
HttpServerHandler will close the connection immediately without sending
anything. Instead, the server should send a '400 Bad Request' response.

Modifications:

- HttpServerHandler now catches an exception raised by
  ServiceCodec.decodeRequest() and responds with a '400 Bad Request'
  response.
- ThriftServiceCodec.decodeRequest() now catches an exception raised by
  TProtocol.readMessageBegin() and returns a failed DecoderResult
  instead of raising an exception.

Result:

- Armeria server sends a 400 Bad Request even if
  ServiceCodec.decodeRequest() raises an exception.
- ThriftServiceCodec.decodeRequest() deals with a bad request better.