### PR TITLE
Fix response timeout & Do not send a GET request with the transfer-encoding header

### DIFF
--- a/src/main/java/com/linecorp/armeria/client/http/Http1ResponseDecoder.java
+++ b/src/main/java/com/linecorp/armeria/client/http/Http1ResponseDecoder.java
@@ -115,9 +115,9 @@ final class Http1ResponseDecoder extends HttpResponseDecoder implements ChannelI
                             state = State.NEED_INFORMATIONAL_DATA;
                         } else {
                             state = State.NEED_DATA_OR_TRAILING_HEADERS;
-                            res.scheduleTimeout(ctx);
                         }
 
+                        res.scheduleTimeout(ctx);
                         res.write(ArmeriaHttpUtil.toArmeria(nettyRes));
                     } else {
                         failWithUnexpectedMessageType(ctx, msg);

--- a/src/main/java/com/linecorp/armeria/client/http/Http2ResponseDecoder.java
+++ b/src/main/java/com/linecorp/armeria/client/http/Http2ResponseDecoder.java
@@ -25,7 +25,6 @@ import com.linecorp.armeria.common.ContentTooLargeException;
 import com.linecorp.armeria.common.http.HttpData;
 import com.linecorp.armeria.common.http.HttpHeaders;
 import com.linecorp.armeria.common.http.HttpResponseWriter;
-import com.linecorp.armeria.common.http.HttpStatusClass;
 import com.linecorp.armeria.internal.http.ArmeriaHttpUtil;
 
 import io.netty.buffer.ByteBuf;
@@ -94,11 +93,8 @@ final class Http2ResponseDecoder extends HttpResponseDecoder implements Http2Con
         }
 
         final HttpHeaders converted = ArmeriaHttpUtil.toArmeria(headers);
-        if (converted.status().codeClass() != HttpStatusClass.INFORMATIONAL) {
-            res.scheduleTimeout(ctx);
-        }
-
         try {
+            res.scheduleTimeout(ctx);
             res.write(converted);
         } catch (Throwable t) {
             res.close(t);

--- a/src/main/java/com/linecorp/armeria/client/http/HttpRequestSubscriber.java
+++ b/src/main/java/com/linecorp/armeria/client/http/HttpRequestSubscriber.java
@@ -139,7 +139,12 @@ final class HttpRequestSubscriber implements Subscriber<HttpObject>, ChannelFutu
                          host, firstHeaders.method().name(), firstHeaders.path());
         logBuilder.attr(RequestLog.HTTP_HEADERS).set(firstHeaders);
 
-        write0(firstHeaders, false, true);
+        if (request.isEmpty()) {
+            setDone();
+            write0(firstHeaders, true, true);
+        } else {
+            write0(firstHeaders, false, true);
+        }
     }
 
     @Override

--- a/src/main/java/com/linecorp/armeria/client/http/HttpRequestSubscriber.java
+++ b/src/main/java/com/linecorp/armeria/client/http/HttpRequestSubscriber.java
@@ -26,11 +26,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.linecorp.armeria.client.WriteTimeoutException;
+import com.linecorp.armeria.client.http.HttpResponseDecoder.HttpResponseWrapper;
 import com.linecorp.armeria.common.ClosedSessionException;
 import com.linecorp.armeria.common.http.HttpData;
 import com.linecorp.armeria.common.http.HttpHeaders;
 import com.linecorp.armeria.common.http.HttpObject;
-import com.linecorp.armeria.common.http.HttpResponseWriter;
+import com.linecorp.armeria.common.http.HttpRequest;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.logging.RequestLogBuilder;
 import com.linecorp.armeria.common.reactivestreams.ClosedPublisherException;
@@ -56,8 +57,8 @@ final class HttpRequestSubscriber implements Subscriber<HttpObject>, ChannelFutu
     private final ChannelHandlerContext ctx;
     private final HttpObjectEncoder encoder;
     private final int id;
-    private final HttpHeaders firstHeaders;
-    private final HttpResponseWriter response;
+    private final HttpRequest request;
+    private final HttpResponseWrapper response;
     private final RequestLogBuilder logBuilder;
     private final long timeoutMillis;
     private Subscription subscription;
