### PR TITLE
Add new decorating client to manipulate HTTP request headers

### DIFF
--- a/src/main/java/com/linecorp/armeria/client/manipulating/AbstractRequestManipulatingClient.java
+++ b/src/main/java/com/linecorp/armeria/client/manipulating/AbstractRequestManipulatingClient.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.manipulating;
+
+import static java.util.Objects.requireNonNull;
+
+import com.linecorp.armeria.client.Client;
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.DecoratingClient;
+import com.linecorp.armeria.common.Request;
+import com.linecorp.armeria.common.Response;
+
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * An abstract {@link DecoratingClient} that manipulates outgoing {@link Request}s with given manipulator.
+ *
+ * @param <I> the {@link Request} type
+ * @param <O> the {@link Response} type
+ */
+public abstract class AbstractRequestManipulatingClient<I extends Request, O extends Response>
+        extends DecoratingClient<I, O, I, O> {
+
+    private final Manipulator<I> requestManipulator;
+
+    /**
+     * Creates a new instance.
+     */
+    protected AbstractRequestManipulatingClient(Client<? super I, ? extends O> delegate,
+                                                Manipulator<I> requestManipulator) {
+        super(delegate);
+        requireNonNull(requestManipulator);
+        this.requestManipulator = requestManipulator;
+    }
+
+    @Override
+    public O execute(ClientRequestContext ctx, I req) throws Exception {
+        requestManipulator.manipulate(req);
+        return delegate().execute(ctx, req);
+    }
+}

--- a/src/main/java/com/linecorp/armeria/client/manipulating/AbstractRequestManipulatingClient.java
+++ b/src/main/java/com/linecorp/armeria/client/manipulating/AbstractRequestManipulatingClient.java
@@ -24,22 +24,6 @@ import com.linecorp.armeria.client.DecoratingClient;
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
 
-/*
- * Copyright 2016 LINE Corporation
- *
- * LINE Corporation licenses this file to you under the Apache License,
- * version 2.0 (the "License"); you may not use this file except in compliance
- * with the License. You may obtain a copy of the License at:
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
-
 /**
  * An abstract {@link DecoratingClient} that manipulates outgoing {@link Request}s with given manipulator.
  *

--- a/src/main/java/com/linecorp/armeria/client/manipulating/HttpHeaderManipulatingClient.java
+++ b/src/main/java/com/linecorp/armeria/client/manipulating/HttpHeaderManipulatingClient.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.manipulating;
+
+import com.linecorp.armeria.client.Client;
+import com.linecorp.armeria.common.http.HttpRequest;
+import com.linecorp.armeria.common.http.HttpResponse;
+
+/**
+ * A decorating client that manipulates the headers of {@link HttpRequest} object.
+ */
+public class HttpHeaderManipulatingClient extends AbstractRequestManipulatingClient<HttpRequest, HttpResponse> {
+    /**
+     * Creates a new instance.
+     */
+    HttpHeaderManipulatingClient(Client<? super HttpRequest, ? extends HttpResponse> delegate,
+                                 Manipulator<HttpRequest> requestManipulator) {
+        super(delegate, requestManipulator);
+    }
+
+}

