### PR TITLE
Make EndpointGroupRegistry.register() replace and Add unregister()

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/routing/EndpointGroupException.java
+++ b/core/src/main/java/com/linecorp/armeria/client/routing/EndpointGroupException.java
@@ -16,7 +16,7 @@
 package com.linecorp.armeria.client.routing;
 
 /**
- * A {@link RuntimeException} raised when the registration or resolution of an {@link EndpointGroup} fails.
+ * A {@link RuntimeException} raised when the resolution of an {@link EndpointGroup} fails.
  */
 public class EndpointGroupException extends RuntimeException {
 

--- a/core/src/test/java/com/linecorp/armeria/client/routing/EndpointGroupRegistryTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/routing/EndpointGroupRegistryTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.routing;
+
+import static com.linecorp.armeria.client.routing.EndpointSelectionStrategy.WEIGHTED_ROUND_ROBIN;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.linecorp.armeria.client.Endpoint;
+
+public class EndpointGroupRegistryTest {
+
+    @Before
+    @After
+    public void setUp() {
+        // Just in case the group 'foo' was registered somewhere.
+        EndpointGroupRegistry.unregister("foo");
+    }
+
+    @Test
+    public void testRegistration() throws Exception {
+        // Unregister a non-existent group.
+        assertThat(EndpointGroupRegistry.unregister("foo")).isFalse();
+
+        final EndpointGroup group1 = new StaticEndpointGroup(Endpoint.of("a.com"));
+        final EndpointGroup group2 = new StaticEndpointGroup(Endpoint.of("b.com"));
+
+        // Register a new group.
+        assertThat(EndpointGroupRegistry.register("foo", group1, WEIGHTED_ROUND_ROBIN)).isTrue();
+        assertThat(EndpointGroupRegistry.get("foo")).isSameAs(group1);
+
+        // Replace the group.
+        assertThat(EndpointGroupRegistry.register("foo", group2, WEIGHTED_ROUND_ROBIN)).isFalse();
+        assertThat(EndpointGroupRegistry.get("foo")).isSameAs(group2);
+
+        // Unregister the group.
+        assertThat(EndpointGroupRegistry.unregister("foo")).isTrue();
+        assertThat(EndpointGroupRegistry.get("foo")).isNull();
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/client/routing/StaticEndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/routing/StaticEndpointGroupTest.java
@@ -126,7 +126,7 @@ public class StaticEndpointGroupTest {
                 Endpoint.of("127.0.0.1", 1234, 3),
                 Endpoint.of("127.0.0.1", 2345, 2),
                 Endpoint.of("127.0.0.1", 3456, 2));
-        EndpointGroupRegistry.replace(groupName, endpointGroup2, WEIGHTED_ROUND_ROBIN);
+        EndpointGroupRegistry.register(groupName, endpointGroup2, WEIGHTED_ROUND_ROBIN);
 
         assertThat(EndpointGroupRegistry.selectNode(groupName).authority(), is("127.0.0.1:1234"));
         assertThat(EndpointGroupRegistry.selectNode(groupName).authority(), is("127.0.0.1:2345"));
@@ -149,7 +149,7 @@ public class StaticEndpointGroupTest {
                 Endpoint.of("127.0.0.1", 1234, 4),
                 Endpoint.of("127.0.0.1", 2345, 4),
                 Endpoint.of("127.0.0.1", 3456, 4));
-        EndpointGroupRegistry.replace(groupName, endpointGroup3, WEIGHTED_ROUND_ROBIN);
+        EndpointGroupRegistry.register(groupName, endpointGroup3, WEIGHTED_ROUND_ROBIN);
 
         assertThat(EndpointGroupRegistry.selectNode(groupName).authority(), is("127.0.0.1:1234"));
         assertThat(EndpointGroupRegistry.selectNode(groupName).authority(), is("127.0.0.1:2345"));
@@ -163,7 +163,7 @@ public class StaticEndpointGroupTest {
                 Endpoint.of("127.0.0.1", 1234, 2),
                 Endpoint.of("127.0.0.1", 2345, 4),
                 Endpoint.of("127.0.0.1", 3456, 6));
-        EndpointGroupRegistry.replace(groupName, endpointGroup4, WEIGHTED_ROUND_ROBIN);
+        EndpointGroupRegistry.register(groupName, endpointGroup4, WEIGHTED_ROUND_ROBIN);
 
         assertThat(EndpointGroupRegistry.selectNode(groupName).authority(), is("127.0.0.1:1234"));
         assertThat(EndpointGroupRegistry.selectNode(groupName).authority(), is("127.0.0.1:2345"));
@@ -224,7 +224,7 @@ public class StaticEndpointGroupTest {
                 Endpoint.of("127.0.0.1", 2345, 4),
                 Endpoint.of("127.0.0.1", 3456, 2));
 
-        EndpointGroupRegistry.replace(groupName, serverGroup2, WEIGHTED_ROUND_ROBIN);
+        EndpointGroupRegistry.register(groupName, serverGroup2, WEIGHTED_ROUND_ROBIN);
 
         ipService = Clients.newClient("tbinary+http://" + endpointGroupMark + groupName + "/serverIp",
                 HelloService.Iface.class);


### PR DESCRIPTION
Motivation:

In a multiple-classloader environment, an application can invoke
EndpointGroupRegistry.register() multiple times with the same group name
when the application is reloaded by the class loader, causing register()
trigger an EndpointGroupException.

Modifications:

- Remove EndpointGroupRegistry.replace()
- Make EndpointGroupRegistry.register() replace.
- Add EndpointGroupRegistry.unregister()

Result:

Less surprising behavior