### PR TITLE
Add support for HTTP encoding server responses.

### DIFF
--- a/src/main/java/com/linecorp/armeria/common/stream/FilteredStreamMessage.java
+++ b/src/main/java/com/linecorp/armeria/common/stream/FilteredStreamMessage.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.stream;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+/**
+ * A {@link StreamMessage} that filters objects as they are published. The filtering
+ * will happen from an IO thread, meaning the order of the filtering will match the
+ * order that the {@code delegate} processes the objects in.
+ */
+public abstract class FilteredStreamMessage<T, U> implements StreamMessage<U> {
+
+    private final StreamMessage<T> delegate;
+
+    /**
+     * Creates a new {@link FilteredStreamMessage} that filters objects published by {@code delegate}
+     * before passing to a subscriber.
+     */
+    protected FilteredStreamMessage(StreamMessage<T> delegate) {
+        requireNonNull(delegate, "delegate");
+        this.delegate = delegate;
+    }
+
+    /**
+     * The filter to apply to published objects. The result of the filter is passed on
+     * to the delegate subscriber.
+     */
+    protected abstract U filter(T obj);
+
+    /**
+     * A callback executed just before calling {@link Subscriber#onComplete()} on {@code subscriber}.
+     * Override this method to execute any cleanup logic that may be needed before completing the
+     * subscription.
+     */
+    protected void beforeComplete(Subscriber<? super U> subscriber) {
+    }
+
+    /**
+     * A callback executed just before calling {@link Subscriber#onError(Throwable)} on {@code subscriber}.
+     * Override this method to execute any cleanup logic that may be needed before failing the
+     * subscription.
+     */
+    protected void beforeError(Subscriber<? super U> subscriber, Throwable t) {
+    }
+
+    @Override
+    public boolean isOpen() {
+        return delegate.isOpen();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return delegate.isEmpty();
+    }
+
+    @Override
+    public CompletableFuture<Void> closeFuture() {
+        return delegate.closeFuture();
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super U> subscriber) {
+        requireNonNull(subscriber, "subscriber");
+        delegate.subscribe(new FilteringSubscriber(subscriber));
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super U> subscriber, Executor executor) {
+        requireNonNull(subscriber, "subscriber");
+        delegate.subscribe(new FilteringSubscriber(subscriber), executor);
+    }
+
+    @Override
+    public void abort() {
+        delegate.abort();
+    }
+
+    private final class FilteringSubscriber implements Subscriber<T> {
+
+        private final Subscriber<? super U> delegate;
+
+        FilteringSubscriber(Subscriber<? super U> delegate) {
+            requireNonNull(delegate, "delegate");
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            delegate.onSubscribe(s);
+        }
+
+        @Override
+        public void onNext(T t) {
+            delegate.onNext(filter(t));
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            beforeError(delegate, t);
+            delegate.onError(t);
+        }
+
+        @Override
+        public void onComplete() {
+            beforeComplete(delegate);
+            delegate.onComplete();
+        }
+    }
+}

--- a/src/main/java/com/linecorp/armeria/server/DecoratingService.java
+++ b/src/main/java/com/linecorp/armeria/server/DecoratingService.java
@@ -21,7 +21,6 @@ import static java.util.Objects.requireNonNull;
 import java.util.Optional;
 import java.util.function.Function;
 
-import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
 
