### PR TITLE
Lambda expression friendly Service decoration

### DIFF
--- a/src/main/java/com/linecorp/armeria/server/DecoratingService.java
+++ b/src/main/java/com/linecorp/armeria/server/DecoratingService.java
@@ -60,7 +60,7 @@ public abstract class DecoratingService<T_I extends Request, T_O extends Respons
     }
 
     @Override
-    public final <T extends Service<?, ?>> Optional<T> as(Class<T> serviceType) {
+    public final <T> Optional<T> as(Class<T> serviceType) {
         final Optional<T> result = Service.super.as(serviceType);
         return result.isPresent() ? result : delegate.as(serviceType);
     }

--- a/src/main/java/com/linecorp/armeria/server/DecoratingServiceFunction.java
+++ b/src/main/java/com/linecorp/armeria/server/DecoratingServiceFunction.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import com.linecorp.armeria.common.Request;
+import com.linecorp.armeria.common.Response;
+
+/**
+ * A functional interface that enables building a {@link DecoratingService} with
+ * {@link Service#decorate(DecoratingServiceFunction)}.
+ *
+ * @param <I> the {@link Request} type
+ * @param <O> the {@link Response} type
+ */
+@FunctionalInterface
+public interface DecoratingServiceFunction<I extends Request, O extends Response> {
+    /**
+     * Serves an incoming {@link Request}.
+     *
+     * @param delegate the {@link Service} being decorated by this function
+     * @param ctx the context of the received {@link Request}
+     * @param req the received {@link Request}
+     *
+     * @return the {@link Response}
+     */
+    O serve(Service<I, O> delegate, ServiceRequestContext ctx, I req) throws Exception;
+}

--- a/src/main/java/com/linecorp/armeria/server/Service.java
+++ b/src/main/java/com/linecorp/armeria/server/Service.java
@@ -66,7 +66,7 @@ public interface Service<I extends Request, O extends Response> {
      * @return the {@link Service} which is an instance of {@code serviceType} if this {@link Service}
      *         decorated such a {@link Service}. {@link Optional#empty()} otherwise.
      */
-    default <T extends Service<?, ?>> Optional<T> as(Class<T> serviceType) {
+    default <T> Optional<T> as(Class<T> serviceType) {
         requireNonNull(serviceType, "serviceType");
         return serviceType.isInstance(this) ? Optional.of(serviceType.cast(this))
                                             : Optional.empty();

--- a/src/main/java/com/linecorp/armeria/server/Service.java
+++ b/src/main/java/com/linecorp/armeria/server/Service.java
@@ -18,8 +18,8 @@ package com.linecorp.armeria.server;
 
 import static java.util.Objects.requireNonNull;
 
+import java.lang.reflect.Constructor;
 import java.util.Optional;
-import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import com.linecorp.armeria.common.Request;
@@ -33,14 +33,6 @@ import com.linecorp.armeria.common.Response;
  */
 @FunctionalInterface
 public interface Service<I extends Request, O extends Response> {
-
-    /**
-     * Creates a new {@link Service} with the specified {@link BiFunction}.
-     */
-    static <I extends Request, O extends Response> Service<I, O> of(
-            BiFunction<? super ServiceRequestContext, ? super I, ? extends O> function) {
-        return new BiFunctionService<>(function);
-    }
 
     /**
      * Invoked when this {@link Service} has been added to a {@link Server} with the specified configuration.
@@ -81,6 +73,36 @@ public interface Service<I extends Request, O extends Response> {
     }
 
     /**
+     * Creates a new {@link Service} that decorates this {@link Service} with a new {@link Service} instance
+     * of the specified {@code serviceType}. The specified {@link Class} must have a single-parameter
+     * constructor which accepts this {@link Service}.
+     */
+    default <R extends Service<?, ?>> R decorate(Class<R> serviceType) {
+        requireNonNull(serviceType, "serviceType");
+
+        Constructor<?> constructor = null;
+        for (Constructor<?> c : serviceType.getConstructors()) {
+            if (c.getParameterCount() != 1) {
+                continue;
+            }
+            if (c.getParameterTypes()[0].isAssignableFrom(getClass())) {
+                constructor = c;
+                break;
+            }
+        }
+
+        if (constructor == null) {
+            throw new IllegalArgumentException("cannot find a matching constructor: " + serviceType.getName());
+        }
+
+        try {
+            return (R) constructor.newInstance(this);
+        } catch (Exception e) {
+            throw new IllegalStateException("failed to instantiate: " + serviceType.getName(), e);
+        }
+    }
+
+    /**
      * Creates a new {@link Service} that decorates this {@link Service} with the specified {@code decorator}.
      */
     default <T extends Service<? super I, ? extends O>,
@@ -94,5 +116,13 @@ public interface Service<I extends Request, O extends Response> {
         }
 
         return newService;
+    }
+
+    /**
+     * Creates a new {@link Service} that decorates this {@link Service} with the specified
+     * {@link DecoratingServiceFunction}.
+     */
+    default Service<I, O> decorate(DecoratingServiceFunction<? super I, ? extends O> function) {
+        return new FunctionalDecoratingService<>(this, function);
     }
 }

--- a/src/test/java/com/linecorp/armeria/server/ServiceTest.java
+++ b/src/test/java/com/linecorp/armeria/server/ServiceTest.java
@@ -40,7 +40,7 @@ public class ServiceTest {
         // Test if Service.as() works as expected.
         assertThat(outer.as(serviceType(inner))).containsSame(inner);
         assertThat(outer.as(serviceType(outer))).containsSame(outer);
-        //assertThat(outer.as(String.class)).isNotPresent();
+        assertThat(outer.as(String.class)).isNotPresent();
 
         // Test if FooService.serviceAdded() is invoked.
         final ServiceConfig cfg = new ServiceConfig(PathMapping.ofCatchAll(), outer, "foo");

--- a/src/test/java/com/linecorp/armeria/server/ServiceTest.java
+++ b/src/test/java/com/linecorp/armeria/server/ServiceTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+import com.linecorp.armeria.common.thrift.ThriftCall;
+import com.linecorp.armeria.common.thrift.ThriftReply;
+
+public class ServiceTest {
+
+    /**
+     * Tests if a user can write a decorator with working as() and serviceAdded() using lambda expressions only.
+     */
+    @Test
+    public void testLambdaExpressionDecorator() throws Exception {
+        final FooService inner = new FooService();
+        final Service<ThriftCall, ThriftReply> outer = inner.decorate((delegate, ctx, req) -> {
+            ThriftCall newReq = new ThriftCall(
+                    req.seqId(), req.serviceType(), "new_" + req.method(), req.params());
+            return delegate.serve(ctx, newReq);
+        });
+
+        // Test if Service.as() works as expected.
+        assertThat(outer.as(serviceType(inner))).containsSame(inner);
+        assertThat(outer.as(serviceType(outer))).containsSame(outer);
+        //assertThat(outer.as(String.class)).isNotPresent();
+
+        // Test if FooService.serviceAdded() is invoked.
+        final ServiceConfig cfg = new ServiceConfig(PathMapping.ofCatchAll(), outer, "foo");
+        outer.serviceAdded(cfg);
+        assertThat(inner.cfg).isSameAs(cfg);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Class<Service<?, ?>> serviceType(Service<?, ?> service) {
+        return (Class<Service<?, ?>>) service.getClass();
+    }
+
+    private static final class FooService implements Service<ThriftCall, ThriftReply> {
+
+        ServiceConfig cfg;
+
+        @Override
+        public void serviceAdded(ServiceConfig cfg) throws Exception {
+            this.cfg = cfg;
+        }
+
+        @Override
+        public ThriftReply serve(ServiceRequestContext ctx, ThriftCall req) throws Exception {
+            // Will never reach here.
+            throw new Error();
+        }
+    }
+}

--- a/src/test/java/com/linecorp/armeria/server/http/HttpServerTest.java
+++ b/src/test/java/com/linecorp/armeria/server/http/HttpServerTest.java
@@ -265,7 +265,7 @@ public class HttpServerTest extends AbstractServerTest {
                 res.write(HttpData.ofUtf8("awesome!"));
                 res.close();
             }
-        }.decorate(HttpEncodingService::new));
+        }.decorate(HttpEncodingService.class));
 
         sb.serviceAt("/images", new AbstractHttpService() {
             @Override
@@ -277,7 +277,7 @@ public class HttpServerTest extends AbstractServerTest {
                 res.write(HttpData.ofUtf8("awesome!"));
                 res.close();
             }
-        }.decorate(HttpEncodingService::new));
+        }.decorate(HttpEncodingService.class));
 
         sb.serviceAt("/small", new AbstractHttpService() {
             @Override
@@ -289,7 +289,7 @@ public class HttpServerTest extends AbstractServerTest {
                 res.write(HttpData.ofUtf8(response));
                 res.close();
             }
-        }.decorate(HttpEncodingService::new));
+        }.decorate(HttpEncodingService.class));
 
         sb.serviceAt("/large", new AbstractHttpService() {
             @Override
@@ -301,7 +301,7 @@ public class HttpServerTest extends AbstractServerTest {
                 res.write(HttpData.ofUtf8(response));
                 res.close();
             }
-        }.decorate(HttpEncodingService::new));
+        }.decorate(HttpEncodingService.class));
 
         final Function<Service<HttpRequest, HttpResponse>, Service<HttpRequest, HttpResponse>> decorator =
                 delegate -> new DecoratingService<HttpRequest, HttpResponse, HttpRequest, HttpResponse>(delegate) {

--- a/src/test/java/com/linecorp/armeria/server/tracing/TracingServiceTest.java
+++ b/src/test/java/com/linecorp/armeria/server/tracing/TracingServiceTest.java
@@ -32,7 +32,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.junit.Test;
-import org.mockito.Matchers;
+import org.mockito.ArgumentMatchers;
 
 import com.github.kristofa.brave.Brave;
 import com.github.kristofa.brave.KeyValueAnnotation;
@@ -121,8 +121,8 @@ public class TracingServiceTest {
         // AbstractTracingService prefers RpcRequest.method() to ctx.method(), so "POST" should be ignored.
         when(ctx.method()).thenReturn("POST");
         when(ctx.requestLogFuture()).thenReturn(reqLog);
-        ctx.onEnter(Matchers.isA(Runnable.class));
-        ctx.onExit(Matchers.isA(Runnable.class));
+        ctx.onEnter(ArgumentMatchers.isA(Runnable.class));
+        ctx.onExit(ArgumentMatchers.isA(Runnable.class));
 
         ThriftReply res = new ThriftReply(0, "Hello, trustin!");
         when(delegate.serve(ctx, req)).thenReturn(res);


### PR DESCRIPTION
### Lambda expression friendly Service decoration

Motivation:

Service.decorate() does not work well with lambda expressions. For
example:

    service.decorate(s -> (ctx, req) -> s.serve(ctx, req));

will decorate 'service' with the Service implemented by the lambda
expression. However, because its as() and serviceAdded() were not
implemented properly, the resulting service will not behave correctly.

Modifications:

- Add a functional interface 'DecoratingServiceFunction' which can be
  used for writing a decorating service using a lambda expression
- Add Service.decorate(DecoratingServiceFunction) which creates a
  decorating service that implements as() and serviceAdded() properly
- Add Service.decorate(Class<?> serviceType) which creates a decorating
  service via reflection. This is useful when the compiler fails to
  determine which decorate() method should be used.
  - e.g. service.decorate(HttpEncodingService::new)
- Remove Service.of() which didn't have any use

Result:

A user can write a decorator easily:

    service.decorate((delegate, ctx, req) -> {
        ...
        return delegate.serve(ctx, req);
    });

### Relax the type constraint of Service.as()

Motivation:

A user might implement a certain non-Service interface for his or her
Service implementations and want to find such Services by specifying the
non-Service type in Service.as(), which is not possible due to the type
parameter constraint.

Modifications:

- Relax the type constraints of Service.as()

Result:

More flexibility
