### PR TITLE
Support HEAD method on HttpHealthCheckService

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/http/healthcheck/HttpHealthCheckService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/healthcheck/HttpHealthCheckService.java
@@ -125,15 +125,19 @@ public class HttpHealthCheckService extends AbstractHttpService {
     }
 
     @Override
-    protected void doGet(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) {
-        final AggregatedHttpMessage response;
-        if (isHealthy()) {
-            response = newHealthyResponse(ctx);
-        } else {
-            response = newUnhealthyResponse(ctx);
-        }
+    protected void doHead(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) throws Exception {
+        res.write(newResponse(ctx).headers()); // Send without the content.
+        res.close();
+    }
 
-        res.respond(response);
+    @Override
+    protected void doGet(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) {
+        res.respond(newResponse(ctx));
+    }
+
+    private AggregatedHttpMessage newResponse(ServiceRequestContext ctx) {
+        return isHealthy() ? newHealthyResponse(ctx)
+                           : newUnhealthyResponse(ctx);
     }
 
     private boolean isHealthy() {


### PR DESCRIPTION
Motivation:

Some load balancers use a HEAD request instead of a GET request to check
the health of a host.

Modifications:

- Implement HttpHealthCheckService.doHead()

Result:

HttpHealthCheckService works with the load balancers that sends a HEAD
request.