### PR TITLE
Use Host header to populate serverName and serverPort, like Tomcat does.

### DIFF
--- a/src/main/java/com/linecorp/armeria/server/http/HttpServerHandler.java
+++ b/src/main/java/com/linecorp/armeria/server/http/HttpServerHandler.java
@@ -240,6 +240,12 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
             return;
         }
 
+        if (headers.authority() == null) {
+            // HTTP/1.1 requests require a host header.
+            respond(ctx, req, HttpStatus.BAD_REQUEST);
+            return;
+        }
+
         final String hostname = hostname(headers);
         final VirtualHost host = config.findVirtualHost(hostname);
 
@@ -334,9 +340,6 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
 
     private static String hostname(HttpHeaders headers) {
         final CharSequence hostname = headers.authority();
-        if (hostname == null) {
-            return "";
-        }
 
         final String hostnameStr = hostname.toString();
         final int hostnameColonIdx = hostnameStr.lastIndexOf(':');

--- a/src/test/resources/tomcat_service/addrs_and_ports.jsp
+++ b/src/test/resources/tomcat_service/addrs_and_ports.jsp
@@ -7,6 +7,7 @@
 <p>LocalAddr: <%= request.getLocalAddr() %></p>
 <p>LocalName: <%= request.getLocalName() %></p>
 <p>LocalPort: <%= request.getLocalPort() %></p>
+<p>ServerName: <%= request.getServerName() %></p>
 <p>ServerPort: <%= request.getServerPort() %></p>
 </body>
 </html>


### PR DESCRIPTION
I realized that the previous fix wasn't really a fix, and that my intuition of headers not including port information was wrong - of course the Host header existed.

Found the code in tomcat that populates serverName/port by host header, so mimicing it here was the correct solution.

https://github.com/apache/tomcat/blob/trunk/java/org/apache/coyote/http11/Http11Processor.java#L1670