### PR TITLE
Allow setting an HttpData object as ending the stream, similar to wha…

### DIFF
--- a/src/main/java/com/linecorp/armeria/client/http/HttpRequestSubscriber.java
+++ b/src/main/java/com/linecorp/armeria/client/http/HttpRequestSubscriber.java
@@ -154,7 +154,7 @@ final class HttpRequestSubscriber implements Subscriber<HttpObject>, ChannelFutu
                     "published an HttpObject that's neither Http2Headers nor Http2Data: " + o);
         }
 
-        boolean endOfStream = false;
+        boolean endOfStream = o.isEndOfStream();
         switch (state) {
             case NEEDS_DATA_OR_TRAILING_HEADERS: {
                 if (o instanceof HttpHeaders) {
@@ -162,6 +162,7 @@ final class HttpRequestSubscriber implements Subscriber<HttpObject>, ChannelFutu
                     if (trailingHeaders.status() != null) {
                         throw newIllegalStateException("published a trailing HttpHeaders with status: " + o);
                     }
+                    // Trailing headers always end the stream even if not explicitly set.
                     endOfStream = true;
                 }
                 break;

--- a/src/main/java/com/linecorp/armeria/common/http/DefaultHttpData.java
+++ b/src/main/java/com/linecorp/armeria/common/http/DefaultHttpData.java
@@ -18,18 +18,21 @@ package com.linecorp.armeria.common.http;
 
 import com.google.common.base.MoreObjects;
 
-final class DefaultHttpData implements HttpData {
-
-    static final HttpData EMPTY_DATA = new DefaultHttpData(new byte[0], 0, 0);
+public final class DefaultHttpData implements HttpData {
 
     private final byte[] data;
     private final int offset;
     private final int length;
+    private final boolean endOfStream;
 
-    DefaultHttpData(byte[] data, int offset, int length) {
+    /**
+     * Creates a new instance.
+     */
+    public DefaultHttpData(byte[] data, int offset, int length, boolean endOfStream) {
         this.data = data;
         this.offset = offset;
         this.length = length;
+        this.endOfStream = endOfStream;
     }
 
     @Override
@@ -89,5 +92,10 @@ final class DefaultHttpData implements HttpData {
                           .add("offset", offset)
                           .add("length", length)
                           .add("array", data.toString()).toString();
+    }
+
+    @Override
+    public boolean isEndOfStream() {
+        return endOfStream;
     }
 }

--- a/src/main/java/com/linecorp/armeria/common/http/HttpData.java
+++ b/src/main/java/com/linecorp/armeria/common/http/HttpData.java
@@ -27,14 +27,15 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 
 /**
- * HTTP/2 data.
+ * HTTP/2 data. Helpers in this class create {@link HttpData} objects that leave the stream open.
+ * To create a {@link HttpData} that closes the stream, directly instantiate {@link DefaultHttpData}.
  */
 public interface HttpData extends HttpObject {
 
     /**
      * Empty HTTP/2 data.
      */
-    HttpData EMPTY_DATA = DefaultHttpData.EMPTY_DATA;
+    HttpData EMPTY_DATA = new DefaultHttpData(new byte[0], 0, 0, false);
 
     /**
      * Creates a new instance from the specified byte array. The array is not copied; any changes made in the
@@ -48,7 +49,7 @@ public interface HttpData extends HttpObject {
             return EMPTY_DATA;
         }
 
-        return new DefaultHttpData(data, 0, data.length);
+        return new DefaultHttpData(data, 0, data.length, false);
     }
 
     /**
@@ -69,7 +70,7 @@ public interface HttpData extends HttpObject {
             return EMPTY_DATA;
         }
 
-        return new DefaultHttpData(data, offset, length);
+        return new DefaultHttpData(data, offset, length, false);
     }
 
     /**

--- a/src/main/java/com/linecorp/armeria/common/http/HttpHeaders.java
+++ b/src/main/java/com/linecorp/armeria/common/http/HttpHeaders.java
@@ -151,11 +151,6 @@ public interface HttpHeaders extends HttpObject, Headers<AsciiString, String, Ht
     HttpHeaders status(HttpStatus status);
 
     /**
-     * Gets whether the stream should be ended when writing the headers (useful for Headers-only responses).
-     */
-    boolean isEndOfStream();
-
-    /**
      * Returns the immutable view of this headers.
      */
     default HttpHeaders asImmutable() {

--- a/src/main/java/com/linecorp/armeria/common/http/HttpObject.java
+++ b/src/main/java/com/linecorp/armeria/common/http/HttpObject.java
@@ -19,4 +19,12 @@ package com.linecorp.armeria.common.http;
 /**
  * The common interface for HTTP/2 message objects, {@link HttpHeaders} and {@link HttpData}.
  */
-public interface HttpObject {}
+public interface HttpObject {
+
+    /**
+     * Gets whether the stream should be ended when writing this object. This can be useful for
+     * {@link HttpHeaders}-only responses or to more efficiently close the stream along with the last piece of
+     * {@link HttpData}. This only has meaning for {@link HttpObject} writers, not readers.
+     */
+    boolean isEndOfStream();
+}


### PR DESCRIPTION
…t was added to HttpHeaders.

This PR does not update callers to end the stream on the final data object where it's allowed, we can do it in another, more mechanical PR.