### PR TITLE
Make RequestContext.blockingTaskExecutor() context-aware

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/RequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestContext.java
@@ -20,6 +20,7 @@ import java.util.Iterator;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -228,6 +229,14 @@ public interface RequestContext extends AttributeMap {
      */
     default Executor makeContextAware(Executor executor) {
         return runnable -> executor.execute(makeContextAware(runnable));
+    }
+
+    /**
+     * Returns an {@link ExecutorService} that will execute callbacks in the given {@code executor}, making
+     * sure to propagate the current {@link RequestContext} into the callback execution.
+     */
+    default ExecutorService makeContextAware(ExecutorService executor) {
+        return new RequestContextAwareExecutorService(this, executor);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/RequestContextAwareEventLoop.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestContextAwareEventLoop.java
@@ -16,14 +16,9 @@
 
 package com.linecorp.armeria.common;
 
-import java.util.Collection;
 import java.util.Iterator;
-import java.util.List;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.stream.Collectors;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
@@ -37,200 +32,137 @@ import io.netty.util.concurrent.Promise;
 import io.netty.util.concurrent.ScheduledFuture;
 
 /**
- * A delegating {@link EventExecutor} that makes sure all submitted tasks are
+ * A delegating {@link EventLoop} that makes sure all submitted tasks are
  * executed within the {@link RequestContext}.
  */
-final class RequestContextAwareEventLoop implements EventLoop {
+final class RequestContextAwareEventLoop extends RequestContextAwareExecutorService implements EventLoop {
 
-    private final RequestContext context;
-    private final EventLoop delegate;
+    RequestContextAwareEventLoop(RequestContext context, EventLoop delegate) {
+        super(context, delegate);
+    }
 
-    RequestContextAwareEventLoop(RequestContext context,EventLoop delegate) {
-        this.context = context;
-        this.delegate = delegate;
+    @Override
+    protected EventLoop delegate() {
+        return (EventLoop) super.delegate();
     }
 
     @Override
     public EventLoop next() {
-        return delegate.next();
+        return delegate().next();
     }
 
     @Override
     public EventLoopGroup parent() {
-        return delegate.parent();
+        return delegate().parent();
     }
 
     @Override
     public boolean inEventLoop() {
-        return delegate.inEventLoop();
+        return delegate().inEventLoop();
     }
 
     @Override
     public boolean inEventLoop(Thread thread) {
-        return delegate.inEventLoop(thread);
+        return delegate().inEventLoop(thread);
     }
 
     @Override
     public <V> Promise<V> newPromise() {
-        return new RequestContextAwarePromise<>(context, delegate.newPromise());
+        return new RequestContextAwarePromise<>(context(), delegate().newPromise());
     }
 
     @Override
     public <V> ProgressivePromise<V> newProgressivePromise() {
-        return new RequestContextAwareProgressivePromise<>(context, delegate.newProgressivePromise());
+        return new RequestContextAwareProgressivePromise<>(context(), delegate().newProgressivePromise());
     }
 
     @Override
     public <V> Future<V> newSucceededFuture(V result) {
-        return new RequestContextAwareFuture<>(context, delegate.newSucceededFuture(result));
+        return new RequestContextAwareFuture<>(context(), delegate().newSucceededFuture(result));
     }
 
     @Override
     public <V> Future<V> newFailedFuture(Throwable cause) {
-        return new RequestContextAwareFuture<>(context, delegate.newFailedFuture(cause));
+        return new RequestContextAwareFuture<>(context(), delegate().newFailedFuture(cause));
     }
 
     @Override
     public boolean isShuttingDown() {
-        return delegate.isShuttingDown();
+        return delegate().isShuttingDown();
     }
 
     @Override
     public Future<?> shutdownGracefully() {
-        return delegate.shutdownGracefully();
+        return delegate().shutdownGracefully();
     }
 
     @Override
     public Future<?> shutdownGracefully(long quietPeriod, long timeout,
                                         TimeUnit unit) {
-        return delegate.shutdownGracefully(quietPeriod, timeout, unit);
+        return delegate().shutdownGracefully(quietPeriod, timeout, unit);
     }
 
     @Override
     public Future<?> terminationFuture() {
-        return delegate.terminationFuture();
-    }
-
-    @Override
-    public void shutdown() {
-        delegate.shutdown();
-    }
-
-    @Override
-    public List<Runnable> shutdownNow() {
-        return delegate.shutdownNow();
+        return delegate().terminationFuture();
     }
 
     @Override
     public Iterator<EventExecutor> iterator() {
-        return delegate.iterator();
+        return delegate().iterator();
     }
 
     @Override
     public Future<?> submit(Runnable task) {
-        return delegate.submit(context.makeContextAware(task));
+        return (Future<?>) super.submit(task);
     }
 
     @Override
     public <T> Future<T> submit(Runnable task, T result) {
-        return delegate.submit(context.makeContextAware(task), result);
+        return (Future<T>) super.submit(task, result);
     }
 
     @Override
     public <T> Future<T> submit(Callable<T> task) {
-        return delegate.submit(context.makeContextAware(task));
+        return (Future<T>) super.submit(task);
     }
 
     @Override
-    public ScheduledFuture<?> schedule(Runnable command, long delay,
-                                       TimeUnit unit) {
-        return delegate.schedule(context.makeContextAware(command), delay, unit);
+    public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+        return delegate().schedule(context().makeContextAware(command), delay, unit);
     }
 
     @Override
-    public <V> ScheduledFuture<V> schedule(Callable<V> callable,
-                                           long delay, TimeUnit unit) {
-        return delegate.schedule(context.makeContextAware(callable), delay, unit);
+    public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+        return delegate().schedule(context().makeContextAware(callable), delay, unit);
     }
 
     @Override
-    public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay,
-                                                  long period,
-                                                  TimeUnit unit) {
-        return delegate.scheduleAtFixedRate(context.makeContextAware(command), initialDelay, period, unit);
+    public ScheduledFuture<?> scheduleAtFixedRate(
+            Runnable command, long initialDelay, long period, TimeUnit unit) {
+        return delegate().scheduleAtFixedRate(context().makeContextAware(command), initialDelay, period, unit);
     }
 
     @Override
-    public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay,
-                                                     long delay,
-                                                     TimeUnit unit) {
-        return delegate.scheduleWithFixedDelay(context.makeContextAware(command), initialDelay, delay, unit);
-    }
-
-    @Override
-    public boolean isShutdown() {
-        return delegate.isShutdown();
-    }
-
-    @Override
-    public boolean isTerminated() {
-        return delegate.isTerminated();
-    }
-
-    @Override
-    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
-        return delegate.awaitTermination(timeout, unit);
-    }
-
-    @Override
-    public <T> List<java.util.concurrent.Future<T>> invokeAll(
-            Collection<? extends Callable<T>> tasks) throws InterruptedException {
-        return delegate.invokeAll(makeContextAware(tasks));
-    }
-
-    @Override
-    public <T> List<java.util.concurrent.Future<T>> invokeAll(
-            Collection<? extends Callable<T>> tasks, long timeout,
-            TimeUnit unit) throws InterruptedException {
-        return delegate.invokeAll(makeContextAware(tasks), timeout, unit);
-    }
-
-    @Override
-    public <T> T invokeAny(Collection<? extends Callable<T>> tasks)
-            throws InterruptedException, ExecutionException {
-        return delegate.invokeAny(makeContextAware(tasks));
-    }
-
-    @Override
-    public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout,
-                           TimeUnit unit) throws InterruptedException, ExecutionException,
-                                                 TimeoutException {
-        return delegate.invokeAny(makeContextAware(tasks), timeout, unit);
-    }
-
-    @Override
-    public void execute(Runnable command) {
-        delegate.execute(context.makeContextAware(command));
-    }
-
-    private <T> Collection<? extends Callable<T>> makeContextAware(
-            Collection<? extends Callable<T>> tasks) {
-        return tasks.stream().map(context::makeContextAware).collect(Collectors.toList());
+    public ScheduledFuture<?> scheduleWithFixedDelay(
+            Runnable command, long initialDelay, long delay, TimeUnit unit) {
+        return delegate().scheduleWithFixedDelay(
+                context().makeContextAware(command), initialDelay, delay, unit);
     }
 
     @Override
     public ChannelFuture register(Channel channel) {
-        return delegate.register(channel);
+        return delegate().register(channel);
     }
 
     @Override
     public ChannelFuture register(ChannelPromise channelPromise) {
-        return delegate.register(channelPromise);
+        return delegate().register(channelPromise);
     }
 
     @Override
     public ChannelFuture register(Channel channel,
                                   ChannelPromise channelPromise) {
-        return delegate.register(channel, channelPromise);
+        return delegate().register(channel, channelPromise);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/RequestContextAwareExecutorService.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestContextAwareExecutorService.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+
+/**
+ * A delegating {@link ExecutorService} that makes sure all submitted tasks are
+ * executed within the {@link RequestContext}.
+ */
+class RequestContextAwareExecutorService implements ExecutorService {
+
+    private final RequestContext context;
+    private final ExecutorService delegate;
+
+    RequestContextAwareExecutorService(RequestContext context, ExecutorService delegate) {
+        this.context = context;
+        this.delegate = delegate;
+    }
+
+    final RequestContext context() {
+        return context;
+    }
+
+    ExecutorService delegate() {
+        return delegate;
+    }
+
+    @Override
+    public final void shutdown() {
+        delegate.shutdown();
+    }
+
+    @Override
+    public final List<Runnable> shutdownNow() {
+        return delegate.shutdownNow();
+    }
+
+    @Override
+    public Future<?> submit(Runnable task) {
+        return delegate.submit(context.makeContextAware(task));
+    }
+
+    @Override
+    public <T> Future<T> submit(Runnable task, T result) {
+        return delegate.submit(context.makeContextAware(task), result);
+    }
+
+    @Override
+    public <T> Future<T> submit(Callable<T> task) {
+        return delegate.submit(context.makeContextAware(task));
+    }
+
+    @Override
+    public final boolean isShutdown() {
+        return delegate.isShutdown();
+    }
+
+    @Override
+    public final boolean isTerminated() {
+        return delegate.isTerminated();
+    }
+
+    @Override
+    public final boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        return delegate.awaitTermination(timeout, unit);
+    }
+
+    @Override
+    public final <T> List<Future<T>> invokeAll(
+            Collection<? extends Callable<T>> tasks) throws InterruptedException {
+        return delegate.invokeAll(makeContextAware(tasks));
+    }
+
+    @Override
+    public final <T> List<Future<T>> invokeAll(
+            Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException {
+        return delegate.invokeAll(makeContextAware(tasks), timeout, unit);
+    }
+
+    @Override
+    public final <T> T invokeAny(Collection<? extends Callable<T>> tasks)
+            throws InterruptedException, ExecutionException {
+        return delegate.invokeAny(makeContextAware(tasks));
+    }
+
+    @Override
+    public final <T> T invokeAny(
+            Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+            throws InterruptedException, ExecutionException, TimeoutException {
+        return delegate.invokeAny(makeContextAware(tasks), timeout, unit);
+    }
+
+    @Override
+    public final void execute(Runnable command) {
+        delegate.execute(context.makeContextAware(command));
+    }
+
+    private <T> Collection<? extends Callable<T>> makeContextAware(
+            Collection<? extends Callable<T>> tasks) {
+        return tasks.stream().map(context::makeContextAware).collect(Collectors.toList());
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
@@ -57,6 +57,8 @@ public final class DefaultServiceRequestContext extends NonWrappingRequestContex
     private final DefaultResponseLog responseLog;
     private final Logger logger;
 
+    private ExecutorService blockingTaskExecutor;
+
     private long requestTimeoutMillis;
     private long maxRequestLength;
 
@@ -124,7 +126,11 @@ public final class DefaultServiceRequestContext extends NonWrappingRequestContex
 
     @Override
     public ExecutorService blockingTaskExecutor() {
-        return server().config().blockingTaskExecutor();
+        if (blockingTaskExecutor != null) {
+            return blockingTaskExecutor;
+        }
+
+        return blockingTaskExecutor = makeContextAware(server().config().blockingTaskExecutor());
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
@@ -381,6 +381,9 @@ public final class ServerConfig {
 
     /**
      * Returns the {@link ExecutorService} dedicated to the execution of blocking tasks or invocations.
+     * Note that the {@link ExecutorService} returned by this method does not set the
+     * {@link ServiceRequestContext} when executing a submitted task.
+     * Use {@link ServiceRequestContext#blockingTaskExecutor()} if possible.
      */
     public ExecutorService blockingTaskExecutor() {
         return blockingTaskExecutor;

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
@@ -58,8 +58,11 @@ public interface ServiceRequestContext extends RequestContext {
 
     /**
      * Returns the {@link ExecutorService} that could be used for executing a potentially long-running task.
-     * Note that performing a long-running task in {@link Service#serve(ServiceRequestContext, Request)} may
-     * block the {@link Server}'s I/O event loop and thus should be executed in other threads.
+     * The {@link ExecutorService} will propagate the {@link ServiceRequestContext} automatically when running
+     * a task.
+     *
+     * <p>Note that performing a long-running task in {@link Service#serve(ServiceRequestContext, Request)}
+     * may block the {@link Server}'s I/O event loop and thus should be executed in other threads.
      */
     ExecutorService blockingTaskExecutor();
 

--- a/core/src/main/java/com/linecorp/armeria/server/thrift/ThriftCallService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/thrift/ThriftCallService.java
@@ -33,8 +33,6 @@ import org.apache.thrift.async.AsyncMethodCallback;
 
 import com.google.common.collect.ImmutableMap;
 
-import com.linecorp.armeria.common.RequestContext;
-import com.linecorp.armeria.common.RequestContext.PushHandle;
 import com.linecorp.armeria.common.thrift.ThriftCall;
 import com.linecorp.armeria.common.thrift.ThriftReply;
 import com.linecorp.armeria.internal.thrift.ThriftFunction;
@@ -169,7 +167,7 @@ public final class ThriftCallService implements Service<ThriftCall, ThriftReply>
                 return;
             }
 
-            try (PushHandle ignored = RequestContext.push(ctx)) {
+            try {
                 @SuppressWarnings("unchecked")
                 TBase<TBase<?, ?>, TFieldIdEnum> result = f.getResult(impl, args);
                 if (func.isOneWay()) {

--- a/tomcat/src/main/java/com/linecorp/armeria/server/http/tomcat/TomcatService.java
+++ b/tomcat/src/main/java/com/linecorp/armeria/server/http/tomcat/TomcatService.java
@@ -56,8 +56,6 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Sets;
 
-import com.linecorp.armeria.common.RequestContext;
-import com.linecorp.armeria.common.RequestContext.PushHandle;
 import com.linecorp.armeria.common.http.AggregatedHttpMessage;
 import com.linecorp.armeria.common.http.DefaultHttpResponse;
 import com.linecorp.armeria.common.http.HttpData;
@@ -405,7 +403,7 @@ public final class TomcatService implements HttpService {
                         return;
                     }
 
-                    try (PushHandle ignored = RequestContext.push(ctx)) {
+                    try {
                         coyoteAdapter.service(coyoteReq, coyoteRes);
                         final HttpHeaders headers = convertResponse(coyoteRes);
                         res.write(headers);


### PR DESCRIPTION
Motivation:

So far, RequestContext.blockingTaskExecutor() was not context-aware,
meaning a user had to make his or her task context-aware by calling
RequestContext.makeContextAware(Runnable). It is error-prone and
inconvenient.

Modifications:

- Add RequestContextAwareExecutorService
  - Make RequestContextAwareEventLoop extend it
- Add RequestContext.makeContextAware(ExecutorService)
- Make RequestContext.blockingTaskExecutor() always return the
  context-aware version
- Update the API documentation of ServerConfig.blockingTaskExecutor()

Result:

User-friendliness