### PR TITLE
Cleanup a stream message after notifying subscribers of completion in…

### DIFF
--- a/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
+++ b/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
@@ -310,23 +310,25 @@ public class DefaultStreamMessage<T> implements StreamMessage<T>, StreamWriter<T
 
     private void notifySubscriberWithCloseEvent(Subscriber<Object> subscriber, CloseEvent o) {
         setState(State.CLEANUP);
-        cleanup();
-
-        final Throwable cause = o.cause();
-        if (cause == null) {
-            try {
-                subscriber.onComplete();
-            } finally {
-                closeFuture.complete(null);
-            }
-        } else {
-            try {
-                if (!o.isCancelled()) {
-                    subscriber.onError(cause);
+        try {
+            final Throwable cause = o.cause();
+            if (cause == null) {
+                try {
+                    subscriber.onComplete();
+                } finally {
+                    closeFuture.complete(null);
                 }
-            } finally {
-                closeFuture.completeExceptionally(cause);
+            } else {
+                try {
+                    if (!o.isCancelled()) {
+                        subscriber.onError(cause);
+                    }
+                } finally {
+                    closeFuture.completeExceptionally(cause);
+                }
             }
+        } finally {
+            cleanup();
         }
     }
 


### PR DESCRIPTION
…stead of before.

Previously, closeFuture would trigger before subscribers, meaning the connection may be closed before finishing the HTTP response. While I saw the bad behavior with nginx, I think it may be possible for any case where Keep-Alive isn't used.

Confirmed this fixes the buggy behavior I saw when using armeria with nginx. The solution seems a bit shady to me though, please check if this makes any sense at all.

Fixes #290 