### PR TITLE
Set serverPort of coyote request in addition to local port.

### DIFF
--- a/src/main/java/com/linecorp/armeria/server/http/tomcat/TomcatService.java
+++ b/src/main/java/com/linecorp/armeria/server/http/tomcat/TomcatService.java
@@ -430,6 +430,7 @@ public final class TomcatService implements HttpService {
         coyoteReq.localName().setString(hostname);
         coyoteReq.serverName().setString(hostname);
         coyoteReq.setLocalPort(localAddr.getPort());
+        coyoteReq.setServerPort(localAddr.getPort());
 
         // Set the method.
         final HttpMethod method = req.method();


### PR DESCRIPTION
Tomcat (or maybe spring) uses server port, not local port, for things like returning a port number to a client (e.g., when returning Location headers for 302 redirects).

Without setting server port, it is defaulted to 80, so http://localhost:9000/ would try to redirect to http://localhost/foo, not http://localhost:9000/foo

I'm not too sure on this, but from my reading here
http://stackoverflow.com/questions/2184286/difference-between-getlocalport-and-getserverport-in-servlets

the only time serverPort and localPort would be different is if using apache with tomcat's native AJP java protocol, not http proxying (I'm not aware of any proxy http header that transmits a port number). Since this is rare nowadays, forcing local and server port to be the same seems fine, though a followup could allow this to be configurable if someone wants it to be.

Fixes #210 