### PR TITLE
Add DeferredStreamMessage and DeferredHttpResponse

### DIFF
--- a/src/main/java/com/linecorp/armeria/common/http/DeferredHttpResponse.java
+++ b/src/main/java/com/linecorp/armeria/common/http/DeferredHttpResponse.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.http;
+
+import com.linecorp.armeria.common.stream.DeferredStreamMessage;
+
+/**
+ * An {@link HttpResponse} whose stream is published later by another {@link HttpResponse}. It is useful when
+ * your {@link HttpResponse} will not be instantiated early. For example:
+ * <pre>{@code
+ * public class DelayService extends DecoratingService<HttpRequest, HttpResponse> {
+ *     public DelayService(Service<HttpRequest, HttpResponse> delegate) {
+ *         super(delegate);
+ *     }
+ *
+ *     public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) {
+ *         // Delay all requests by 3 seconds.
+ *         DeferredHttpResponse res = new DeferredHttpResponse();
+ *         ctx.eventLoop().schedule(() -> {
+ *             res.setDelegate(delegate().serve(ctx, req));
+ *         }, 3, TimeUnit.SECONDS);
+ *         return res;
+ *     }
+ * }
+ * }</pre>
+ */
+public class DeferredHttpResponse extends DeferredStreamMessage<HttpObject> implements HttpResponse {
+
+    /**
+     * Sets the delegate {@link HttpResponse} which will publish the stream actually.
+     *
+     * @throws IllegalStateException if the delegate has been set already
+     */
+    public void setDelegate(HttpResponse delegate) {
+        super.setDelegate(delegate);
+    }
+}

--- a/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
+++ b/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
@@ -375,6 +375,10 @@ public class DefaultStreamMessage<T> implements StreamMessage<T>, StreamWriter<T
             }
 
             if (e instanceof CloseEvent) {
+                final Throwable closeCause = ((CloseEvent) e).cause();
+                if (closeCause != null) {
+                    closeFuture.completeExceptionally(closeCause);
+                }
                 continue;
             }
 

