### PR TITLE
Support client-side TMultiplexedProtocol

### DIFF
--- a/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
+++ b/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
@@ -24,7 +24,6 @@ import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.Response;
 import com.linecorp.armeria.common.http.HttpHeaders;
 import com.linecorp.armeria.common.http.HttpRequest;
-import com.linecorp.armeria.server.ServerConfig;
 
 import io.netty.util.Attribute;
 import io.netty.util.AttributeKey;
@@ -51,6 +50,14 @@ public interface ClientRequestContext extends RequestContext {
      * Returns the {@link ClientOptions} of the current {@link Request}.
      */
     ClientOptions options();
+
+    /**
+     * Returns the fragment part of the URI of the current {@link Request}, as defined in
+     * <a href="https://tools.ietf.org/html/rfc3986#section-3.5">the section 3.5 of RFC3986</a>.
+     *
+     * @return the fragment part of the request URI, or an empty string if no fragment was specified
+     */
+    String fragment();
 
     /**
      * Returns the amount of time allowed until sending out the current {@link Request} completely.

--- a/src/main/java/com/linecorp/armeria/client/ClientRequestContextWrapper.java
+++ b/src/main/java/com/linecorp/armeria/client/ClientRequestContextWrapper.java
@@ -40,6 +40,11 @@ public class ClientRequestContextWrapper
     }
 
     @Override
+    public String fragment() {
+        return delegate().fragment();
+    }
+
+    @Override
     public ClientOptions options() {
         return delegate().options();
     }

--- a/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -44,6 +44,7 @@ public final class DefaultClientRequestContext extends NonWrappingRequestContext
     private final EventLoop eventLoop;
     private final ClientOptions options;
     private final Endpoint endpoint;
+    private final String fragment;
 
     private final DefaultRequestLog requestLog;
     private final DefaultResponseLog responseLog;
@@ -61,14 +62,15 @@ public final class DefaultClientRequestContext extends NonWrappingRequestContext
      * @param request the request associated with this context
      */
     public DefaultClientRequestContext(
-            EventLoop eventLoop, SessionProtocol sessionProtocol,
-            Endpoint endpoint, String method, String path, ClientOptions options, Object request) {
+            EventLoop eventLoop, SessionProtocol sessionProtocol, Endpoint endpoint,
+            String method, String path, String fragment, ClientOptions options, Object request) {
 
         super(sessionProtocol, method, path, request);
 
-        this.eventLoop = eventLoop;
-        this.options = options;
-        this.endpoint = endpoint;
+        this.eventLoop = requireNonNull(eventLoop, "eventLoop");
+        this.options = requireNonNull(options, "options");
+        this.endpoint = requireNonNull(endpoint, "endpoint");
+        this.fragment = requireNonNull(fragment, "fragment");
 
         requestLog = new DefaultRequestLog();
         responseLog = new DefaultResponseLog(requestLog);
@@ -100,6 +102,11 @@ public final class DefaultClientRequestContext extends NonWrappingRequestContext
     @Override
     public Endpoint endpoint() {
         return endpoint;
+    }
+
+    @Override
+    public String fragment() {
+        return fragment;
     }
 
     @Override

--- a/src/main/java/com/linecorp/armeria/client/UserClient.java
+++ b/src/main/java/com/linecorp/armeria/client/UserClient.java
@@ -107,15 +107,16 @@ public abstract class UserClient<T, I extends Request, O extends Response> imple
      * Executes the specified {@link Request} via {@link #delegate()}.
      *
      * @param method the method of the {@link Request}
-     * @param path the path of the {@link Request}
+     * @param path the path of the {@link Request} URI
+     * @param fragment the fragment part of the {@link Request} URI
      * @param req the {@link Request}
      * @param fallback the fallback response {@link Function} to use when
      *                 {@link Client#execute(ClientRequestContext, Request)} of {@link #delegate()} throws
      *                 an exception instead of returning an error response
      */
     protected final O execute(
-            String method, String path, I req, Function<Throwable, O> fallback) {
-        return execute(eventLoop(), method, path, req, fallback);
+            String method, String path, String fragment, I req, Function<Throwable, O> fallback) {
+        return execute(eventLoop(), method, path,  fragment, req, fallback);
     }
 
     /**
@@ -123,17 +124,18 @@ public abstract class UserClient<T, I extends Request, O extends Response> imple
      *
      * @param eventLoop the {@link EventLoop} to execute the {@link Request}
      * @param method the method of the {@link Request}
-     * @param path the path of the {@link Request}
+     * @param path the path part of the {@link Request} URI
+     * @param fragment the fragment part of the {@link Request} URI
      * @param req the {@link Request}
      * @param fallback the fallback response {@link Function} to use when
-     *                 {@link Client#execute(ClientRequestContext, Request)} of {@link #delegate()} throws
-     *                 an exception instead of returning an error response
+ *                 {@link Client#execute(ClientRequestContext, Request)} of {@link #delegate()} throws
      */
     protected final O execute(
-            EventLoop eventLoop, String method, String path, I req, Function<Throwable, O> fallback) {
+            EventLoop eventLoop, String method, String path, String fragment, I req,
+            Function<Throwable, O> fallback) {
 
         final ClientRequestContext ctx = new DefaultClientRequestContext(
-                eventLoop, sessionProtocol, endpoint, method, path, options, req);
+                eventLoop, sessionProtocol, endpoint, method, path, fragment, options, req);
         try (PushHandle ignored = RequestContext.push(ctx)) {
             return delegate().execute(ctx, req);
         } catch (Throwable cause) {

--- a/src/main/java/com/linecorp/armeria/client/http/DefaultHttpClient.java
+++ b/src/main/java/com/linecorp/armeria/client/http/DefaultHttpClient.java
@@ -52,7 +52,7 @@ final class DefaultHttpClient extends UserClient<HttpClient, HttpRequest, HttpRe
     }
 
     private HttpResponse execute(EventLoop eventLoop, HttpRequest req) {
-        return execute(eventLoop, req.method().name(), req.path(), req, cause -> {
+        return execute(eventLoop, req.method().name(), req.path(), "", req, cause -> {
             final DefaultHttpResponse res = new DefaultHttpResponse();
             res.close(cause);
             return res;

--- a/src/main/java/com/linecorp/armeria/client/thrift/DefaultTHttpClient.java
+++ b/src/main/java/com/linecorp/armeria/client/thrift/DefaultTHttpClient.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.client.thrift;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
@@ -41,8 +43,15 @@ final class DefaultTHttpClient extends UserClient<THttpClient, ThriftCall, Thrif
 
     @Override
     public ThriftReply execute(String path, Class<?> serviceType, String method, Object... args) {
+        return executeMultiplexed(path, serviceType, "", method, args);
+    }
+
+    @Override
+    public ThriftReply executeMultiplexed(
+            String path, Class<?> serviceType, String serviceName, String method, Object... args) {
+        requireNonNull(serviceName, "serviceName");
         final ThriftCall call = new ThriftCall(nextSeqId.getAndIncrement(), serviceType, method, args);
-        return execute(call.method(), path, call, cause -> new ThriftReply(call.seqId(), cause));
+        return execute(call.method(), path, serviceName, call, cause -> new ThriftReply(call.seqId(), cause));
     }
 
     @Override

--- a/src/main/java/com/linecorp/armeria/client/thrift/THttpClient.java
+++ b/src/main/java/com/linecorp/armeria/client/thrift/THttpClient.java
@@ -46,4 +46,16 @@ public interface THttpClient extends ClientOptionDerivable<THttpClient> {
      * @param args the arguments of the call
      */
     ThriftReply execute(String path, Class<?> serviceType, String method, Object... args);
+
+    /**
+     * Executes the specified multiplexed Thrift call.
+     *
+     * @param path the path of the Thrift service
+     * @param serviceType the Thrift service interface
+     * @param serviceName the Thrift service name
+     * @param method the method name
+     * @param args the arguments of the call
+     */
+    ThriftReply executeMultiplexed(
+            String path, Class<?> serviceType, String serviceName, String method, Object... args);
 }

--- a/src/main/java/com/linecorp/armeria/client/thrift/THttpClientDelegate.java
+++ b/src/main/java/com/linecorp/armeria/client/thrift/THttpClientDelegate.java
@@ -103,7 +103,7 @@ final class THttpClientDelegate implements Client<ThriftCall, ThriftReply> {
         try {
             final TMemoryBuffer outTransport = new TMemoryBuffer(128);
             final TProtocol tProtocol = protocolFactory.getProtocol(outTransport);
-            final TMessage tMessage = new TMessage(method, func.messageType(), seqId);
+            final TMessage tMessage = new TMessage(fullMethod(ctx, method), func.messageType(), seqId);
 
             tProtocol.writeMessageBegin(tMessage);
             @SuppressWarnings("rawtypes")
@@ -144,6 +144,15 @@ final class THttpClientDelegate implements Client<ThriftCall, ThriftReply> {
         }
 
         return reply;
+    }
+
+    private static String fullMethod(ClientRequestContext ctx, String method) {
+        final String service = ctx.fragment();
+        if (service.isEmpty()) {
+            return method;
+        } else {
+            return service + ':' + method;
+        }
     }
 
     private ThriftServiceMetadata metadata(Class<?> serviceType) {

--- a/src/main/java/com/linecorp/armeria/client/thrift/THttpClientFactory.java
+++ b/src/main/java/com/linecorp/armeria/client/thrift/THttpClientFactory.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.client.thrift;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
 import static java.util.Objects.requireNonNull;
 
 import java.lang.reflect.Proxy;
@@ -105,7 +106,11 @@ public class THttpClientFactory extends DecoratingClientFactory {
             T client = (T) Proxy.newProxyInstance(
                     clientType.getClassLoader(),
                     new Class<?>[] { clientType, ClientOptionDerivable.class },
-                    new THttpClientInvocationHandler(thriftClient, uri.getPath(), clientType));
+                    new THttpClientInvocationHandler(
+                            thriftClient,
+                            firstNonNull(uri.getPath(), "/"),
+                            firstNonNull(uri.getFragment(), ""),
+                            clientType));
             return client;
         }
     }

--- a/src/main/java/com/linecorp/armeria/client/thrift/THttpClientInvocationHandler.java
+++ b/src/main/java/com/linecorp/armeria/client/thrift/THttpClientInvocationHandler.java
@@ -38,17 +38,20 @@ final class THttpClientInvocationHandler implements InvocationHandler {
 
     private final THttpClient thriftClient;
     private final String path;
+    private final String fragment;
     private final Class<?> clientType;
 
-    THttpClientInvocationHandler(THttpClient thriftClient, String path, Class<?> clientType) {
+    THttpClientInvocationHandler(THttpClient thriftClient, String path, String fragment, Class<?> clientType) {
         this.thriftClient = thriftClient;
         this.path = path;
+        this.fragment = fragment;
         this.clientType = clientType;
     }
 
     private THttpClientInvocationHandler(THttpClientInvocationHandler handler, THttpClient thriftClient) {
         this.thriftClient = thriftClient;
         path = handler.path;
+        fragment = handler.fragment;
         clientType = handler.clientType;
     }
 
@@ -128,7 +131,8 @@ final class THttpClientInvocationHandler implements InvocationHandler {
         }
 
         try {
-            final ThriftReply reply = thriftClient.execute(path, clientType, method.getName(), args);
+            final ThriftReply reply = thriftClient.executeMultiplexed(
+                    path, clientType, fragment, method.getName(), args);
 
             if (callback != null) {
                 reply.handle(voidFunction((result, cause) -> {

--- a/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClientTest.java
+++ b/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClientTest.java
@@ -60,13 +60,13 @@ public class CircuitBreakerClientTest {
     private static final ClientRequestContext ctx = new DefaultClientRequestContext(
             new DefaultEventLoop(), SessionProtocol.H2C,
             Endpoint.of("dummyhost", 8080),
-            "POST", "/", ClientOptions.DEFAULT,
+            "POST", "/", "", ClientOptions.DEFAULT,
             new ThriftCall(0, HelloService.Iface.class, "methodA", "a", "b"));
 
     private static final ClientRequestContext ctxB = new DefaultClientRequestContext(
             new DefaultEventLoop(), SessionProtocol.H2C,
             Endpoint.of("dummyhost", 8080),
-            "POST", "/", ClientOptions.DEFAULT,
+            "POST", "/", "", ClientOptions.DEFAULT,
             new ThriftCall(0, HelloService.Iface.class, "methodB", "c", "d"));
 
     private static final ThriftCall req = ctx.request();

--- a/src/test/java/com/linecorp/armeria/client/tracing/HttpTracingClientTest.java
+++ b/src/test/java/com/linecorp/armeria/client/tracing/HttpTracingClientTest.java
@@ -34,9 +34,7 @@ import com.linecorp.armeria.common.http.DefaultHttpRequest;
 import com.linecorp.armeria.common.http.HttpHeaders;
 import com.linecorp.armeria.common.http.HttpMethod;
 import com.linecorp.armeria.common.http.HttpRequest;
-import com.linecorp.armeria.common.thrift.ThriftCall;
 import com.linecorp.armeria.common.tracing.HttpTracingTestBase;
-import com.linecorp.armeria.service.test.thrift.main.HelloService;
 
 import io.netty.channel.DefaultEventLoop;
 
@@ -79,6 +77,6 @@ public class HttpTracingClientTest extends HttpTracingTestBase {
     private static ClientRequestContext newClientContext(HttpRequest req) {
         return new DefaultClientRequestContext(
                 new DefaultEventLoop(), SessionProtocol.H2C, Endpoint.of("localhost", 8080),
-                req.method().toString(), req.path(), ClientOptions.DEFAULT, req);
+                req.method().toString(), req.path(), "", ClientOptions.DEFAULT, req);
     }
 }

--- a/src/test/java/com/linecorp/armeria/client/tracing/TracingClientTest.java
+++ b/src/test/java/com/linecorp/armeria/client/tracing/TracingClientTest.java
@@ -45,7 +45,6 @@ import com.linecorp.armeria.client.ClientOptions;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.DefaultClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
-import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.thrift.ThriftCall;
 import com.linecorp.armeria.common.thrift.ThriftReply;
@@ -107,7 +106,7 @@ public class TracingClientTest {
         final ThriftReply res = new ThriftReply(0, "Hello, Armeria!");
         final ClientRequestContext ctx = new DefaultClientRequestContext(
                 new DefaultEventLoop(), SessionProtocol.H2C, Endpoint.of("localhost", 8080),
-                "POST", "/", ClientOptions.DEFAULT, req);
+                "POST", "/", "", ClientOptions.DEFAULT, req);
 
         ctx.requestLogBuilder().start(mock(Channel.class), SessionProtocol.H2C, "localhost", "POST", "/");
         ctx.requestLogBuilder().end();


### PR DESCRIPTION
Related: #242 and #240

Motivation:

Community request for TMultiplexedProtocol. TMultiplexedProtocol is a
simple variation of Thrift which prepends a service name to the method
name field (e.g. serviceName:methodName) so that a single endpoint can
serve the requests for different Thrift services

Modifications:

- Add ClientRequestContext.fragments()
- Use the fragment part of the request URI as the service name of a
  multiplexed Thrift call
- Add THttpClient.executeMultiplexed()

Result:

A user can make a multiplexed Thrift call:

    // The service name is 'foo'.
    FooService.Iface client =
            Clients.newClient("tbinary+http://127.0.0.1:8080/thrift#foo",
                              FooService.Iface.class);