### PR TITLE
Fix DropwizardRequestMetrics leak

### DIFF
--- a/src/main/java/com/linecorp/armeria/internal/logging/DropwizardMetricConsumer.java
+++ b/src/main/java/com/linecorp/armeria/internal/logging/DropwizardMetricConsumer.java
@@ -40,7 +40,7 @@ public final class DropwizardMetricConsumer implements MessageLogConsumer {
 
     private final MetricRegistry metricRegistry;
     private final BiFunction<RequestContext, RequestLog, String> metricNameFunc;
-    private final Map<RequestLog, DropwizardRequestMetrics> methodRequestMetrics;
+    private final Map<String, DropwizardRequestMetrics> methodRequestMetrics;
 
     /**
      * Creates a new instance.
@@ -100,18 +100,16 @@ public final class DropwizardMetricConsumer implements MessageLogConsumer {
     }
 
     private DropwizardRequestMetrics getRequestMetrics(RequestContext ctx, RequestLog req) {
+        final String metricName = metricNameFunc.apply(ctx, req);
         return methodRequestMetrics.computeIfAbsent(
-                req,
-                reqLog -> {
-                    final String metricName = metricNameFunc.apply(ctx, reqLog);
-                    return new DropwizardRequestMetrics(
-                            metricName,
-                            metricRegistry.timer(MetricRegistry.name(metricName, "requests")),
-                            metricRegistry.meter(MetricRegistry.name(metricName, "successes")),
-                            metricRegistry.meter(MetricRegistry.name(metricName, "failures")),
-                            metricRegistry.counter(MetricRegistry.name(metricName, "activeRequests")),
-                            metricRegistry.meter(MetricRegistry.name(metricName, "requestBytes")),
-                            metricRegistry.meter(MetricRegistry.name(metricName, "responseBytes")));
-                });
+                metricName,
+                name -> new DropwizardRequestMetrics(
+                        name,
+                        metricRegistry.timer(MetricRegistry.name(name, "requests")),
+                        metricRegistry.meter(MetricRegistry.name(name, "successes")),
+                        metricRegistry.meter(MetricRegistry.name(name, "failures")),
+                        metricRegistry.counter(MetricRegistry.name(name, "activeRequests")),
+                        metricRegistry.meter(MetricRegistry.name(name, "requestBytes")),
+                        metricRegistry.meter(MetricRegistry.name(name, "responseBytes"))));
     }
 }

--- a/src/main/java/com/linecorp/armeria/internal/logging/DropwizardRequestMetrics.java
+++ b/src/main/java/com/linecorp/armeria/internal/logging/DropwizardRequestMetrics.java
@@ -48,10 +48,6 @@ final class DropwizardRequestMetrics {
         this.responseBytes = responseBytes;
     }
 
-    String name() {
-        return name;
-    }
-
     void updateTime(long durationNanos) {
         timer.update(durationNanos, TimeUnit.NANOSECONDS);
     }


### PR DESCRIPTION
Motivation:

Commit c2dad254f19f5b3eccec987efde850b34eac9e32 introduced a regression
where a new DropwizardRequestMetrics instance is created for every
request, because it used RequestLog as a key of the Map that holds
DropwizardRequestMetrics. As a result, the Map will grow infinitely.

Modifications:

- Use String as a key again

Result:

Leak is gone.