### PR TITLE
Fix invalid regular expression in example gradle script

### DIFF
--- a/src/site/sphinx/setup-gradle.rst
+++ b/src/site/sphinx/setup-gradle.rst
@@ -45,7 +45,7 @@ You might want to use the following  ``build.gradle`` as a starting point if you
         from configurations.javaAgent
         into "$buildDir/javaAgents"
         rename { String fileName ->
-            fileName.replaceFirst("-[0-9]+\\.[0-9]+\\.[0-9]+\\.[^\\.]+\\.jar", ".jar")
+            fileName.replaceFirst("-[0-9]+\\\\.[0-9]+\\\\.[0-9]+(?:\\\\.[^\\\\.]+)?\\\\.jar", ".jar")
         }
     }
 


### PR DESCRIPTION
- Escape a backslash so that parsed-literal directive handles it
  correctly
- Update the regular expression so that the recent jetty-alpn-agent
  version numbers are handled correctly (Thanks @dayflower)
