### PR TITLE
Fix missing version information in user-agent header

### DIFF
--- a/src/main/java/com/linecorp/armeria/client/http/HttpHeaderUtil.java
+++ b/src/main/java/com/linecorp/armeria/client/http/HttpHeaderUtil.java
@@ -35,8 +35,10 @@ final class HttpHeaderUtil {
     }
 
     private static String createUserAgentName() {
-        Version version = Version.identify().get(CLIENT_ARTIFACT_ID);
-        return CLIENT_ARTIFACT_ID + '/' + (version != null ? version.artifactId() : "unknown");
+        final Version version = Version.identify(HttpHeaderUtil.class.getClassLoader())
+                                       .get(CLIENT_ARTIFACT_ID);
+
+        return CLIENT_ARTIFACT_ID + '/' + (version != null ? version.artifactVersion() : "unknown");
     }
 
     private HttpHeaderUtil() {}


### PR DESCRIPTION
Motivation:

HttpClient sends the 'user-agent' header with incorrect version
information. It's sending artifactId instead of artifactVersion.

Modifications:

- Use artifactVersion instead of artifactId
- Use correct class loader

Result:

The 'user-agent' header value includes the version information.