### PR TITLE
Use daemon threads for default ClientFactory threads

### DIFF
--- a/src/main/java/com/linecorp/armeria/client/AllInOneClientFactory.java
+++ b/src/main/java/com/linecorp/armeria/client/AllInOneClientFactory.java
@@ -59,16 +59,34 @@ public class AllInOneClientFactory extends AbstractClientFactory {
      * Creates a new instance with the default {@link SessionOptions}.
      */
     public AllInOneClientFactory() {
-        this(SessionOptions.DEFAULT);
+        this(false);
+    }
+
+    /**
+     * Creates a new instance with the default {@link SessionOptions}.
+     *
+     * @param useDaemonThreads whether to create I/O event loop threads as daemon threads
+     */
+    public AllInOneClientFactory(boolean useDaemonThreads) {
+        this(SessionOptions.DEFAULT, useDaemonThreads);
     }
 
     /**
      * Creates a new instance with the specified {@link SessionOptions}.
      */
     public AllInOneClientFactory(SessionOptions options) {
+        this(options, false);
+    }
+
+    /**
+     * Creates a new instance with the specified {@link SessionOptions}.
+     *
+     * @param useDaemonThreads whether to create I/O event loop threads as daemon threads
+     */
+    public AllInOneClientFactory(SessionOptions options, boolean useDaemonThreads) {
         // TODO(trustin): Allow specifying different options for different session protocols.
         //                We have only one session protocol at the moment, so this is OK so far.
-        final HttpClientFactory httpClientFactory = new HttpClientFactory(options);
+        final HttpClientFactory httpClientFactory = new HttpClientFactory(options, useDaemonThreads);
         final THttpClientFactory thriftClientFactory = new THttpClientFactory(httpClientFactory);
 
         final ImmutableMap.Builder<Scheme, ClientFactory> builder = ImmutableMap.builder();

--- a/src/main/java/com/linecorp/armeria/client/ClientFactory.java
+++ b/src/main/java/com/linecorp/armeria/client/ClientFactory.java
@@ -50,7 +50,7 @@ public interface ClientFactory extends AutoCloseable {
     /**
      * The default {@link ClientFactory} implementation.
      */
-    ClientFactory DEFAULT = new AllInOneClientFactory();
+    ClientFactory DEFAULT = new AllInOneClientFactory(true);
 
     /**
      * Closes the default {@link ClientFactory}.

--- a/src/main/java/com/linecorp/armeria/client/NonDecoratingClientFactory.java
+++ b/src/main/java/com/linecorp/armeria/client/NonDecoratingClientFactory.java
@@ -72,21 +72,25 @@ public abstract class NonDecoratingClientFactory extends AbstractClientFactory {
 
     /**
      * Creates a new instance with the default {@link SessionOptions}.
+     *
+     * @param useDaemonThreads whether to create I/O event loop threads as daemon threads
      */
-    protected NonDecoratingClientFactory() {
-        this(SessionOptions.DEFAULT);
+    protected NonDecoratingClientFactory(boolean useDaemonThreads) {
+        this(SessionOptions.DEFAULT, useDaemonThreads);
     }
 
     /**
      * Creates a new instance with the specified {@link SessionOptions}.
+     *
+     * @param useDaemonThreads whether to create I/O event loop threads as daemon threads
      */
-    protected NonDecoratingClientFactory(SessionOptions options) {
+    protected NonDecoratingClientFactory(SessionOptions options, boolean useDaemonThreads) {
         this(options, type -> {
             switch (type) {
                 case NIO:
-                    return new DefaultThreadFactory("armeria-client-nio", false);
+                    return new DefaultThreadFactory("armeria-client-nio", useDaemonThreads);
                 case EPOLL:
-                    return new DefaultThreadFactory("armeria-client-epoll", false);
+                    return new DefaultThreadFactory("armeria-client-epoll", useDaemonThreads);
                 default:
                     throw new Error();
             }

--- a/src/main/java/com/linecorp/armeria/client/http/HttpClientFactory.java
+++ b/src/main/java/com/linecorp/armeria/client/http/HttpClientFactory.java
@@ -56,14 +56,32 @@ public class HttpClientFactory extends NonDecoratingClientFactory {
      * Creates a new instance with the default {@link SessionOptions}.
      */
     public HttpClientFactory() {
-        this(SessionOptions.DEFAULT);
+        this(false);
+    }
+
+    /**
+     * Creates a new instance with the default {@link SessionOptions}.
+     *
+     * @param useDaemonThreads whether to create I/O event loop threads as daemon threads
+     */
+    public HttpClientFactory(boolean useDaemonThreads) {
+        this(SessionOptions.DEFAULT, useDaemonThreads);
     }
 
     /**
      * Creates a new instance with the specified {@link SessionOptions}.
      */
     public HttpClientFactory(SessionOptions options) {
-        super(options);
+        this(options, false);
+    }
+
+    /**
+     * Creates a new instance with the specified {@link SessionOptions}.
+     *
+     * @param useDaemonThreads whether to create I/O event loop threads as daemon threads
+     */
+    public HttpClientFactory(SessionOptions options, boolean useDaemonThreads) {
+        super(options, useDaemonThreads);
         delegate = new HttpClientDelegate(this);
     }
 


### PR DESCRIPTION
Motivation:

Before 0.21, the I/O event loop threads created by ClientFactory
(RemoteInvokerFactory) were daemon threads. However, they are not daemon
threads anymore, preventing a client application from terminating
automatically when its main thread exited already.

Modifications:

- Add the constructors that can specify whether the event loop threads
  are daemon threads or not to some ClientFactory implementations:
  - NonDecoratingClientFactory
  - HttpClientFactory
  - AllInOneClientFactory
- Make ClientFactory.DEFAULT use daemon threads

Result:

The default ClientFactory threads have saner life cycle.