@@ -29,10 +28,10 @@ import com.linecorp.armeria.common.Response;
  * A {@link Service} that decorates another {@link Service}. Do not use this class unless you want to define
  * a new dedicated {@link Service} type by extending this class; prefer {@link Service#decorate(Function)}.
  *
- * @param <T_I> the {@link Request} type of the {@link Client} being decorated
- * @param <T_O> the {@link Response} type of the {@link Client} being decorated
- * @param <R_I> the {@link Request} type of this {@link Client}
- * @param <R_O> the {@link Response} type of this {@link Client}
+ * @param <T_I> the {@link Request} type of the {@link Service} being decorated
+ * @param <T_O> the {@link Response} type of the {@link Service} being decorated
+ * @param <R_I> the {@link Request} type of this {@link Service}
+ * @param <R_O> the {@link Response} type of this {@link Service}
  */
 public abstract class DecoratingService<T_I extends Request, T_O extends Response,
                                         R_I extends Request, R_O extends Response>

--- a/src/main/java/com/linecorp/armeria/server/http/encoding/HttpEncodedResponse.java
+++ b/src/main/java/com/linecorp/armeria/server/http/encoding/HttpEncodedResponse.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.http.encoding;
+
+import static java.util.Objects.requireNonNull;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.function.Predicate;
+import java.util.zip.DeflaterOutputStream;
+
+import javax.annotation.Nullable;
+
+import org.reactivestreams.Subscriber;
+
+import com.google.common.net.MediaType;
+
+import com.linecorp.armeria.common.http.HttpData;
+import com.linecorp.armeria.common.http.HttpHeaderNames;
+import com.linecorp.armeria.common.http.HttpHeaders;
+import com.linecorp.armeria.common.http.HttpObject;
+import com.linecorp.armeria.common.http.HttpResponse;
+import com.linecorp.armeria.common.http.HttpStatusClass;
+import com.linecorp.armeria.common.stream.FilteredStreamMessage;
+import com.linecorp.armeria.common.stream.StreamMessage;
+
+/**
+ * A {@link FilteredStreamMessage} that applies HTTP encoding to {@link HttpObject}s as they are published.
+ */
+class HttpEncodedResponse extends FilteredStreamMessage<HttpObject, HttpObject> implements HttpResponse {
+
+    private final HttpEncodingType encodingType;
+    private final Predicate<MediaType> encodableContentTypePredicate;
+    private final int minBytesToForceChunkedAndEncoding;
+
+    @Nullable
+    private ByteArrayOutputStream encodedStream;
+
+    @Nullable
+    private DeflaterOutputStream encodingStream;
+
+    private boolean headersSent;
+
+    HttpEncodedResponse(
+            StreamMessage<HttpObject> delegate,
+            HttpEncodingType encodingType,
+            Predicate<MediaType> encodableContentTypePredicate,
+            int minBytesToForceChunkedAndEncoding) {
+        super(delegate);
+        this.encodingType = requireNonNull(encodingType, "encodingType");
+        this.encodableContentTypePredicate = requireNonNull(encodableContentTypePredicate,
+                                                            "encodableContentTypePredicate");
+        this.minBytesToForceChunkedAndEncoding = HttpEncodingService.validateMinBytesToForceChunkedAndEncoding(
+                minBytesToForceChunkedAndEncoding);
+    }
+
+    @Override
+    protected HttpObject filter(HttpObject obj) {
+        if (obj instanceof HttpHeaders) {
+            HttpHeaders headers = (HttpHeaders) obj;
+
+            // Skip informational headers.
+            if (headers.status().codeClass() == HttpStatusClass.INFORMATIONAL) {
+                return obj;
+            }
+
+            if (headersSent) {
+                // Trailing headers, no modification.
+                return obj;
+            }
+            headersSent = true;
+            if (!shouldEncodeResponse(headers)) {
+                return obj;
+            }
+
+            encodedStream = new ByteArrayOutputStream();
+            encodingStream = HttpEncoders.getEncodingOutputStream(encodingType, encodedStream);
+
+            // Always use chunked encoding when compressing.
+            headers.remove(HttpHeaderNames.CONTENT_LENGTH);
+            switch (encodingType) {
+                case GZIP:
+                    headers.set(HttpHeaderNames.CONTENT_ENCODING, "gzip");
+                    break;
+                case DEFLATE:
+                    headers.set(HttpHeaderNames.CONTENT_ENCODING, "deflate");
+                    break;
+            }
+            headers.set(HttpHeaderNames.VARY, HttpHeaderNames.ACCEPT_ENCODING.toString());
+            return headers;
+        }
+
+        if (encodingStream == null) {
+            // Encoding was disabled for this response.
+            return obj;
+        }
+
+        HttpData data = (HttpData) obj;
+        try {
+            encodingStream.write(data.array(), data.offset(), data.length());
+            encodingStream.flush();
+            return HttpData.of(encodedStream.toByteArray());
+        } catch (IOException e) {
+            throw new IllegalStateException(
+                    "Error encoding HttpData, this should not happen with byte arrays.",
+                    e);
+        } finally {
+            encodedStream.reset();
+        }
+    }
+
+    @Override
+    protected void beforeComplete(Subscriber<? super HttpObject> subscriber) {
+        closeEncoder();
+        if (encodedStream != null && encodedStream.size() > 0) {
+            subscriber.onNext(HttpData.of(encodedStream.toByteArray()));
+        }
+    }
+
+    @Override
+    protected void beforeError(Subscriber<? super HttpObject> subscriber, Throwable t) {
+        closeEncoder();
+    }
+
+    private void closeEncoder() {
+        if (encodingStream == null) {
+            return;
+        }
+        try {
+            encodingStream.close();
+        } catch (IOException e) {
+            throw new IllegalStateException(
+                    "Error closing encodingStream, this should not happen with byte arrays.",
+                    e);
+        }
+    }
+
+    private boolean shouldEncodeResponse(HttpHeaders headers) {
+        if (headers.contains(HttpHeaderNames.CONTENT_ENCODING)) {
+            // We don't do automatic encoding if the user-supplied headers contain
+            // Content-Encoding.
+            return false;
+        }
+        if (headers.contains(HttpHeaderNames.CONTENT_TYPE)) {
+            // Make sure the content type is worth encoding.
+            try {
+                MediaType contentType = MediaType.parse(headers.get(HttpHeaderNames.CONTENT_TYPE));
+                if (!encodableContentTypePredicate.test(contentType)) {
+                    return false;
+                }
+            } catch (IllegalArgumentException e) {
+                // Don't know content type of response, don't encode.
+                return false;
+            }
+        }
+        if (headers.contains(HttpHeaderNames.CONTENT_LENGTH)) {
+            // We switch to chunked encoding and compress the response if it's reasonably
+            // large as the compression savings should outweigh the chunked encoding
+            // overhead.
+            if (headers.getInt(HttpHeaderNames.CONTENT_LENGTH) < minBytesToForceChunkedAndEncoding) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/linecorp/armeria/server/http/encoding/HttpEncodingService.java
+++ b/src/main/java/com/linecorp/armeria/server/http/encoding/HttpEncodingService.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.http.encoding;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import com.google.common.net.MediaType;
+
+import com.linecorp.armeria.common.http.HttpRequest;
+import com.linecorp.armeria.common.http.HttpResponse;
+import com.linecorp.armeria.server.DecoratingService;
+import com.linecorp.armeria.server.Service;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.http.HttpService;
+
+/**
+ * A {@link DecoratingService} that applies HTTP encoding (e.g., gzip) to an {@link HttpService}.
+ * HTTP encoding will be applied if the client specifies it, the response content type is a reasonable
+ * type to encode, and the response either has no fixed content length or the length is larger than 1KB.
+ */
+public class HttpEncodingService
+        extends DecoratingService<HttpRequest, HttpResponse, HttpRequest, HttpResponse> {
+
+    private static final Predicate<MediaType> DEFAULT_ENCODABLE_CONTENT_TYPE_PREDICATE =
+            contentType -> Stream.of(MediaType.ANY_TEXT_TYPE,
+                                     MediaType.APPLICATION_XML_UTF_8,
+                                     MediaType.JAVASCRIPT_UTF_8,
+                                     MediaType.JSON_UTF_8)
+                                 .anyMatch(contentType::is);
+
+    private static final int DEFAULT_MIN_BYTES_TO_FORCE_CHUNKED_AND_ENCODING = 1024;
+
+    private final Predicate<MediaType> encodableContentTypePredicate;
+    private final int minBytesToForceChunkedAndEncoding;
+
+    /**
+     * Creates a new {@link DecoratingService} that HTTP encodes response data published from {@code delegate}.
+     * Encoding will be applied when the client supports it, the response content type is a common web
+     * text format, and the response either has variable content length or a length greater than 1024.
+     */
+    public HttpEncodingService(Service<? super HttpRequest, ? extends HttpResponse> delegate) {
+        this(delegate, DEFAULT_ENCODABLE_CONTENT_TYPE_PREDICATE,
+             DEFAULT_MIN_BYTES_TO_FORCE_CHUNKED_AND_ENCODING);
+    }
+
+    /**
+     * Creates a new {@link DecoratingService} that HTTP encodes response data published from {@code delegate}.
+     * Encoding will be applied when the client supports it, the response content type passes the supplied
+     * {@code encodableContentTypePredicate} and the response either has variable content length or a length
+     * greater than {@code minBytesToForceChunkedAndEncoding}.
+     */
+    public HttpEncodingService(Service<? super HttpRequest, ? extends HttpResponse> delegate,
+                               Predicate<MediaType> encodableContentTypePredicate,
+                               int minBytesToForceChunkedAndEncoding) {
+        super(delegate);
+        this.encodableContentTypePredicate = requireNonNull(encodableContentTypePredicate,
+                                                            "encodableContentTypePredicate");
+        this.minBytesToForceChunkedAndEncoding = validateMinBytesToForceChunkedAndEncoding(
+                minBytesToForceChunkedAndEncoding);
+    }
+
+    @Override
+    public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+        HttpEncodingType encodingType = HttpEncoders.getWrapperForRequest(req);
+        HttpResponse delegateResponse = delegate().serve(ctx, req);
+        if (encodingType == null) {
+            return delegateResponse;
+        }
+        return new HttpEncodedResponse(
+                delegateResponse,
+                encodingType,
+                encodableContentTypePredicate,
+                minBytesToForceChunkedAndEncoding);
+    }
+
+    static int validateMinBytesToForceChunkedAndEncoding(int minBytesToForceChunkedAndEncoding) {
+        if (minBytesToForceChunkedAndEncoding <= 0) {
+            throw new IllegalArgumentException("minBytesToForceChunkedAndEncoding must be greater than 0.");
+        }
+        return minBytesToForceChunkedAndEncoding;
+    }
+}

--- a/src/main/java/com/linecorp/armeria/server/http/encoding/HttpEncodingType.java
+++ b/src/main/java/com/linecorp/armeria/server/http/encoding/HttpEncodingType.java
@@ -1,0 +1,9 @@
+package com.linecorp.armeria.server.http.encoding;
+
+/**
+ * A type of HTTP encoding, which is usually included in accept-encoding and content-encoding headers.
+ */
+enum HttpEncodingType {
+    GZIP,
+    DEFLATE;
+}

--- a/src/test/java/com/linecorp/armeria/server/http/encoding/HttpEncodersTest.java
+++ b/src/test/java/com/linecorp/armeria/server/http/encoding/HttpEncodersTest.java
@@ -1,0 +1,52 @@
+package com.linecorp.armeria.server.http.encoding;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.when;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import com.linecorp.armeria.common.http.HttpHeaderNames;
+import com.linecorp.armeria.common.http.HttpHeaders;
+import com.linecorp.armeria.common.http.HttpRequest;
+
+public class HttpEncodersTest {
+
+    @Rule public MockitoRule mocks = MockitoJUnit.rule();
+
+    @Mock private HttpRequest request;
+
+    @Test
+    public void noAcceptEncoding() {
+        when(request.headers()).thenReturn(HttpHeaders.EMPTY_HEADERS);
+        assertThat(HttpEncoders.getWrapperForRequest(request)).isNull();
+    }
+
+    @Test
+    public void acceptEncodingGzip() {
+        when(request.headers()).thenReturn(HttpHeaders.of(HttpHeaderNames.ACCEPT_ENCODING, "gzip"));
+        assertThat(HttpEncoders.getWrapperForRequest(request)).isEqualTo(HttpEncodingType.GZIP);
+    }
+
+    @Test
+    public void acceptEncodingDeflate() {
+        when(request.headers()).thenReturn(HttpHeaders.of(HttpHeaderNames.ACCEPT_ENCODING, "deflate"));
+        assertThat(HttpEncoders.getWrapperForRequest(request)).isEqualTo(HttpEncodingType.DEFLATE);
+    }
+
+    @Test
+    public void acceptEncodingBoth() {
+        when(request.headers()).thenReturn(HttpHeaders.of(HttpHeaderNames.ACCEPT_ENCODING, "gzip, deflate"));
+        assertThat(HttpEncoders.getWrapperForRequest(request)).isEqualTo(HttpEncodingType.GZIP);
+    }
+
+    @Test
+    public void acceptEncodingUnknown() {
+        when(request.headers()).thenReturn(HttpHeaders.of(HttpHeaderNames.ACCEPT_ENCODING, "piedpiper"));
+        assertThat(HttpEncoders.getWrapperForRequest(request)).isNull();
+    }
+
+}


### PR DESCRIPTION
When enabled, the server will look for the Accept-Encoding header from a client and respect it if set to gzip or deflate.

Encoding doesn't happen if
1) The user is publishing a response with Content-Encoding set. It's presumed the user has encoded the content themselves and we won't reencode.
2) Not part of accepted media types
3) The response has a small fixed content-length (e.g., not using chunked / framed encoding). For larger ones, we switch to chunked encoding and do the compression for a hopefully larger return.

Miscellanous:
- Fix a docstring