### PR TITLE
Add RAW_RPC_REQUEST and RAW_RPC_RESPONSE to RequestLog and ResponseLog

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -783,7 +783,10 @@
           </groups>
 
           <links>
-            <link>http://netty.io/4.1/api</link>
+            <link>https://netty.io/4.1/api</link>
+            <link>https://developers.google.com/protocol-buffers/docs/reference/java</link>
+            <link>https://people.apache.org/~thejas/thrift-0.9/javadoc/</link>
+            <link></link>
           </links>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -786,7 +786,6 @@
             <link>https://netty.io/4.1/api</link>
             <link>https://developers.google.com/protocol-buffers/docs/reference/java</link>
             <link>https://people.apache.org/~thejas/thrift-0.9/javadoc/</link>
-            <link></link>
           </links>
         </configuration>
       </plugin>

--- a/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
+++ b/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
@@ -18,13 +18,12 @@ package com.linecorp.armeria.common.logging;
 
 import static java.util.Objects.requireNonNull;
 
-import com.google.common.base.MoreObjects.ToStringHelper;
-
 import com.linecorp.armeria.common.Scheme;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.SessionProtocol;
 
 import io.netty.channel.Channel;
+import io.netty.util.Attribute;
 
 /**
  * Default {@link RequestLog} implementation.
@@ -95,12 +94,21 @@ public final class DefaultRequestLog
     }
 
     @Override
-    protected void append(ToStringHelper helper) {
-        helper.add("channel", channel)
-              .add("scheme", (serializationFormat != null ? serializationFormat.uriText() : null) + '+' +
-                             (sessionProtocol != null ? sessionProtocol.uriText() : null))
-              .add("host", host)
-              .add("method", method)
-              .add("path", path);
+    protected void appendProperties(StringBuilder buf) {
+        buf.append(", scheme=")
+           .append(serializationFormat != null ? serializationFormat.uriText() : null)
+           .append('+')
+           .append(sessionProtocol != null ? sessionProtocol.uriText() : null)
+           .append(", host=")
+           .append(host)
+           .append(", method=")
+           .append(method)
+           .append(", path=")
+           .append(path);
+    }
+
+    @Override
+    boolean includeAttr(Attribute<?> attr) {
+        return attr.key() != RAW_RPC_REQUEST;
     }
 }

--- a/src/main/java/com/linecorp/armeria/common/logging/DefaultResponseLog.java
+++ b/src/main/java/com/linecorp/armeria/common/logging/DefaultResponseLog.java
@@ -16,7 +16,7 @@
 
 package com.linecorp.armeria.common.logging;
 
-import com.google.common.base.MoreObjects.ToStringHelper;
+import io.netty.util.Attribute;
 
 /**
  * Default {@link ResponseLog} implementation.
@@ -61,8 +61,12 @@ public final class DefaultResponseLog
     }
 
     @Override
-    protected void append(ToStringHelper helper) {
-        helper.add("statusCode", statusCode);
+    protected void appendProperties(StringBuilder buf) {
+        buf.append(", statusCode=").append(statusCode);
     }
 
+    @Override
+    boolean includeAttr(Attribute<?> attr) {
+        return attr.key() != RAW_RPC_RESPONSE;
+    }
 }

--- a/src/main/java/com/linecorp/armeria/common/logging/RequestLog.java
+++ b/src/main/java/com/linecorp/armeria/common/logging/RequestLog.java
@@ -16,13 +16,18 @@
 
 package com.linecorp.armeria.common.logging;
 
+import com.google.protobuf.Message;
+import com.google.protobuf.MessageLite;
+
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.Scheme;
 import com.linecorp.armeria.common.http.HttpHeaders;
 import com.linecorp.armeria.common.http.HttpRequest;
+import com.linecorp.armeria.common.thrift.ApacheThriftCall;
 
 import io.netty.channel.Channel;
+import io.netty.util.Attribute;
 import io.netty.util.AttributeKey;
 
 /**
@@ -40,6 +45,16 @@ public interface RequestLog extends MessageLog {
      * The {@link AttributeKey} of the processed {@link RpcRequest}.
      */
     AttributeKey<RpcRequest> RPC_REQUEST = AttributeKey.valueOf(RequestLog.class, "RPC_REQUEST");
