### PR TITLE
Easier ClientOptions construction and client derivation

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClientDecoration.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientDecoration.java
@@ -54,6 +54,10 @@ public final class ClientDecoration {
         this.entries = Collections.unmodifiableList(entries);
     }
 
+    List<Entry<?, ?>> entries() {
+        return entries;
+    }
+
     /**
      * Decorates the specified {@link Client} using the decorator with matching {@code requestType} and
      * {@code responseType}.
@@ -108,6 +112,36 @@ public final class ClientDecoration {
 
         Function<Client<? super I, ? extends O>, Client<I, O>> decorator() {
             return decorator;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            final Entry<?, ?> entry = (Entry<?, ?>) o;
+
+            if (!requestType.equals(entry.requestType)) {
+                return false;
+            }
+            if (!responseType.equals(entry.responseType)) {
+                return false;
+            }
+
+            final Function<?, ?> decorator = this.decorator;
+            return decorator == entry.decorator;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = requestType.hashCode();
+            result = 31 * result + responseType.hashCode();
+            result = 31 * result + System.identityHashCode(decorator);
+            return result;
         }
 
         @Override

--- a/core/src/main/java/com/linecorp/armeria/client/ClientOptionDerivable.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientOptionDerivable.java
@@ -19,30 +19,53 @@ package com.linecorp.armeria.client;
 import static java.util.Objects.requireNonNull;
 
 import java.net.URI;
-import java.util.Arrays;
+import java.util.function.Function;
 
 /**
  * A client that allows creating a new client with alternative {@link ClientOption}s.
  *
  * @param <T> self type
+ *
+ * @see ClientOptionsBuilder ClientOptionsBuilder, for more information about how the base options and
+ *                           additional options are merged when a derived client is created.
  */
 @FunctionalInterface
 public interface ClientOptionDerivable<T> {
 
     /**
-     * Creates a new derived client that connects to the same {@link URI} with the specified {@code client}
-     * with the specified {@code additionalOptions}. Note that the derived client will use the options of
-     * the specified {@code client} unless specified in {@code additionalOptions}.
+     * Creates a new derived client that connects to the same {@link URI} with this client and
+     * the specified {@code additionalOptions}.
      */
     default T withOptions(ClientOptionValue<?>... additionalOptions) {
         requireNonNull(additionalOptions, "additionalOptions");
-        return withOptions(Arrays.asList(additionalOptions));
+        return derive(options -> new ClientOptionsBuilder(options).options(additionalOptions).build());
     }
 
     /**
-     * Creates a new derived client that connects to the same {@link URI} with the specified {@code client}
-     * with the specified {@code additionalOptions}. Note that the derived client will use the options of
-     * the specified {@code client} unless specified in {@code additionalOptions}.
+     * Creates a new derived client that connects to the same {@link URI} with this client and
+     * the specified {@code additionalOptions}.
      */
-    T withOptions(Iterable<ClientOptionValue<?>> additionalOptions);
+    default T withOptions(Iterable<ClientOptionValue<?>> additionalOptions) {
+        requireNonNull(additionalOptions, "additionalOptions");
+        return derive(options -> new ClientOptionsBuilder(options).options(additionalOptions).build());
+    }
+
+    /**
+     * Creates a new derived client that connects to the same {@link URI} with this client but with different
+     * {@link ClientOption}s. For example:
+     *
+     * <pre>{@code
+     * HttpClient derivedHttpClient = httpClient.derive(options -> {
+     *     ClientOptionsBuilder builder = new ClientOptionsBuilder(options);
+     *     builder.decorator(...);   // Add a decorator.
+     *     builder.httpHeader(...); // Add an HTTP header.
+     *     return builder.build();
+     * });
+     * }</pre>
+     *
+     * @param configurator a {@link Function} whose input is the original {@link ClientOptions} of the client
+     *                     being derived from and whose output is the {@link ClientOptions} of the new derived
+     *                     client
+     */
+    T derive(Function<? super ClientOptions, ClientOptions> configurator);
 }

