### PR TITLE
BugFix at HttpServerHandler, prohibited patterns

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/http/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/HttpServerHandler.java
@@ -89,8 +89,12 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
     private static final String ALLOWED_METHODS_STRING =
             ALLOWED_METHODS.stream().map(HttpMethod::name).collect(Collectors.joining(","));
 
+    /**
+     * According to rfc 3986 section 3.3, path can contain a colon. except that first segment.
+     * @See https://tools.ietf.org/html/rfc3986#section-3.3
+     */
     private static final Pattern PROHIBITED_PATH_PATTERN =
-            Pattern.compile("(?:[:<>|?*\\\\]|/\\.\\.|\\.\\.$|\\.\\./)");
+            Pattern.compile("^[/][^/]*[:][^/]*[/]|[|<>*\\\\]|/\\.\\.|\\.\\.$|\\.\\./");
 
     private static final Pattern CONSECUTIVE_SLASHES_PATTERN = Pattern.compile("/{2,}");
 


### PR DESCRIPTION
According to rfc 3986 section 3.3, path can contain a colon. except
first segment.
check this link.
https://tools.ietf.org/html/rfc3986#section-3.3

1. add validation for first path of segment
2. remove unnecessary grouping of regexp
3. remove unnecessary pattern 
    - '?' : already removed at Strip the query string step