### PR TITLE
Fix DocService to handle oneway function properly

### DIFF
--- a/src/main/java/com/linecorp/armeria/server/docs/FunctionInfo.java
+++ b/src/main/java/com/linecorp/armeria/server/docs/FunctionInfo.java
@@ -105,7 +105,7 @@ final class FunctionInfo {
     private FunctionInfo(String namespace,
                          String name,
                          Class<? extends TBase<?, ?>> argsClass,
-                         Class<? extends TBase<?, ?>> resultClass,
+                         @Nullable Class<? extends TBase<?, ?>> resultClass,
                          Class<? extends TException>[] exceptionClasses,
                          String sampleJsonRequest,
                          Map<String, String> docStrings) {

--- a/src/main/java/com/linecorp/armeria/server/docs/FunctionInfo.java
+++ b/src/main/java/com/linecorp/armeria/server/docs/FunctionInfo.java
@@ -75,13 +75,20 @@ final class FunctionInfo {
             }
         }
 
+        Class<?> resultClass;
+        try {
+            resultClass =  Class.forName(serviceName + '$' + methodName + "_result", false, classLoader);
+        } catch (ClassNotFoundException ignored) {
+            // Oneway function does not have a result type.
+            resultClass = null;
+        }
+
         @SuppressWarnings("unchecked")
         final FunctionInfo function =
                 new FunctionInfo(namespace,
                                  methodName,
                                  argsClass,
-                                 (Class<? extends TBase<?, ?>>) Class.forName(
-                                         serviceName + '$' + methodName + "_result", false, classLoader),
+                                 (Class<? extends TBase<?, ?>>) resultClass,
                                  (Class<? extends TException>[]) method.getExceptionTypes(),
                                  sampleJsonRequest,
                                  docStrings);
@@ -107,7 +114,6 @@ final class FunctionInfo {
         final String functionNamespace = ThriftDocString.key(namespace, name);
         this.docString = docStrings.get(functionNamespace);
         requireNonNull(argsClass, "argsClass");
-        requireNonNull(resultClass, "resultClass");
         requireNonNull(exceptionClasses, "exceptionClasses");
 
         final Map<? extends TFieldIdEnum, FieldMetaData> argsMetaData =
@@ -117,13 +123,16 @@ final class FunctionInfo {
                             .map(fieldMetaData -> FieldInfo.of(fieldMetaData, functionNamespace, docStrings))
                             .collect(Collectors.toList()));
 
-        final Map<? extends TFieldIdEnum, FieldMetaData> resultMetaData =
-                FieldMetaData.getStructMetaDataMap(resultClass);
         FieldInfo fieldInfo = null;
-        for (FieldMetaData fieldMetaData : resultMetaData.values()) {
-            if ("success".equals(fieldMetaData.fieldName)) {
-                fieldInfo = FieldInfo.of(fieldMetaData, functionNamespace, docStrings);
-                break;
+        if (resultClass != null) { // Function isn't "oneway" function
+            final Map<? extends TFieldIdEnum, FieldMetaData> resultMetaData =
+                    FieldMetaData.getStructMetaDataMap(resultClass);
+
+            for (FieldMetaData fieldMetaData : resultMetaData.values()) {
+                if ("success".equals(fieldMetaData.fieldName)) {
+                    fieldInfo = FieldInfo.of(fieldMetaData, functionNamespace, docStrings);
+                    break;
+                }
             }
         }
         if (fieldInfo == null) {

--- a/src/main/resources/com/linecorp/armeria/server/docs/assets/js/armeria.js
+++ b/src/main/resources/com/linecorp/armeria/server/docs/assets/js/armeria.js
@@ -248,7 +248,8 @@ $(function () {
         headers: httpHeaders,
         contentType: TTEXT_MIME_TYPE,
         success: function (response) {
-          debugResponse.text(response);
+          var result = response.length > 0 ? response : "Oneway: OK";
+          debugResponse.text(result);
           hljs.highlightBlock(debugResponse.get(0));
 
           // Set the URL with request

--- a/src/main/resources/com/linecorp/armeria/server/docs/assets/js/armeria.js
+++ b/src/main/resources/com/linecorp/armeria/server/docs/assets/js/armeria.js
@@ -248,7 +248,7 @@ $(function () {
         headers: httpHeaders,
         contentType: TTEXT_MIME_TYPE,
         success: function (response) {
-          var result = response.length > 0 ? response : "Oneway: OK";
+          var result = response.length > 0 ? response : "Request sent to one-way function";
           debugResponse.text(result);
           hljs.highlightBlock(debugResponse.get(0));
 

--- a/src/test/java/com/linecorp/armeria/server/docs/DocServiceTest.java
+++ b/src/test/java/com/linecorp/armeria/server/docs/DocServiceTest.java
@@ -49,6 +49,7 @@ import com.linecorp.armeria.service.test.thrift.hbase.Hbase;
 import com.linecorp.armeria.service.test.thrift.main.FooService;
 import com.linecorp.armeria.service.test.thrift.main.HelloService;
 import com.linecorp.armeria.service.test.thrift.main.HelloService.hello_args;
+import com.linecorp.armeria.service.test.thrift.main.OnewayHelloService;
 import com.linecorp.armeria.service.test.thrift.main.SleepService;
 
 public class DocServiceTest extends AbstractServerTest {
@@ -76,12 +77,14 @@ public class DocServiceTest extends AbstractServerTest {
         final THttpService cassandraServiceDebug =
                 THttpService.ofFormats(mock(Cassandra.AsyncIface.class), THRIFT_TEXT);
         final THttpService hbaseService = THttpService.of(mock(Hbase.AsyncIface.class));
+        final THttpService onewayHelloService = THttpService.of(mock(OnewayHelloService.AsyncIface.class));
 
         sb.serviceAt("/", helloAndSleepService);
         sb.serviceAt("/foo", fooService);
         sb.serviceAt("/cassandra", cassandraService);
         sb.serviceAt("/cassandra/debug", cassandraServiceDebug);
         sb.serviceAt("/hbase", hbaseService);
+        sb.serviceAt("/oneway", onewayHelloService);
 
         sb.serviceUnder("/docs/",
                         new DocService(ImmutableList.of(SAMPLE_HELLO), SAMPLE_HTTP_HEADERS)
@@ -102,6 +105,8 @@ public class DocServiceTest extends AbstractServerTest {
                 EndpointInfo.of("*", "/cassandra/debug", "", THRIFT_TEXT, EnumSet.of(THRIFT_TEXT))));
         serviceMap.put(Hbase.class, Collections.singletonList(
                 EndpointInfo.of("*", "/hbase", "", THRIFT_BINARY, SerializationFormat.ofThrift())));
+        serviceMap.put(OnewayHelloService.class, Collections.singletonList(
+                EndpointInfo.of("*", "/oneway", "", THRIFT_BINARY, SerializationFormat.ofThrift())));
 
         final ObjectMapper mapper = new ObjectMapper();
         final String expectedJson = mapper.writeValueAsString(


### PR DESCRIPTION
Motivation:
- Let DocService to handle oneway function as well

Modifications:
- Fix DocService not to try finding _result class for DocService
- Display static text in the response field of DocService if the response is empty with successful HTTP code

Result:
- Users can test oneway function on DocService as well
