### PR TITLE
Set scheme in TomcatService.

### DIFF
--- a/src/main/java/com/linecorp/armeria/server/http/tomcat/TomcatService.java
+++ b/src/main/java/com/linecorp/armeria/server/http/tomcat/TomcatService.java
@@ -438,6 +438,8 @@ public final class TomcatService implements HttpService {
 
         final Request coyoteReq = new Request();
 
+        coyoteReq.scheme().setString(req.scheme());
+
         // Set the remote host/address.
         final InetSocketAddress remoteAddr = ctx.remoteAddress();
         coyoteReq.remoteAddr().setString(remoteAddr.getAddress().getHostAddress());

--- a/src/test/java/com/linecorp/armeria/server/http/jetty/JettyServiceTest.java
+++ b/src/test/java/com/linecorp/armeria/server/http/jetty/JettyServiceTest.java
@@ -56,6 +56,7 @@ public class JettyServiceTest extends WebAppContainerTest {
 
     @Override
     protected void configureServer(ServerBuilder sb) throws Exception {
+        super.configureServer(sb);
         sb.serviceUnder(
                 "/jsp/",
                 new JettyServiceBuilder()

--- a/src/test/java/com/linecorp/armeria/server/http/jetty/UnmanagedJettyServiceTest.java
+++ b/src/test/java/com/linecorp/armeria/server/http/jetty/UnmanagedJettyServiceTest.java
@@ -29,6 +29,7 @@ public class UnmanagedJettyServiceTest extends WebAppContainerTest {
 
     @Override
     protected void configureServer(ServerBuilder sb) throws Exception {
+        super.configureServer(sb);
         jetty = new Server(0);
         jetty.setHandler(JettyServiceTest.newWebAppContext());
         jetty.start();

--- a/src/test/java/com/linecorp/armeria/server/http/tomcat/TomcatServiceTest.java
+++ b/src/test/java/com/linecorp/armeria/server/http/tomcat/TomcatServiceTest.java
@@ -45,7 +45,8 @@ public class TomcatServiceTest extends WebAppContainerTest {
     private final List<Service> tomcatServices = new ArrayList<>();
 
     @Override
-    protected void configureServer(ServerBuilder sb) {
+    protected void configureServer(ServerBuilder sb) throws Exception {
+        super.configureServer(sb);
         sb.serviceUnder(
                 "/jsp/",
                 TomcatServiceBuilder.forCurrentClassPath("tomcat_service")

--- a/src/test/resources/tomcat_service/index.jsp
+++ b/src/test/resources/tomcat_service/index.jsp
@@ -9,5 +9,6 @@
 <%-- Print some request properties for testing purpose. --%>
 <p>Context path: <%= request.getContextPath() %></p>
 <p>Request URI: <%= request.getRequestURI() %></p>
+<p>Scheme: <%= request.getScheme() %></p>
 </body>
 </html>


### PR DESCRIPTION
Without a correct scheme, Tomcat apps can't do http<->https redirects correctly.