### PR TITLE
Add Logback integration which exports context properties to MDC

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -157,6 +157,7 @@ configure(javaProjects) {
             // Netty
             dependencySet(group: 'io.netty', version: ext.versionOf('netty')) {
                 entry 'netty-transport'
+                entry 'netty-handler'
                 entry 'netty-codec-http2'
                 entry 'netty-resolver-dns'
             }
@@ -275,6 +276,10 @@ configure(javaProjects) {
         configProperties = [ 'checkstyleConfigDir': "$checkstyleConfigDir" ]
         toolVersion = '7.1'
     }
+    task checkstyle(group: 'Verification',
+                    description: 'Runs the checkstyle rules.')
+    tasks.checkstyle.dependsOn 'checkstyleMain'
+    tasks.checkstyle.dependsOn 'checkstyleTest'
 
     // Enable full exception logging for test failures.
     test {

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -38,8 +38,7 @@ import io.netty.channel.EventLoop;
 /**
  * Default {@link ClientRequestContext} implementation.
  */
-public final class DefaultClientRequestContext extends NonWrappingRequestContext
-        implements ClientRequestContext {
+public class DefaultClientRequestContext extends NonWrappingRequestContext implements ClientRequestContext {
 
     private final EventLoop eventLoop;
     private final ClientOptions options;
@@ -87,6 +86,11 @@ public final class DefaultClientRequestContext extends NonWrappingRequestContext
                 attr(HTTP_HEADERS).set(headersCopy);
             }
         }
+    }
+
+    @Override
+    protected Channel channel() {
+        return requestLog.channel();
     }
 
     @Override
@@ -187,7 +191,7 @@ public final class DefaultClientRequestContext extends NonWrappingRequestContext
         final StringBuilder buf = new StringBuilder(96);
 
         // Prepend the current channel information if available.
-        final Channel ch = requestLog.channel();
+        final Channel ch = channel();
         final boolean hasChannel = ch != null;
         if (hasChannel) {
             buf.append(ch);

--- a/core/src/main/java/com/linecorp/armeria/common/RequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestContext.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.common;
 
+import java.net.SocketAddress;
 import java.util.Iterator;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
@@ -24,6 +25,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
+import javax.net.ssl.SSLSession;
 
 import org.slf4j.LoggerFactory;
 
@@ -160,6 +162,25 @@ public interface RequestContext extends AttributeMap {
      * Returns the {@link SessionProtocol} of the current {@link Request}.
      */
     SessionProtocol sessionProtocol();
+
+    /**
+     * Returns the remote address of this request, or {@code null} if the connection is not established yet.
+     */
+    @Nullable
+    <A extends SocketAddress> A remoteAddress();
+
+    /**
+     * Returns the local address of this request, or {@code null} if the connection is not established yet.
+     */
+    @Nullable
+    <A extends SocketAddress> A localAddress();
+
+    /**
+     * The {@link SSLSession} for this request if the connection is made over TLS, or {@code null} if
+     * the connection is not established yet or the connection is not a TLS connection.
+     */
+    @Nullable
+    SSLSession sslSession();
 
     /**
      * Returns the session-layer method name of the current {@link Request}. e.g. "GET" or "POST" for HTTP

--- a/core/src/main/java/com/linecorp/armeria/common/RequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestContextWrapper.java
@@ -18,8 +18,12 @@ package com.linecorp.armeria.common;
 
 import static java.util.Objects.requireNonNull;
 
+import java.net.SocketAddress;
 import java.util.Iterator;
 import java.util.concurrent.CompletableFuture;
+
+import javax.annotation.Nullable;
+import javax.net.ssl.SSLSession;
 
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.logging.RequestLogBuilder;
@@ -56,6 +60,24 @@ public abstract class RequestContextWrapper<T extends RequestContext> extends Ab
     @Override
     public SessionProtocol sessionProtocol() {
         return delegate().sessionProtocol();
+    }
+
+    @Nullable
+    @Override
+    public <A extends SocketAddress> A remoteAddress() {
+        return delegate().remoteAddress();
+    }
+
+    @Nullable
+    @Override
+    public <A extends SocketAddress> A localAddress() {
+        return delegate().localAddress();
+    }
+
+    @Nullable
+    @Override
+    public SSLSession sslSession() {
+        return delegate().sslSession();
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/logging/MessageLogConsumerInvoker.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/MessageLogConsumerInvoker.java
@@ -20,6 +20,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.common.RequestContext.PushHandle;
 
 /**
  * Utility methods that invokes the callback methods of {@link MessageLogConsumer} safely.
@@ -34,7 +35,7 @@ public final class MessageLogConsumerInvoker {
      * Invokes {@link MessageLogConsumer#onRequest(RequestContext, RequestLog)}.
      */
     public static void invokeOnRequest(MessageLogConsumer consumer, RequestContext ctx, RequestLog req) {
-        try {
+        try (PushHandle ignored = RequestContext.push(ctx)) {
             consumer.onRequest(ctx, req);
         } catch (Throwable e) {
             logger.warn("onRequest() failed with an exception: {}", e);
@@ -45,7 +46,7 @@ public final class MessageLogConsumerInvoker {
      * Invokes {@link MessageLogConsumer#onResponse(RequestContext, ResponseLog)}.
      */
     public static void invokeOnResponse(MessageLogConsumer consumer, RequestContext ctx, ResponseLog res) {
-        try {
+        try (PushHandle ignored = RequestContext.push(ctx)) {
             consumer.onResponse(ctx, res);
         } catch (Throwable e) {
             logger.warn("onResponse() failed with an exception: {}", e);

--- a/core/src/main/java/com/linecorp/armeria/server/AbstractVirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AbstractVirtualHostBuilder.java
@@ -219,12 +219,10 @@ abstract class AbstractVirtualHostBuilder<B extends AbstractVirtualHostBuilder> 
     }
 
     /**
-     * Binds the specified {@link Service} at the specified {@link PathMapping}.
-     *
-     * @param loggerName the name of the {@linkplain ServiceRequestContext#logger() service logger};
-     *                   must be a string of valid Java identifier names concatenated by period ({@code '.'}),
-     *                   such as a package name or a fully-qualified class name
+     * @deprecated Use a logging framework integration such as {@code RequestContextExportingAppender} in
+     *             {@code armeria-logback}.
      */
+    @Deprecated
     public B service(PathMapping pathMapping, Service<?, ?> service, String loggerName) {
         services.add(new ServiceConfig(pathMapping, service, loggerName));
         return self();

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
@@ -19,7 +19,6 @@ package com.linecorp.armeria.server;
 import static java.util.Objects.requireNonNull;
 
 import java.net.InetSocketAddress;
-import java.net.SocketAddress;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
@@ -45,8 +44,7 @@ import io.netty.channel.EventLoop;
 /**
  * Default {@link ServiceRequestContext} implementation.
  */
-public final class DefaultServiceRequestContext extends NonWrappingRequestContext
-        implements ServiceRequestContext {
+public class DefaultServiceRequestContext extends NonWrappingRequestContext implements ServiceRequestContext {
 
     private final Channel ch;
     private final ServiceConfig cfg;
@@ -103,6 +101,11 @@ public final class DefaultServiceRequestContext extends NonWrappingRequestContex
     }
 
     @Override
+    protected Channel channel() {
+        return ch;
+    }
+
+    @Override
     public Server server() {
         return cfg.server();
     }
@@ -125,18 +128,6 @@ public final class DefaultServiceRequestContext extends NonWrappingRequestContex
     @Override
     public ExecutorService blockingTaskExecutor() {
         return server().config().blockingTaskExecutor();
-    }
-
-    @Override
-    @SuppressWarnings("unchecked")
-    public <A extends SocketAddress> A remoteAddress() {
-        return (A) ch.remoteAddress();
-    }
-
-    @Override
-    @SuppressWarnings("unchecked")
-    public <A extends SocketAddress> A localAddress() {
-        return (A) ch.localAddress();
     }
 
     @Override
@@ -223,7 +214,7 @@ public final class DefaultServiceRequestContext extends NonWrappingRequestContex
         final StringBuilder buf = new StringBuilder(96);
 
         // Prepend the current channel information if available.
-        final Channel ch = requestLog.channel();
+        final Channel ch = channel();
         final boolean hasChannel = ch != null;
         if (hasChannel) {
             buf.append(ch);

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -391,16 +391,10 @@ public final class ServerBuilder {
     }
 
     /**
-     * Binds the specified {@link Service} at the specified {@link PathMapping} of the default
-     * {@link VirtualHost}.
-     *
-     * @param loggerName the name of the {@linkplain ServiceRequestContext#logger() service logger};
-     *                   must be a string of valid Java identifier names concatenated by period ({@code '.'}),
-     *                   such as a package name or a fully-qualified class name
-     *
-     * @throws IllegalStateException if the default {@link VirtualHost} has been set via
-     *                               {@link #defaultVirtualHost(VirtualHost)} already
+     * @deprecated Use a logging framework integration such as {@code RequestContextExportingAppender} in
+     *             {@code armeria-logback}.
      */
+    @Deprecated
     public ServerBuilder service(PathMapping pathMapping, Service<?, ?> service, String loggerName) {
         defaultVirtualHostBuilderUpdated();
         defaultVirtualHostBuilder.service(pathMapping, service, loggerName);

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceConfig.java
@@ -115,10 +115,10 @@ public final class ServiceConfig {
     }
 
     /**
-     * Returns the preferred name of the {@link ServiceRequestContext#logger() service logger}.
-     *
-     *
+     * @deprecated Use a logging framework integration such as {@code RequestContextExportingAppender} in
+     *             {@code armeria-logback}.
      */
+    @Deprecated
     public Optional<String> loggerName() {
         return Optional.ofNullable(loggerName);
     }

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
@@ -16,12 +16,8 @@
 
 package com.linecorp.armeria.server;
 
-import java.net.SocketAddress;
 import java.time.Duration;
 import java.util.concurrent.ExecutorService;
-
-import javax.annotation.Nullable;
-import javax.net.ssl.SSLSession;
 
 import org.slf4j.Logger;
 
@@ -64,16 +60,6 @@ public interface ServiceRequestContext extends RequestContext {
     ExecutorService blockingTaskExecutor();
 
     /**
-     * Returns the remote address of this invocation.
-     */
-    <A extends SocketAddress> A remoteAddress();
-
-    /**
-     * Returns the local address of this invocation.
-     */
-    <A extends SocketAddress> A localAddress();
-
-    /**
      * Returns the path with its context path removed. This method can be useful for a reusable service bound
      * at various path prefixes. For client side invocations, this method always returns the same value as
      * {@link #path()}.
@@ -81,19 +67,11 @@ public interface ServiceRequestContext extends RequestContext {
     String mappedPath();
 
     /**
-     * Returns the {@link Logger}  which logs information about this invocation as the prefix of log messages.
-     * e.g. If a user called {@code ctx.logger().info("Hello")},
-     * <pre>{@code
-     * [id: 0x270781f4, /127.0.0.1:63466 => /127.0.0.1:63432][tbinary+h2c://example.com/path#method][42] Hello
-     * }</pre>
+     * @deprecated Use a logging framework integration such as {@code RequestContextExportingAppender} in
+     *             {@code armeria-logback}.
      */
+    @Deprecated
     Logger logger();
-
-    /**
-     * The {@link SSLSession} for this request if the connection is made over TLS, or null otherwise.
-     */
-    @Nullable
-    SSLSession sslSession();
 
     /**
      * Returns the amount of time allowed until receiving the current {@link Request} completely.

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
@@ -16,12 +16,8 @@
 
 package com.linecorp.armeria.server;
 
-import java.net.SocketAddress;
 import java.time.Duration;
 import java.util.concurrent.ExecutorService;
-
-import javax.annotation.Nullable;
-import javax.net.ssl.SSLSession;
 
 import org.slf4j.Logger;
 
@@ -66,16 +62,6 @@ public class ServiceRequestContextWrapper
     }
 
     @Override
-    public <A extends SocketAddress> A remoteAddress() {
-        return delegate().remoteAddress();
-    }
-
-    @Override
-    public <A extends SocketAddress> A localAddress() {
-        return delegate().localAddress();
-    }
-
-    @Override
     public String mappedPath() {
         return delegate().mappedPath();
     }
@@ -83,12 +69,6 @@ public class ServiceRequestContextWrapper
     @Override
     public Logger logger() {
         return delegate().logger();
-    }
-
-    @Nullable
-    @Override
-    public SSLSession sslSession() {
-        return delegate().sslSession();
     }
 
     @Override

--- a/core/src/test/java/com/linecorp/armeria/common/RequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/RequestContextTest.java
@@ -256,6 +256,11 @@ public class RequestContextTest {
         }
 
         @Override
+        protected Channel channel() {
+            return channel;
+        }
+
+        @Override
         public RequestLogBuilder requestLogBuilder() {
             throw new UnsupportedOperationException();
         }

--- a/core/src/test/java/com/linecorp/armeria/internal/logging/DropwizardMetricConsumerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/logging/DropwizardMetricConsumerTest.java
@@ -37,6 +37,7 @@ import com.linecorp.armeria.common.logging.RequestLogBuilder;
 import com.linecorp.armeria.common.logging.ResponseLog;
 import com.linecorp.armeria.common.logging.ResponseLogBuilder;
 
+import io.netty.channel.Channel;
 import io.netty.channel.EventLoop;
 
 public class DropwizardMetricConsumerTest {
@@ -84,6 +85,11 @@ public class DropwizardMetricConsumerTest {
         @Override
         public EventLoop eventLoop() {
             throw new UnsupportedOperationException();
+        }
+
+        @Override
+        protected Channel channel() {
+            return null;
         }
 
         @Override

--- a/logback/build.gradle
+++ b/logback/build.gradle
@@ -1,0 +1,6 @@
+dependencies {
+    compile project(':core')
+
+    // Logback
+    compile 'ch.qos.logback:logback-classic'
+}

--- a/logback/src/main/java/com/linecorp/armeria/common/logback/BuiltInProperties.java
+++ b/logback/src/main/java/com/linecorp/armeria/common/logback/BuiltInProperties.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common.logback;
+
+import static com.linecorp.armeria.common.logback.BuiltInProperty.LOCAL_HOST;
+import static com.linecorp.armeria.common.logback.BuiltInProperty.LOCAL_IP;
+import static com.linecorp.armeria.common.logback.BuiltInProperty.LOCAL_PORT;
+import static com.linecorp.armeria.common.logback.BuiltInProperty.REMOTE_HOST;
+import static com.linecorp.armeria.common.logback.BuiltInProperty.REMOTE_IP;
+import static com.linecorp.armeria.common.logback.BuiltInProperty.REMOTE_PORT;
+import static com.linecorp.armeria.common.logback.BuiltInProperty.REQ_RPC_METHOD;
+import static com.linecorp.armeria.common.logback.BuiltInProperty.REQ_RPC_PARAMS;
+import static com.linecorp.armeria.common.logback.BuiltInProperty.RES_RPC_RESULT;
+import static com.linecorp.armeria.common.logback.BuiltInProperty.TLS_CIPHER;
+import static com.linecorp.armeria.common.logback.BuiltInProperty.TLS_PROTO;
+import static com.linecorp.armeria.common.logback.BuiltInProperty.TLS_SESSION_ID;
+
+final class BuiltInProperties {
+
+    private static final BuiltInProperty[] allValues = BuiltInProperty.values();
+
+    private static final long MASK_ADDRESSES =
+            mask(REMOTE_HOST, REMOTE_IP, REMOTE_PORT, LOCAL_HOST, LOCAL_IP, LOCAL_PORT);
+    private static final long MASK_RPC = mask(REQ_RPC_METHOD, REQ_RPC_PARAMS, RES_RPC_RESULT);
+    private static final long MASK_SSL = mask(TLS_SESSION_ID, TLS_CIPHER, TLS_PROTO);
+
+    private long elements;
+
+    void add(BuiltInProperty e) {
+        elements |= 1L << e.ordinal();
+    }
+
+    boolean contains(BuiltInProperty e) {
+        return (elements & mask(e)) != 0;
+    }
+
+    boolean containsAddresses() {
+        return (elements & MASK_ADDRESSES) != 0;
+    }
+
+    boolean containsRpc() {
+        return (elements & MASK_RPC) != 0;
+    }
+
+    boolean containsSsl() {
+        return (elements & MASK_SSL) != 0;
+    }
+
+    private static long mask(BuiltInProperty e) {
+        return 1L << e.ordinal();
+    }
+
+    private static long mask(BuiltInProperty... elems) {
+        long mask = 0L;
+        for (BuiltInProperty e : elems) {
+            mask |= mask(e);
+        }
+        return mask;
+    }
+}

--- a/logback/src/main/java/com/linecorp/armeria/common/logback/BuiltInProperty.java
+++ b/logback/src/main/java/com/linecorp/armeria/common/logback/BuiltInProperty.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common.logback;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.net.ssl.SSLSession;
+
+import com.google.common.collect.ImmutableMap;
+
+import com.linecorp.armeria.common.Scheme;
+
+/**
+ * A built-in property exported by {@link RequestContextExportingAppender}.
+ *
+ * @see RequestContextExportingAppender#addBuiltIn(BuiltInProperty)
+ */
+public enum BuiltInProperty {
+    /**
+     * {@code "remote.host"} - the host name part of the remote socket address. Unavailable if the connection
+     * is not established yet.
+     */
+    REMOTE_HOST("remote.host"),
+    /**
+     * {@code "remote.ip"} - the IP address part of the remote socket address. Unavailable if the connection
+     * is not established yet.
+     */
+    REMOTE_IP("remote.ip"),
+    /**
+     * {@code "remote.port"} - the port number part of the remote socket address. Unavailable if the connection
+     * is not established yet.
+     */
+    REMOTE_PORT("remote.port"),
+    /**
+     * {@code "local.host"} - the host name part of the local socket address. Unavailable if the connection
+     * is not established yet.
+     */
+    LOCAL_HOST("local.host"),
+    /**
+     * {@code "local.ip"} - the IP address part of the local socket address. Unavailable if the connection
+     * is not established yet.
+     */
+    LOCAL_IP("local.ip"),
+    /**
+     * {@code "local.port"} - the port number part of the local socket address. Unavailable if the connection
+     * is not established yet.
+     */
+    LOCAL_PORT("local.port"),
+    /**
+     * {@code "scheme"} - the scheme of the request, represented by {@link Scheme#uriText()}.
+     * e.g. {@code "tbinary+h2"}
+     */
+    SCHEME("scheme"),
+    /**
+     * {@code "elapsed_nanos"} - the amount of time in nanoseconds taken to handle the request. Unavailable if
+     * the request was not handled completely yet.
+     */
+    ELAPSED_NANOS("elapsed_nanos"),
+    /**
+     * {@code "req.direction"} - the direction of the request, which is {@code "INBOUND"} for servers and
+     *  {@code "OUTBOUND"} for clients.
+     */
+    REQ_DIRECTION("req.direction"),
+    /**
+     * {@code "req.authority"} - the authority of the request, represented as {@code "<hostname>[:<port>]"}.
+     * The port number is omitted when it is same with the default port number of the current {@link Scheme}.
+     */
+    REQ_AUTHORITY("req.authority"),
+    /**
+     * {@code "req.path"} - the path of the request.
+     */
+    REQ_PATH("req.path"),
+    /**
+     * {@code "req.method"} - the method name of the request. e.g. {@code "GET"} and {@code "POST"}
+     */
+    REQ_METHOD("req.method"),
+    /**
+     * {@code "req.rpc_method"} - the RPC method name of the request. Unavailable if the current request is not
+     * an RPC request or is not decoded yet.
+     */
+    REQ_RPC_METHOD("req.rpc_method"),
+    /**
+     * {@code "req.rpc_params"} - the RPC parameter list, represented by {@link Arrays#toString(Object...)}.
+     * Unavailable if the current request is not an RPC request or is not decoded yet.
+     */
+    REQ_RPC_PARAMS("req.rpc_params"),
+    /**
+     * {@code "req.content_length"} - the byte-length of the request content. Unavailable if the current
+     * request is not fully received yet.
+     */
+    REQ_CONTENT_LENGTH("req.content_length"),
+    /**
+     * {@code "res.status_code"} - the protocol-specific integer representation of the response status code.
+     * Unavailable if the current response is not fully sent yet.
+     */
+    RES_STATUS_CODE("res.status_code"),
+    /**
+     * {@code "res.rpc_result"} - the RPC result value of the response. Unavailable if the current response
+     * is not fully sent yet.
+     */
+    RES_RPC_RESULT("res.rpc_result"),
+    /**
+     * {@code "res.content_length"} - the byte-length of the response content. Unavailable if the current
+     * response is not fully sent yet.
+     */
+    RES_CONTENT_LENGTH("res.content_length"),
+    /**
+     * {@code "tls.session_id"} - the hexadecimal representation of the current
+     * {@linkplain SSLSession#getId() TLS session ID}. Unavailable if TLS handshake is not finished or
+     * the connection is not a TLS connection.
+     */
+    TLS_SESSION_ID("tls.session_id"),
+    /**
+     * {@code "tls.cipher"} - the current {@linkplain SSLSession#getCipherSuite() TLS cipher suite}.
+     * Unavailable if TLS handshake is not finished or the connection is not a TLS connection.
+     * e.g. {@code "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384"}
+     */
+    TLS_CIPHER("tls.cipher"),
+    /**
+     * {@code "tls.proto"} - the current {@linkplain SSLSession#getProtocol()} TLS protocol}.
+     * Unavailable if TLS handshake is not finished or the connection is not a TLS connection.
+     * e.g. {@code "TLSv1.2"}
+     */
+    TLS_PROTO("tls.proto");
+
+    private static final Map<String, BuiltInProperty> mdcKeyToEnum;
+
+    static {
+        ImmutableMap.Builder<String, BuiltInProperty> builder = ImmutableMap.builder();
+        for (BuiltInProperty k : BuiltInProperty.values()) {
+            builder.put(k.mdcKey, k);
+        }
+        mdcKeyToEnum = builder.build();
+    }
+
+    static Optional<BuiltInProperty> findByMdcKey(String mdcKey) {
+        return Optional.ofNullable(mdcKeyToEnum.get(mdcKey));
+    }
+
+    final String mdcKey;
+
+    BuiltInProperty(String mdcKey) {
+        this.mdcKey = mdcKey;
+    }
+}

--- a/logback/src/main/java/com/linecorp/armeria/common/logback/RequestContextExporter.java
+++ b/logback/src/main/java/com/linecorp/armeria/common/logback/RequestContextExporter.java
@@ -1,0 +1,451 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.logback;
+
+import static com.linecorp.armeria.common.logback.BuiltInProperty.ELAPSED_NANOS;
+import static com.linecorp.armeria.common.logback.BuiltInProperty.LOCAL_HOST;
+import static com.linecorp.armeria.common.logback.BuiltInProperty.LOCAL_IP;
+import static com.linecorp.armeria.common.logback.BuiltInProperty.LOCAL_PORT;
+import static com.linecorp.armeria.common.logback.BuiltInProperty.REMOTE_HOST;
+import static com.linecorp.armeria.common.logback.BuiltInProperty.REMOTE_IP;
+import static com.linecorp.armeria.common.logback.BuiltInProperty.REMOTE_PORT;
+import static com.linecorp.armeria.common.logback.BuiltInProperty.REQ_AUTHORITY;
+import static com.linecorp.armeria.common.logback.BuiltInProperty.REQ_CONTENT_LENGTH;
+import static com.linecorp.armeria.common.logback.BuiltInProperty.REQ_DIRECTION;
+import static com.linecorp.armeria.common.logback.BuiltInProperty.REQ_METHOD;
+import static com.linecorp.armeria.common.logback.BuiltInProperty.REQ_PATH;
+import static com.linecorp.armeria.common.logback.BuiltInProperty.REQ_RPC_METHOD;
+import static com.linecorp.armeria.common.logback.BuiltInProperty.REQ_RPC_PARAMS;
+import static com.linecorp.armeria.common.logback.BuiltInProperty.RES_CONTENT_LENGTH;
+import static com.linecorp.armeria.common.logback.BuiltInProperty.RES_RPC_RESULT;
+import static com.linecorp.armeria.common.logback.BuiltInProperty.RES_STATUS_CODE;
+import static com.linecorp.armeria.common.logback.BuiltInProperty.SCHEME;
+import static com.linecorp.armeria.common.logback.BuiltInProperty.TLS_CIPHER;
+import static com.linecorp.armeria.common.logback.BuiltInProperty.TLS_PROTO;
+import static com.linecorp.armeria.common.logback.BuiltInProperty.TLS_SESSION_ID;
+
+import java.net.InetSocketAddress;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.annotation.Nullable;
+import javax.net.ssl.SSLSession;
+
+import com.google.common.io.BaseEncoding;
+
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.common.Request;
+import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.common.RpcRequest;
+import com.linecorp.armeria.common.RpcResponse;
+import com.linecorp.armeria.common.http.HttpHeaders;
+import com.linecorp.armeria.common.http.HttpRequest;
+import com.linecorp.armeria.common.logging.RequestLog;
+import com.linecorp.armeria.common.logging.ResponseLog;
+import com.linecorp.armeria.server.ServiceRequestContext;
+
+import io.netty.channel.Channel;
+import io.netty.util.AsciiString;
+import io.netty.util.AttributeKey;
+
+final class RequestContextExporter {
+
+    private static final Pattern PORT_443 = Pattern.compile(":0*443$");
+    private static final Pattern PORT_80 = Pattern.compile(":0*80$");
+
+    private static final BaseEncoding lowerCasedBase16 = BaseEncoding.base16().lowerCase();
+
+    private final BuiltInProperties builtIns;
+    private final ExportEntry<AttributeKey<?>>[] attrs;
+    private final ExportEntry<AsciiString>[] httpReqHeaders;
+    private final ExportEntry<AsciiString>[] httpResHeaders;
+
+    @SuppressWarnings("unchecked")
+    RequestContextExporter(Set<BuiltInProperty> builtIns,
+                           Set<ExportEntry<AttributeKey<?>>> attrs,
+                           Set<ExportEntry<AsciiString>> httpReqHeaders,
+                           Set<ExportEntry<AsciiString>> httpResHeaders) {
+
+        this.builtIns = new BuiltInProperties();
+        builtIns.forEach(this.builtIns::add);
+
+        if (!attrs.isEmpty()) {
+            this.attrs = attrs.toArray(new ExportEntry[attrs.size()]);
+        } else {
+            this.attrs = null;
+        }
+
+        if (!httpReqHeaders.isEmpty()) {
+            this.httpReqHeaders = httpReqHeaders.toArray(new ExportEntry[httpReqHeaders.size()]);
+        } else {
+            this.httpReqHeaders = null;
+        }
+
+        if (!httpResHeaders.isEmpty()) {
+            this.httpResHeaders = httpResHeaders.toArray(new ExportEntry[httpResHeaders.size()]);
+        } else {
+            this.httpResHeaders = null;
+        }
+    }
+
+    void export(Map<String, String> out, RequestContext ctx,
+                @Nullable RequestLog req, @Nullable ResponseLog res) {
+
+        // Built-ins
+        if (builtIns.containsAddresses()) {
+            exportAddresses(out, ctx);
+        }
+        if (builtIns.contains(SCHEME)) {
+            exportScheme(out, ctx, req);
+        }
+        if (builtIns.contains(REQ_DIRECTION)) {
+            exportDirection(out, ctx);
+        }
+        if (builtIns.contains(REQ_AUTHORITY)) {
+            exportAuthority(out, ctx, req);
+        }
+        if (builtIns.contains(REQ_PATH)) {
+            exportPath(out, ctx);
+        }
+        if (builtIns.contains(REQ_METHOD)) {
+            exportMethod(out, ctx);
+        }
+        if (builtIns.contains(REQ_CONTENT_LENGTH)) {
+            exportRequestContentLength(out, req);
+        }
+        if (builtIns.contains(RES_STATUS_CODE)) {
+            exportStatusCode(out, res);
+        }
+        if (builtIns.contains(RES_CONTENT_LENGTH)) {
+            exportResponseContentLength(out, res);
+        }
+        if (builtIns.contains(ELAPSED_NANOS)) {
+            exportElapsedNanos(out, req, res);
+        }
+
+        // SSL
+        if (builtIns.containsSsl()) {
+            exportTlsProperties(out, ctx);
+        }
+
+        // RPC
+        if (builtIns.containsRpc()) {
+            exportRpcRequest(out, req);
+            exportRpcResponse(out, res);
+        }
+
+        // Attributes
+        if (attrs != null) {
+            exportAttributes(out, ctx);
+        }
+
+        // HTTP headers
+        if (httpReqHeaders != null) {
+            exportHttpRequestHeaders(out, ctx, req);
+        }
+        if (httpResHeaders != null) {
+            exportHttpResponseHeaders(out, ctx, res);
+        }
+    }
+
+    private void exportAddresses(Map<String, String> out, RequestContext ctx) {
+        final InetSocketAddress raddr = ctx.remoteAddress();
+        final InetSocketAddress laddr = ctx.localAddress();
+
+        if (raddr != null) {
+            if (builtIns.contains(REMOTE_HOST)) {
+                out.put(REMOTE_HOST.mdcKey, raddr.getHostString());
+            }
+            if (builtIns.contains(REMOTE_IP)) {
+                out.put(REMOTE_IP.mdcKey, raddr.getAddress().getHostAddress());
+            }
+            if (builtIns.contains(REMOTE_PORT)) {
+                out.put(REMOTE_PORT.mdcKey, String.valueOf(raddr.getPort()));
+            }
+        }
+
+        if (laddr != null) {
+            if (builtIns.contains(LOCAL_HOST)) {
+                out.put(LOCAL_HOST.mdcKey, laddr.getHostString());
+            }
+            if (builtIns.contains(LOCAL_IP)) {
+                out.put(LOCAL_IP.mdcKey, laddr.getAddress().getHostAddress());
+            }
+            if (builtIns.contains(LOCAL_PORT)) {
+                out.put(LOCAL_PORT.mdcKey, String.valueOf(laddr.getPort()));
+            }
+        }
+    }
+
+    private static void exportScheme(Map<String, String> out, RequestContext ctx, @Nullable RequestLog req) {
+        if (req != null) {
+            out.put(SCHEME.mdcKey, req.scheme().uriText());
+        } else {
+            out.put(SCHEME.mdcKey, "unknown+" + ctx.sessionProtocol().uriText());
+        }
+    }
+
+    private static void exportDirection(Map<String, String> out, RequestContext ctx) {
+        final String d;
+        if (ctx instanceof ServiceRequestContext) {
+            d = "INBOUND";
+        } else if (ctx instanceof ClientRequestContext) {
+            d = "OUTBOUND";
+        } else {
+            d = "UNKNOWN";
+        }
+        out.put(REQ_DIRECTION.mdcKey, d);
+    }
+
+    private static void exportAuthority(Map<String, String> out, RequestContext ctx, @Nullable RequestLog req) {
+        if (req != null) {
+            String authority = req.host();
+            if (authority != null) {
+                final Channel ch = req.channel();
+                final InetSocketAddress addr = (InetSocketAddress)
+                        (ctx instanceof ServiceRequestContext ? ch.localAddress() : ch.remoteAddress());
+                final int port = addr.getPort();
+
+                if (ctx.sessionProtocol().defaultPort() != port) {
+                    authority = authority + ':' + port;
+                }
+                out.put(REQ_AUTHORITY.mdcKey, authority);
+                return;
+            }
+        }
+
+        final Request origReq = ctx.request();
+        if (origReq instanceof HttpRequest) {
+            String authority = ((HttpRequest) origReq).authority();
+            if (authority != null) {
+                final Pattern portPattern = ctx.sessionProtocol().isTls() ? PORT_443 : PORT_80;
+                final Matcher m = portPattern.matcher(authority);
+                if (m.find()) {
+                    authority = authority.substring(0, m.start());
+                }
+                out.put(REQ_AUTHORITY.mdcKey, authority);
+                return;
+            }
+        }
+
+        final String authority;
+        if (ctx instanceof ServiceRequestContext) {
+            final ServiceRequestContext sCtx = (ServiceRequestContext) ctx;
+            final int port = ((InetSocketAddress) sCtx.remoteAddress()).getPort();
+            final String hostname = sCtx.virtualHost().defaultHostname();
+            if (port == ctx.sessionProtocol().defaultPort()) {
+                authority = hostname;
+            } else {
+                authority = hostname + ':' + port;
+            }
+        } else {
+            final ClientRequestContext cCtx = (ClientRequestContext) ctx;
+            final Endpoint endpoint = cCtx.endpoint();
+            if (endpoint.isGroup()) {
+                authority = endpoint.authority();
+            } else {
+                final int defaultPort = cCtx.sessionProtocol().defaultPort();
+                final int port = endpoint.port(defaultPort);
+                if (port == defaultPort) {
+                    authority = endpoint.host();
+                } else {
+                    authority = endpoint.host() + ':' + port;
+                }
+            }
+        }
+
+        out.put(REQ_AUTHORITY.mdcKey, authority);
+    }
+
+    private static void exportPath(Map<String, String> out, RequestContext ctx) {
+        out.put(REQ_PATH.mdcKey, ctx.path());
+    }
+
+    private static void exportMethod(Map<String, String> out, RequestContext ctx) {
+        out.put(REQ_METHOD.mdcKey, ctx.method());
+    }
+
+    private static void exportRequestContentLength(Map<String, String> out, @Nullable RequestLog req) {
+        if (req != null) {
+            out.put(REQ_CONTENT_LENGTH.mdcKey, String.valueOf(req.contentLength()));
+        }
+    }
+
+    private static void exportStatusCode(Map<String, String> out, @Nullable ResponseLog res) {
+        if (res != null) {
+            out.put(RES_STATUS_CODE.mdcKey, String.valueOf(res.statusCode()));
+        }
+    }
+
+    private static void exportResponseContentLength(Map<String, String> out, @Nullable ResponseLog res) {
+        if (res != null) {
+            out.put(RES_CONTENT_LENGTH.mdcKey, String.valueOf(res.contentLength()));
+        }
+    }
+
+    private static void exportElapsedNanos(Map<String, String> out, @Nullable RequestLog req,
+                                           @Nullable ResponseLog res) {
+        if (req != null && res != null) {
+            out.put(ELAPSED_NANOS.mdcKey, String.valueOf(res.endTimeNanos() - req.startTimeNanos()));
+        }
+    }
+
+    private void exportTlsProperties(Map<String, String> out, RequestContext ctx) {
+        final SSLSession s = ctx.sslSession();
+        if (s != null) {
+            if (builtIns.contains(TLS_SESSION_ID)) {
+                final byte[] id = s.getId();
+                if (id != null) {
+                    out.put(TLS_SESSION_ID.mdcKey, lowerCasedBase16.encode(id));
+                }
+            }
+            if (builtIns.contains(TLS_CIPHER)) {
+                final String cs = s.getCipherSuite();
+                if (cs != null) {
+                    out.put(TLS_CIPHER.mdcKey, cs);
+                }
+            }
+            if (builtIns.contains(TLS_PROTO)) {
+                final String p = s.getProtocol();
+                if (p != null) {
+                    out.put(TLS_PROTO.mdcKey, p);
+                }
+            }
+        }
+    }
+
+    private void exportRpcRequest(Map<String, String> out, @Nullable RequestLog req) {
+        if (req != null && req.hasAttr(RequestLog.RPC_REQUEST)) {
+            RpcRequest rpcReq = req.attr(RequestLog.RPC_REQUEST).get();
+            if (builtIns.contains(REQ_RPC_METHOD)) {
+                out.put(REQ_RPC_METHOD.mdcKey, rpcReq.method());
+            }
+            if (builtIns.contains(REQ_RPC_PARAMS)) {
+                out.put(REQ_RPC_PARAMS.mdcKey, String.valueOf(rpcReq.params()));
+            }
+        }
+    }
+
+    private void exportRpcResponse(Map<String, String> out, @Nullable ResponseLog res) {
+        if (res != null && res.hasAttr(ResponseLog.RPC_RESPONSE)) {
+            final RpcResponse rpcRes = res.attr(ResponseLog.RPC_RESPONSE).get();
+            if (builtIns.contains(RES_RPC_RESULT)) {
+                out.put(RES_RPC_RESULT.mdcKey, String.valueOf(rpcRes.toCompletableFuture().getNow(null)));
+            }
+        }
+    }
+
+    private void exportAttributes(Map<String, String> out, RequestContext ctx) {
+        for (ExportEntry<AttributeKey<?>> e : attrs) {
+            final AttributeKey<?> attrKey = e.key;
+            final String mdcKey = e.mdcKey;
+            if (ctx.hasAttr(attrKey)) {
+                final Object value = ctx.attr(attrKey).get();
+                if (value != null) {
+                    out.put(mdcKey, e.stringify(value));
+                }
+            }
+        }
+    }
+
+    private void exportHttpRequestHeaders(Map<String, String> out, RequestContext ctx, RequestLog req) {
+        final HttpHeaders headers;
+        if (req != null && req.hasAttr(RequestLog.HTTP_HEADERS)) {
+            headers = req.attr(RequestLog.HTTP_HEADERS).get();
+        } else if (ctx.request() instanceof HttpRequest) {
+            headers = ((HttpRequest) ctx.request()).headers();
+        } else {
+            return;
+        }
+
+        exportHttpHeaders(out, headers, httpReqHeaders);
+    }
+
+    private void exportHttpResponseHeaders(Map<String, String> out, RequestContext ctx, ResponseLog res) {
+        final HttpHeaders headers;
+        if (res != null && res.hasAttr(ResponseLog.HTTP_HEADERS)) {
+            headers = res.attr(ResponseLog.HTTP_HEADERS).get();
+        } else if (ctx.request() instanceof HttpRequest) {
+            headers = ((HttpRequest) ctx.request()).headers();
+        } else {
+            return;
+        }
+
+        exportHttpHeaders(out, headers, httpResHeaders);
+    }
+
+    private static void exportHttpHeaders(Map<String, String> out, HttpHeaders headers,
+                                          ExportEntry<AsciiString>[] requiredHeaderNames) {
+        for (ExportEntry<AsciiString> e : requiredHeaderNames) {
+            final String value = headers.get(e.key);
+            final String mdcKey = e.mdcKey;
+            if (value != null) {
+                out.put(mdcKey, e.stringify(value));
+            }
+        }
+    }
+
+    static final class ExportEntry<T> {
+        final T key;
+        final String mdcKey;
+        final Function<Object, String> stringifier;
+
+        @SuppressWarnings("unchecked")
+        ExportEntry(T key, String mdcKey, Function<?, ?> stringifier) {
+            assert key != null;
+            assert mdcKey != null;
+            this.key = key;
+            this.mdcKey = mdcKey;
+            this.stringifier = (Function<Object, String>) stringifier;
+        }
+
+        String stringify(Object value) {
+            if (stringifier == null) {
+                return value != null ? value.toString() : null;
+            } else {
+                return stringifier.apply(value);
+            }
+        }
+
+        @Override
+        public int hashCode() {
+            return key.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            return key.equals(((ExportEntry<?>) o).key);
+        }
+
+        @Override
+        public String toString() {
+            return mdcKey + ':' + key;
+        }
+    }
+}

--- a/logback/src/main/java/com/linecorp/armeria/common/logback/RequestContextExporterBuilder.java
+++ b/logback/src/main/java/com/linecorp/armeria/common/logback/RequestContextExporterBuilder.java
@@ -1,0 +1,163 @@
+package com.linecorp.armeria.common.logback;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import com.linecorp.armeria.common.http.HttpHeaderNames;
+import com.linecorp.armeria.common.logback.RequestContextExporter.ExportEntry;
+
+import io.netty.util.AsciiString;
+import io.netty.util.AttributeKey;
+
+final class RequestContextExporterBuilder {
+
+    private static final String PREFIX_ATTRS = "attrs.";
+    private static final String PREFIX_HTTP_REQ_HEADERS = "req.http_headers.";
+    private static final String PREFIX_HTTP_RES_HEADERS = "res.http_headers.";
+
+    private final Set<BuiltInProperty> builtIns = EnumSet.noneOf(BuiltInProperty.class);
+    private final Set<ExportEntry<AttributeKey<?>>> attrs = new HashSet<>();
+    private final Set<ExportEntry<AsciiString>> httpReqHeaders = new HashSet<>();
+    private final Set<ExportEntry<AsciiString>> httpResHeaders = new HashSet<>();
+
+    void addBuiltIn(BuiltInProperty property) {
+        builtIns.add(requireNonNull(property, "property"));
+    }
+
+    boolean containsBuiltIn(BuiltInProperty property) {
+        return builtIns.contains(requireNonNull(property, "property"));
+    }
+
+    Set<BuiltInProperty> getBuiltIns() {
+        return Collections.unmodifiableSet(builtIns);
+    }
+
+    void addAttribute(String alias, AttributeKey<?> attrKey) {
+        requireNonNull(alias, "alias");
+        requireNonNull(attrKey, "attrKey");
+        attrs.add(new ExportEntry<>(attrKey, PREFIX_ATTRS + alias, null));
+    }
+
+    void addAttribute(String alias, AttributeKey<?> attrKey, Function<?, String> stringifier) {
+        requireNonNull(alias, "alias");
+        requireNonNull(attrKey, "attrKey");
+        requireNonNull(stringifier, "stringifier");
+        attrs.add(new ExportEntry<>(attrKey, PREFIX_ATTRS + alias, stringifier));
+    }
+
+    boolean containsAttribute(AttributeKey<?> key) {
+        requireNonNull(key, "key");
+        return attrs.stream().anyMatch(e -> e.key.equals(key));
+    }
+
+    Map<String, AttributeKey<?>> getAttributes() {
+        return Collections.unmodifiableMap(attrs.stream().collect(
+                Collectors.toMap(e -> e.mdcKey.substring(PREFIX_ATTRS.length()), e -> e.key)));
+    }
+
+    void addHttpRequestHeader(CharSequence name) {
+        addHttpHeader(PREFIX_HTTP_REQ_HEADERS, httpReqHeaders, name);
+    }
+
+    void addHttpResponseHeader(CharSequence name) {
+        addHttpHeader(PREFIX_HTTP_RES_HEADERS, httpResHeaders, name);
+    }
+
+    private static void addHttpHeader(
+            String mdcKeyPrefix, Set<ExportEntry<AsciiString>> httpHeaders, CharSequence name) {
+        final AsciiString key = toHeaderName(name);
+        final String value = mdcKeyPrefix + key;
+        httpHeaders.add(new ExportEntry<>(key, value, null));
+    }
+
+    boolean containsHttpRequestHeader(CharSequence name) {
+        return httpReqHeaders.stream().anyMatch(e -> e.key.contentEqualsIgnoreCase(name));
+    }
+
+    boolean containsHttpResponseHeader(CharSequence name) {
+        return httpResHeaders.stream().anyMatch(e -> e.key.contentEqualsIgnoreCase(name));
+    }
+
+    private static AsciiString toHeaderName(CharSequence name) {
+        return HttpHeaderNames.of(requireNonNull(name, "name").toString());
+    }
+
+    Set<AsciiString> getHttpRequestHeaders() {
+        return Collections.unmodifiableSet(
+                httpReqHeaders.stream().map(e -> e.key).collect(Collectors.toSet()));
+    }
+
+    Set<AsciiString> getHttpResponseHeaders() {
+        return Collections.unmodifiableSet(
+                httpResHeaders.stream().map(e -> e.key).collect(Collectors.toSet()));
+    }
+
+    void export(String mdcKey) {
+        requireNonNull(mdcKey, "mdcKey");
+
+        final Optional<BuiltInProperty> opt = BuiltInProperty.findByMdcKey(mdcKey);
+        if (opt.isPresent()) {
+            builtIns.add(opt.get());
+            return;
+        }
+
+        if (mdcKey.startsWith(PREFIX_ATTRS)) {
+            final String[] components = mdcKey.split(":");
+            switch (components.length) {
+                case 2:
+                    addAttribute(components[0].substring(PREFIX_ATTRS.length()),
+                                 AttributeKey.valueOf(components[1]));
+                    break;
+                case 3:
+                    final Function<?, String> stringifier = newStringifier(mdcKey, components[2]);
+
+                    addAttribute(components[0].substring(PREFIX_ATTRS.length()),
+                                 AttributeKey.valueOf(components[1]),
+                                 stringifier);
+                    break;
+                default:
+                    throw new IllegalArgumentException(
+                            "invalid attribute export: " + mdcKey +
+                            " (expected: attrs.<alias>:<AttributeKey.name>[:<FQCN of Function<?, String>>])");
+            }
+            return;
+        }
+
+        if (mdcKey.startsWith(PREFIX_HTTP_REQ_HEADERS)) {
+            addHttpRequestHeader(mdcKey.substring(PREFIX_HTTP_REQ_HEADERS.length()));
+            return;
+        }
+
+        if (mdcKey.startsWith(PREFIX_HTTP_RES_HEADERS)) {
+            addHttpResponseHeader(mdcKey.substring(PREFIX_HTTP_RES_HEADERS.length()));
+            return;
+        }
+
+        throw new IllegalArgumentException("unknown MDC key: " + mdcKey);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Function<?, String> newStringifier(String mdcKey, String className) {
+        final Function<?, String> stringifier;
+        try {
+            stringifier = (Function<?, String>) Class.forName(
+                    className, true, getClass().getClassLoader()).newInstance();
+        } catch (Exception e) {
+            throw new IllegalArgumentException("failed to instantiate a stringifier function: " +
+                                               mdcKey, e);
+        }
+        return stringifier;
+    }
+
+    RequestContextExporter build() {
+        return new RequestContextExporter(builtIns, attrs, httpReqHeaders, httpResHeaders);
+    }
+}

--- a/logback/src/main/java/com/linecorp/armeria/common/logback/RequestContextExportingAppender.java
+++ b/logback/src/main/java/com/linecorp/armeria/common/logback/RequestContextExportingAppender.java
@@ -1,0 +1,459 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common.logback;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+import javax.annotation.Nullable;
+
+import org.slf4j.MDC;
+import org.slf4j.Marker;
+
+import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.common.logging.RequestLog;
+import com.linecorp.armeria.common.logging.ResponseLog;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.IThrowableProxy;
+import ch.qos.logback.classic.spi.LoggerContextVO;
+import ch.qos.logback.core.Appender;
+import ch.qos.logback.core.UnsynchronizedAppenderBase;
+import ch.qos.logback.core.spi.AppenderAttachable;
+import ch.qos.logback.core.spi.AppenderAttachableImpl;
+import io.netty.util.AsciiString;
+import io.netty.util.Attribute;
+import io.netty.util.AttributeKey;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+import io.netty.util.internal.logging.Slf4JLoggerFactory;
+
+/**
+ * A <a href="http://logback.qos.ch/">Logback</a> {@link Appender} that exports the properties of the current
+ * {@link RequestContext} to {@link MDC}.
+ *
+ * <p>Read '<a href="http://line.github.io/armeria/server-basics.html">Logging contextual information</a>'
+ * for more information.
+ */
+public class RequestContextExportingAppender extends UnsynchronizedAppenderBase<ILoggingEvent>
+                                             implements AppenderAttachable<ILoggingEvent> {
+    static {
+        if (InternalLoggerFactory.getDefaultFactory() == null) {
+            // Can happen due to initialization order.
+            InternalLoggerFactory.setDefaultFactory(Slf4JLoggerFactory.INSTANCE);
+        }
+    }
+
+    private static final AttributeKey<State> STATE =
+            AttributeKey.valueOf(RequestContextExportingAppender.class, "STATE");
+
+    private RequestContextExporter exporter;
+
+    private final AppenderAttachableImpl<ILoggingEvent> aai = new AppenderAttachableImpl<>();
+    private final RequestContextExporterBuilder builder = new RequestContextExporterBuilder();
+
+    /**
+     * Adds the specified {@link BuiltInProperty} to the export list.
+     */
+    public void addBuiltIn(BuiltInProperty property) {
+        ensureNotStarted();
+        builder.addBuiltIn(property);
+    }
+
+    /**
+     * Returns {@code true} if the specified {@link BuiltInProperty} is in the export list.
+     */
+    public boolean containsBuiltIn(BuiltInProperty property) {
+        return builder.containsBuiltIn(property);
+    }
+
+    /**
+     * Returns all {@link BuiltInProperty}s in the export list.
+     */
+    public Set<BuiltInProperty> getBuiltIns() {
+        return builder.getBuiltIns();
+    }
+
+    /**
+     * Adds the specified {@link AttributeKey} to the export list.
+     *
+     * @param alias the alias of the attribute to export
+     * @param attrKey the key of the attribute to export
+     */
+    public void addAttribute(String alias, AttributeKey<?> attrKey) {
+        ensureNotStarted();
+        builder.addAttribute(alias, attrKey);
+    }
+
+    /**
+     * Adds the specified {@link AttributeKey} to the export list.
+     *
+     * @param alias the alias of the attribute to export
+     * @param attrKey the key of the attribute to export
+     * @param stringifier the {@link Function} that converts the attribute value into a {@link String}
+     */
+    public void addAttribute(String alias, AttributeKey<?> attrKey, Function<?, String> stringifier) {
+        ensureNotStarted();
+        builder.addAttribute(alias, attrKey, stringifier);
+    }
+
+    /**
+     * Returns {@code true} if the specified {@link AttributeKey} is in the export list.
+     */
+    public boolean containsAttribute(AttributeKey<?> key) {
+        requireNonNull(key, "key");
+        return builder.containsAttribute(key);
+    }
+
+    /**
+     * Returns all {@link AttributeKey}s in the export list.
+     *
+     * @return the {@link Map} whose key is an alias and value is an {@link AttributeKey}
+     */
+    public Map<String, AttributeKey<?>> getAttributes() {
+        return builder.getAttributes();
+    }
+
+    /**
+     * Adds the specified HTTP request header name to the export list.
+     */
+    public void addHttpRequestHeader(CharSequence name) {
+        ensureNotStarted();
+        builder.addHttpRequestHeader(name);
+    }
+
+    /**
+     * Adds the specified HTTP response header name to the export list.
+     */
+    public void addHttpResponseHeader(CharSequence name) {
+        ensureNotStarted();
+        builder.addHttpResponseHeader(name);
+    }
+
+    /**
+     * Returns {@code true} if the specified HTTP request header name is in the export list.
+     */
+    public boolean containsHttpRequestHeader(CharSequence name) {
+        return builder.containsHttpRequestHeader(name);
+    }
+
+    /**
+     * Returns {@code true} if the specified HTTP response header name is in the export list.
+     */
+    public boolean containsHttpResponseHeader(CharSequence name) {
+        return builder.containsHttpResponseHeader(name);
+    }
+
+    /**
+     * Returns all HTTP request header names in the export list.
+     */
+    public Set<AsciiString> getHttpRequestHeaders() {
+        return builder.getHttpRequestHeaders();
+    }
+
+    /**
+     * Returns all HTTP response header names in the export list.
+     */
+    public Set<AsciiString> getHttpResponseHeaders() {
+        return builder.getHttpResponseHeaders();
+    }
+
+    /**
+     * Adds the property represented by the specified MDC key to the export list.
+     * Note: this method is meant to be used for XML configuration.
+     * Use {@code add*()} methods instead.
+     */
+    public void setExport(String mdcKey) {
+        ensureNotStarted();
+        builder.export(mdcKey);
+    }
+
+    /**
+     * Adds the properties represented by the specified comma-separated MDC keys to the export list.
+     * Note: this method is meant to be used for XML configuration.
+     * Use {@code add*()} methods instead.
+     */
+    public void setExports(String mdcKeys) {
+        ensureNotStarted();
+        requireNonNull(mdcKeys, "mdcKeys");
+        Arrays.stream(mdcKeys.split(",")).map(String::trim).forEach(this::setExport);
+    }
+
+    private void ensureNotStarted() {
+        if (exporter != null) {
+            throw new IllegalStateException("can't update the export list once started");
+        }
+    }
+
+    @Override
+    protected void append(ILoggingEvent eventObject) {
+        final RequestContext ctx = RequestContext.mapCurrent(Function.identity(), () -> null);
+        if (ctx != null) {
+            final State state = state(ctx);
+            final RequestLog req;
+            final ResponseLog res;
+
+            if (ctx.requestLogFuture().isDone()) {
+                req = ctx.requestLogFuture().join();
+            } else {
+                req = null;
+            }
+
+            if (ctx.responseLogFuture().isDone()) {
+                res = ctx.responseLogFuture().join();
+            } else {
+                res = null;
+            }
+
+            final LogAvailability availability = LogAvailability.of(req, res);
+            if (state.availability != availability) {
+                state.availability = availability;
+                export(state, ctx, req, res);
+            }
+
+            final Map<String, String> originalMdcMap = eventObject.getMDCPropertyMap();
+            final Map<String, String> mdcMap;
+            if (!originalMdcMap.isEmpty()) {
+                mdcMap = new UnionMap<>(state, originalMdcMap);
+            } else {
+                mdcMap = state.asUnmodifiable();
+            }
+
+            eventObject = new LoggingEventWrapper(eventObject, mdcMap);
+        }
+
+        aai.appendLoopOnAppenders(eventObject);
+    }
+
+    private static State state(RequestContext ctx) {
+        final Attribute<State> attr = ctx.attr(STATE);
+        final State state = attr.get();
+        if (state == null) {
+            State newState = new State();
+            State oldState = attr.setIfAbsent(newState);
+            if (oldState != null) {
+                return oldState;
+            } else {
+                return newState;
+            }
+        }
+        return state;
+    }
+
+    /**
+     * Exports the necessary properties to {@link MDC}. By default, this method exports all properties added
+     * to the export list via {@code add*()} calls and {@code <export />} tags. Override this method to export
+     * additional properties.
+     */
+    protected void export(Map<String, String> out, RequestContext ctx,
+                          @Nullable RequestLog req, @Nullable ResponseLog res) {
+        exporter.export(out, ctx, req, res);
+    }
+
+    @Override
+    public void start() {
+        if (!aai.iteratorForAppenders().hasNext()) {
+            addWarn("No appender was attached to " + getClass().getSimpleName() + '.');
+        }
+        if (exporter == null) {
+            exporter = builder.build();
+        }
+        super.start();
+    }
+
+    @Override
+    public void stop() {
+        try {
+            aai.detachAndStopAllAppenders();
+        } finally {
+            super.stop();
+        }
+    }
+
+    @Override
+    public void addAppender(Appender<ILoggingEvent> newAppender) {
+        aai.addAppender(newAppender);
+    }
+
+    @Override
+    public Iterator<Appender<ILoggingEvent>> iteratorForAppenders() {
+        return aai.iteratorForAppenders();
+    }
+
+    @Override
+    public Appender<ILoggingEvent> getAppender(String name) {
+        return aai.getAppender(name);
+    }
+
+    @Override
+    public boolean isAttached(Appender<ILoggingEvent> appender) {
+        return aai.isAttached(appender);
+    }
+
+    @Override
+    public void detachAndStopAllAppenders() {
+        aai.detachAndStopAllAppenders();
+    }
+
+    @Override
+    public boolean detachAppender(Appender<ILoggingEvent> appender) {
+        return aai.detachAppender(appender);
+    }
+
+    @Override
+    public boolean detachAppender(String name) {
+        return aai.detachAppender(name);
+    }
+
+    private enum LogAvailability {
+        NONE, REQ, RES, REQ_AND_RES;
+
+        static LogAvailability of(RequestLog req, ResponseLog res) {
+            if (req != null) {
+                if (res != null) {
+                    return REQ_AND_RES;
+                } else {
+                    return REQ;
+                }
+            } else if (res != null) {
+                return RES;
+            } else {
+                return NONE;
+            }
+        }
+    }
+
+    private static final class State extends HashMap<String, String> {
+        private static final long serialVersionUID = -7084248226635055988L;
+
+        private Map<String, String> unmodifiableMap;
+
+        LogAvailability availability;
+
+        Map<String, String> asUnmodifiable() {
+            if (unmodifiableMap != null) {
+                return unmodifiableMap;
+            }
+
+            return unmodifiableMap = Collections.unmodifiableMap(this);
+        }
+    }
+
+    private static final class LoggingEventWrapper implements ILoggingEvent {
+        private final ILoggingEvent event;
+        private final Map<String, String> mdcPropertyMap;
+        private final LoggerContextVO vo;
+
+        LoggingEventWrapper(ILoggingEvent event, Map<String, String> mdcPropertyMap) {
+            this.event = event;
+            this.mdcPropertyMap = mdcPropertyMap;
+
+            final LoggerContextVO oldVo = event.getLoggerContextVO();
+            if (oldVo != null) {
+                vo = new LoggerContextVO(oldVo.getName(), mdcPropertyMap, oldVo.getBirthTime());
+            } else {
+                vo = null;
+            }
+        }
+
+        @Override
+        public Object[] getArgumentArray() {
+            return event.getArgumentArray();
+        }
+
+        @Override
+        public Level getLevel() {
+            return event.getLevel();
+        }
+
+        @Override
+        public String getLoggerName() {
+            return event.getLoggerName();
+        }
+
+        @Override
+        public String getThreadName() {
+            return event.getThreadName();
+        }
+
+        @Override
+        public IThrowableProxy getThrowableProxy() {
+            return event.getThrowableProxy();
+        }
+
+        @Override
+        public void prepareForDeferredProcessing() {
+            event.prepareForDeferredProcessing();
+        }
+
+        @Override
+        public LoggerContextVO getLoggerContextVO() {
+            return vo;
+        }
+
+        @Override
+        public String getMessage() {
+            return event.getMessage();
+        }
+
+        @Override
+        public long getTimeStamp() {
+            return event.getTimeStamp();
+        }
+
+        @Override
+        public StackTraceElement[] getCallerData() {
+            return event.getCallerData();
+        }
+
+        @Override
+        public boolean hasCallerData() {
+            return event.hasCallerData();
+        }
+
+        @Override
+        public Marker getMarker() {
+            return event.getMarker();
+        }
+
+        @Override
+        public String getFormattedMessage() {
+            return event.getFormattedMessage();
+        }
+
+        @Override
+        public Map<String, String> getMDCPropertyMap() {
+            return mdcPropertyMap;
+        }
+
+        @Override
+        public Map<String, String> getMdc() {
+            return event.getMdc();
+        }
+
+        @Override
+        public String toString() {
+            return event.toString();
+        }
+    }
+}

--- a/logback/src/main/java/com/linecorp/armeria/common/logback/UnionMap.java
+++ b/logback/src/main/java/com/linecorp/armeria/common/logback/UnionMap.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.logback;
+
+import java.util.AbstractMap;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.collect.Sets;
+
+final class UnionMap<K, V> extends AbstractMap<K, V> {
+
+    private final Map<K, V> first;
+    private final Map<K, V> second;
+    private int size = -1;
+    private Set<Entry<K, V>> entrySet;
+
+    UnionMap(Map<K, V> first, Map<K, V> second) {
+        this.first = first;
+        this.second = second;
+    }
+
+    @Override
+    public int size() {
+        if (size >= 0) {
+            return size;
+        }
+
+        final Map<K, V> a;
+        final Map<K, V> b;
+        if (first.size() >= second.size()) {
+            a = first;
+            b = second;
+        } else {
+            a = second;
+            b = first;
+        }
+
+        int size = a.size();
+        if (!b.isEmpty()) {
+            for (K k : b.keySet()) {
+                if (!a.containsKey(k)) {
+                    size++;
+                }
+            }
+        }
+
+        return this.size = size;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return first.isEmpty() && second.isEmpty();
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        return first.containsKey(key) || second.containsKey(key);
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        return first.containsValue(value) || second.containsValue(value);
+    }
+
+    @Override
+    public V get(Object key) {
+        final V value = first.get(key);
+        return value != null ? value : second.get(key);
+    }
+
+    @Override
+    public V put(K key, V value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public V remove(Object key) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void clear() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Set<Entry<K, V>> entrySet() {
+        if (entrySet != null) {
+            return entrySet;
+        }
+
+        return entrySet = Collections.unmodifiableSet(Sets.union(first.entrySet(), second.entrySet()));
+    }
+}

--- a/logback/src/main/java/com/linecorp/armeria/common/logback/package-info.java
+++ b/logback/src/main/java/com/linecorp/armeria/common/logback/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * <a href="http://logback.qos.ch/">Logback</a> integration.
+ *
+ * <p>Read '<a href="http://line.github.io/armeria/server-basics.html">Logging contextual information</a>'
+ * for more information.
+ */
+package com.linecorp.armeria.common.logback;

--- a/logback/src/test/java/com/linecorp/armeria/common/logback/CustomValue.java
+++ b/logback/src/test/java/com/linecorp/armeria/common/logback/CustomValue.java
@@ -1,0 +1,15 @@
+package com.linecorp.armeria.common.logback;
+
+public class CustomValue {
+
+    final String value;
+
+    public CustomValue(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public String toString() {
+        return "CustomValue(" + value + ')';
+    }
+}

--- a/logback/src/test/java/com/linecorp/armeria/common/logback/CustomValueStringifier.java
+++ b/logback/src/test/java/com/linecorp/armeria/common/logback/CustomValueStringifier.java
@@ -1,0 +1,10 @@
+package com.linecorp.armeria.common.logback;
+
+import java.util.function.Function;
+
+public final class CustomValueStringifier implements Function<CustomValue, String> {
+    @Override
+    public String apply(CustomValue o) {
+        return o.value;
+    }
+}

--- a/logback/src/test/java/com/linecorp/armeria/common/logback/RequestContextExportingAppenderTest.java
+++ b/logback/src/test/java/com/linecorp/armeria/common/logback/RequestContextExportingAppenderTest.java
@@ -1,0 +1,550 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common.logback;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.AbstractMap.SimpleEntry;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Consumer;
+
+import javax.annotation.Nullable;
+import javax.net.ssl.SSLSession;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+import com.linecorp.armeria.client.ClientOptions;
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.DefaultClientRequestContext;
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.common.SerializationFormat;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.http.HttpHeaderNames;
+import com.linecorp.armeria.common.http.HttpHeaders;
+import com.linecorp.armeria.common.http.HttpMethod;
+import com.linecorp.armeria.common.http.HttpRequest;
+import com.linecorp.armeria.common.logging.RequestLog;
+import com.linecorp.armeria.common.logging.RequestLogBuilder;
+import com.linecorp.armeria.common.logging.ResponseLog;
+import com.linecorp.armeria.common.logging.ResponseLogBuilder;
+import com.linecorp.armeria.common.thrift.ThriftCall;
+import com.linecorp.armeria.common.thrift.ThriftReply;
+import com.linecorp.armeria.server.DefaultServiceRequestContext;
+import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.Service;
+import com.linecorp.armeria.server.ServiceConfig;
+import com.linecorp.armeria.server.ServiceRequestContext;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.joran.JoranConfigurator;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import ch.qos.logback.core.status.Status;
+import ch.qos.logback.core.status.StatusManager;
+import io.netty.channel.Channel;
+import io.netty.channel.EventLoop;
+import io.netty.util.AttributeKey;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+
+public class RequestContextExportingAppenderTest {
+
+    private static final AttributeKey<CustomValue> MY_ATTR =
+            AttributeKey.valueOf(RequestContextExportingAppenderTest.class, "MY_ATTR");
+
+    private static final LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
+    private static final Logger rootLogger =
+            (Logger) LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
+    private static final Logger logger =
+            (Logger) LoggerFactory.getLogger(RequestContextExportingAppenderTest.class);
+
+    @Rule
+    public final TestName testName = new TestName();
+    private Logger testLogger;
+
+    @Before
+    public void setUp() {
+        rootLogger.getLoggerContext().getStatusManager().clear();
+        MDC.clear();
+        testLogger = (Logger) LoggerFactory.getLogger("loggerTest." + testName.getMethodName());
+        testLogger.setLevel(Level.ALL);
+    }
+
+    @After
+    public void tearDown() {
+        final Logger logger = (Logger) LoggerFactory.getLogger(getClass());
+        final StatusManager sm = rootLogger.getLoggerContext().getStatusManager();
+        int count = 0;
+        for (Status s : sm.getCopyOfStatusList()) {
+            final int level = s.getEffectiveLevel();
+            if (level == Status.INFO) {
+                continue;
+            }
+            if (s.getMessage().contains(InternalLoggerFactory.class.getName())) {
+                // Skip the warnings related with Netty.
+                continue;
+            }
+
+            count++;
+            switch (level) {
+                case Status.WARN:
+                    if (s.getThrowable() != null) {
+                        logger.warn(s.getMessage(), s.getThrowable());
+                    } else {
+                        logger.warn(s.getMessage());
+                    }
+                    break;
+                case Status.ERROR:
+                    if (s.getThrowable() != null) {
+                        logger.warn(s.getMessage(), s.getThrowable());
+                    } else {
+                        logger.warn(s.getMessage());
+                    }
+                    break;
+            }
+        }
+
+        if (count > 0) {
+            fail("Appender raised an exception.");
+        }
+    }
+
+    @Test
+    public void testMutabilityAndImmutability() {
+        final AttributeKey<Object> someAttr =
+                AttributeKey.valueOf(RequestContextExportingAppenderTest.class, "SOME_ATTR");
+        final RequestContextExportingAppender a = new RequestContextExportingAppender();
+
+        // Ensure mutability before start.
+        a.addBuiltIn(BuiltInProperty.ELAPSED_NANOS);
+        assertThat(a.getBuiltIns()).containsExactly(BuiltInProperty.ELAPSED_NANOS);
+
+        a.addAttribute("some-attr", someAttr);
+        assertThat(a.getAttributes()).containsOnlyKeys("some-attr")
+                                     .containsValue(someAttr);
+
+        a.addHttpRequestHeader(HttpHeaderNames.USER_AGENT);
+        assertThat(a.getHttpRequestHeaders()).containsExactly(HttpHeaderNames.USER_AGENT);
+
+        a.addHttpResponseHeader(HttpHeaderNames.SET_COOKIE);
+        assertThat(a.getHttpResponseHeaders()).containsExactly(HttpHeaderNames.SET_COOKIE);
+
+        final ListAppender<ILoggingEvent> la = new ListAppender<>();
+        a.addAppender(la);
+        a.start();
+        la.start();
+
+        // Ensure immutability after start.
+        assertThatThrownBy(() -> a.addBuiltIn(BuiltInProperty.REQ_PATH))
+                .isExactlyInstanceOf(IllegalStateException.class);
+
+        assertThatThrownBy(() -> a.addAttribute("my-attr", MY_ATTR))
+                .isExactlyInstanceOf(IllegalStateException.class);
+
+        assertThatThrownBy(() -> a.addHttpRequestHeader(HttpHeaderNames.ACCEPT))
+                .isExactlyInstanceOf(IllegalStateException.class);
+
+        assertThatThrownBy(() -> a.addHttpResponseHeader(HttpHeaderNames.DATE))
+                .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void testXmlConfig() throws Exception {
+        try {
+            final JoranConfigurator configurator = new JoranConfigurator();
+            configurator.setContext(context);
+            context.reset();
+
+            configurator.doConfigure(getClass().getResource("testXmlConfig.xml"));
+
+            final RequestContextExportingAppender rcia =
+                    (RequestContextExportingAppender) logger.getAppender("RCIA");
+
+            assertThat(rcia).isNotNull();
+            assertThat(rcia.getBuiltIns()).containsExactly(BuiltInProperty.REMOTE_HOST);
+            assertThat(rcia.getHttpRequestHeaders()).containsExactly(HttpHeaderNames.USER_AGENT);
+            assertThat(rcia.getHttpResponseHeaders()).containsExactly(HttpHeaderNames.SET_COOKIE);
+
+            final AttributeKey<Object> fooAttr = AttributeKey.valueOf("com.example.AttrKeys#FOO");
+            final AttributeKey<Object> barAttr = AttributeKey.valueOf("com.example.AttrKeys#BAR");
+            assertThat(rcia.getAttributes()).containsOnly(new SimpleEntry<>("foo", fooAttr),
+                                                          new SimpleEntry<>("bar", barAttr));
+        } finally {
+            // Revert to the original configuration.
+            final JoranConfigurator configurator = new JoranConfigurator();
+            configurator.setContext(context);
+            context.reset();
+
+            configurator.doConfigure(getClass().getResource("/logback-test.xml"));
+        }
+    }
+
+    @Test
+    public void testWithoutContext() {
+        final List<ILoggingEvent> events = prepare();
+        final ILoggingEvent e = log(events);
+        assertThat(e.getMDCPropertyMap()).isEmpty();
+    }
+
+    @Test
+    public void testMdcPropertyPreservation() throws Exception {
+        final List<ILoggingEvent> events = prepare(a -> a.addBuiltIn(BuiltInProperty.REQ_DIRECTION));
+
+        MDC.put("some-prop", "some-value");
+        final ServiceRequestContext ctx = newServiceContext("/foo");
+        try (RequestContext.PushHandle ignored = RequestContext.push(ctx)) {
+            final ILoggingEvent e = log(events);
+            final Map<String, String> mdc = e.getMDCPropertyMap();
+            assertThat(mdc).containsEntry("req.direction", "INBOUND")
+                           .containsEntry("some-prop", "some-value")
+                           .hasSize(2);
+        } finally {
+            MDC.remove("some-prop");
+        }
+    }
+
+    @Test
+    public void testServiceContextWithoutLogs() throws Exception {
+        final List<ILoggingEvent> events = prepare(a -> {
+            // Export all properties.
+            for (BuiltInProperty p : BuiltInProperty.values()) {
+                a.addBuiltIn(p);
+            }
+        });
+
+        final ServiceRequestContext ctx = newServiceContext("/foo");
+        try (RequestContext.PushHandle ignored = RequestContext.push(ctx)) {
+            final ILoggingEvent e = log(events);
+            final Map<String, String> mdc = e.getMDCPropertyMap();
+            assertThat(mdc).containsEntry("local.host", "server.com")
+                           .containsEntry("local.ip", "5.6.7.8")
+                           .containsEntry("local.port", "8080")
+                           .containsEntry("remote.host", "client.com")
+                           .containsEntry("remote.ip", "1.2.3.4")
+                           .containsEntry("remote.port", "5678")
+                           .containsEntry("req.direction", "INBOUND")
+                           .containsEntry("req.authority", "server.com:8080")
+                           .containsEntry("req.method", "GET")
+                           .containsEntry("req.path", "/foo")
+                           .containsEntry("scheme", "unknown+h2")
+                           .containsEntry("tls.session_id", "0101020305080d15")
+                           .containsEntry("tls.proto", "TLSv1.2")
+                           .containsEntry("tls.cipher", "some-cipher")
+                           .hasSize(14);
+        }
+    }
+
+    @Test
+    public void testServiceContextWithMinimalLogs() throws Exception {
+        final List<ILoggingEvent> events = prepare(a -> {
+            // Export all properties.
+            for (BuiltInProperty p : BuiltInProperty.values()) {
+                a.addBuiltIn(p);
+            }
+        });
+
+        final ServiceRequestContext ctx = newServiceContext("/foo");
+        try (RequestContext.PushHandle ignored = RequestContext.push(ctx)) {
+            final RequestLogBuilder req = ctx.requestLogBuilder();
+            final ResponseLogBuilder res = ctx.responseLogBuilder();
+            req.end();
+            res.end();
+
+            final ILoggingEvent e = log(events);
+            final Map<String, String> mdc = e.getMDCPropertyMap();
+            assertThat(mdc).containsEntry("local.host", "server.com")
+                           .containsEntry("local.ip", "5.6.7.8")
+                           .containsEntry("local.port", "8080")
+                           .containsEntry("remote.host", "client.com")
+                           .containsEntry("remote.ip", "1.2.3.4")
+                           .containsEntry("remote.port", "5678")
+                           .containsEntry("req.direction", "INBOUND")
+                           .containsEntry("req.authority", "some-host.server.com:8080")
+                           .containsEntry("req.method", "GET")
+                           .containsEntry("req.path", "/foo")
+                           .containsEntry("scheme", "none+h2")
+                           .containsEntry("req.content_length", "0")
+                           .containsEntry("res.status_code", "0")
+                           .containsEntry("res.content_length", "0")
+                           .containsEntry("tls.session_id", "0101020305080d15")
+                           .containsEntry("tls.proto", "TLSv1.2")
+                           .containsEntry("tls.cipher", "some-cipher")
+                           .containsKey("elapsed_nanos")
+                           .hasSize(18);
+        }
+    }
+
+    @Test
+    public void testServiceContextWithFullLogs() throws Exception {
+        final List<ILoggingEvent> events = prepare(a -> {
+            // Export all properties.
+            for (BuiltInProperty p : BuiltInProperty.values()) {
+                a.addBuiltIn(p);
+            }
+            // .. and an attribute.
+            a.addAttribute("my_attr", MY_ATTR, new CustomValueStringifier());
+            // .. and some HTTP headers.
+            a.addHttpRequestHeader(HttpHeaderNames.USER_AGENT);
+            a.addHttpResponseHeader(HttpHeaderNames.DATE);
+        });
+
+        final ServiceRequestContext ctx = newServiceContext("/foo");
+        try (RequestContext.PushHandle ignored = RequestContext.push(ctx)) {
+            final RequestLogBuilder req = ctx.requestLogBuilder();
+            final ResponseLogBuilder res = ctx.responseLogBuilder();
+            req.serializationFormat(SerializationFormat.THRIFT_BINARY);
+            req.contentLength(64);
+            req.attr(RequestLog.HTTP_HEADERS).set(HttpHeaders.of(HttpHeaderNames.USER_AGENT, "some-client"));
+            req.attr(RequestLog.RPC_REQUEST).set(new ThriftCall(1, Object.class, "hello", "world"));
+            req.end();
+            res.statusCode(200);
+            res.contentLength(128);
+            res.attr(ResponseLog.HTTP_HEADERS).set(HttpHeaders.of(HttpHeaderNames.DATE, "some-date"));
+            res.attr(ResponseLog.RPC_RESPONSE).set(new ThriftReply(1, "Hello, world!"));
+            res.end();
+
+            final ILoggingEvent e = log(events);
+            final Map<String, String> mdc = e.getMDCPropertyMap();
+            assertThat(mdc).containsEntry("local.host", "server.com")
+                           .containsEntry("local.ip", "5.6.7.8")
+                           .containsEntry("local.port", "8080")
+                           .containsEntry("remote.host", "client.com")
+                           .containsEntry("remote.ip", "1.2.3.4")
+                           .containsEntry("remote.port", "5678")
+                           .containsEntry("req.direction", "INBOUND")
+                           .containsEntry("req.authority", "some-host.server.com:8080")
+                           .containsEntry("req.method", "GET")
+                           .containsEntry("req.path", "/foo")
+                           .containsEntry("scheme", "tbinary+h2")
+                           .containsEntry("req.content_length", "64")
+                           .containsEntry("req.rpc_method", "hello")
+                           .containsEntry("req.rpc_params", "[world]")
+                           .containsEntry("res.status_code", "200")
+                           .containsEntry("res.content_length", "128")
+                           .containsEntry("res.rpc_result", "Hello, world!")
+                           .containsEntry("req.http_headers.user-agent", "some-client")
+                           .containsEntry("res.http_headers.date", "some-date")
+                           .containsEntry("tls.session_id", "0101020305080d15")
+                           .containsEntry("tls.proto", "TLSv1.2")
+                           .containsEntry("tls.cipher", "some-cipher")
+                           .containsEntry("attrs.my_attr", "some-attr")
+                           .containsKey("elapsed_nanos")
+                           .hasSize(24);
+        }
+    }
+
+    private ILoggingEvent log(List<ILoggingEvent> events) {
+        final Integer value = ThreadLocalRandom.current().nextInt();
+        testLogger.trace("{}", value);
+
+        assertThat(events).hasSize(1);
+
+        final ILoggingEvent event = events.remove(0);
+        assertThat(event.getLevel()).isEqualTo(Level.TRACE);
+        assertThat(event.getFormattedMessage()).isEqualTo(value.toString());
+        assertThat(event.getArgumentArray()).containsExactly(value);
+        return event;
+    }
+
+    private static ServiceRequestContext newServiceContext(String path) throws Exception {
+        final Channel ch = mock(Channel.class);
+        when(ch.remoteAddress()).thenReturn(
+                new InetSocketAddress(InetAddress.getByAddress("client.com", new byte[] { 1, 2, 3, 4 }),
+                                      5678));
+        when(ch.localAddress()).thenReturn(
+                new InetSocketAddress(InetAddress.getByAddress("server.com", new byte[] { 5, 6, 7, 8 }),
+                                      8080));
+
+        final Service<?, ?> service = mock(Service.class);
+        final Server server = new ServerBuilder().withVirtualHost("some-host.server.com")
+                                                 .serviceUnder("/", service)
+                                                 .and().build();
+        final ServiceConfig serviceConfig = server.config().findVirtualHost("some-host.server.com")
+                                                  .serviceConfigs().get(0);
+        final HttpRequest req = HttpRequest.of(HttpHeaders.of(HttpMethod.GET, path)
+                                                          .authority("server.com:8080"));
+
+        final ServiceRequestContext ctx = new DefaultServiceRequestContext(
+                serviceConfig,
+                ch, SessionProtocol.H2, req.method().name(), req.path(), req.path(),
+                req, newSslSession());
+
+        ctx.attr(MY_ATTR).set(new CustomValue("some-attr"));
+        return ctx;
+    }
+
+    @Test
+    public void testClientContextWithMinimalLogs() throws Exception {
+        final List<ILoggingEvent> events = prepare(a -> {
+            // Export all properties.
+            for (BuiltInProperty p : BuiltInProperty.values()) {
+                a.addBuiltIn(p);
+            }
+        });
+
+        final ClientRequestContext ctx = newClientContext("/foo");
+        try (RequestContext.PushHandle ignored = RequestContext.push(ctx)) {
+            final ILoggingEvent e = log(events);
+            final Map<String, String> mdc = e.getMDCPropertyMap();
+            assertThat(mdc).containsEntry("local.host", "client.com")
+                           .containsEntry("local.ip", "5.6.7.8")
+                           .containsEntry("local.port", "5678")
+                           .containsEntry("remote.host", "server.com")
+                           .containsEntry("remote.ip", "1.2.3.4")
+                           .containsEntry("remote.port", "8080")
+                           .containsEntry("req.direction", "OUTBOUND")
+                           .containsEntry("req.authority", "server.com:8080")
+                           .containsEntry("req.method", "GET")
+                           .containsEntry("req.path", "/foo")
+                           .containsEntry("scheme", "unknown+h2")
+                           .containsEntry("tls.session_id", "0101020305080d15")
+                           .containsEntry("tls.proto", "TLSv1.2")
+                           .containsEntry("tls.cipher", "some-cipher")
+                           .hasSize(14);
+        }
+    }
+
+    @Test
+    public void testClientContextWithFullLogs() throws Exception {
+        final List<ILoggingEvent> events = prepare(a -> {
+            // Export all properties.
+            for (BuiltInProperty p : BuiltInProperty.values()) {
+                a.addBuiltIn(p);
+            }
+            // .. and an attribute.
+            a.addAttribute("my_attr", MY_ATTR, new CustomValueStringifier());
+            // .. and some HTTP headers.
+            a.addHttpRequestHeader(HttpHeaderNames.USER_AGENT);
+            a.addHttpResponseHeader(HttpHeaderNames.DATE);
+        });
+
+        final ClientRequestContext ctx = newClientContext("/bar");
+        try (RequestContext.PushHandle ignored = RequestContext.push(ctx)) {
+            final RequestLogBuilder req = ctx.requestLogBuilder();
+            final ResponseLogBuilder res = ctx.responseLogBuilder();
+            req.serializationFormat(SerializationFormat.THRIFT_BINARY);
+            req.contentLength(64);
+            req.attr(RequestLog.HTTP_HEADERS).set(HttpHeaders.of(HttpHeaderNames.USER_AGENT, "some-client"));
+            req.attr(RequestLog.RPC_REQUEST).set(new ThriftCall(1, Object.class, "hello", "world"));
+            req.end();
+            res.statusCode(200);
+            res.contentLength(128);
+            res.attr(ResponseLog.HTTP_HEADERS).set(HttpHeaders.of(HttpHeaderNames.DATE, "some-date"));
+            res.attr(ResponseLog.RPC_RESPONSE).set(new ThriftReply(1, "Hello, world!"));
+            res.end();
+
+            final ILoggingEvent e = log(events);
+            final Map<String, String> mdc = e.getMDCPropertyMap();
+            assertThat(mdc).containsEntry("local.host", "client.com")
+                           .containsEntry("local.ip", "5.6.7.8")
+                           .containsEntry("local.port", "5678")
+                           .containsEntry("remote.host", "server.com")
+                           .containsEntry("remote.ip", "1.2.3.4")
+                           .containsEntry("remote.port", "8080")
+                           .containsEntry("req.direction", "OUTBOUND")
+                           .containsEntry("req.authority", "some-host.server.com:8080")
+                           .containsEntry("req.method", "GET")
+                           .containsEntry("req.path", "/bar")
+                           .containsEntry("scheme", "tbinary+h2")
+                           .containsEntry("req.content_length", "64")
+                           .containsEntry("req.rpc_method", "hello")
+                           .containsEntry("req.rpc_params", "[world]")
+                           .containsEntry("res.status_code", "200")
+                           .containsEntry("res.content_length", "128")
+                           .containsEntry("res.rpc_result", "Hello, world!")
+                           .containsEntry("req.http_headers.user-agent", "some-client")
+                           .containsEntry("res.http_headers.date", "some-date")
+                           .containsEntry("tls.session_id", "0101020305080d15")
+                           .containsEntry("tls.proto", "TLSv1.2")
+                           .containsEntry("tls.cipher", "some-cipher")
+                           .containsEntry("attrs.my_attr", "some-attr")
+                           .containsKey("elapsed_nanos")
+                           .hasSize(24);
+        }
+    }
+
+    private static ClientRequestContext newClientContext(String path) throws Exception {
+        final Channel ch = mock(Channel.class);
+        when(ch.remoteAddress()).thenReturn(
+                new InetSocketAddress(InetAddress.getByAddress("server.com", new byte[] { 1, 2, 3, 4 }),
+                                      8080));
+        when(ch.localAddress()).thenReturn(
+                new InetSocketAddress(InetAddress.getByAddress("client.com", new byte[] { 5, 6, 7, 8 }),
+                                      5678));
+
+        final HttpRequest req = HttpRequest.of(HttpHeaders.of(HttpMethod.GET, path)
+                                                          .authority("server.com:8080"));
+
+        final DefaultClientRequestContext ctx = new DefaultClientRequestContext(
+                mock(EventLoop.class), SessionProtocol.H2,
+                Endpoint.of("server.com", 8080),
+                req.method().name(), req.path(), "",
+                ClientOptions.DEFAULT, req) {
+
+            @Nullable
+            @Override
+            public SSLSession sslSession() {
+                return newSslSession();
+            }
+        };
+
+        ctx.requestLogBuilder().start(
+                ch, ctx.sessionProtocol(), "some-host.server.com", ctx.method(), ctx.path());
+
+        ctx.attr(MY_ATTR).set(new CustomValue("some-attr"));
+        return ctx;
+    }
+
+    private static SSLSession newSslSession() {
+        final SSLSession sslSession = mock(SSLSession.class);
+        when(sslSession.getId()).thenReturn(new byte[] { 1, 1, 2, 3, 5, 8, 13, 21 });
+        when(sslSession.getProtocol()).thenReturn("TLSv1.2");
+        when(sslSession.getCipherSuite()).thenReturn("some-cipher");
+        return sslSession;
+    }
+
+    @SafeVarargs
+    private final List<ILoggingEvent> prepare(Consumer<RequestContextExportingAppender>... configurators) {
+        final RequestContextExportingAppender a = new RequestContextExportingAppender();
+        for (Consumer<RequestContextExportingAppender> c : configurators) {
+            c.accept(a);
+        }
+
+        final ListAppender<ILoggingEvent> la = new ListAppender<>();
+        a.addAppender(la);
+        a.start();
+        la.start();
+        testLogger.addAppender(a);
+        return la.list;
+    }
+}

--- a/logback/src/test/java/com/linecorp/armeria/common/logback/UnionMapTest.java
+++ b/logback/src/test/java/com/linecorp/armeria/common/logback/UnionMapTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.logback;
+
+import static com.google.common.collect.ImmutableMap.of;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Iterator;
+import java.util.Map.Entry;
+
+import org.junit.Test;
+
+public class UnionMapTest {
+
+    @Test
+    public void testSize() {
+        assertThat(new UnionMap<>(of("1", "a"), of("2", "b"))).hasSize(2);
+        assertThat(new UnionMap<>(of("1", "a", "2", "b"), of("1", "b"))).hasSize(2);
+        assertThat(new UnionMap<>(of("1", "a"), of("1", "b", "2", "b"))).hasSize(2);
+    }
+
+    @Test
+    public void testIsEmpty() {
+        assertThat(new UnionMap<String, String>(of(), of())).isEmpty();
+        assertThat(new UnionMap<>(of(), of("1", "a"))).isNotEmpty();
+        assertThat(new UnionMap<>(of("1", "a"), of())).isNotEmpty();
+    }
+
+    @Test
+    public void testContainsKey() {
+        assertThat(new UnionMap<>(of("1", "a"), of("2", "b"))).containsKey("1");
+        assertThat(new UnionMap<>(of("1", "a"), of("2", "b"))).containsKey("2");
+    }
+
+    @Test
+    public void testContainsValue() {
+        assertThat(new UnionMap<>(of("1", "a"), of("2", "b"))).containsValue("a");
+        assertThat(new UnionMap<>(of("1", "a"), of("2", "b"))).containsValue("b");
+    }
+
+    @Test
+    public void testGet() {
+        assertThat(new UnionMap<>(of("1", "a"), of("2", "b"))).containsEntry("1", "a");
+        assertThat(new UnionMap<>(of("1", "a"), of("2", "b"))).containsEntry("2", "b");
+        assertThat(new UnionMap<>(of("1", "a"), of("1", "b"))).containsEntry("1", "a");
+    }
+
+    @Test
+    public void testImmutability() {
+        final UnionMap<String, String> map = new UnionMap<>(of("1", "a"), of("2", "b"));
+
+        assertThatThrownBy(() -> map.put("foo", "bar"))
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> map.remove("foo"))
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(map::clear)
+                .isInstanceOf(UnsupportedOperationException.class);
+
+        assertThatThrownBy(() -> {
+            final Iterator<Entry<String, String>> i = map.entrySet().iterator();
+            i.next();
+            i.remove();
+        }).isInstanceOf(UnsupportedOperationException.class);
+    }
+}

--- a/logback/src/test/resources/com/linecorp/armeria/common/logback/testXmlConfig.xml
+++ b/logback/src/test/resources/com/linecorp/armeria/common/logback/testXmlConfig.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2015 LINE Corporation
+  ~ Copyright 2016 LINE Corporation
   ~
   ~ LINE Corporation licenses this file to you under the Apache License,
   ~ version 2.0 (the "License"); you may not use this file except in compliance
@@ -14,26 +14,29 @@
   ~ License for the specific language governing permissions and limitations
   ~ under the License.
   -->
-
 <configuration>
-  <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
-    <resetJUL>true</resetJUL>
-  </contextListener>
+  <appender name="NOP" class="ch.qos.logback.core.helpers.NOPAppender" />
+  <appender name="RCIA" class="com.linecorp.armeria.common.logback.RequestContextExportingAppender">
+    <appender-ref ref="NOP"/>
+    <export>remote.host</export>
+    <export>req.http_headers.user-agent</export>
+    <export>res.http_headers.set-cookie</export>
+    <export>attrs.foo:com.example.AttrKeys#FOO</export>
+    <export>attrs.bar:com.example.AttrKeys#BAR:com.linecorp.armeria.common.logback.CustomValueStringifier</export>
+  </appender>
 
+  <logger name="com.linecorp.armeria.common.logback.RequestContextExportingAppenderTest" level="TRACE">
+    <appender-ref ref="RCIA" />
+  </logger>
+
+  <!-- Copied from /settings/logback/logback-test.xml -->
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
     </encoder>
   </appender>
 
-  <appender name="NOP" class="ch.qos.logback.core.helpers.NOPAppender" />
-
   <logger name="com.linecorp.armeria" level="DEBUG" />
-  <logger name="com.linecorp.armeria.internal.http.Http2GoAwayListener" level="INFO" />
-  <logger name="armeria" level="DEBUG" />
-  <logger name="loggerTest" level="ALL" additivity="false">
-    <appender-ref ref="NOP" />
-  </logger>
 
   <root level="WARN">
     <appender-ref ref="STDOUT" />

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,9 +1,11 @@
 rootProject.name = 'armeria'
+
 // Java projects
 include 'core'
 include 'grpc'
 include 'it'
 include 'jetty'
+include 'logback'
 include 'retrofit2'
 include 'tomcat'
 include 'zipkin'

--- a/site/build.gradle
+++ b/site/build.gradle
@@ -43,7 +43,16 @@ task javadoc(type: Javadoc,
         def title = "Armeria ${project.version} API reference"
         docTitle = title
         windowTitle = title
-        bottom = project.ext.copyrightFooter
+        bottom = project.ext.copyrightFooter +
+                 '<script>' + // Open an external link in a new tab/window.
+                 'for(var i in document.links) {' +
+                 '  var l = document.links[i];' +
+                 '  if (l.href.indexOf("http") === 0) {' +
+                 '    l.target = "_blank";' +
+                 '  }' +
+                 '}' +
+                 '</script>'
+
         encoding = 'UTF-8'
         docEncoding = 'UTF-8'
         breakIterator = true
@@ -68,9 +77,11 @@ task javadoc(type: Javadoc,
         group 'Common', 'com.linecorp.armeria.common*'
 
         // External Javadoc links
-        links 'https://netty.io/4.1/api',
-              'https://developers.google.com/protocol-buffers/docs/reference/java',
-              'https://people.apache.org/~thejas/thrift-0.9/javadoc/'
+        links 'http://www.slf4j.org/api/',
+              'https://netty.io/4.1/api/',
+              'https://developers.google.com/protocol-buffers/docs/reference/java/',
+              'https://people.apache.org/~thejas/thrift-0.9/javadoc/',
+              'http://logback.qos.ch/apidocs/'
     }
 }
 

--- a/site/src/sphinx/advanced-logging.rst
+++ b/site/src/sphinx/advanced-logging.rst
@@ -1,0 +1,130 @@
+.. _`Logback`: http://logback.qos.ch/
+.. _`RequestContextExportingAppender`: apidocs/index.html?com/linecorp/armeria/common/logback/RequestContextExportingAppender.html
+.. _`BuiltInProperty`: apidocs/index.html?com/linecorp/armeria/common/logback/BuiltInProperty.html
+.. _`RequestContext`: apidocs/index.html?com/linecorp/armeria/common/RequestContext.html
+.. _`MDC`: http://logback.qos.ch/manual/mdc.html
+
+Logging contextual information
+==============================
+With Armeria's `Logback`_ integration, you can log the properties of the `RequestContext`_ of the
+request being handled. `RequestContextExportingAppender`_ is a Logback appender that exports the properties
+of the current ``RequestContext`` to `MDC`_ (mapped diagnostic context).
+
+For example, the following configuration:
+
+.. code-block:: xml
+
+    <?xml version="1.0" encoding="UTF-8"?>
+    <configuration>
+      <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+          <pattern>%d{HH:mm:ss.SSS} %X{remote.ip} %X{tls.cipher}
+                   %X{req.http_headers.user-agent} %X{attrs.some_value} %msg%n</pattern>
+        </encoder>
+      </appender>
+
+      <appender name="RCIA" class="com.linecorp.armeria.common.logback.RequestContextExportingAppender">
+        <appender-ref ref="CONSOLE" />
+        <export>remote.ip</export>
+        <export>tls.cipher</export>
+        <export>req.http_headers.user-agent</export>
+        <export>attrs.req_id:com.example.AttrKeys#SOME_VALUE</export>
+        <!-- ... or alternatively:
+        <exports>remote.ip, remote.port, tls.cipher,
+                 req.http_headers.user-agent,
+                 attrs.some_value:com.example.AttrKeys#SOME_VALUE</exports>
+        -->
+      </appender>
+      ...
+    </configuration>
+
+will define an appender called ``RCIA`` which exports the following:
+
+- ``remote.ip``
+
+  - the IP address of the remote peer,
+
+- ``tls.cipher``
+
+  - the SSL/TLS cipher suite of the connection,
+
+- ``req.http_headers.user-agent``
+
+  - the user agent of the client,
+
+- ``attrs.some_value``
+
+  - a custom attribute set via ``RequestContext.attr(AttributeKey.valueOf(AttrKeys.class, "SOME_VALUE")).set(...)``
+
+... to the `MDC`_ property map and forwards the log message to the appender ``CONSOLE``, as defined in the
+``<appender-ref />`` element.
+
+There are three types of properties you can export using `RequestContextExportingAppender`_.
+
+Built-in properties
+-------------------
+A built-in property is a common property available for most requests. See the complete list of the built-in
+properties and their MDC keys at `BuiltInProperty`_.
+
+HTTP request and response headers
+---------------------------------
+When the session protocol of the current connection is HTTP, a user can export HTTP headers of the current
+request and response. The MDC key of the exported header is ``"req.http_headers.<lower-case header name>"`` or
+``"res.http_headers.<lower-case header name>"``. For example:
+
+- ``"req.http_headers.user-agent"``
+- ``"res.http_headers.set-cookie"``
+
+Custom attributes
+-----------------
+A user can attach an arbitrary custom attribute to a ``RequestContext`` by using
+``RequestContext.attr(...).set(...)`` to store the information associated with the request being handled.
+`RequestContextExportingAppender`_ can export such attributes to the `MDC`_ property map as well.
+
+Unlike other property types, you need to specify the full name of an attribute as well as its alias.
+For example, if you want to export an attribute ``com.example.Foo#ATTR_BAR`` with the alias ``bar``, you need to add
+``<export>attrs.bar:com.example.Foo#ATTR_BAR</export>`` to the XML configuration. The resulting MDC key to
+access the attribute value is ``attrs.bar``, which follows the form of ``attrs.<alias>``.
+
+Using an alternative string converter for a custom attribute
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+By default, `RequestContextExportingAppender`_ uses ``Object.toString()`` to convert an attribute value into
+an `MDC`_ value. If you want an alternative string repredentation of an attribute value, you can define
+a ``Function`` class with a public no-args constructor that transforms an attribute value into a ``String``:
+
+.. code-block:: java
+
+    package com.example;
+
+    public class SomeValue {
+        public final String value;
+
+        @Override
+        public String toString() {
+            // Too verbose for logging
+            return "SomeValue(value=" + value + ')';
+        }
+    }
+
+    public class MyStringifier implements Function<SomeValue, String> {
+        @Override
+        public String apply(SomeValue o) {
+            return o.value;
+        }
+    }
+
+Once the ``Function`` is implemented, specify the fully-qualified class name of the ``Function`` implementation
+as the 3rd component of the ``<export />`` element in the XML configuration:
+
+.. code-block:: xml
+
+    <?xml version="1.0" encoding="UTF-8"?>
+    <configuration>
+      ...
+      <appender name="RCIA" class="com.linecorp.armeria.common.logback.RequestContextExportingAppender">
+        ...
+        <export>attrs.some_value:com.example.AttrKeys#SOME_VALUE:com.example.MyStringifier</export>
+        ...
+      </appender>
+      ...
+    </configuration>

--- a/site/src/sphinx/advanced.rst
+++ b/site/src/sphinx/advanced.rst
@@ -1,0 +1,7 @@
+Advanced topics
+===============
+
+.. toctree::
+    :maxdepth: 1
+
+    advanced-logging

--- a/site/src/sphinx/client-basics.rst
+++ b/site/src/sphinx/client-basics.rst
@@ -1,5 +1,6 @@
 .. _`Server basics`: server-basics.html
 .. _`Using Armeria as an HTTP client`: client-http.html
+.. _`Using Armeria as a Retrofit2 HTTP client`: client-http-retrofit.html
 .. _`Clients`: apidocs/index.html?com/linecorp/armeria/client/Clients.html
 .. _`ClientBuilder`: apidocs/index.html?com/linecorp/armeria/client/ClientBuilder.html
 
@@ -80,6 +81,7 @@ Next steps
 ----------
 - `Server basics`_ if you did not write a Thrift RPC server with Armeria yet
 - `Using Armeria as an HTTP client`_ if you want to send an HTTP request asynchronously
+- `Using Armeria as a Retrofit2 HTTP client`_ if you want to build a REST client
 - or you could explore the client-side API documentation:
    - `Clients`_
    - `ClientBuilder`_

--- a/site/src/sphinx/index.rst
+++ b/site/src/sphinx/index.rst
@@ -73,6 +73,7 @@ Read more
     setup
     server
     client
+    advanced
     Release notes <https://github.com/line/armeria/releases>
     API documentation <apidocs/index.html#://>
     Source cross-reference <xref/index.html#://>


### PR DESCRIPTION
- Add RequestContextExportingAppender
- Deprecate ServiceRequestContext.logger() and its related configuration
  properties