### PR TITLE
(De)serialize large integers correctly in the DocService debug form / Add 'sticky HTTP headers' checkbox in the DocService debug form

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -70,6 +70,11 @@ This product contains a modified part of GRPC, distributed by Google:
   * License: licenses/LICENSE.grpc.bsd.txt (New BSD License)
   * Homepage: http://www.grpc.io/
 
+This product contains a modified part of json-minify, distributed by Kyle Simpson:
+
+  * License: licenses/LICENSE.json-minify.mit.txt (New BSD License)
+  * Homepage: https://github.com/getify/JSON.minify
+
 This product contains a modified part of Netty, distributed by Netty.io:
 
   * License: licenses/LICENSE.netty.al20.txt (Apache License v2.0)

--- a/licenses/LICENSE.json-minify.mit.txt
+++ b/licenses/LICENSE.json-minify.mit.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+Copyright © 2016 Kyle Simpson <getify@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/main/resources/com/linecorp/armeria/server/docs/assets/js/vendor/json-minify-0.1.js
+++ b/src/main/resources/com/linecorp/armeria/server/docs/assets/js/vendor/json-minify-0.1.js
@@ -1,0 +1,61 @@
+/*! JSON.minify()
+ v0.1 (c) Kyle Simpson
+ MIT License
+ */
+
+(function(global){
+  if (typeof global.JSON == "undefined" || !global.JSON) {
+    global.JSON = {};
+  }
+
+  global.JSON.minify = function(json) {
+
+    var tokenizer = /"|(\/\*)|(\*\/)|(\/\/)|\n|\r/g,
+        in_string = false,
+        in_multiline_comment = false,
+        in_singleline_comment = false,
+        tmp, tmp2, new_str = [], ns = 0, from = 0, lc, rc
+        ;
+
+    tokenizer.lastIndex = 0;
+
+    while (tmp = tokenizer.exec(json)) {
+      lc = RegExp.leftContext;
+      rc = RegExp.rightContext;
+      if (!in_multiline_comment && !in_singleline_comment) {
+        tmp2 = lc.substring(from);
+        if (!in_string) {
+          tmp2 = tmp2.replace(/(\n|\r|\s)*/g,"");
+        }
+        new_str[ns++] = tmp2;
+      }
+      from = tokenizer.lastIndex;
+
+      if (tmp[0] == "\"" && !in_multiline_comment && !in_singleline_comment) {
+        tmp2 = lc.match(/(\\)*$/);
+        if (!in_string || !tmp2 || (tmp2[0].length % 2) == 0) {	// start of string with ", or unescaped " character found to end string
+          in_string = !in_string;
+        }
+        from--; // include " character in next catch
+        rc = json.substring(from);
+      }
+      else if (tmp[0] == "/*" && !in_string && !in_multiline_comment && !in_singleline_comment) {
+        in_multiline_comment = true;
+      }
+      else if (tmp[0] == "*/" && !in_string && in_multiline_comment && !in_singleline_comment) {
+        in_multiline_comment = false;
+      }
+      else if (tmp[0] == "//" && !in_string && !in_multiline_comment && !in_singleline_comment) {
+        in_singleline_comment = true;
+      }
+      else if ((tmp[0] == "\n" || tmp[0] == "\r") && !in_string && !in_multiline_comment && in_singleline_comment) {
+        in_singleline_comment = false;
+      }
+      else if (!in_multiline_comment && !in_singleline_comment && !(/\n|\r|\s/.test(tmp[0]))) {
+        new_str[ns++] = tmp[0];
+      }
+    }
+    new_str[ns++] = rc;
+    return new_str.join("");
+  };
+})(this);

--- a/src/main/resources/com/linecorp/armeria/server/docs/assets/js/vendor/json-prettify-0.1.js
+++ b/src/main/resources/com/linecorp/armeria/server/docs/assets/js/vendor/json-prettify-0.1.js
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+// A modified version of JSON.minify() by Kyle Simpson that prettifies a JSON string without fully parsing it.
+(function(global){
+  if (typeof global.JSON == "undefined" || !global.JSON) {
+    global.JSON = {};
+  }
+
+  global.JSON.prettify = function(json) {
+
+    var tokenizer = /"|\n|\r/g,
+        in_string = false,
+        tmp, tmp2, new_str = [], ns = 0, from = 0, lc, rc;
+
+    tokenizer.lastIndex = 0;
+
+    var indentation = 0;
+
+    function prettify(ch, indentation) {
+      var prettified;
+      switch (ch) {
+        case ':':
+          prettified = ': ';
+          break;
+        case '{':
+        case '[':
+          indentation++;
+          prettified = ch + '\n' + '  '.repeat(indentation);
+          break;
+        case '}':
+        case ']':
+          indentation--;
+          prettified = '\n' + '  '.repeat(indentation) + ch;
+          break;
+        case ',':
+          prettified = ',\n' + '  '.repeat(indentation);
+          break;
+        default:
+          prettified = ch;
+      }
+
+      return [ prettified, indentation ];
+    }
+
+    while (tmp = tokenizer.exec(json)) {
+      lc = RegExp.leftContext;
+      rc = RegExp.rightContext;
+
+      tmp2 = lc.substring(from);
+      if (!in_string) {
+        tmp2 = tmp2.replace(/(\n|\r|\s)*/g,"");
+        for (var i = 0; i < tmp2.length; i++) {
+          var prettified = prettify(tmp2.charAt(i), indentation);
+          new_str[ns++] = prettified[0];
+          indentation = prettified[1];
+        }
+      } else {
+        new_str[ns++] = tmp2;
+      }
+      from = tokenizer.lastIndex;
+
+      if (tmp[0] == "\"") {
+        tmp2 = lc.match(/(\\)*$/);
+        if (!in_string || !tmp2 || (tmp2[0].length % 2) == 0) {	// start of string with ", or unescaped " character found to end string
+          in_string = !in_string;
+        }
+        from--; // include " character in next catch
+        rc = json.substring(from);
+      }
+      else if (!(/\n|\r|\s/.test(tmp[0]))) {
+        new_str[ns++] = tmp[0];
+      }
+    }
+
+    for (var i = 0; i < rc.length; i++) {
+      var prettified = prettify(rc.charAt(i), indentation);
+      new_str[ns++] = prettified[0];
+      indentation = prettified[1];
+    }
+
+    return new_str.join("");
+  };
+})(this);