--- a/core/src/main/java/com/linecorp/armeria/client/ClientOptions.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientOptions.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 
+import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.http.DefaultHttpHeaders;
 import com.linecorp.armeria.common.http.HttpHeaderNames;
 import com.linecorp.armeria.common.http.HttpHeaders;
@@ -238,5 +239,12 @@ public final class ClientOptions extends AbstractOptions {
     public ClientDecoration decoration() {
         return getOrElse(DECORATION, ClientDecoration.NONE);
     }
-}
 
+    /**
+     * Returns the additional HTTP headers to send with requests. Used only when the underlying
+     * {@link SessionProtocol} is HTTP.
+     */
+    public HttpHeaders httpHeaders() {
+        return getOrElse(HTTP_HEADERS, HttpHeaders.EMPTY_HEADERS);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/client/ClientOptionsBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientOptionsBuilder.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client;
+
+import static java.util.Objects.requireNonNull;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+import com.google.common.collect.Iterables;
+
+import com.linecorp.armeria.common.Request;
+import com.linecorp.armeria.common.Response;
+import com.linecorp.armeria.common.http.DefaultHttpHeaders;
+import com.linecorp.armeria.common.http.HttpHeaders;
+
+import io.netty.handler.codec.Headers;
+import io.netty.util.AsciiString;
+
+/**
+ * Creates a new {@link ClientOptions} using the builder pattern.
+ *
+ * <h3>{@link ClientOption#DECORATION} and {@link ClientOption#HTTP_HEADERS}</h3>
+ * Unlike other options, when a user calls {@link #option(ClientOption, Object)} or {@code options()} with
+ * a {@link ClientOption#DECORATION} or a {@link ClientOption#HTTP_HEADERS}, this builder will not simply
+ * replace the old option but <em>merge</em> the specified option into the previous option value. For example:
+ * <pre>{@code
+ * ClientOptionsBuilder b = new ClientOptionsBuilder();
+ * b.option(ClientOption.HTTP_HEADERS, headersA);
+ * b.option(ClientOption.HTTP_HEADERS, headersB);
+ * b.option(ClientOption.DECORATION, decorationA);
+ * b.option(ClientOption.DECORATION, decorationB);
+ *
+ * ClientOptions opts = b.build();
+ * HttpHeaders httpHeaders = opts.httpHeaders();
+ * ClientDecoration decorations = opts.decoration();
+ * }</pre>
+ * {@code httpHeaders} will contain all HTTP headers of {@code headersA} and {@code headersB}.
+ * If {@code headersA} and {@code headersB} have the headers with the same name, the duplicate header in
+ * {@code headerB} will replace the one with the same name in {@code headerA}.
+ * Similarly, {@code decorations} will contain all decorators of {@code decorationA} and {@code decorationB},
+ * but there will be no replacement but only addition.
+ */
+public final class ClientOptionsBuilder {
+
+    private final Map<ClientOption<?>, ClientOptionValue<?>> options = new LinkedHashMap<>();
+    private final ClientDecorationBuilder decoration = new ClientDecorationBuilder();
+    private final HttpHeaders httpHeaders = new DefaultHttpHeaders();
+
+    /**
+     * Creates a new instance with the default options.
+     */
+    public ClientOptionsBuilder() {}
+
+    /**
+     * Creates a new instance with the specified base options.
+     */
+    public ClientOptionsBuilder(ClientOptions options) {
+        requireNonNull(options, "options");
+        options(options);
+    }
+
+    /**
+     * Adds the specified {@link ClientOptions}.
+     */
+    public ClientOptionsBuilder options(ClientOptions options) {
+        requireNonNull(options, "options");
+        options.asMap().values().forEach(this::option);
+        return this;
+    }
+
+    /**
+     * Adds the specified {@link ClientOptionValue}s.
+     */
+    public ClientOptionsBuilder options(ClientOptionValue<?>... options) {
+        requireNonNull(options, "options");
+        for (ClientOptionValue<?> o : options) {
+            option(o);
+        }
+        return this;
+    }
+
+    /**
+     * Adds the specified {@link ClientOptionValue}s.
+     */
+    public ClientOptionsBuilder options(Iterable<ClientOptionValue<?>> options) {
+        requireNonNull(options, "options");
+        options(Iterables.toArray(options, ClientOptionValue.class));
+        return this;
+    }
+
+    /**
+     * Adds the specified {@link ClientOption} and its {@code value}.
+     */
+    public <T> ClientOptionsBuilder option(ClientOption<T> option, T value) {
+        requireNonNull(option, "option");
+        requireNonNull(value, "value");
+        return option(option.newValue(value));
+    }
+
+    /**
+     * Adds the specified {@link ClientOptionValue}.
+     */
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public <T> ClientOptionsBuilder option(ClientOptionValue<T> optionValue) {
+        requireNonNull(optionValue, "optionValue");
+        final ClientOption<?> opt = optionValue.option();
+        if (opt == ClientOption.DECORATION) {
+            final ClientDecoration d = (ClientDecoration) optionValue.value();
+            d.entries().forEach(e -> decorator((Class) e.requestType(), e.responseType(),
+                                               (Function) e.decorator()));
+        } else if (opt == ClientOption.HTTP_HEADERS) {
+            final HttpHeaders h = (HttpHeaders) optionValue.value();
+            setHttpHeaders(h);
+        } else {
+            options.put(opt, optionValue);
+        }
+        return this;
+    }
+
+    /**
+     * Sets the default timeout of a socket write attempt in milliseconds.
+     *
+     * @param defaultWriteTimeoutMillis the timeout in milliseconds. {@code 0} disables the timeout.
+     */
+    public ClientOptionsBuilder defaultWriteTimeoutMillis(long defaultWriteTimeoutMillis) {
+        return option(ClientOption.DEFAULT_WRITE_TIMEOUT_MILLIS, defaultWriteTimeoutMillis);
+    }
+
+    /**
+     * Sets the default timeout of a socket write attempt.
+     *
+     * @param defaultWriteTimeout the timeout. {@code 0} disables the timeout.
+     */
+    public ClientOptionsBuilder defaultWriteTimeout(Duration defaultWriteTimeout) {
+        return defaultWriteTimeoutMillis(requireNonNull(defaultWriteTimeout, "defaultWriteTimeout").toMillis());
+    }
+
+    /**
+     * Sets the default timeout of a response in milliseconds.
+     *
+     * @param defaultResponseTimeoutMillis the timeout in milliseconds. {@code 0} disables the timeout.
+     */
+    public ClientOptionsBuilder defaultResponseTimeoutMillis(long defaultResponseTimeoutMillis) {
+        return option(ClientOption.DEFAULT_RESPONSE_TIMEOUT_MILLIS, defaultResponseTimeoutMillis);
+    }
+
+    /**
+     * Sets the default timeout of a response.
+     *
+     * @param defaultResponseTimeout the timeout. {@code 0} disables the timeout.
+     */
+    public ClientOptionsBuilder defaultResponseTimeout(Duration defaultResponseTimeout) {
+        return defaultResponseTimeoutMillis(
+                requireNonNull(defaultResponseTimeout, "defaultResponseTimeout").toMillis());
+    }
+
+    /**
+     * Sets the default maximum allowed length of a server response in bytes.
+     *
+     * @param defaultMaxResponseLength the maximum length in bytes. {@code 0} disables the limit.
+     */
+    public ClientOptionsBuilder defaultMaxResponseLength(long defaultMaxResponseLength) {
+        return option(ClientOption.DEFAULT_MAX_RESPONSE_LENGTH, defaultMaxResponseLength);
+    }
+
+    /**
+     * Adds the specified {@code decorator}.
+     */
+    public <T extends Client<? super I, ? extends O>, R extends Client<I, O>,
+            I extends Request, O extends Response>
+    ClientOptionsBuilder decorator(Class<I> requestType, Class<O> responseType, Function<T, R> decorator) {
+        decoration.add(requestType, responseType, decorator);
+        return this;
+    }
+
+    /**
+     * Adds the specified HTTP header.
+     */
+    public ClientOptionsBuilder addHttpHeader(AsciiString name, Object value) {
+        requireNonNull(name, "name");
+        requireNonNull(value, "value");
+        httpHeaders.addObject(name, value);
+        return this;
+    }
+
+    /**
+     * Adds the specified HTTP headers.
+     */
+    public ClientOptionsBuilder addHttpHeaders(Headers<AsciiString, String, ?> httpHeaders) {
+        requireNonNull(httpHeaders, "httpHeaders");
+        this.httpHeaders.add(httpHeaders);
+        return this;
+    }
+
+    /**
+     * Sets the specified HTTP header.
+     */
+    public ClientOptionsBuilder setHttpHeader(AsciiString name, Object value) {
+        requireNonNull(name, "name");
+        requireNonNull(value, "value");
+        httpHeaders.setObject(name, value);
+        return this;
+    }
+
+    /**
+     * Sets the specified HTTP headers.
+     */
+    public ClientOptionsBuilder setHttpHeaders(Headers<AsciiString, String, ?> httpHeaders) {
+        requireNonNull(httpHeaders, "httpHeaders");
+        this.httpHeaders.setAll(httpHeaders);
+        return this;
+    }
+
+    /**
+     * Creates a new {@link ClientOptions}.
+     */
+    public ClientOptions build() {
+        final Collection<ClientOptionValue<?>> optVals = options.values();
+        final int numOpts = optVals.size();
+        ClientOptionValue<?>[] optValArray = optVals.toArray(new ClientOptionValue[numOpts + 2]);
+        optValArray[numOpts] = ClientOption.DECORATION.newValue(decoration.build());
+        optValArray[numOpts + 1] = ClientOption.HTTP_HEADERS.newValue(httpHeaders);
+
+        return ClientOptions.of(optValArray);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/client/UserClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/UserClient.java
@@ -146,14 +146,18 @@ public abstract class UserClient<T, I extends Request, O extends Response> imple
 
     @Override
     public final T withOptions(ClientOptionValue<?>... additionalOptions) {
-        final ClientOptions options = ClientOptions.of(options(), additionalOptions);
-        return newInstance(delegate(), eventLoopSupplier, sessionProtocol(), options, endpoint());
+        return ClientOptionDerivable.super.withOptions(additionalOptions);
     }
 
     @Override
     public final T withOptions(Iterable<ClientOptionValue<?>> additionalOptions) {
-        final ClientOptions options = ClientOptions.of(options(), additionalOptions);
-        return newInstance(delegate(), eventLoopSupplier, sessionProtocol(), options, endpoint());
+        return ClientOptionDerivable.super.withOptions(additionalOptions);
+    }
+
+    @Override
+    public final T derive(Function<? super ClientOptions, ClientOptions> configurator) {
+        final ClientOptions newOptions = configurator.apply(options());
+        return newInstance(delegate(), eventLoopSupplier, sessionProtocol(), newOptions, endpoint());
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/http/DefaultSimpleHttpClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/http/DefaultSimpleHttpClient.java
@@ -20,8 +20,9 @@ import static com.linecorp.armeria.common.util.Functions.voidFunction;
 
 import java.net.URI;
 import java.util.Arrays;
+import java.util.function.Function;
 
-import com.linecorp.armeria.client.ClientOptionValue;
+import com.linecorp.armeria.client.ClientOptions;
 import com.linecorp.armeria.common.http.AggregatedHttpMessage;
 import com.linecorp.armeria.common.http.HttpData;
 import com.linecorp.armeria.common.http.HttpMethod;
@@ -100,7 +101,7 @@ final class DefaultSimpleHttpClient implements SimpleHttpClient {
     }
 
     @Override
-    public SimpleHttpClient withOptions(Iterable<ClientOptionValue<?>> additionalOptions) {
-        return new DefaultSimpleHttpClient((DefaultHttpClient) client.withOptions(additionalOptions));
+    public SimpleHttpClient derive(Function<? super ClientOptions, ClientOptions> configurator) {
+        return new DefaultSimpleHttpClient((DefaultHttpClient) client.derive(configurator));
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/ClientOptionsBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientOptionsBuilderTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.function.Function;
+
+import org.junit.Test;
+
+import com.linecorp.armeria.client.ClientDecoration.Entry;
+import com.linecorp.armeria.client.logging.LoggingClient;
+import com.linecorp.armeria.common.http.HttpHeaderNames;
+import com.linecorp.armeria.common.http.HttpHeaders;
+import com.linecorp.armeria.common.http.HttpRequest;
+import com.linecorp.armeria.common.http.HttpResponse;
+import com.linecorp.armeria.common.thrift.ThriftCall;
+import com.linecorp.armeria.common.thrift.ThriftReply;
+
+public class ClientOptionsBuilderTest {
+    @Test
+    public void testBaseOptions() {
+        final ClientOptionsBuilder b = new ClientOptionsBuilder(
+                ClientOptions.of(ClientOption.DEFAULT_MAX_RESPONSE_LENGTH.newValue(42L)));
+        assertThat(b.build().defaultMaxResponseLength()).isEqualTo(42);
+    }
+
+    @Test
+    public void testOptions() {
+        final ClientOptionsBuilder b = new ClientOptionsBuilder();
+        b.options(ClientOptions.of(ClientOption.DEFAULT_RESPONSE_TIMEOUT_MILLIS.newValue(42L)));
+        assertThat(b.build().defaultResponseTimeoutMillis()).isEqualTo(42);
+
+        b.options(ClientOption.DEFAULT_WRITE_TIMEOUT_MILLIS.newValue(84L));
+        assertThat(b.build().defaultResponseTimeoutMillis()).isEqualTo(42);
+        assertThat(b.build().defaultWriteTimeoutMillis()).isEqualTo(84);
+    }
+
+    @Test
+    public void testOption() {
+        final ClientOptionsBuilder b = new ClientOptionsBuilder();
+        b.option(ClientOption.DEFAULT_MAX_RESPONSE_LENGTH, 123L);
+        assertThat(b.build().defaultMaxResponseLength()).isEqualTo(123);
+    }
+
+    @Test
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public void testDecorators() {
+        final ClientOptionsBuilder b = new ClientOptionsBuilder();
+        final Function decorator = service -> new LoggingClient((Client) service);
+
+        b.option(ClientOption.DECORATION.newValue(
+                new ClientDecorationBuilder()
+                        .add(HttpRequest.class, HttpResponse.class, decorator)
+                        .build()));
+
+        assertThat(b.build().decoration().entries()).containsExactly(
+                new Entry<>(HttpRequest.class, HttpResponse.class, decorator));
+
+        // Add another decorator to ensure that the builder does not replace the previous one.
+        b.option(ClientOption.DECORATION.newValue(
+                new ClientDecorationBuilder()
+                        .add(ThriftCall.class, ThriftReply.class, decorator)
+                        .build()));
+        assertThat(b.build().decoration().entries()).containsExactly(
+                new Entry<>(HttpRequest.class, HttpResponse.class, decorator),
+                new Entry<>(ThriftCall.class, ThriftReply.class, decorator));
+    }
+
+    @Test
+    public void testHttpHeaders() {
+        final ClientOptionsBuilder b = new ClientOptionsBuilder();
+
+        b.option(ClientOption.HTTP_HEADERS.newValue(HttpHeaders.of(HttpHeaderNames.ACCEPT, "*/*")));
+        assertThat(b.build().httpHeaders().get(HttpHeaderNames.ACCEPT)).isEqualTo("*/*");
+
+        // Add another header to ensure that the builder does not replace the previous one.
+        b.option(ClientOption.HTTP_HEADERS.newValue(HttpHeaders.of(HttpHeaderNames.USER_AGENT, "foo")));
+
+        final HttpHeaders mergedHeaders = b.build().httpHeaders();
+        assertThat(mergedHeaders.get(HttpHeaderNames.ACCEPT)).isEqualTo("*/*");
+        assertThat(mergedHeaders.get(HttpHeaderNames.USER_AGENT)).isEqualTo("foo");
+    }
+
+    @Test
+    public void testSetHttpHeader() {
+        final ClientOptionsBuilder b = new ClientOptionsBuilder();
+        b.setHttpHeader(HttpHeaderNames.AUTHORIZATION, "Basic QWxhZGRpbjpPcGVuU2VzYW1l");
+
+        assertThat(b.build().httpHeaders().get(HttpHeaderNames.AUTHORIZATION))
+                .isEqualTo("Basic QWxhZGRpbjpPcGVuU2VzYW1l");
+
+        // Ensure setHttpHeader replaces instead of adding.
+        b.setHttpHeader(HttpHeaderNames.AUTHORIZATION, "Lost token");
+        assertThat(b.build().httpHeaders().get(HttpHeaderNames.AUTHORIZATION)).isEqualTo("Lost token");
+    }
+
+    @Test
+    public void testAddHttpHeader() {
+        final ClientOptionsBuilder b = new ClientOptionsBuilder();
+        b.addHttpHeaders(HttpHeaders.of(HttpHeaderNames.AUTHORIZATION, "Basic QWxhZGRpbjpPcGVuU2VzYW1l"));
+
+        assertThat(b.build().httpHeaders().get(HttpHeaderNames.AUTHORIZATION))
+                .isEqualTo("Basic QWxhZGRpbjpPcGVuU2VzYW1l");
+
+        // Ensure addHttpHeader does not replace.
+        b.addHttpHeader(HttpHeaderNames.AUTHORIZATION, "Lost token");
+        assertThat(b.build().httpHeaders().getAll(HttpHeaderNames.AUTHORIZATION)).containsExactly(
+                "Basic QWxhZGRpbjpPcGVuU2VzYW1l", "Lost token");
+    }
+
+    @Test
+    public void testShortcutMethods() {
+        final ClientOptionsBuilder b = new ClientOptionsBuilder();
+        b.defaultWriteTimeout(Duration.ofSeconds(1));
+        b.defaultResponseTimeout(Duration.ofSeconds(2));
+        b.defaultMaxResponseLength(3000);
+
+        final ClientOptions opts = b.build();
+        assertThat(opts.defaultWriteTimeoutMillis()).isEqualTo(1000);
+        assertThat(opts.defaultResponseTimeoutMillis()).isEqualTo(2000);
+        assertThat(opts.defaultMaxResponseLength()).isEqualTo(3000);
+    }
+}


### PR DESCRIPTION
Motivation:

The construction of ClientOptions is not very convenient when specifying
decorators and HTTP headers because a ClientOption does not provide an
easy way to add a decorator or an HTTP header to an existing
ClientOptions.

Modifications:

- Add ClientOptionsBuilder that handles ClientOptions.DECORATION and
  HTTP_HEADERS specially
  - Specifying a decoration will not replace the previous decoration
    anymore. The previous decoration and the new decoration will be
    merged automatically.
  - Specifying an HttpHeaders will not replace the previous headers
    anymore. The previous headers and the new headers will be merged
    automatically.
- ClientBuilder now delegates all its option-building methods to
  ClientOptionsBuilder.
- Add ClientOptionDerivable.derive() which provide a lot more flexible
  option building

Result:

- It is much easier to build a ClientOptions.
- The behavior of Clients.newDerivedClient() and
  ClientOptionDerivable.withOptions() is changed in a backward
  incompatible way when additional options contain DECORATIONS or
  HTTP_HEADERS due to how ClientOptionsBuilder merges them.