### PR TITLE
Fix RequestContext propagation and callback invocation

### DIFF
--- a/src/main/java/com/linecorp/armeria/client/ClientRequestContextWrapper.java
+++ b/src/main/java/com/linecorp/armeria/client/ClientRequestContextWrapper.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import java.time.Duration;
+
+import com.linecorp.armeria.common.RequestContextWrapper;
+
+public class ClientRequestContextWrapper
+        extends RequestContextWrapper<ClientRequestContext> implements ClientRequestContext {
+
+    protected ClientRequestContextWrapper(ClientRequestContext delegate) {
+        super(delegate);
+    }
+
+    @Override
+    public Endpoint endpoint() {
+        return delegate().endpoint();
+    }
+
+    @Override
+    public ClientOptions options() {
+        return delegate().options();
+    }
+
+    @Override
+    public long writeTimeoutMillis() {
+        return delegate().writeTimeoutMillis();
+    }
+
+    @Override
+    public void setWriteTimeoutMillis(long writeTimeoutMillis) {
+        delegate().setWriteTimeoutMillis(writeTimeoutMillis);
+    }
+
+    @Override
+    public void setWriteTimeout(Duration writeTimeout) {
+        delegate().setWriteTimeout(writeTimeout);
+    }
+
+    @Override
+    public long responseTimeoutMillis() {
+        return delegate().responseTimeoutMillis();
+    }
+
+    @Override
+    public void setResponseTimeoutMillis(long responseTimeoutMillis) {
+        delegate().setResponseTimeoutMillis(responseTimeoutMillis);
+    }
+
+    @Override
+    public void setResponseTimeout(Duration responseTimeout) {
+        delegate().setResponseTimeout(responseTimeout);
+    }
+
+    @Override
+    public long maxResponseLength() {
+        return delegate().maxResponseLength();
+    }
+
+    @Override
+    public void setMaxResponseLength(long maxResponseLength) {
+        delegate().setMaxResponseLength(maxResponseLength);
+    }
+}

--- a/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -21,7 +21,7 @@ import static java.util.Objects.requireNonNull;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 
-import com.linecorp.armeria.common.AbstractRequestContext;
+import com.linecorp.armeria.common.NonWrappingRequestContext;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.http.DefaultHttpHeaders;
 import com.linecorp.armeria.common.http.HttpHeaders;
@@ -38,7 +38,8 @@ import io.netty.channel.EventLoop;
 /**
  * Default {@link ClientRequestContext} implementation.
  */
