### PR TITLE
Send 400 Bad Request instead of 500 Internal Server Error on invalid request path

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/http/SimpleHttpRequestBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/http/SimpleHttpRequestBuilder.java
@@ -19,7 +19,6 @@ package com.linecorp.armeria.client.http;
 import static java.util.Objects.requireNonNull;
 
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.nio.charset.Charset;
 
 import com.linecorp.armeria.common.http.AggregatedHttpMessage;
@@ -102,11 +101,7 @@ public final class SimpleHttpRequestBuilder {
 
     private static SimpleHttpRequestBuilder createRequestBuilder(String uri, HttpMethod method) {
         requireNonNull(uri);
-        try {
-            return new SimpleHttpRequestBuilder(new URI(uri), method);
-        } catch (URISyntaxException e) {
-            throw new IllegalArgumentException("invalid uri: " + uri, e);
-        }
+        return new SimpleHttpRequestBuilder(URI.create(uri), method);
     }
 
     private SimpleHttpRequestBuilder(URI uri, HttpMethod method) {

--- a/core/src/main/java/com/linecorp/armeria/server/http/Http1RequestDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/Http1RequestDecoder.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.server.http;
 
+import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 
 import org.slf4j.Logger;
@@ -175,6 +176,11 @@ final class Http1RequestDecoder extends ChannelDuplexHandler {
                     req.close();
                     this.req = req = null;
                 }
+            }
+        } catch (URISyntaxException e) {
+            fail(ctx, HttpResponseStatus.BAD_REQUEST);
+            if (req != null) {
+                req.close(e);
             }
         } catch (Throwable t) {
             fail(ctx, HttpResponseStatus.INTERNAL_SERVER_ERROR);

--- a/core/src/test/java/com/linecorp/armeria/server/http/HttpServerPathTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/http/HttpServerPathTest.java
@@ -65,6 +65,7 @@ public class HttpServerPathTest extends AbstractServerTest {
     static {
         // 200 test
         TEST_URLS.put("/", HttpStatus.OK);
+        TEST_URLS.put("//", HttpStatus.OK);
         TEST_URLS.put("/service//foo", HttpStatus.OK);
         TEST_URLS.put("/service/foo..bar", HttpStatus.OK);
         TEST_URLS.put("/service..hello/foobar", HttpStatus.OK);
@@ -75,7 +76,8 @@ public class HttpServerPathTest extends AbstractServerTest {
         TEST_URLS.put("/cache/v1.0/rnd_team/get/krisjey:56578015655:1223", HttpStatus.OK);
 
         TEST_URLS.put("/signout/56578015655?crumb=s-1475829101-cec4230588-%E2%98%83", HttpStatus.OK);
-        TEST_URLS.put("/search/num=20&newwindow=1&espv=2&q=url+path+colon&oq=url+path+colon&gs_l=serp.3" +
+        TEST_URLS.put(
+                "/search/num=20&newwindow=1&espv=2&q=url+path+colon&oq=url+path+colon&gs_l=serp.3" +
                 "..0i30k1.80626.89265.0.89464.18.16.1.1.1.0.154.1387.0j12.12.0....0...1c.1j4.64.s" +
                 "erp..4.14.1387...0j35i39k1j0i131k1j0i19k1j0i30i19k1j0i8i30i19k1j0i5i30i19k1j0i8i10" +
                 "i30i19k1.Z6SsEq-rZDw",
@@ -83,7 +85,13 @@ public class HttpServerPathTest extends AbstractServerTest {
 
         // 400 test
         TEST_URLS.put("..", HttpStatus.BAD_REQUEST);
+        TEST_URLS.put(".\\", HttpStatus.BAD_REQUEST);
         TEST_URLS.put("something", HttpStatus.BAD_REQUEST);
+        TEST_URLS.put("/service/foo|bar5", HttpStatus.BAD_REQUEST);
+        TEST_URLS.put("/service/foo\\bar6", HttpStatus.BAD_REQUEST);
+        TEST_URLS.put("/\\\\", HttpStatus.BAD_REQUEST);
+        TEST_URLS.put("/service/foo>bar", HttpStatus.BAD_REQUEST);
+        TEST_URLS.put("/service/foo<bar", HttpStatus.BAD_REQUEST);
 
         // 404 test
         TEST_URLS.put("/..service/foobar1", HttpStatus.NOT_FOUND);
@@ -93,29 +101,6 @@ public class HttpServerPathTest extends AbstractServerTest {
         TEST_URLS.put("/service/foo*bar4", HttpStatus.NOT_FOUND);
         TEST_URLS.put("/service:name/hello", HttpStatus.NOT_FOUND);
         TEST_URLS.put("/service::::name/hello", HttpStatus.NOT_FOUND);
-
-        // 500 test
-        TEST_URLS.put("/service/foo|bar5", HttpStatus.INTERNAL_SERVER_ERROR);
-        TEST_URLS.put("/service/foo\bar6", HttpStatus.INTERNAL_SERVER_ERROR);
-        TEST_URLS.put(".\\", HttpStatus.INTERNAL_SERVER_ERROR);
-        TEST_URLS.put("//", HttpStatus.INTERNAL_SERVER_ERROR);
-        TEST_URLS.put("/\\\\", HttpStatus.INTERNAL_SERVER_ERROR);
-
-        /**
-         * TODO(krisjey) should move validation code to ArmeriaHttpUtil
-         * Http1RequestDecoder, Http2RequestDecoder
-         * expected 404. but 500 
-         * @see com.linecorp.armeria.common.http.HttpHeaders.toArmeria(HttpMessage in) 
-         */
-        TEST_URLS.put("/service/foo>bar", HttpStatus.INTERNAL_SERVER_ERROR);
-
-        /**
-         * TODO(krisjey) should move validation code to ArmeriaHttpUtil
-         * Http1RequestDecoder, Http2RequestDecoder
-         * expected 404. but 500 
-         * @see com.linecorp.armeria.common.http.HttpHeaders.toArmeria(HttpMessage in) 
-         */
-        TEST_URLS.put("/service/foo<bar", HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
     @Test(timeout = 10000)
@@ -125,7 +110,7 @@ public class HttpServerPathTest extends AbstractServerTest {
         }
     }
 
-    private void urlPathAssertion(HttpStatus expected, String path) throws Exception {
+    private static void urlPathAssertion(HttpStatus expected, String path) throws Exception {
         final String requestString = "GET " + path + " HTTP/1.0\r\n\r\n";
 
         try (Socket s = new Socket(NetUtil.LOCALHOST, httpPort())) {


### PR DESCRIPTION
Motivation:

Armeria currently responds with 500 Internal Server Error when an HTTP/1
client sends a request with an invalid path. Armeria should respond with
400 Bad Request instead.

Modifications:

- Split ArmeriaHttpUtil.toArmeria(HttpMessage) into toArmeria(HttpRequest)
  and toArmeria(HttpResponse) for clarity
- Raise URISyntaxException rather than IllegalArgumentException when
  request path is invalid for distiction from other runtime exceptions
- Handle the case where a client sends a path that starts with '//' so
  that 400 Bad Request response is not sent

Result:

- Sensible response code
- Server log is not polluted by invalid requests anymore.