+
+    /**
+     * The {@link AttributeKey} of the processed {@link RpcRequest} in its protocol-dependent low-level form.
+     *
+     * <p>For a Thrift request, the value of this {@link Attribute} is an {@link ApacheThriftCall}.
+     *
+     * <p>For a Protocol Buffers request, the value of this {@link Attribute} is a {@link Message} or
+     * a {@link MessageLite}.
+     */
+    AttributeKey<Object> RAW_RPC_REQUEST = AttributeKey.valueOf(RequestLog.class, "RAW_RPC_REQUEST");
 
     /**
      * Returns the Netty {@link Channel} which handled the {@link Request}.

--- a/src/main/java/com/linecorp/armeria/common/logging/ResponseLog.java
+++ b/src/main/java/com/linecorp/armeria/common/logging/ResponseLog.java
@@ -16,13 +16,18 @@
 
 package com.linecorp.armeria.common.logging;
 
+import com.google.protobuf.Message;
+import com.google.protobuf.MessageLite;
+
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
 import com.linecorp.armeria.common.RpcResponse;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.http.HttpHeaders;
 import com.linecorp.armeria.common.http.HttpResponse;
+import com.linecorp.armeria.common.thrift.ApacheThriftReply;
 
+import io.netty.util.Attribute;
 import io.netty.util.AttributeKey;
 
 /**
@@ -40,6 +45,16 @@ public interface ResponseLog extends MessageLog {
      * The {@link AttributeKey} of the processed {@link RpcResponse}.
      */
     AttributeKey<RpcResponse> RPC_RESPONSE = AttributeKey.valueOf(RequestLog.class, "RPC_RESPONSE");
+
+    /**
+     * The {@link AttributeKey} of the processed {@link RpcResponse} in its protocol-dependent low-level form.
+     *
+     * <p>For a Thrift response, the value of this {@link Attribute} is an {@link ApacheThriftReply}.
+     *
+     * <p>For a Protocol Buffers request, the value of this {@link Attribute} is a {@link Message} or
+     * a {@link MessageLite}.
+     */
+    AttributeKey<Object> RAW_RPC_RESPONSE = AttributeKey.valueOf(ResponseLog.class, "RAW_RPC_RESPONSE");
 
     /**
      * Returns the {@link RequestLog} of the corresponding {@link Request}.

--- a/src/main/java/com/linecorp/armeria/common/logging/ResponseLog.java
+++ b/src/main/java/com/linecorp/armeria/common/logging/ResponseLog.java
@@ -39,12 +39,12 @@ public interface ResponseLog extends MessageLog {
     /**
      * The {@link AttributeKey} of the {@link HttpHeaders} of the processed {@link HttpResponse}.
      */
-    AttributeKey<HttpHeaders> HTTP_HEADERS = AttributeKey.valueOf(RequestLog.class, "HTTP_HEADERS");
+    AttributeKey<HttpHeaders> HTTP_HEADERS = AttributeKey.valueOf(ResponseLog.class, "HTTP_HEADERS");
 
     /**
      * The {@link AttributeKey} of the processed {@link RpcResponse}.
      */
