### PR TITLE
Add CORS support

### DIFF
--- a/settings/checkstyle/checkstyle.xml
+++ b/settings/checkstyle/checkstyle.xml
@@ -20,6 +20,8 @@
     <property name="eachLine" value="true"/>
   </module>
 
+  <module name="JavadocPackage"/>
+
   <module name="TreeWalker">
     <module name="SuppressWarningsHolder"/>
 

--- a/src/main/java/com/linecorp/armeria/client/http/package-info.java
+++ b/src/main/java/com/linecorp/armeria/client/http/package-info.java
@@ -15,6 +15,6 @@
  */
 
 /**
- * Simple HTTP client.
+ * HTTP client.
  */
 package com.linecorp.armeria.client.http;

--- a/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -525,7 +525,7 @@ public final class ServerBuilder {
             defaultVirtualHost = defaultVirtualHostBuilder.build().decorate(decorator);
         }
 
-        virtualHostBuilders.forEach(vhb -> this.virtualHosts.add(vhb.build()));
+        virtualHostBuilders.forEach(vhb -> virtualHosts.add(vhb.build()));
 
         final List<VirtualHost> virtualHosts;
         if (decorator != null) {

--- a/src/main/java/com/linecorp/armeria/server/ServerConfig.java
+++ b/src/main/java/com/linecorp/armeria/server/ServerConfig.java
@@ -92,7 +92,6 @@ public final class ServerConfig {
         validateGreaterThanOrEqual(gracefulShutdownTimeout, "gracefulShutdownTimeout",
                                    gracefulShutdownQuietPeriod, "gracefulShutdownQuietPeriod");
 
-
         requireNonNull(blockingTaskExecutor, "blockingTaskExecutor");
         if (blockingTaskExecutor instanceof ExecutorService) {
             this.blockingTaskExecutor = new InterminableExecutorService((ExecutorService) blockingTaskExecutor);

--- a/src/main/java/com/linecorp/armeria/server/grpc/package-info.java
+++ b/src/main/java/com/linecorp/armeria/server/grpc/package-info.java
@@ -15,6 +15,6 @@
  */
 
 /**
- * Service that allows an armeria server to host a GRPC API using the GRPC wire protocol.
+ * Allows an Armeria server to host a GRPC API using the GRPC wire protocol.
  */
 package com.linecorp.armeria.server.grpc;

--- a/src/main/java/com/linecorp/armeria/server/http/cors/CorsConfig.java
+++ b/src/main/java/com/linecorp/armeria/server/http/cors/CorsConfig.java
@@ -1,0 +1,396 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package com.linecorp.armeria.server.http.cors;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+import com.linecorp.armeria.common.http.DefaultHttpHeaders;
+import com.linecorp.armeria.common.http.HttpHeaderNames;
+import com.linecorp.armeria.common.http.HttpHeaders;
+import com.linecorp.armeria.common.http.HttpMethod;
+
+import io.netty.util.AsciiString;
+
+/**
+ * <a href="https://en.wikipedia.org/wiki/Cross-origin_resource_sharing">Cross-Origin Resource Sharing
+ * (CORS)</a> configuration.
+ *
+ * @see CorsServiceBuilder
+ * @see CorsService#config()
+ */
+public final class CorsConfig {
+
+    /**
+     * {@link CorsConfig} with CORS disabled.
+     */
+    public static final CorsConfig DISABLED = new CorsConfig();
+
+    private final boolean enabled;
+    private final Set<String> origins;
+    private final boolean anyOriginSupported;
+    private final boolean nullOriginAllowed;
+    private final boolean credentialsAllowed;
+    private final boolean shortCircuit;
+    private final long maxAge;
+    private final Set<AsciiString> exposedHeaders;
+    private final Set<HttpMethod> allowedRequestMethods;
+    private final Set<AsciiString> allowedRequestHeaders;
+    private final Map<AsciiString, Supplier<?>> preflightResponseHeaders;
+
+    CorsConfig() {
+        enabled = false;
+        origins = null;
+        anyOriginSupported = false;
+        nullOriginAllowed = false;
+        credentialsAllowed = false;
+        shortCircuit = false;
+        maxAge = 0;
+        exposedHeaders = null;
+        allowedRequestMethods = null;
+        allowedRequestHeaders = null;
+        preflightResponseHeaders = null;
+    }
+
+    CorsConfig(final CorsServiceBuilder builder) {
+        enabled = true;
+        origins = builder.origins;
+        anyOriginSupported = builder.anyOriginSupported;
+        nullOriginAllowed = builder.nullOriginAllowed;
+        credentialsAllowed = builder.credentialsAllowed;
+        shortCircuit = builder.shortCircuit;
+        maxAge = builder.maxAge;
+
+        exposedHeaders = builder.exposedHeaders.isEmpty() ? Collections.emptySet()
+                                                          : ImmutableSet.copyOf(builder.exposedHeaders);
+        allowedRequestMethods = EnumSet.copyOf(builder.allowedRequestMethods);
+        allowedRequestHeaders =
+                builder.allowedRequestHeaders.isEmpty() ? Collections.emptySet()
+                                                        : ImmutableSet.copyOf(builder.allowedRequestHeaders);
+
+        final Map<AsciiString, Supplier<?>> preflightResponseHeaders;
+        if (builder.preflightResponseHeadersDisabled) {
+            preflightResponseHeaders = Collections.emptyMap();
+        } else if (builder.preflightResponseHeaders.isEmpty()) {
+            preflightResponseHeaders = ImmutableMap.of(HttpHeaderNames.DATE, DateValueSupplier.INSTANCE,
+                                               HttpHeaderNames.CONTENT_LENGTH, ConstantValueSupplier.ZERO);
+        } else {
+            preflightResponseHeaders = ImmutableMap.copyOf(builder.preflightResponseHeaders);
+        }
+
+        this.preflightResponseHeaders = preflightResponseHeaders;
+    }
+
+    /**
+     * Determines if support for CORS is enabled.
+     *
+     * @return {@code true} if support for CORS is enabled, false otherwise.
+     */
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Returns the allowed origin. This can either be a wildcard or an origin value.
+     *
+     * @return the value that will be used for the CORS response header 'Access-Control-Allow-Origin'
+     *
+     * @throws IllegalStateException if CORS support is not enabled
+     */
+    public String origin() {
+        ensureEnabled();
+        return origins.isEmpty() ? "*" : origins.iterator().next();
+    }
+
+    /**
+     * Returns the set of allowed origins.
+     *
+     * @throws IllegalStateException if CORS support is not enabled
+     */
+    public Set<String> origins() {
+        ensureEnabled();
+        return origins;
+    }
+
+    /**
+     * Determines whether a wildcard origin, '*', is supported.
+     *
+     * @return {@code true} if any origin is allowed.
+     *
+     * @throws IllegalStateException if CORS support is not enabled
+     */
+    public boolean isAnyOriginSupported() {
+        ensureEnabled();
+        return anyOriginSupported;
+    }
+
+    /**
+     * Web browsers may set the 'Origin' request header to 'null' if a resource is loaded
+     * from the local file system.
+     *
+     * <p>If this property is true, the server will response with the wildcard for the
+     * the CORS response header 'Access-Control-Allow-Origin'.
+     *
+     * @return {@code true} if a 'null' origin should be supported.
+     *
+     * @throws IllegalStateException if CORS support is not enabled
+     */
+    public boolean isNullOriginAllowed() {
+        ensureEnabled();
+        return nullOriginAllowed;
+    }
+
+    /**
+     * Determines if cookies are supported for CORS requests.
+     *
+     * <p>By default cookies are not included in CORS requests but if isCredentialsAllowed returns
+     * true cookies will be added to CORS requests. Setting this value to true will set the
+     * CORS 'Access-Control-Allow-Credentials' response header to true.
+     *
+     * <p>Please note that cookie support needs to be enabled on the client side as well.
+     * The client needs to opt-in to send cookies by calling:
+     * <pre>
+     * xhr.withCredentials = true;
+     * </pre>
+     *
+     * <p>The default value for 'withCredentials' is false in which case no cookies are sent.
+     * Setting this to true will included cookies in cross origin requests.
+     *
+     * @return {@code true} if cookies are supported.
+     *
+     * @throws IllegalStateException if CORS support is not enabled
+     */
+    public boolean isCredentialsAllowed() {
+        ensureEnabled();
+        return credentialsAllowed;
+    }
+
+    /**
+     * Determines whether a CORS request should be rejected if it's invalid before being
+     * further processing.
+     *
+     * <p>CORS headers are set after a request is processed. This may not always be desired
+     * and this setting will check that the Origin is valid and if it is not valid no
+     * further processing will take place, and a error will be returned to the calling client.
+     *
+     * @return {@code true} if a CORS request should short-circuit upon receiving an invalid Origin header.
+     *
+     * @throws IllegalStateException if CORS support is not enabled
+     */
+    public boolean isShortCircuit() {
+        ensureEnabled();
+        return shortCircuit;
+    }
+
+    /**
+     * Gets the maxAge setting.
+     *
+     * <p>When making a preflight request the client has to perform two request with can be inefficient.
+     * This setting will set the CORS 'Access-Control-Max-Age' response header and enables the
+     * caching of the preflight response for the specified time. During this time no preflight
+     * request will be made.
+     *
+     * @return the time in seconds that a preflight request may be cached.
+     *
+     * @throws IllegalStateException if CORS support is not enabled
+     */
+    public long maxAge() {
+        ensureEnabled();
+        return maxAge;
+    }
+
+    /**
+     * Returns a set of headers to be exposed to calling clients.
+     *
+     * <p>During a simple CORS request only certain response headers are made available by the
+     * browser, for example using:
+     * <pre>
+     * xhr.getResponseHeader("Content-Type");
+     * </pre>
+     * The headers that are available by default are:
+     * <ul>
+     * <li>Cache-Control</li>
+     * <li>Content-Language</li>
+     * <li>Content-Type</li>
+     * <li>Expires</li>
+     * <li>Last-Modified</li>
+     * <li>Pragma</li>
+     * </ul>
+     *
+     * <p>To expose other headers they need to be specified, which is what this method enables by
+     * adding the headers names to the CORS 'Access-Control-Expose-Headers' response header.
+     *
+     * @return the list of the headers to expose.
+     *
+     * @throws IllegalStateException if CORS support is not enabled
+     */
+    public Set<AsciiString> exposedHeaders() {
+        ensureEnabled();
+        return exposedHeaders;
+    }
+
+    /**
+     * Returns the allowed set of Request Methods. The Http methods that should be returned in the
+     * CORS 'Access-Control-Request-Method' response header.
+     *
+     * @return the {@link HttpMethod}s that represent the allowed Request Methods.
+     *
+     * @throws IllegalStateException if CORS support is not enabled
+     */
+    public Set<HttpMethod> allowedRequestMethods() {
+        ensureEnabled();
+        return allowedRequestMethods;
+    }
+
+    /**
+     * Returns the allowed set of Request Headers.
+     *
+     * <p>The header names returned from this method will be used to set the CORS
+     * 'Access-Control-Allow-Headers' response header.
+     *
+     * @throws IllegalStateException if CORS support is not enabled
+     */
+    public Set<AsciiString> allowedRequestHeaders() {
+        ensureEnabled();
+        return allowedRequestHeaders;
+    }
+
+    /**
+     * Returns HTTP response headers that should be added to a CORS preflight response.
+     *
+     * @return {@link HttpHeaders} the HTTP response headers to be added.
+     *
+     * @throws IllegalStateException if CORS support is not enabled
+     */
+    public HttpHeaders preflightResponseHeaders() {
+        ensureEnabled();
+
+        if (preflightResponseHeaders.isEmpty()) {
+            return HttpHeaders.EMPTY_HEADERS;
+        }
+
+        final HttpHeaders preflightHeaders = new DefaultHttpHeaders(false);
+        for (Entry<AsciiString, Supplier<?>> entry : preflightResponseHeaders.entrySet()) {
+            final Object value = getValue(entry.getValue());
+            if (value instanceof Iterable) {
+                preflightHeaders.addObject(entry.getKey(), (Iterable<?>) value);
+            } else {
+                preflightHeaders.addObject(entry.getKey(), value);
+            }
+        }
+        return preflightHeaders;
+    }
+
+    private void ensureEnabled() {
+        if (!isEnabled()) {
+            throw new IllegalStateException("CORS support not enabled");
+        }
+    }
+
+    private static <T> T getValue(final Supplier<T> callable) {
+        try {
+            return callable.get();
+        } catch (final Exception e) {
+            throw new IllegalStateException("could not generate value for supplier: " + callable, e);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return toString(this, enabled, origins, anyOriginSupported, nullOriginAllowed, credentialsAllowed,
+                        shortCircuit, maxAge, exposedHeaders, allowedRequestMethods, allowedRequestHeaders,
+                        preflightResponseHeaders);
+    }
+
+    static String toString(Object obj, boolean enabled, Set<String> origins, boolean anyOriginSupported,
+                           boolean nullOriginAllowed, boolean credentialsAllowed, boolean shortCircuit,
+                           long maxAge, Set<AsciiString> exposedHeaders, Set<HttpMethod> allowedRequestMethods,
+                           Set<AsciiString> allowedRequestHeaders,
+                           Map<AsciiString, Supplier<?>> preflightResponseHeaders) {
+        if (enabled) {
+            return MoreObjects.toStringHelper(obj)
+                              .add("origins", origins)
+                              .add("anyOriginSupported", anyOriginSupported)
+                              .add("nullOriginAllowed", nullOriginAllowed)
+                              .add("credentialsAllowed", credentialsAllowed)
+                              .add("shortCircuit", shortCircuit)
+                              .add("maxAge", maxAge)
+                              .add("exposedHeaders", exposedHeaders)
+                              .add("allowedRequestMethods", allowedRequestMethods)
+                              .add("allowedRequestHeaders", allowedRequestHeaders)
+                              .add("preflightResponseHeaders", preflightResponseHeaders).toString();
+        } else {
+            return obj.getClass().getSimpleName() + "{disabled}";
+        }
+    }
+
+    /**
+     * This class is used for preflight HTTP response values that do not need to be
+     * generated, but instead the value is "static" in that the same value will be returned
+     * for each call.
+     */
+    static final class ConstantValueSupplier implements Supplier<Object> {
+
+        static final ConstantValueSupplier ZERO = new ConstantValueSupplier("0");
+
+        private final Object value;
+
+        ConstantValueSupplier(final Object value) {
+            this.value = value;
+        }
+
+        @Override
+        public Object get() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(value);
+        }
+    }
+
+    /**
+     * This {@link Supplier} is used for the DATE preflight HTTP response HTTP header.
+     * It's value must be generated when the response is generated, hence will be
+     * different for every call.
+     */
+    static final class DateValueSupplier implements Supplier<Date> {
+
+        static final DateValueSupplier INSTANCE = new DateValueSupplier();
+
+        @Override
+        public Date get() {
+            return new Date();
+        }
+
+        @Override
+        public String toString() {
+            return "<date>";
+        }
+    }
+}

--- a/src/main/java/com/linecorp/armeria/server/http/cors/CorsService.java
+++ b/src/main/java/com/linecorp/armeria/server/http/cors/CorsService.java
@@ -1,0 +1,299 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.http.cors;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linecorp.armeria.common.Request;
+import com.linecorp.armeria.common.Response;
+import com.linecorp.armeria.common.http.DefaultHttpResponse;
+import com.linecorp.armeria.common.http.FilteredHttpResponse;
+import com.linecorp.armeria.common.http.HttpHeaderNames;
+import com.linecorp.armeria.common.http.HttpHeaders;
+import com.linecorp.armeria.common.http.HttpMethod;
+import com.linecorp.armeria.common.http.HttpObject;
+import com.linecorp.armeria.common.http.HttpRequest;
+import com.linecorp.armeria.common.http.HttpResponse;
+import com.linecorp.armeria.common.http.HttpStatus;
+import com.linecorp.armeria.common.http.HttpStatusClass;
+import com.linecorp.armeria.server.DecoratingService;
+import com.linecorp.armeria.server.Service;
+import com.linecorp.armeria.server.ServiceRequestContext;
+
+import io.netty.util.AsciiString;
+
+/**
+ * Decorates an HTTP {@link Service} to add the
+ * <a href="https://en.wikipedia.org/wiki/Cross-origin_resource_sharing">Cross-Origin Resource Sharing
+ * (CORS)</a> support.
+ *
+ * @param <I> the {@link Request} type of the {@link Service} being decorated
+ * @param <O> the {@link Response} type of the {@link Service} being decorated
+ *
+ * @see CorsServiceBuilder
+ */
+public final class CorsService<I extends HttpRequest, O extends HttpResponse>
+        extends DecoratingService<I, O, I, HttpResponse> {
+
+    private static final Logger logger = LoggerFactory.getLogger(CorsService.class);
+
+    private static final String ANY_ORIGIN = "*";
+    private static final String NULL_ORIGIN = "null";
+
+    private final CorsConfig config;
+
+    /**
+     * Creates a new {@link CorsService} that decorates the specified {@code delegate} to add CORS support.
+     */
+    public CorsService(Service<? super I, ? extends O> delegate, CorsConfig config) {
+        super(delegate);
+        this.config = requireNonNull(config, "config");
+    }
+
+    /**
+     * Returns the {@link CorsConfig}.
+     */
+    public CorsConfig config() {
+        return config;
+    }
+
+    @Override
+    public HttpResponse serve(ServiceRequestContext ctx, I req) throws Exception {
+        // check if CORS preflight must be returned, or if
+        // we need to forbid access because origin could not be validated
+        if (config.isEnabled()) {
+            if (isCorsPreflightRequest(req)) {
+                return handleCorsPreflight(req);
+            }
+            if (config.isShortCircuit() && !validateCorsOrigin(req)) {
+                return forbidden();
+            }
+        }
+
+        return new FilteredHttpResponse(delegate().serve(ctx, req)) {
+            @Override
+            protected HttpObject filter(HttpObject obj) {
+                if (!(obj instanceof HttpHeaders)) {
+                    return obj;
+                }
+
+                final HttpHeaders headers = (HttpHeaders) obj;
+                final HttpStatus status = headers.status();
+                if (status == null || status.codeClass() == HttpStatusClass.INFORMATIONAL) {
+                    return headers;
+                }
+
+                setCorsResponseHeaders(req, headers);
+                return headers;
+            }
+        };
+    }
+
+    /**
+     * Check for a CORS preflight request.
+     *
+     * @param request the HTTP request with CORS info
+     *
+     * @return {@code true} if HTTP request is a CORS preflight request
+     */
+    private static boolean isCorsPreflightRequest(final HttpRequest request) {
+        return request.method() == HttpMethod.OPTIONS &&
+               request.headers().contains(HttpHeaderNames.ORIGIN) &&
+               request.headers().contains(HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD);
+    }
+
+    /**
+     * Handles CORS preflight by setting the appropriate headers.
+     *
+     * @param req the decoded HTTP request
+     */
+    private HttpResponse handleCorsPreflight(HttpRequest req) {
+        DefaultHttpResponse res = new DefaultHttpResponse();
+        HttpHeaders headers = HttpHeaders.of(HttpStatus.OK);
+        if (setCorsOrigin(req, headers)) {
+            setCorsAllowMethods(headers);
+            setCorsAllowHeaders(headers);
+            setCorsAllowCredentials(headers);
+            setCorsMaxAge(headers);
+            setPreflightHeaders(headers);
+        }
+
+        res.write(headers);
+        res.close();
+        return res;
+    }
+
+    /**
+     * This is a non CORS specification feature which enables the setting of preflight
+     * response headers that might be required by intermediaries.
+     *
+     * @param headers the {@link HttpHeaders} to which the preflight headers should be added.
+     */
+    private void setPreflightHeaders(final HttpHeaders headers) {
+        for (Map.Entry<AsciiString, String> entry : config.preflightResponseHeaders()) {
+            headers.add(entry.getKey(), entry.getValue());
+        }
+    }
+
+
+    /**
+     * Emit CORS headers if origin was found.
+     *
+     * @param req the HTTP request with the CORS info
+     * @param headers the headers to modify
+     */
+    private void setCorsResponseHeaders(final HttpRequest req, HttpHeaders headers) {
+        if (setCorsOrigin(req, headers)) {
+            setCorsAllowCredentials(headers);
+            setCorsAllowHeaders(headers);
+            setCorsExposeHeaders(headers);
+        }
+    }
+
+    /**
+     * Return a "forbidden" response.
+     */
+    private static HttpResponse forbidden() {
+        final DefaultHttpResponse res = new DefaultHttpResponse();
+        res.respond(HttpStatus.FORBIDDEN);
+        return res;
+    }
+
+    /**
+     * Validates if origin matches the CORS requirements.
+     *
+     * @param request the HTTP request to check
+     * @return {@code true} if origin matches
+     */
+    private boolean validateCorsOrigin(final HttpRequest request) {
+        if (config.isAnyOriginSupported()) {
+            return true;
+        }
+
+        final String origin = request.headers().get(HttpHeaderNames.ORIGIN);
+        return origin == null ||
+               NULL_ORIGIN.equals(origin) && config.isNullOriginAllowed() ||
+               config.origins().contains(origin.toLowerCase(Locale.ENGLISH));
+    }
+
+    /**
+     * Sets origin header according to the given CORS configuration and HTTP request.
+     *
+     * @param request the HTTP request
+     * @param headers the HTTP headers to modify
+     *
+     * @return {@code true} if CORS configuration matches, otherwise false
+     */
+    private boolean setCorsOrigin(final HttpRequest request, final HttpHeaders headers) {
+        if (!config.isEnabled()) {
+            return false;
+        }
+
+        final String origin = request.headers().get(HttpHeaderNames.ORIGIN);
+        if (origin != null) {
+            if (NULL_ORIGIN.equals(origin) && config.isNullOriginAllowed()) {
+                setCorsNullOrigin(headers);
+                return true;
+            }
+            if (config.isAnyOriginSupported()) {
+                if (config.isCredentialsAllowed()) {
+                    echoCorsRequestOrigin(request, headers);
+                    setCorsVaryHeader(headers);
+                } else {
+                    setCorsAnyOrigin(headers);
+                }
+                return true;
+            }
+            if (config.origins().contains(origin.toLowerCase(Locale.ENGLISH))) {
+                setCorsOrigin(headers, origin);
+                setCorsVaryHeader(headers);
+                return true;
+            }
+            logger.debug("Request origin [{}]] was not among the configured origins [{}]",
+                         origin, config.origins());
+        }
+        return false;
+    }
+
+    private static void setCorsOrigin(final HttpHeaders headers, final String origin) {
+        headers.set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN, origin);
+    }
+
+    private static void echoCorsRequestOrigin(final HttpRequest request, final HttpHeaders headers) {
+        setCorsOrigin(headers, request.headers().get(HttpHeaderNames.ORIGIN));
+    }
+
+    private static void setCorsVaryHeader(final HttpHeaders headers) {
+        headers.set(HttpHeaderNames.VARY, HttpHeaderNames.ORIGIN.toString());
+    }
+
+    private static void setCorsAnyOrigin(final HttpHeaders headers) {
+        setCorsOrigin(headers, ANY_ORIGIN);
+    }
+
+    private static void setCorsNullOrigin(final HttpHeaders headers) {
+        setCorsOrigin(headers, NULL_ORIGIN);
+    }
+
+    private void setCorsAllowCredentials(final HttpHeaders headers) {
+        if (config.isCredentialsAllowed() &&
+            !headers.get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN).equals(ANY_ORIGIN)) {
+            headers.set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_CREDENTIALS, "true");
+        }
+    }
+
+    private void setCorsExposeHeaders(final HttpHeaders headers) {
+        final Set<AsciiString> exposedHeaders = config.exposedHeaders();
+        if (exposedHeaders.isEmpty()) {
+            return;
+        }
+
+        for (AsciiString header : exposedHeaders) {
+            headers.add(HttpHeaderNames.ACCESS_CONTROL_EXPOSE_HEADERS, header.toString());
+        }
+    }
+
+    private void setCorsAllowMethods(final HttpHeaders headers) {
+        List<String> methods = config.allowedRequestMethods()
+                                     .stream().map(HttpMethod::name).collect(Collectors.toList());
+        headers.set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS, methods);
+    }
+
+    private void setCorsAllowHeaders(final HttpHeaders headers) {
+        final Set<AsciiString> allowedHeaders = config.allowedRequestHeaders();
+        if (allowedHeaders.isEmpty()) {
+            return;
+        }
+
+        for (AsciiString header : allowedHeaders) {
+            headers.add(HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS, header.toString());
+        }
+    }
+
+    private void setCorsMaxAge(final HttpHeaders headers) {
+        headers.setLong(HttpHeaderNames.ACCESS_CONTROL_MAX_AGE, config.maxAge());
+    }
+}

