### PR TITLE
Log socket traffic at TRACE level

### DIFF
--- a/src/main/java/com/linecorp/armeria/client/http/HttpClientPipelineConfigurator.java
+++ b/src/main/java/com/linecorp/armeria/client/http/HttpClientPipelineConfigurator.java
@@ -44,6 +44,7 @@ import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.common.util.NativeLibraries;
 import com.linecorp.armeria.internal.FlushConsolidationHandler;
 import com.linecorp.armeria.internal.ReadSuppressingHandler;
+import com.linecorp.armeria.internal.TrafficLoggingHandler;
 import com.linecorp.armeria.internal.http.Http1ClientCodec;
 import com.linecorp.armeria.internal.http.Http2GoAwayListener;
 
@@ -203,6 +204,7 @@ class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
         final ChannelPipeline p = ch.pipeline();
         final SslHandler sslHandler = sslCtx.newHandler(ch.alloc());
         p.addLast(sslHandler);
+        p.addLast(TrafficLoggingHandler.CLIENT);
         p.addLast(new ChannelInboundHandlerAdapter() {
             @Override
             public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
@@ -254,6 +256,7 @@ class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
     // refer https://http2.github.io/http2-spec/#discover-http
     private void configureAsHttp(Channel ch) {
         final ChannelPipeline pipeline = ch.pipeline();
+        pipeline.addLast(TrafficLoggingHandler.CLIENT);
 
         final boolean attemptUpgrade;
         switch (httpPreference) {

--- a/src/main/java/com/linecorp/armeria/internal/TrafficLoggingHandler.java
+++ b/src/main/java/com/linecorp/armeria/internal/TrafficLoggingHandler.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import io.netty.handler.logging.LogLevel;
+import io.netty.handler.logging.LoggingHandler;
+
+/**
+ * A Netty handler that logs the I/O traffic of a connection.
+ */
+public final class TrafficLoggingHandler extends LoggingHandler {
+
+    public static final TrafficLoggingHandler SERVER = new TrafficLoggingHandler(true);
+    public static final TrafficLoggingHandler CLIENT = new TrafficLoggingHandler(false);
+
+    private TrafficLoggingHandler(boolean server) {
+        super("com.linecorp.armeria.traffic." + (server ? "server" : "client"), LogLevel.TRACE);
+    }
+
+    @Override
+    public void channelRegistered(ChannelHandlerContext ctx) throws Exception {
+        ctx.fireChannelRegistered();
+    }
+
+    @Override
+    public void channelUnregistered(ChannelHandlerContext ctx) throws Exception {
+        ctx.fireChannelUnregistered();
+    }
+
+    @Override
+    public void flush(ChannelHandlerContext ctx) throws Exception {
+        ctx.flush();
+    }
+
+    @Override
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+        if (msg instanceof ByteBuf && !((ByteBuf) msg).isReadable()) {
+            ctx.write(msg, promise);
+        } else {
+            super.write(ctx, msg, promise);
+        }
+    }
+}

--- a/src/main/java/com/linecorp/armeria/server/http/HttpServerPipelineConfigurator.java
+++ b/src/main/java/com/linecorp/armeria/server/http/HttpServerPipelineConfigurator.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.internal.FlushConsolidationHandler;
 import com.linecorp.armeria.internal.ReadSuppressingHandler;
+import com.linecorp.armeria.internal.TrafficLoggingHandler;
 import com.linecorp.armeria.internal.http.Http2GoAwayListener;
 import com.linecorp.armeria.server.ServerConfig;
 import com.linecorp.armeria.server.ServerPort;
@@ -95,8 +96,10 @@ public final class HttpServerPipelineConfigurator extends ChannelInitializer<Cha
 
         if (port.protocol().isTls()) {
             p.addLast(new SniHandler(sslContexts));
+            p.addLast(TrafficLoggingHandler.SERVER);
             configureHttps(p);
         } else {
+            p.addLast(TrafficLoggingHandler.SERVER);
             configureHttp(p);
         }
     }


### PR DESCRIPTION
Motivation:

It is sometimes necessary to investigate protocol-level traffic to
figure out the root cause of the problem.

Modifications:

- Add a Netty handler 'TrafficLoggingHandler` which logs the traffic at
  TRACE level
  - Server-side traffic is logged at
    'com.linecorp.armeria.traffic.server'.
  - Client-side traffic is logged at
    'com.linecorp.armeria.traffic.client'.
  - Note that the TrafficLoggingHandler is always added to
    ChannelPipeline so that a user can turn the logging on or off at
    runtime.

Result:

A user can look into the socket traffic easily without modifying Armeria
source code and inserting Netty LoggingHandler. In Logback, a user can
add the following configuration to enable traffic logging:

    <logger name="com.linecorp.armeria.traffic" level="TRACE" />

To enable traffic logging for server or client side only:

    <logger name="com.linecorp.armeria.traffic.client" level="TRACE" />
    <!-- or -->
    <logger name="com.linecorp.armeria.traffic.server" level="TRACE" />