### PR TITLE
Allow rescheduling server-side request timeout

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/RequestTimeoutChangeListener.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RequestTimeoutChangeListener.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server;
+
+/**
+ * A listener that is notified when {@linkplain ServiceRequestContext#requestTimeoutMillis() request timeout}
+ * setting is changed.
+ *
+ * <p>Note: This interface is meant for internal use by server-side protocol implementation to reschedule
+ * a timeout task when a user updates the request timeout configuration.
+ */
+@FunctionalInterface
+public interface RequestTimeoutChangeListener {
+    /**
+     * Invoked when the request timeout of the current request has been changed.
+     *
+     * @param newRequestTimeoutMillis the new timeout value in milliseconds. {@code 0} if disabled.
+     */
+    void onRequestTimeoutChange(long newRequestTimeoutMillis);
+}

--- a/core/src/test/java/com/linecorp/armeria/it/thrift/ThriftDynamicTimeoutTest.java
+++ b/core/src/test/java/com/linecorp/armeria/it/thrift/ThriftDynamicTimeoutTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.it.thrift;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+
+import com.google.common.base.Stopwatch;
+
+import com.linecorp.armeria.client.Client;
+import com.linecorp.armeria.client.ClientBuilder;
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.DecoratingClient;
+import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.common.thrift.ThriftCall;
+import com.linecorp.armeria.common.thrift.ThriftReply;
+import com.linecorp.armeria.server.DecoratingService;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.Service;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.thrift.THttpService;
+import com.linecorp.armeria.server.thrift.ThriftCallService;
+import com.linecorp.armeria.service.test.thrift.main.SleepService;
+import com.linecorp.armeria.test.AbstractServerTest;
+
+/**
+ * Tests if Armeria decorators can alter the request/response timeout specified in Thrift call parameters.
+ */
+public class ThriftDynamicTimeoutTest extends AbstractServerTest {
+
+    private static final SleepService.AsyncIface sleepService = (delay, resultHandler) ->
+            RequestContext.current().eventLoop().schedule(
+                    () -> resultHandler.onComplete(delay), delay, TimeUnit.MILLISECONDS);
+
+    @Override
+    protected void configureServer(ServerBuilder sb) throws Exception {
+        sb.serviceAt("/sleep", ThriftCallService.of(sleepService)
+                                                .decorate(DynamicTimeoutService::new)
+                                                .decorate(THttpService.newDecorator()));
+        sb.defaultRequestTimeout(Duration.ofSeconds(1));
+    }
+
+    @Test
+    public void testDynamicTimeout() throws Exception {
+        final SleepService.Iface client = new ClientBuilder("tbinary+" + uri("/sleep"))
+                .decorator(ThriftCall.class, ThriftReply.class, DynamicTimeoutClient::new)
+                .defaultResponseTimeout(Duration.ofSeconds(1)).build(SleepService.Iface.class);
+
+        final long delay = 1500;
+        final Stopwatch sw = Stopwatch.createStarted();
+        client.sleep(delay);
+        assertThat(sw.elapsed(TimeUnit.MILLISECONDS)).isGreaterThanOrEqualTo(delay);
+    }
+
+    private static final class DynamicTimeoutService
+            extends DecoratingService<ThriftCall, ThriftReply, ThriftCall, ThriftReply> {
+
+        DynamicTimeoutService(Service<? super ThriftCall, ? extends ThriftReply> delegate) {
+            super(delegate);
+        }
+
+        @Override
+        public ThriftReply serve(ServiceRequestContext ctx, ThriftCall req) throws Exception {
+            ctx.setRequestTimeoutMillis(((Number) req.params().get(0)).longValue() +
+                                        ctx.requestTimeoutMillis());
+            return delegate().serve(ctx, req);
+        }
+    }
+
+    private static final class DynamicTimeoutClient
+            extends DecoratingClient<ThriftCall, ThriftReply, ThriftCall, ThriftReply> {
+
+        DynamicTimeoutClient(Client<? super ThriftCall, ? extends ThriftReply> delegate) {
+            super(delegate);
+        }
+
+        @Override
+        public ThriftReply execute(ClientRequestContext ctx, ThriftCall req) throws Exception {
+            ctx.setResponseTimeoutMillis(((Number) req.params().get(0)).longValue() +
+                                         ctx.responseTimeoutMillis());
+            return delegate().execute(ctx, req);
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

Unlike the client side, we may not know the appropriate timeout value of
the current request until the full request content is received. For
example, a Thrift service operation could have a 'timeout' parameter
that determines the request timeout.

That is, it is possible that the request timeout is known *after* the
timeout task has been scheduled by HttpResponseSubscriber already. In
such a case, updating the request timeout with
ServiceRequestContext.setRequestTimeout() will not have any effect.

Modifications:

- Add RequestTimeoutChangeListener which is notified by
  DefaultServiceRequestContext when request timeout is changed by a
  user
- Update HttpResponseSubscriber so that it implements
  RequestTimeoutChangeListener and thus it reschedules the timeout task
  on ServiceRequestContext.setRequestTimeout()
- Add a test case 'ThriftDynamicTimeoutTest` that demonstrates what this
  changeset does

Result:

A user can update the server-side request timeout at any time.