### PR TITLE
Fix query and fragment removed from request

### DIFF
--- a/src/main/java/com/linecorp/armeria/client/http/DefaultSimpleHttpClient.java
+++ b/src/main/java/com/linecorp/armeria/client/http/DefaultSimpleHttpClient.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.client.http;
 
 import static com.linecorp.armeria.common.util.Functions.voidFunction;
 
+import java.net.URI;
 import java.util.Arrays;
 
 import com.linecorp.armeria.client.ClientOptionValue;
@@ -47,9 +48,19 @@ final class DefaultSimpleHttpClient implements SimpleHttpClient {
         final EventLoop eventLoop = client.eventLoop0();
         final Promise<SimpleHttpResponse> promise = eventLoop.newPromise();
         try {
+            URI uri = sReq.uri();
+            StringBuilder uriBuilder = new StringBuilder(uri.getPath());
+            if (uri.getQuery() != null) {
+                uriBuilder.append('?');
+                uriBuilder.append(uri.getQuery());
+            }
+            if (uri.getFragment() != null) {
+                uriBuilder.append('#');
+                uriBuilder.append(uri.getFragment());
+            }
             final AggregatedHttpMessage aReq = AggregatedHttpMessage.of(
                     HttpMethod.valueOf(sReq.method().name()),
-                    sReq.uri().getPath(),
+                    uriBuilder.toString(),
                     HttpData.of(sReq.content()));
 
             // Convert the headers.


### PR DESCRIPTION
Motivation:

DefaultSimpleHttpClient did not used query and fragment from original
URI from request.

Modifications:

- Build string from path, query and fragment in original URI so query
  and fragment are not removed.

Result:

Proper request while using `SimpleHttpClient`