### PR TITLE
Fix NPE in HttpFileServiceTest for files without a detectable mime type.

### DIFF
--- a/src/main/java/com/linecorp/armeria/server/http/file/HttpFileService.java
+++ b/src/main/java/com/linecorp/armeria/server/http/file/HttpFileService.java
@@ -170,10 +170,12 @@ public final class HttpFileService extends AbstractHttpService {
         }
 
         HttpHeaders headers = HttpHeaders.of(HttpStatus.OK)
-                   .set(HttpHeaderNames.CONTENT_TYPE, entry.mediaType().toString())
                    .setInt(HttpHeaderNames.CONTENT_LENGTH, data.length())
                    .setTimeMillis(HttpHeaderNames.DATE, config().clock().millis())
                    .setTimeMillis(HttpHeaderNames.LAST_MODIFIED, lastModifiedMillis);
+        if (entry.mediaType() != null) {
+            headers.set(HttpHeaderNames.CONTENT_TYPE, entry.mediaType().toString());
+        }
         if (entry.contentEncoding() != null) {
             headers.set(HttpHeaderNames.CONTENT_ENCODING, entry.contentEncoding());
         }

--- a/src/main/java/com/linecorp/armeria/server/http/file/HttpVfs.java
+++ b/src/main/java/com/linecorp/armeria/server/http/file/HttpVfs.java
@@ -146,6 +146,7 @@ public interface HttpVfs {
     abstract class AbstractEntry implements Entry {
 
         private final String path;
+        @Nullable
         private final MediaType mediaType;
         @Nullable
         private final String contentEncoding;
@@ -167,6 +168,7 @@ public interface HttpVfs {
         }
 
         @Override
+        @Nullable
         public MediaType mediaType() {
             return mediaType;
         }

--- a/src/main/java/com/linecorp/armeria/server/http/file/MimeTypeUtil.java
+++ b/src/main/java/com/linecorp/armeria/server/http/file/MimeTypeUtil.java
@@ -24,6 +24,8 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
+import javax.annotation.Nullable;
+
 import com.google.common.net.MediaType;
 
 final class MimeTypeUtil {
@@ -77,6 +79,7 @@ final class MimeTypeUtil {
         }
     }
 
+    @Nullable
     static MediaType guessFromPath(String path, boolean preCompressed) {
         requireNonNull(path, "path");
         // If the path is for a precompressed file, it will have an additional extension indicating the

--- a/src/test/java/com/linecorp/armeria/server/http/file/HttpFileServiceTest.java
+++ b/src/test/java/com/linecorp/armeria/server/http/file/HttpFileServiceTest.java
@@ -150,6 +150,14 @@ public class HttpFileServiceTest {
     }
 
     @Test
+    public void testUnknownMediaType() throws Exception {
+        try (CloseableHttpClient hc = HttpClients.createMinimal();
+             CloseableHttpResponse res = hc.execute(new HttpGet(newUri("/bar.unknown")))) {
+            assert200Ok(res, null, "Unknown Media Type\n");
+        }
+    }
+
+    @Test
     public void testGetPreCompressedSupportsNone() throws Exception {
         try (CloseableHttpClient hc = HttpClients.createMinimal()) {
             HttpGet request = new HttpGet(newUri("/compressed/foo.txt"));
@@ -281,8 +289,13 @@ public class HttpFileServiceTest {
         // Ensure the content and its type are correct.
         assertThat(EntityUtils.toString(res.getEntity()), is(expectedContent));
 
-        assertThat(res.containsHeader(HttpHeaders.CONTENT_TYPE), is(true));
-        assertThat(res.getFirstHeader(HttpHeaders.CONTENT_TYPE).getValue(), startsWith(expectedContentType));
+        if (expectedContentType != null) {
+            assertThat(res.containsHeader(HttpHeaders.CONTENT_TYPE), is(true));
+            assertThat(res.getFirstHeader(HttpHeaders.CONTENT_TYPE).getValue(),
+                       startsWith(expectedContentType));
+        } else {
+            assertThat(res.containsHeader(HttpHeaders.CONTENT_TYPE), is(false));
+        }
 
         return lastModified;
     }

--- a/src/test/resources/com/linecorp/armeria/server/http/file/bar/bar.unknown
+++ b/src/test/resources/com/linecorp/armeria/server/http/file/bar/bar.unknown
@@ -1,0 +1,1 @@
+Unknown Media Type


### PR DESCRIPTION
Oops #230 wasn't enough.