### PR TITLE
Do not send an AAAA DNS query when -Djava.net.preferIPv4Stack=true (0.20)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,6 @@
     <url>${project.url}</url>
     <connection>scm:git:https://github.com/line/armeria.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/line/armeria.git</developerConnection>
-    <tag>HEAD</tag>
   </scm>
 
   <developers>
@@ -81,11 +80,11 @@
     <maven.compiler.showWarnings>true</maven.compiler.showWarnings>
 
     <!-- Dependency versions -->
-    <jackson.version>2.7.5</jackson.version>
-    <jetty.version>9.3.10.v20160621</jetty.version>
+    <jackson.version>2.7.6</jackson.version>
+    <jetty.version>9.3.11.v20160721</jetty.version>
     <logback.version>1.1.7</logback.version>
     <metrics.version>3.1.2</metrics.version>
-    <netty.version>4.1.3.Final</netty.version>
+    <netty.version>4.1.4.Final</netty.version>
     <slf4j.version>1.7.21</slf4j.version>
     <tomcat.version>8.5.4</tomcat.version>
     <jetty.alpnAgent.version>2.0.3</jetty.alpnAgent.version>
@@ -99,7 +98,7 @@
     <thrift.source.test>${project.basedir}/src/test/thrift</thrift.source.test>
     <thrift.generated.main>${project.build.directory}/generated-sources</thrift.generated.main>
     <thrift.generated.test>${project.build.directory}/generated-test-sources</thrift.generated.test>
-    <brave.version>3.9.0</brave.version>
+    <brave.version>3.9.1</brave.version>
     <guava.version>19.0</guava.version>
     <reflections.version>0.9.10</reflections.version>
   </properties>


### PR DESCRIPTION
Motivation:

According to the Oracle documentation:

> java.net.preferIPv4Stack (default: false)
>
> If IPv6 is available on the operating system, the underlying native
> socket will be an IPv6 socket. This allows Java applications to
> connect to, and accept connections from, both IPv4 and IPv6 hosts.
>
> If an application has a preference to only use IPv4 sockets, then
> this property can be set to true. The implication is that the
> application will not be able to communicate with IPv6 hosts.

which means, if DnsNameResolver returns an IPv6 address, a user (or
Netty) will not be able to connect to it.

Modifications:

- Disable IPv6 DNS queries when -Djava.net.preferIPv4Stack=true is set

Result:

No more intermittent connection attempt failure due to IPv6 addresses in
an IPv4-only environment