### PR TITLE
Do not set 'connection' header for HTTP/2 messages

### DIFF
--- a/src/main/java/com/linecorp/armeria/internal/http/ArmeriaHttpUtil.java
+++ b/src/main/java/com/linecorp/armeria/internal/http/ArmeriaHttpUtil.java
@@ -276,6 +276,7 @@ public final class ArmeriaHttpUtil {
     public static Http2Headers toNettyHttp2(HttpHeaders inputHeaders) {
         final Http2Headers outputHeaders = new DefaultHttp2Headers(false, inputHeaders.size());
         outputHeaders.set(inputHeaders);
+        outputHeaders.remove(HttpHeaderNames.CONNECTION);
         outputHeaders.remove(HttpHeaderNames.TRANSFER_ENCODING);
         outputHeaders.remove(HttpHeaderNames.TRAILER);
         return outputHeaders;

--- a/src/main/java/com/linecorp/armeria/server/http/HttpServerHandler.java
+++ b/src/main/java/com/linecorp/armeria/server/http/HttpServerHandler.java
@@ -459,8 +459,17 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
      * Sets the keep alive header as per:
      * - http://www.w3.org/Protocols/HTTP/1.1/draft-ietf-http-v11-spec-01.html#Connection
      */
-    private static void addKeepAliveHeaders(HttpRequest req, AggregatedHttpMessage res) {
-        res.headers().set(HttpHeaderNames.CONNECTION, "keep-alive");
+    private void addKeepAliveHeaders(HttpRequest req, AggregatedHttpMessage res) {
+        switch (protocol) {
+            case H1:
+            case H1C:
+                res.headers().set(HttpHeaderNames.CONNECTION, "keep-alive");
+                break;
+            default:
+                // Do not add the 'connection' header for HTTP/2 responses.
+                // See https://tools.ietf.org/html/rfc7540#section-8.1.2.2
+        }
+
         setContentLength(req, res);
     }
 
@@ -477,7 +486,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
         res.headers().setInt(HttpHeaderNames.CONTENT_LENGTH, res.content().length());
     }
 
-    private SSLSession getSSLSession(Channel channel) {
+    private static SSLSession getSSLSession(Channel channel) {
         SslHandler sslHandler = channel.pipeline().get(SslHandler.class);
         return sslHandler != null ? sslHandler.engine().getSession() : null;
     }


### PR DESCRIPTION
Motivation:

HTTP/2 specification forbids setting the 'connection' header for HTTP/2
messages: https://tools.ietf.org/html/rfc7540#section-8.1.2.2

cURL (Nghttp2 to be precise) rejects the response that contains a
'connection' header. As a result, attempting to query an Armeria HTTP/2
server with cURL fails.

Modifications:

- Do not add (or remove) the 'connection' header when the current
  protocol is HTTP/2

Result:

- Conformance with standard
- Interoperability