-public final class DefaultClientRequestContext extends AbstractRequestContext implements ClientRequestContext {
+public final class DefaultClientRequestContext extends NonWrappingRequestContext
+        implements ClientRequestContext {
 
     private final EventLoop eventLoop;
     private final ClientOptions options;

--- a/src/main/java/com/linecorp/armeria/client/UserClient.java
+++ b/src/main/java/com/linecorp/armeria/client/UserClient.java
@@ -20,6 +20,8 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import com.linecorp.armeria.common.Request;
+import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.common.RequestContext.PushHandle;
 import com.linecorp.armeria.common.Response;
 import com.linecorp.armeria.common.SessionProtocol;
 
@@ -74,7 +76,7 @@ public abstract class UserClient<T, I extends Request, O extends Response> imple
 
         final ClientRequestContext ctx = new DefaultClientRequestContext(
                 eventLoop, sessionProtocol, endpoint, method, path, options, req);
-        try {
+        try (PushHandle ignored = RequestContext.push(ctx)) {
             return delegate().execute(ctx, req);
         } catch (Throwable cause) {
             ctx.responseLogBuilder().end(cause);

--- a/src/main/java/com/linecorp/armeria/common/NonWrappingRequestContext.java
+++ b/src/main/java/com/linecorp/armeria/common/NonWrappingRequestContext.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import com.linecorp.armeria.internal.DefaultAttributeMap;
+
+import io.netty.util.Attribute;
+import io.netty.util.AttributeKey;
+
+/**
+ * Default {@link RequestContext} implementation.
+ */
+public abstract class NonWrappingRequestContext extends AbstractRequestContext {
+
+    private final DefaultAttributeMap attrs = new DefaultAttributeMap();
+    private final SessionProtocol sessionProtocol;
+    private final String method;
+    private final String path;
+    private final Object request;
+    private List<Runnable> onEnterCallbacks;
+    private List<Runnable> onExitCallbacks;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param sessionProtocol the {@link SessionProtocol} of the invocation
+     * @param request the request associated with this context
+     */
+    protected NonWrappingRequestContext(
+            SessionProtocol sessionProtocol, String method, String path, Object request) {
+        this.sessionProtocol = sessionProtocol;
+        this.method = method;
+        this.path = path;
+        this.request = request;
+    }
+
+    @Override
+    public final SessionProtocol sessionProtocol() {
+        return sessionProtocol;
+    }
+
+    @Override
+    public final String method() {
+        return method;
+    }
+
+    @Override
+    public final String path() {
+        return path;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public final <T> T request() {
+        return (T) request;
+    }
+
+    @Override
+    public <T> Attribute<T> attr(AttributeKey<T> key) {
+        return attrs.attr(key);
+    }
+
+    @Override
+    public <T> boolean hasAttr(AttributeKey<T> key) {
+        return attrs.hasAttr(key);
+    }
+
+    @Override
+    public Iterator<Attribute<?>> attrs() {
+        return attrs.attrs();
+    }
+
+    @Override
+    public final void onEnter(Runnable callback) {
+        if (onEnterCallbacks == null) {
+            onEnterCallbacks = new ArrayList<>(4);
+        }
+        onEnterCallbacks.add(callback);
+    }
+
+    @Override
+    public final void onExit(Runnable callback) {
+        if (onExitCallbacks == null) {
+            onExitCallbacks = new ArrayList<>(4);
+        }
+        onExitCallbacks.add(callback);
+    }
+
+    @Override
+    public void invokeOnEnterCallbacks() {
+        final List<Runnable> onEnterCallbacks = this.onEnterCallbacks;
+        if (onEnterCallbacks != null) {
+            onEnterCallbacks.forEach(Runnable::run);
+        }
+    }
+
+    @Override
+    public void invokeOnExitCallbacks() {
+        final List<Runnable> onExitCallbacks = this.onExitCallbacks;
+        if (onExitCallbacks != null) {
+            onExitCallbacks.forEach(Runnable::run);
+        }
+    }
+}

--- a/src/main/java/com/linecorp/armeria/common/RequestContextWrapper.java
+++ b/src/main/java/com/linecorp/armeria/common/RequestContextWrapper.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Iterator;
+import java.util.concurrent.CompletableFuture;
+
+import com.linecorp.armeria.common.logging.RequestLog;
+import com.linecorp.armeria.common.logging.RequestLogBuilder;
+import com.linecorp.armeria.common.logging.ResponseLog;
+import com.linecorp.armeria.common.logging.ResponseLogBuilder;
+
+import io.netty.channel.EventLoop;
+import io.netty.util.Attribute;
+import io.netty.util.AttributeKey;
+
+public abstract class RequestContextWrapper<T extends RequestContext> extends AbstractRequestContext {
+
+    private final T delegate;
+
+    protected RequestContextWrapper(T delegate) {
+        this.delegate = requireNonNull(delegate, "delegate");
+    }
+
+    protected final T delegate() {
+        return delegate;
+    }
+
+    @Override
+    public SessionProtocol sessionProtocol() {
+        return delegate().sessionProtocol();
+    }
+
+    @Override
+    public String method() {
+        return delegate().method();
+    }
+
+    @Override
+    public String path() {
+        return delegate().path();
+    }
+
+    @Override
+    public <T> T request() {
+        return delegate().request();
+    }
+
+    @Override
+    public RequestLogBuilder requestLogBuilder() {
+        return delegate().requestLogBuilder();
+    }
+
+    @Override
+    public ResponseLogBuilder responseLogBuilder() {
+        return delegate().responseLogBuilder();
+    }
+
+    @Override
+    public CompletableFuture<RequestLog> requestLogFuture() {
+        return delegate().requestLogFuture();
+    }
+
+    @Override
+    public CompletableFuture<ResponseLog> responseLogFuture() {
+        return delegate().responseLogFuture();
+    }
+
+    @Override
+    public Iterator<Attribute<?>> attrs() {
+        return delegate().attrs();
+    }
+
+    @Override
+    public EventLoop eventLoop() {
+        return delegate().eventLoop();
+    }
+
+    @Override
+    public void onEnter(Runnable callback) {
+        delegate().onEnter(callback);
+    }
+
+    @Override
+    public void onExit(Runnable callback) {
+        delegate().onExit(callback);
+    }
+
+    @Override
+    public void invokeOnEnterCallbacks() {
+        delegate().invokeOnEnterCallbacks();
+    }
+
+    @Override
+    public void invokeOnExitCallbacks() {
+        delegate().invokeOnExitCallbacks();
+    }
+
+    @Override
+    public <V> Attribute<V> attr(AttributeKey<V> key) {
+        return delegate().attr(key);
+    }
+
+    @Override
+    public <V> boolean hasAttr(AttributeKey<V> key) {
+        return delegate().hasAttr(key);
+    }
+}

--- a/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
+++ b/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
@@ -26,7 +26,7 @@ import java.util.concurrent.ExecutorService;
 
 import org.slf4j.Logger;
 
-import com.linecorp.armeria.common.AbstractRequestContext;
+import com.linecorp.armeria.common.NonWrappingRequestContext;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.logging.DefaultRequestLog;
 import com.linecorp.armeria.common.logging.DefaultResponseLog;
@@ -41,7 +41,8 @@ import io.netty.channel.EventLoop;
 /**
  * Default {@link ServiceRequestContext} implementation.
  */
-public final class DefaultServiceRequestContext extends AbstractRequestContext implements ServiceRequestContext {
+public final class DefaultServiceRequestContext extends NonWrappingRequestContext
+        implements ServiceRequestContext {
 
     private final Channel ch;
     private final ServiceConfig cfg;

--- a/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
+++ b/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
@@ -16,48 +16,19 @@
 
 package com.linecorp.armeria.server;
 
-import static java.util.Objects.requireNonNull;
-
 import java.net.SocketAddress;
 import java.time.Duration;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 
 import org.slf4j.Logger;
 
-import com.linecorp.armeria.common.AbstractRequestContext;
-import com.linecorp.armeria.common.logging.RequestLog;
-import com.linecorp.armeria.common.logging.RequestLogBuilder;
-import com.linecorp.armeria.common.logging.ResponseLog;
-import com.linecorp.armeria.common.logging.ResponseLogBuilder;
+import com.linecorp.armeria.common.RequestContextWrapper;
 
-import io.netty.channel.EventLoop;
-import io.netty.util.Attribute;
-import io.netty.util.AttributeKey;
-
-public class ServiceRequestContextWrapper extends AbstractRequestContext implements ServiceRequestContext {
-
-    private final ServiceRequestContext delegate;
+public class ServiceRequestContextWrapper
+        extends RequestContextWrapper<ServiceRequestContext> implements ServiceRequestContext {
 
     protected ServiceRequestContextWrapper(ServiceRequestContext delegate) {
-        super(requireNonNull(delegate, "delegate").sessionProtocol(),
-              delegate.method(), delegate.path(), delegate.request());
-
-        this.delegate = delegate;
-    }
-
-    protected final ServiceRequestContext delegate() {
-        return delegate;
-    }
-
-    @Override
-    public ExecutorService blockingTaskExecutor() {
-        return delegate().blockingTaskExecutor();
-    }
-
-    @Override
-    public String mappedPath() {
-        return delegate().mappedPath();
+        super(delegate);
     }
 
     @Override
@@ -76,6 +47,11 @@ public class ServiceRequestContextWrapper extends AbstractRequestContext impleme
     }
 
     @Override
+    public ExecutorService blockingTaskExecutor() {
+        return delegate().blockingTaskExecutor();
+    }
+
+    @Override
     public <A extends SocketAddress> A remoteAddress() {
         return delegate().remoteAddress();
     }
@@ -83,6 +59,11 @@ public class ServiceRequestContextWrapper extends AbstractRequestContext impleme
     @Override
     public <A extends SocketAddress> A localAddress() {
         return delegate().localAddress();
+    }
+
+    @Override
+    public String mappedPath() {
+        return delegate().mappedPath();
     }
 
     @Override
@@ -113,45 +94,5 @@ public class ServiceRequestContextWrapper extends AbstractRequestContext impleme
     @Override
     public void setMaxRequestLength(long maxRequestLength) {
         delegate().setMaxRequestLength(maxRequestLength);
-    }
-
-    @Override
-    public EventLoop eventLoop() {
-        return delegate().eventLoop();
-    }
-
-    @Override
-    public <T> Attribute<T> attr(AttributeKey<T> key) {
-        return delegate().attr(key);
-    }
-
-    @Override
-    public <T> boolean hasAttr(AttributeKey<T> key) {
-        return delegate().hasAttr(key);
-    }
-
-    @Override
-    public RequestLogBuilder requestLogBuilder() {
-        return delegate.requestLogBuilder();
-    }
-
-    @Override
-    public ResponseLogBuilder responseLogBuilder() {
-        return delegate.responseLogBuilder();
-    }
-
-    @Override
-    public CompletableFuture<RequestLog> requestLogFuture() {
-        return delegate.requestLogFuture();
-    }
-
-    @Override
-    public CompletableFuture<ResponseLog> responseLogFuture() {
-        return delegate.responseLogFuture();
-    }
-
-    @Override
-    public String toString() {
-        return delegate().toString();
     }
 }

--- a/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
+++ b/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
@@ -46,6 +46,8 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.net.MediaType;
 
+import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.common.RequestContext.PushHandle;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.http.AggregatedHttpMessage;
 import com.linecorp.armeria.common.http.HttpData;
@@ -456,7 +458,7 @@ public class THttpService extends AbstractHttpService {
         final ThriftReply reply;
         ctx.requestLogBuilder().attr(RequestLog.RPC_REQUEST).set(call);
 
-        try {
+        try (PushHandle ignored = RequestContext.push(ctx)) {
             reply = delegate.serve(ctx, call);
             ctx.responseLogBuilder().attr(ResponseLog.RPC_RESPONSE).set(reply);
         } catch (Throwable cause) {

--- a/src/main/java/com/linecorp/armeria/server/thrift/ThriftCallService.java
+++ b/src/main/java/com/linecorp/armeria/server/thrift/ThriftCallService.java
@@ -117,23 +117,21 @@ public class ThriftCallService implements Service<ThriftCall, ThriftReply> {
             ThriftFunction func, TBase<TBase<?, ?>, TFieldIdEnum> args, ThriftReply reply) throws TException {
 
         final AsyncProcessFunction<Object, TBase<TBase<?, ?>, TFieldIdEnum>, Object> f = func.asyncFunc();
-        try (PushHandle ignored = RequestContext.push(ctx)) {
-            f.start(implementation, args, new AsyncMethodCallback<Object>() {
-                @Override
-                public void onComplete(Object response) {
-                    if (func.isOneway()) {
-                        reply.complete(null);
-                    } else {
-                        reply.complete(response);
-                    }
+        f.start(implementation, args, new AsyncMethodCallback<Object>() {
+            @Override
+            public void onComplete(Object response) {
+                if (func.isOneway()) {
+                    reply.complete(null);
+                } else {
+                    reply.complete(response);
                 }
+            }
 
-                @Override
-                public void onError(Exception e) {
-                    reply.completeExceptionally(e);
-                }
-            });
-        }
+            @Override
+            public void onError(Exception e) {
+                reply.completeExceptionally(e);
+            }
+        });
     }
 
     private void invokeSynchronously(

--- a/src/main/java/com/linecorp/armeria/server/tracing/AbstractTracingService.java
+++ b/src/main/java/com/linecorp/armeria/server/tracing/AbstractTracingService.java
@@ -74,7 +74,6 @@ public abstract class AbstractTracingService<I extends Request, O extends Respon
         try {
             final O res = delegate().serve(ctx, req);
             if (sampled) {
-
                 ctx.requestLogFuture().thenAcceptBoth(
                         res.closeFuture(),
                         (log, unused) -> serverInterceptor.closeSpan(serverSpan, createResponseAdapter(ctx, log, res)))

--- a/src/test/java/com/linecorp/armeria/common/RequestContextTest.java
+++ b/src/test/java/com/linecorp/armeria/common/RequestContextTest.java
@@ -78,7 +78,6 @@ public class RequestContextTest {
     private final AtomicBoolean entered = new AtomicBoolean();
 
     @Test
-    @Ignore("Ignore until https://github.com/netty/netty/issues/5507 is fixed.")
     public void contextAwareEventExecutor() throws Exception {
         EventLoop eventLoop = new DefaultEventLoop();
         when(channel.eventLoop()).thenReturn(eventLoop);
@@ -183,7 +182,7 @@ public class RequestContextTest {
     @Test
     public void contextPropagationSameContextAlreadySet() {
         final RequestContext context = createContext();
-        try (PushHandle ignored = RequestContext.push(context)) {
+        try (PushHandle ignored = RequestContext.push(context, false)) {
             context.makeContextAware(() -> {
                 assertEquals(context, RequestContext.current());
                 // Context was already correct, so handlers were not run (in real code they would already be
@@ -247,7 +246,7 @@ public class RequestContextTest {
         return ctx;
     }
 
-    private class DummyRequestContext extends AbstractRequestContext {
+    private class DummyRequestContext extends NonWrappingRequestContext {
         DummyRequestContext() {
             super(SessionProtocol.HTTP, "GET", "/", new DefaultHttpRequest());
         }

--- a/src/test/java/com/linecorp/armeria/it/logging/HttpTracingIntegrationTest.java
+++ b/src/test/java/com/linecorp/armeria/it/logging/HttpTracingIntegrationTest.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.it.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import org.apache.thrift.async.AsyncMethodCallback;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.github.kristofa.brave.Brave;
+import com.github.kristofa.brave.EmptySpanCollector;
+import com.github.kristofa.brave.Sampler;
+import com.twitter.zipkin.gen.Span;
+
+import com.linecorp.armeria.client.ClientBuilder;
+import com.linecorp.armeria.client.Clients;
+import com.linecorp.armeria.client.tracing.HttpTracingClient;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.http.HttpRequest;
+import com.linecorp.armeria.common.http.HttpResponse;
+import com.linecorp.armeria.server.AbstractServerTest;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.Service;
+import com.linecorp.armeria.server.thrift.THttpService;
+import com.linecorp.armeria.server.tracing.HttpTracingService;
+import com.linecorp.armeria.service.test.thrift.main.HelloService;
+import com.linecorp.armeria.service.test.thrift.main.HelloService.AsyncIface;
+
+public class HttpTracingIntegrationTest extends AbstractServerTest {
+
+    private static final SpanCollectorImpl spanCollector = new SpanCollectorImpl();
+
+    private HelloService.Iface fooClient;
+    private HelloService.Iface fooClientWithoutTracing;
+    private HelloService.AsyncIface barClient;
+    private HelloService.AsyncIface quxClient;
+
+    @Override
+    protected void configureServer(ServerBuilder sb) throws Exception {
+        sb.port(0, SessionProtocol.HTTP);
+
+        sb.serviceAt("/foo", decorate("service/foo", THttpService.of(
+                (AsyncIface) (name, resultHandler) ->
+                        barClient.hello("Miss. " + name, new DelegatingCallback(resultHandler)))));
+
+        sb.serviceAt("/bar", decorate("service/bar", THttpService.of(
+                (AsyncIface) (name, resultHandler) -> {
+                    if (name.startsWith("Miss. ")) {
+                        name = "Ms. " + name.substring(6);
+                    }
+                    quxClient.hello(name, new DelegatingCallback(resultHandler));
+                })));
+
+        sb.serviceAt("/qux", decorate("service/qux", THttpService.of(
+                (AsyncIface) (name, resultHandler) -> resultHandler.onComplete("Hello, " + name + '!'))));
+    }
+
+    @Before
+    public void setupClients() {
+        fooClient = new ClientBuilder("tbinary+" + uri("/foo"))
+                .decorator(HttpRequest.class, HttpResponse.class,
+                           HttpTracingClient.newDecorator(newBrave("client/foo")))
+                .build(HelloService.Iface.class);
+        fooClientWithoutTracing = Clients.newClient("tbinary+" + uri("/foo"), HelloService.Iface.class);
+        barClient = newClient("/bar");
+        quxClient = newClient("/qux");
+    }
+
+    @After
+    public void shouldHaveNoExtraSpans() {
+        assertThat(spanCollector.spans).isEmpty();
+    }
+
+    private static HttpTracingService decorate(String name, Service<HttpRequest, HttpResponse> service) {
+        return HttpTracingService.newDecorator(newBrave(name)).apply(service);
+    }
+
+    private static HelloService.AsyncIface newClient(String path) {
+        return new ClientBuilder("tbinary+" + uri(path))
+                .decorator(HttpRequest.class, HttpResponse.class,
+                           HttpTracingClient.newDecorator(newBrave("client" + path)))
+                .build(HelloService.AsyncIface.class);
+    }
+
+    private static Brave newBrave(String name) {
+        return new Brave.Builder(name).spanCollector(spanCollector)
+                                      .traceSampler(Sampler.ALWAYS_SAMPLE).build();
+    }
+
+    @Test(timeout = 10000)
+    public void testClientInitiatedTrace() throws Exception {
+        assertThat(fooClient.hello("Lee")).isEqualTo("Hello, Ms. Lee!");
+
+        final Span[] spans = spanCollector.take(6);
+        final long traceId = spans[0].getTrace_id();
+        assertThat(spans).allMatch(s -> s.getTrace_id() == traceId);
+
+        // client/foo and service/foo should have no parents.
+        assertThat(spans[0].getParent_id()).isNull();
+        assertThat(spans[1].getParent_id()).isNull();
+
+        // client/foo and service/foo should have the ID values identical with their traceIds.
+        assertThat(spans[0].getId()).isEqualTo(traceId);
+        assertThat(spans[1].getId()).isEqualTo(traceId);
+
+        // The spans that do no cross the network boundary should have the same ID.
+        for (int i = 0; i < spans.length; i += 2) {
+            assertThat(spans[i].getId()).isEqualTo(spans[i + 1].getId());
+        }
+
+        // Check the parentIds.
+        for (int i = 2; i < spans.length; i += 2) {
+            final long expectedParentId = spans[i - 2].getId();
+            assertThat(spans[i].getParent_id()).isEqualTo(expectedParentId);
+            assertThat(spans[i + 1].getParent_id()).isEqualTo(expectedParentId);
+        }
+
+        // Check the service names.
+        assertThat(spans[0].getAnnotations()).allMatch(a -> "client/foo".equals(a.host.service_name));
+        assertThat(spans[1].getAnnotations()).allMatch(a -> "service/foo".equals(a.host.service_name));
+        assertThat(spans[2].getAnnotations()).allMatch(a -> "client/bar".equals(a.host.service_name));
+        assertThat(spans[3].getAnnotations()).allMatch(a -> "service/bar".equals(a.host.service_name));
+        assertThat(spans[4].getAnnotations()).allMatch(a -> "client/qux".equals(a.host.service_name));
+        assertThat(spans[5].getAnnotations()).allMatch(a -> "service/qux".equals(a.host.service_name));
+    }
+
+    @Test(timeout = 10000)
+    public void testServiceInitiatedTrace() throws Exception {
+        assertThat(fooClientWithoutTracing.hello("Lee")).isEqualTo("Hello, Ms. Lee!");
+
+        final Span[] spans = spanCollector.take(5);
+        final long traceId = spans[0].getTrace_id();
+        assertThat(spans).allMatch(s -> s.getTrace_id() == traceId);
+
+        // service/foo should have no parent.
+        assertThat(spans[0].getParent_id()).isNull();
+
+        // service/foo should have the ID value identical with its traceId.
+        assertThat(spans[0].getId()).isEqualTo(traceId);
+
+        // The spans that do no cross the network boundary should have the same ID.
+        for (int i = 1; i < spans.length; i += 2) {
+            assertThat(spans[i].getId()).isEqualTo(spans[i + 1].getId());
+        }
+
+        // Check the parentIds
+        for (int i = 1; i < spans.length; i += 2) {
+            final long expectedParentId = spans[i - 1].getId();
+            assertThat(spans[i].getParent_id()).isEqualTo(expectedParentId);
+            assertThat(spans[i + 1].getParent_id()).isEqualTo(expectedParentId);
+        }
+
+        // Check the service names.
+        assertThat(spans[0].getAnnotations()).allMatch(a -> "service/foo".equals(a.host.service_name));
+        assertThat(spans[1].getAnnotations()).allMatch(a -> "client/bar".equals(a.host.service_name));
+        assertThat(spans[2].getAnnotations()).allMatch(a -> "service/bar".equals(a.host.service_name));
+        assertThat(spans[3].getAnnotations()).allMatch(a -> "client/qux".equals(a.host.service_name));
+        assertThat(spans[4].getAnnotations()).allMatch(a -> "service/qux".equals(a.host.service_name));
+    }
+
+    private static class DelegatingCallback implements AsyncMethodCallback<String> {
+        private final AsyncMethodCallback<Object> resultHandler;
+
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        DelegatingCallback(AsyncMethodCallback resultHandler) {
+            this.resultHandler = resultHandler;
+        }
+
+        @Override
+        public void onComplete(String response) {
+            resultHandler.onComplete(response);
+        }
+
+        @Override
+        public void onError(Exception exception) {
+            resultHandler.onError(exception);
+        }
+    }
+
+    private static class SpanCollectorImpl extends EmptySpanCollector {
+
+        private final BlockingQueue<Span> spans = new LinkedBlockingQueue<>();
+
+        @Override
+        public void collect(Span span) {
+            spans.add(span);
+        }
+
+        Span[] take(int numSpans) throws InterruptedException {
+            final List<Span> taken = new ArrayList<>();
+            while (taken.size() < numSpans) {
+                taken.add(spans.take());
+            }
+
+            // Reverse the collected spans to sort the spans by request time.
+            Collections.reverse(taken);
+            return taken.toArray(new Span[numSpans]);
+        }
+    }
+}

--- a/src/test/java/com/linecorp/armeria/server/thrift/ThriftServiceTest.java
+++ b/src/test/java/com/linecorp/armeria/server/thrift/ThriftServiceTest.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.server.thrift;
 
 import static com.linecorp.armeria.common.util.Functions.voidFunction;
 import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.replay;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
@@ -587,6 +588,10 @@ public class ThriftServiceTest {
         expect(ctx.blockingTaskExecutor()).andReturn(ImmediateEventExecutor.INSTANCE).anyTimes();
         expect(ctx.requestLogBuilder()).andReturn(reqLogBuilder).anyTimes();
         expect(ctx.responseLogBuilder()).andReturn(resLogBuilder).anyTimes();
+        ctx.invokeOnEnterCallbacks();
+        expectLastCall().anyTimes();
+        ctx.invokeOnExitCallbacks();
+        expectLastCall().anyTimes();
         replay(ctx);
 
         final DefaultHttpRequest req = new DefaultHttpRequest(


### PR DESCRIPTION
Motivation:

We currently use RequestContext.push(..) to propagate a RequestContext
to a non-I/O thread or to replace the current context with another.

When propagating a RequestContext a non-I/O thread, the onEnter and
onExit callbacks must be invoked, while they should not be invoked when
replacing a context.

RequestContext.push(...) currently never invokes the callbacks, which
can lead to inconsistent state transition between threads.

Modifications:

- Modify RequestContext.push() so that the caller can choose to call the
  callbacks, where the default behavior is to call the callback
  - Add RequestContext.invokeOnEnter/ExitCallbacks()
- Reorganize the type hierarchy of RequestContext and its subtypes
  - Split AbstractRequestContext into:
    - AbstractRequestContext
    - NonWrappingRequestContext extends AbstractRequestContext
    - Default*RequestContext extend NonWrappingRequestContext
  - Add RequestContextWrapper that extend AbstractRequestContext
    - Rewrite ServiceRequestContextWrapper using RequestContextWrapper
    - Add ClientRequestContextWrapper
- Fix a bug where THttpService does not push its context when calling
  its delegate such as ThriftCallService
- Fix a bug where ThriftCallService pushes its context unnecessarily
- Fix a bug where AbstractCompositeService does not push its context
  wrapper
- Add HttpTracingIntegrationTest which ensures that Zipkin/Brave's
  thread-local variables are transferred correctly.
- Miscellaneous
  - Unignore RequestContextTest.contextAwareEventExecutor()

Result:

- RequestContext propagation works as expected
- Call tracing of nested calls works as expected