--- a/src/main/java/com/linecorp/armeria/server/http/cors/CorsServiceBuilder.java
+++ b/src/main/java/com/linecorp/armeria/server/http/cors/CorsServiceBuilder.java
@@ -1,0 +1,443 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package com.linecorp.armeria.server.http.cors;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import com.linecorp.armeria.common.http.HttpHeaderNames;
+import com.linecorp.armeria.common.http.HttpMethod;
+import com.linecorp.armeria.common.http.HttpRequest;
+import com.linecorp.armeria.common.http.HttpResponse;
+import com.linecorp.armeria.server.Service;
+import com.linecorp.armeria.server.http.cors.CorsConfig.ConstantValueSupplier;
+
+import io.netty.util.AsciiString;
+
+/**
+ * Builds a new {@link CorsService} or its decorator function.
+ */
+public final class CorsServiceBuilder {
+
+    /**
+     * Creates a new builder with its origin set to '*'.
+     */
+    public static CorsServiceBuilder forAnyOrigin() {
+        return new CorsServiceBuilder();
+    }
+
+    /**
+     * Creates a new builder with the specified origin.
+     */
+    public static CorsServiceBuilder forOrigin(final String origin) {
+        requireNonNull(origin, "origin");
+
+        if ("*".equals(origin)) {
+            return new CorsServiceBuilder();
+        }
+        return new CorsServiceBuilder(origin);
+    }
+
+    /**
+     * Creates a new builder with the specified origins.
+     */
+    public static CorsServiceBuilder forOrigins(final String... origins) {
+        requireNonNull(origins, "origins");
+        for (int i = 0; i < origins.length; i++) {
+            if (origins[i] == null) {
+                throw new NullPointerException("origins[" + i + ']');
+            }
+        }
+        return new CorsServiceBuilder(origins);
+    }
+
+    final Set<String> origins;
+    final boolean anyOriginSupported;
+    boolean nullOriginAllowed;
+    boolean credentialsAllowed;
+    boolean shortCircuit;
+    long maxAge;
+    final Set<AsciiString> exposedHeaders = new HashSet<>();
+    @SuppressWarnings("SetReplaceableByEnumSet")
+    final Set<HttpMethod> allowedRequestMethods = new HashSet<>();
+    final Set<AsciiString> allowedRequestHeaders = new HashSet<>();
+    final Map<AsciiString, Supplier<?>> preflightResponseHeaders = new HashMap<>();
+    boolean preflightResponseHeadersDisabled;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param origins the origin to be used for this builder.
+     */
+    CorsServiceBuilder(final String... origins) {
+        final Set<String> originsCopy = new LinkedHashSet<>();
+        for (String o : origins) {
+            originsCopy.add(o.toLowerCase(Locale.ENGLISH));
+        }
+        this.origins = Collections.unmodifiableSet(originsCopy);
+        anyOriginSupported = false;
+    }
+
+    /**
+     * Creates a new Builder instance allowing any origin, "*" which is the
+     * wildcard origin.
+     */
+    CorsServiceBuilder() {
+        anyOriginSupported = true;
+        origins = Collections.emptySet();
+    }
+
+    /**
+     * Web browsers may set the 'Origin' request header to 'null' if a resource is loaded
+     * from the local file system. Calling this method will enable a successful CORS response
+     * with a {@code "null"} value for the the CORS response header 'Access-Control-Allow-Origin'.
+     *
+     * @return {@link CorsServiceBuilder} to support method chaining.
+     */
+    public CorsServiceBuilder allowNullOrigin() {
+        nullOriginAllowed = true;
+        return this;
+    }
+
+    /**
+     * By default cookies are not included in CORS requests, but this method will enable cookies to
+     * be added to CORS requests. Calling this method will set the CORS 'Access-Control-Allow-Credentials'
+     * response header to true.
+     *
+     * <p>Please note, that cookie support needs to be enabled on the client side as well.
+     * The client needs to opt-in to send cookies by calling:
+     * <pre>
+     * xhr.withCredentials = true;
+     * </pre>
+     *
+     * <p>The default value for 'withCredentials' is false in which case no cookies are sent.
+     * Setting this to true will included cookies in cross origin requests.
+     *
+     * @return {@link CorsServiceBuilder} to support method chaining.
+     */
+    public CorsServiceBuilder allowCredentials() {
+        credentialsAllowed = true;
+        return this;
+    }
+
+    /**
+     * Specifies that a CORS request should be rejected if it's invalid before being
+     * further processing.
+     *
+     * <p>CORS headers are set after a request is processed. This may not always be desired
+     * and this setting will check that the Origin is valid and if it is not valid no
+     * further processing will take place, and a error will be returned to the calling client.
+     *
+     * @return {@link CorsServiceBuilder} to support method chaining.
+     */
+    public CorsServiceBuilder shortCircuit() {
+        shortCircuit = true;
+        return this;
+    }
+
+    /**
+     * When making a preflight request the client has to perform two request with can be inefficient.
+     * This setting will set the CORS 'Access-Control-Max-Age' response header and enables the
+     * caching of the preflight response for the specified time. During this time no preflight
+     * request will be made.
+     *
+     * @param maxAge the maximum time, in seconds, that the preflight response may be cached.
+     * @return {@link CorsServiceBuilder} to support method chaining.
+     */
+    public CorsServiceBuilder maxAge(final long maxAge) {
+        if (maxAge <= 0) {
+            throw new IllegalArgumentException("maxAge: " + maxAge + " (expected: > 0)");
+        }
+        this.maxAge = maxAge;
+        return this;
+    }
+
+    /**
+     * Specifies the headers to be exposed to calling clients.
+     *
+     * <p>During a simple CORS request, only certain response headers are made available by the
+     * browser, for example using:
+     * <pre>
+     * xhr.getResponseHeader("Content-Type");
+     * </pre>
+     *
+     * <p>The headers that are available by default are:
+     * <ul>
+     * <li>Cache-Control</li>
+     * <li>Content-Language</li>
+     * <li>Content-Type</li>
+     * <li>Expires</li>
+     * <li>Last-Modified</li>
+     * <li>Pragma</li>
+     * </ul>
+     *
+     * <p>To expose other headers they need to be specified which is what this method enables by
+     * adding the headers to the CORS 'Access-Control-Expose-Headers' response header.
+     *
+     * @param headers the values to be added to the 'Access-Control-Expose-Headers' response header
+     * @return {@link CorsServiceBuilder} to support method chaining.
+     */
+    public CorsServiceBuilder exposeHeaders(final String... headers) {
+        requireNonNull(headers, "headers");
+        for (int i = 0; i < headers.length; i++) {
+            if (headers[i] == null) {
+                throw new NullPointerException("headers[" + i + ']');
+            }
+        }
+
+        Arrays.stream(headers).map(HttpHeaderNames::of).forEach(exposedHeaders::add);
+        return this;
+    }
+
+    /**
+     * Specifies the headers to be exposed to calling clients.
+     *
+     * <p>During a simple CORS request, only certain response headers are made available by the
+     * browser, for example using:
+     * <pre>
+     * xhr.getResponseHeader("Content-Type");
+     * </pre>
+     *
+     * <p>The headers that are available by default are:
+     * <ul>
+     * <li>Cache-Control</li>
+     * <li>Content-Language</li>
+     * <li>Content-Type</li>
+     * <li>Expires</li>
+     * <li>Last-Modified</li>
+     * <li>Pragma</li>
+     * </ul>
+     *
+     * <p>To expose other headers they need to be specified which is what this method enables by
+     * adding the headers to the CORS 'Access-Control-Expose-Headers' response header.
+     *
+     * @param headers the values to be added to the 'Access-Control-Expose-Headers' response header
+     * @return {@link CorsServiceBuilder} to support method chaining.
+     */
+    public CorsServiceBuilder exposeHeaders(final AsciiString... headers) {
+        requireNonNull(headers, "headers");
+        for (int i = 0; i < headers.length; i++) {
+            if (headers[i] == null) {
+                throw new NullPointerException("headers[" + i + ']');
+            }
+        }
+        Collections.addAll(exposedHeaders, headers);
+        return this;
+    }
+
+    /**
+     * Specifies the allowed set of HTTP Request Methods that should be returned in the
+     * CORS 'Access-Control-Request-Method' response header.
+     *
+     * @param methods the {@link HttpMethod}s that should be allowed.
+     * @return {@link CorsServiceBuilder} to support method chaining.
+     */
+    public CorsServiceBuilder allowRequestMethods(final HttpMethod... methods) {
+        requireNonNull(methods, "methods");
+        for (int i = 0; i < methods.length; i++) {
+            if (methods[i] == null) {
+                throw new NullPointerException("methods[" + i + ']');
+            }
+        }
+        Collections.addAll(allowedRequestMethods, methods);
+        return this;
+    }
+
+    /**
+     * Specifies the if headers that should be returned in the CORS 'Access-Control-Allow-Headers'
+     * response header.
+     *
+     * <p>If a client specifies headers on the request, for example by calling:
+     * <pre>
+     * xhr.setRequestHeader('My-Custom-Header', "SomeValue");
+     * </pre>
+     * the server will receive the above header name in the 'Access-Control-Request-Headers' of the
+     * preflight request. The server will then decide if it allows this header to be sent for the
+     * real request (remember that a preflight is not the real request but a request asking the server
+     * if it allow a request).
+     *
+     * @param headers the headers to be added to the preflight 'Access-Control-Allow-Headers' response header.
+     * @return {@link CorsServiceBuilder} to support method chaining.
+     */
+    public CorsServiceBuilder allowRequestHeaders(final String... headers) {
+        requireNonNull(headers, "headers");
+        for (int i = 0; i < headers.length; i++) {
+            if (headers[i] == null) {
+                throw new NullPointerException("headers[" + i + ']');
+            }
+        }
+
+        Arrays.stream(headers).map(HttpHeaderNames::of).forEach(allowedRequestHeaders::add);
+        return this;
+    }
+
+    /**
+     * Specifies the if headers that should be returned in the CORS 'Access-Control-Allow-Headers'
+     * response header.
+     *
+     * <p>If a client specifies headers on the request, for example by calling:
+     * <pre>
+     * xhr.setRequestHeader('My-Custom-Header', "SomeValue");
+     * </pre>
+     * the server will receive the above header name in the 'Access-Control-Request-Headers' of the
+     * preflight request. The server will then decide if it allows this header to be sent for the
+     * real request (remember that a preflight is not the real request but a request asking the server
+     * if it allow a request).
+     *
+     * @param headers the headers to be added to the preflight 'Access-Control-Allow-Headers' response header.
+     * @return {@link CorsServiceBuilder} to support method chaining.
+     */
+    public CorsServiceBuilder allowRequestHeaders(final AsciiString... headers) {
+        requireNonNull(headers, "headers");
+        for (int i = 0; i < headers.length; i++) {
+            if (headers[i] == null) {
+                throw new NullPointerException("headers[" + i + ']');
+            }
+        }
+        allowedRequestHeaders.addAll(Arrays.asList(headers));
+        return this;
+    }
+
+    /**
+     * Returns HTTP response headers that should be added to a CORS preflight response.
+     *
+     * <p>An intermediary like a load balancer might require that a CORS preflight request
+     * have certain headers set. This enables such headers to be added.
+     *
+     * @param name the name of the HTTP header.
+     * @param values the values for the HTTP header.
+     * @return {@link CorsServiceBuilder} to support method chaining.
+     */
+    public CorsServiceBuilder preflightResponseHeader(final String name, final Object... values) {
+        requireNonNull(name, "name");
+        return preflightResponseHeader(HttpHeaderNames.of(name), values);
+    }
+
+    /**
+     * Returns HTTP response headers that should be added to a CORS preflight response.
+     *
+     * <p>An intermediary like a load balancer might require that a CORS preflight request
+     * have certain headers set. This enables such headers to be added.
+     *
+     * @param name the name of the HTTP header.
+     * @param values the values for the HTTP header.
+     * @return {@link CorsServiceBuilder} to support method chaining.
+     */
+    public CorsServiceBuilder preflightResponseHeader(final AsciiString name, final Object... values) {
+        requireNonNull(name, "name");
+        requireNonNull(values, "values");
+        for (int i = 0;i < values.length; i++) {
+            if (values[i] == null) {
+                throw new NullPointerException("values[" + i + ']');
+            }
+        }
+
+        if (values.length == 1) {
+            preflightResponseHeaders.put(name, new ConstantValueSupplier(values[0]));
+        } else {
+            preflightResponseHeader(name, Arrays.asList(values));
+        }
+        return this;
+    }
+
+    /**
+     * Returns HTTP response headers that should be added to a CORS preflight response.
+     *
+     * <p>An intermediary like a load balancer might require that a CORS preflight request
+     * have certain headers set. This enables such headers to be added.
+     *
+     * @param name the name of the HTTP header.
+     * @param values the values for the HTTP header.
+     * @param <T> the type of values that the Iterable contains.
+     * @return {@link CorsServiceBuilder} to support method chaining.
+     */
+    public <T> CorsServiceBuilder preflightResponseHeader(final AsciiString name, final Iterable<T> values) {
+        requireNonNull(name, "name");
+        requireNonNull(values, "values");
+        preflightResponseHeaders.put(name, new ConstantValueSupplier(values));
+        return this;
+    }
+
+    /**
+     * Returns HTTP response headers that should be added to a CORS preflight response.
+     *
+     * <p>An intermediary like a load balancer might require that a CORS preflight request
+     * have certain headers set. This enables such headers to be added.
+     *
+     * <p>Some values must be dynamically created when the HTTP response is created, for
+     * example the 'Date' response header. This can be accomplished by using a {@link Supplier}
+     * which will have its 'call' method invoked when the HTTP response is created.
+     *
+     * @param name the name of the HTTP header.
+     * @param valueSupplier a {@link Supplier} which will be invoked at HTTP response creation.
+     * @param <T> the type of the value that the {@link Supplier} can return.
+     * @return {@link CorsServiceBuilder} to support method chaining.
+     */
+    public <T> CorsServiceBuilder preflightResponseHeader(AsciiString name, Supplier<T> valueSupplier) {
+        requireNonNull(name, "name");
+        requireNonNull(valueSupplier, "valueSupplier");
+        preflightResponseHeaders.put(name, valueSupplier);
+        return this;
+    }
+
+    /**
+     * Specifies that no preflight response headers should be added to a preflight response.
+     *
+     * @return {@link CorsServiceBuilder} to support method chaining.
+     */
+    public CorsServiceBuilder disablePreflightResponseHeaders() {
+        preflightResponseHeadersDisabled = true;
+        return this;
+    }
+
+    /**
+     * Builds a {@link CorsConfig} with settings specified by previous method calls.
+     *
+     * @return {@link CorsConfig} the configured CorsConfig instance.
+     */
+    public <I extends HttpRequest, O extends HttpResponse>
+    CorsService<I, O> build(Service<? super I, ? extends O> delegate) {
+        return new CorsService<>(delegate, new CorsConfig(this));
+    }
+
+    /**
+     * Creates a new decorator that decorates a {@link Service} with a new {@link CorsService}.
+     */
+    public <I extends HttpRequest, O extends HttpResponse>
+    Function<Service<? super I, ? extends O>, CorsService<I, O>> newDecorator() {
+        final CorsConfig config = new CorsConfig(this);
+        return s -> new CorsService<>(s, config);
+    }
+
+    @Override
+    public String toString() {
+        return CorsConfig.toString(this, true, origins, anyOriginSupported, nullOriginAllowed,
+                                   credentialsAllowed, shortCircuit, maxAge, exposedHeaders,
+                                   allowedRequestMethods, allowedRequestHeaders, preflightResponseHeaders);
+    }
+}