-    AttributeKey<RpcResponse> RPC_RESPONSE = AttributeKey.valueOf(RequestLog.class, "RPC_RESPONSE");
+    AttributeKey<RpcResponse> RPC_RESPONSE = AttributeKey.valueOf(ResponseLog.class, "RPC_RESPONSE");
 
     /**
      * The {@link AttributeKey} of the processed {@link RpcResponse} in its protocol-dependent low-level form.

--- a/src/main/java/com/linecorp/armeria/common/thrift/ApacheThriftCall.java
+++ b/src/main/java/com/linecorp/armeria/common/thrift/ApacheThriftCall.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.thrift;
+
+import static java.util.Objects.requireNonNull;
+
+import org.apache.thrift.TBase;
+import org.apache.thrift.protocol.TMessage;
+import org.apache.thrift.protocol.TMessageType;
+
+import com.google.common.base.MoreObjects;
+
+import com.linecorp.armeria.common.logging.RequestLog;
+
+/**
+ * A container of a Thrift one-way or two-way call object ({@link TBase}) and its header ({@link TMessage}).
+ * It is exported to {@link RequestLog} as a {@link RequestLog#RAW_RPC_REQUEST} attribute when a Thrift call
+ * is processed.
+ */
+public final class ApacheThriftCall extends ApacheThriftMessage {
+
+    private final TBase<?, ?> args;
+
+    /**
+     * Creates a new instance that contains a Thrift {@link TMessageType#CALL} or {@link TMessageType#ONEWAY}
+     * message.
+     */
+    public ApacheThriftCall(TMessage header, TBase<?, ?> args) {
+        super(header);
+        if (header.type != TMessageType.CALL && header.type != TMessageType.ONEWAY) {
+            throw new IllegalArgumentException(
+                    "header.type: " + typeStr(header.type) + " (expected: CALL or ONEWAY)");
+        }
+
+        this.args = requireNonNull(args, "args");
+    }
+
+    /**
+     * Returns the arguments of this call.
+     */
+    public TBase<?, ?> args() {
+        return args;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        return super.equals(o) && args.equals(((ApacheThriftCall) o).args);
+    }
+
+    @Override
+    public int hashCode() {
+        return 31 * super.hashCode() + args.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("seqId", header().seqid)
+                          .add("type", typeStr())
+                          .add("name", header().name)
+                          .add("args", args).toString();
+    }
+}

--- a/src/main/java/com/linecorp/armeria/common/thrift/ApacheThriftMessage.java
+++ b/src/main/java/com/linecorp/armeria/common/thrift/ApacheThriftMessage.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.thrift;
+
+import static java.util.Objects.requireNonNull;
+
+import org.apache.thrift.protocol.TMessage;
+import org.apache.thrift.protocol.TMessageType;
+
+/**
+ * A container of a Thrift message produced by Apache Thrift.
+ */
+public abstract class ApacheThriftMessage {
+
+    private final TMessage header;
+
+    ApacheThriftMessage(TMessage header) {
+        this.header = requireNonNull(header, "header");
+    }
+
+    /**
+     * Returns the header part of the message.
+     */
+    public final TMessage header() {
+        return header;
+    }
+
+    @Override
+    public int hashCode() {
+        return header.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        return header.equals(((ApacheThriftMessage) o).header);
+    }
+
+    final String typeStr() {
+        return typeStr(header.type);
+    }
+
+    static String typeStr(byte type) {
+        switch (type) {
+            case TMessageType.CALL:
+                return "CALL";
+            case TMessageType.ONEWAY:
+                return "ONEWAY";
+            case TMessageType.REPLY:
+                return "REPLY";
+            case TMessageType.EXCEPTION:
+                return "EXCEPTION";
+            default:
+                return "UNKNOWN(" + (type & 0xFF) + ')';
+        }
+    }
+}

