### PR TITLE
Make TomcatService support Tomcat 8.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <metrics.version>3.1.2</metrics.version>
     <netty.version>4.1.2.Final</netty.version>
     <slf4j.version>1.7.21</slf4j.version>
-    <tomcat.version>8.0.36</tomcat.version>
+    <tomcat.version>8.5.4</tomcat.version>
     <jetty.alpnAgent.version>2.0.3</jetty.alpnAgent.version>
     <jetty.alpnAgent.path>${settings.localRepository}/org/mortbay/jetty/alpn/jetty-alpn-agent/${jetty.alpnAgent.version}/jetty-alpn-agent-${jetty.alpnAgent.version}.jar</jetty.alpnAgent.path>
     <argLine.alpnAgent>-javaagent:${jetty.alpnAgent.path}</argLine.alpnAgent>
@@ -181,12 +181,6 @@
     <dependency>
       <groupId>org.apache.tomcat.embed</groupId>
       <artifactId>tomcat-embed-el</artifactId>
-      <version>${tomcat.version}</version>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.tomcat.embed</groupId>
-      <artifactId>tomcat-embed-logging-log4j</artifactId>
       <version>${tomcat.version}</version>
       <optional>true</optional>
     </dependency>
@@ -550,6 +544,30 @@
             <exclude>**/package-info.java</exclude>
           </excludes>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.gmaven</groupId>
+        <artifactId>groovy-maven-plugin</artifactId>
+        <version>2.0</version>
+        <executions>
+          <execution>
+            <id>tomcat80-compat</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>execute</goal>
+            </goals>
+            <configuration>
+              <source>${basedir}/src/build/tomcat80-compat.groovy</source>
+            </configuration>
+          </execution>
+        </executions>
+        <dependencies>
+          <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm</artifactId>
+            <version>5.1</version>
+          </dependency>
+        </dependencies>
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>

--- a/src/build/tomcat80-compat.groovy
+++ b/src/build/tomcat80-compat.groovy
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.objectweb.asm.ClassReader
+import org.objectweb.asm.ClassVisitor
+import org.objectweb.asm.ClassWriter
+import org.objectweb.asm.MethodVisitor
+import org.objectweb.asm.Opcodes
+
+import java.nio.file.Files
+import java.nio.file.Paths
+
+// This script removes the methods that did not exist until Tomcat 8.5 from the ProtocolHandler implementation.
+// We need the methods to exist during compilation time since we compile the ProtocolHandler implementation
+// against Tomcat 8.5, but want to make sure the methods do not exist because otherwise JVM will fail to load
+// the ProtocolHandler due to the references to the non-existent classes in the method signatures.
+
+path = Paths.get("target", "classes", "com", "linecorp", "armeria", "server", "http", "tomcat",
+                 "Tomcat80ProtocolHandler.class")
+
+reader = new ClassReader(Files.readAllBytes(path))
+writer = new ClassWriter(ClassWriter.COMPUTE_MAXS)
+
+reader.accept(new ClassVisitor(Opcodes.ASM5, writer) {
+    @Override
+    MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
+        if (name == "addSslHostConfig" || name == "findSslHostConfigs" ||
+            name == "addUpgradeProtocol" || name == "findUpgradeProtocols") {
+            return null
+        } else {
+            return super.visitMethod(access, name, desc, signature, exceptions)
+        }
+    }
+}, 0)
+
+Files.write(path, writer.toByteArray())