--- a/src/main/java/com/linecorp/armeria/common/stream/DeferredStreamMessage.java
+++ b/src/main/java/com/linecorp/armeria/common/stream/DeferredStreamMessage.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.stream;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import com.linecorp.armeria.common.http.HttpResponse;
+import com.linecorp.armeria.common.util.CompletionActions;
+
+/**
+ * A {@link StreamMessage} whose stream is published later by another {@link StreamMessage}. It is useful when
+ * your {@link StreamMessage} will not be instantiated early.
+ *
+ * @param <T> the type of element signaled
+ */
+public class DeferredStreamMessage<T> implements StreamMessage<T> {
+
+    @SuppressWarnings({ "AtomicFieldUpdaterIssues", "rawtypes" })
+    private static final AtomicReferenceFieldUpdater<DeferredStreamMessage, StreamMessage> delegateUpdater =
+            AtomicReferenceFieldUpdater.newUpdater(DeferredStreamMessage.class, StreamMessage.class, "delegate");
+    @SuppressWarnings({ "AtomicFieldUpdaterIssues", "rawtypes" })
+    private static final AtomicReferenceFieldUpdater<DeferredStreamMessage, Subscriber> subscriberUpdater =
+            AtomicReferenceFieldUpdater.newUpdater(DeferredStreamMessage.class, Subscriber.class, "subscriber");
+
+    private static final Subscriber<?> ABORTED_SUBSCRIBER = new Subscriber<Object>() {
+        @Override
+        public void onSubscribe(Subscription s) {}
+
+        @Override
+        public void onNext(Object o) {}
+
+        @Override
+        public void onError(Throwable t) {}
+
+        @Override
+        public void onComplete() {}
+    };
+
+    private final CompletableFuture<Void> closeFuture = new CompletableFuture<>();
+
+    @SuppressWarnings("unused") // Updated only via delegateUpdater
+    private volatile StreamMessage<T> delegate;
+    @SuppressWarnings("unused") // Updated only via subscriberUpdater
+    private volatile Subscriber<T> subscriber;
+    private volatile Executor subscriberExecutor;
+    private volatile boolean abortPending;
+
+    /**
+     * Returns the delegate {@link HttpResponse} which will publish the stream actually.
+     *
+     * @return the delegate, or {@code null} if not set yet
+     */
+    @SuppressWarnings("unchecked")
+    protected final <U extends StreamMessage<T>> U delegate() {
+        return (U) delegate;
+    }
+
+    /**
+     * Sets the delegate {@link HttpResponse} which will publish the stream actually.
+     *
+     * @throws IllegalStateException if the delegate has been set already
+     */
+    protected void setDelegate(StreamMessage<T> delegate) {
+        requireNonNull(delegate, "delegate");
+        if (!delegateUpdater.compareAndSet(this, null, delegate)) {
+            throw new IllegalStateException("delegate set already");
+        }
+
+        delegate.closeFuture().handle((unused, cause) -> {
+            if (cause == null) {
+                closeFuture.complete(null);
+            } else {
+                closeFuture.completeExceptionally(cause);
+            }
+            return null;
+        }).exceptionally(CompletionActions::log);
+
+        final Subscriber<T> subscriber = this.subscriber;
+        if (subscriber != null && subscriber != ABORTED_SUBSCRIBER) {
+            subscribeToDelegate(subscriber, subscriberExecutor);
+        }
+
+        if (abortPending) {
+            delegate.abort();
+        }
+    }
+
+    @Override
+    public boolean isOpen() {
+        return !closeFuture.isDone();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        final StreamMessage<T> delegate = this.delegate;
+        if (delegate != null) {
+            return delegate.isEmpty();
+        }
+
+        return !isOpen();
+    }
+
+    @Override
+    public CompletableFuture<Void> closeFuture() {
+        return closeFuture;
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super T> subscriber) {
+        requireNonNull(subscriber, "subscriber");
+        subscribe0(subscriber, null);
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super T> s, Executor executor) {
+        requireNonNull(subscriber, "subscriber");
+        requireNonNull(executor, "executor");
+        subscribe0(subscriber, executor);
+    }
+
+    private void subscribe0(Subscriber<? super T> subscriber, Executor executor) {
+        if (!subscriberUpdater.compareAndSet(this, null, subscriber)) {
+            if (this.subscriber == ABORTED_SUBSCRIBER) {
+                throw new IllegalStateException("cannot subscribe to an aborted publisher");
+            } else {
+                throw new IllegalStateException("subscribed by other subscriber already: " + this.subscriber);
+            }
+        }
+
+        subscriberExecutor = executor;
+        subscribeToDelegate(subscriber, executor);
+    }
+
+    private void subscribeToDelegate(Subscriber<? super T> subscriber, Executor executor) {
+        final StreamMessage<T> delegate = this.delegate;
+        if (delegate != null) {
+            if (executor == null) {
+                delegate.subscribe(subscriber);
+            } else {
+                delegate.subscribe(subscriber, executor);
+            }
+        }
+    }
+
+    @Override
+    public void abort() {
+        abortPending = true;
+
+        // Prevent the future subscription.
+        subscriberUpdater.compareAndSet(this, null, ABORTED_SUBSCRIBER);
+
+        final StreamMessage<T> delegate = this.delegate;
+        if (delegate != null) {
+            delegate.abort();
+        } else {
+            closeFuture.completeExceptionally(CancelledSubscriptionException.get());
+        }
+    }
+}

