### PR TITLE
Update dependencies to their latest stable versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     <jetty.version>9.3.10.v20160621</jetty.version>
     <logback.version>1.1.7</logback.version>
     <metrics.version>3.1.2</metrics.version>
-    <netty.version>4.1.2.Final</netty.version>
+    <netty.version>4.1.3.Final</netty.version>
     <slf4j.version>1.7.21</slf4j.version>
     <tomcat.version>8.0.36</tomcat.version>
     <jetty.alpnAgent.version>2.0.3</jetty.alpnAgent.version>
@@ -138,14 +138,14 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative-boringssl-static</artifactId>
-      <version>1.1.33.Fork18</version>
+      <version>1.1.33.Fork19</version>
     </dependency>
 
     <!-- ALPN -->
     <dependency>
       <groupId>org.eclipse.jetty.alpn</groupId>
       <artifactId>alpn-api</artifactId>
-      <version>1.1.2.v20150522</version>
+      <version>1.1.3.v20160715</version>
       <scope>provided</scope>
     </dependency>
 
@@ -287,7 +287,7 @@
     <dependency>
       <groupId>org.jmock</groupId>
       <artifactId>jmock-junit4</artifactId>
-      <version>2.8.1</version>
+      <version>2.8.2</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -311,7 +311,7 @@
     <dependency>
       <groupId>net.javacrumbs.json-unit</groupId>
       <artifactId>json-unit</artifactId>
-      <version>1.7.0</version>
+      <version>1.13.0</version>
       <scope>test</scope>
     </dependency>
 
@@ -379,7 +379,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.4.1.Final</version>
+        <version>1.5.0.Final</version>
       </extension>
     </extensions>
     <plugins>
@@ -516,7 +516,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
-        <version>1.9.1</version>
+        <version>1.11</version>
         <executions>
           <execution>
             <id>add-thrift-main-sources</id>
@@ -546,7 +546,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.3</version>
+        <version>3.5.1</version>
         <configuration>
           <excludes>
             <exclude>**/package-info.java</exclude>
@@ -555,7 +555,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.19</version>
+        <version>2.19.1</version>
         <configuration>
           <includes>
             <include>**/*Test*.java</include>
@@ -571,11 +571,11 @@
       </plugin>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>2.6</version>
+        <version>3.0.2</version>
       </plugin>
       <plugin>
         <artifactId>maven-source-plugin</artifactId>
-        <version>2.4</version>
+        <version>3.0.1</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -619,7 +619,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
-        <version>3.4</version>
+        <version>3.5.1</version>
       </plugin>
     </plugins>
   </build>
@@ -630,7 +630,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-project-info-reports-plugin</artifactId>
-        <version>2.8.1</version>
+        <version>2.9</version>
         <reportSets>
           <reportSet>
             <reports />
@@ -640,7 +640,7 @@
       <!-- Generate the API documentation -->
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.10.3</version>
+        <version>2.10.4</version>
         <reportSets>
           <reportSet>
             <reports>


### PR DESCRIPTION
- Netty 4.1.3
- Netty TCNative (BoringSSL static) 1.1.33.Fork19
- Jetty ALPN API 1.1.3.v20150715
- jMock 2.8.2
- json-unit 1.13.0
- Maven plugins
  - os-maven-plugin 1.5.0
  - build-helper-maven-plugin 1.11
  - maven-compiler-plugin 3.5.1
  - maven-surefire-plugin 2.19.1
  - maven-jar-plugin 3.0.2
  - maven-source-plugin 3.0.1
  - maven-site-plugin 3.5.1
  - maven-project-info-reports-plugin 2.9
  - maven-javadoc-plugin 2.10.4