### PR TITLE
Fix potential NPE and missing maxRequestLength enforcement

### DIFF
--- a/src/main/java/com/linecorp/armeria/client/http/HttpClientPipelineConfigurator.java
+++ b/src/main/java/com/linecorp/armeria/client/http/HttpClientPipelineConfigurator.java
@@ -410,7 +410,7 @@ class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
             });
 
             // NB: No need to set the response timeout because we have session creation timeout.
-            responseDecoder.addResponse(0, res, ResponseLogBuilder.NOOP, 0, UPGRADE_RESPONSE_MAX_LENGTH);
+            responseDecoder.addResponse(0, null, res, ResponseLogBuilder.NOOP, 0, UPGRADE_RESPONSE_MAX_LENGTH);
             ctx.fireChannelActive();
         }
 
@@ -560,8 +560,7 @@ class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
         Http2ConnectionEncoder encoder = new DefaultHttp2ConnectionEncoder(conn, writer);
         Http2ConnectionDecoder decoder = new DefaultHttp2ConnectionDecoder(conn, encoder, reader);
 
-        final Http2ResponseDecoder listener = new Http2ResponseDecoder(
-                ch);
+        final Http2ResponseDecoder listener = new Http2ResponseDecoder(conn, ch);
 
         final Http2ClientConnectionHandler handler =
                 new Http2ClientConnectionHandler(decoder, encoder, new Http2Settings(), listener);

--- a/src/main/java/com/linecorp/armeria/client/http/HttpSessionHandler.java
+++ b/src/main/java/com/linecorp/armeria/client/http/HttpSessionHandler.java
@@ -119,7 +119,7 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
 
         final int numRequestsSent = ++this.numRequestsSent;
         final HttpResponseWrapper wrappedRes =
-                responseDecoder.addResponse(numRequestsSent, res, ctx.responseLogBuilder(),
+                responseDecoder.addResponse(numRequestsSent, req, res, ctx.responseLogBuilder(),
                                             responseTimeoutMillis, maxContentLength);
         req.subscribe(
                 new HttpRequestSubscriber(channel, requestEncoder,

--- a/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
+++ b/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
@@ -379,9 +379,7 @@ public class DefaultStreamMessage<T> implements StreamMessage<T>, StreamWriter<T
             }
 
             if (e instanceof CompletableFuture) {
-                @SuppressWarnings("unchecked")
-                final CompletableFuture<Void> f = (CompletableFuture<Void>) e;
-                f.completeExceptionally(cause);
+                ((CompletableFuture<?>) e).completeExceptionally(cause);
             }
 
             @SuppressWarnings("unchecked")

--- a/src/main/java/com/linecorp/armeria/server/http/HttpServerPipelineConfigurator.java
+++ b/src/main/java/com/linecorp/armeria/server/http/HttpServerPipelineConfigurator.java
@@ -133,7 +133,8 @@ public final class HttpServerPipelineConfigurator extends ChannelInitializer<Cha
                 new Http2ServerConnectionHandler(decoder, encoder, new Http2Settings());
 
         // Setup post build options
-        final Http2RequestDecoder listener = new Http2RequestDecoder(pipeline.channel(), handler.encoder());
+        final Http2RequestDecoder listener =
+                new Http2RequestDecoder(config, pipeline.channel(), handler.encoder());
 
         handler.connection().addListener(listener);
         handler.decoder().frameListener(listener);
@@ -174,7 +175,7 @@ public final class HttpServerPipelineConfigurator extends ChannelInitializer<Cha
         private void addHttpHandlers(ChannelHandlerContext ctx) {
             final ChannelPipeline p = ctx.pipeline();
             p.addLast(new HttpServerCodec());
-            p.addLast(new Http1RequestDecoder(ctx.channel(), SCHEME_HTTPS));
+            p.addLast(new Http1RequestDecoder(config, ctx.channel(), SCHEME_HTTPS));
             configureRequestCountingHandlers(p);
             p.addLast(new HttpServerHandler(config, SessionProtocol.H1));
         }
@@ -225,7 +226,7 @@ public final class HttpServerPipelineConfigurator extends ChannelInitializer<Cha
                     },
                     UPGRADE_REQUEST_MAX_LENGTH));
 
-            addAfter(p, baseName, new Http1RequestDecoder(ctx.channel(), SCHEME_HTTP));
+            addAfter(p, baseName, new Http1RequestDecoder(config, ctx.channel(), SCHEME_HTTP));
         }
 
         private void configureHttp2(ChannelHandlerContext ctx) {

--- a/src/test/java/com/linecorp/armeria/server/http/HttpServerTest.java
+++ b/src/test/java/com/linecorp/armeria/server/http/HttpServerTest.java
@@ -256,6 +256,8 @@ public class HttpServerTest extends AbstractServerTest {
                     }
                 };
         sb.decorator(decorator);
+
+        sb.defaultMaxRequestLength(MAX_CONTENT_LENGTH);
     }
 
     @AfterClass
@@ -347,6 +349,14 @@ public class HttpServerTest extends AbstractServerTest {
         assertThat(res.status(), is(HttpStatus.REQUEST_ENTITY_TOO_LARGE));
         assertThat(res.headers().get(HttpHeaderNames.CONTENT_TYPE), is(MediaType.PLAIN_TEXT_UTF_8.toString()));
         assertThat(res.content().toStringUtf8(), is("413 Request Entity Too Large"));
+    }
+
+    @Test(timeout = 10000)
+    public void testTooLargeContentToNonExistentService() throws Exception {
+        final byte[] content = new byte[(int) MAX_CONTENT_LENGTH + 1];
+        final AggregatedHttpMessage res = client().post("/non-existent", content).aggregate().get();
+        assertThat(res.headers().status(), is(HttpStatus.NOT_FOUND));
+        assertThat(res.content().toStringUtf8(), is("404 Not Found"));
     }
 
     @Test(timeout = 60000)


### PR DESCRIPTION
Motivation:

When there is no service that matches the request path,
HttpServerHandler does not initialize a DecodedHttpRequest with a
ServiceRequestContext because it cannot create a context for a
non-existent service. This leaves DecodedHttpRequest.ctx to be null, and
attempting to access it may result in NPE.

Modification:

- Use defaultMaxRequestLength when DecodedHttpRequest.ctx is not
  available
- Disallow sending beyond defaultMaxRequestLength if the server
  responded already on a request to a non-existent service
- Ignore an empty HTTP/2 DATA frame so that the Subscriber always gets a
  non-empty HttpData
- Close the stream instead of sending a GOAWAY frame when a client sends
  too large content, so that other streams are not interrupted
  - Do not send a GOAWAY frame when received the RST_STREAM with unknown
    stream ID if it may be just a timing issue.

Result:

- Robustness
- Ill-behaving client cannot send more than defaultMaxRequestLength