### PR TITLE
Fix ClassCastException when using Thrift binary type

### DIFF
--- a/src/main/java/com/linecorp/armeria/client/thrift/THttpClientDelegate.java
+++ b/src/main/java/com/linecorp/armeria/client/thrift/THttpClientDelegate.java
@@ -56,6 +56,7 @@ import com.linecorp.armeria.common.thrift.ThriftCall;
 import com.linecorp.armeria.common.thrift.ThriftProtocolFactories;
 import com.linecorp.armeria.common.thrift.ThriftReply;
 import com.linecorp.armeria.common.util.CompletionActions;
+import com.linecorp.armeria.internal.thrift.ThriftFieldAccess;
 import com.linecorp.armeria.internal.thrift.ThriftFunction;
 import com.linecorp.armeria.internal.thrift.ThriftServiceMetadata;
 
@@ -192,7 +193,7 @@ final class THttpClientDelegate implements Client<ThriftCall, ThriftReply> {
 
         for (TFieldIdEnum fieldIdEnum : method.exceptionFields()) {
             if (result.isSet(fieldIdEnum)) {
-                throw (TException) result.getFieldValue(fieldIdEnum);
+                throw (TException) ThriftFieldAccess.get(result, fieldIdEnum);
             }
         }
 
@@ -201,7 +202,7 @@ final class THttpClientDelegate implements Client<ThriftCall, ThriftReply> {
             return null;
         }
         if (result.isSet(successField)) {
-            return result.getFieldValue(successField);
+            return ThriftFieldAccess.get(result, successField);
         }
 
         throw new TApplicationException(TApplicationException.MISSING_RESULT,

--- a/src/main/java/com/linecorp/armeria/common/thrift/ThriftCall.java
+++ b/src/main/java/com/linecorp/armeria/common/thrift/ThriftCall.java
@@ -33,6 +33,7 @@ import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.common.AbstractRpcRequest;
 import com.linecorp.armeria.common.RpcRequest;
+import com.linecorp.armeria.internal.thrift.ThriftFieldAccess;
 
 /**
  * A Thrift {@link RpcRequest}.
@@ -70,7 +71,8 @@ public final class ThriftCall extends AbstractRpcRequest {
         final TBase<TBase<?, ?>, TFieldIdEnum> castThriftArgs = (TBase<TBase<?, ?>, TFieldIdEnum>) thriftArgs;
         return Collections.unmodifiableList(
                 FieldMetaData.getStructMetaDataMap(castThriftArgs.getClass()).keySet().stream()
-                             .map(castThriftArgs::getFieldValue).collect(Collectors.toList()));
+                             .map(field -> ThriftFieldAccess.get(castThriftArgs, field))
+                             .collect(Collectors.toList()));
     }
 
     private ThriftCall(int seqId, Class<?> serviceType, String method, List<Object> args) {

--- a/src/main/java/com/linecorp/armeria/internal/thrift/ThriftFieldAccess.java
+++ b/src/main/java/com/linecorp/armeria/internal/thrift/ThriftFieldAccess.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.thrift;
+
+import java.nio.ByteBuffer;
+
+import org.apache.thrift.TBase;
+import org.apache.thrift.TFieldIdEnum;
+
+/**
+ * Provides the access to a Thrift field.
+ */
+public final class ThriftFieldAccess {
+
+    /**
+     * Gets a field value from the specified struct.
+     */
+    public static Object get(TBase<? extends TBase<?, ?>, TFieldIdEnum> struct, TFieldIdEnum field) {
+        Object value = struct.getFieldValue(field);
+        if (value instanceof byte[]) {
+            return ByteBuffer.wrap((byte[]) value);
+        } else {
+            return value;
+        }
+    }
+
+    private ThriftFieldAccess() {}
+}

--- a/src/main/java/com/linecorp/armeria/internal/thrift/ThriftFunction.java
+++ b/src/main/java/com/linecorp/armeria/internal/thrift/ThriftFunction.java
@@ -236,7 +236,7 @@ public final class ThriftFunction {
     public Object getResult(TBase<TBase<?, ?>, TFieldIdEnum> result) throws TException {
         for (TFieldIdEnum fieldIdEnum : exceptionFields()) {
             if (result.isSet(fieldIdEnum)) {
-                throw (TException) result.getFieldValue(fieldIdEnum);
+                throw (TException) ThriftFieldAccess.get(result, fieldIdEnum);
             }
         }
 
@@ -244,7 +244,7 @@ public final class ThriftFunction {
         if (successField == null) { //void method
             return null;
         } else if (result.isSet(successField)) {
-            return result.getFieldValue(successField);
+            return ThriftFieldAccess.get(result, successField);
         } else {
             throw new TApplicationException(
                     TApplicationException.MISSING_RESULT,

--- a/src/test/java/com/linecorp/armeria/server/metrics/DropwizardMetricsIntegrationTest.java
+++ b/src/test/java/com/linecorp/armeria/server/metrics/DropwizardMetricsIntegrationTest.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.server.metrics;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
@@ -81,12 +82,14 @@ public class DropwizardMetricsIntegrationTest extends AbstractServerTest {
         assertEquals(210, metricRegistry.getMeters()
                                       .get("client.HelloService.hello.requestBytes")
                                       .getCount());
-        assertEquals(368, metricRegistry.getMeters()
-                                      .get("server.HelloService.hello.responseBytes")
-                                      .getCount());
-        assertEquals(368, metricRegistry.getMeters()
-                                      .get("client.HelloService.hello.responseBytes")
-                                      .getCount());
+
+        // Can't assert with exact byte count because the failure responses contain stack traces.
+        assertThat(metricRegistry.getMeters()
+                                 .get("server.HelloService.hello.responseBytes")
+                                 .getCount()).isGreaterThan(0);
+        assertThat(metricRegistry.getMeters()
+                                 .get("client.HelloService.hello.responseBytes")
+                                 .getCount()).isGreaterThan(0);
     }
 
     private void makeRequest(String name) {

--- a/src/test/thrift/main.thrift
+++ b/src/test/thrift/main.thrift
@@ -91,3 +91,8 @@ service FooService {
 service HeaderService {
     string header(1: string name)
 }
+
+// Tests a binary parameter
+service BinaryService {
+    binary process(1: binary data)
+}


### PR DESCRIPTION
Motivation:

When a Thrift operation has a parameter or a return value whose type is
binary, a ThriftCallService will fail with a ClassCastException. It is
primarily because TBase.getFieldValue() for a binary field returns a
byte array (byte[]) while TBase.setFieldValue() requires a ByteBuffer.

Also, it is not very easy to figure out the root cause of this sort of
internal server errors because the stack trace of the
TApplicationException shown on the client-side tells a user only the
exception type and message of the server-side exception. There's no way
to get the server-side stack trace.

Modifications:

- Add an internal utility class 'ThriftFieldAccess' which converts a
  byte[] into a ByteBuffer
  - Use it everywhere TBase.getFieldValue() is used.
- When an internal server error occurs, attach the full stack trace of
  the server-side exception.
- Add a test case for a Thrift service with a binary parameter and a
  binary return value
  - ThriftServiceTest
  - ThriftOverHttpClientTest (thanks to @imasahiro)
- Miscellaneous:
  - Remove redundant instantiation of Thrift result object in some case

Result:

- Bug squashed
- Easier tracing at the cost of larger error response. Example:

```
org.apache.thrift.TApplicationException: internal server error:
---- BEGIN server-side trace ----
java.lang.ClassCastException: [B cannot be cast to java.nio.ByteBuffer
        at com.linecorp.armeria.service.test.thrift.main.BinaryService$process_args.setFieldValue(BinaryService.java:401)
        at com.linecorp.armeria.service.test.thrift.main.BinaryService$process_args.setFieldValue(BinaryService.java:252)
        at com.linecorp.armeria.internal.thrift.ThriftFunction.newArgs(ThriftFunction.java:212)
        at com.linecorp.armeria.server.thrift.ThriftCallService.invoke(ThriftCallService.java:104)
        at com.linecorp.armeria.server.thrift.ThriftCallService.serve(ThriftCallService.java:95)
        at com.linecorp.armeria.server.thrift.ThriftCallService.serve(ThriftCallService.java:46)
        at com.linecorp.armeria.server.thrift.THttpService.invoke(THttpService.java:463)
        at com.linecorp.armeria.server.thrift.THttpService.decodeAndInvoke(THttpService.java:436)
        at com.linecorp.armeria.server.thrift.THttpService.lambda$doPost$3(THttpService.java:318)
        at com.linecorp.armeria.common.util.Functions.lambda$voidFunction$1(Functions.java:192)
        at java.util.concurrent.CompletableFuture.uniHandle(CompletableFuture.java:822)
        at java.util.concurrent.CompletableFuture.uniHandleStage(CompletableFuture.java:834)
        at java.util.concurrent.CompletableFuture.handle(CompletableFuture.java:2155)
        at com.linecorp.armeria.server.thrift.THttpService.doPost(THttpService.java:311)
        at com.linecorp.armeria.server.http.AbstractHttpService.serve(AbstractHttpService.java:79)
        at com.linecorp.armeria.server.thrift.ThriftServiceTest.invoke0(ThriftServiceTest.java:620)
        at com.linecorp.armeria.server.thrift.ThriftServiceTest.invoke(ThriftServiceTest.java:589)
        at com.linecorp.armeria.server.thrift.ThriftServiceTest.testBinary(ThriftServiceTest.java:529)
        ...
---- END server-side trace ----

        at org.apache.thrift.TApplicationException.read(TApplicationException.java:111)
        at org.apache.thrift.TServiceClient.receiveBase(TServiceClient.java:79)
        at com.linecorp.armeria.service.test.thrift.main.BinaryService$Client.recv_process(BinaryService.java:88)
        at com.linecorp.armeria.server.thrift.ThriftServiceTest.testBinary(ThriftServiceTest.java:531)
        ...
```