@@ -65,14 +66,14 @@ final class HttpRequestSubscriber implements Subscriber<HttpObject>, ChannelFutu
     private State state = State.NEEDS_DATA_OR_TRAILING_HEADERS;
 
     HttpRequestSubscriber(Channel ch, HttpObjectEncoder encoder,
-                          int id, HttpHeaders firstHeaders, HttpResponseWriter response,
+                          int id, HttpRequest request, HttpResponseWrapper response,
                           RequestLogBuilder logBuilder, long timeoutMillis) {
 
         ctx = ch.pipeline().lastContext();
 
         this.encoder = encoder;
         this.id = id;
-        this.firstHeaders = firstHeaders;
+        this.request = request;
         this.response = response;
         this.logBuilder = logBuilder;
         this.timeoutMillis = timeoutMillis;
@@ -84,7 +85,10 @@ final class HttpRequestSubscriber implements Subscriber<HttpObject>, ChannelFutu
     @Override
     public void operationComplete(ChannelFuture future) throws Exception {
         if (future.isSuccess()) {
-            if (state != State.DONE) {
+            if (state == State.DONE) {
+                // Successfully sent the request; schedule the response timeout.
+                response.scheduleTimeout(ctx);
+            } else {
                 subscription.request(1);
             }
             return;
@@ -124,7 +128,7 @@ final class HttpRequestSubscriber implements Subscriber<HttpObject>, ChannelFutu
 
     private void writeFirstHeader() {
         final Channel ch = ctx.channel();
-        final HttpHeaders firstHeaders = this.firstHeaders;
+        final HttpHeaders firstHeaders = request.headers();
 
         String host = firstHeaders.authority();
         if (host == null) {
@@ -135,8 +139,7 @@ final class HttpRequestSubscriber implements Subscriber<HttpObject>, ChannelFutu
                          host, firstHeaders.method().name(), firstHeaders.path());
         logBuilder.attr(RequestLog.HTTP_HEADERS).set(firstHeaders);
 
-        encoder.writeHeaders(ctx, id, streamId(), firstHeaders, false).addListener(this);
-        ctx.flush();
+        write0(firstHeaders, false, true);
     }
 
     @Override

--- a/src/main/java/com/linecorp/armeria/client/http/HttpSessionHandler.java
+++ b/src/main/java/com/linecorp/armeria/client/http/HttpSessionHandler.java
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory;
 
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.SessionProtocolNegotiationException;
+import com.linecorp.armeria.client.http.HttpResponseDecoder.HttpResponseWrapper;
 import com.linecorp.armeria.common.ClosedSessionException;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.http.HttpRequest;
@@ -117,11 +118,12 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
         final long maxContentLength = ctx.maxResponseLength();
 
         final int numRequestsSent = ++this.numRequestsSent;
-        responseDecoder.addResponse(numRequestsSent, res, ctx.responseLogBuilder(),
-                                    responseTimeoutMillis, maxContentLength);
+        final HttpResponseWrapper wrappedRes =
+                responseDecoder.addResponse(numRequestsSent, res, ctx.responseLogBuilder(),
+                                            responseTimeoutMillis, maxContentLength);
         req.subscribe(
                 new HttpRequestSubscriber(channel, requestEncoder,
-                                          numRequestsSent, req.headers(), res, ctx.requestLogBuilder(),
+                                          numRequestsSent, req, wrappedRes, ctx.requestLogBuilder(),
                                           writeTimeoutMillis),
                 channel.eventLoop());
 

--- a/src/main/java/com/linecorp/armeria/common/http/HttpRequest.java
+++ b/src/main/java/com/linecorp/armeria/common/http/HttpRequest.java
@@ -41,6 +41,16 @@ public interface HttpRequest extends Request, RichPublisher<HttpObject> {
     }
 
     /**
+     * Returns a new {@link HttpRequest} with empty content.
+     */
+    static HttpRequest of(HttpHeaders headers) {
+        // TODO(trustin): Use no-op Queue implementation for QueueBasedPublisher?
+        final DefaultHttpRequest req = new DefaultHttpRequest(headers);
+        req.close();
+        return req;
+    }
+
+    /**
      * Returns the initial HTTP/2 headers of this request.
      */
     HttpHeaders headers();

--- a/src/main/java/com/linecorp/armeria/common/reactivestreams/QueueBasedPublisher.java
+++ b/src/main/java/com/linecorp/armeria/common/reactivestreams/QueueBasedPublisher.java
@@ -117,6 +117,8 @@ public class QueueBasedPublisher<T> implements RichPublisher<T>, Writer<T> {
     @SuppressWarnings("FieldMayBeFinal")
     private volatile State state = State.OPEN;
 
+    private volatile boolean wroteAny;
+
     /**
      * Creates a new instance with a new {@link ConcurrentLinkedQueue}.
      */
@@ -134,6 +136,11 @@ public class QueueBasedPublisher<T> implements RichPublisher<T>, Writer<T> {
     @Override
     public boolean isOpen() {
         return state == State.OPEN;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return !isOpen() && !wroteAny;
     }
 
     @Override
@@ -186,6 +193,7 @@ public class QueueBasedPublisher<T> implements RichPublisher<T>, Writer<T> {
             return false;
         }
 
+        wroteAny = true;
         pushObject(obj);
         return true;
     }

--- a/src/main/java/com/linecorp/armeria/common/reactivestreams/RichPublisher.java
+++ b/src/main/java/com/linecorp/armeria/common/reactivestreams/RichPublisher.java
@@ -35,6 +35,13 @@ public interface RichPublisher<T> extends Publisher<T> {
     boolean isOpen();
 
     /**
+     * Returns {@code true} if this stream has been closed and did not publish any elements.
+     * Note that this method will not return {@code true} when the stream is open even if it has not
+     * published anything so far, because it may publish something later.
+     */
+    boolean isEmpty();
+
+    /**
      * Returns a {@link CompletableFuture} that completes when this publisher is complete,
      * either successfully or exceptionally.
      */


### PR DESCRIPTION
### Fix a bug where response timeout does not occur until the first headers are received

Motivation:

Even if an Armeria HttpClient finishes sending a request, its response
timeout is not scheduled until the first response header is received,
which is not correct.

Modifications:

- Make HttpResponseWrapper.scheduleTimeout() idempotent
- Call HttpResponseWrapper.scheduleTimeout() even for informational
  headers
- Call HttpResponseWrapper.scheduleTimeout() if finished sending the
  request

Result:

Correct response timeout behavior

### Do not send a GET request with the transfer-encoding header

Motivation:

When a user sends a GET/HEAD/DELETE/TRACE request which is supposed to
have empty content, Armeria sets the 'transfer-encoding: chunked' header
followed by a zero-length chunk.

It is not strictly prohibited by HTTP/1.1 to send such a request, it is
not desirable to do so and some servers do not accept it.

Modifications:

- Assume empty content for GET/HEAD/DELETE/TRACE/CONNECT requests
  - Set neither 'transfer-encoding' or 'content-length'
- Add a test case

Result:

Armeria now sends more sensible GET/HEAD/DELETE/TRACE requests.