--- a/src/main/java/com/linecorp/armeria/client/manipulating/HttpHeaderManipulatingClientBuilder.java
+++ b/src/main/java/com/linecorp/armeria/client/manipulating/HttpHeaderManipulatingClientBuilder.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.manipulating;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.LinkedList;
+
+import java.util.function.BiPredicate;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import com.linecorp.armeria.client.Client;
+import com.linecorp.armeria.common.http.HttpHeaders;
+import com.linecorp.armeria.common.http.HttpRequest;
+import com.linecorp.armeria.common.http.HttpResponse;
+
+import io.netty.util.AsciiString;
+
+/**
+ * A builder class to build an instance of {@link HttpHeaderManipulatingClient} class, providing
+ * various methods to create the client, with a chain of manipulating operations. Each operation
+ * calls the method on {@link HttpHeaders} with same name.
+ *
+ * @see HttpHeaders
+ */
+public class HttpHeaderManipulatingClientBuilder {
+
+    private LinkedList<Consumer<HttpRequest>> requestManipulatingOperations;
+
+    public HttpHeaderManipulatingClientBuilder() {
+        this.requestManipulatingOperations = new LinkedList<>();
+    }
+
+    /**
+     * Creates a decorator with {@link HttpHeaderManipulatingClient}.
+     *
+     * @return this::{@link #buildClient(Client)}
+     */
+    public Function<Client<? super HttpRequest, ? extends HttpResponse>, HttpHeaderManipulatingClient>
+    newDecorator() {
+        return this::buildClient;
+    }
+
+    /**
+     * Creates a new {@link HttpHeaderManipulatingClient} instance with chained operations.
+     *
+     * @return new instance of {@link HttpHeaderManipulatingClient}
+     */
+    public HttpHeaderManipulatingClient buildClient(
+            Client<? super HttpRequest, ? extends HttpResponse> delegate) {
+        Manipulator<HttpRequest> manipulator = new Manipulator(requestManipulatingOperations);
+        return new HttpHeaderManipulatingClient(delegate, manipulator);
+    }
+
+    private HttpHeaderManipulatingClientBuilder appendOperator(Consumer<HttpRequest> operator) {
+        this.requestManipulatingOperations.add(operator);
+        return this;
+    }
+
+    /**
+     * Appends an add operation that adds a (header, value) entry to every request.
+     *
+     * @param header header to be added
+     * @param value  the value to be added
+     *
+     * @return this instance
+     *
+     * @throws NullPointerException when header or value is null
+     * @throws IllegalArgumentException when header or value is empty
+     */
+
+    public HttpHeaderManipulatingClientBuilder add(AsciiString header, String value) {
+        requireNotEmpty(header, "header");
+        requireNotEmpty(value, "value");
+        return appendOperator(request -> request.headers().add(header, value));
+    }
+
+    /**
+     * Appends a set operation that sets (header, value) entry to every request.
+     *
+     * <p>Existing header entries will be removed and a new, single (header, value) will replace them.
+     *
+     * @param header header to be replaced
+     * @param value new value to replace with
+     *
+     * @return this instance
+     *
+     * @throws NullPointerException when header or value is null.
+     * @throws IllegalArgumentException when header or value is empty, or header is restricted.
+     */
+    public HttpHeaderManipulatingClientBuilder set(AsciiString header, String value) {
+        requireNotEmpty(header, "header");
+        requireNotEmpty(value, "value");
+        return appendOperator(request -> request.headers().set(header, value));
+    }
+
+    /**
+     * Appends a set operation that sets (header, value) entry to every request, with a value returned by
+     * generator function.
+     *
+     * <p>Existing header entries will be removed and a new, single (header, value) will replace them.
+     *
+     * @param header header to replace value
+     * @param generator a function that receives current value and returns the new value to be set.
+     *                  When request has no header entry of given name, generator gets null input.
+     *                  When generator returns null or empty value, the returned value will be ignored.
+     *
+     * @return this instance
+     *
+     * @throws NullPointerException when header or generator function is null
+     * @throws IllegalArgumentException when header is empty
+     */
+    public HttpHeaderManipulatingClientBuilder set(AsciiString header,
+                                                   Function<String, String> generator) {
+        requireNotEmpty(header, "header");
+        requireNonNull(generator, "generator should not be null");
+        return appendOperator(request -> {
+            String oldValue = request.headers().get(header);
+            String newValue = generator.apply(oldValue);
+            if (newValue != null && !newValue.isEmpty()) {
+                request.headers().set(header, newValue);
+            }
+        });
+    }
+
+    /**
+     * Appends an remove operation that removes given header from request.
+     * @param header header to remove
+     *
+     * @return this instance
+     *
+     * @throws NullPointerException when header is null
+     * @throws IllegalArgumentException when header is empty
+     */
+
+    public HttpHeaderManipulatingClientBuilder remove(AsciiString header) {
+        requireNotEmpty(header, "header");
+        return appendOperator(request -> request.headers().remove(header));
+    }
+
+    /**
+     * Appends an conditional remove operation that removes all (header, value) entries passes the test
+     * of given predicate.
+     *
+     * @param predicate function that returns true when input (header, value) is to be removed.
+     * @return this instance
+     *
+     * @throws NullPointerException when predicate is null
+     */
+    public HttpHeaderManipulatingClientBuilder remove(BiPredicate<AsciiString, String> predicate) {
+        requireNonNull(predicate, "predicate should not be null");
+        return appendOperator(request -> {
+            HttpHeaders headers = request.headers();
+            headers.forEach(entry -> {
+                AsciiString header = entry.getKey();
+                if (predicate.test(header, entry.getValue())) {
+                    headers.remove(header);
+                }
+            });
+        });
+    }
+
+    /**
+     * Appends an update operation to manipulator to do some complex operation that cannot be done with
+     * other simple operations.
+     *
+     * @param updater function that updates given request headers.
+     * @return this instance
+     * @throws NullPointerException when updater is null
+     */
+    public HttpHeaderManipulatingClientBuilder update(Consumer<HttpHeaders> updater) {
+        requireNonNull(updater, "updater should not be null");
+        return appendOperator(request -> updater.accept(request.headers()));
+    }
+
+    private static void requireNotEmpty(CharSequence str, String target) {
+        requireNonNull(str, target + " should not be null");
+        if (str.length() < 1) {
+            throw new IllegalArgumentException(target + " should not be empty");
+        }
+    }
+}