--- a/src/main/java/com/linecorp/armeria/common/thrift/ApacheThriftReply.java
+++ b/src/main/java/com/linecorp/armeria/common/thrift/ApacheThriftReply.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.thrift;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Objects;
+
+import org.apache.thrift.TApplicationException;
+import org.apache.thrift.TBase;
+import org.apache.thrift.protocol.TMessage;
+import org.apache.thrift.protocol.TMessageType;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.MoreObjects.ToStringHelper;
+
+import com.linecorp.armeria.common.logging.ResponseLog;
+
+/**
+ * A container of a Thrift reply or exception object ({@link TBase} or {@link TApplicationException}) and
+ * its header ({@link TMessage}). It is exported to {@link ResponseLog} as a
+ * {@link ResponseLog#RAW_RPC_RESPONSE} attribute when a Thrift call is processed.
+ */
+public final class ApacheThriftReply extends ApacheThriftMessage {
+
+    private final TBase<?, ?> result;
+    private final TApplicationException exception;
+
+    /**
+     * Creates a new instance that contains a Thrift {@link TMessageType#REPLY} message.
+     */
+    public ApacheThriftReply(TMessage header, TBase<?, ?> result) {
+        super(header);
+        if (header.type != TMessageType.REPLY) {
+            throw new IllegalArgumentException(
+                    "header.type: " + typeStr(header.type) + " (expected: REPLY)");
+        }
+
+        this.result = requireNonNull(result, "result");
+        exception = null;
+    }
+
+    /**
+     * Creates a new instance that contains a Thrift {@link TMessageType#EXCEPTION} message.
+     */
+    public ApacheThriftReply(TMessage header, TApplicationException exception) {
+        super(header);
+        if (header.type != TMessageType.EXCEPTION) {
+            throw new IllegalArgumentException(
+                    "header.type: " + typeStr(header.type) + " (expected: EXCEPTION)");
+        }
+
+        result = null;
+        this.exception = requireNonNull(exception, "exception");
+    }
+
+    /**
+     * Returns {@code true} if the type of this reply is {@link TMessageType#EXCEPTION}.
+     */
+    public boolean isException() {
+        return exception != null;
+    }
+
+    /**
+     * Returns the result of this reply.
+     *
+     * @throws IllegalStateException if the type of this reply is not {@link TMessageType#REPLY}
+     */
+    public TBase<?, ?> result() {
+        if (isException()) {
+            throw new IllegalStateException("not a reply but an exception");
+        }
+        return result;
+    }
+
+    /**
+     * Returns the exception of this reply.
+     *
+     * @throws IllegalStateException if the type of this reply is not {@link TMessageType#EXCEPTION}
+     */
+    public TApplicationException exception() {
+        if (!isException()) {
+            throw new IllegalStateException("not an exception but a reply");
+        }
+        return exception;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final ApacheThriftReply that = (ApacheThriftReply) o;
+        return super.equals(that) &&
+               Objects.equals(result, that.result) &&
+               Objects.equals(exception, that.exception);
+    }
+
+    @Override
+    public int hashCode() {
+        return (super.hashCode() * 31 + Objects.hashCode(result)) * 31 + Objects.hashCode(exception);
+    }
+
+    @Override
+    public String toString() {
+        final ToStringHelper helper = MoreObjects.toStringHelper(this)
+                                                 .add("seqId", header().seqid)
+                                                 .add("type", typeStr())
+                                                 .add("name", header().name);
+        if (result != null) {
+            helper.add("result", result);
+        } else {
+            helper.add("exception", exception);
+        }
+
+        return helper.toString();
+    }
+}

--- a/src/test/java/com/linecorp/armeria/server/thrift/AbstractThriftOverHttpTest.java
+++ b/src/test/java/com/linecorp/armeria/server/thrift/AbstractThriftOverHttpTest.java
@@ -15,27 +15,44 @@
  */
 package com.linecorp.armeria.server.thrift;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
+import org.apache.thrift.TApplicationException;
 import org.apache.thrift.TException;
 import org.apache.thrift.async.AsyncMethodCallback;
+import org.apache.thrift.protocol.TMessageType;
 import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.logging.MessageLogConsumer;
+import com.linecorp.armeria.common.logging.RequestLog;
+import com.linecorp.armeria.common.logging.ResponseLog;
+import com.linecorp.armeria.common.thrift.ApacheThriftCall;
+import com.linecorp.armeria.common.thrift.ApacheThriftReply;
+import com.linecorp.armeria.common.thrift.ThriftCall;
 import com.linecorp.armeria.common.thrift.ThriftProtocolFactories;
