### PR TITLE
Add support for hosting GRPC services in an armeria server.

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -65,6 +65,11 @@ by Adobe Systems Incorporated:
 Modified redistributions
 ========================
 
+This product contains a modified part of GRPC, distributed by Google:
+
+  * License: licenses/LICENSE.grpc.bsd.txt (New BSD License)
+  * Homepage: http://www.grpc.io/
+
 This product contains a modified part of Netty, distributed by Netty.io:
 
   * License: licenses/LICENSE.netty.al20.txt (Apache License v2.0)
@@ -94,6 +99,11 @@ This product depends on FindBugs-JSR305, distributed by
 
   * License: licenses/LICENSE.jsr305.al20.txt (Apache License v2.0)
   * Homepage: http://findbugs.sourceforge.net/
+
+This product depends on GRPC, distributed by Google:
+
+  * License: licenses/LICENSE.grpc.bsd.txt (New BSD License)
+  * Homepage: http://www.grpc.io/
 
 This product depends on Guava, distributed by Google:
 

--- a/licenses/LICENSE.grpc.bsd.txt
+++ b/licenses/LICENSE.grpc.bsd.txt
@@ -1,0 +1,28 @@
+Copyright 2014, Google Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/pom.xml
+++ b/pom.xml
@@ -183,6 +183,38 @@
       </exclusions>
     </dependency>
 
+    <!-- GRPC (optional) -->
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-core</artifactId>
+      <version>1.0.0</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-stub</artifactId>
+      <version>1.0.0</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-protobuf</artifactId>
+      <version>1.0.0</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-interop-testing</artifactId>
+      <version>1.0.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava-jdk5</artifactId>
+        </exclusion>
+      </exclusions>
+      <scope>test</scope>
+    </dependency>
+
     <!-- Embedded Tomcat (optional)
          Pull tomcat-embed-* and log4j-over-slf4j to use TomcatService. -->
     <dependency>

--- a/settings/checkstyle/checkstyle-suppressions.xml
+++ b/settings/checkstyle/checkstyle-suppressions.xml
@@ -13,4 +13,6 @@
   <suppress checks="JavadocMethod" files="[\\/](test|internal)[\\/]" />
   <!-- Suppress all checks in generates sources -->
   <suppress checks=".*" files="[\\/]generated[^\\/]*-sources[\\/]" />
+  <!-- Suppress checks in large forks to make diffing against upstream easier -->
+  <suppress checks=".*" files="/src/main/java/com/linecorp/armeria/server/grpc/ServerCallImpl.java" />
 </suppressions>

--- a/src/main/java/com/linecorp/armeria/common/http/DefaultHttpHeaders.java
+++ b/src/main/java/com/linecorp/armeria/common/http/DefaultHttpHeaders.java
@@ -48,6 +48,8 @@ public final class DefaultHttpHeaders
         }
     };
 
+    private final boolean endOfStream;
+
     private HttpMethod method;
     private HttpStatus status;
 
