### PR TITLE
Add ConcurrencyLimiting(Http)Client

### DIFF
--- a/src/main/java/com/linecorp/armeria/client/SessionOption.java
+++ b/src/main/java/com/linecorp/armeria/client/SessionOption.java
@@ -59,11 +59,6 @@ public class SessionOption<T> extends AbstractOption<T> {
     public static final SessionOption<Duration> IDLE_TIMEOUT = valueOf("IDLE_TIMEOUT");
 
     /**
-     * The maximum number of concurrent in-progress invocations.
-     */
-    public static final SessionOption<Integer> MAX_CONCURRENCY = valueOf("MAX_CONCURRENCY");
-
-    /**
      * The {@link TrustManagerFactory} of a TLS connection.
      */
     public static final SessionOption<TrustManagerFactory> TRUST_MANAGER_FACTORY =

--- a/src/main/java/com/linecorp/armeria/client/SessionOptions.java
+++ b/src/main/java/com/linecorp/armeria/client/SessionOptions.java
@@ -19,7 +19,6 @@ import static com.linecorp.armeria.client.SessionOption.ADDRESS_RESOLVER_GROUP;
 import static com.linecorp.armeria.client.SessionOption.CONNECT_TIMEOUT;
 import static com.linecorp.armeria.client.SessionOption.EVENT_LOOP_GROUP;
 import static com.linecorp.armeria.client.SessionOption.IDLE_TIMEOUT;
-import static com.linecorp.armeria.client.SessionOption.MAX_CONCURRENCY;
 import static com.linecorp.armeria.client.SessionOption.POOL_HANDLER_DECORATOR;
 import static com.linecorp.armeria.client.SessionOption.TRUST_MANAGER_FACTORY;
 import static com.linecorp.armeria.client.SessionOption.USE_HTTP2_PREFACE;
@@ -52,7 +51,6 @@ public class SessionOptions extends AbstractOptions {
 
     private static final Duration DEFAULT_CONNECTION_TIMEOUT = Duration.ofMillis(3200);
     private static final Duration DEFAULT_IDLE_TIMEOUT = Duration.ofSeconds(10);
-    private static final Integer DEFAULT_MAX_CONCURRENCY = Integer.MAX_VALUE;
     private static final Boolean DEFAULT_USE_HTTP2_PREFACE =
             "true".equals(System.getProperty("com.linecorp.armeria.defaultUseHttp2Preface", "false"));
 
@@ -63,7 +61,6 @@ public class SessionOptions extends AbstractOptions {
     private static final SessionOptionValue<?>[] DEFAULT_OPTION_VALUES = {
             CONNECT_TIMEOUT.newValue(DEFAULT_CONNECTION_TIMEOUT),
             IDLE_TIMEOUT.newValue(DEFAULT_IDLE_TIMEOUT),
-            MAX_CONCURRENCY.newValue(DEFAULT_MAX_CONCURRENCY),
             USE_HTTP2_PREFACE.newValue(DEFAULT_USE_HTTP2_PREFACE)
     };
 
@@ -96,8 +93,6 @@ public class SessionOptions extends AbstractOptions {
             validateConnectionTimeout((Duration) value);
         } else if (option == IDLE_TIMEOUT) {
             validateIdleTimeout((Duration) value);
-        } else if (option == MAX_CONCURRENCY) {
-            validateMaxConcurrency((Integer) value);
         }
 
         return optionValue;
@@ -119,13 +114,6 @@ public class SessionOptions extends AbstractOptions {
                     "idleTimeout: " + idleTimeout + " (expected: >= 0)");
         }
         return idleTimeout;
-    }
-
-    private static int validateMaxConcurrency(int maxConcurrency) {
-        if (maxConcurrency <= 0) {
-            throw new IllegalArgumentException("maxConcurrency: " + maxConcurrency + " (expected: > 0)");
-        }
-        return maxConcurrency;
     }
 
     private SessionOptions(SessionOptionValue<?>... options) {
@@ -222,13 +210,6 @@ public class SessionOptions extends AbstractOptions {
      */
     public long idleTimeoutMillis() {
         return idleTimeout().toMillis();
-    }
-
-    /**
-     * Returns the {@link SessionOption#MAX_CONCURRENCY} value.
-     */
-    public int maxConcurrency() {
-        return getOrElse(MAX_CONCURRENCY, DEFAULT_MAX_CONCURRENCY);
     }
 
     /**

--- a/src/main/java/com/linecorp/armeria/client/http/HttpSessionHandler.java
+++ b/src/main/java/com/linecorp/armeria/client/http/HttpSessionHandler.java
@@ -107,10 +107,10 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
 
     @Override
     public boolean invoke(ClientRequestContext ctx, HttpRequest req, DecodedHttpResponse res) {
-        final SessionProtocol sessionProtocol = protocol();
-        if (sessionProtocol == null) {
-            res.close(ClosedSessionException.get());
-            return false;
+        if (!res.isOpen()) {
+            // The response has been closed even before its request is sent.
+            req.abort();
+            return true;
         }
 
         final long writeTimeoutMillis = ctx.writeTimeoutMillis();

--- a/src/main/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingClient.java
+++ b/src/main/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingClient.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.limit;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.linecorp.armeria.client.Client;
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.DecoratingClient;
+import com.linecorp.armeria.client.ResponseTimeoutException;
+import com.linecorp.armeria.common.Request;
+import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.common.RequestContext.PushHandle;
+import com.linecorp.armeria.common.Response;
+
+import io.netty.util.concurrent.ScheduledFuture;
+
+/**
+ * An abstract {@link Client} decorator that limits the concurrent number of active requests.
+ *
+ * <p>{@link #numActiveRequests()} increases when {@link Client#execute(ClientRequestContext, Request)} is
+ * invoked and decreases when the {@link Response} returned by the
+ * {@link Client#execute(ClientRequestContext, Request)} is closed. When {@link #numActiveRequests()} reaches
+ * at the configured {@code maxConcurrency} the {@link Request}s are deferred until the currently active
+ * {@link Request}s are completed.
+ *
+ * @param <I> the {@link Request} type
+ * @param <O> the {@link Response} type
+ */
+public abstract class ConcurrencyLimitingClient<I extends Request, O extends Response>
+        extends DecoratingClient<I, O, I, O> {
+
+    private static final long DEFAULT_TIMEOUT_MILLIS = 10000L;
+
+    private final int maxConcurrency;
+    private final long timeoutMillis;
+    private final AtomicInteger numActiveRequests = new AtomicInteger();
+    private final Queue<PendingTask> pendingRequests = new ConcurrentLinkedQueue<>();
+
+    protected ConcurrencyLimitingClient(Client<? super I, ? extends O> delegate, int maxConcurrency) {
+        this(delegate, maxConcurrency, DEFAULT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+    }
+
+    protected ConcurrencyLimitingClient(Client<? super I, ? extends O> delegate,
+                                        int maxConcurrency, long timeout, TimeUnit unit) {
+        super(delegate);
+
+        validateAll(maxConcurrency, timeout, unit);
+
+        this.maxConcurrency = maxConcurrency;
+        timeoutMillis = unit.toMillis(timeout);
+    }
+
+    static void validateAll(int maxConcurrency, long timeout, TimeUnit unit) {
+        validateMaxConcurrency(maxConcurrency);
+        if (timeout < 0) {
+            throw new IllegalArgumentException("timeout: " + timeout + " (expected: >= 0)");
+        }
+        requireNonNull(unit, "unit");
+    }
+
+    static void validateMaxConcurrency(int maxConcurrency) {
+        if (maxConcurrency < 0) {
+            throw new IllegalArgumentException("maxConcurrency: " + maxConcurrency + " (expected: >= 0)");
+        }
+    }
+
+    /**
+     * Returns the number of the {@link Request}s that are being executed.
+     */
+    public int numActiveRequests() {
+        return numActiveRequests.get();
+    }
+
+    @Override
+    public O execute(ClientRequestContext ctx, I req) throws Exception {
+        return maxConcurrency == 0 ? unlimitedExecute(ctx, req)
+                                   : limitedExecute(ctx, req);
+    }
+
+    private O limitedExecute(ClientRequestContext ctx, I req) throws Exception {
+        final Deferred<O> deferred = defer(ctx, req);
+        final PendingTask currentTask = new PendingTask(ctx, req, deferred);
+
+        pendingRequests.add(currentTask);
+        drain();
+
+        if (!currentTask.isRun() && timeoutMillis != 0) {
+            // Current request was not delegated. Schedule a timeout.
+            final ScheduledFuture<?> timeoutFuture = ctx.eventLoop().schedule(
+                    () -> deferred.close(ResponseTimeoutException.get()),
+                    timeoutMillis, TimeUnit.MILLISECONDS);
+            currentTask.set(timeoutFuture);
+        }
+
+        return deferred.response();
+    }
+
+    private O unlimitedExecute(ClientRequestContext ctx, I req) throws Exception {
+        numActiveRequests.incrementAndGet();
+        boolean success = false;
+        try {
+            final O res = delegate().execute(ctx, req);
+            res.closeFuture().whenComplete((unused, cause) -> numActiveRequests.decrementAndGet());
+            success = true;
+            return res;
+        } finally {
+            if (!success) {
+                numActiveRequests.decrementAndGet();
+            }
+        }
+    }
+
+    void drain() {
+        while (!pendingRequests.isEmpty()) {
+            final int currentActiveRequests = numActiveRequests.get();
+            if (currentActiveRequests >= maxConcurrency) {
+                break;
+            }
+
+            if (numActiveRequests.compareAndSet(currentActiveRequests, currentActiveRequests + 1)) {
+                final PendingTask task = pendingRequests.poll();
+                if (task == null) {
+                    numActiveRequests.decrementAndGet();
+                    if (!pendingRequests.isEmpty()) {
+                        // Another request might have been added to the queue while numActiveRequests reached
+                        // at its limit.
+                        continue;
+                    } else {
+                        break;
+                    }
+                }
+
+                task.run();
+            }
+        }
+    }
+
+    /**
+     * Defers the specified {@link Request}.
+     *
+     * @return a new {@link Deferred} which provides the interface for updating the result of
+     *         {@link Request} execution later.
+     */
+    protected abstract Deferred<O> defer(ClientRequestContext ctx, I req) throws Exception;
+
+    /**
+     * Provides the interface for updating the result of a {@link Request} execution when its {@link Response}
+     * is ready.
+     *
+     * @param <O> the {@link Response} type
+     */
+    public interface Deferred<O extends Response> {
+        /**
+         * Returns the {@link Response} which will delegate to the {@link Response} set by
+         * {@link #delegate(Response)}.
+         */
+        O response();
+
+        /**
+         * Delegates the {@link #response() response} to the specified {@link Response}.
+         */
+        void delegate(O response);
+
+        /**
+         * Closes the {@link #response()} without delegating.
+         */
+        void close(Throwable cause);
+    }
+
+    private final class PendingTask extends AtomicReference<ScheduledFuture<?>> implements Runnable {
+
+        private static final long serialVersionUID = -7092037489640350376L;
+
+        private final ClientRequestContext ctx;
+        private final I req;
+        private final Deferred<O> deferred;
+        private boolean isRun;
+
+        PendingTask(ClientRequestContext ctx, I req, Deferred<O> deferred) {
+            this.ctx = ctx;
+            this.req = req;
+            this.deferred = deferred;
+        }
+
+        boolean isRun() {
+            return isRun;
+        }
+
+        @Override
+        public void run() {
+            isRun = true;
+
+            ScheduledFuture<?> timeoutFuture = get();
+            if (timeoutFuture != null) {
+                if (timeoutFuture.isDone() || !timeoutFuture.cancel(false)) {
+                    // Timeout task ran already or is determined to run.
+                    numActiveRequests.decrementAndGet();
+                    return;
+                }
+            }
+
+            try (PushHandle ignored = RequestContext.push(ctx)) {
+                try {
+                    final O actualRes = delegate().execute(ctx, req);
+                    actualRes.closeFuture().whenCompleteAsync((unused, cause) -> {
+                        numActiveRequests.decrementAndGet();
+                        drain();
+                    }, ctx.eventLoop());
+                    deferred.delegate(actualRes);
+                } catch (Throwable t) {
+                    numActiveRequests.decrementAndGet();
+                    deferred.close(t);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingHttpClient.java
+++ b/src/main/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingHttpClient.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.limit;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+import com.linecorp.armeria.client.Client;
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.common.http.DeferredHttpResponse;
+import com.linecorp.armeria.common.http.HttpRequest;
+import com.linecorp.armeria.common.http.HttpResponse;
+
+/**
+ * A {@link Client} decorator that limits the concurrent number of active HTTP requests.
+ *
+ * For example:
+ * <pre>{@code
+ * ClientBuilder builder = new ClientBuilder(...);
+ * builder.decorator(HttpRequest.class, HttpResponse.class, ConcurrencyLimitingHttpClient.newDecorator(16));
+ * client = builder.build(...);
+ * }</pre>
+ *
+ */
+public class ConcurrencyLimitingHttpClient
+        extends ConcurrencyLimitingClient<HttpRequest, HttpResponse> {
+
+    /**
+     * Creates a new {@link Client} decorator that limits the concurrent number of active HTTP requests.
+     */
+    public static Function<Client<? super HttpRequest, ? extends HttpResponse>, ConcurrencyLimitingHttpClient>
+    newDecorator(int maxConcurrency) {
+        validateMaxConcurrency(maxConcurrency);
+        return delegate -> new ConcurrencyLimitingHttpClient(delegate, maxConcurrency);
+    }
+
+    /**
+     * Creates a new {@link Client} decorator that limits the concurrent number of active HTTP requests.
+     */
+    public static Function<Client<? super HttpRequest, ? extends HttpResponse>, ConcurrencyLimitingHttpClient>
+    newDecorator(int maxConcurrency, long timeout, TimeUnit unit) {
+        validateAll(maxConcurrency, timeout, unit);
+        return delegate -> new ConcurrencyLimitingHttpClient(delegate, maxConcurrency, timeout, unit);
+    }
+
+
+    private ConcurrencyLimitingHttpClient(Client<? super HttpRequest, ? extends HttpResponse> delegate,
+                                          int maxConcurrency) {
+        super(delegate, maxConcurrency);
+    }
+
+    private ConcurrencyLimitingHttpClient(Client<? super HttpRequest, ? extends HttpResponse> delegate,
+                                          int maxConcurrency, long timeout, TimeUnit unit) {
+        super(delegate, maxConcurrency, timeout, unit);
+    }
+
+    @Override
+    protected Deferred<HttpResponse> defer(ClientRequestContext ctx, HttpRequest req) throws Exception {
+        final DeferredHttpResponse res = new DeferredHttpResponse();
+        return new Deferred<HttpResponse>() {
+            @Override
+            public HttpResponse response() {
+                return res;
+            }
+
+            @Override
+            public void delegate(HttpResponse response) {
+                res.delegate(response);
+            }
+
+            @Override
+            public void close(Throwable cause) {
+                res.close(cause);
+            }
+        };
+    }
+}

--- a/src/main/java/com/linecorp/armeria/client/limit/package-info.java
+++ b/src/main/java/com/linecorp/armeria/client/limit/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * Limits the number of executed {@link com.linecorp.armeria.common.Request}s.
+ */
+package com.linecorp.armeria.client.limit;

--- a/src/main/java/com/linecorp/armeria/common/http/DeferredHttpResponse.java
+++ b/src/main/java/com/linecorp/armeria/common/http/DeferredHttpResponse.java
@@ -39,13 +39,13 @@ import com.linecorp.armeria.common.stream.DeferredStreamMessage;
  * }</pre>
  */
 public class DeferredHttpResponse extends DeferredStreamMessage<HttpObject> implements HttpResponse {
-
     /**
      * Sets the delegate {@link HttpResponse} which will publish the stream actually.
      *
-     * @throws IllegalStateException if the delegate has been set already
+     * @throws IllegalStateException if the delegate has been set already or
+     *                               if {@link #close()} or {@link #close(Throwable)} was called already.
      */
-    public void setDelegate(HttpResponse delegate) {
-        super.setDelegate(delegate);
+    public void delegate(HttpResponse delegate) {
+        super.delegate(delegate);
     }
 }

--- a/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
+++ b/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
@@ -378,6 +378,8 @@ public class DefaultStreamMessage<T> implements StreamMessage<T>, StreamWriter<T
                 final Throwable closeCause = ((CloseEvent) e).cause();
                 if (closeCause != null) {
                     closeFuture.completeExceptionally(closeCause);
+                } else {
+                    closeFuture.complete(null);
                 }
                 continue;
             }

--- a/src/main/java/com/linecorp/armeria/common/stream/NoopSubscriber.java
+++ b/src/main/java/com/linecorp/armeria/common/stream/NoopSubscriber.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.stream;
+
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+/**
+ * A {@link Subscriber} that discards all elements silently.
+ */
+public final class NoopSubscriber<T> implements Subscriber<T> {
+
+    private static final NoopSubscriber<?> INSTANCE = new NoopSubscriber<>();
+
+    /**
+     * Returns a singleton {@link NoopSubscriber}.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> NoopSubscriber<T> get() {
+        return (NoopSubscriber<T>) INSTANCE;
+    }
+
+    @Override
+    public void onSubscribe(Subscription s) {
+        s.request(Long.MAX_VALUE);
+    }
+
+    @Override
+    public void onNext(T t) {}
+
+    @Override
+    public void onError(Throwable t) {}
+
+    @Override
+    public void onComplete() {}
+}

--- a/src/test/java/com/linecorp/armeria/client/SessionOptionsTest.java
+++ b/src/test/java/com/linecorp/armeria/client/SessionOptionsTest.java
@@ -18,10 +18,8 @@ package com.linecorp.armeria.client;
 import static com.linecorp.armeria.client.SessionOption.CONNECT_TIMEOUT;
 import static com.linecorp.armeria.client.SessionOption.EVENT_LOOP_GROUP;
 import static com.linecorp.armeria.client.SessionOption.IDLE_TIMEOUT;
-import static com.linecorp.armeria.client.SessionOption.MAX_CONCURRENCY;
 import static com.linecorp.armeria.client.SessionOption.TRUST_MANAGER_FACTORY;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.Mockito.mock;
@@ -43,7 +41,6 @@ public class SessionOptionsTest {
         assertThat(options.connectTimeout(), is(notNullValue()));
         assertThat(options.idleTimeout(), is(notNullValue()));
         assertThat(options.trustManagerFactory(), is(Optional.empty()));
-        assertThat(options.maxConcurrency(), greaterThan(0));
     }
 
     @Test
@@ -58,15 +55,12 @@ public class SessionOptionsTest {
                 CONNECT_TIMEOUT.newValue(connectionTimeout),
                 IDLE_TIMEOUT.newValue(idleTimeout),
                 EVENT_LOOP_GROUP.newValue(eventLoop),
-                TRUST_MANAGER_FACTORY.newValue(trustManagerFactory),
-                MAX_CONCURRENCY.newValue(maxConcurrency)
+                TRUST_MANAGER_FACTORY.newValue(trustManagerFactory)
         );
 
         assertThat(options.get(CONNECT_TIMEOUT),is(Optional.of(connectionTimeout)));
         assertThat(options.get(IDLE_TIMEOUT),is(Optional.of(idleTimeout)));
         assertThat(options.get(EVENT_LOOP_GROUP),is(Optional.of(eventLoop)));
-        assertThat(options.get(MAX_CONCURRENCY), is(Optional.of(maxConcurrency)));
-
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -77,11 +71,6 @@ public class SessionOptionsTest {
     @Test(expected = IllegalArgumentException.class)
     public void testValidateFailIdleTimeout(){
         SessionOptions.of(IDLE_TIMEOUT.newValue(Duration.ofMillis(-1)));
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testValidateMaxConcurrency(){
-        SessionOptions.of(MAX_CONCURRENCY.newValue(0));
     }
 }
 

--- a/src/test/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingHttpClientTest.java
+++ b/src/test/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingHttpClientTest.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.limit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.AfterClass;
+import org.junit.Test;
+
+import com.linecorp.armeria.client.Client;
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.ResponseTimeoutException;
+import com.linecorp.armeria.common.http.DefaultHttpResponse;
+import com.linecorp.armeria.common.http.DeferredHttpResponse;
+import com.linecorp.armeria.common.http.HttpRequest;
+import com.linecorp.armeria.common.http.HttpResponse;
+import com.linecorp.armeria.common.stream.NoopSubscriber;
+
+import io.netty.channel.DefaultEventLoop;
+import io.netty.channel.EventLoop;
+
+public class ConcurrencyLimitingHttpClientTest {
+
+    private static final EventLoop eventLoop = new DefaultEventLoop();
+
+    @AfterClass
+    public static void destroy() {
+        eventLoop.shutdownGracefully();
+    }
+
+    /**
+     * Tests the request pattern  that does not exceed maxConcurrency.
+     */
+    @Test
+    public void testOrdinaryRequest() throws Exception {
+        final ClientRequestContext ctx = newContext();
+        final HttpRequest req = mock(HttpRequest.class);
+        final DefaultHttpResponse actualRes = new DefaultHttpResponse();
+
+        @SuppressWarnings("unchecked")
+        final Client<HttpRequest, HttpResponse> delegate = mock(Client.class);
+        when(delegate.execute(ctx, req)).thenReturn(actualRes);
+
+        final ConcurrencyLimitingHttpClient client =
+                ConcurrencyLimitingHttpClient.newDecorator(1).apply(delegate);
+        assertThat(client.numActiveRequests()).isZero();
+
+        final HttpResponse res = client.execute(ctx, req);
+        assertThat(res).isInstanceOf(DeferredHttpResponse.class);
+        assertThat(res.isOpen()).isTrue();
+        assertThat(client.numActiveRequests()).isEqualTo(1);
+
+        closeAndDrain(actualRes, res);
+
+        assertThat(res.isOpen()).isFalse();
+        assertThat(client.numActiveRequests()).isZero();
+    }
+
+    /**
+     * Tests the request pattern that exceeds maxConcurrency.
+     */
+    @Test
+    public void testLimitedRequest() throws Exception {
+        final ClientRequestContext ctx1 = newContext();
+        final ClientRequestContext ctx2 = newContext();
+        final HttpRequest req1 = mock(HttpRequest.class);
+        final HttpRequest req2 = mock(HttpRequest.class);
+        final DefaultHttpResponse actualRes1 = new DefaultHttpResponse();
+        final DefaultHttpResponse actualRes2 = new DefaultHttpResponse();
+
+        @SuppressWarnings("unchecked")
+        final Client<HttpRequest, HttpResponse> delegate = mock(Client.class);
+        when(delegate.execute(ctx1, req1)).thenReturn(actualRes1);
+        when(delegate.execute(ctx2, req2)).thenReturn(actualRes2);
+
+        final ConcurrencyLimitingHttpClient client =
+                ConcurrencyLimitingHttpClient.newDecorator(1).apply(delegate);
+
+        // The first request should be delegated immediately.
+        final HttpResponse res1 = client.execute(ctx1, req1);
+        verify(delegate).execute(ctx1, req1);
+        assertThat(res1).isInstanceOf(DeferredHttpResponse.class);
+        assertThat(res1.isOpen()).isTrue();
+
+        // The second request should never be delegated until the first response is closed.
+        final HttpResponse res2 = client.execute(ctx2, req2);
+        verify(delegate, never()).execute(ctx2, req2);
+        assertThat(res2).isInstanceOf(DeferredHttpResponse.class);
+        assertThat(res2.isOpen()).isTrue();
+        assertThat(client.numActiveRequests()).isEqualTo(1); // Only req1 is active.
+
+        // Complete res1.
+        closeAndDrain(actualRes1, res1);
+
+        // Once res1 is complete, req2 should be delegated.
+        verify(delegate).execute(ctx2, req2);
+        assertThat(client.numActiveRequests()).isEqualTo(1); // Only req2 is active.
+
+        // Complete res2, leaving no active requests.
+        closeAndDrain(actualRes2, res2);
+        assertThat(client.numActiveRequests()).isZero();
+    }
+
+    /**
+     * Tests if the request is not delegated but closed when the timeout is reached before delegation.
+     */
+    @Test
+    public void testTimeout() throws Exception {
+        final ClientRequestContext ctx1 = newContext();
+        final ClientRequestContext ctx2 = newContext();
+        final HttpRequest req1 = mock(HttpRequest.class);
+        final HttpRequest req2 = mock(HttpRequest.class);
+        final DefaultHttpResponse actualRes1 = new DefaultHttpResponse();
+        final DefaultHttpResponse actualRes2 = new DefaultHttpResponse();
+
+        @SuppressWarnings("unchecked")
+        final Client<HttpRequest, HttpResponse> delegate = mock(Client.class);
+        when(delegate.execute(ctx1, req1)).thenReturn(actualRes1);
+        when(delegate.execute(ctx2, req2)).thenReturn(actualRes2);
+
+        final ConcurrencyLimitingHttpClient client =
+                ConcurrencyLimitingHttpClient.newDecorator(1, 500, TimeUnit.MILLISECONDS).apply(delegate);
+
+        // Send two requests, where only the first one is delegated.
+        final HttpResponse res1 = client.execute(ctx1, req1);
+        final HttpResponse res2 = client.execute(ctx2, req2);
+
+        // Let req2 time out.
+        Thread.sleep(1000);
+        res2.subscribe(NoopSubscriber.get());
+        assertThat(res2.isOpen()).isFalse();
+        assertThat(res2.closeFuture()).isCompletedExceptionally();
+        assertThatThrownBy(() -> res2.closeFuture().get()).hasCauseInstanceOf(ResponseTimeoutException.class);
+
+        // req1 should not time out because it's been delegated already.
+        res1.subscribe(NoopSubscriber.get());
+        assertThat(res1.isOpen()).isTrue();
+        assertThat(res1.closeFuture()).isNotDone();
+
+        // Close req1 and make sure req2 does not affect numActiveRequests.
+        actualRes1.close();
+        waitForEventLoop();
+        assertThat(client.numActiveRequests()).isZero();
+    }
+
+    /**
+     * Tests the case where a delegate raises an exception rather than returning a response.
+     */
+    @Test
+    public void testFaultyDelegate() throws Exception {
+        final ClientRequestContext ctx = newContext();
+        final HttpRequest req = mock(HttpRequest.class);
+
+        @SuppressWarnings("unchecked")
+        final Client<HttpRequest, HttpResponse> delegate = mock(Client.class);
+        when(delegate.execute(ctx, req)).thenThrow(Exception.class);
+
+        final ConcurrencyLimitingHttpClient client =
+                ConcurrencyLimitingHttpClient.newDecorator(1).apply(delegate);
+        assertThat(client.numActiveRequests()).isZero();
+
+        final HttpResponse res = client.execute(ctx, req);
+
+        // Consume everything from the returned response so its close future is completed.
+        res.subscribe(NoopSubscriber.get());
+
+        assertThat(res).isInstanceOf(DeferredHttpResponse.class);
+        assertThat(res.isOpen()).isFalse();
+        assertThat(res.closeFuture()).isCompletedExceptionally();
+        assertThatThrownBy(() -> res.closeFuture().get()).hasCauseInstanceOf(Exception.class);
+        assertThat(client.numActiveRequests()).isZero();
+    }
+
+    @Test
+    public void testUnlimitedRequest() throws Exception {
+        final ClientRequestContext ctx = newContext();
+        final HttpRequest req = mock(HttpRequest.class);
+        final DefaultHttpResponse actualRes = new DefaultHttpResponse();
+
+        @SuppressWarnings("unchecked")
+        final Client<HttpRequest, HttpResponse> delegate = mock(Client.class);
+        when(delegate.execute(ctx, req)).thenReturn(actualRes);
+
+        final ConcurrencyLimitingHttpClient client =
+                ConcurrencyLimitingHttpClient.newDecorator(0).apply(delegate);
+
+        // A request should be delegated immediately, creating no deferred response.
+        final HttpResponse res = client.execute(ctx, req);
+        verify(delegate).execute(ctx, req);
+        assertThat(res).isNotInstanceOf(DeferredHttpResponse.class);
+        assertThat(res.isOpen()).isTrue();
+        assertThat(client.numActiveRequests()).isEqualTo(1);
+
+        // Complete the response, leaving no active requests.
+        closeAndDrain(actualRes, res);
+        assertThat(client.numActiveRequests()).isZero();
+    }
+
+    @Test
+    public void testUnlimitedRequestWithFaultyDelegate() throws Exception {
+        final ClientRequestContext ctx = newContext();
+        final HttpRequest req = mock(HttpRequest.class);
+
+        @SuppressWarnings("unchecked")
+        final Client<HttpRequest, HttpResponse> delegate = mock(Client.class);
+        when(delegate.execute(ctx, req)).thenThrow(Exception.class);
+
+        final ConcurrencyLimitingHttpClient client =
+                ConcurrencyLimitingHttpClient.newDecorator(0).apply(delegate);
+
+        // A request should be delegated immediately, rethrowing the exception from the delegate.
+        assertThatThrownBy(() -> client.execute(ctx, req)).isInstanceOf(Exception.class);
+        verify(delegate).execute(ctx, req);
+
+        // The number of active requests should increase and then immediately decrease. i.e. stay back at 0.
+        assertThat(client.numActiveRequests()).isZero();
+    }
+
+    private static ClientRequestContext newContext() {
+        final ClientRequestContext ctx = mock(ClientRequestContext.class);
+        when(ctx.eventLoop()).thenReturn(eventLoop);
+        return ctx;
+    }
+
+    /**
+     * Closes the response returned by the delegate and consumes everything from it, so that its close future
+     * is completed.
+     */
+    private static void closeAndDrain(DefaultHttpResponse actualRes, HttpResponse deferredRes) {
+        actualRes.close();
+        deferredRes.subscribe(NoopSubscriber.get());
+        waitForEventLoop();
+    }
+
+    private static void waitForEventLoop() {
+        eventLoop.submit(() -> {}).syncUninterruptibly();
+    }
+}

--- a/src/test/java/com/linecorp/armeria/common/stream/DeferredStreamMessageTest.java
+++ b/src/test/java/com/linecorp/armeria/common/stream/DeferredStreamMessageTest.java
@@ -39,16 +39,16 @@ public class DeferredStreamMessageTest {
         final DeferredStreamMessage<Object> m = new DeferredStreamMessage<>();
         assertThat(m.isOpen()).isTrue();
         assertThat(m.isEmpty()).isFalse();
-        assertThat(m.closeFuture()).isNotCompleted();
+        assertThat(m.closeFuture()).isNotDone();
     }
 
     @Test
     public void testSetDelegate() throws Exception {
         final DeferredStreamMessage<Object> m = new DeferredStreamMessage<>();
-        m.setDelegate(new DefaultStreamMessage<>());
-        assertThatThrownBy(() -> m.setDelegate(new DefaultStreamMessage<>()))
+        m.delegate(new DefaultStreamMessage<>());
+        assertThatThrownBy(() -> m.delegate(new DefaultStreamMessage<>()))
                 .isInstanceOf(IllegalStateException.class);
-        assertThatThrownBy(() -> m.setDelegate(null)).isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> m.delegate(null)).isInstanceOf(NullPointerException.class);
     }
 
     @Test
@@ -67,7 +67,7 @@ public class DeferredStreamMessageTest {
         assertAborted(m);
 
         final DefaultStreamMessage<Object> d = new DefaultStreamMessage<>();
-        m.setDelegate(d);
+        m.delegate(d);
         assertAborted(d);
     }
 
@@ -76,7 +76,7 @@ public class DeferredStreamMessageTest {
         final DeferredStreamMessage<Object> m = new DeferredStreamMessage<>();
         final DefaultStreamMessage<Object> d = new DefaultStreamMessage<>();
 
-        m.setDelegate(d);
+        m.delegate(d);
         m.abort();
 
         assertAborted(m);
@@ -91,7 +91,7 @@ public class DeferredStreamMessageTest {
         final Subscriber<Object> subscriber = mock(Subscriber.class);
 
         m.subscribe(subscriber);
-        m.setDelegate(d);
+        m.delegate(d);
         verify(subscriber).onSubscribe(any());
 
         m.abort();
@@ -111,7 +111,7 @@ public class DeferredStreamMessageTest {
         m.subscribe(subscriber);
         assertThatThrownBy(() -> m.subscribe(mock(Subscriber.class))).isInstanceOf(IllegalStateException.class);
 
-        m.setDelegate(d);
+        m.delegate(d);
         verify(subscriber).onSubscribe(any());
     }
 
@@ -120,7 +120,7 @@ public class DeferredStreamMessageTest {
         final DeferredStreamMessage<Object> m = new DeferredStreamMessage<>();
         final DefaultStreamMessage<Object> d = new DefaultStreamMessage<>();
 
-        m.setDelegate(d);
+        m.delegate(d);
 
         @SuppressWarnings("unchecked")
         final Subscriber<Object> subscriber = mock(Subscriber.class);
@@ -143,7 +143,7 @@ public class DeferredStreamMessageTest {
     public void testStreaming() throws Exception {
         final DeferredStreamMessage<Object> m = new DeferredStreamMessage<>();
         final DefaultStreamMessage<Object> d = new DefaultStreamMessage<>();
-        m.setDelegate(d);
+        m.delegate(d);
 
         final List<Object> streamed = new ArrayList<>();
         m.subscribe(new Subscriber<Object>() {


### PR DESCRIPTION
Motivation:

It is often useful to limit the concurrent number of active requests.

Modifications:

- Add ConcurrencyLimitingClient and ConcurrencyLimitingHttpClient with
  maxConcurrency and timeout settings
- Add DeferredStreamMessage.close()
- Remove SessionOption.MAX_CONCURRENCY
- Miscellaneous:
  - Abort the client HTTP request if its response has been closed
    already
  - Add NoopSubscriber for easier testing

Result:

Implemented MAX_CONCURRENCY option using a decorator.