### PR TITLE
Set 'content-length' header when creating AggregatedHttpMessage / Handle an HTTP/1.0 request

### DIFF
--- a/src/test/java/com/linecorp/armeria/server/http/healthcheck/HttpHealthCheckServiceTest.java
+++ b/src/test/java/com/linecorp/armeria/server/http/healthcheck/HttpHealthCheckServiceTest.java
@@ -16,8 +16,14 @@
 
 package com.linecorp.armeria.server.http.healthcheck;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -26,20 +32,21 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
+import com.google.common.io.ByteStreams;
+
+import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.http.AggregatedHttpMessage;
 import com.linecorp.armeria.common.http.DefaultHttpRequest;
 import com.linecorp.armeria.common.http.HttpHeaders;
 import com.linecorp.armeria.common.http.HttpMethod;
 import com.linecorp.armeria.common.http.HttpStatus;
+import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
-import io.netty.util.concurrent.EventExecutor;
-import io.netty.util.concurrent.ImmediateEventExecutor;
-import io.netty.util.concurrent.Promise;
+import io.netty.util.NetUtil;
 
 public class HttpHealthCheckServiceTest {
-
-    private static final EventExecutor executor = ImmediateEventExecutor.INSTANCE;
 
     @Rule
     public MockitoRule rule = MockitoJUnit.rule();
@@ -97,12 +104,37 @@ public class HttpHealthCheckServiceTest {
         assertNotOk();
     }
 
-    private void assertNotOk() throws Exception {Promise<Object> promise = executor.newPromise();
+    private void assertNotOk() throws Exception {
         final DefaultHttpRequest req = new DefaultHttpRequest(HttpHeaders.of(HttpMethod.GET, "/"));
         req.close();
         final AggregatedHttpMessage res = service.serve(context, req).aggregate().get();
 
         assertEquals(HttpStatus.SERVICE_UNAVAILABLE, res.status());
         assertEquals("not ok", res.content().toStringAscii());
+    }
+
+    @Test
+    public void defaultResponseIsNotChunked() throws Exception {
+        final ServerBuilder builder = new ServerBuilder();
+        builder.port(0, SessionProtocol.HTTP);
+        builder.serviceAt("/l7check", new HttpHealthCheckService());
+        final Server server = builder.build();
+        try {
+            server.start().join();
+
+            final int port = server.activePort().get().localAddress().getPort();
+            try (Socket s = new Socket(NetUtil.LOCALHOST, port)) {
+                s.setSoTimeout(10000);
+                final InputStream in = s.getInputStream();
+                final OutputStream out = s.getOutputStream();
+                out.write("GET /l7check HTTP/1.0\r\n\r\n".getBytes(StandardCharsets.US_ASCII));
+
+                // Should not be chunked.
+                assertThat(new String(ByteStreams.toByteArray(in))).isEqualTo(
+                        "HTTP/1.1 200 OK\r\ncontent-length: 2\r\n\r\nok");
+            }
+        } finally {
+            server.stop();
+        }
     }
 }


### PR DESCRIPTION
Motivation:

1. We found a problem where HttpHealthCheckService sends a chunked
response rather than a non-chunked one with 'content-length' header.
It turned out that AggregatedHttpMessage.of() does not set the
'content-length' header, making the encoder fall back to chunked
encoding.

2. Also, some ancient load balancers seem to send an HTTP/1.0 request
which does not have the 'Host' header. Armeria currently sends a 400 Bad
Request response to the request without 'Host' header.

Modifications:

- Set the 'content-length' header when necessary in
  AggregatedHttpMessage.of()
- Do not send 400 Bad Request response when Host header is not set. Just
  assume the default host name.
- Add a test case that makes sure the response from
  HttpHealthCheckService is not chunked and an HTTP/1.0 request is
  handled fine

Result:

- AggregatedHttpMessage is not encoded in chunked mode unnecessarily.
- HTTP/1.0 friendly