### PR TITLE
Do not close Http2ObjectEncoder on an HTTP/2 SETTINGS frame

### DIFF
--- a/src/main/java/com/linecorp/armeria/server/http/HttpServerHandler.java
+++ b/src/main/java/com/linecorp/armeria/server/http/HttpServerHandler.java
@@ -202,10 +202,12 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
         }
 
         final Http2ConnectionHandler handler = ctx.pipeline().get(Http2ConnectionHandler.class);
-        if (responseEncoder != null) {
+        if (responseEncoder == null) {
+            responseEncoder = new Http2ObjectEncoder(handler.encoder());
+        } else if (responseEncoder instanceof Http1ObjectEncoder) {
             responseEncoder.close();
+            responseEncoder = new Http2ObjectEncoder(handler.encoder());
         }
-        responseEncoder = new Http2ObjectEncoder(handler.encoder());
     }
 
     private void handleRequest(ChannelHandlerContext ctx, DecodedHttpRequest req) throws Exception {


### PR DESCRIPTION
Motivation:

When cleartext H1C-to-H2C upgrade occurs, HttpServerHandler uses the
reception of an HTTP/2 SETTINGS frame as a signal of successful upgrade.
When an HTTP/2 SETTINGS frame is received, HttpServerHandler will
replace its responseEncoder (Http1ObjectEncoder) with a new
Http2ObjectEncoder.

However, when a client sends more than one SETTINGS frame, the second
SETTINGS frame will make HttpServerHandler replace its responseEncoder
again, closing the Http2ObjectEncoder created when the first SETTINGS
frame was received.

A closed Http2ObjectEncoder causes unexpectedly closed streams.

Modifications:

Do not replace Http2ObjectEncoder but only Http1ObjectEncoder.

Result:

- The H1C request with HTTP/2 upgrade headers set is handled correctly.
- Interoperability with cURL