+import com.linecorp.armeria.common.thrift.ThriftReply;
+import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.Service;
+import com.linecorp.armeria.server.logging.LogCollectingService;
 import com.linecorp.armeria.server.logging.LoggingService;
 import com.linecorp.armeria.service.test.thrift.main.HelloService;
 import com.linecorp.armeria.service.test.thrift.main.HelloService.AsyncIface;
+import com.linecorp.armeria.service.test.thrift.main.OnewayHelloService;
 import com.linecorp.armeria.service.test.thrift.main.SleepService;
 
 import io.netty.handler.ssl.util.SelfSignedCertificate;
@@ -46,6 +63,10 @@ public abstract class AbstractThriftOverHttpTest {
 
     private static int httpPort;
     private static int httpsPort;
+
+    private static volatile boolean recordMessageLogs;
+    private static final BlockingQueue<RequestLog> requestLogs = new LinkedBlockingQueue<>();
+    private static final BlockingQueue<ResponseLog> responseLogs = new LinkedBlockingQueue<>();
 
     abstract static class HelloServiceBase implements AsyncIface {
         @Override
@@ -77,8 +98,16 @@ public abstract class AbstractThriftOverHttpTest {
             sb.sslContext(SessionProtocol.HTTPS, ssc.certificate(), ssc.privateKey());
 
             sb.serviceAt("/hello", THttpService.of(
+                    (AsyncIface) (name, resultHandler) -> resultHandler.onComplete("Hello, " + name + '!')));
+
+            sb.serviceAt("/hellochild", THttpService.of(new HelloServiceChild()));
+
+            sb.serviceAt("/oneway", THttpService.of(
+                    (OnewayHelloService.AsyncIface) (name, resultHandler) -> resultHandler.onComplete(null)));
+
+            sb.serviceAt("/exception", THttpService.of(
                     (AsyncIface) (name, resultHandler) ->
-                            resultHandler.onComplete("Hello, " + name + '!')).decorate(LoggingService::new));
+                            resultHandler.onError(Exceptions.clearTrace(new Exception(name)))));
 
             sb.serviceAt("/hellochild", THttpService.of(new HelloServiceChild()));
 
@@ -86,7 +115,29 @@ public abstract class AbstractThriftOverHttpTest {
                     (SleepService.AsyncIface) (milliseconds, resultHandler) ->
                             RequestContext.current().eventLoop().schedule(
                                     () -> resultHandler.onComplete(milliseconds),
-                                    milliseconds, TimeUnit.MILLISECONDS)).decorate(LoggingService::new));
+                                    milliseconds, TimeUnit.MILLISECONDS)));
+
+            sb.decorator(LoggingService::new);
+
+            final Function<Service<ThriftCall, ThriftReply>,
+                    LogCollectingService<ThriftCall, ThriftReply>> logCollectingDecorator =
+                    s -> new LogCollectingService<>(s, new MessageLogConsumer() {
+                        @Override
+                        public void onRequest(RequestContext ctx, RequestLog req) throws Exception {
+                            if (recordMessageLogs) {
+                                requestLogs.add(req);
+                            }
+                        }
+
+                        @Override
+                        public void onResponse(RequestContext ctx, ResponseLog res) throws Exception {
+                            if (recordMessageLogs) {
+                                responseLogs.add(res);
+                            }
+                        }
+                    });
+
+            sb.decorator(logCollectingDecorator);
         } catch (Exception e) {
             throw new Error(e);
         }
@@ -108,14 +159,21 @@ public abstract class AbstractThriftOverHttpTest {
         server.stop();
     }
 
+    @Before
+    public void beforeTest() {
+        recordMessageLogs = false;
+        requestLogs.clear();
+        responseLogs.clear();
+    }
+
     @Test
     public void testHttpInvocation() throws Exception {
         try (TTransport transport = newTransport("http", "/hello")) {
             HelloService.Client client =
                     new HelloService.Client.Factory().getClient(
                             ThriftProtocolFactories.BINARY.getProtocol(transport));
-            String res = client.hello("Trustin");
-            assertThat(res, is("Hello, Trustin!"));
+
+            assertThat(client.hello("Trustin")).isEqualTo("Hello, Trustin!");
         }
     }
 
