### PR TITLE
Add version information to default user-agent header

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -624,6 +624,16 @@
         <version>2.0</version>
         <executions>
           <execution>
+            <id>create-version-props</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>execute</goal>
+            </goals>
+            <configuration>
+              <source>${basedir}/src/build/versions-props.groovy</source>
+            </configuration>
+          </execution>
+          <execution>
             <id>tomcat80-compat</id>
             <phase>process-classes</phase>
             <goals>

--- a/src/build/versions-props.groovy
+++ b/src/build/versions-props.groovy
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+//
+// This script generates version.properties, similar to Netty
+//
+
+def PROJECT_ARTIFACT_ID = project.artifactId
+def PROPS_DIR_PATH = project.build.outputDirectory + "/META-INF"
+def PROPS_FILE_PATH = PROPS_DIR_PATH + "/" + project.groupId + ".versions.properties";
+
+println('Generate properties for ' + PROJECT_ARTIFACT_ID);
+
+def keyOf = [
+    version: PROJECT_ARTIFACT_ID + ".version",
+    buildDate: PROJECT_ARTIFACT_ID + ".buildDate",
+    longCommitHash : PROJECT_ARTIFACT_ID + ".longCommitHash",
+    shortCommitHash : PROJECT_ARTIFACT_ID + ".shortCommitHash",
+    commitDate : PROJECT_ARTIFACT_ID + ".commitDate",
+    repoStatus : PROJECT_ARTIFACT_ID + ".repoStatus"
+]
+
+// default values are taken from Netty.
+def valueOf = [
+    version : project.version,
+    buildDate : new Date().format("yyyy-MM-dd HH:mm:ss Z"), // same with git log date format
+    longCommitHash : "0000000000000000000000000000000000000000",
+    shortCommitHash : "0",
+    commitDate : "1970-01-01 00:00:00 +0000",
+    repoStatus : "unknown"
+]
+
+String executeCommand(String command) {
+    def output = '';
+    try {
+        proc = command.execute();
+        proc.waitFor();
+        if (!proc.exitValue()) {
+            output = proc.in.text;
+        } else {
+            println("'${command}' error ${proc.exitValue()}: ${proc.err.text}")
+        }
+    } catch (all) {
+        print("Could not run '${command}': ")
+        println(all);
+    }
+    return output;
+}
+
+def gitLogOut = executeCommand('git log -1 "--format=format:%h %H %cd" --date=iso')
+if (gitLogOut) {
+    println("Latest commit : ${gitLogOut}")
+    def tokens = gitLogOut.tokenize(' ')
+    valueOf.shortCommitHash = tokens[0]
+    valueOf.longCommitHash = tokens[1]
+    valueOf.commitDate = tokens[2..4].join(' ')
+}
+
+def gitStatusOut = executeCommand('git status --porcelain');
+if (gitStatusOut) {
+    valueOf.repoStatus = "dirty"
+    print("Repository is dirty, for\n${gitStatusOut}")
+} else {
+    valueOf.repoStatus = "clean";
+}
+
+def props = new Properties()
+File propsDir = new File(PROPS_DIR_PATH)
+propsDir.mkdir();
+
+File propsFile = new File(PROPS_FILE_PATH)
+if (propsFile.exists()) {
+    println("Update ${PROPS_FILE_PATH}")
+    props.load(propsFile.newDataInputStream())
+} else {
+    println("Create ${PROPS_FILE_PATH}")
+    propsFile.createNewFile();
+}
+
+keyOf.each { key, propName -> props.setProperty(propName, valueOf[key]) }
+props.store(propsFile.newWriter(), null)

--- a/src/main/java/com/linecorp/armeria/client/http/HttpHeaderUtil.java
+++ b/src/main/java/com/linecorp/armeria/client/http/HttpHeaderUtil.java
@@ -16,12 +16,15 @@
 
 package com.linecorp.armeria.client.http;
 