--- a/src/main/java/com/linecorp/armeria/server/http/cors/package-info.java
+++ b/src/main/java/com/linecorp/armeria/server/http/cors/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -15,6 +15,7 @@
  */
 
 /**
- * Metrics service.
+ * <a href="https://en.wikipedia.org/wiki/Cross-origin_resource_sharing">Cross-Origin Resource Sharing
+ * (CORS)</a> support.
  */
-package com.linecorp.armeria.server.metrics;
+package com.linecorp.armeria.server.http.cors;

--- a/src/main/java/com/linecorp/armeria/server/http/encoding/package-info.java
+++ b/src/main/java/com/linecorp/armeria/server/http/encoding/package-info.java
@@ -15,6 +15,6 @@
  */
 
 /**
- * A decorator that will apply HTTP encoding (e.g., GZIP compression) to responses.
+ * Applies HTTP encoding (e.g. GZIP compression) to responses.
  */
 package com.linecorp.armeria.server.http.encoding;

--- a/src/test/java/com/linecorp/armeria/server/http/HttpServerCorsTest.java
+++ b/src/test/java/com/linecorp/armeria/server/http/HttpServerCorsTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.http;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+import com.linecorp.armeria.client.ClientFactory;
+import com.linecorp.armeria.client.Clients;
+import com.linecorp.armeria.client.http.HttpClient;
+import com.linecorp.armeria.common.http.AggregatedHttpMessage;
+import com.linecorp.armeria.common.http.HttpHeaderNames;
+import com.linecorp.armeria.common.http.HttpHeaders;
+import com.linecorp.armeria.common.http.HttpMethod;
+import com.linecorp.armeria.common.http.HttpRequest;
+import com.linecorp.armeria.common.http.HttpResponseWriter;
+import com.linecorp.armeria.common.http.HttpStatus;
+import com.linecorp.armeria.server.AbstractServerTest;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.http.cors.CorsServiceBuilder;
+
+import io.netty.util.AsciiString;
+
+public class HttpServerCorsTest extends AbstractServerTest {
+
+    private static final ClientFactory clientFactory = ClientFactory.DEFAULT;
+
+    @Override
+    protected void configureServer(ServerBuilder sb) throws Exception {
+        sb.serviceAt("/cors", new AbstractHttpService() {
+            @Override
+            protected void doGet(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) {
+                res.respond(HttpStatus.OK);
+            }
+
+            @Override
+            protected void doPost(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) {
+                res.respond(HttpStatus.OK);
+            }
+
+            @Override
+            protected void doHead(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) {
+                res.respond(HttpStatus.OK);
+            }
+
+            @Override
+            protected void doOptions(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) {
+                res.respond(HttpStatus.OK);
+            }
+        }.decorate(CorsServiceBuilder.forOrigin("http://example.com")
+                                     .allowRequestMethods(HttpMethod.POST)
+                                     .preflightResponseHeader("x-preflight-cors", "Hello CORS")
+                                     .newDecorator()));
+    }
+
+    @Test
+    public void testCorsPreflight() throws Exception {
+        HttpClient client = Clients.newClient(clientFactory, "none+" + uri("/"), HttpClient.class);
+        AggregatedHttpMessage response = client.execute(
+                HttpHeaders.of(HttpMethod.OPTIONS, "/cors")
+                           .set(HttpHeaderNames.ACCEPT, "utf-8")
+                           .set(HttpHeaderNames.ORIGIN, "http://example.com")
+                           .set(HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD, "POST")
+        ).aggregate().get();
+
+        assertEquals(HttpStatus.OK, response.status());
+        assertEquals("http://example.com", response.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN));
+        assertEquals("Hello CORS", response.headers().get(AsciiString.of("x-preflight-cors")));
+    }
+
+    @Test
+    public void testCorsAllowed() throws Exception {
+        HttpClient client = Clients.newClient(clientFactory, "none+" + uri("/"), HttpClient.class);
+        AggregatedHttpMessage response = client.execute(
+                HttpHeaders.of(HttpMethod.POST, "/cors")
+                           .set(HttpHeaderNames.ACCEPT, "utf-8")
+                           .set(HttpHeaderNames.ORIGIN, "http://example.com")
+                           .set(HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD, "POST")).aggregate().get();
+
+        assertEquals(HttpStatus.OK, response.status());
+        assertEquals("http://example.com", response.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN));
+    }
+
+    @Test
+    public void testCorsForbidden() throws Exception {
+        HttpClient client = Clients.newClient(clientFactory, "none+" + uri("/"), HttpClient.class);
+        AggregatedHttpMessage response = client.execute(
+                HttpHeaders.of(HttpMethod.POST, "/cors")
+                           .set(HttpHeaderNames.ACCEPT, "utf-8")
+                           .set(HttpHeaderNames.ORIGIN, "http://example.org")
+                           .set(HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD, "POST")).aggregate().get();
+
+        assertNull(response.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN));
+    }
+}


### PR DESCRIPTION
Related: #206 #205

Credits:

Original work by @jprante. @trustin made cosmetic improvements and cleanup.

Motivation:

Armeria HTTP server lacks CORS (cross-origin resource sharing) support.

Modifications:

- Add CorsConfig and CorsConfigBuilder, forked from Netty project
  - Replace CorsConfigBuilder.disable() with CorsConfig.DISABLED
  - Property getters in CorsConfig throws an IllegalStateException when
    disabled.
- Add CorsService that handles CORS preflight requests and emits CORS
  response headers
- Add HttpServerCorsTest
- Miscellaneous:
  - Add JavadocPackage checkstyle rule
  - Update existing package-info.java

Result:

Armeria gets CORS support.