--- a/src/main/resources/com/linecorp/armeria/server/docs/index.html
+++ b/src/main/resources/com/linecorp/armeria/server/docs/index.html
@@ -178,6 +178,12 @@
                 <a class="btn btn-link debug-http-headers-collapser" data-toggle="collapse">Edit additional HTTP Headers</a>
                 <div class="collapse">
                   <textarea class="debug-http-headers form-control code">{&#10;&#10;}&#10;</textarea>
+                  <div class="checkbox">
+                    <label>
+                      <input class="debug-http-headers-sticky" type="checkbox">
+                      Use these HTTP headers for all functions.
+                    </label>
+                  </div>
                 </div>
               </div>
               <div>

--- a/src/main/resources/com/linecorp/armeria/server/docs/index.html
+++ b/src/main/resources/com/linecorp/armeria/server/docs/index.html
@@ -251,6 +251,8 @@
 <script src="assets/js/vendor/bootstrap-3.3.5.min.js"></script>
 <script src="assets/js/vendor/handlebars-4.0.4.min.js"></script>
 <script src="assets/js/vendor/highlight-jsononly-8.9.1.pack.js"></script>
+<script src="assets/js/vendor/json-minify-0.1.js"></script>
+<script src="assets/js/vendor/json-prettify-0.1.js"></script>
 <script src="assets/js/vendor/URI-1.17.0.min.js"></script>
 <script src="assets/js/armeria.js"></script>
 </body>

--- a/src/test/java/com/linecorp/armeria/server/docs/DocServiceTest.java
+++ b/src/test/java/com/linecorp/armeria/server/docs/DocServiceTest.java
@@ -18,15 +18,13 @@ package com.linecorp.armeria.server.docs;
 import static com.linecorp.armeria.common.SerializationFormat.THRIFT_BINARY;
 import static com.linecorp.armeria.common.SerializationFormat.THRIFT_COMPACT;
 import static com.linecorp.armeria.common.SerializationFormat.THRIFT_TEXT;
-import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
-import java.util.LinkedHashMap;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -51,11 +49,15 @@ import com.linecorp.armeria.service.test.thrift.hbase.Hbase;
 import com.linecorp.armeria.service.test.thrift.main.FooService;
 import com.linecorp.armeria.service.test.thrift.main.HelloService;
 import com.linecorp.armeria.service.test.thrift.main.HelloService.hello_args;
+import com.linecorp.armeria.service.test.thrift.main.SleepService;
 
 public class DocServiceTest extends AbstractServerTest {
 
     private static final HelloService.AsyncIface HELLO_SERVICE_HANDLER =
             (name, resultHandler) -> resultHandler.onComplete("Hello " + name);
+
+    private static final SleepService.AsyncIface SLEEP_SERVICE_HANDLER =
+            (duration, resultHandler) -> resultHandler.onComplete(duration);
 
     private static final hello_args SAMPLE_HELLO = new hello_args().setName("sample user");
     private static final Map<Class<?>, Map<String, String>> SAMPLE_HTTP_HEADERS = ImmutableMap.of(
@@ -64,7 +66,9 @@ public class DocServiceTest extends AbstractServerTest {
 
     @Override
     protected void configureServer(ServerBuilder sb) {
-        final THttpService helloService = THttpService.of(ImmutableMap.of("hello", HELLO_SERVICE_HANDLER));
+        final THttpService helloAndSleepService = THttpService.of(ImmutableMap.of(
+                "hello", HELLO_SERVICE_HANDLER,
+                "sleep", SLEEP_SERVICE_HANDLER));
         final THttpService fooService = THttpService.ofFormats(mock(FooService.AsyncIface.class),
                                                                THRIFT_COMPACT);
         final THttpService cassandraService = THttpService.ofFormats(mock(Cassandra.AsyncIface.class),
@@ -73,7 +77,7 @@ public class DocServiceTest extends AbstractServerTest {
                 THttpService.ofFormats(mock(Cassandra.AsyncIface.class), THRIFT_TEXT);
         final THttpService hbaseService = THttpService.of(mock(Hbase.AsyncIface.class));
 
-        sb.serviceAt("/", helloService);
+        sb.serviceAt("/", helloAndSleepService);
         sb.serviceAt("/foo", fooService);
         sb.serviceAt("/cassandra", cassandraService);
         sb.serviceAt("/cassandra/debug", cassandraServiceDebug);
@@ -86,9 +90,11 @@ public class DocServiceTest extends AbstractServerTest {
 
     @Test
     public void testOk() throws Exception {
-        final Map<Class<?>, Iterable<EndpointInfo>> serviceMap = new LinkedHashMap<>();
+        final Map<Class<?>, Iterable<EndpointInfo>> serviceMap = new HashMap<>();
         serviceMap.put(HelloService.class, Collections.singletonList(
                 EndpointInfo.of("*", "/", "hello", THRIFT_BINARY, SerializationFormat.ofThrift())));
+        serviceMap.put(SleepService.class, Collections.singletonList(
+                EndpointInfo.of("*", "/", "sleep", THRIFT_BINARY, SerializationFormat.ofThrift())));
         serviceMap.put(FooService.class, Collections.singletonList(
                 EndpointInfo.of("*", "/foo", "", THRIFT_COMPACT, EnumSet.of(THRIFT_COMPACT))));
         serviceMap.put(Cassandra.class, Arrays.asList(
@@ -97,7 +103,8 @@ public class DocServiceTest extends AbstractServerTest {
         serviceMap.put(Hbase.class, Collections.singletonList(
                 EndpointInfo.of("*", "/hbase", "", THRIFT_BINARY, SerializationFormat.ofThrift())));
 
-        final String expected = new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(
+        final ObjectMapper mapper = new ObjectMapper();
+        final String expectedJson = mapper.writeValueAsString(
                 Specification.forServiceClasses(serviceMap,
                                                 ImmutableMap.of(hello_args.class, SAMPLE_HELLO),
                                                 SAMPLE_HTTP_HEADERS));
@@ -106,9 +113,13 @@ public class DocServiceTest extends AbstractServerTest {
             final HttpGet req = new HttpGet(specificationUri());
 
             try (CloseableHttpResponse res = hc.execute(req)) {
-                assertThat(res.getStatusLine().toString(), is("HTTP/1.1 200 OK"));
+                assertThat(res.getStatusLine().toString()).isEqualTo("HTTP/1.1 200 OK");
                 String responseJson = EntityUtils.toString(res.getEntity());
-                assertThatJson(responseJson).isEqualTo(expected);
+
+                // Convert to Map for order-insensitive comparison.
+                Map<?, ?> actual = mapper.readValue(responseJson, Map.class);
+                Map<?, ?> expected = mapper.readValue(expectedJson, Map.class);
+                assertThat(actual).isEqualTo(expected);
             }
         }
     }
@@ -119,7 +130,7 @@ public class DocServiceTest extends AbstractServerTest {
             final HttpPost req = new HttpPost(specificationUri());
 
             try (CloseableHttpResponse res = hc.execute(req)) {
-                assertThat(res.getStatusLine().toString(), is("HTTP/1.1 405 Method Not Allowed"));
+                assertThat(res.getStatusLine().toString()).isEqualTo("HTTP/1.1 405 Method Not Allowed");
             }
         }
     }


### PR DESCRIPTION
Motivation:

JSON.parse() can lose the digits of a large integer value when parsing a
JSON string. Therefore, specifying a 64-bit integer as a parameter can
cause the loss of precision.

Modifications:

- Do not use JSON.parse() when handling the debug form or the query
  parameters.
- Use json-minify to minify the JSON in the debug form instead.
  - json-minify was licensed under MIT license by Kyle Simpson.
- Use json-prettify to prettify the JSON in the query parameters
  instead.
  - json-prettify was forked from json-minify.
- Split the 'req' query parameter into 'args and 'http_headers' as we
  initially wished to (/cc @taicki)
- Miscellaneous:
  - More validation
  - Add SleepService to DocServiceTest so that it's easier to test an
    operation that accepts a long integer
  - Use AssertJ instead of Hamcrest in DocServiceTest

Result:

- Fixes #273
- The precision of a large integer value is not lost anymore.
- The 'req' query parameter is always compact.
- The content of the debug form is always minified before being sent to
  Armeria.

--------

Motivation:

When sending a request via the DocService debug form, it's often the
case different requests have identical HTTP headers (e.g. authentication
token.)

It will be useful if there's a way to keep the HTTP headers in the debug
form when a user switches to other functions, so that he or she does not
need to enter the authentication token again and again.

Modifications:

- Add 'Use these HTTP headers for all functions.' checkbox, which
  makes the HTTP headers in the debug form is retained when switching to
  other function.
- Add 'http_headers_sticky' query parameter which preserves the checkbox
  state

Result:

- Fixes #276
- @taicki is happy. :-)