+import com.linecorp.armeria.common.util.Version;
+
 import io.netty.util.AsciiString;
 
 final class HttpHeaderUtil {
 
-    // TODO(trustin): Add version information
-    static final AsciiString USER_AGENT = AsciiString.of("Armeria");
+    private static final String CLIENT_ARTIFACT_ID = "armeria";
+
+    static final AsciiString USER_AGENT = AsciiString.of(createUserAgentName());
 
     static String hostHeader(String host, int port, int defaultPort) {
         if (port == defaultPort) {
@@ -29,6 +32,11 @@ final class HttpHeaderUtil {
         }
 
         return new StringBuilder(host.length() + 6).append(host).append(':').append(port).toString();
+    }
+
+    private static String createUserAgentName() {
+        Version version = Version.identify().get(CLIENT_ARTIFACT_ID);
+        return CLIENT_ARTIFACT_ID + '/' + (version != null ? version.artifactId() : "unknown");
     }
 
     private HttpHeaderUtil() {}

--- a/src/main/java/com/linecorp/armeria/common/util/Version.java
+++ b/src/main/java/com/linecorp/armeria/common/util/Version.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+// This file is forked from Netty,
+// https://github.com/netty/netty/tree/4.1/common/src/main/java/io/netty/util/Version.java
+
+/*
+ * Copyright 2013 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common.util;
+
+import java.io.InputStream;
+import java.net.URL;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+/**
+ * Retrieves the version information of available Armeria artifacts.
+ *
+ * <p>This class retrieves the version information from
+ * {@code META-INF/com.linecorp.armeria.versions.properties}, which is generated in build time. Note that
+ * it may not be possible to retrieve the information completely, depending on your environment, such as
+ * the specified {@link ClassLoader}, the current {@link SecurityManager}.
+ */
+public final class Version {
+
+    private static final String PROP_RESOURCE_PATH = "META-INF/com.linecorp.armeria.versions.properties";
+
+    private static final String PROP_VERSION = ".version";
+    private static final String PROP_BUILD_DATE = ".buildDate";
+    private static final String PROP_COMMIT_DATE = ".commitDate";
+    private static final String PROP_SHORT_COMMIT_HASH = ".shortCommitHash";
+    private static final String PROP_LONG_COMMIT_HASH = ".longCommitHash";
+    private static final String PROP_REPO_STATUS = ".repoStatus";
+
+    /**
+     * Retrieves the version information of Armeria artifacts using the current
+     * {@linkplain Thread#getContextClassLoader() context class loader}.
+     *
+     * @return A {@link Map} whose keys are Maven artifact IDs and whose values are {@link Version}s
+     */
+    public static Map<String, Version> identify() {
+        return identify(null);
+    }
+
+    /**
+     * Retrieves the version information of Armeria artifacts using the specified {@link ClassLoader}.
+     *
+     * @return A {@link Map} whose keys are Maven artifact IDs and whose values are {@link Version}s
+     */
+    public static Map<String, Version> identify(ClassLoader classLoader) {
+        if (classLoader == null) {
+            classLoader = getContextClassLoader();
+        }
+
+        // Collect all properties.
+        Properties props = new Properties();
+        try {
+            Enumeration<URL> resources = classLoader.getResources(PROP_RESOURCE_PATH);
+            while (resources.hasMoreElements()) {
+                URL url = resources.nextElement();
+                InputStream in = url.openStream();
+                try {
+                    props.load(in);
+                } finally {
+                    try {
+                        in.close();
+                    } catch (Exception ignore) {
+                        ignore.printStackTrace();
+                    }
+                }
+            }
+        } catch (Exception ignore) {
+            // Not critical. Just ignore.
+        }
+
+        // Collect all artifactIds.
+        Set<String> artifactIds = new HashSet<String>();
+        for (Object o: props.keySet()) {
+            String k = (String) o;
+
+            int dotIndex = k.indexOf('.');
+            if (dotIndex <= 0) {
+                continue;
+            }
+
+            String artifactId = k.substring(0, dotIndex);
+
+            // Skip the entries without required information.
+            if (!props.containsKey(artifactId + PROP_VERSION) ||
+                    !props.containsKey(artifactId + PROP_BUILD_DATE) ||
+                    !props.containsKey(artifactId + PROP_COMMIT_DATE) ||
+                    !props.containsKey(artifactId + PROP_SHORT_COMMIT_HASH) ||
+                    !props.containsKey(artifactId + PROP_LONG_COMMIT_HASH) ||
+                    !props.containsKey(artifactId + PROP_REPO_STATUS)) {
+                continue;
+            }
+
+            artifactIds.add(artifactId);
+        }
+
+        Map<String, Version> versions = new HashMap<>();
+        for (String artifactId: artifactIds) {
+            versions.put(
+                    artifactId,
+                    new Version(
+                            artifactId,
+                            props.getProperty(artifactId + PROP_VERSION),
+                            parseIso8601(props.getProperty(artifactId + PROP_BUILD_DATE)),
+                            parseIso8601(props.getProperty(artifactId + PROP_COMMIT_DATE)),
+                            props.getProperty(artifactId + PROP_SHORT_COMMIT_HASH),
+                            props.getProperty(artifactId + PROP_LONG_COMMIT_HASH),
+                            props.getProperty(artifactId + PROP_REPO_STATUS)));
+        }
+
+        return versions;
+    }
+
+    private static ClassLoader getContextClassLoader() {
+        if (System.getSecurityManager() == null) {
+            return Thread.currentThread().getContextClassLoader();
+        } else {
+            return AccessController.doPrivileged(new PrivilegedAction<ClassLoader>() {
+                @Override
+                public ClassLoader run() {
+                    return Thread.currentThread().getContextClassLoader();
+                }
+            });
+        }
+    }
+
+    private static long parseIso8601(String value) {
+        try {
+            return new SimpleDateFormat("yyyy-MM-dd HH:mm:ss Z").parse(value).getTime();
+        } catch (ParseException ignored) {
+            return 0;
+        }
+    }
+
+    private final String artifactId;
+    private final String artifactVersion;
+    private final long buildTimeMillis;
+    private final long commitTimeMillis;
+    private final String shortCommitHash;
+    private final String longCommitHash;
+    private final String repositoryStatus;
+
+    private Version(
+            String artifactId, String artifactVersion,
+            long buildTimeMillis, long commitTimeMillis,
+            String shortCommitHash, String longCommitHash, String repositoryStatus) {
+        this.artifactId = artifactId;
+        this.artifactVersion = artifactVersion;
+        this.buildTimeMillis = buildTimeMillis;
+        this.commitTimeMillis = commitTimeMillis;
+        this.shortCommitHash = shortCommitHash;
+        this.longCommitHash = longCommitHash;
+        this.repositoryStatus = repositoryStatus;
+    }
+
+    public String artifactId() {
+        return artifactId;
+    }
+
+    public String artifactVersion() {
+        return artifactVersion;
+    }
+
+    public long buildTimeMillis() {
+        return buildTimeMillis;
+    }
+
+    public long commitTimeMillis() {
+        return commitTimeMillis;
+    }
+
+    public String shortCommitHash() {
+        return shortCommitHash;
+    }
+
+    public String longCommitHash() {
+        return longCommitHash;
+    }
+
+    public String repositoryStatus() {
+        return repositoryStatus;
+    }
+
+    @Override
+    public String toString() {
+        return artifactId + '-' + artifactVersion + '.' + shortCommitHash +
+                (isClean() ? "" : "(repository: " + repositoryStatus + ')');
+    }
+
+    /**
+     * Returns true if repository status is not dirty.
+     */
+    public boolean isClean() {
+        return "clean".equals(repositoryStatus);
+    }
+}

--- a/src/test/java/com/linecorp/armeria/client/http/HttpClientIntegrationTest.java
+++ b/src/test/java/com/linecorp/armeria/client/http/HttpClientIntegrationTest.java
@@ -173,7 +173,7 @@ public class HttpClientIntegrationTest {
                 "/foo",
                 port -> "GET /foo HTTP/1.1\r\n" +
                         "host: 127.0.0.1:" + port + "\r\n" +
-                        "user-agent: Armeria\r\n\r\n");
+                        "user-agent: " + HttpHeaderUtil.USER_AGENT + "\r\n\r\n");
     }
 
     @Test
@@ -273,7 +273,7 @@ public class HttpClientIntegrationTest {
                 path,
                 port -> "GET " + normalizedPath + " HTTP/1.1\r\n" +
                         "host: 127.0.0.1:" + port + "\r\n" +
-                        "user-agent: Armeria\r\n\r\n"
+                        "user-agent: " + HttpHeaderUtil.USER_AGENT + "\r\n\r\n"
         );
     }
 


### PR DESCRIPTION
PR resolves #267 

Motivation:
 - Hard to distinguish client version in server, generally need for statistics.
 - Sometimes, the version information is quite useful for client/server apps.
  (e.g. negotiating capabilities, work-around with known bugs, ...)

Modifications:
 - Added a groovy script to generate a Java class with project name & version
 - Fixed some tests that rely on hard-coded UA string

Result:
 - Now UA string is `${project.name}/${project.version}`
 - The version information is accessible as public constant string.