--- a/src/main/java/com/linecorp/armeria/client/manipulating/HttpHeaderManipulatingClientBuilder.java
+++ b/src/main/java/com/linecorp/armeria/client/manipulating/HttpHeaderManipulatingClientBuilder.java
@@ -47,9 +47,9 @@ public class HttpHeaderManipulatingClientBuilder {
     }
 
     /**
-     * Creates a decorator with {@link HttpHeaderManipulatingClient}.
+     * Creates a decorator function using newly built {@link HttpHeaderManipulatingClient} instance.
      *
-     * @return this::{@link #buildClient(Client)}
+     * @return the new decorator function
      */
     public Function<Client<? super HttpRequest, ? extends HttpResponse>, HttpHeaderManipulatingClient>
     newDecorator() {
@@ -63,7 +63,7 @@ public class HttpHeaderManipulatingClientBuilder {
      */
     public HttpHeaderManipulatingClient buildClient(
             Client<? super HttpRequest, ? extends HttpResponse> delegate) {
-        Manipulator<HttpRequest> manipulator = new Manipulator(requestManipulatingOperations);
+        Manipulator<HttpRequest> manipulator = new Manipulator<>(requestManipulatingOperations);
         return new HttpHeaderManipulatingClient(delegate, manipulator);
     }
 
@@ -128,7 +128,7 @@ public class HttpHeaderManipulatingClientBuilder {
     public HttpHeaderManipulatingClientBuilder set(AsciiString header,
                                                    Function<String, String> generator) {
         requireNotEmpty(header, "header");
-        requireNonNull(generator, "generator should not be null");
+        requireNonNull(generator, "generator");
         return appendOperator(request -> {
             String oldValue = request.headers().get(header);
             String newValue = generator.apply(oldValue);
@@ -139,7 +139,7 @@ public class HttpHeaderManipulatingClientBuilder {
     }
 
     /**
-     * Appends an remove operation that removes given header from request.
+     * Appends a remove operation that removes given header from request.
      * @param header header to remove
      *
      * @return this instance
@@ -154,7 +154,7 @@ public class HttpHeaderManipulatingClientBuilder {
     }
 
     /**
-     * Appends an conditional remove operation that removes all (header, value) entries passes the test
+     * Appends a conditional remove operation that removes all (header, value) entries passes the test
      * of given predicate.
      *
      * @param predicate function that returns true when input (header, value) is to be removed.
@@ -163,7 +163,7 @@ public class HttpHeaderManipulatingClientBuilder {
      * @throws NullPointerException when predicate is null
      */
     public HttpHeaderManipulatingClientBuilder remove(BiPredicate<AsciiString, String> predicate) {
-        requireNonNull(predicate, "predicate should not be null");
+        requireNonNull(predicate, "predicate");
         return appendOperator(request -> {
             HttpHeaders headers = request.headers();
             headers.forEach(entry -> {
@@ -184,12 +184,12 @@ public class HttpHeaderManipulatingClientBuilder {
      * @throws NullPointerException when updater is null
      */
     public HttpHeaderManipulatingClientBuilder update(Consumer<HttpHeaders> updater) {
-        requireNonNull(updater, "updater should not be null");
+        requireNonNull(updater, "updater");
         return appendOperator(request -> updater.accept(request.headers()));
     }
 
     private static void requireNotEmpty(CharSequence str, String target) {
-        requireNonNull(str, target + " should not be null");
+        requireNonNull(str, target);
         if (str.length() < 1) {
             throw new IllegalArgumentException(target + " should not be empty");
         }

--- a/src/main/java/com/linecorp/armeria/client/manipulating/Manipulator.java
+++ b/src/main/java/com/linecorp/armeria/client/manipulating/Manipulator.java
@@ -1,0 +1,47 @@
+package com.linecorp.armeria.client.manipulating;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+import java.util.function.Consumer;
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Manipulates some object(request) with a chain of operation.
+ */
+public class Manipulator<T> {
+
+    private List<Consumer<T>> operations;
+
+    /**
+     * constructor.
+     *
+     * @param operations A list of {@link Consumer} objects. Each consumer (operation)
+     *                   can update a request.
+     *
+     * @throws NullPointerException when operations are null.
+     */
+    public Manipulator(List<Consumer<T>> operations) {
+        requireNonNull(operations);
+        this.operations = operations;
+    }
+    
+    void manipulate(T target) {
+        operations.forEach(op -> op.accept(target));
+    }
+
+}

--- a/src/main/java/com/linecorp/armeria/client/manipulating/package-info.java
+++ b/src/main/java/com/linecorp/armeria/client/manipulating/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Manipulating decorators that manipulates request and response with sequential operations.
+ */
+package com.linecorp.armeria.client.manipulating;

--- a/src/test/java/com/linecorp/armeria/client/manipulating/HttpHeaderManipulatingClientBuilderTest.java
+++ b/src/test/java/com/linecorp/armeria/client/manipulating/HttpHeaderManipulatingClientBuilderTest.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.manipulating;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import com.linecorp.armeria.client.Client;
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.common.http.DefaultHttpRequest;
+import com.linecorp.armeria.common.http.HttpHeaders;
+import com.linecorp.armeria.common.http.HttpMethod;
+import com.linecorp.armeria.common.http.HttpRequest;
+
+import io.netty.util.AsciiString;
+
+
+public class HttpHeaderManipulatingClientBuilderTest {
+
+    @Test
+    public void testErrorOnNullOrEmptyHeader() {
+        HttpHeaderManipulatingClientBuilder builder = newBuilder();
+        boolean thrown = false;
+        try {
+            builder.add(null, "value");
+            fail("Exception not thrown on null header ");
+
+            builder.add(EMPTY_HEADER, "value");
+            fail("Exception not thrown on empty header");
+
+            builder.set(null, "value");
+            fail("Exception not thrown on null header");
+
+            builder.set(EMPTY_HEADER, "value");
+            fail("Exception not thrown on empty header");
+
+            builder.remove((AsciiString) null);
+            fail("Exception not thrown on null header");
+
+            builder.remove(EMPTY_HEADER);
+            fail("Exception not thrown on empty header");
+
+            builder.update(null);
+            fail("Exception not thrown on null updater");
+
+        } catch (Exception e) {
+            thrown = true;
+        }
+        assertEquals(true, thrown);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static final Client dummyDelegate = mock(Client.class);
+    private static final ClientRequestContext dummyContext = mock(ClientRequestContext.class);
+
+    @Test
+    public void testEmpty() throws Exception {
+        HttpRequest request = newRequest();
+        Client client = newBuilder().buildClient(dummyDelegate);
+        client.execute(dummyContext, request);
+        assertEquals(3, request.headers().size());
+    }
+
+    @Test
+    public void testAdd() throws Exception {
+        HttpRequest request = newRequest();
+        Client client = newBuilder()
+            .add(HEADER_1, "a1")
+            .add(HEADER_0, "a0")
+            .buildClient(dummyDelegate);
+
+        client.execute(dummyContext, request);
+        HttpHeaders headers = request.headers();
+        
+        List<String> value0 = headers.getAll(HEADER_0);
+        List<String> value1 = headers.getAll(HEADER_1);
+
+        assertEquals("[v0, a0]", value0.toString());
+        assertEquals("[a1]", value1.toString());
+    }
+
+    @Test
+    public void testSet() throws Exception {
+        HttpRequest request = newRequest();
+        Client client = newBuilder()
+                .add(HEADER_0, "a0").add(HEADER_0, "a00").add(HEADER_0, "a000")
+                .set(HEADER_0, "s0") // should replace all entries
+                .set(HEADER_1, "s1") // should set value of non-existing header
+                .set(HEADER_1, value -> value + "!!") // can read old value and change it
+                .set(HEADER_2, "s2")
+                .set(HEADER_2, value -> "") // should ignore empty value
+                .set(HEADER_2, value -> null) // should ignore null value
+                .set(HEADER_3, value -> value == null ? "s3" : "BUG!") // should be called with null
+                .buildClient(dummyDelegate);
+
+        client.execute(dummyContext, request);
+        HttpHeaders headers = request.headers();
+        
+        List<String> value0 = headers.getAll(HEADER_0);
+        List<String> value1 = headers.getAll(HEADER_1);
+        List<String> value2 = headers.getAll(HEADER_2);
+        List<String> value3 = headers.getAll(HEADER_3);
+
+        assertEquals("[s0]", value0.toString());
+        assertEquals("[s1!!]", value1.toString());
+        assertEquals("[s2]", value2.toString());
+        assertEquals("[s3]", value3.toString());
+    }
+
+    @Test
+    public void testRemove() throws Exception {
+        HttpRequest request = newRequest();
+        request.headers().add(HEADER_0, "a0")
+                         .set(HEADER_1, "v1")
+                         .set(X_HEADER_1, "x1")
+                         .set(X_HEADER_2, "x2")
+                         .set(X_HEADER_3, "x3");
+        
+        Client client = newBuilder()
+                .remove(HEADER_0) // should remove all entries
+                .remove((header, value) -> header.toString().startsWith("x-")) // conditional remove
+                .add(X_HEADER_3, "X3")
+                .buildClient(dummyDelegate);
+
+        client.execute(dummyContext, request);
+        HttpHeaders headers = request.headers();
+
+        assertEquals(null, headers.get(HEADER_0));
+        assertEquals("v1", headers.get(HEADER_1));
+        assertEquals(null, headers.get(X_HEADER_1));
+        assertEquals(null, headers.get(X_HEADER_2));
+        assertEquals("X3", headers.get(X_HEADER_3));
+    }
+
+    @Test
+    public void testUpdate() throws Exception {
+        HttpRequest request = newRequest();
+        request.headers()
+                .set(HEADER_1, "v1")
+                .set(HEADER_2, "v2")
+                .set(HEADER_3, "v3")
+                .set(X_HEADER_1, "x1")
+                .set(X_HEADER_2, "x2")
+                .set(X_HEADER_3, "x3");
+
+
+        Updater updater = new Updater("!!");
+        Client client = newBuilder()
+                                .update(updater::update)
+                                .buildClient(dummyDelegate);
+
+        client.execute(dummyContext, request);
+        HttpHeaders headers = request.headers();
+
+        assertEquals(null, headers.get(X_HEADER_1));
+        assertEquals(null, headers.get(X_HEADER_2));
+        assertEquals(null, headers.get(X_HEADER_3));
+        assertEquals("!!v0v1v2v3x1x2x3", headers.get(X_HEADER_0));
+    }
+
+    private static HttpRequest newRequest() {
+        final DefaultHttpRequest req = new DefaultHttpRequest(HttpMethod.POST, "/hello");
+        req.headers().set(HEADER_0, "v0");
+        req.close();
+        return req;
+    }
+
+    private static HttpHeaderManipulatingClientBuilder newBuilder() {
+        return new HttpHeaderManipulatingClientBuilder();
+    }
+
+    private static AsciiString EMPTY_HEADER = new AsciiString("");
+
+    private static AsciiString HEADER_0 = new AsciiString("h0");
+    private static AsciiString HEADER_1 = new AsciiString("h1");
+    private static AsciiString HEADER_2 = new AsciiString("h2");
+    private static AsciiString HEADER_3 = new AsciiString("h3");
+
+    private static AsciiString X_HEADER_0 = new AsciiString("x-h0");
+    private static AsciiString X_HEADER_1 = new AsciiString("x-h1");
+    private static AsciiString X_HEADER_2 = new AsciiString("x-h2");
+    private static AsciiString X_HEADER_3 = new AsciiString("x-h3");
+
+    private static class Updater {
+        private String seed;
+
+        Updater(String seed) {
+            this.seed = seed;
+        }
+
+        void update(HttpHeaders headers) {
+            StringBuilder sb = new StringBuilder(seed);
+            headers.forEach(entry -> {
+                if (!entry.getKey().startsWith(":")) {
+                    sb.append(entry.getValue());
+                }
+            });
+            headers.set(X_HEADER_0, sb.toString());
+            headers.remove(X_HEADER_1);
+            headers.remove(X_HEADER_2);
+            headers.remove(X_HEADER_3);
+        }
+    }
+
+}


### PR DESCRIPTION
Related: #275 #266

Motivation:
- If a user derives a client and wants to add some more headers than base client,  he  should create whole headers again to replace option.
- Need more flexible and easy way to add/set/remove http headers. 

Modifications:
- Add the new decorating client, HttpHeaderManipulatingClient,
- Add a builder (HttpHeaderManipulatingClientBuilder) to build the client  with simple methods similar with HttpHeaders.

Result:
- Using the new decorator, users can modify(add/set/remove header entry) http request headers without the HTTP_HEADERS option
