### PR TITLE
Set the :scheme header when sending an HTTP/2 request.

### DIFF
--- a/src/main/java/com/linecorp/armeria/client/http/HttpClient.java
+++ b/src/main/java/com/linecorp/armeria/client/http/HttpClient.java
@@ -20,9 +20,7 @@ import java.nio.charset.Charset;
 
 import com.linecorp.armeria.client.ClientOptionDerivable;
 import com.linecorp.armeria.common.http.AggregatedHttpMessage;
-import com.linecorp.armeria.common.http.DefaultHttpRequest;
 import com.linecorp.armeria.common.http.HttpData;
-import com.linecorp.armeria.common.http.HttpHeaderNames;
 import com.linecorp.armeria.common.http.HttpHeaders;
 import com.linecorp.armeria.common.http.HttpMethod;
 import com.linecorp.armeria.common.http.HttpRequest;
@@ -41,26 +39,7 @@ public interface HttpClient extends ClientOptionDerivable<HttpClient> {
     /**
      * Sends the specified HTTP request.
      */
-    default HttpResponse execute(AggregatedHttpMessage aggregatedReq) {
-        final HttpHeaders headers = aggregatedReq.headers();
-        final DefaultHttpRequest req = new DefaultHttpRequest(headers);
-        final HttpData content = aggregatedReq.content();
-
-        // Add content if not empty.
-        if (!content.isEmpty()) {
-            headers.setInt(HttpHeaderNames.CONTENT_LENGTH, content.length());
-            req.write(content);
-        }
-
-        // Add trailing headers if not empty.
-        final HttpHeaders trailingHeaders = aggregatedReq.trailingHeaders();
-        if (!trailingHeaders.isEmpty()) {
-            req.write(trailingHeaders);
-        }
-
-        req.close();
-        return execute(req);
-    }
+    HttpResponse execute(AggregatedHttpMessage aggregatedReq);
 
     /**
      * Sends an empty HTTP request with the specified headers.

--- a/src/main/java/com/linecorp/armeria/client/http/HttpClientDelegate.java
+++ b/src/main/java/com/linecorp/armeria/client/http/HttpClientDelegate.java
@@ -119,6 +119,10 @@ final class HttpClientDelegate implements Client<HttpRequest, HttpResponse> {
             headers.authority(authority);
         }
 
+        if (headers.scheme() == null) {
+            headers.scheme(ctx.sessionProtocol().isTls() ? "https" : "http");
+        }
+
         // Add the handlers specified in ClientOptions.
         if (ctx.hasAttr(ClientRequestContext.HTTP_HEADERS)) {
             headers.setAll(ctx.attr(ClientRequestContext.HTTP_HEADERS).get());

--- a/src/main/java/com/linecorp/armeria/internal/http/ArmeriaHttpUtil.java
+++ b/src/main/java/com/linecorp/armeria/internal/http/ArmeriaHttpUtil.java
@@ -343,11 +343,7 @@ public final class ArmeriaHttpUtil {
         static {
             RESPONSE_HEADER_TRANSLATIONS.add(Http2Headers.PseudoHeaderName.AUTHORITY.value(),
                                              HttpHeaderNames.HOST);
-            RESPONSE_HEADER_TRANSLATIONS.add(Http2Headers.PseudoHeaderName.SCHEME.value(),
-                                             ExtensionHeaderNames.SCHEME.text());
             REQUEST_HEADER_TRANSLATIONS.add(RESPONSE_HEADER_TRANSLATIONS);
-            RESPONSE_HEADER_TRANSLATIONS.add(Http2Headers.PseudoHeaderName.PATH.value(),
-                                             ExtensionHeaderNames.PATH.text());
         }
 
         private final io.netty.handler.codec.http.HttpHeaders output;

--- a/src/test/java/com/linecorp/armeria/client/http/HttpClientIntegrationTest.java
+++ b/src/test/java/com/linecorp/armeria/client/http/HttpClientIntegrationTest.java
@@ -176,12 +176,12 @@ public class HttpClientIntegrationTest {
             s.setSoTimeout(10000);
             ByteStreams.readFully(in, buf);
 
+            // Ensure that the encoded request matches.
+            assertThat(new String(buf, StandardCharsets.US_ASCII)).isEqualTo(expected);
+
             // Should not send anything more.
             s.setSoTimeout(1000);
             assertThatThrownBy(in::read).isInstanceOf(SocketTimeoutException.class);
-
-            // Ensure that the encoded request matches.
-            assertThat(new String(buf, StandardCharsets.US_ASCII)).isEqualTo(expected);
         } finally {
             Closeables.close(s, true);
             Closeables.close(ss, true);


### PR DESCRIPTION
Motivtion:

HttpClientDelegate does not set the :scheme header when sending an
HTTP/2 request, which is clearly a protocol violation.

Modifications:

Set the :scheme header when sending an HTTP/2 request.

Result:

Fixes interoperability