### PR TITLE
Add SSLSession to ServiceRequestContext to allow handlers to have acc…

### DIFF
--- a/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
+++ b/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
@@ -24,6 +24,9 @@ import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 
+import javax.annotation.Nullable;
+import javax.net.ssl.SSLSession;
+
 import org.slf4j.Logger;
 
 import com.linecorp.armeria.common.NonWrappingRequestContext;
@@ -48,6 +51,7 @@ public final class DefaultServiceRequestContext extends NonWrappingRequestContex
     private final ServiceConfig cfg;
     private final String mappedPath;
     private final Logger logger;
+    private final SSLSession sslSession;
 
     private final DefaultRequestLog requestLog;
     private final DefaultResponseLog responseLog;
@@ -64,10 +68,12 @@ public final class DefaultServiceRequestContext extends NonWrappingRequestContex
      * @param sessionProtocol the {@link SessionProtocol} of the invocation
      * @param logger the {@link Logger} for the invocation
      * @param request the request associated with this context
+     * @param sslSession the {@link SSLSession} for this invocation if it is over TLS
      */
     public DefaultServiceRequestContext(
             ServiceConfig cfg, Channel ch, SessionProtocol sessionProtocol,
-            String method, String path, String mappedPath, Logger logger, Object request) {
+            String method, String path, String mappedPath, Logger logger, Object request,
+            @Nullable SSLSession sslSession) {
 
         super(sessionProtocol, method, path, request);
 
@@ -75,6 +81,7 @@ public final class DefaultServiceRequestContext extends NonWrappingRequestContex
         this.cfg = cfg;
         this.mappedPath = mappedPath;
         this.logger = new RequestContextAwareLogger(this, logger);
+        this.sslSession = sslSession;
 
         requestLog = new DefaultRequestLog();
         requestLog.start(ch, sessionProtocol, cfg.virtualHost().defaultHostname(), method, path);
@@ -130,6 +137,12 @@ public final class DefaultServiceRequestContext extends NonWrappingRequestContex
     @Override
     public Logger logger() {
         return logger;
+    }
+
+    @Nullable
+    @Override
+    public SSLSession sslSession() {
+        return sslSession;
     }
 
     @Override

--- a/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
+++ b/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
@@ -20,6 +20,9 @@ import java.net.SocketAddress;
 import java.time.Duration;
 import java.util.concurrent.ExecutorService;
 
+import javax.annotation.Nullable;
+import javax.net.ssl.SSLSession;
+
 import org.slf4j.Logger;
 
 import com.linecorp.armeria.common.ContentTooLargeException;
@@ -79,6 +82,12 @@ public interface ServiceRequestContext extends RequestContext {
      * }</pre>
      */
     Logger logger();
+
+    /**
+     * The {@link SSLSession} for this request if the connection is made over TLS, or null otherwise.
+     */
+    @Nullable
+    SSLSession sslSession();
 
     /**
      * Returns the amount of time allowed until receiving the current {@link Request} completely.

--- a/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
+++ b/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
@@ -20,6 +20,9 @@ import java.net.SocketAddress;
 import java.time.Duration;
 import java.util.concurrent.ExecutorService;
 
+import javax.annotation.Nullable;
+import javax.net.ssl.SSLSession;
+
 import org.slf4j.Logger;
 
 import com.linecorp.armeria.common.RequestContextWrapper;
@@ -75,6 +78,12 @@ public class ServiceRequestContextWrapper
     @Override
     public Logger logger() {
         return delegate().logger();
+    }
+
+    @Nullable
+    @Override
+    public SSLSession sslSession() {
+        return delegate().sslSession();
     }
 
     @Override

--- a/src/main/java/com/linecorp/armeria/server/http/HttpServerHandler.java
+++ b/src/main/java/com/linecorp/armeria/server/http/HttpServerHandler.java
@@ -26,6 +26,8 @@ import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import javax.net.ssl.SSLSession;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -72,6 +74,7 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.EventLoop;
 import io.netty.handler.codec.http2.Http2ConnectionHandler;
 import io.netty.handler.codec.http2.Http2Settings;
+import io.netty.handler.ssl.SslHandler;
 
 final class HttpServerHandler extends ChannelInboundHandlerAdapter implements HttpServer {
 
@@ -264,7 +267,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
                 serviceCfg, channel,
                 protocol,
                 req.method().name(), path, mappedPath,
-                LoggerFactory.getLogger(serviceCfg.loggerName()), req);
+                LoggerFactory.getLogger(serviceCfg.loggerName()), req, getSSLSession(channel));
 
         final RequestLogBuilder reqLogBuilder = reqCtx.requestLogBuilder();
         final HttpResponse res;
@@ -472,6 +475,11 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
             return;
         }
         res.headers().setInt(HttpHeaderNames.CONTENT_LENGTH, res.content().length());
+    }
+
+    private SSLSession getSSLSession(Channel channel) {
+        SslHandler sslHandler = channel.pipeline().get(SslHandler.class);
+        return sslHandler != null ? sslHandler.engine().getSession() : null;
     }
 
     @Override


### PR DESCRIPTION
…ess to information about SSL peers.

This can be useful for establishing restricted RPC connections based on client certificate authentication. For example, an authorizing decorator could check the name of the principal in the SSL session and only allow those in a whitelist. The certificates would generally be issued by a custom CA created for the company whose public certificate is automatically loaded into the SSLContext of all servers during armeria server setup.