### PR TITLE
Clean up the build script

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -459,7 +459,9 @@ configure(javaProjects) {
             onlyIf { isPublishing() }
         }
     }
-    task install(dependsOn: publishToMavenLocal)
+    task install(dependsOn: publishToMavenLocal,
+                 group: 'Publishing',
+                 description: 'An alias of publishToMavenLocal')
 
     // Print only interesting test results and progress.
     test {
@@ -519,21 +521,31 @@ private def getRepoStatus() {
             repoStatus : 'unknown'
     ]
 
-    def gitLogOut = executeCommand('git', 'log', '-1', '--format=format:%h%x20%H%x20%cd', '--date=iso')
-    if (gitLogOut) {
-        logger.info("Latest commit: ${gitLogOut}")
-        def tokens = gitLogOut.tokenize(' ')
-        result.shortCommitHash = tokens[0]
-        result.longCommitHash = tokens[1]
-        result.commitDate = tokens[2..4].join(' ')
+    // Do not run 'git' if the project is not from a Git repository.
+    if (!rootProject.file("${rootProject.projectDir}/.git").isDirectory()) {
+        return result
     }
 
-    def gitStatusOut = executeCommand('git', 'status', '--porcelain')
-    if (!gitStatusOut.empty) {
-        result.repoStatus = 'dirty'
-        logger.info("Repository is dirty:${System.lineSeparator()}${gitStatusOut}")
-    } else {
-        result.repoStatus = 'clean'
+    // Retrieve the repository status from the Git repository.
+    try {
+        def gitLogOut = executeCommand('git', 'log', '-1', '--format=format:%h%x20%H%x20%cd', '--date=iso')
+        if (gitLogOut) {
+            logger.info("Latest commit: ${gitLogOut}")
+            def tokens = gitLogOut.tokenize(' ')
+            result.shortCommitHash = tokens[0]
+            result.longCommitHash = tokens[1]
+            result.commitDate = tokens[2..4].join(' ')
+        }
+
+        def gitStatusOut = executeCommand('git', 'status', '--porcelain')
+        if (!gitStatusOut.empty) {
+            result.repoStatus = 'dirty'
+            logger.info("Repository is dirty:${System.lineSeparator()}${gitStatusOut}")
+        } else {
+            result.repoStatus = 'clean'
+        }
+    } catch (e) {
+        logger.warn("Failed to retrieve the repository status:", e)
     }
 
     return result
@@ -544,7 +556,7 @@ private def generateVersionProperties(Project project) {
     def propsFile = project.file(
             "${project.buildDir}/resources/main/META-INF/${project.group}.versions.properties")
 
-    logger.info("Generating version properties for ${artifactId} ..")
+    logger.info("Generating versions.properties for ${artifactId} ..")
 
     def props = new Properties()
     rootProject.ext.repoStatus.each { k, v ->
@@ -553,29 +565,23 @@ private def generateVersionProperties(Project project) {
 
     project.mkdir(propsFile.parent)
     if (propsFile.exists()) {
-        logger.info("Updating ${propsFile} ..")
+        logger.debug("Updating ${propsFile} ..")
         props.load(propsFile.newDataInputStream())
     } else {
-        logger.info("Creating ${propsFile} ..")
+        logger.debug("Creating ${propsFile} ..")
         propsFile.createNewFile()
     }
 
     props.store(propsFile.newWriter(), null)
 }
 
-private String executeCommand(String[] command) {
-    def output = ''
-    try {
-        def proc = command.execute()
-        proc.waitFor()
-        if (!proc.exitValue()) {
-            output = proc.in.text
-        } else {
-            logger.warn("'${command}' exited with a non-zero exit code: ${proc.exitValue()}: ${proc.err.text}")
-        }
-    } catch (all) {
-        logger.warn("Could not run '${command}':", all)
+private static String executeCommand(String[] command) {
+    def proc = command.execute()
+    proc.waitFor()
+    if (proc.exitValue() != 0) {
+        throw new IOException(
+                "'${command}' exited with a non-zero exit code: ${proc.exitValue()}: ${proc.err.text}")
     }
 
-    return output
+    return proc.in.text
 }

--- a/site/build.gradle
+++ b/site/build.gradle
@@ -15,6 +15,7 @@ buildscript {
     }
 }
 
+apply plugin: 'base'
 apply plugin: 'kr.motd.sphinx'
 
 ext.copyrightFooter =
@@ -23,14 +24,15 @@ ext.copyrightFooter =
         'All rights reserved.'
 
 sphinx {
+    group = 'Documentation'
+    description = 'Generates the Sphinx web site.'
     sourceDirectory "${project.projectDir}/src/sphinx"
 }
 
-task clean << {
-    project.delete(project.buildDir)
-}
+task javadoc(type: Javadoc,
+             group: 'Documentation',
+             description: 'Generates Javadoc API documentation for the main source code.') {
 
-task apidocs(type: Javadoc) {
     destinationDir = project.file("${project.buildDir}/site/apidocs")
     javaProjects.each { source it.sourceSets.main.java.srcDirs }
     classpath = javaProjects.inject(project.files()) { result, project ->
@@ -72,28 +74,36 @@ task apidocs(type: Javadoc) {
     }
 }
 
-task xref << {
-    JXR jxr = new JXR ()
-    jxr.dest = "${project.buildDir}/site/xref"
-    jxr.inputEncoding = 'UTF-8'
-    jxr.outputEncoding = 'UTF-8'
-    jxr.log = new JxrLog(logger: logger)
+task xref(group: 'Documentation',
+          description: 'Generates the source cross-reference.') {
 
+    def outputDir = "${project.buildDir}/site/xref"
     def sourceDirs = javaProjects.inject([]) { srcDirs, project ->
         project.sourceSets.main.java.srcDirs.each { srcDirs << it.path }
         return srcDirs
     }
 
-    def title = "Armeria ${project.version} cross-reference"
-    jxr.xref(sourceDirs, 'templates', title, title, project.ext.copyrightFooter)
-    ant.copy(file: "${project.projectDir}/src/xref/stylesheet.css", todir: jxr.dest)
+    inputs.dir sourceDirs
+    outputs.dir outputDir
+
+    doLast {
+        JXR jxr = new JXR()
+        jxr.dest = outputDir
+        jxr.inputEncoding = 'UTF-8'
+        jxr.outputEncoding = 'UTF-8'
+        jxr.log = new JxrLog(logger: logger)
+
+        def title = "Armeria ${project.version} cross-reference"
+        jxr.xref(sourceDirs, 'templates', title, title, project.ext.copyrightFooter)
+        ant.copy(file: "${project.projectDir}/src/xref/stylesheet.css", todir: jxr.dest)
+    }
 }
 
 tasks.site {
+    group = 'Documentation'
+    description = 'Generates the project web site.'
     dependsOn xref
-    dependsOn apidocs
+    dependsOn javadoc
 }
 
-task build {
-    dependsOn site
-}
+tasks.build.dependsOn(tasks.site)


### PR DESCRIPTION
- Add groups and descriptions to commonly used tasks without
  description
- Do not run 'git' command more than once if the previous execution
  failed
- Apply the 'base' plugin to the 'site' project so that the common tasks
  such as 'clean' and 'build' are populated automatically
- Rename the 'apidocs' task to 'javadoc' to match the task names of Java
  projects