### PR TITLE
Do not send an AAAA DNS query when -Djava.net.preferIPv4Stack=true (0.21)

### DIFF
--- a/src/main/java/com/linecorp/armeria/client/NonDecoratingClientFactory.java
+++ b/src/main/java/com/linecorp/armeria/client/NonDecoratingClientFactory.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.client;
 
 import static java.util.Objects.requireNonNull;
 
+import java.net.InetAddress;
 import java.util.Optional;
 import java.util.concurrent.ThreadFactory;
 import java.util.function.Function;
@@ -27,6 +28,7 @@ import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.util.NativeLibraries;
 
 import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.ChannelFactory;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
@@ -35,10 +37,13 @@ import io.netty.channel.epoll.EpollEventLoopGroup;
 import io.netty.channel.epoll.EpollSocketChannel;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.DatagramChannel;
+import io.netty.channel.socket.InternetProtocolFamily;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioDatagramChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.resolver.NameResolver;
 import io.netty.resolver.dns.DnsAddressResolverGroup;
+import io.netty.resolver.dns.DnsNameResolverBuilder;
 import io.netty.resolver.dns.DnsServerAddresses;
 import io.netty.util.concurrent.DefaultThreadFactory;
 
@@ -89,8 +94,7 @@ public abstract class NonDecoratingClientFactory extends AbstractClientFactory {
         baseBootstrap.channel(channelType());
         baseBootstrap.resolver(
                 options.addressResolverGroup()
-                       .orElseGet(() -> new DnsAddressResolverGroup(
-                               datagramChannelType(), DnsServerAddresses.defaultAddresses())));
+                       .orElseGet(DnsAddressResolverGroup5657::new));
 
         baseBootstrap.option(ChannelOption.CONNECT_TIMEOUT_MILLIS,
                              ConvertUtils.safeLongToInt(options.connectTimeoutMillis()));
@@ -146,6 +150,30 @@ public abstract class NonDecoratingClientFactory extends AbstractClientFactory {
     public void close() {
         if (closeEventLoopGroup) {
             eventLoopGroup.shutdownGracefully().syncUninterruptibly();
+        }
+    }
+
+    private static class DnsAddressResolverGroup5657 extends DnsAddressResolverGroup {
+
+        DnsAddressResolverGroup5657() {
+            super(datagramChannelType(), DnsServerAddresses.defaultAddresses());
+        }
+
+        @Override
+        protected NameResolver<InetAddress> newNameResolver(
+                EventLoop eventLoop, ChannelFactory<? extends DatagramChannel> channelFactory,
+                DnsServerAddresses nameServerAddresses) throws Exception {
+
+            final DnsNameResolverBuilder builder = new DnsNameResolverBuilder(eventLoop);
+            builder.channelFactory(channelFactory);
+            builder.nameServerAddresses(nameServerAddresses);
+            if (Boolean.getBoolean("java.net.preferIPv4Stack")) {
+                // Resolve IPv4 addresses only when -Djava.net.preferIPv4Stack is enabled,
+                // because JDK will fail or refuse connecting to an IPv6 address at all.
+                // See: https://github.com/netty/netty/issues/5657
+                builder.resolvedAddressTypes(InternetProtocolFamily.IPv4);
+            }
+            return builder.build();
         }
     }
 }


### PR DESCRIPTION
Motivation:

According to the Oracle documentation:

> java.net.preferIPv4Stack (default: false)
>
> If IPv6 is available on the operating system, the underlying native
> socket will be an IPv6 socket. This allows Java applications to
> connect to, and accept connections from, both IPv4 and IPv6 hosts.
>
> If an application has a preference to only use IPv4 sockets, then
> this property can be set to true. The implication is that the
> application will not be able to communicate with IPv6 hosts.

which means, if DnsNameResolver returns an IPv6 address, a user (or
Netty) will not be able to connect to it.

Modifications:

- Disable IPv6 DNS queries when -Djava.net.preferIPv4Stack=true is set

Result:

No more intermittent connection attempt failure due to IPv6 addresses in
an IPv4-only environment