@@ -125,8 +183,8 @@ public abstract class AbstractThriftOverHttpTest {
             HelloService.Client client =
                     new HelloService.Client.Factory().getClient(
                             ThriftProtocolFactories.BINARY.getProtocol(transport));
-            String res = client.hello("Trustin");
-            assertThat(res, is("Goodbye, Trustin!"));
+
+            assertThat(client.hello("Trustin")).isEqualTo("Goodbye, Trustin!");
         }
     }
 
@@ -136,9 +194,78 @@ public abstract class AbstractThriftOverHttpTest {
             HelloService.Client client =
                     new HelloService.Client.Factory().getClient(
                             ThriftProtocolFactories.BINARY.getProtocol(transport));
-            String res = client.hello("Trustin");
-            assertThat(res, is("Hello, Trustin!"));
+
+            assertThat(client.hello("Trustin")).isEqualTo("Hello, Trustin!");
         }
+    }
+
+    @Test(timeout = 10000)
+    public void testMessageLogsForCall() throws Exception {
+        try (TTransport transport = newTransport("http", "/hello")) {
+            HelloService.Client client =
+                    new HelloService.Client.Factory().getClient(
+                            ThriftProtocolFactories.BINARY.getProtocol(transport));
+            recordMessageLogs = true;
+            client.hello("Trustin");
+        }
+
+        final RequestLog req = requestLogs.take();
+        final ResponseLog res = responseLogs.take();
+
+        assertThat(req.hasAttr(RequestLog.HTTP_HEADERS)).isTrue();
+        assertThat(req.hasAttr(RequestLog.RPC_REQUEST)).isTrue();
+        assertThat(req.hasAttr(RequestLog.RAW_RPC_REQUEST)).isTrue();
+
+        final ApacheThriftCall rawRequest = (ApacheThriftCall) req.attr(RequestLog.RAW_RPC_REQUEST).get();
+        assertThat(rawRequest.header().type).isEqualTo(TMessageType.CALL);
+        assertThat(rawRequest.header().name).isEqualTo("hello");
+        assertThat(rawRequest.args()).isInstanceOf(HelloService.hello_args.class);
+        assertThat(((HelloService.hello_args) rawRequest.args()).getName()).isEqualTo("Trustin");
+
+        assertThat(res.hasAttr(ResponseLog.HTTP_HEADERS)).isTrue();
+        assertThat(res.hasAttr(ResponseLog.RPC_RESPONSE)).isTrue();
+        assertThat(res.hasAttr(ResponseLog.RAW_RPC_RESPONSE)).isTrue();
+
+        final ApacheThriftReply rawResponse = (ApacheThriftReply) res.attr(ResponseLog.RAW_RPC_RESPONSE).get();
+        assertThat(rawResponse.header().type).isEqualTo(TMessageType.REPLY);
+        assertThat(rawResponse.header().name).isEqualTo("hello");
+        assertThat(rawResponse.result()).isInstanceOf(HelloService.hello_result.class);
+        assertThat(((HelloService.hello_result) rawResponse.result()).getSuccess())
+                .isEqualTo("Hello, Trustin!");
+    }
+
+    @Test(timeout = 10000)
+    public void testMessageLogsForException() throws Exception {
+        try (TTransport transport = newTransport("http", "/exception")) {
+            HelloService.Client client =
+                    new HelloService.Client.Factory().getClient(
+                            ThriftProtocolFactories.BINARY.getProtocol(transport));
+            recordMessageLogs = true;
+            assertThatThrownBy(() -> client.hello("Trustin")).isInstanceOf(TApplicationException.class);
+        }
+
+        final RequestLog req = requestLogs.take();
+        final ResponseLog res = responseLogs.take();
+
+        assertThat(req.hasAttr(RequestLog.HTTP_HEADERS)).isTrue();
+        assertThat(req.hasAttr(RequestLog.RPC_REQUEST)).isTrue();
+        assertThat(req.hasAttr(RequestLog.RAW_RPC_REQUEST)).isTrue();
+
+        final ApacheThriftCall rawRequest = (ApacheThriftCall) req.attr(RequestLog.RAW_RPC_REQUEST).get();
+        assertThat(rawRequest.header().type).isEqualTo(TMessageType.CALL);
+        assertThat(rawRequest.header().name).isEqualTo("hello");
+        assertThat(rawRequest.args()).isInstanceOf(HelloService.hello_args.class);
+        assertThat(((HelloService.hello_args) rawRequest.args()).getName()).isEqualTo("Trustin");
+
+        assertThat(res.hasAttr(ResponseLog.HTTP_HEADERS)).isTrue();
+        assertThat(res.hasAttr(ResponseLog.RPC_RESPONSE)).isTrue();
+        assertThat(res.hasAttr(ResponseLog.RAW_RPC_RESPONSE)).isTrue();
+
+        final ApacheThriftReply rawResponse = (ApacheThriftReply) res.attr(ResponseLog.RAW_RPC_RESPONSE)
+                                                                     .get();
+        assertThat(rawResponse.header().type).isEqualTo(TMessageType.EXCEPTION);
+        assertThat(rawResponse.header().name).isEqualTo("hello");
+        assertThat(rawResponse.exception()).isNotNull();
     }
 
     protected final TTransport newTransport(String scheme, String path) throws TTransportException {

--- a/src/test/java/com/linecorp/armeria/server/thrift/AbstractThriftOverHttpTest.java
+++ b/src/test/java/com/linecorp/armeria/server/thrift/AbstractThriftOverHttpTest.java
@@ -102,9 +102,6 @@ public abstract class AbstractThriftOverHttpTest {
 
             sb.serviceAt("/hellochild", THttpService.of(new HelloServiceChild()));
 
-            sb.serviceAt("/oneway", THttpService.of(
-                    (OnewayHelloService.AsyncIface) (name, resultHandler) -> resultHandler.onComplete(null)));
-
             sb.serviceAt("/exception", THttpService.of(
                     (AsyncIface) (name, resultHandler) ->
                             resultHandler.onError(Exceptions.clearTrace(new Exception(name)))));

--- a/src/test/java/com/linecorp/armeria/server/thrift/AbstractThriftOverHttpTest.java
+++ b/src/test/java/com/linecorp/armeria/server/thrift/AbstractThriftOverHttpTest.java
@@ -52,7 +52,6 @@ import com.linecorp.armeria.server.logging.LogCollectingService;
 import com.linecorp.armeria.server.logging.LoggingService;
 import com.linecorp.armeria.service.test.thrift.main.HelloService;
 import com.linecorp.armeria.service.test.thrift.main.HelloService.AsyncIface;
-import com.linecorp.armeria.service.test.thrift.main.OnewayHelloService;
 import com.linecorp.armeria.service.test.thrift.main.SleepService;
 
 import io.netty.handler.ssl.util.SelfSignedCertificate;


### PR DESCRIPTION
Motivation:

There's currently no way to get the protocol-dependent RPC request and
response objects from RequestLog and ResponseLog.

Modifications:

- Add ApacheThriftCall and ApacheThriftReply
- Add RAW_RPC_REQUEST and RAW_RPC_RESPONSE attribute
- Set RAW_RPC_REQUEST and RAW_RPC_RESPONSE attribute where applicable
- Add test cases that ensures the required attributes are available in
  RequestLog and ResponseLog
- Improve MessageLog.toString()
  - Optimize using StringBuilder in lieu of MoreObjects.ToStringHelper
  - Exclude RAW_RPC_REQUEST and RAW_RPC_RESPONSE from the attributes
  - Exclude 'channel' property since it's often logged by service logger
  - Use simpler attribute names

Result:

- A user can access the low-level details about RPC calls.
- Log messages from LoggingClient/Service look better.
