### PR TITLE
Fluent API for building virtual hosts with ServerBuilder

### DIFF
--- a/src/main/java/com/linecorp/armeria/server/ChainedVirtualHostBuilder.java
+++ b/src/main/java/com/linecorp/armeria/server/ChainedVirtualHostBuilder.java
@@ -19,10 +19,12 @@ package com.linecorp.armeria.server;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Build a new {@link VirtualHost}.
- * This class can only be created through 
- * the withDefaultVirtualHost() or withVirtualHost() method of the serverBuilder.
- * call and() method can also return to ServerBuilder.
+ * Builds a new {@link VirtualHost}.
+ * 
+ * <p>This class can only be created through the {@link ServerBuilder#withDefaultVirtualHost()} or
+ * {@link ServerBuilder#withVirtualHost()} method of the {@link ServerBuilder}.
+ * 
+ * <p>Call {@link #and()} method can also return to {@link ServerBuilder}.
  * 
  * @see ServerBuilder
  * @see PathMapping
@@ -31,43 +33,51 @@ import static java.util.Objects.requireNonNull;
 public final class ChainedVirtualHostBuilder extends AbstractVirtualHostBuilder<ChainedVirtualHostBuilder> {
 
     private final ServerBuilder serverBuilder;
-    
+
     /**
-     * Creates a new {@link VirtualHostBuilder} whose hostname pattern is {@code "*"} (match-all).
+     * Creates a new {@link ChainedVirtualHostBuilder} whose hostname pattern is {@code "*"} (match-all).
      * 
-     * @param serverBuilder parent {@link ServerBuilder} for return
+     * @param serverBuilder the parent {@link ServerBuilder} to be returned by {@link #and()}.
      */
     ChainedVirtualHostBuilder(ServerBuilder serverBuilder) {
-        super(LOCAL_HOSTNAME, "*");
-        
+        super();
+
         requireNonNull(serverBuilder, "serverBuilder");
         this.serverBuilder = serverBuilder;
     }
 
     /**
-     * Creates a new {@link VirtualHostBuilder} with the specified hostname pattern.
+     * Creates a new {@link ChainedVirtualHostBuilder} with the specified hostname pattern.
      * 
-     * @param hostnamePattern virtual host name regular expression
-     * @param serverBuilder parent {@link ServerBuilder} for return
+     * @param hostnamePattern the hostname pattern of this virtual host.
+     * @param serverBuilder the parent {@link ServerBuilder} to be returned by {@link #and()}.
      */
     ChainedVirtualHostBuilder(String hostnamePattern, ServerBuilder serverBuilder) {
         super(hostnamePattern);
-        
-        requireNonNull(serverBuilder, "serverBuilder");
-        this.serverBuilder = serverBuilder;
-    }
 
-    ChainedVirtualHostBuilder(String defaultHostname, String hostnamePattern, ServerBuilder serverBuilder) {
-        super(defaultHostname, hostnamePattern);
-        
         requireNonNull(serverBuilder, "serverBuilder");
         this.serverBuilder = serverBuilder;
     }
 
     /**
-     * Return parent serverBuilder.
+     * Creates a new {@link ChainedVirtualHostBuilder} with
+     * the default host name and the specified hostname pattern.
      * 
-     * @return serverBuiler
+     * @param defaultHostname the default hostname of this virtual host.
+     * @param hostnamePattern the hostname pattern of this virtual host.
+     * @param serverBuilder the parent {@link ServerBuilder} to be returned by {@link #and()}.
+     */
+    ChainedVirtualHostBuilder(String defaultHostname, String hostnamePattern, ServerBuilder serverBuilder) {
+        super(defaultHostname, hostnamePattern);
+
+        requireNonNull(serverBuilder, "serverBuilder");
+        this.serverBuilder = serverBuilder;
+    }
+
+    /**
+     * Returns the parent {@link ServerBuilder}.
+     * 
+     * @return serverBuiler the parent {@link ServerBuilder}.
      */
     public ServerBuilder and() {
         return serverBuilder;

--- a/src/main/java/com/linecorp/armeria/server/ChainedVirtualHostBuilder.java
+++ b/src/main/java/com/linecorp/armeria/server/ChainedVirtualHostBuilder.java
@@ -18,17 +18,6 @@ package com.linecorp.armeria.server;
 
 import static java.util.Objects.requireNonNull;
 
-import java.io.File;
-import java.util.function.Function;
-
-import javax.net.ssl.SSLException;
-
-import com.linecorp.armeria.common.Request;
-import com.linecorp.armeria.common.Response;
-import com.linecorp.armeria.common.SessionProtocol;
-
-import io.netty.handler.ssl.SslContext;
-
 /**
  * Build a new {@link VirtualHost}.
  * This class can only be created through 
@@ -39,9 +28,7 @@ import io.netty.handler.ssl.SslContext;
  * @see PathMapping
  * @see VirtualHostBuilder
  */
-public final class ChainedVirtualHostBuilder {
-
-    private final InternalVirtualHostBuilder internalVirtualHostBuilder;
+public final class ChainedVirtualHostBuilder extends AbstractVirtualHostBuilder<ChainedVirtualHostBuilder> {
 
     private final ServerBuilder serverBuilder;
     
@@ -51,8 +38,7 @@ public final class ChainedVirtualHostBuilder {
      * @param serverBuilder parent {@link ServerBuilder} for return
      */
     ChainedVirtualHostBuilder(ServerBuilder serverBuilder) {
-        internalVirtualHostBuilder =
-                new InternalVirtualHostBuilder(InternalVirtualHostBuilder.LOCAL_HOSTNAME, "*");
+        super(LOCAL_HOSTNAME, "*");
         
         requireNonNull(serverBuilder, "serverBuilder");
         this.serverBuilder = serverBuilder;
@@ -65,100 +51,17 @@ public final class ChainedVirtualHostBuilder {
      * @param serverBuilder parent {@link ServerBuilder} for return
      */
     ChainedVirtualHostBuilder(String hostnamePattern, ServerBuilder serverBuilder) {
-        internalVirtualHostBuilder = new InternalVirtualHostBuilder(hostnamePattern);
+        super(hostnamePattern);
         
         requireNonNull(serverBuilder, "serverBuilder");
         this.serverBuilder = serverBuilder;
     }
 
     ChainedVirtualHostBuilder(String defaultHostname, String hostnamePattern, ServerBuilder serverBuilder) {
-        internalVirtualHostBuilder = new InternalVirtualHostBuilder(defaultHostname, hostnamePattern);
+        super(defaultHostname, hostnamePattern);
         
         requireNonNull(serverBuilder, "serverBuilder");
         this.serverBuilder = serverBuilder;
-    }
-
-    /**
-     * Sets the {@link SslContext} of this {@link VirtualHost}.
-     */
-    public ChainedVirtualHostBuilder sslContext(SslContext sslContext) {
-        internalVirtualHostBuilder.sslContext(sslContext);
-        return this;
-    }
-
-    /**
-     * Sets the {@link SslContext} of this {@link VirtualHost} from the specified {@link SessionProtocol},
-     * {@code keyCertChainFile} and cleartext {@code keyFile}.
-     */
-    public ChainedVirtualHostBuilder sslContext(
-            SessionProtocol protocol, File keyCertChainFile, File keyFile) throws SSLException {
-        return sslContext(protocol, keyCertChainFile, keyFile, null);
-    }
-
-    /**
-     * Sets the {@link SslContext} of this {@link VirtualHost} from the specified {@link SessionProtocol},
-     * {@code keyCertChainFile}, {@code keyFile} and {@code keyPassword}.
-     */
-    public ChainedVirtualHostBuilder sslContext(
-            SessionProtocol protocol,
-            File keyCertChainFile, File keyFile, String keyPassword) throws SSLException {
-
-        internalVirtualHostBuilder.sslContext(protocol, keyCertChainFile, keyFile, keyPassword);
-        return this;
-    }
-
-    /**
-     * Binds the specified {@link Service} at the specified exact path.
-     */
-    public ChainedVirtualHostBuilder serviceAt(String exactPath, Service<?, ?> service) {
-        return service(PathMapping.ofExact(exactPath), service);
-    }
-
-    /**
-     * Binds the specified {@link Service} under the specified directory..
-     */
-    public ChainedVirtualHostBuilder serviceUnder(String pathPrefix, Service<?, ?> service) {
-        return service(PathMapping.ofPrefix(pathPrefix), service);
-    }
-
-    /**
-     * Binds the specified {@link Service} at the specified {@link PathMapping}.
-     */
-    public ChainedVirtualHostBuilder service(PathMapping pathMapping, Service<?, ?> service) {
-        internalVirtualHostBuilder.service(pathMapping, service);
-        return this;
-    }
-
-    /**
-     * Binds the specified {@link Service} at the specified {@link PathMapping}.
-     *
-     * @param loggerName the name of the {@linkplain ServiceRequestContext#logger() service logger};
-     *                   must be a string of valid Java identifier names concatenated by period ({@code '.'}),
-     *                   such as a package name or a fully-qualified class name
-     */
-    public ChainedVirtualHostBuilder service(PathMapping pathMapping, Service<?, ?> service,
-                                             String loggerName) {
-        internalVirtualHostBuilder.service(pathMapping, service, loggerName);
-        return this;
-    }
-
-    /**
-     * Decorates all {@link Service}s with the specified {@code decorator}.
-     *
-     * @param decorator the {@link Function} that decorates a {@link Service}
-     * @param <T> the type of the {@link Service} being decorated
-     * @param <R> the type of the {@link Service} {@code decorator} will produce
-     */
-    public <T extends Service<T_I, T_O>, T_I extends Request, T_O extends Response,
-            R extends Service<R_I, R_O>, R_I extends Request, R_O extends Response>
-    ChainedVirtualHostBuilder decorator(Function<T, R> decorator) {
-
-        internalVirtualHostBuilder.decorator(decorator);
-        return this;
-    }
-
-    VirtualHost build() {
-        return internalVirtualHostBuilder.build();
     }
 
     /**
@@ -168,10 +71,5 @@ public final class ChainedVirtualHostBuilder {
      */
     public ServerBuilder and() {
         return serverBuilder;
-    }
-
-    @Override
-    public String toString() {
-        return internalVirtualHostBuilder.toString();
     }
 }

--- a/src/main/java/com/linecorp/armeria/server/ChainedVirtualHostBuilder.java
+++ b/src/main/java/com/linecorp/armeria/server/ChainedVirtualHostBuilder.java
@@ -22,7 +22,7 @@ import static java.util.Objects.requireNonNull;
  * Builds a new {@link VirtualHost}.
  * 
  * <p>This class can only be created through the {@link ServerBuilder#withDefaultVirtualHost()} or
- * {@link ServerBuilder#withVirtualHost()} method of the {@link ServerBuilder}.
+ * {@link ServerBuilder#withVirtualHost(String)} method of the {@link ServerBuilder}.
  * 
  * <p>Call {@link #and()} method can also return to {@link ServerBuilder}.
  * 

--- a/src/main/java/com/linecorp/armeria/server/InternalVirtualHostBuilder.java
+++ b/src/main/java/com/linecorp/armeria/server/InternalVirtualHostBuilder.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static com.linecorp.armeria.server.VirtualHost.ensureHostnamePatternMatchesDefaultHostname;
+import static com.linecorp.armeria.server.VirtualHost.normalizeDefaultHostname;
+import static com.linecorp.armeria.server.VirtualHost.normalizeHostnamePattern;
+import static java.util.Objects.requireNonNull;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.InputStreamReader;
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+import javax.net.ssl.SSLException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linecorp.armeria.common.Request;
+import com.linecorp.armeria.common.Response;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.util.NativeLibraries;
+
+import io.netty.handler.codec.http2.Http2SecurityUtil;
+import io.netty.handler.ssl.ApplicationProtocolConfig;
+import io.netty.handler.ssl.ApplicationProtocolConfig.Protocol;
+import io.netty.handler.ssl.ApplicationProtocolConfig.SelectedListenerFailureBehavior;
+import io.netty.handler.ssl.ApplicationProtocolConfig.SelectorFailureBehavior;
+import io.netty.handler.ssl.ApplicationProtocolNames;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.SslProvider;
+import io.netty.handler.ssl.SupportedCipherSuiteFilter;
+
+/**
+ * Contains information for the build of the virtual host.
+ * 
+ * @see ChainedVirtualHostBuilder
+ * @see VirtualHostBuilder
+ */
+public final class InternalVirtualHostBuilder {
+
+    private static final Logger logger = LoggerFactory.getLogger(InternalVirtualHostBuilder.class);
+    
+    protected static final ApplicationProtocolConfig HTTPS_ALPN_CFG = new ApplicationProtocolConfig(
+            Protocol.ALPN,
+            // NO_ADVERTISE is currently the only mode supported by both OpenSsl and JDK providers.
+            SelectorFailureBehavior.NO_ADVERTISE,
+            // ACCEPT is currently the only mode supported by both OpenSsl and JDK providers.
+            SelectedListenerFailureBehavior.ACCEPT,
+            ApplicationProtocolNames.HTTP_2,
+            ApplicationProtocolNames.HTTP_1_1);
+
+    protected static final String LOCAL_HOSTNAME;
+
+    static {
+        // Try the '/usr/bin/hostname' command first, which is more reliable.
+        Process process = null;
+        String hostname = null;
+        try {
+            process = Runtime.getRuntime().exec("hostname");
+            final String line = new BufferedReader(new InputStreamReader(process.getInputStream())).readLine();
+            if (line == null) {
+                logger.warn("The 'hostname' command returned nothing; " +
+                            "using InetAddress.getLocalHost() instead", line);
+            } else {
+                hostname = normalizeDefaultHostname(line.trim());
+                logger.info("Hostname: {} (via 'hostname' command)", hostname);
+            }
+        } catch (Exception e) {
+            logger.warn("Failed to get the hostname using the 'hostname' command; " +
+                        "using InetAddress.getLocalHost() instead", e);
+        } finally {
+            if (process != null) {
+                process.destroy();
+            }
+        }
+
+        if (hostname == null) {
+            try {
+                hostname = normalizeDefaultHostname(InetAddress.getLocalHost().getHostName());
+                logger.info("Hostname: {} (via InetAddress.getLocalHost())", hostname);
+            } catch (Exception e) {
+                hostname = "localhost";
+                logger.warn("Failed to get the hostname using InetAddress.getLocalHost(); " +
+                            "using 'localhost' instead", e);
+            }
+        }
+
+        LOCAL_HOSTNAME = hostname;
+    }
+
+    private final String defaultHostname;
+    private final String hostnamePattern;
+    private final List<ServiceConfig> services = new ArrayList<>();
+    private SslContext sslContext;
+    private Function<Service<Request, Response>, Service<Request, Response>> decorator;
+
+    /**
+     * Creates a new {@link VirtualHostBuilder} whose hostname pattern is {@code "*"} (match-all).
+     */
+    InternalVirtualHostBuilder() {
+        this(LOCAL_HOSTNAME, "*");
+    }
+
+    /**
+     * Creates a new {@link VirtualHostBuilder} with the specified hostname pattern.
+     */
+    InternalVirtualHostBuilder(String hostnamePattern) {
+        hostnamePattern = normalizeHostnamePattern(hostnamePattern);
+
+        if ("*".equals(hostnamePattern)) {
+            defaultHostname = LOCAL_HOSTNAME;
+        } else if (hostnamePattern.startsWith("*.")) {
+            defaultHostname = hostnamePattern.substring(2);
+        } else {
+            defaultHostname = hostnamePattern;
+        }
+
+        this.hostnamePattern = hostnamePattern;
+    }
+
+    /**
+     * Creates a new {@link VirtualHostBuilder} with the specified hostname pattern.
+     */
+    InternalVirtualHostBuilder(String defaultHostname, String hostnamePattern) {
+        requireNonNull(defaultHostname, "defaultHostname");
+
+        defaultHostname = normalizeDefaultHostname(defaultHostname);
+        hostnamePattern = normalizeHostnamePattern(hostnamePattern);
+        ensureHostnamePatternMatchesDefaultHostname(hostnamePattern, defaultHostname);
+
+        this.defaultHostname = defaultHostname;
+        this.hostnamePattern = hostnamePattern;
+    }
+
+    /**
+     * Sets the {@link SslContext} of this {@link VirtualHost}.
+     */
+    void sslContext(SslContext sslContext) {
+        this.sslContext = VirtualHost.validateSslContext(requireNonNull(sslContext, "sslContext"));
+    }
+
+    /**
+     * Sets the {@link SslContext} of this {@link VirtualHost} from the specified {@link SessionProtocol},
+     * {@code keyCertChainFile} and cleartext {@code keyFile}.
+     */
+    void sslContext(
+            SessionProtocol protocol, File keyCertChainFile, File keyFile) throws SSLException {
+        sslContext(protocol, keyCertChainFile, keyFile, null);
+    }
+
+    /**
+     * Sets the {@link SslContext} of this {@link VirtualHost} from the specified {@link SessionProtocol},
+     * {@code keyCertChainFile}, {@code keyFile} and {@code keyPassword}.
+     */
+    void sslContext(
+            SessionProtocol protocol,
+            File keyCertChainFile, File keyFile, String keyPassword) throws SSLException {
+
+        if (requireNonNull(protocol, "protocol") != SessionProtocol.HTTPS) {
+            throw new IllegalArgumentException("unsupported protocol: " + protocol);
+        }
+
+        final SslContextBuilder builder = SslContextBuilder.forServer(keyCertChainFile, keyFile, keyPassword);
+
+        builder.sslProvider(NativeLibraries.isOpenSslAvailable() ? SslProvider.OPENSSL : SslProvider.JDK);
+        builder.ciphers(Http2SecurityUtil.CIPHERS, SupportedCipherSuiteFilter.INSTANCE);
+        builder.applicationProtocolConfig(HTTPS_ALPN_CFG);
+
+        sslContext(builder.build());
+    }
+
+    /**
+     * Binds the specified {@link Service} at the specified exact path.
+     */
+    void serviceAt(String exactPath, Service<?, ?> service) {
+        service(PathMapping.ofExact(exactPath), service);
+    }
+
+    /**
+     * Binds the specified {@link Service} under the specified directory..
+     */
+    void serviceUnder(String pathPrefix, Service<?, ?> service) {
+        service(PathMapping.ofPrefix(pathPrefix), service);
+    }
+
+    /**
+     * Binds the specified {@link Service} at the specified {@link PathMapping}.
+     */
+    void service(PathMapping pathMapping, Service<?, ?> service) {
+        services.add(new ServiceConfig(pathMapping, service, null));
+    }
+
+    /**
+     * Binds the specified {@link Service} at the specified {@link PathMapping}.
+     *
+     * @param loggerName the name of the {@linkplain ServiceRequestContext#logger() service logger};
+     *                   must be a string of valid Java identifier names concatenated by period ({@code '.'}),
+     *                   such as a package name or a fully-qualified class name
+     */
+    void service(PathMapping pathMapping, Service<?, ?> service, String loggerName) {
+        services.add(new ServiceConfig(pathMapping, service, loggerName));
+    }
+
+    /**
+     * Decorates all {@link Service}s with the specified {@code decorator}.
+     *
+     * @param decorator the {@link Function} that decorates a {@link Service}
+     * @param <T> the type of the {@link Service} being decorated
+     * @param <R> the type of the {@link Service} {@code decorator} will produce
+     */
+    <T extends Service<T_I, T_O>, T_I extends Request, T_O extends Response,
+    R extends Service<R_I, R_O>, R_I extends Request, R_O extends Response>
+    void decorator(Function<T, R> decorator) {
+
+        requireNonNull(decorator, "decorator");
+
+        @SuppressWarnings("unchecked")
+        final Function<Service<Request, Response>, Service<Request, Response>> castDecorator =
+                (Function<Service<Request, Response>, Service<Request, Response>>) decorator;
+
+        if (this.decorator != null) {
+            this.decorator = this.decorator.andThen(castDecorator);
+        } else {
+            this.decorator = castDecorator;
+        }
+    }
+
+    /**
+     * Creates a new {@link VirtualHost}.
+     */
+    VirtualHost build() {
+        final VirtualHost virtualHost = new VirtualHost(defaultHostname, hostnamePattern, sslContext, services);
+        return decorator != null ? virtualHost.decorate(decorator) : virtualHost;
+    }
+
+    @Override
+    public String toString() {
+        return VirtualHost.toString(getClass(), defaultHostname, hostnamePattern, sslContext, services);
+    }
+}

--- a/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -104,7 +104,8 @@ public final class ServerBuilder {
 
     private final List<ServerPort> ports = new ArrayList<>();
     private final List<VirtualHost> virtualHosts = new ArrayList<>();
-    private final VirtualHostBuilder defaultVirtualHostBuilder = new VirtualHostBuilder();
+    private final List<VirtualHostBuilder> virtualHostBuilders = new ArrayList<>();
+    private final VirtualHostBuilder defaultVirtualHostBuilder = new VirtualHostBuilder(this);
     private boolean updatedDefaultVirtualHostBuilder;
 
     private VirtualHost defaultVirtualHost;
@@ -471,6 +472,8 @@ public final class ServerBuilder {
             defaultVirtualHost = defaultVirtualHostBuilder.build().decorate(decorator);
         }
 
+        virtualHostBuilders.forEach(vhb -> this.virtualHosts.add(vhb.build()));
+
         final List<VirtualHost> virtualHosts;
         if (decorator != null) {
             virtualHosts = this.virtualHosts.stream()
@@ -495,5 +498,17 @@ public final class ServerBuilder {
                 defaultRequestTimeoutMillis, defaultMaxRequestLength,
                 gracefulShutdownQuietPeriod, gracefulShutdownTimeout,
                 blockingTaskExecutor, serviceLoggerPrefix);
+    }
+
+    public VirtualHostBuilder withDefaultHost() {
+        defaultVirtualHostBuilderUpdated();
+        return defaultVirtualHostBuilder;
+    }
+
+    public VirtualHostBuilder withVirtualHost(String hostnamePattern) {
+        VirtualHostBuilder virtualHostBuilder = new VirtualHostBuilder(hostnamePattern, this);
+        virtualHostBuilders.add(virtualHostBuilder);
+        
+        return virtualHostBuilder;
     }
 }

--- a/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -522,10 +522,10 @@ public final class ServerBuilder {
         if (this.defaultVirtualHost != null) {
             defaultVirtualHost = this.defaultVirtualHost.decorate(decorator);
         } else {
-            defaultVirtualHost = defaultVirtualHostBuilder.build().decorate(decorator);
+            defaultVirtualHost = defaultVirtualHostBuilder.doBuild().decorate(decorator);
         }
 
-        virtualHostBuilders.forEach(vhb -> this.virtualHosts.add(vhb.build()));
+        virtualHostBuilders.forEach(vhb -> this.virtualHosts.add(vhb.doBuild()));
 
         final List<VirtualHost> virtualHosts;
         if (decorator != null) {

--- a/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -57,7 +57,20 @@ import io.netty.util.concurrent.DefaultThreadFactory;
  * // Build a server.
  * Server s = sb.build();
  * }</pre>
- *
+ * 
+ * <h2>Example 2</h2>
+ * <pre>{@code
+ * ServerBuilder sb = new ServerBuilder();
+ * Server server =
+ *      sb.port(8080, SessionProtocol.HTTP) // Add a port to listen
+ *      .withDefaultVirtualHost() // Add services to the default virtual host.
+ *          .serviceAt(...)
+ *          .serviceUnder(...)
+ *      .and().withVirtualHost("*.foo.com") // Add a virtual host.
+ *          .serviceAt(...)
+ *          .serviceUnder(...)
+ *      .and().build(); // Build
+ * }</pre>
  * @see VirtualHostBuilder
  */
 public final class ServerBuilder {
@@ -426,6 +439,32 @@ public final class ServerBuilder {
         return this;
     }
 
+
+    /**
+     * Adds the <a href="https://en.wikipedia.org/wiki/Virtual_hosting#Name-based">name-based virtual host</a>
+     * specified by {@link VirtualHost}.
+     * 
+     * @return {@link VirtualHostBuilder} for build the default virtual host
+     */
+    public VirtualHostBuilder withDefaultVirtualHost() {
+        defaultVirtualHostBuilderUpdated();
+        return defaultVirtualHostBuilder;
+    }
+
+    /**
+     * Adds the <a href="https://en.wikipedia.org/wiki/Virtual_hosting#Name-based">name-based virtual host</a>
+     * specified by {@link VirtualHost}.
+     * 
+     * @param hostnamePattern virtual host name regular expression
+     * @return {@link VirtualHostBuilder} for build the virtual host
+     */
+    public VirtualHostBuilder withVirtualHost(String hostnamePattern) {
+        VirtualHostBuilder virtualHostBuilder = new VirtualHostBuilder(hostnamePattern, this);
+        virtualHostBuilders.add(virtualHostBuilder);
+        
+        return virtualHostBuilder;
+    }
+
     /**
      * Decorates all {@link Service}s with the specified {@code decorator}.
      *
@@ -498,17 +537,5 @@ public final class ServerBuilder {
                 defaultRequestTimeoutMillis, defaultMaxRequestLength,
                 gracefulShutdownQuietPeriod, gracefulShutdownTimeout,
                 blockingTaskExecutor, serviceLoggerPrefix);
-    }
-
-    public VirtualHostBuilder withDefaultHost() {
-        defaultVirtualHostBuilderUpdated();
-        return defaultVirtualHostBuilder;
-    }
-
-    public VirtualHostBuilder withVirtualHost(String hostnamePattern) {
-        VirtualHostBuilder virtualHostBuilder = new VirtualHostBuilder(hostnamePattern, this);
-        virtualHostBuilders.add(virtualHostBuilder);
-        
-        return virtualHostBuilder;
     }
 }

--- a/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -522,10 +522,10 @@ public final class ServerBuilder {
         if (this.defaultVirtualHost != null) {
             defaultVirtualHost = this.defaultVirtualHost.decorate(decorator);
         } else {
-            defaultVirtualHost = defaultVirtualHostBuilder.doBuild().decorate(decorator);
+            defaultVirtualHost = defaultVirtualHostBuilder.build().decorate(decorator);
         }
 
-        virtualHostBuilders.forEach(vhb -> this.virtualHosts.add(vhb.doBuild()));
+        virtualHostBuilders.forEach(vhb -> this.virtualHosts.add(vhb.build()));
 
         final List<VirtualHost> virtualHosts;
         if (decorator != null) {

--- a/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -50,7 +50,7 @@ import io.netty.util.concurrent.DefaultThreadFactory;
  * // Add a port to listen
  * sb.port(8080, SessionProtocol.HTTP);
  * // Build and add a virtual host.
- * sb.virtualHost(new VirtualHost("*.foo.com").serviceAt(...).build());
+ * sb.virtualHost(new VirtualHostBuilder("*.foo.com").serviceAt(...).build());
  * // Add services to the default virtual host.
  * sb.serviceAt(...);
  * sb.serviceUnder(...);
@@ -66,10 +66,10 @@ import io.netty.util.concurrent.DefaultThreadFactory;
  *      .withDefaultVirtualHost() // Add services to the default virtual host.
  *          .serviceAt(...)
  *          .serviceUnder(...)
- *      .and().withVirtualHost("*.foo.com") // Add a virtual host.
+ *      .and().withVirtualHost("*.foo.com") // Add a another virtual host.
  *          .serviceAt(...)
  *          .serviceUnder(...)
- *      .and().build(); // Build
+ *      .and().build(); // Build a server.
  * }</pre>
  * @see VirtualHostBuilder
  */
@@ -117,8 +117,8 @@ public final class ServerBuilder {
 
     private final List<ServerPort> ports = new ArrayList<>();
     private final List<VirtualHost> virtualHosts = new ArrayList<>();
-    private final List<VirtualHostBuilder> virtualHostBuilders = new ArrayList<>();
-    private final VirtualHostBuilder defaultVirtualHostBuilder = new VirtualHostBuilder(this);
+    private final List<ChainedVirtualHostBuilder> virtualHostBuilders = new ArrayList<>();
+    private final ChainedVirtualHostBuilder defaultVirtualHostBuilder = new ChainedVirtualHostBuilder(this);
     private boolean updatedDefaultVirtualHostBuilder;
 
     private VirtualHost defaultVirtualHost;
@@ -446,7 +446,7 @@ public final class ServerBuilder {
      * 
      * @return {@link VirtualHostBuilder} for build the default virtual host
      */
-    public VirtualHostBuilder withDefaultVirtualHost() {
+    public ChainedVirtualHostBuilder withDefaultVirtualHost() {
         defaultVirtualHostBuilderUpdated();
         return defaultVirtualHostBuilder;
     }
@@ -458,10 +458,24 @@ public final class ServerBuilder {
      * @param hostnamePattern virtual host name regular expression
      * @return {@link VirtualHostBuilder} for build the virtual host
      */
-    public VirtualHostBuilder withVirtualHost(String hostnamePattern) {
-        VirtualHostBuilder virtualHostBuilder = new VirtualHostBuilder(hostnamePattern, this);
+    public ChainedVirtualHostBuilder withVirtualHost(String hostnamePattern) {
+        ChainedVirtualHostBuilder virtualHostBuilder = new ChainedVirtualHostBuilder(hostnamePattern, this);
         virtualHostBuilders.add(virtualHostBuilder);
-        
+        return virtualHostBuilder;
+    }
+
+    /**
+     * Adds the <a href="https://en.wikipedia.org/wiki/Virtual_hosting#Name-based">name-based virtual host</a>
+     * specified by {@link VirtualHost}.
+     * 
+     * @param defaultHostname default hostname of this virtual host
+     * @param hostnamePattern virtual host name regular expression
+     * @return {@link VirtualHostBuilder} for build the virtual host
+     */
+    public ChainedVirtualHostBuilder withVirtualHost(String defaultHostname, String hostnamePattern) {
+        ChainedVirtualHostBuilder virtualHostBuilder =
+                new ChainedVirtualHostBuilder(defaultHostname, hostnamePattern, this);
+        virtualHostBuilders.add(virtualHostBuilder);
         return virtualHostBuilder;
     }
 

--- a/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
+++ b/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
@@ -16,17 +16,6 @@
 
 package com.linecorp.armeria.server;
 
-import java.io.File;
-import java.util.function.Function;
-
-import javax.net.ssl.SSLException;
-
-import com.linecorp.armeria.common.Request;
-import com.linecorp.armeria.common.Response;
-import com.linecorp.armeria.common.SessionProtocol;
-
-import io.netty.handler.ssl.SslContext;
-
 /**
  * Builds a new {@link VirtualHost}.
  * <h2>Example</h2>
@@ -41,119 +30,33 @@ import io.netty.handler.ssl.SslContext;
  *
  * @see PathMapping
  */
-public class VirtualHostBuilder {
+public class VirtualHostBuilder extends AbstractVirtualHostBuilder<VirtualHostBuilder> {
 
-    private InternalVirtualHostBuilder internalVirtualHostBuilder;
-    
     /**
      * Creates a new {@link VirtualHostBuilder} whose hostname pattern is {@code "*"} (match-all).
      */
     public VirtualHostBuilder() {
-        internalVirtualHostBuilder =
-                new InternalVirtualHostBuilder(InternalVirtualHostBuilder.LOCAL_HOSTNAME, "*");
+        super(LOCAL_HOSTNAME, "*");
     }
 
     /**
      * Creates a new {@link VirtualHostBuilder} with the specified hostname pattern.
      */
     public VirtualHostBuilder(String hostnamePattern) {
-        internalVirtualHostBuilder = new InternalVirtualHostBuilder(hostnamePattern);
+        super(hostnamePattern);
     }
 
     /**
      * Creates a new {@link VirtualHostBuilder} with the specified hostname pattern.
      */
     public VirtualHostBuilder(String defaultHostname, String hostnamePattern) {
-        internalVirtualHostBuilder = new InternalVirtualHostBuilder(defaultHostname, hostnamePattern);
-    }
-
-    /**
-     * Sets the {@link SslContext} of this {@link VirtualHost}.
-     */
-    public VirtualHostBuilder sslContext(SslContext sslContext) {
-        internalVirtualHostBuilder.sslContext(sslContext);
-        return this;
-    }
-
-    /**
-     * Sets the {@link SslContext} of this {@link VirtualHost} from the specified {@link SessionProtocol},
-     * {@code keyCertChainFile} and cleartext {@code keyFile}.
-     */
-    public VirtualHostBuilder sslContext(
-            SessionProtocol protocol, File keyCertChainFile, File keyFile) throws SSLException {
-        return sslContext(protocol, keyCertChainFile, keyFile, null);
-    }
-
-    /**
-     * Sets the {@link SslContext} of this {@link VirtualHost} from the specified {@link SessionProtocol},
-     * {@code keyCertChainFile}, {@code keyFile} and {@code keyPassword}.
-     */
-    public VirtualHostBuilder sslContext(
-            SessionProtocol protocol,
-            File keyCertChainFile, File keyFile, String keyPassword) throws SSLException {
-
-        internalVirtualHostBuilder.sslContext(protocol, keyCertChainFile, keyFile, keyPassword);
-        return this;
-    }
-
-    /**
-     * Binds the specified {@link Service} at the specified exact path.
-     */
-    public VirtualHostBuilder serviceAt(String exactPath, Service<?, ?> service) {
-        return service(PathMapping.ofExact(exactPath), service);
-    }
-
-    /**
-     * Binds the specified {@link Service} under the specified directory..
-     */
-    public VirtualHostBuilder serviceUnder(String pathPrefix, Service<?, ?> service) {
-        return service(PathMapping.ofPrefix(pathPrefix), service);
-    }
-
-    /**
-     * Binds the specified {@link Service} at the specified {@link PathMapping}.
-     */
-    public VirtualHostBuilder service(PathMapping pathMapping, Service<?, ?> service) {
-        internalVirtualHostBuilder.service(pathMapping, service);
-        return this;
-    }
-
-    /**
-     * Binds the specified {@link Service} at the specified {@link PathMapping}.
-     *
-     * @param loggerName the name of the {@linkplain ServiceRequestContext#logger() service logger};
-     *                   must be a string of valid Java identifier names concatenated by period ({@code '.'}),
-     *                   such as a package name or a fully-qualified class name
-     */
-    public VirtualHostBuilder service(PathMapping pathMapping, Service<?, ?> service, String loggerName) {
-        internalVirtualHostBuilder.service(pathMapping, service, loggerName);
-        return this;
-    }
-
-    /**
-     * Decorates all {@link Service}s with the specified {@code decorator}.
-     *
-     * @param decorator the {@link Function} that decorates a {@link Service}
-     * @param <T> the type of the {@link Service} being decorated
-     * @param <R> the type of the {@link Service} {@code decorator} will produce
-     */
-    public <T extends Service<T_I, T_O>, T_I extends Request, T_O extends Response,
-            R extends Service<R_I, R_O>, R_I extends Request, R_O extends Response>
-    VirtualHostBuilder decorator(Function<T, R> decorator) {
-
-        internalVirtualHostBuilder.decorator(decorator);
-        return this;
+        super(defaultHostname, hostnamePattern);
     }
 
     /**
      * Creates a new {@link VirtualHost}.
      */
     public VirtualHost build() {
-        return internalVirtualHostBuilder.build();
-    }
-
-    @Override
-    public String toString() {
-        return internalVirtualHostBuilder.toString();
+        return doBuild();
     }
 }

--- a/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
+++ b/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
@@ -67,7 +67,9 @@ import io.netty.handler.ssl.SupportedCipherSuiteFilter;
 public final class VirtualHostBuilder {
 
     private static final Logger logger = LoggerFactory.getLogger(VirtualHostBuilder.class);
-
+    
+    private ServerBuilder serverBuilder;
+    
     private static final ApplicationProtocolConfig HTTPS_ALPN_CFG = new ApplicationProtocolConfig(
             Protocol.ALPN,
             // NO_ADVERTISE is currently the only mode supported by both OpenSsl and JDK providers.
@@ -127,6 +129,16 @@ public final class VirtualHostBuilder {
      */
     public VirtualHostBuilder() {
         this(LOCAL_HOSTNAME, "*");
+    }
+    
+    public VirtualHostBuilder(ServerBuilder serverBuilder) {
+        this(LOCAL_HOSTNAME, "*");
+        this.serverBuilder = serverBuilder;
+    }
+    
+    public VirtualHostBuilder(String hostnamePattern, ServerBuilder serverBuilder) {
+        this(hostnamePattern);
+        this.serverBuilder = serverBuilder;
     }
 
     /**
@@ -271,5 +283,9 @@ public final class VirtualHostBuilder {
     @Override
     public String toString() {
         return VirtualHost.toString(getClass(), defaultHostname, hostnamePattern, sslContext, services);
+    }
+
+    public ServerBuilder and() {
+        return serverBuilder;
     }
 }

--- a/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
+++ b/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
@@ -130,7 +130,7 @@ public final class VirtualHostBuilder {
     public VirtualHostBuilder() {
         this(LOCAL_HOSTNAME, "*");
     }
-    
+
     /**
      * Creates a new {@link VirtualHostBuilder} whose hostname pattern is {@code "*"} (match-all).
      * 
@@ -142,7 +142,7 @@ public final class VirtualHostBuilder {
         requireNonNull(serverBuilder, "serverBuilder");
         this.serverBuilder = serverBuilder;
     }
-    
+
     /**
      * Creates a new {@link VirtualHostBuilder} with the specified hostname pattern.
      * 
@@ -300,7 +300,16 @@ public final class VirtualHostBuilder {
         return VirtualHost.toString(getClass(), defaultHostname, hostnamePattern, sslContext, services);
     }
 
+    /**
+     * return parent serverBuiler
+     * 
+     * @return serverBuiler
+     */
     public ServerBuilder and() {
+        if (serverBuilder == null) {
+            throw new IllegalStateException("Only you can call and() only created through ServerBuilder.with*VirtualHost () in the ServerBuilder.");
+        }
+        
         return serverBuilder;
     }
 }

--- a/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
+++ b/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
@@ -58,6 +58,6 @@ public class VirtualHostBuilder extends AbstractVirtualHostBuilder<VirtualHostBu
      * Creates a new {@link VirtualHost}.
      */
     public VirtualHost build() {
-        return build();
+        return super.build();
     }
 }

--- a/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
+++ b/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
@@ -36,7 +36,7 @@ public class VirtualHostBuilder extends AbstractVirtualHostBuilder<VirtualHostBu
      * Creates a new {@link VirtualHostBuilder} whose hostname pattern is {@code "*"} (match-all).
      */
     public VirtualHostBuilder() {
-        super(LOCAL_HOSTNAME, "*");
+        super();
     }
 
     /**
@@ -47,7 +47,8 @@ public class VirtualHostBuilder extends AbstractVirtualHostBuilder<VirtualHostBu
     }
 
     /**
-     * Creates a new {@link VirtualHostBuilder} with the specified hostname pattern.
+     * Creates a new {@link VirtualHostBuilder} with
+     * the default host name and the specified hostname pattern.
      */
     public VirtualHostBuilder(String defaultHostname, String hostnamePattern) {
         super(defaultHostname, hostnamePattern);
@@ -57,6 +58,6 @@ public class VirtualHostBuilder extends AbstractVirtualHostBuilder<VirtualHostBu
      * Creates a new {@link VirtualHost}.
      */
     public VirtualHost build() {
-        return doBuild();
+        return build();
     }
 }

--- a/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
+++ b/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
@@ -131,13 +131,28 @@ public final class VirtualHostBuilder {
         this(LOCAL_HOSTNAME, "*");
     }
     
+    /**
+     * Creates a new {@link VirtualHostBuilder} whose hostname pattern is {@code "*"} (match-all).
+     * 
+     * @param serverBuilder parent {@link ServerBuilder} for return
+     */
     public VirtualHostBuilder(ServerBuilder serverBuilder) {
         this(LOCAL_HOSTNAME, "*");
+        
+        requireNonNull(serverBuilder, "serverBuilder");
         this.serverBuilder = serverBuilder;
     }
     
+    /**
+     * Creates a new {@link VirtualHostBuilder} with the specified hostname pattern.
+     * 
+     * @param hostnamePattern virtual host name regular expression
+     * @param serverBuilder parent {@link ServerBuilder} for return
+     */
     public VirtualHostBuilder(String hostnamePattern, ServerBuilder serverBuilder) {
         this(hostnamePattern);
+        
+        requireNonNull(serverBuilder, "serverBuilder");
         this.serverBuilder = serverBuilder;
     }
 

--- a/src/site/sphinx/client-basics.rst
+++ b/src/site/sphinx/client-basics.rst
@@ -66,7 +66,7 @@ You can also use the builder pattern for client construction:
 
     HelloService.Iface helloService = new ClientBuilder("tbinary+http://127.0.0.1:8080/hello")
             .defaultResponseTimeoutMillis(10000)
-            .decorator(HttpRequest.class, HttpResponse.class LoggingClient::new)
+            .decorator(HttpRequest.class, HttpResponse.class, LoggingClient::new)
             .build(HelloService.Iface.class); // or AsyncIface.class
 
     String greeting = helloService.hello("Armerian World");

--- a/src/test/java/com/linecorp/armeria/server/ChainedVirtualHostBuilderTest.java
+++ b/src/test/java/com/linecorp/armeria/server/ChainedVirtualHostBuilderTest.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import com.linecorp.armeria.common.http.HttpRequest;
+import com.linecorp.armeria.common.http.HttpResponse;
+import com.linecorp.armeria.server.http.HttpService;
+
+public class ChainedVirtualHostBuilderTest {
+    
+    @Test
+    public void defaultVirtualHost() {
+        final ServerBuilder sb = new ServerBuilder();
+        final ChainedVirtualHostBuilder chainedVirtualHostBuilder = sb.withDefaultVirtualHost();
+        assertNotNull(chainedVirtualHostBuilder);
+        assertThat(chainedVirtualHostBuilder, is(sb.withDefaultVirtualHost()));
+        
+        final Server server = sb.withDefaultVirtualHost()
+                .serviceAt("/test", new TempService())
+                .and().build();
+        assertNotNull(server);
+        
+        final VirtualHost virtualHost = server.config().defaultVirtualHost();
+        assertNotNull(virtualHost);
+        assertThat(virtualHost.hostnamePattern(), is("*"));
+        assertThat(virtualHost.defaultHostname(), is(not("*")));
+    }
+    
+    @Test
+    public void defaultVirtualHostWithImplicitStyle() {
+        final ServerBuilder sb = new ServerBuilder();
+        final Server server = sb.serviceAt("/test", new TempService()).build();
+        assertNotNull(server);
+        
+        final VirtualHost virtualHost = server.config().defaultVirtualHost();
+        assertNotNull(virtualHost);
+        assertThat(virtualHost.hostnamePattern(), is("*"));
+    }
+    
+    @Test
+    public void virtualHostWithHostnamepattern() {
+        final ServerBuilder sb = new ServerBuilder();
+        final ChainedVirtualHostBuilder chainedVirtualHostBuilder = sb.withVirtualHost("*.foo.com");
+        assertNotNull(chainedVirtualHostBuilder);
+        
+        final Server server = sb.withDefaultVirtualHost()
+                .serviceAt("/test", new TempService())
+                .and().build();
+        assertNotNull(server);
+        
+        final List<VirtualHost> virtualHosts = server.config().virtualHosts();
+        
+        assertNotNull(virtualHosts);
+        assertThat(virtualHosts.size(), is(2));
+        
+        final VirtualHost virtualHost = virtualHosts.get(0);
+        assertNotNull(virtualHost);
+        assertThat(virtualHost.hostnamePattern(), is("*.foo.com"));
+        assertThat(virtualHost.defaultHostname(), is("foo.com"));
+        
+        final VirtualHost defaultVirtualHost = virtualHosts.get(1);
+        assertNotNull(defaultVirtualHost);
+        assertThat(defaultVirtualHost, is(server.config().defaultVirtualHost()));
+    }
+
+    @Test
+    public void virtualHostWithDefaultHostnameAndHostnamepattern() {
+        final ServerBuilder sb = new ServerBuilder();
+        final ChainedVirtualHostBuilder chainedVirtualHostBuilder = sb.withVirtualHost("foo", "*");
+        assertNotNull(chainedVirtualHostBuilder);
+        
+        chainedVirtualHostBuilder.serviceAt("/test", new TempService());
+        final Server server = sb.build();
+        assertNotNull(server);
+        
+        final List<VirtualHost> virtualHosts = server.config().virtualHosts();
+        
+        assertNotNull(virtualHosts);
+        assertThat(virtualHosts.size(), is(2));
+        
+        final VirtualHost virtualHost = virtualHosts.get(0);
+        assertNotNull(virtualHost);
+        assertThat(virtualHost.hostnamePattern(), is("*"));
+        assertThat(virtualHost.defaultHostname(), is("foo"));
+        
+        final VirtualHost defaultVirtualHost = virtualHosts.get(1);
+        assertNotNull(defaultVirtualHost);
+        assertThat(defaultVirtualHost, is(server.config().defaultVirtualHost()));
+    }
+
+    @Test
+    public void virtualHostWithCreateStyle() {
+        final VirtualHost h = new VirtualHostBuilder("foo", "*").build();
+        assertThat(h.hostnamePattern(), is("*"));
+        assertThat(h.defaultHostname(), is("foo"));
+        
+        final ServerBuilder sb = new ServerBuilder();
+        sb.virtualHost(h);
+        final Server server = sb.serviceAt("/test", new TempService()).build();
+        assertNotNull(server);
+        
+        final List<VirtualHost> virtualHosts = server.config().virtualHosts();
+        assertNotNull(virtualHosts);
+        assertThat(virtualHosts.size(), is(2));
+        
+        final VirtualHost virtualHost = virtualHosts.get(0);
+        assertNotNull(virtualHost);
+        assertThat(virtualHost.hostnamePattern(), is("*"));
+        assertThat(virtualHost.defaultHostname(), is("foo"));
+        
+        final VirtualHost defaultVirtualHost = virtualHosts.get(1);
+        assertNotNull(defaultVirtualHost);
+        assertThat(defaultVirtualHost, is(server.config().defaultVirtualHost()));
+    }
+    
+    @Test
+    public void defaultVirtalHostMixedStyle() {
+        final ServerBuilder sb = new ServerBuilder();
+        sb.serviceAt("/test", new TempService())
+        .withDefaultVirtualHost()
+            .serviceAt("/test2", new TempService());
+        
+        final Server server = sb.build();
+        assertNotNull(server);
+        
+        final List<ServiceConfig> serviceConfigs = server.config()
+                .defaultVirtualHost()
+                .serviceConfigs();
+        assertThat(serviceConfigs.size(), is(2));
+    }
+
+    @Test
+    public void virtualHostMixedStyleTest() {
+        final VirtualHost h = new VirtualHostBuilder("bar.foo.com")
+                .serviceAt("/test", new TempService())
+                .build();
+        
+        final ServerBuilder sb = new ServerBuilder();
+        sb.withVirtualHost("*.some.com")
+            .serviceAt("/test2", new TempService())
+        .and().virtualHost(h);
+        
+        final Server server = sb.build();
+        assertNotNull(server);
+        
+        final List<VirtualHost> virtualHosts = server.config().virtualHosts();
+        assertThat(virtualHosts.size(), is(3));
+        
+        final VirtualHost virtualHost = virtualHosts.get(0);
+        assertNotNull(virtualHost);
+        assertThat(virtualHost.hostnamePattern(), is("bar.foo.com"));
+        assertThat(virtualHost.defaultHostname(), is("bar.foo.com"));
+        
+        final VirtualHost virtualHost2 = virtualHosts.get(1);
+        assertNotNull(virtualHost2);
+        assertThat(virtualHost2.hostnamePattern(), is("*.some.com"));
+        assertThat(virtualHost2.defaultHostname(), is("some.com"));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void virtualHostWithNull() {
+        final ServerBuilder sb = new ServerBuilder();
+        sb.withVirtualHost(null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void virtualHostWithNull2() {
+        final ServerBuilder sb = new ServerBuilder();
+        sb.withVirtualHost(null,  "foo.com");
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void virtualHostWithNull3() {
+        final ServerBuilder sb = new ServerBuilder();
+        sb.withVirtualHost(null,  null);
+    }
+
+    private static class TempService implements HttpService {
+        @Override
+        public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+            return null;
+        }
+        
+    }
+}

--- a/src/test/java/com/linecorp/armeria/server/ChainedVirtualHostBuilderTest.java
+++ b/src/test/java/com/linecorp/armeria/server/ChainedVirtualHostBuilderTest.java
@@ -16,10 +16,7 @@
 
 package com.linecorp.armeria.server;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
@@ -30,154 +27,146 @@ import com.linecorp.armeria.common.http.HttpResponse;
 import com.linecorp.armeria.server.http.HttpService;
 
 public class ChainedVirtualHostBuilderTest {
-    
+
     @Test
     public void defaultVirtualHost() {
         final ServerBuilder sb = new ServerBuilder();
         final ChainedVirtualHostBuilder chainedVirtualHostBuilder = sb.withDefaultVirtualHost();
-        assertNotNull(chainedVirtualHostBuilder);
-        assertThat(chainedVirtualHostBuilder, is(sb.withDefaultVirtualHost()));
-        
-        final Server server = sb.withDefaultVirtualHost()
-                .serviceAt("/test", new TempService())
-                .and().build();
-        assertNotNull(server);
-        
+        assertThat(chainedVirtualHostBuilder).isNotNull();
+        assertThat(chainedVirtualHostBuilder).isEqualTo(sb.withDefaultVirtualHost());
+
+        final Server server = sb.withDefaultVirtualHost().serviceAt("/test", new TempService())
+        .and().build();
+        assertThat(server).isNotNull();
+
         final VirtualHost virtualHost = server.config().defaultVirtualHost();
-        assertNotNull(virtualHost);
-        assertThat(virtualHost.hostnamePattern(), is("*"));
-        assertThat(virtualHost.defaultHostname(), is(not("*")));
+        assertThat(virtualHost).isNotNull();
+        assertThat(virtualHost.hostnamePattern()).isEqualTo("*");
+        assertThat(virtualHost.defaultHostname()).isNotEqualTo("*");
     }
-    
+
     @Test
     public void defaultVirtualHostWithImplicitStyle() {
         final ServerBuilder sb = new ServerBuilder();
         final Server server = sb.serviceAt("/test", new TempService()).build();
-        assertNotNull(server);
-        
+        assertThat(server).isNotNull();
+
         final VirtualHost virtualHost = server.config().defaultVirtualHost();
-        assertNotNull(virtualHost);
-        assertThat(virtualHost.hostnamePattern(), is("*"));
+        assertThat(virtualHost).isNotNull();
+        assertThat(virtualHost.hostnamePattern()).isEqualTo("*");
     }
-    
+
     @Test
     public void virtualHostWithHostnamepattern() {
         final ServerBuilder sb = new ServerBuilder();
         final ChainedVirtualHostBuilder chainedVirtualHostBuilder = sb.withVirtualHost("*.foo.com");
-        assertNotNull(chainedVirtualHostBuilder);
-        
-        final Server server = sb.withDefaultVirtualHost()
-                .serviceAt("/test", new TempService())
-                .and().build();
-        assertNotNull(server);
-        
+        assertThat(chainedVirtualHostBuilder).isNotNull();
+
+        final Server server = sb.withDefaultVirtualHost().serviceAt("/test", new TempService())
+        .and().build();
+        assertThat(server).isNotNull();
+
         final List<VirtualHost> virtualHosts = server.config().virtualHosts();
-        
-        assertNotNull(virtualHosts);
-        assertThat(virtualHosts.size(), is(2));
-        
+        assertThat(virtualHosts).isNotNull();
+        assertThat(virtualHosts.size()).isEqualTo(2);
+
         final VirtualHost virtualHost = virtualHosts.get(0);
-        assertNotNull(virtualHost);
-        assertThat(virtualHost.hostnamePattern(), is("*.foo.com"));
-        assertThat(virtualHost.defaultHostname(), is("foo.com"));
-        
+        assertThat(virtualHost).isNotNull();
+        assertThat(virtualHost.hostnamePattern()).isEqualTo("*.foo.com");
+        assertThat(virtualHost.defaultHostname()).isEqualTo("foo.com");
+
         final VirtualHost defaultVirtualHost = virtualHosts.get(1);
-        assertNotNull(defaultVirtualHost);
-        assertThat(defaultVirtualHost, is(server.config().defaultVirtualHost()));
+        assertThat(defaultVirtualHost).isNotNull();
+        assertThat(defaultVirtualHost).isEqualTo(server.config().defaultVirtualHost());
     }
 
     @Test
     public void virtualHostWithDefaultHostnameAndHostnamepattern() {
         final ServerBuilder sb = new ServerBuilder();
         final ChainedVirtualHostBuilder chainedVirtualHostBuilder = sb.withVirtualHost("foo", "*");
-        assertNotNull(chainedVirtualHostBuilder);
-        
+        assertThat(chainedVirtualHostBuilder).isNotNull();
+
         chainedVirtualHostBuilder.serviceAt("/test", new TempService());
         final Server server = sb.build();
-        assertNotNull(server);
-        
+        assertThat(server).isNotNull();
+
         final List<VirtualHost> virtualHosts = server.config().virtualHosts();
-        
-        assertNotNull(virtualHosts);
-        assertThat(virtualHosts.size(), is(2));
-        
+        assertThat(virtualHosts).isNotNull();
+        assertThat(virtualHosts.size()).isEqualTo(2);
+
         final VirtualHost virtualHost = virtualHosts.get(0);
-        assertNotNull(virtualHost);
-        assertThat(virtualHost.hostnamePattern(), is("*"));
-        assertThat(virtualHost.defaultHostname(), is("foo"));
-        
+        assertThat(virtualHost).isNotNull();
+        assertThat(virtualHost.hostnamePattern()).isEqualTo("*");
+        assertThat(virtualHost.defaultHostname()).isEqualTo("foo");
+
         final VirtualHost defaultVirtualHost = virtualHosts.get(1);
-        assertNotNull(defaultVirtualHost);
-        assertThat(defaultVirtualHost, is(server.config().defaultVirtualHost()));
+        assertThat(defaultVirtualHost).isNotNull();
+        assertThat(defaultVirtualHost).isEqualTo(server.config().defaultVirtualHost());
     }
 
     @Test
     public void virtualHostWithCreateStyle() {
         final VirtualHost h = new VirtualHostBuilder("foo", "*").build();
-        assertThat(h.hostnamePattern(), is("*"));
-        assertThat(h.defaultHostname(), is("foo"));
-        
+        assertThat(h.hostnamePattern()).isEqualTo("*");
+        assertThat(h.defaultHostname()).isEqualTo("foo");
+
         final ServerBuilder sb = new ServerBuilder();
         sb.virtualHost(h);
         final Server server = sb.serviceAt("/test", new TempService()).build();
-        assertNotNull(server);
-        
+        assertThat(server).isNotNull();
+
         final List<VirtualHost> virtualHosts = server.config().virtualHosts();
-        assertNotNull(virtualHosts);
-        assertThat(virtualHosts.size(), is(2));
-        
+        assertThat(virtualHosts).isNotNull();
+        assertThat(virtualHosts.size()).isEqualTo(2);
+
         final VirtualHost virtualHost = virtualHosts.get(0);
-        assertNotNull(virtualHost);
-        assertThat(virtualHost.hostnamePattern(), is("*"));
-        assertThat(virtualHost.defaultHostname(), is("foo"));
-        
+        assertThat(virtualHost).isNotNull();
+        assertThat(virtualHost.hostnamePattern()).isEqualTo("*");
+        assertThat(virtualHost.defaultHostname()).isEqualTo("foo");
+
         final VirtualHost defaultVirtualHost = virtualHosts.get(1);
-        assertNotNull(defaultVirtualHost);
-        assertThat(defaultVirtualHost, is(server.config().defaultVirtualHost()));
+        assertThat(defaultVirtualHost).isNotNull();
+        assertThat(defaultVirtualHost).isEqualTo(server.config().defaultVirtualHost());
     }
-    
+
     @Test
     public void defaultVirtalHostMixedStyle() {
         final ServerBuilder sb = new ServerBuilder();
         sb.serviceAt("/test", new TempService())
-        .withDefaultVirtualHost()
-            .serviceAt("/test2", new TempService());
-        
+        .withDefaultVirtualHost().serviceAt("/test2", new TempService());
+
         final Server server = sb.build();
-        assertNotNull(server);
-        
+        assertThat(server).isNotNull();
+
         final List<ServiceConfig> serviceConfigs = server.config()
-                .defaultVirtualHost()
-                .serviceConfigs();
-        assertThat(serviceConfigs.size(), is(2));
+        .defaultVirtualHost().serviceConfigs();
+        assertThat(serviceConfigs.size()).isEqualTo(2);
     }
 
     @Test
-    public void virtualHostMixedStyleTest() {
+    public void virtualHostMixedStyle() {
         final VirtualHost h = new VirtualHostBuilder("bar.foo.com")
-                .serviceAt("/test", new TempService())
-                .build();
-        
+        .serviceAt("/test", new TempService()).build();
+
         final ServerBuilder sb = new ServerBuilder();
-        sb.withVirtualHost("*.some.com")
-            .serviceAt("/test2", new TempService())
+        sb.withVirtualHost("*.some.com").serviceAt("/test2", new TempService())
         .and().virtualHost(h);
-        
+
         final Server server = sb.build();
-        assertNotNull(server);
-        
+        assertThat(server).isNotNull();
+
         final List<VirtualHost> virtualHosts = server.config().virtualHosts();
-        assertThat(virtualHosts.size(), is(3));
-        
+        assertThat(virtualHosts.size()).isEqualTo(3);
+
         final VirtualHost virtualHost = virtualHosts.get(0);
-        assertNotNull(virtualHost);
-        assertThat(virtualHost.hostnamePattern(), is("bar.foo.com"));
-        assertThat(virtualHost.defaultHostname(), is("bar.foo.com"));
-        
+        assertThat(virtualHost).isNotNull();
+        assertThat(virtualHost.hostnamePattern()).isEqualTo("bar.foo.com");
+        assertThat(virtualHost.defaultHostname()).isEqualTo("bar.foo.com");
+
         final VirtualHost virtualHost2 = virtualHosts.get(1);
-        assertNotNull(virtualHost2);
-        assertThat(virtualHost2.hostnamePattern(), is("*.some.com"));
-        assertThat(virtualHost2.defaultHostname(), is("some.com"));
+        assertThat(virtualHost2).isNotNull();
+        assertThat(virtualHost2.hostnamePattern()).isEqualTo("*.some.com");
+        assertThat(virtualHost2.defaultHostname()).isEqualTo("some.com");
     }
 
     @Test(expected = NullPointerException.class)
@@ -203,6 +192,5 @@ public class ChainedVirtualHostBuilderTest {
         public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
             return null;
         }
-        
     }
 }


### PR DESCRIPTION
**Motivation**
Setting of defaultVirtualHost and virtualHost will propose a method to be processed at the same level in serverBuilder.

**Modifications**
modified class:

- ServerBulder - add method for configure to build default virtual host
- VirtualHostBuilder - add constructor for contain ServerBuilder, add method for return ServerBuilder

**Result**
I think that looks more fluent.
Proceed as follows

```
ServerBuilder sb = new ServerBuilder();
Server server =
     sb.port(8080, SessionProtocol.HTTP) // Add a port to listen
     .withDefaultVirtualHost() // Add services to the default virtual host.
         .serviceAt(...)
         .serviceUnder(...)
     .and().withVirtualHost("*.foo.com") // Add a virtual host.
         .serviceAt(...)
         .serviceUnder(...)
     .and().build(); // Build
```

**etc**
modified file:
src/site/sphinx/client-basics.rst: add the missing character