--- a/src/main/java/com/linecorp/armeria/server/http/tomcat/ArmeriaWebResourceRoot.java
+++ b/src/main/java/com/linecorp/armeria/server/http/tomcat/ArmeriaWebResourceRoot.java
@@ -41,10 +41,10 @@ final class ArmeriaWebResourceRoot extends StandardRoot {
     @Override
     protected WebResourceSet createMainResourceSet() {
         final Path docBase = config.docBase();
-        final String docBaseStr = docBase.toString();
-
         assert docBase.isAbsolute();
-        assert docBaseStr.equals(getContext().getDocBase());
+
+        final String docBaseStr = docBase.toString();
+        getContext().setDocBase(docBaseStr);
 
         if (Files.isDirectory(docBase)) {
             return new DirResourceSet(this, "/", docBaseStr, "/");

--- a/src/main/java/com/linecorp/armeria/server/http/tomcat/Tomcat80ProtocolHandler.java
+++ b/src/main/java/com/linecorp/armeria/server/http/tomcat/Tomcat80ProtocolHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -22,11 +22,14 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.catalina.connector.Connector;
 import org.apache.coyote.Adapter;
 import org.apache.coyote.ProtocolHandler;
+import org.apache.coyote.UpgradeProtocol;
+import org.apache.tomcat.util.net.SSLHostConfig;
 
 /**
- * A Tomcat {@link ProtocolHandler}. Do not use; loaded and instantiated by Tomcat via reflection.
+ * A {@link ProtocolHandler} for Tomcat 8.0 and below.
+ * Do not use; loaded and instantiated by Tomcat via reflection.
  */
-public final class TomcatProtocolHandler implements ProtocolHandler {
+public final class Tomcat80ProtocolHandler implements ProtocolHandler {
 
     private static final AtomicInteger nextId = new AtomicInteger();
 
@@ -79,12 +82,14 @@ public final class TomcatProtocolHandler implements ProtocolHandler {
         return false;
     }
 
-    @Override
+    // NB: Do not remove; required for Tomcat 8.0 and older.
+    @SuppressWarnings("unused")
     public boolean isCometSupported() {
         return false;
     }
 
-    @Override
+    // NB: Do not remove; required for Tomcat 8.0 and older.
+    @SuppressWarnings("unused")
     public boolean isCometTimeoutSupported() {
         return false;
     }
@@ -92,5 +97,21 @@ public final class TomcatProtocolHandler implements ProtocolHandler {
     @Override
     public boolean isSendfileSupported() {
         return false;
+    }
+
+    @Override
+    public void addSslHostConfig(SSLHostConfig sslHostConfig) {}
+
+    @Override
+    public SSLHostConfig[] findSslHostConfigs() {
+        return null;
+    }
+
+    @Override
+    public void addUpgradeProtocol(UpgradeProtocol upgradeProtocol) {}
+
+    @Override
+    public UpgradeProtocol[] findUpgradeProtocols() {
+        return null;
     }
 }

--- a/src/main/java/com/linecorp/armeria/server/http/tomcat/Tomcat85ProtocolHandler.java
+++ b/src/main/java/com/linecorp/armeria/server/http/tomcat/Tomcat85ProtocolHandler.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2015 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.http.tomcat;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.catalina.connector.Connector;
+import org.apache.coyote.Adapter;
+import org.apache.coyote.ProtocolHandler;
+import org.apache.coyote.UpgradeProtocol;
+import org.apache.tomcat.util.net.SSLHostConfig;
+
+/**
+ * A {@link ProtocolHandler} for Tomcat 8.5 and above.
+ * Do not use; loaded and instantiated by Tomcat via reflection.
+ */
+public final class Tomcat85ProtocolHandler implements ProtocolHandler {
+
+    private static final AtomicInteger nextId = new AtomicInteger();
+
+    private final int id = nextId.getAndIncrement();
+    private Adapter adapter;
+
+    @Override
+    public void setAdapter(Adapter adapter) {
+        this.adapter = adapter;
+    }
+
+    @Override
+    public Adapter getAdapter() {
+        return adapter;
+    }
+
+    /**
+     * Accessed by {@link Connector} via reflection.
+     */
+    public int getNameIndex() {
+        return id;
+    }
+
+    @Override
+    public Executor getExecutor() {
+        // Doesn't seem to be used.
+        return null;
+    }
+
+    @Override
+    public void init() throws Exception {}
+
+    @Override
+    public void start() throws Exception {}
+
+    @Override
+    public void pause() throws Exception {}
+
+    @Override
+    public void resume() throws Exception {}
+
+    @Override
+    public void stop() throws Exception {}
+
+    @Override
+    public void destroy() {}
+
+    @Override
+    public boolean isAprRequired() {
+        return false;
+    }
+
+    // NB: Do not remove; required for Tomcat 8.0 and older.
+    @SuppressWarnings("unused")
+    public boolean isCometSupported() {
+        return false;
+    }
+
+    // NB: Do not remove; required for Tomcat 8.0 and older.
+    @SuppressWarnings("unused")
+    public boolean isCometTimeoutSupported() {
+        return false;
+    }
+
+    @Override
+    public boolean isSendfileSupported() {
+        return false;
+    }
+
+    @Override
+    public void addSslHostConfig(SSLHostConfig sslHostConfig) {}
+
+    @Override
+    @SuppressWarnings("ZeroLengthArrayAllocation")
+    public SSLHostConfig[] findSslHostConfigs() {
+        return new SSLHostConfig[0];
+    }
+
+    @Override
+    public void addUpgradeProtocol(UpgradeProtocol upgradeProtocol) {}
+
+    @Override
+    @SuppressWarnings("ZeroLengthArrayAllocation")
+    public UpgradeProtocol[] findUpgradeProtocols() {
+        return new UpgradeProtocol[0];
+    }
+}

--- a/src/main/java/com/linecorp/armeria/server/http/tomcat/TomcatService.java
+++ b/src/main/java/com/linecorp/armeria/server/http/tomcat/TomcatService.java
@@ -45,29 +45,6 @@ public final class TomcatService extends HttpService {
 
     private static final Logger logger = LoggerFactory.getLogger(TomcatService.class);
 
-    private static final int TOMCAT_MAJOR_VERSION;
-
-    static {
-        final Pattern pattern = Pattern.compile("^([1-9][0-9]*)\\.");
-        final String version = ServerInfo.getServerNumber();
-        final Matcher matcher = pattern.matcher(version);
-        int tomcatMajorVersion = -1;
-        if (matcher.find()) {
-            try {
-                tomcatMajorVersion = Integer.parseInt(matcher.group(1));
-            } catch (NumberFormatException ignored) {
-                // Probably greater than Integer.MAX_VALUE
-            }
-        }
-
-        TOMCAT_MAJOR_VERSION = tomcatMajorVersion;
-        if (TOMCAT_MAJOR_VERSION > 0) {
-            logger.info("Tomcat version: {} (major: {})", version, TOMCAT_MAJOR_VERSION);
-        } else {
-            logger.info("Tomcat version: {} (major: unknown)", version);
-        }
-    }
-
     /**
      * Creates a new {@link TomcatService} with the web application at the root directory inside the
      * JAR/WAR/directory where the caller class is located at.
@@ -190,7 +167,7 @@ public final class TomcatService extends HttpService {
 
         buf.append("(serviceName: ");
         buf.append(serviceName);
-        if (TOMCAT_MAJOR_VERSION >= 8) {
+        if (TomcatVersion.major() >= 8) {
             buf.append(", catalinaBase: " + server.getCatalinaBase());
         }
         buf.append(')');

--- a/src/main/java/com/linecorp/armeria/server/http/tomcat/TomcatVersion.java
+++ b/src/main/java/com/linecorp/armeria/server/http/tomcat/TomcatVersion.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.http.tomcat;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.catalina.util.ServerInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+final class TomcatVersion {
+
+    private static final Logger logger = LoggerFactory.getLogger(TomcatVersion.class);
+
+    private static final int TOMCAT_MAJOR_VERSION;
+    private static final int TOMCAT_MINOR_VERSION;
+
+    static {
+        final Pattern pattern = Pattern.compile("^([1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.");
+        final String version = ServerInfo.getServerNumber();
+        final Matcher matcher = pattern.matcher(version);
+        int tomcatMajorVersion = -1;
+        int tomcatMinorVersion = -1;
+        if (matcher.find()) {
+            try {
+                tomcatMajorVersion = Integer.parseInt(matcher.group(1));
+                tomcatMinorVersion = Integer.parseInt(matcher.group(2));
+            } catch (NumberFormatException ignored) {
+                // Probably greater than Integer.MAX_VALUE
+            }
+        }
+
+        TOMCAT_MAJOR_VERSION = tomcatMajorVersion;
+        TOMCAT_MINOR_VERSION = tomcatMinorVersion;
+        if (TOMCAT_MAJOR_VERSION > 0) {
+            logger.info("Tomcat version: {} ({}.{})", version, TOMCAT_MAJOR_VERSION, TOMCAT_MINOR_VERSION);
+        } else {
+            logger.info("Tomcat version: {} (unknown)", version);
+        }
+    }
+
+    static int major() {
+        return TOMCAT_MAJOR_VERSION;
+    }
+
+    static int minor() {
+        return TOMCAT_MINOR_VERSION;
+    }
+
+    private TomcatVersion() {}
+}

--- a/src/site/sphinx/setup-gradle.rst
+++ b/src/site/sphinx/setup-gradle.rst
@@ -25,7 +25,7 @@ You might want to use the following  ``build.gradle`` as a starting point if you
         runtime group: 'ch.qos.logback', name: 'logback-classic', version: '\ |logback_version|\ '
 
         // Embedded Tomcat
-        [ "core", "jasper", "el", "logging-log4j" ].each { module ->
+        [ "core", "jasper", "el" ].each { module ->
             runtime group: 'org.apache.tomcat.embed', name: "tomcat-embed-$module", version: '\ |tomcat_version|\ '
         }
         runtime group: 'org.slf4j', name: 'log4j-over-slf4j', version: '\ |slf4j_version|\ '

--- a/src/site/sphinx/setup-maven.rst
+++ b/src/site/sphinx/setup-maven.rst
@@ -107,11 +107,6 @@ If you want to embed Tomcat into Armeria, you'll have to add the optional depend
           <version>${tomcat.version}</version>
         </dependency>
         <dependency>
-          <groupId>org.apache.tomcat.embed</groupId>
-          <artifactId>tomcat-embed-logging-log4j</artifactId>
-          <version>${tomcat.version}</version>
-        </dependency>
-        <dependency>
           <groupId>org.slf4j</groupId>
           <artifactId>log4j-over-slf4j</artifactId>
           <version>${slf4j.version}</version>


### PR DESCRIPTION
Motivation:

8.5.4 is the latest stable Tomcat version and Armeria's TomcatService does not
work with it.

Modifications:

- Replace TomcatProtocolHandler into two:
  - Tomcat80ProtocolHandler for Tomcat 7.5-8.0
  - Tomcat85ProtocolHandler for Tomcat 8.5
- Add the Groovy script that removes the ProtocolHandler methods newly
  added in 8.5 from Tomcat80ProtocolHandler so that it does not have the
  classes that do not exist in Tomcat 7.5-8.0 in method signatures
- Replace the direct Service.getContainer() calls with
  TomcatUtil.engine(Service) due to its method signature difference
  between 8.0 and 8.5
- Adapt to Tomcat's InputBuffer and OutputBuffer had signature changes
- Move the Tomcat version detection logic to TomcatVersion
- Fix an assertion error which occurs when ArmeriaWebResourceRoot is
  used with Tomcat 8.5
- Update documentation

Result:

Works with Tomcat 7.5, 8.0 and 8.5