@@ -74,9 +76,21 @@ public final class DefaultHttpHeaders
      * @param initialCapacity the initial capacity of the internal data structure
      */
     public DefaultHttpHeaders(boolean validate, int initialCapacity) {
+        this(validate, initialCapacity, false);
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param validate whether to validate the header names and values
+     * @param initialCapacity the initial capacity of the internal data structure
+     * @param endOfStream whether the stream should be closed after writing these headers
+     */
+    public DefaultHttpHeaders(boolean validate, int initialCapacity, boolean endOfStream) {
         super(ArmeriaHttpUtil.HTTP2_HEADER_NAME_HASHER,
               StringValueConverter.INSTANCE,
               validate ? HTTP2_NAME_VALIDATOR : NameValidator.NOT_NULL, initialCapacity);
+        this.endOfStream = endOfStream;
     }
 
     @Override
@@ -172,6 +186,11 @@ public final class DefaultHttpHeaders
     public HttpHeaders status(HttpStatus status) {
         requireNonNull(status, "status");
         return status(status.code());
+    }
+
+    @Override
+    public boolean isEndOfStream() {
+        return endOfStream;
     }
 
     @Override

--- a/src/main/java/com/linecorp/armeria/common/http/HttpHeaders.java
+++ b/src/main/java/com/linecorp/armeria/common/http/HttpHeaders.java
@@ -151,6 +151,11 @@ public interface HttpHeaders extends HttpObject, Headers<AsciiString, String, Ht
     HttpHeaders status(HttpStatus status);
 
     /**
+     * Gets whether the stream should be ended when writing the headers (useful for Headers-only responses).
+     */
+    boolean isEndOfStream();
+
+    /**
      * Returns the immutable view of this headers.
      */
     default HttpHeaders asImmutable() {

--- a/src/main/java/com/linecorp/armeria/common/http/ImmutableHttpHeaders.java
+++ b/src/main/java/com/linecorp/armeria/common/http/ImmutableHttpHeaders.java
@@ -95,6 +95,11 @@ final class ImmutableHttpHeaders implements HttpHeaders {
     }
 
     @Override
+    public boolean isEndOfStream() {
+        return delegate.isEndOfStream();
+    }
+
+    @Override
     public String get(AsciiString name) {
         return delegate.get(name);
     }

--- a/src/main/java/com/linecorp/armeria/internal/grpc/NettyWritableBuffer.java
+++ b/src/main/java/com/linecorp/armeria/internal/grpc/NettyWritableBuffer.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.linecorp.armeria.internal.grpc;
+
+import io.grpc.internal.WritableBuffer;
+import io.netty.buffer.ByteBuf;
+
+/**
+ * The {@link WritableBuffer} used by the Netty transport.
+ *
+ * <p>Forked from grpc-java.
+ */
+public class NettyWritableBuffer implements WritableBuffer {
+
+    private final ByteBuf bytebuf;
+
+    NettyWritableBuffer(ByteBuf bytebuf) {
+        this.bytebuf = bytebuf;
+    }
+
+    @Override
+    public void write(byte[] src, int srcIndex, int length) {
+        bytebuf.writeBytes(src, srcIndex, length);
+    }
+
+    @Override
+    public void write(byte b) {
+        bytebuf.writeByte(b);
+    }
+
+    @Override
+    public int writableBytes() {
+        return bytebuf.writableBytes();
+    }
+
+    @Override
+    public int readableBytes() {
+        return bytebuf.readableBytes();
+    }
+
+    @Override
+    public void release() {
+        bytebuf.release();
+    }
+
+    public ByteBuf bytebuf() {
+        return bytebuf;
+    }
+}

--- a/src/main/java/com/linecorp/armeria/internal/grpc/NettyWritableBufferAllocator.java
+++ b/src/main/java/com/linecorp/armeria/internal/grpc/NettyWritableBufferAllocator.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.linecorp.armeria.internal.grpc;
+
+import io.grpc.internal.WritableBuffer;
+import io.grpc.internal.WritableBufferAllocator;
+import io.netty.buffer.PooledByteBufAllocator;
+
+/**
+ * The default allocator for {@link NettyWritableBuffer}s used by the Netty transport. We set a
+ * minimum bound to avoid unnecessary re-allocation for small follow-on writes and to facilitate
+ * Netty's caching of buffer objects for small writes. We set an upper-bound to avoid allocations
+ * outside of the arena-pool which are orders of magnitude slower. The Netty transport can receive
+ * buffers of arbitrary size and will chunk them based on flow-control so there is no transport
+ * requirement for an upper bound.
+ *
+ * <p>Note: It is assumed that most applications will be using Netty's direct buffer pools for
+ * maximum performance.
+ *
+ * <p>NOTE: Forked from grpc-java.
+ */
+public class NettyWritableBufferAllocator implements WritableBufferAllocator {
+
+    // Use 4k as our minimum buffer size.
+    private static final int MIN_BUFFER = 4096;
+
+    // Set the maximum buffer size to 1MB
+    private static final int MAX_BUFFER = 1024 * 1024;
+
+    @Override
+    public WritableBuffer allocate(int capacityHint) {
+        capacityHint = Math.min(MAX_BUFFER, Math.max(MIN_BUFFER, capacityHint));
+        return new NettyWritableBuffer(PooledByteBufAllocator.DEFAULT.buffer(capacityHint, capacityHint));
+    }
+}

--- a/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaGrpcServerStream.java
+++ b/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaGrpcServerStream.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.grpc;
+
+import java.nio.charset.StandardCharsets;
+
+import javax.annotation.Nullable;
+
+import com.linecorp.armeria.common.http.DefaultHttpHeaders;
+import com.linecorp.armeria.common.http.HttpData;
+import com.linecorp.armeria.common.http.HttpHeaderNames;
+import com.linecorp.armeria.common.http.HttpHeaders;
+import com.linecorp.armeria.common.http.HttpResponseWriter;
+import com.linecorp.armeria.common.http.HttpStatus;
+import com.linecorp.armeria.internal.grpc.NettyWritableBuffer;
+import com.linecorp.armeria.internal.grpc.NettyWritableBufferAllocator;
+
+import io.grpc.Metadata;
+import io.grpc.Status;
+import io.grpc.internal.AbstractServerStream;
+import io.grpc.internal.GrpcUtil;
+import io.grpc.internal.TransportFrameUtil;
+import io.grpc.internal.WritableBuffer;
+import io.netty.buffer.ByteBuf;
+import io.netty.util.AsciiString;
+
+/**
+ * An {@link AbstractServerStream} that converts GRPC structures and writes to an Armeria
+ * {@link HttpResponseWriter}. GRPC will have already taken care of compression, framing, etc.
+ */
+final class ArmeriaGrpcServerStream extends AbstractServerStream {
+
+    private final ArmeriaMessageReader messageReader;
+    private final HttpResponseWriter responseWriter;
+    private final Sink sink;
+    private final TransportState transportState;
+    private final long maxMessageSize;
+
+    ArmeriaGrpcServerStream(HttpResponseWriter responseWriter, long maxMessageSize) {
+        super(new NettyWritableBufferAllocator());
+        this.responseWriter = responseWriter;
+        this.maxMessageSize = maxMessageSize;
+        this.sink = new Sink();
+        this.transportState = new TransportState();
+        this.messageReader = new ArmeriaMessageReader(transportState);
+    }
+
+    ArmeriaMessageReader messageReader() {
+        return this.messageReader;
+    }
+
+    @Override
+    protected TransportState transportState() {
+        return transportState;
+    }
+
+    @Override
+    protected Sink abstractServerStreamSink() {
+        return sink;
+    }
+
+    private class Sink implements AbstractServerStream.Sink {
+
+        @Override
+        public void writeHeaders(Metadata metadata) {
+            HttpHeaders armeriaHeaders = new DefaultHttpHeaders(true, metadata.headerCount());
+            fillArmeriaHeaders(metadata, armeriaHeaders);
+            responseWriter.write(armeriaHeaders);
+        }
+
+        // Armeria always flushes so we ignore the flush parameter.
+        @Override
+        public void writeFrame(@Nullable WritableBuffer frame, boolean flush) {
+            if (frame == null) {
+                // GRPC uses a null frame to indicate a request to flush the stream.
+                // Armeria flushes every message so no need to do anything here.
+                return;
+            }
+            ByteBuf buf = ((NettyWritableBuffer) frame).bytebuf();
+            HttpData data = HttpData.of(buf);
+            responseWriter.write(data);
+        }
+
+        @Override
+        public void writeTrailers(Metadata trailers, boolean headersSent) {
+            if (!headersSent) {
+                HttpHeaders armeriaHeaders = new DefaultHttpHeaders(true, trailers.headerCount(), true);
+                fillArmeriaHeaders(trailers, armeriaHeaders);
+                responseWriter.write(armeriaHeaders);
+            } else {
+                HttpHeaders armeriaHeaders = new DefaultHttpHeaders();
+                convertAndFillMetadata(trailers, armeriaHeaders);
+                responseWriter.write(armeriaHeaders);
+            }
+            responseWriter.close();
+        }
+
+        @Override
+        public void request(int numMessages) {
+            transportState().requestMessagesFromDeframer(numMessages);
+        }
+
+        @Override
+        public void cancel(Status status) {
+            messageReader.cancel();
+            responseWriter.close(status.getCause());
+        }
+
+        private void fillArmeriaHeaders(Metadata headers, HttpHeaders armeriaHeaders) {
+            armeriaHeaders.status(HttpStatus.OK);
+            armeriaHeaders.set(HttpHeaderNames.CONTENT_TYPE, GrpcUtil.CONTENT_TYPE_GRPC);
+            convertAndFillMetadata(headers, armeriaHeaders);
+        }
+
+        private void convertAndFillMetadata(Metadata headers, HttpHeaders armeriaHeaders) {
+            // GRPC only allows ascii in headers, and this utility converts into ascii bytes,
+            // so we can use its result as is.
+            byte[][] serializedMetadata = TransportFrameUtil.toHttp2Headers(headers);
+            assert serializedMetadata.length % 2 == 0;
+            for (int i = 0; i < serializedMetadata.length; i += 2) {
+                armeriaHeaders.set(new AsciiString(serializedMetadata[i], false),
+                                   new String(serializedMetadata[i + 1], StandardCharsets.US_ASCII));
+            }
+        }
+    }
+
+    class TransportState extends AbstractServerStream.TransportState {
+
+        TransportState() {
+            super((int) maxMessageSize);
+        }
+
+        @Override
+        protected void deframeFailed(Throwable cause) {
+            transportReportStatus(Status.fromThrowable(cause));
+            messageReader.cancel();
+        }
+
+        @Override
+        public void bytesRead(int numBytes) {
+            // Armeria does flow control so we don't need to handle this here.
+        }
+    }
+}

--- a/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaMessageReader.java
+++ b/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaMessageReader.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.grpc;
+
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linecorp.armeria.common.http.HttpData;
+import com.linecorp.armeria.common.http.HttpHeaders;
+import com.linecorp.armeria.common.http.HttpObject;
+import com.linecorp.armeria.server.grpc.ArmeriaGrpcServerStream.TransportState;
+
+import io.grpc.Status;
+import io.grpc.internal.ReadableBuffers;
+
+/**
+ * A {@link Subscriber} to read request data and pass it to a GRPC {@link TransportState}
+ * for processing. GRPC code will then handle deframing, decompressing, etc.
+ */
+public class ArmeriaMessageReader implements Subscriber<HttpObject> {
+
+    private static final Logger logger = LoggerFactory.getLogger(ArmeriaMessageReader.class);
+
+    private final ArmeriaGrpcServerStream.TransportState transportState;
+
+    private Subscription subscription;
+
+    public ArmeriaMessageReader(TransportState transportState) {
+        this.transportState = transportState;
+    }
+
+    @Override
+    public void onSubscribe(Subscription subscription) {
+        this.subscription = subscription;
+        subscription.request(1);
+    }
+
+    @Override
+    public void onNext(HttpObject obj) {
+        if (obj instanceof HttpHeaders) {
+            // GRPC clients never send trailing headers so we should treat this as a bad request.
+            logger.info("Trailing headers received from GRPC client, this should never happen: {}.", obj);
+            transportState.transportReportStatus(Status.ABORTED);
+            subscription.cancel();
+            return;
+        }
+        HttpData data = (HttpData) obj;
+        transportState.inboundDataReceived(ReadableBuffers.wrap(data.array(), data.offset(), data.length()),
+                                           false);
+        subscription.request(1);
+    }
+
+    @Override
+    public void onError(Throwable cause) {
+        transportState.transportReportStatus(Status.fromThrowable(cause));
+    }
+
+    @Override
+    public void onComplete() {
+        transportState.endOfStream();
+    }
+
+    void cancel() {
+        subscription.cancel();
+    }
+}

--- a/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
+++ b/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.grpc;
+
+import static java.util.Objects.requireNonNull;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
+import com.google.common.net.MediaType;
+
+import com.linecorp.armeria.common.http.HttpHeaderNames;
+import com.linecorp.armeria.common.http.HttpHeaders;
+import com.linecorp.armeria.common.http.HttpRequest;
+import com.linecorp.armeria.common.http.HttpResponseWriter;
+import com.linecorp.armeria.common.http.HttpStatus;
+import com.linecorp.armeria.server.ServiceConfig;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.http.AbstractHttpService;
+
+import io.grpc.CompressorRegistry;
+import io.grpc.DecompressorRegistry;
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerMethodDefinition;
+import io.grpc.Status;
+import io.grpc.internal.GrpcUtil;
+import io.grpc.internal.ServerStream;
+import io.grpc.internal.ServerStreamListener;
+import io.grpc.internal.TransportFrameUtil;
+import io.netty.handler.codec.http2.Http2Exception;
+import io.netty.util.AsciiString;
+
+/**
+ * A {@link AbstractHttpService} that implements the GRPC wire protocol.
+ */
+final class GrpcService extends AbstractHttpService {
+
+    private static final Metadata EMPTY_METADATA = new Metadata();
+
+    private final InternalHandlerRegistry registry;
+    private final DecompressorRegistry decompressorRegistry;
+    private final CompressorRegistry compressorRegistry;
+
+    private long maxMessageSize = -1;
+
+    GrpcService(InternalHandlerRegistry registry,
+                DecompressorRegistry decompressorRegistry,
+                CompressorRegistry compressorRegistry) {
+        this.registry = requireNonNull(registry, "registry");
+        this.decompressorRegistry = requireNonNull(decompressorRegistry, "decompressorRegistry");
+        this.compressorRegistry = requireNonNull(compressorRegistry, "compressorRegistry");
+    }
+
+    @Override
+    protected void doPost(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) throws Exception {
+        if (!verifyContentType(req.headers())) {
+            res.respond(HttpStatus.BAD_REQUEST,
+                        MediaType.PLAIN_TEXT_UTF_8,
+                        "Missing or invalid Content-Type header.");
+            return;
+        }
+        String methodName = determineMethod(ctx);
+        if (methodName == null) {
+            res.respond(HttpStatus.BAD_REQUEST,
+                        MediaType.PLAIN_TEXT_UTF_8,
+                        "Invalid path.");
+            return;
+        }
+
+        ArmeriaGrpcServerStream stream = new ArmeriaGrpcServerStream(res, maxMessageSize);
+
+        ServerMethodDefinition<?, ?> method = registry.lookupMethod(methodName);
+        if (method == null) {
+            stream.close(Status.UNIMPLEMENTED.withDescription("Method not found: " + methodName),
+                         EMPTY_METADATA);
+            return;
+        }
+
+        Metadata metadata = new Metadata(convertHeadersToArray(req.headers()));
+
+        ServerStreamListener listener = startCall(stream, methodName, method, metadata);
+        stream.transportState().setListener(listener);
+        req.subscribe(stream.messageReader());
+    }
+
+    private <T_I, T_O> ServerStreamListener startCall(ServerStream stream,
+                                                      String fullMethodName,
+                                                      ServerMethodDefinition<T_I, T_O> methodDef,
+                                                      Metadata headers) {
+        ServerCallImpl<T_I, T_O> call = new ServerCallImpl<>(
+                stream, methodDef.getMethodDescriptor(), headers, decompressorRegistry,
+                compressorRegistry);
+        ServerCall.Listener<T_I> listener =
+                methodDef.getServerCallHandler().startCall(call, headers);
+        if (listener == null) {
+            throw new NullPointerException(
+                    "startCall() returned a null listener for method " + fullMethodName);
+        }
+        return call.newServerStreamListener(listener);
+    }
+
+    private boolean verifyContentType(HttpHeaders headers) throws Http2Exception {
+        String contentType = headers.get(HttpHeaderNames.CONTENT_TYPE);
+        return contentType != null && GrpcUtil.isGrpcContentType(contentType);
+    }
+
+    @Nullable
+    private String determineMethod(ServiceRequestContext ctx) throws Http2Exception {
+        // Remove the leading slash of the path and get the fully qualified method name
+        String path = ctx.mappedPath();
+        if (path.charAt(0) != '/') {
+            return null;
+        }
+        return path.substring(1, path.length());
+    }
+
+    private byte[][] convertHeadersToArray(HttpHeaders headers) {
+        // The Netty AsciiString class is really just a wrapper around a byte[] and supports
+        // arbitrary binary data, not just ASCII.
+        byte[][] headerValues = new byte[headers.size() * 2][];
+        int i = 0;
+        for (Map.Entry<AsciiString, String> entry : headers) {
+            AsciiString key = entry.getKey();
+            headerValues[i++] = key.isEntireArrayUsed() ? key.array() : key.toByteArray();
+            headerValues[i++] = entry.getValue().getBytes(StandardCharsets.US_ASCII);
+        }
+        return TransportFrameUtil.toRawSerializedHeaders(headerValues);
+    }
+
+    @Override
+    public void serviceAdded(ServiceConfig cfg) throws Exception {
+        maxMessageSize = cfg.server().config().defaultMaxRequestLength();
+    }
+}

--- a/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
+++ b/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.grpc;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static java.util.Objects.requireNonNull;
+
+import javax.annotation.Nullable;
+
+import com.linecorp.armeria.server.Service;
+
+import io.grpc.BindableService;
+import io.grpc.CompressorRegistry;
+import io.grpc.DecompressorRegistry;
+import io.grpc.ServerServiceDefinition;
+
+/**
+ * Constructs a {@link GrpcService} to serve GRPC services from within Armeria.
+ */
+public final class GrpcServiceBuilder {
+
+    private final InternalHandlerRegistry.Builder registryBuilder =
+            new InternalHandlerRegistry.Builder();
+
+    @Nullable
+    private DecompressorRegistry decompressorRegistry;
+
+    @Nullable
+    private CompressorRegistry compressorRegistry;
+
+    /**
+     * Adds a GRPC {@link ServerServiceDefinition} to this {@link GrpcServiceBuilder}, such as
+     * what's returned by {@link BindableService#bindService()}.
+     */
+    public GrpcServiceBuilder addService(ServerServiceDefinition service) {
+        registryBuilder.addService(requireNonNull(service, "service"));
+        return this;
+    }
+
+    /**
+     * Adds a GRPC {@link BindableService} to this {@link GrpcServiceBuilder}. Most GRPC service
+     * implementations are {@link BindableService}s.
+     */
+    public GrpcServiceBuilder addService(BindableService bindableService) {
+        return addService(bindableService.bindService());
+    }
+
+    /**
+     * Sets the {@link DecompressorRegistry} to use when decompressing messages. If not set, will use
+     * the default, which supports gzip only.
+     */
+    public GrpcServiceBuilder decompressorRegistry(DecompressorRegistry registry) {
+        decompressorRegistry = requireNonNull(registry, "registry");
+        return this;
+    }
+
+    /**
+     * Sets the {@link CompressorRegistry} to use when compressing messages. If not set, will use the
+     * default, which supports gzip only.
+     */
+    public GrpcServiceBuilder compressorRegistry(CompressorRegistry registry) {
+        compressorRegistry = requireNonNull(registry, "registry");
+        return this;
+    }
+
+    /**
+     * Constructs a new {@link GrpcService} that can be bound to
+     * {@link com.linecorp.armeria.server.ServerBuilder}. As GRPC services themselves are mounted at a path that
+     * corresponds to their protobuf package, you will almost always want to bind to a prefix, e.g. by using
+     * {@link com.linecorp.armeria.server.ServerBuilder#serviceUnder(String, Service)}.
+     */
+    public GrpcService build() {
+        return new GrpcService(registryBuilder.build(),
+                               firstNonNull(decompressorRegistry, DecompressorRegistry.getDefaultInstance()),
+                               firstNonNull(compressorRegistry, CompressorRegistry.getDefaultInstance()));
+    }
+}

--- a/src/main/java/com/linecorp/armeria/server/grpc/InternalHandlerRegistry.java
+++ b/src/main/java/com/linecorp/armeria/server/grpc/InternalHandlerRegistry.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.grpc;
+
+import java.util.HashMap;
+
+import javax.annotation.Nullable;
+
+import com.google.common.collect.ImmutableMap;
+
+import io.grpc.ServerMethodDefinition;
+import io.grpc.ServerServiceDefinition;
+
+// Copied as is from grpc.
+final class InternalHandlerRegistry {
+    private final ImmutableMap<String, ServerMethodDefinition<?, ?>> methods;
+
+    private InternalHandlerRegistry(ImmutableMap<String, ServerMethodDefinition<?, ?>> methods) {
+        this.methods = methods;
+    }
+
+    @Nullable
+    ServerMethodDefinition<?, ?> lookupMethod(String methodName) {
+        return methods.get(methodName);
+    }
+
+    static class Builder {
+        // Store per-service first, to make sure services are added/replaced atomically.
+        private final HashMap<String, ServerServiceDefinition> services =
+                new HashMap<String, ServerServiceDefinition>();
+
+        Builder addService(ServerServiceDefinition service) {
+            services.put(service.getServiceDescriptor().getName(), service);
+            return this;
+        }
+
+        InternalHandlerRegistry build() {
+            ImmutableMap.Builder<String, ServerMethodDefinition<?, ?>> mapBuilder =
+                    ImmutableMap.builder();
+            for (ServerServiceDefinition service : services.values()) {
+                for (ServerMethodDefinition<?, ?> method : service.getMethods()) {
+                    mapBuilder.put(method.getMethodDescriptor().getFullMethodName(), method);
+                }
+            }
+            return new InternalHandlerRegistry(mapBuilder.build());
+        }
+    }
+}

--- a/src/main/java/com/linecorp/armeria/server/grpc/ServerCallImpl.java
+++ b/src/main/java/com/linecorp/armeria/server/grpc/ServerCallImpl.java
@@ -1,0 +1,294 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.linecorp.armeria.server.grpc;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static io.grpc.internal.GrpcUtil.ACCEPT_ENCODING_SPLITER;
+import static io.grpc.internal.GrpcUtil.MESSAGE_ACCEPT_ENCODING_KEY;
+import static io.grpc.internal.GrpcUtil.MESSAGE_ENCODING_KEY;
+import static java.util.Objects.requireNonNull;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Throwables;
+
+import io.grpc.Attributes;
+import io.grpc.Codec;
+import io.grpc.Compressor;
+import io.grpc.CompressorRegistry;
+import io.grpc.Decompressor;
+import io.grpc.DecompressorRegistry;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.MethodDescriptor.MethodType;
+import io.grpc.ServerCall;
+import io.grpc.Status;
+import io.grpc.internal.ServerStream;
+import io.grpc.internal.ServerStreamListener;
+
+// Copied as is from grpc. Too bad it's not public :(
+final class ServerCallImpl<ReqT, RespT> extends ServerCall<ReqT, RespT> {
+    private final ServerStream stream;
+    private final MethodDescriptor<ReqT, RespT> method;
+    private final String messageAcceptEncoding;
+    private final DecompressorRegistry decompressorRegistry;
+    private final CompressorRegistry compressorRegistry;
+
+    // state
+    private volatile boolean cancelled;
+    private boolean sendHeadersCalled;
+    private boolean closeCalled;
+    private Compressor compressor;
+
+    ServerCallImpl(ServerStream stream, MethodDescriptor<ReqT, RespT> method,
+                   Metadata inboundHeaders,
+                   DecompressorRegistry decompressorRegistry, CompressorRegistry compressorRegistry) {
+        this.stream = stream;
+        this.method = method;
+        this.messageAcceptEncoding = inboundHeaders.get(MESSAGE_ACCEPT_ENCODING_KEY);
+        this.decompressorRegistry = decompressorRegistry;
+        this.compressorRegistry = compressorRegistry;
+
+        if (inboundHeaders.containsKey(MESSAGE_ENCODING_KEY)) {
+            String encoding = inboundHeaders.get(MESSAGE_ENCODING_KEY);
+            Decompressor decompressor = decompressorRegistry.lookupDecompressor(encoding);
+            if (decompressor == null) {
+                throw Status.UNIMPLEMENTED
+                        .withDescription(String.format("Can't find decompressor for %s", encoding))
+                        .asRuntimeException();
+            }
+            stream.setDecompressor(decompressor);
+        }
+    }
+
+    @Override
+    public void request(int numMessages) {
+        stream.request(numMessages);
+    }
+
+    @Override
+    public void sendHeaders(Metadata headers) {
+        checkState(!sendHeadersCalled, "sendHeaders has already been called");
+        checkState(!closeCalled, "call is closed");
+
+        headers.removeAll(MESSAGE_ENCODING_KEY);
+        if (compressor == null) {
+            compressor = Codec.Identity.NONE;
+        } else {
+            if (messageAcceptEncoding != null) {
+                List<String> acceptedEncodingsList =
+                        ACCEPT_ENCODING_SPLITER.splitToList(messageAcceptEncoding);
+                if (!acceptedEncodingsList.contains(compressor.getMessageEncoding())) {
+                    // resort to using no compression.
+                    compressor = Codec.Identity.NONE;
+                }
+            } else {
+                compressor = Codec.Identity.NONE;
+            }
+        }
+
+        // Always put compressor, even if it's identity.
+        headers.put(MESSAGE_ENCODING_KEY, compressor.getMessageEncoding());
+
+        stream.setCompressor(compressor);
+
+        headers.removeAll(MESSAGE_ACCEPT_ENCODING_KEY);
+        String advertisedEncodings = decompressorRegistry.getRawAdvertisedMessageEncodings();
+        if (!advertisedEncodings.isEmpty()) {
+            headers.put(MESSAGE_ACCEPT_ENCODING_KEY, advertisedEncodings);
+        }
+
+        // Don't check if sendMessage has been called, since it requires that sendHeaders was already
+        // called.
+        sendHeadersCalled = true;
+        stream.writeHeaders(headers);
+    }
+
+    @Override
+    public void sendMessage(RespT message) {
+        checkState(sendHeadersCalled, "sendHeaders has not been called");
+        checkState(!closeCalled, "call is closed");
+        try {
+            InputStream resp = method.streamResponse(message);
+            stream.writeMessage(resp);
+            stream.flush();
+        } catch (RuntimeException e) {
+            close(Status.fromThrowable(e), new Metadata());
+            throw e;
+        } catch (Throwable t) {
+            close(Status.fromThrowable(t), new Metadata());
+            throw new RuntimeException(t);
+        }
+    }
+
+    @Override
+    public void setMessageCompression(boolean enable) {
+        stream.setMessageCompression(enable);
+    }
+
+    @Override
+    public void setCompression(String compressorName) {
+        // Added here to give a better error message.
+        checkState(!sendHeadersCalled, "sendHeaders has been called");
+
+        compressor = compressorRegistry.lookupCompressor(compressorName);
+        checkArgument(compressor != null, "Unable to find compressor by name %s", compressorName);
+    }
+
+    @Override
+    public boolean isReady() {
+        return stream.isReady();
+    }
+
+    @Override
+    public void close(Status status, Metadata trailers) {
+        checkState(!closeCalled, "call already closed");
+        closeCalled = true;
+        stream.close(status, trailers);
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    ServerStreamListener newServerStreamListener(ServerCall.Listener<ReqT> listener) {
+        return new ServerStreamListenerImpl<ReqT>(this, listener);
+    }
+
+    @Override
+    public Attributes attributes() {
+        return stream.attributes();
+    }
+
+    @Override
+    public MethodDescriptor<ReqT, RespT> getMethodDescriptor() {
+        return method;
+    }
+
+    /**
+     * All of these callbacks are assumed to called on an application thread, and the caller is
+     * responsible for handling thrown exceptions.
+     */
+    @VisibleForTesting
+    static final class ServerStreamListenerImpl<ReqT> implements ServerStreamListener {
+        private final ServerCallImpl<ReqT, ?> call;
+        private final ServerCall.Listener<ReqT> listener;
+        private boolean messageReceived;
+
+        public ServerStreamListenerImpl(
+                ServerCallImpl<ReqT, ?> call, ServerCall.Listener<ReqT> listener) {
+            this.call = requireNonNull(call, "call");
+            this.listener = requireNonNull(listener, "listener must not be null");
+        }
+
+        @Override
+        public void messageRead(final InputStream message) {
+            Throwable t = null;
+            try {
+                if (call.cancelled) {
+                    return;
+                }
+                // Special case for unary calls.
+                if (messageReceived && call.method.getType() == MethodType.UNARY) {
+                    call.stream.close(Status.INTERNAL.withDescription(
+                            "More than one request messages for unary call or server streaming call"),
+                                      new Metadata());
+                    return;
+                }
+                messageReceived = true;
+
+                listener.onMessage(call.method.parseRequest(message));
+            } catch (Throwable e) {
+                t = e;
+            } finally {
+                try {
+                    message.close();
+                } catch (IOException e) {
+                    if (t != null) {
+                        // TODO(carl-mastrangelo): Maybe log e here.
+                        Throwables.propagateIfPossible(t);
+                        throw new RuntimeException(t);
+                    }
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+
+        @Override
+        public void halfClosed() {
+            if (call.cancelled) {
+                return;
+            }
+
+            listener.onHalfClose();
+        }
+
+        @Override
+        public void closed(Status status) {
+            if (status.isOk()) {
+                listener.onComplete();
+            } else {
+                call.cancelled = true;
+                listener.onCancel();
+            }
+        }
+
+        @Override
+        public void onReady() {
+            if (call.cancelled) {
+                return;
+            }
+            listener.onReady();
+        }
+    }
+}
+

--- a/src/main/java/com/linecorp/armeria/server/http/HttpResponseSubscriber.java
+++ b/src/main/java/com/linecorp/armeria/server/http/HttpResponseSubscriber.java
@@ -149,7 +149,7 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject>, ChannelFut
                 logBuilder.statusCode(statusCode);
                 logBuilder.attr(ResponseLog.HTTP_HEADERS).set(headers);
 
-                if (req.method() == HttpMethod.HEAD) {
+                if (req.method() == HttpMethod.HEAD || headers.isEndOfStream()) {
                     endOfStream = true;
                     break;
                 }

--- a/src/test/java/com/linecorp/armeria/server/grpc/ArmeriaGrpcServerStreamTest.java
+++ b/src/test/java/com/linecorp/armeria/server/grpc/ArmeriaGrpcServerStreamTest.java
@@ -1,0 +1,270 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.grpc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.reactivestreams.Subscription;
+
+import com.google.common.io.ByteStreams;
+
+import com.linecorp.armeria.common.http.DefaultHttpHeaders;
+import com.linecorp.armeria.common.http.HttpData;
+import com.linecorp.armeria.common.http.HttpHeaderNames;
+import com.linecorp.armeria.common.http.HttpHeaders;
+import com.linecorp.armeria.common.http.HttpResponseWriter;
+import com.linecorp.armeria.common.http.HttpStatus;
+
+import io.grpc.Metadata;
+import io.grpc.Status;
+import io.grpc.internal.GrpcUtil;
+import io.grpc.internal.ReadableBuffers;
+import io.grpc.internal.ServerStreamListener;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.Unpooled;
+import io.netty.util.AsciiString;
+
+// Based on NettyServerStreamTest from grpc. The main difference is flow control tests aren't copied as they
+// are handled within armeria itself.
+public class ArmeriaGrpcServerStreamTest {
+
+    private static final long MAX_MESSAGE_SIZE = 1 * 1024 * 1024;
+    private static final String MESSAGE = "hello world";
+
+    @Rule
+    public MockitoRule mocks = MockitoJUnit.rule();
+
+    @Mock
+    private HttpResponseWriter responseWriter;
+
+    @Mock
+    private ServerStreamListener serverListener;
+
+    @Mock
+    private Subscription subscription;
+
+    private ArmeriaGrpcServerStream stream;
+
+    @Before
+    public void setUp() {
+        stream = new ArmeriaGrpcServerStream(responseWriter, MAX_MESSAGE_SIZE);
+        stream.transportState().setListener(serverListener);
+        stream.messageReader().onSubscribe(subscription);
+        verify(subscription).request(1);
+        verify(serverListener, atLeastOnce()).onReady();
+        verifyNoMoreInteractions(serverListener);
+    }
+
+    @Test
+    public void inboundMessageShouldCallListener() throws Exception {
+        stream.request(1);
+
+        stream.transportState().inboundDataReceived(ReadableBuffers.wrap(messageFrame(MESSAGE)), false);
+        ArgumentCaptor<InputStream> captor = ArgumentCaptor.forClass(InputStream.class);
+        verify(serverListener).messageRead(captor.capture());
+
+        assertThat(MESSAGE).isEqualTo(toString(captor.getValue()));
+    }
+
+    @Test
+    public void shouldBeImmediatelyReadyForData() {
+        assertThat(stream.isReady()).isTrue();
+    }
+
+    @Test
+    public void closedShouldNotBeReady() throws IOException {
+        assertThat(stream.isReady()).isTrue();
+        stream.close(Status.ABORTED, new Metadata());
+        assertThat(stream.isReady()).isFalse();
+    }
+
+    @Test
+    public void notifiedOnReadyAfterWriteCompletes() throws IOException {
+        stream.writeHeaders(new Metadata());
+        assertThat(stream.isReady()).isTrue();
+        byte[] msg = largeMessage();
+        // The future is set up to automatically complete, indicating that the write is done.
+        stream.writeMessage(new ByteArrayInputStream(msg));
+        stream.flush();
+        assertThat(stream.isReady()).isTrue();
+        verify(serverListener).onReady();
+    }
+
+    @Test
+    public void writeHeadersAndResponse() throws Exception {
+        stream.writeHeaders(new Metadata());
+        byte[] msg = smallMessage();
+        stream.writeMessage(new ByteArrayInputStream(msg));
+        stream.flush();
+
+        verify(responseWriter).write(HttpHeaders.of(HttpStatus.OK)
+                                                .set(HttpHeaderNames.CONTENT_TYPE,
+                                                     GrpcUtil.CONTENT_TYPE_GRPC));
+        verify(responseWriter).write(HttpData.of(messageFrame(MESSAGE)));
+        verifyNoMoreInteractions(responseWriter);
+    }
+
+    @Test
+    public void closeBeforeClientHalfCloseShouldSucceed() throws Exception {
+        stream.close(Status.OK, new Metadata());
+
+        verify(responseWriter).write(new DefaultHttpHeaders(true, 0, true)
+                                             .status(HttpStatus.OK)
+                                             .set(HttpHeaderNames.CONTENT_TYPE,
+                                                  GrpcUtil.CONTENT_TYPE_GRPC)
+                                             .set(AsciiString.of("grpc-status"), "0"));
+        verify(responseWriter).close();
+        verifyNoMoreInteractions(responseWriter);
+        verifyZeroInteractions(serverListener);
+
+        stream.transportState().complete();
+        verify(serverListener).closed(Status.OK);
+        verifyNoMoreInteractions(serverListener);
+    }
+
+    @Test
+    public void closeWithErrorBeforeClientHalfCloseShouldSucceed() throws Exception {
+        // Error is sent on wire and ends the stream
+        stream.close(Status.CANCELLED, new Metadata());
+
+        verify(responseWriter).write(new DefaultHttpHeaders(true, 0, true)
+                                             .status(HttpStatus.OK)
+                                             .set(HttpHeaderNames.CONTENT_TYPE,
+                                                  GrpcUtil.CONTENT_TYPE_GRPC)
+                                             .set(AsciiString.of("grpc-status"), "1"));
+        verify(responseWriter).close();
+        verifyNoMoreInteractions(responseWriter);
+        verifyZeroInteractions(serverListener);
+
+        // Sending complete. Listener gets closed()
+        stream.transportState().complete();
+        verify(serverListener).closed(Status.OK);
+        verifyNoMoreInteractions(serverListener);
+    }
+
+    @Test
+    public void closeAfterClientHalfCloseShouldSucceed() throws Exception {
+        // Client half-closes. Listener gets halfClosed()
+        stream.transportState()
+                .inboundDataReceived(ReadableBuffers.empty(), true);
+
+        verify(serverListener).halfClosed();
+
+        // Server closes. Status sent
+        stream.close(Status.OK, new Metadata());
+        verifyZeroInteractions(serverListener);
+
+        verify(responseWriter).write(new DefaultHttpHeaders(true, 0, true)
+                                             .status(HttpStatus.OK)
+                                             .set(HttpHeaderNames.CONTENT_TYPE,
+                                                  GrpcUtil.CONTENT_TYPE_GRPC)
+                                             .set(AsciiString.of("grpc-status"), "0"));
+        verify(responseWriter).close();
+        verifyNoMoreInteractions(responseWriter);
+
+        // Sending and receiving complete. Listener gets closed()
+        stream.transportState().complete();
+        verify(serverListener).closed(Status.OK);
+        verifyNoMoreInteractions(serverListener);
+    }
+
+    @Test
+    public void abortStreamAndNotSendStatus() throws Exception {
+        Status status = Status.INTERNAL.withCause(new Throwable());
+        stream.transportState().transportReportStatus(status);
+        verify(serverListener).closed(same(status));
+        verifyZeroInteractions(responseWriter);
+        verifyNoMoreInteractions(serverListener);
+    }
+
+    @Test
+    public void abortStreamAfterClientHalfCloseShouldCallClose() {
+        Status status = Status.INTERNAL.withCause(new Throwable());
+        // Client half-closes. Listener gets halfClosed()
+        stream.transportState().inboundDataReceived(ReadableBuffers.empty(), true);
+        verify(serverListener).halfClosed();
+        // Abort from the transport layer
+        stream.transportState().transportReportStatus(status);
+        verify(serverListener).closed(same(status));
+        verifyNoMoreInteractions(serverListener);
+    }
+
+    @Test
+    public void cancelStreamShouldSucceed() {
+        stream.cancel(Status.DEADLINE_EXCEEDED);
+        verify(responseWriter).close(Status.DEADLINE_EXCEEDED.getCause());
+        verifyNoMoreInteractions(responseWriter);
+        verify(subscription).cancel();
+    }
+
+    private static byte[] smallMessage() {
+        return MESSAGE.getBytes();
+    }
+
+    private static byte[] largeMessage() {
+        byte[] smallMessage = smallMessage();
+        int size = smallMessage.length * 10 * 1024;
+        byte[] largeMessage = new byte[size];
+        for (int ix = 0; ix < size; ix += smallMessage.length) {
+            System.arraycopy(smallMessage, 0, largeMessage, ix, smallMessage.length);
+        }
+        return largeMessage;
+    }
+
+    private static byte[] messageFrame(String message) throws Exception {
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        DataOutputStream dos = new DataOutputStream(os);
+        dos.write(message.getBytes(StandardCharsets.UTF_8));
+        dos.close();
+
+        // Write the compression header followed by the context frame.
+        return compressionFrame(os.toByteArray());
+    }
+
+    private static byte[] compressionFrame(byte[] data) {
+        ByteBuf buf = Unpooled.buffer();
+        buf.writeByte(0);
+        buf.writeInt(data.length);
+        buf.writeBytes(data);
+        return ByteBufUtil.getBytes(buf);
+    }
+
+    private static String toString(InputStream in) throws Exception {
+        byte[] bytes = ByteStreams.toByteArray(in);
+        return new String(bytes, StandardCharsets.UTF_8);
+    }
+}

--- a/src/test/java/com/linecorp/armeria/server/grpc/ArmeriaMessageReaderTest.java
+++ b/src/test/java/com/linecorp/armeria/server/grpc/ArmeriaMessageReaderTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.grpc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.reactivestreams.Subscription;
+
+import com.linecorp.armeria.common.http.HttpData;
+import com.linecorp.armeria.server.grpc.ArmeriaGrpcServerStream.TransportState;
+
+import io.grpc.internal.ReadableBuffer;
+
+// Client error is tested in ArmeriaGrpcServerStreamTest, we can't check it here since
+// TransportState.transportReportStatus is marked final.
+public class ArmeriaMessageReaderTest {
+
+    @Rule
+    public MockitoRule mocks = MockitoJUnit.rule();
+
+    @Mock
+    private TransportState transportState;
+
+    @Mock
+    private Subscription subscription;
+
+    private ArmeriaMessageReader reader;
+
+    @Before
+    public void setUp() {
+        reader = new ArmeriaMessageReader(transportState);
+        reader.onSubscribe(subscription);
+        verify(subscription).request(1);
+        reset(subscription);
+    }
+
+    @Test
+    public void sendMessage() {
+        byte[] msg = new byte[] { 1, 2, 3, 5};
+        reader.onNext(HttpData.of(msg));
+        // ReadableBuffer doesn't seem to implement equals so we need to capture.
+        ArgumentCaptor<ReadableBuffer> bufferCaptor = ArgumentCaptor.forClass(ReadableBuffer.class);
+        verify(transportState).inboundDataReceived(bufferCaptor.capture(), eq(false));
+        verify(subscription).request(1);
+        assertThat(bufferCaptor.getValue().array()).isEqualTo(msg);
+    }
+
+    @Test
+    public void clientDone() {
+        reader.onComplete();
+        verify(transportState).endOfStream();
+    }
+
+    @Test
+    public void serverCancelled() {
+        reader.cancel();
+        verify(subscription).cancel();
+    }
+}

--- a/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceTest.java
+++ b/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.grpc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.Executors;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import com.linecorp.armeria.common.http.AggregatedHttpMessage;
+import com.linecorp.armeria.common.http.DefaultHttpResponse;
+import com.linecorp.armeria.common.http.HttpData;
+import com.linecorp.armeria.common.http.HttpHeaderNames;
+import com.linecorp.armeria.common.http.HttpHeaders;
+import com.linecorp.armeria.common.http.HttpMethod;
+import com.linecorp.armeria.common.http.HttpRequest;
+import com.linecorp.armeria.common.http.HttpStatus;
+import com.linecorp.armeria.server.ServiceRequestContext;
+
+import io.grpc.internal.GrpcUtil;
+import io.grpc.testing.integration.TestServiceImpl;
+import io.netty.util.AsciiString;
+
+// Tests error cases, success cases are checked in ArmeriaGrpcServiceInteropTest
+public class GrpcServiceTest {
+
+    @Rule
+    public MockitoRule mocks = MockitoJUnit.rule();
+
+    @Mock
+    private ServiceRequestContext ctx;
+
+    private DefaultHttpResponse response;
+
+    private GrpcService grpcService;
+
+    @Before
+    public void setUp() {
+        response = new DefaultHttpResponse();
+        grpcService = new GrpcServiceBuilder()
+                .addService(new TestServiceImpl(Executors.newSingleThreadScheduledExecutor()))
+                .build();
+    }
+
+    @Test
+    public void missingContentType() throws Exception {
+        grpcService.doPost(
+                ctx,
+                HttpRequest.of(HttpHeaders.of(HttpMethod.POST, "/grpc.testing.TestService.UnaryCall")),
+                response);
+        assertThat(response.aggregate().get()).isEqualTo(AggregatedHttpMessage.of(
+                HttpHeaders.of(HttpStatus.BAD_REQUEST)
+                           .set(HttpHeaderNames.CONTENT_TYPE, "text/plain; charset=utf-8"),
+                HttpData.ofUtf8("Missing or invalid Content-Type header.")));
+    }
+
+    @Test
+    public void badContentType() throws Exception {
+        grpcService.doPost(
+                ctx,
+                HttpRequest.of(HttpHeaders.of(HttpMethod.POST, "/grpc.testing.TestService.UnaryCall")
+                                          .set(HttpHeaderNames.CONTENT_TYPE, "application/json")),
+                response);
+        assertThat(response.aggregate().get()).isEqualTo(AggregatedHttpMessage.of(
+                HttpHeaders.of(HttpStatus.BAD_REQUEST)
+                           .set(HttpHeaderNames.CONTENT_TYPE, "text/plain; charset=utf-8"),
+                HttpData.ofUtf8("Missing or invalid Content-Type header.")));
+    }
+
+    @Test
+    public void pathMissingSlash() throws Exception {
+        when(ctx.mappedPath()).thenReturn("grpc.testing.TestService.UnaryCall");
+        grpcService.doPost(
+                ctx,
+                HttpRequest.of(HttpHeaders.of(HttpMethod.POST, "grpc.testing.TestService.UnaryCall")
+                                          .set(HttpHeaderNames.CONTENT_TYPE, GrpcUtil.CONTENT_TYPE_GRPC)),
+                response);
+        assertThat(response.aggregate().get()).isEqualTo(AggregatedHttpMessage.of(
+                HttpHeaders.of(HttpStatus.BAD_REQUEST)
+                           .set(HttpHeaderNames.CONTENT_TYPE, "text/plain; charset=utf-8"),
+                HttpData.ofUtf8("Invalid path.")));
+    }
+
+    @Test
+    public void missingMethod() throws Exception {
+        when(ctx.mappedPath()).thenReturn("/grpc.testing.TestService/FooCall");
+        grpcService.doPost(
+                ctx,
+                HttpRequest.of(HttpHeaders.of(HttpMethod.POST, "/grpc.testing.TestService/FooCall")
+                                          .set(HttpHeaderNames.CONTENT_TYPE, GrpcUtil.CONTENT_TYPE_GRPC)),
+                response);
+        assertThat(response.aggregate().get()).isEqualTo(AggregatedHttpMessage.of(
+                HttpHeaders.of(HttpStatus.OK)
+                           .set(HttpHeaderNames.CONTENT_TYPE, GrpcUtil.CONTENT_TYPE_GRPC)
+                           .set(AsciiString.of("grpc-status"), "12")
+                           .set(AsciiString.of("grpc-message"),
+                                "Method not found: grpc.testing.TestService/FooCall")
+                           .set(HttpHeaderNames.CONTENT_LENGTH, "0"),
+                HttpData.of(new byte[] {})));
+    }
+}

--- a/src/test/java/com/linecorp/armeria/server/grpc/interop/ArmeriaGrpcServer.java
+++ b/src/test/java/com/linecorp/armeria/server/grpc/interop/ArmeriaGrpcServer.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.grpc.interop;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import com.google.common.util.concurrent.UncheckedExecutionException;
+
+import com.linecorp.armeria.server.ServerListener;
+
+import io.grpc.Server;
+
+/**
+ * Wraps an armeria server so GRPC interop tests can operate it.
+ */
+public class ArmeriaGrpcServer extends Server implements ServerListener {
+
+    private final com.linecorp.armeria.server.Server armeriaServer;
+
+    private boolean isShutdown;
+    private boolean isTerminated;
+    private CompletableFuture<Void> shutdownFuture;
+
+    public ArmeriaGrpcServer(com.linecorp.armeria.server.Server armeriaServer) {
+        this.armeriaServer = armeriaServer;
+    }
+
+    @Override
+    public Server start() throws IOException {
+        try {
+            armeriaServer.start().get();
+        } catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException(e);
+        }
+        return this;
+    }
+
+    @Override
+    public int getPort() {
+        return armeriaServer.activePort().get().localAddress().getPort();
+    }
+
+    @Override
+    public Server shutdown() {
+        armeriaServer.stop();
+        return this;
+    }
+
+    @Override
+    public Server shutdownNow() {
+        shutdownFuture = armeriaServer.stop();
+        return this;
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return isShutdown;
+    }
+
+    @Override
+    public boolean isTerminated() {
+        return isTerminated;
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        try {
+            shutdownFuture.get(timeout, unit);
+        } catch (ExecutionException e) {
+            throw new UncheckedExecutionException(e);
+        } catch (TimeoutException e) {
+            // Ignore.
+        }
+        return isTerminated;
+    }
+
+    @Override
+    public void awaitTermination() throws InterruptedException {
+        try {
+            shutdownFuture.get();
+        } catch (ExecutionException e) {
+            throw new UncheckedExecutionException(e);
+        }
+    }
+
+    @Override
+    public void serverStarting(com.linecorp.armeria.server.Server server) throws Exception {
+
+    }
+
+    @Override
+    public void serverStarted(com.linecorp.armeria.server.Server server) throws Exception {
+
+    }
+
+    @Override
+    public void serverStopping(com.linecorp.armeria.server.Server server) throws Exception {
+        isShutdown = true;
+    }
+
+    @Override
+    public void serverStopped(com.linecorp.armeria.server.Server server) throws Exception {
+        isTerminated = true;
+    }
+}

--- a/src/test/java/com/linecorp/armeria/server/grpc/interop/ArmeriaGrpcServerBuilder.java
+++ b/src/test/java/com/linecorp/armeria/server/grpc/interop/ArmeriaGrpcServerBuilder.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+
+package com.linecorp.armeria.server.grpc.interop;
+
+import java.io.File;
+import java.util.concurrent.Executor;
+
+import javax.annotation.Nullable;
+import javax.net.ssl.SSLException;
+
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.server.grpc.GrpcServiceBuilder;
+
+import io.grpc.BindableService;
+import io.grpc.CompressorRegistry;
+import io.grpc.DecompressorRegistry;
+import io.grpc.HandlerRegistry;
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import io.grpc.ServerServiceDefinition;
+
+public class ArmeriaGrpcServerBuilder extends ServerBuilder<ArmeriaGrpcServerBuilder> {
+
+    private final com.linecorp.armeria.server.ServerBuilder armeriaServerBuilder;
+    private final GrpcServiceBuilder grpcServiceBuilder;
+
+    public ArmeriaGrpcServerBuilder(com.linecorp.armeria.server.ServerBuilder armeriaServerBuilder,
+                                    GrpcServiceBuilder grpcServiceBuilder) {
+        this.armeriaServerBuilder = armeriaServerBuilder;
+        this.grpcServiceBuilder = grpcServiceBuilder;
+    }
+
+    @Override
+    public ArmeriaGrpcServerBuilder directExecutor() {
+        return this;
+    }
+
+    @Override
+    public ArmeriaGrpcServerBuilder executor(@Nullable Executor executor) {
+        return this;
+    }
+
+    @Override
+    public ArmeriaGrpcServerBuilder addService(ServerServiceDefinition serverServiceDefinition) {
+        grpcServiceBuilder.addService(serverServiceDefinition);
+        return this;
+    }
+
+    @Override
+    public ArmeriaGrpcServerBuilder addService(BindableService bindableService) {
+        grpcServiceBuilder.addService(bindableService);
+        return this;
+    }
+
+    @Override
+    public ArmeriaGrpcServerBuilder fallbackHandlerRegistry(@Nullable HandlerRegistry handlerRegistry) {
+        // Not supported
+        return this;
+    }
+
+    @Override
+    public ArmeriaGrpcServerBuilder useTransportSecurity(File certChain, File privateKey) {
+        try {
+            armeriaServerBuilder.sslContext(SessionProtocol.HTTPS, certChain, privateKey);
+        } catch (SSLException e) {
+            throw new IllegalArgumentException(e);
+        }
+        return this;
+    }
+
+    @Override
+    public ArmeriaGrpcServerBuilder decompressorRegistry(@Nullable DecompressorRegistry decompressorRegistry) {
+        grpcServiceBuilder.decompressorRegistry(decompressorRegistry);
+        return this;
+    }
+
+    @Override
+    public ArmeriaGrpcServerBuilder compressorRegistry(@Nullable CompressorRegistry compressorRegistry) {
+        grpcServiceBuilder.compressorRegistry(compressorRegistry);
+        return this;
+    }
+
+    @Override
+    public Server build() {
+        armeriaServerBuilder.serviceUnder("/", grpcServiceBuilder.build());
+        return new ArmeriaGrpcServer(armeriaServerBuilder.build());
+    }
+}

--- a/src/test/java/com/linecorp/armeria/server/grpc/interop/ArmeriaGrpcServerInteropTest.java
+++ b/src/test/java/com/linecorp/armeria/server/grpc/interop/ArmeriaGrpcServerInteropTest.java
@@ -1,0 +1,323 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.grpc.interop;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.security.cert.CertificateException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.google.protobuf.ByteString;
+
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.grpc.GrpcServiceBuilder;
+
+import io.grpc.ManagedChannel;
+import io.grpc.Status;
+import io.grpc.netty.GrpcSslContexts;
+import io.grpc.netty.NettyChannelBuilder;
+import io.grpc.stub.StreamObserver;
+import io.grpc.testing.TestUtils;
+import io.grpc.testing.integration.AbstractInteropTest;
+import io.grpc.testing.integration.Messages.Payload;
+import io.grpc.testing.integration.Messages.PayloadType;
+import io.grpc.testing.integration.Messages.ResponseParameters;
+import io.grpc.testing.integration.Messages.StreamingOutputCallRequest;
+import io.grpc.testing.integration.Messages.StreamingOutputCallResponse;
+import io.grpc.testing.integration.TestServiceGrpc;
+import io.grpc.testing.integration.TestServiceGrpc.TestServiceStub;
+import io.netty.handler.ssl.ClientAuth;
+import io.netty.handler.ssl.SupportedCipherSuiteFilter;
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import io.netty.handler.ssl.util.SelfSignedCertificate;
+
+/**
+ * Interop test based on grpc-interop-testing. Should provide reasonable confidence in armeria's
+ * handling of the grpc protocol.
+ */
+public class ArmeriaGrpcServerInteropTest extends AbstractInteropTest {
+
+    /** Starts the server with HTTPS. */
+    @BeforeClass
+    public static void startServer() {
+        try {
+            SelfSignedCertificate ssc = new SelfSignedCertificate();
+            ServerBuilder sb = new ServerBuilder()
+                    .port(0, SessionProtocol.HTTPS)
+                    .defaultMaxRequestLength(16 * 1024 * 1024)
+                    .sslContext(
+                            GrpcSslContexts.forServer(ssc.certificate(), ssc.privateKey())
+                                           .clientAuth(ClientAuth.REQUIRE)
+                                           .trustManager(TestUtils.loadCert("ca.pem"))
+                                           .ciphers(TestUtils.preferredTestCiphers(),
+                                                    SupportedCipherSuiteFilter.INSTANCE)
+                                           .build());
+            startStaticServer(new ArmeriaGrpcServerBuilder(sb, new GrpcServiceBuilder()));
+        } catch (IOException | CertificateException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    @AfterClass
+    public static void stopServer() {
+        stopStaticServer();
+    }
+
+    @Override
+    protected ManagedChannel createChannel() {
+        try {
+            // Use reflection to access package-private method.
+            Method getPort = AbstractInteropTest.class.getDeclaredMethod("getPort");
+            getPort.setAccessible(true);
+            return NettyChannelBuilder
+                    .forAddress("localhost", (int) getPort.invoke(this))
+                    .flowControlWindow(65 * 1024)
+                    .maxMessageSize(16 * 1024 * 1024)
+                    .sslContext(GrpcSslContexts
+                                        .forClient()
+                                        .keyManager(TestUtils.loadCert("client.pem"),
+                                                    TestUtils.loadCert("client.key"))
+                                        .trustManager(InsecureTrustManagerFactory.INSTANCE)
+                                        .ciphers(TestUtils.preferredTestCiphers(),
+                                                 SupportedCipherSuiteFilter.INSTANCE)
+                                        .build())
+                    .build();
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    // Several tests copied due to Mockito version mismatch (timeout() was moved).
+
+    @Override
+    @Test(timeout = 10000)
+    public void pingPong() throws Exception {
+        final List<StreamingOutputCallRequest> requests = Arrays.asList(
+                StreamingOutputCallRequest.newBuilder()
+                                          .addResponseParameters(ResponseParameters.newBuilder()
+                                                                                   .setSize(31415))
+                                          .setPayload(Payload.newBuilder()
+                                                             .setBody(ByteString.copyFrom(new byte[27182])))
+                                          .build(),
+                StreamingOutputCallRequest.newBuilder()
+                                          .addResponseParameters(ResponseParameters.newBuilder()
+                                                                                   .setSize(9))
+                                          .setPayload(Payload.newBuilder()
+                                                             .setBody(ByteString.copyFrom(new byte[8])))
+                                          .build(),
+                StreamingOutputCallRequest.newBuilder()
+                                          .addResponseParameters(ResponseParameters.newBuilder()
+                                                                                   .setSize(2653))
+                                          .setPayload(Payload.newBuilder()
+                                                             .setBody(ByteString.copyFrom(new byte[1828])))
+                                          .build(),
+                StreamingOutputCallRequest.newBuilder()
+                                          .addResponseParameters(ResponseParameters.newBuilder()
+                                                                                   .setSize(58979))
+                                          .setPayload(Payload.newBuilder()
+                                                             .setBody(ByteString.copyFrom(new byte[45904])))
+                                          .build());
+        final List<StreamingOutputCallResponse> goldenResponses = Arrays.asList(
+                StreamingOutputCallResponse.newBuilder()
+                                           .setPayload(Payload.newBuilder()
+                                                              .setType(PayloadType.COMPRESSABLE)
+                                                              .setBody(ByteString.copyFrom(new byte[31415])))
+                                           .build(),
+                StreamingOutputCallResponse.newBuilder()
+                                           .setPayload(Payload.newBuilder()
+                                                              .setType(PayloadType.COMPRESSABLE)
+                                                              .setBody(ByteString.copyFrom(new byte[9])))
+                                           .build(),
+                StreamingOutputCallResponse.newBuilder()
+                                           .setPayload(Payload.newBuilder()
+                                                              .setType(PayloadType.COMPRESSABLE)
+                                                              .setBody(ByteString.copyFrom(new byte[2653])))
+                                           .build(),
+                StreamingOutputCallResponse.newBuilder()
+                                           .setPayload(Payload.newBuilder()
+                                                              .setType(PayloadType.COMPRESSABLE)
+                                                              .setBody(ByteString.copyFrom(new byte[58979])))
+                                           .build());
+
+        @SuppressWarnings("unchecked")
+        StreamObserver<StreamingOutputCallResponse> responseObserver = mock(StreamObserver.class);
+        StreamObserver<StreamingOutputCallRequest> requestObserver
+                = asyncStub.fullDuplexCall(responseObserver);
+        for (int i = 0; i < requests.size(); i++) {
+            requestObserver.onNext(requests.get(i));
+            verify(responseObserver, timeout(operationTimeoutMillis())).onNext(goldenResponses.get(i));
+            verifyNoMoreInteractions(responseObserver);
+        }
+        requestObserver.onCompleted();
+        verify(responseObserver, timeout(operationTimeoutMillis())).onCompleted();
+        verifyNoMoreInteractions(responseObserver);
+    }
+
+    // FIXME: This doesn't work yet and may require some complicated changes. Armeria should continue to accept
+    // requests after a channel is gracefully closed but doesn't appear to (maybe because it supports both
+    // HTTP1, which has no concept of graceful shutdown, and HTTP2).
+    @Ignore
+    @Test(timeout = 10000)
+    public void gracefulShutdown() throws Exception {
+        final List<StreamingOutputCallRequest> requests = Arrays.asList(
+                StreamingOutputCallRequest.newBuilder()
+                                          .addResponseParameters(ResponseParameters.newBuilder()
+                                                                                   .setSize(3))
+                                          .setPayload(Payload.newBuilder()
+                                                             .setBody(ByteString.copyFrom(new byte[2])))
+                                          .build(),
+                StreamingOutputCallRequest.newBuilder()
+                                          .addResponseParameters(ResponseParameters.newBuilder()
+                                                                                   .setSize(1))
+                                          .setPayload(Payload.newBuilder()
+                                                             .setBody(ByteString.copyFrom(new byte[7])))
+                                          .build(),
+                StreamingOutputCallRequest.newBuilder()
+                                          .addResponseParameters(ResponseParameters.newBuilder()
+                                                                                   .setSize(4))
+                                          .setPayload(Payload.newBuilder()
+                                                             .setBody(ByteString.copyFrom(new byte[1])))
+                                          .build());
+        final List<StreamingOutputCallResponse> goldenResponses = Arrays.asList(
+                StreamingOutputCallResponse.newBuilder()
+                                           .setPayload(Payload.newBuilder()
+                                                              .setType(PayloadType.COMPRESSABLE)
+                                                              .setBody(ByteString.copyFrom(new byte[3])))
+                                           .build(),
+                StreamingOutputCallResponse.newBuilder()
+                                           .setPayload(Payload.newBuilder()
+                                                              .setType(PayloadType.COMPRESSABLE)
+                                                              .setBody(ByteString.copyFrom(new byte[1])))
+                                           .build(),
+                StreamingOutputCallResponse.newBuilder()
+                                           .setPayload(Payload.newBuilder()
+                                                              .setType(PayloadType.COMPRESSABLE)
+                                                              .setBody(ByteString.copyFrom(new byte[4])))
+                                           .build());
+
+        @SuppressWarnings("unchecked")
+        StreamObserver<StreamingOutputCallResponse> responseObserver = mock(StreamObserver.class);
+        StreamObserver<StreamingOutputCallRequest> requestObserver
+                = asyncStub.fullDuplexCall(responseObserver);
+        requestObserver.onNext(requests.get(0));
+        verify(responseObserver, timeout(operationTimeoutMillis())).onNext(goldenResponses.get(0));
+        // Initiate graceful shutdown.
+        channel.shutdown();
+        requestObserver.onNext(requests.get(1));
+        verify(responseObserver, timeout(operationTimeoutMillis())).onNext(goldenResponses.get(1));
+        // The previous ping-pong could have raced with the shutdown, but this one certainly shouldn't.
+        requestObserver.onNext(requests.get(2));
+        verify(responseObserver, timeout(operationTimeoutMillis())).onNext(goldenResponses.get(2));
+        requestObserver.onCompleted();
+        verify(responseObserver, timeout(operationTimeoutMillis())).onCompleted();
+        verifyNoMoreInteractions(responseObserver);
+    }
+
+    @Override
+    @Test(timeout = 10000)
+    public void timeoutOnSleepingServer() {
+        TestServiceStub stub = TestServiceGrpc.newStub(channel)
+                                              .withDeadlineAfter(1, TimeUnit.MILLISECONDS);
+        @SuppressWarnings("unchecked")
+        StreamObserver<StreamingOutputCallResponse> responseObserver = mock(StreamObserver.class);
+        StreamObserver<StreamingOutputCallRequest> requestObserver
+                = stub.fullDuplexCall(responseObserver);
+
+        try {
+            requestObserver.onNext(StreamingOutputCallRequest.newBuilder()
+                                                             .setPayload(Payload.newBuilder()
+                                                                                .setBody(ByteString.copyFrom(
+                                                                                        new byte[27182])))
+                                                             .build());
+        } catch (IllegalStateException expected) {
+            // This can happen if the stream has already been terminated due to deadline exceeded.
+        }
+
+        ArgumentCaptor<Throwable> captor = ArgumentCaptor.forClass(Throwable.class);
+        verify(responseObserver, timeout(operationTimeoutMillis())).onError(captor.capture());
+        assertEquals(Status.DEADLINE_EXCEEDED.getCode(),
+                     Status.fromThrowable(captor.getValue()).getCode());
+        verifyNoMoreInteractions(responseObserver);
+    }
+
+    @Test(timeout = 10000)
+    public void cancelAfterFirstResponse() throws Exception {
+        final StreamingOutputCallRequest request = StreamingOutputCallRequest
+                .newBuilder()
+                .addResponseParameters(
+                        ResponseParameters
+                                .newBuilder()
+                                .setSize(31415))
+                .setPayload(Payload.newBuilder()
+                                   .setBody(
+                                           ByteString
+                                                   .copyFrom(
+                                                           new byte[27182])))
+                .build();
+        final StreamingOutputCallResponse goldenResponse = StreamingOutputCallResponse
+                .newBuilder()
+                .setPayload(
+                        Payload.newBuilder()
+                               .setType(
+                                       PayloadType.COMPRESSABLE)
+                               .setBody(
+                                       ByteString
+                                               .copyFrom(
+                                                       new byte[31415])))
+                .build();
+
+        @SuppressWarnings("unchecked")
+        StreamObserver<StreamingOutputCallResponse> responseObserver = mock(StreamObserver.class);
+        StreamObserver<StreamingOutputCallRequest> requestObserver
+                = asyncStub.fullDuplexCall(responseObserver);
+        requestObserver.onNext(request);
+        verify(responseObserver, timeout(operationTimeoutMillis())).onNext(goldenResponse);
+        verifyNoMoreInteractions(responseObserver);
+
+        requestObserver.onError(new RuntimeException());
+        ArgumentCaptor<Throwable> captor = ArgumentCaptor.forClass(Throwable.class);
+        verify(responseObserver, timeout(operationTimeoutMillis())).onError(captor.capture());
+        assertEquals(Status.Code.CANCELLED, Status.fromThrowable(captor.getValue()).getCode());
+        verifyNoMoreInteractions(responseObserver);
+    }
+
+    @Test(timeout = 10000)
+    public void emptyStream() throws Exception {
+        @SuppressWarnings("unchecked")
+        StreamObserver<StreamingOutputCallResponse> responseObserver = mock(StreamObserver.class);
+        StreamObserver<StreamingOutputCallRequest> requestObserver
+                = asyncStub.fullDuplexCall(responseObserver);
+        requestObserver.onCompleted();
+        verify(responseObserver, timeout(operationTimeoutMillis())).onCompleted();
+        verifyNoMoreInteractions(responseObserver);
+    }
+}


### PR DESCRIPTION
This is closer to TomcatService than THttpService in that it only really adds logic to marshal headers and byte blobs, and relies on GRPC logic to handle them appropriately. 

Why would an armeria user use GRPC instead of the natively supported Thrift?
- Full support for request/response streaming
- Protocol buffer generated code can be a nice change
- Efficient clients on a variety of platforms (Android, iOS, Go, etc)

Why would a GRPC user use armeria for their servers?
- Support for HTTP1 (not verified, will probably require some followup work). HTTP1 should open GRPC to the browser and work better with Cloud load balancers that generally translate HTTP2 -> HTTP1
- Once implemented, DocService and Grpc on the same server
- And any other servers they feel like having on the same server since armeria's flexible that way :)

Some specific points to look at
- Change to HttpResponseSubscriber and HttpHeaders to allow returning a Headers-Only w/ EOS response as required by GRPC. Now I remember why I asked for this before ;)
- General design of the message publishing / subscribing
- What it'd take to get the @Ignore'd gracefulShutdown test to work