### PR TITLE
Ensure RequestLog future is completed always before ResponseLog future

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -73,7 +73,7 @@ public final class DefaultClientRequestContext extends NonWrappingRequestContext
         this.fragment = requireNonNull(fragment, "fragment");
 
         requestLog = new DefaultRequestLog();
-        responseLog = new DefaultResponseLog(requestLog);
+        responseLog = new DefaultResponseLog(requestLog, requestLog);
 
         writeTimeoutMillis = options.defaultWriteTimeoutMillis();
         responseTimeoutMillis = options.defaultResponseTimeoutMillis();

--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
@@ -18,6 +18,8 @@ package com.linecorp.armeria.common.logging;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.concurrent.CompletableFuture;
+
 import com.linecorp.armeria.common.Scheme;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.SessionProtocol;
@@ -105,6 +107,11 @@ public final class DefaultRequestLog
            .append(method)
            .append(", path=")
            .append(path);
+    }
+
+    @Override
+    CompletableFuture<?> parentLogFuture() {
+        return null;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultResponseLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultResponseLog.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.common.logging;
 
+import java.util.concurrent.CompletableFuture;
+
 import io.netty.util.Attribute;
 
 /**
@@ -25,6 +27,7 @@ public final class DefaultResponseLog
         extends AbstractMessageLog<ResponseLog> implements ResponseLog, ResponseLogBuilder {
 
     private final RequestLog request;
+    private final CompletableFuture<?> requestLogFuture;
     private int statusCode;
 
     /**
@@ -32,8 +35,9 @@ public final class DefaultResponseLog
      *
      * @param request the {@link RequestLog} of the corresponding request
      */
-    public DefaultResponseLog(RequestLog request) {
+    public DefaultResponseLog(RequestLog request, CompletableFuture<?> requestLogFuture) {
         this.request = request;
+        this.requestLogFuture = requestLogFuture;
     }
 
     @Override
@@ -63,6 +67,11 @@ public final class DefaultResponseLog
     @Override
     protected void appendProperties(StringBuilder buf) {
         buf.append(", statusCode=").append(statusCode);
+    }
+
+    @Override
+    CompletableFuture<?> parentLogFuture() {
+        return requestLogFuture;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
@@ -84,7 +84,7 @@ public final class DefaultServiceRequestContext extends NonWrappingRequestContex
 
         requestLog = new DefaultRequestLog();
         requestLog.start(ch, sessionProtocol, cfg.virtualHost().defaultHostname(), method, path);
-        responseLog = new DefaultResponseLog(requestLog);
+        responseLog = new DefaultResponseLog(requestLog, requestLog);
         logger = newLogger(cfg);
 
         final ServerConfig serverCfg = cfg.server().config();

--- a/core/src/test/java/com/linecorp/armeria/server/thrift/ThriftServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/thrift/ThriftServiceTest.java
@@ -604,7 +604,7 @@ public class ThriftServiceTest {
 
         final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
         final DefaultRequestLog reqLogBuilder = new DefaultRequestLog();
-        final DefaultResponseLog resLogBuilder = new DefaultResponseLog(reqLogBuilder);
+        final DefaultResponseLog resLogBuilder = new DefaultResponseLog(reqLogBuilder, reqLogBuilder);
 
         when(ctx.blockingTaskExecutor()).thenReturn(ImmediateEventExecutor.INSTANCE);
         when(ctx.requestLogBuilder()).thenReturn(reqLogBuilder);


### PR DESCRIPTION
Motivation:

It is currently possible that the CompletableFuture of RequestLog is
complete before the CompletableFuture of ResponseLog is complete.
In such a case, a user can access the incomplete RequestLog via
ResponseLog.request().

Modifications:

- Complete the CompletableFuture of ResponseLog only after the
  CompletableFuture of RequestLog is complete.
- Miscellaneous:
  - Use CompletableFuture.whenComplete() instead of handle() when
    AbstractMessageLog adds a callback to the futures it is interested,
    because it is not supposed to consume the result but only to monitor

Result:

- A user cannot access the incomplete state of RequestLog via
  ResponseLog.request()