### PR TITLE
Fix ByteBuf leak in ArmeriaGrpcServerStream

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -295,6 +295,11 @@
       <version>${slf4j.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jul-to-slf4j</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
+    <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <version>${logback.version}</version>

--- a/src/test/java/com/linecorp/armeria/server/grpc/interop/ArmeriaGrpcServerInteropTest.java
+++ b/src/test/java/com/linecorp/armeria/server/grpc/interop/ArmeriaGrpcServerInteropTest.java
@@ -34,6 +34,7 @@ import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.slf4j.bridge.SLF4JBridgeHandler;
 
 import com.google.protobuf.ByteString;
 
@@ -69,6 +70,9 @@ public class ArmeriaGrpcServerInteropTest extends AbstractInteropTest {
     /** Starts the server with HTTPS. */
     @BeforeClass
     public static void startServer() {
+        SLF4JBridgeHandler.removeHandlersForRootLogger();
+        SLF4JBridgeHandler.install();
+
         try {
             SelfSignedCertificate ssc = new SelfSignedCertificate();
             ServerBuilder sb = new ServerBuilder()

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -16,6 +16,10 @@
   -->
 
 <configuration>
+  <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
+    <resetJUL>true</resetJUL>
+  </contextListener>
+
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>


### PR DESCRIPTION
Motivation:

- ArmeriaGrpcServerStream.writeFrame() does not release the ByteBuf,
  resulting a LEAK error from Netty.
- ArmeriaGrpcServerInteropTest logs its messages via JUL, which is not
  consistent.

Modifications:

- Release the ByteBuf in ArmeriaGrpcServerStream.writeFrame()
- Use SLF4J when running ArmeriaGrpcServerInteropTest

Result:

- ByteBuf leak is gone.
- No more log messages from java.util.logging