### PR TITLE
Fix NullPointerException from HttpServerHandler.CLOSE

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/http/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/HttpServerHandler.java
@@ -98,7 +98,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
         final Throwable cause = future.cause();
         final Channel ch = future.channel();
         if (cause != null) {
-            Exceptions.logIfUnexpected(logger, ch, HttpServer.get(ch).protocol(), cause);
+            logException(ch, cause);
         }
         safeClose(ch);
     };
@@ -107,10 +107,19 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
         final Throwable cause = future.cause();
         if (cause != null && !(cause instanceof ClosedPublisherException)) {
             final Channel ch = future.channel();
-            Exceptions.logIfUnexpected(logger, ch, HttpServer.get(ch).protocol(), cause);
+            logException(ch, cause);
             safeClose(ch);
         }
     };
+
+    private static void logException(Channel ch, Throwable cause) {
+        final HttpServer server = HttpServer.get(ch);
+        if (server != null) {
+            Exceptions.logIfUnexpected(logger, ch, server.protocol(), cause);
+        } else {
+            Exceptions.logIfUnexpected(logger, ch, cause);
+        }
+    }
 
     static void safeClose(Channel ch) {
         if (!ch.isActive()) {


### PR DESCRIPTION
Motivation:

HttpServerHandler.CLOSE attempts to get the current HttpServer instance
via HttpServer.get() when logging an exception. However, the
HttpServer.get() can return null, resulting in a NullPointerException,
when the connection is already cleaned up.

Modifications:

Handle the case where HttpServer.get() returns null.

Result:

One less NPE