### PR TITLE
Add an area to send additional HTTP Headers when requesting from DocService

### DIFF
--- a/src/main/java/com/linecorp/armeria/server/docs/Specification.java
+++ b/src/main/java/com/linecorp/armeria/server/docs/Specification.java
@@ -38,7 +38,8 @@ import com.linecorp.armeria.server.thrift.THttpService;
 class Specification {
 
     static Specification forServiceConfigs(Iterable<ServiceConfig> serviceConfigs,
-                                           Map<Class<?>, ? extends TBase<?, ?>> sampleRequests) {
+                                           Map<Class<?>, ? extends TBase<?, ?>> sampleRequests,
+                                           Map<Class<?>, Map<String, String>> sampleHttpHeaders) {
 
         final Map<Class<?>, Iterable<EndpointInfo>> map = new LinkedHashMap<>();
 
@@ -58,18 +59,20 @@ class Specification {
             });
         }
 
-        return forServiceClasses(map, sampleRequests);
+        return forServiceClasses(map, sampleRequests, sampleHttpHeaders);
     }
 
     static Specification forServiceClasses(Map<Class<?>, Iterable<EndpointInfo>> map,
-                                           Map<Class<?>, ? extends TBase<?, ?>> sampleRequests) {
+                                           Map<Class<?>, ? extends TBase<?, ?>> sampleRequests,
+                                           Map<Class<?>, Map<String, String>> sampleHttpHeaders) {
         requireNonNull(map, "map");
 
         final List<ServiceInfo> services = new ArrayList<>(map.size());
         final Set<ClassInfo> classes = new HashSet<>();
         map.forEach((serviceClass, endpoints) -> {
             try {
-                final ServiceInfo service = ServiceInfo.of(serviceClass, endpoints, sampleRequests);
+                final ServiceInfo service = ServiceInfo.of(
+                        serviceClass, endpoints, sampleRequests, sampleHttpHeaders.get(serviceClass));
                 services.add(service);
                 classes.addAll(service.classes().values());
             } catch (ClassNotFoundException e) {

--- a/src/main/resources/com/linecorp/armeria/server/docs/assets/css/armeria.css
+++ b/src/main/resources/com/linecorp/armeria/server/docs/assets/css/armeria.css
@@ -167,6 +167,13 @@ label {
   min-height: 256px;
 }
 
+.debug-httpheaders {
+  width: 100%;
+  max-width: 100%;
+  font-size: 90%;
+  min-height: 120px;
+}
+
 .debug-submit {
   margin-top: 8px;
 }

--- a/src/main/resources/com/linecorp/armeria/server/docs/assets/css/armeria.css
+++ b/src/main/resources/com/linecorp/armeria/server/docs/assets/css/armeria.css
@@ -167,11 +167,15 @@ label {
   min-height: 256px;
 }
 
-.debug-httpheaders {
+.debug-http-headers {
   width: 100%;
   max-width: 100%;
   font-size: 90%;
-  min-height: 120px;
+  min-height: 140px;
+}
+
+.debug-http-headers-collapser.opened:after {
+  content: ': ';
 }
 
 .debug-submit {

--- a/src/main/resources/com/linecorp/armeria/server/docs/assets/js/armeria.js
+++ b/src/main/resources/com/linecorp/armeria/server/docs/assets/js/armeria.js
@@ -179,9 +179,11 @@ $(function () {
 
     var submitDebugRequest = function () {
       var args;
-      var httpHeaders;
+      var httpHeaders = {};
       try {
-        httpHeaders = JSON.parse(debugHttpHeadersText.val());
+        if (debugHttpHeadersText.val()) {
+          httpHeaders = JSON.parse(debugHttpHeadersText.val());
+        }
         args = JSON.parse(debugText.val());
       } catch (e) {
         debugResponse.text("Failed to parse a JSON object, please check your request:\n" + e);
@@ -203,7 +205,10 @@ $(function () {
           hljs.highlightBlock(debugResponse.get(0));
           var uri = URI(window.location.href);
           var fragment = uri.fragment(true);
-          fragment.setQuery('req', debugText.val());
+          fragment.setQuery({
+            req: debugText.val(),
+            httpHeaders: debugHttpHeadersText.val()
+          });
           window.location.href = uri.toString();
         },
         error: function (jqXHR, textStatus, errorThrown) {
@@ -218,6 +223,9 @@ $(function () {
 
     var fragment = URI(window.location.href).fragment(true);
     var fragmentParams = fragment.query(true);
+    if ("httpHeaders" in fragmentParams) {
+      debugHttpHeadersText.val(fragmentParams.httpHeaders);
+    }
     if (fragmentParams.req) {
       debugText.val(fragmentParams.req);
       submitDebugRequest();

--- a/src/main/resources/com/linecorp/armeria/server/docs/assets/js/armeria.js
+++ b/src/main/resources/com/linecorp/armeria/server/docs/assets/js/armeria.js
@@ -174,11 +174,14 @@ $(function () {
     }));
 
     var debugText = functionContainer.find('.debug-textarea').val(functionInfo.sampleJsonRequest);
+    var debugHttpHeadersText = functionContainer.find('.debug-httpheaders');
     var debugResponse = functionContainer.find('.debug-response code');
 
     var submitDebugRequest = function () {
       var args;
+      var httpHeaders;
       try {
+        httpHeaders = JSON.parse(debugHttpHeadersText.val());
         args = JSON.parse(debugText.val());
       } catch (e) {
         debugResponse.text("Failed to parse a JSON object, please check your request:\n" + e);
@@ -193,6 +196,7 @@ $(function () {
         type: 'POST',
         url: serviceInfo.debugPath,
         data: JSON.stringify(request),
+        headers: httpHeaders,
         contentType: TTEXT_MIME_TYPE,
         success: function (response) {
           debugResponse.text(response);

--- a/src/main/resources/com/linecorp/armeria/server/docs/assets/js/armeria.js
+++ b/src/main/resources/com/linecorp/armeria/server/docs/assets/js/armeria.js
@@ -250,7 +250,7 @@ $(function () {
         debugHttpHeadersText.val(''); // Remove the default value if set
       }
 
-      submitDebugRequest();
+      functionContainer.find('.debug-submit').focus();
     }
 
     // Open debug-http-headers section when a value is set

--- a/src/main/resources/com/linecorp/armeria/server/docs/assets/js/armeria.js
+++ b/src/main/resources/com/linecorp/armeria/server/docs/assets/js/armeria.js
@@ -250,7 +250,7 @@ $(function () {
         debugHttpHeadersText.val(''); // Remove the default value if set
       }
 
-      functionContainer.find('.debug-submit').focus();
+      functionContainer.find('.debug-textarea').focus();
     }
 
     // Open debug-http-headers section when a value is set

--- a/src/main/resources/com/linecorp/armeria/server/docs/assets/js/armeria.js
+++ b/src/main/resources/com/linecorp/armeria/server/docs/assets/js/armeria.js
@@ -174,7 +174,7 @@ $(function () {
     }));
 
     var debugText = functionContainer.find('.debug-textarea').val(functionInfo.sampleJsonRequest);
-    var debugHttpHeadersText = functionContainer.find('.debug-httpheaders');
+    var debugHttpHeadersText = functionContainer.find('.debug-httpheaders').val(serviceInfo.sampleHttpHeaders);
     var debugResponse = functionContainer.find('.debug-response code');
 
     var submitDebugRequest = function () {

--- a/src/main/resources/com/linecorp/armeria/server/docs/assets/js/armeria.js
+++ b/src/main/resources/com/linecorp/armeria/server/docs/assets/js/armeria.js
@@ -177,6 +177,12 @@ $(function () {
     var debugHttpHeadersText = functionContainer.find('.debug-httpheaders').val(serviceInfo.sampleHttpHeaders);
     var debugResponse = functionContainer.find('.debug-response code');
 
+    // handle 'debug-httpheaders' section
+    var collapser = functionContainer.find('.debug-httpheaders-collapser');
+    collapser.click(function() {
+      $(this).next().collapse('toggle');
+    });
+
     var submitDebugRequest = function () {
       var args;
       var httpHeaders = {};
@@ -225,6 +231,9 @@ $(function () {
     var fragmentParams = fragment.query(true);
     if ("httpHeaders" in fragmentParams) {
       debugHttpHeadersText.val(fragmentParams.httpHeaders);
+      if (fragmentParams.httpHeaders) { // unhide by default when headers are given from URL
+        collapser.next().collapse('toggle');
+      }
     }
     if (fragmentParams.req) {
       debugText.val(fragmentParams.req);

--- a/src/main/resources/com/linecorp/armeria/server/docs/index.html
+++ b/src/main/resources/com/linecorp/armeria/server/docs/index.html
@@ -175,6 +175,10 @@
                 <textarea class="debug-textarea form-control code">{&#10;&#32;&#32;"": ""&#10;}&#10;</textarea>
               </div>
               <div>
+                <label>HTTP Headers as a JSON object:</label>
+                <textarea class="debug-httpheaders form-control code">{&#10;&#10;}&#10;</textarea>
+              </div>
+              <div>
                 <button class="debug-submit btn btn-primary">Submit to: <code>{{{serviceDebugPath}}}</code></button>
               </div>
             </div>

--- a/src/main/resources/com/linecorp/armeria/server/docs/index.html
+++ b/src/main/resources/com/linecorp/armeria/server/docs/index.html
@@ -175,9 +175,9 @@
                 <textarea class="debug-textarea form-control code">{&#10;&#32;&#32;"": ""&#10;}&#10;</textarea>
               </div>
               <div>
-                <a class="debug-httpheaders-collapser" data-toggle="collapse">Edit additional HTTP Headers:</a>
+                <a class="btn btn-link debug-http-headers-collapser" data-toggle="collapse">Edit additional HTTP Headers</a>
                 <div class="collapse">
-                  <textarea class="debug-httpheaders form-control code">{&#10;&#10;}&#10;</textarea>
+                  <textarea class="debug-http-headers form-control code">{&#10;&#10;}&#10;</textarea>
                 </div>
               </div>
               <div>

--- a/src/main/resources/com/linecorp/armeria/server/docs/index.html
+++ b/src/main/resources/com/linecorp/armeria/server/docs/index.html
@@ -175,8 +175,10 @@
                 <textarea class="debug-textarea form-control code">{&#10;&#32;&#32;"": ""&#10;}&#10;</textarea>
               </div>
               <div>
-                <label>HTTP Headers as a JSON object:</label>
-                <textarea class="debug-httpheaders form-control code">{&#10;&#10;}&#10;</textarea>
+                <a class="debug-httpheaders-collapser" data-toggle="collapse">Edit additional HTTP Headers:</a>
+                <div class="collapse">
+                  <textarea class="debug-httpheaders form-control code">{&#10;&#10;}&#10;</textarea>
+                </div>
               </div>
               <div>
                 <button class="debug-submit btn btn-primary">Submit to: <code>{{{serviceDebugPath}}}</code></button>

--- a/src/test/java/com/linecorp/armeria/server/docs/ServiceInfoTest.java
+++ b/src/test/java/com/linecorp/armeria/server/docs/ServiceInfoTest.java
@@ -18,8 +18,10 @@ package com.linecorp.armeria.server.docs;
 
 import static net.javacrumbs.jsonunit.JsonAssert.assertJsonEquals;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
@@ -49,7 +51,8 @@ public class ServiceInfoTest {
                                                        EnumSet.of(SerializationFormat.THRIFT_BINARY)),
                                        EndpointInfo.of("*", "/debug/foo", SerializationFormat.THRIFT_TEXT,
                                                        EnumSet.of(SerializationFormat.THRIFT_TEXT))),
-                               ImmutableMap.of(bar3_args.class, new bar3_args().setIntVal(10)));
+                               ImmutableMap.of(bar3_args.class, new bar3_args().setIntVal(10)),
+                               ImmutableMap.of("foobar", "barbaz"));
 
         assertThat(service.endpoints(), hasSize(2));
         // Should be sorted alphabetically
@@ -100,5 +103,9 @@ public class ServiceInfoTest {
         assertThat(bar5.returnType(), is(MapInfo.of(string, foo)));
         assertThat(bar5.exceptions().size(), is(1));
         assertEquals("", bar5.sampleJsonRequest());
+
+        final String sampleHttpHeaders = service.sampleHttpHeaders();
+        assertThat(sampleHttpHeaders, notNullValue());
+        assertThat(sampleHttpHeaders, equalTo("{\n  \"foobar\" : \"barbaz\"\n}"));
     }
 }

--- a/src/test/java/com/linecorp/armeria/server/docs/SpecificationTest.java
+++ b/src/test/java/com/linecorp/armeria/server/docs/SpecificationTest.java
@@ -40,8 +40,8 @@ public class SpecificationTest {
 
     @Test
     public void servicesTest() throws Exception {
-        final Specification specification =
-                Specification.forServiceConfigs(Arrays.asList(
+        final Specification specification = Specification.forServiceConfigs(
+                Arrays.asList(
                         new ServiceConfig(
                                 new VirtualHostBuilder().build(),
                                 PathMapping.ofExact("/hello"),
@@ -51,7 +51,8 @@ public class SpecificationTest {
                                 PathMapping.ofExact("/foo"),
                                 THttpService.ofFormats(mock(FooService.AsyncIface.class),
                                                        SerializationFormat.THRIFT_COMPACT))),
-                                                Collections.emptyMap());
+                Collections.emptyMap(),
+                Collections.emptyMap());
 
         final Map<String, ServiceInfo> services = specification.services();
         assertThat(services.size(), is(2));


### PR DESCRIPTION
Motivation:

Sometimes a service can use additional HTTP Headers when processing requests, but it is not possible to do that with the current DocService.

Modifications:

* Add an area in DocService to add additional HTTP Headers when calling APIs from DocService
* Make DocService take service-to-sampleHttpHeaders from its constructor