### PR TITLE
Fix create directory failed when using war for TomcatService

### DIFF
--- a/tomcat/src/main/java/com/linecorp/armeria/server/http/tomcat/ManagedConnectorFactory.java
+++ b/tomcat/src/main/java/com/linecorp/armeria/server/http/tomcat/ManagedConnectorFactory.java
@@ -91,7 +91,6 @@ final class ManagedConnectorFactory implements Function<String, Connector> {
         return connector;
     }
 
-
     private StandardServer newServer(String hostname, Connector connector, TomcatServiceConfig config) {
         //
         // server <------ services <------ engines <------ realm
@@ -130,10 +129,14 @@ final class ManagedConnectorFactory implements Function<String, Connector> {
             engine.addChild(host);
         }
 
+        if (!host.getAppBaseFile().mkdirs()) {
+            throw new TomcatServiceException("failed to create app base file: " + host.getAppBaseFile());
+        }
+
         // Create a new context and add it to the host.
         final Context ctx;
         try {
-            ctx = (Context) Class.forName(host.getContextClass(), true,getClass().getClassLoader())
+            ctx = (Context) Class.forName(host.getContextClass(), true, getClass().getClassLoader())
                                  .newInstance();
         } catch (Exception e) {
             throw new TomcatServiceException("failed to create a new context: " + config, e);
@@ -160,7 +163,6 @@ final class ManagedConnectorFactory implements Function<String, Connector> {
     private void checkConfiguration(StandardServer server,
                                     Service expectedService, Connector expectedConnector,
                                     Engine expectedEngine, StandardHost expectedHost, Context expectedContext) {
-
 
         // Check if Catalina base and home directories have not been changed.
         final File expectedBaseDir = config.baseDir().toFile();


### PR DESCRIPTION
Apply this change will fix `java.io.IOException: Unable to create the directory`. But even this throws exception, it still works. So this PR just fix annoying msg.

reference: http://www.mail-archive.com/users@tomcat.apache.org/msg122417.html

```
java.io.IOException: Unable to create the directory [/private/var/folders/pg/hr1wt4pd4yl97t21pl33lf_00000gp/T/tomcat-armeria.4815329135503493333/webapps/ROOT]
	at org.apache.catalina.startup.ExpandWar.expand(ExpandWar.java:115) ~[tomcat-embed-core-8.0.30.jar:8.0.30]
	at org.apache.catalina.startup.ContextConfig.fixDocBase(ContextConfig.java:618) [tomcat-embed-core-8.0.30.jar:8.0.30]
	at org.apache.catalina.startup.ContextConfig.beforeStart(ContextConfig.java:744) [tomcat-embed-core-8.0.30.jar:8.0.30]
	at org.apache.catalina.startup.ContextConfig.lifecycleEvent(ContextConfig.java:307) [tomcat-embed-core-8.0.30.jar:8.0.30]
	at org.apache.catalina.util.LifecycleSupport.fireLifecycleEvent(LifecycleSupport.java:95) [tomcat-embed-core-8.0.30.jar:8.0.30]
	at org.apache.catalina.util.LifecycleBase.fireLifecycleEvent(LifecycleBase.java:90) [tomcat-embed-core-8.0.30.jar:8.0.30]
	at org.apache.catalina.util.LifecycleBase.setStateInternal(LifecycleBase.java:402) [tomcat-embed-core-8.0.30.jar:8.0.30]
	at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:147) [tomcat-embed-core-8.0.30.jar:8.0.30]
	at org.apache.catalina.core.ContainerBase$StartChild.call(ContainerBase.java:1408) [tomcat-embed-core-8.0.30.jar:8.0.30]
	at org.apache.catalina.core.ContainerBase$StartChild.call(ContainerBase.java:1398) [tomcat-embed-core-8.0.30.jar:8.0.30]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) [na:1.8.0_102]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [na:1.8.0_102]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [na:1.8.0_102]
	at java.lang.Thread.run(Thread.java:745) [na:1.8.0_102]

```