--- a/src/test/java/com/linecorp/armeria/common/stream/DeferredStreamMessageTest.java
+++ b/src/test/java/com/linecorp/armeria/common/stream/DeferredStreamMessageTest.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import com.google.common.base.Throwables;
+
+public class DeferredStreamMessageTest {
+
+    @Test
+    public void testInitialState() throws Exception {
+        final DeferredStreamMessage<Object> m = new DeferredStreamMessage<>();
+        assertThat(m.isOpen()).isTrue();
+        assertThat(m.isEmpty()).isFalse();
+        assertThat(m.closeFuture()).isNotCompleted();
+    }
+
+    @Test
+    public void testSetDelegate() throws Exception {
+        final DeferredStreamMessage<Object> m = new DeferredStreamMessage<>();
+        m.setDelegate(new DefaultStreamMessage<>());
+        assertThatThrownBy(() -> m.setDelegate(new DefaultStreamMessage<>()))
+                .isInstanceOf(IllegalStateException.class);
+        assertThatThrownBy(() -> m.setDelegate(null)).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    public void testEarlyAbort() throws Exception {
+        final DeferredStreamMessage<Object> m = new DeferredStreamMessage<>();
+        m.abort();
+        assertAborted(m);
+        assertThatThrownBy(() -> m.subscribe(mock(Subscriber.class))).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void testEarlyAbortWithSubscriber() throws Exception {
+        final DeferredStreamMessage<Object> m = new DeferredStreamMessage<>();
+        m.subscribe(mock(Subscriber.class));
+        m.abort();
+        assertAborted(m);
+
+        final DefaultStreamMessage<Object> d = new DefaultStreamMessage<>();
+        m.setDelegate(d);
+        assertAborted(d);
+    }
+
+    @Test
+    public void testLateAbort() throws Exception {
+        final DeferredStreamMessage<Object> m = new DeferredStreamMessage<>();
+        final DefaultStreamMessage<Object> d = new DefaultStreamMessage<>();
+
+        m.setDelegate(d);
+        m.abort();
+
+        assertAborted(m);
+        assertAborted(d);
+    }
+
+    @Test
+    public void testLateAbortWithSubscriber() throws Exception {
+        final DeferredStreamMessage<Object> m = new DeferredStreamMessage<>();
+        final DefaultStreamMessage<Object> d = new DefaultStreamMessage<>();
+        @SuppressWarnings("unchecked")
+        final Subscriber<Object> subscriber = mock(Subscriber.class);
+
+        m.subscribe(subscriber);
+        m.setDelegate(d);
+        verify(subscriber).onSubscribe(any());
+
+        m.abort();
+        verify(subscriber, never()).onError(any());
+
+        assertAborted(m);
+        assertAborted(d);
+    }
+
+    @Test
+    public void testEarlySubscription() throws Exception {
+        final DeferredStreamMessage<Object> m = new DeferredStreamMessage<>();
+        final DefaultStreamMessage<Object> d = new DefaultStreamMessage<>();
+        @SuppressWarnings("unchecked")
+        final Subscriber<Object> subscriber = mock(Subscriber.class);
+
+        m.subscribe(subscriber);
+        assertThatThrownBy(() -> m.subscribe(mock(Subscriber.class))).isInstanceOf(IllegalStateException.class);
+
+        m.setDelegate(d);
+        verify(subscriber).onSubscribe(any());
+    }
+
+    @Test
+    public void testLateSubscription() throws Exception {
+        final DeferredStreamMessage<Object> m = new DeferredStreamMessage<>();
+        final DefaultStreamMessage<Object> d = new DefaultStreamMessage<>();
+
+        m.setDelegate(d);
+
+        @SuppressWarnings("unchecked")
+        final Subscriber<Object> subscriber = mock(Subscriber.class);
+
+        m.subscribe(subscriber);
+        verify(subscriber).onSubscribe(any());
+
+        assertThatThrownBy(() -> m.subscribe(mock(Subscriber.class))).isInstanceOf(IllegalStateException.class);
+    }
+
+    private static void assertAborted(StreamMessage<?> m) {
+        assertThat(m.isOpen()).isFalse();
+        assertThat(m.isEmpty()).isTrue();
+        assertThat(m.closeFuture()).isCompletedExceptionally();
+        assertThatThrownBy(() -> m.closeFuture().get())
+                .hasCauseInstanceOf(CancelledSubscriptionException.class);
+    }
+
+    @Test
+    public void testStreaming() throws Exception {
+        final DeferredStreamMessage<Object> m = new DeferredStreamMessage<>();
+        final DefaultStreamMessage<Object> d = new DefaultStreamMessage<>();
+        m.setDelegate(d);
+
+        final List<Object> streamed = new ArrayList<>();
+        m.subscribe(new Subscriber<Object>() {
+            @Override
+            public void onSubscribe(Subscription s) {
+                streamed.add("onSubscribe");
+                s.request(1);
+            }
+
+            @Override
+            public void onNext(Object o) {
+                streamed.add(o);
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                streamed.add("onError: " + Throwables.getStackTraceAsString(t));
+            }
+
+            @Override
+            public void onComplete() {
+                streamed.add("onComplete");
+            }
+        });
+
+        assertThat(streamed).containsExactly("onSubscribe");
+        d.write("A");
+        assertThat(streamed).containsExactly("onSubscribe", "A");
+        d.close();
+        assertThat(streamed).containsExactly("onSubscribe", "A", "onComplete");
+
+        assertThat(m.isOpen()).isFalse();
+        assertThat(m.isEmpty()).isFalse();
+        assertThat(m.closeFuture()).isCompletedWithValue(null);
+
+        assertThat(d.isOpen()).isFalse();
+        assertThat(d.isEmpty()).isFalse();
+        assertThat(d.closeFuture()).isCompletedWithValue(null);
+    }
+}


### PR DESCRIPTION
Motivation:

Sometimes you cannot prepare your HttpResponse or StreamMessage instance
when returning from Service.serve() or Client.execute(). It will be
useful to have a placeholder StreamMessage implementation whose stream
is actually delegated from another StreamMessage.

Modifications:

- Add DeferredStreamMessage and DeferredHttpRequest

Result:

Easier to write a Service or a Client that delays its execution.