### PR TITLE
Update Netty to 4.1.5.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     <jsonunit.version>1.15.0</jsonunit.version>
     <logback.version>1.1.7</logback.version>
     <metrics.version>3.1.2</metrics.version>
-    <netty.version>4.1.4.Final</netty.version>
+    <netty.version>4.1.5.Final</netty.version>
     <reactive-streams.version>1.0.0</reactive-streams.version>
     <reflections.version>0.9.10</reflections.version>
     <slf4j.version>1.7.21</slf4j.version>
@@ -151,7 +151,7 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative-boringssl-static</artifactId>
-      <version>1.1.33.Fork19</version>
+      <version>1.1.33.Fork21</version>
     </dependency>
 
     <!-- Reactive Streams API -->
@@ -210,6 +210,10 @@
       <artifactId>grpc-interop-testing</artifactId>
       <version>1.0.0</version>
       <exclusions>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-codec-http2</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>com.google.guava</groupId>
           <artifactId>guava-jdk5</artifactId>

--- a/src/test/java/com/linecorp/armeria/server/thrift/ThriftOverHttp1Test.java
+++ b/src/test/java/com/linecorp/armeria/server/thrift/ThriftOverHttp1Test.java
@@ -26,7 +26,7 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
+import org.apache.http.conn.ssl.TrustStrategy;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
@@ -48,7 +48,8 @@ public class ThriftOverHttp1Test extends AbstractThriftOverHttpTest {
     public ThriftOverHttp1Test() {
         try {
             SSLContext sslCtx =
-                    SSLContextBuilder.create().loadTrustMaterial(TrustSelfSignedStrategy.INSTANCE).build();
+                    SSLContextBuilder.create().loadTrustMaterial(
+                            (TrustStrategy) (chain, authType) -> true).build();
 
             httpClient = HttpClientBuilder.create().setSSLContext(sslCtx).build();
         } catch (Exception e) {


### PR DESCRIPTION
- Update netty-tcnative-boringssl-tcnative to 1.1.33.Fork21
- Exclude netty-codec-http2 from grpc-interop-testing to avoid version
  clashes