### PR TITLE
Add Clients.withHttpHeaders() and withHttpHeader()

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingClient.java
@@ -30,8 +30,8 @@ import com.linecorp.armeria.client.DecoratingClient;
 import com.linecorp.armeria.client.ResponseTimeoutException;
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.RequestContext;
-import com.linecorp.armeria.common.RequestContext.PushHandle;
 import com.linecorp.armeria.common.Response;
+import com.linecorp.armeria.common.util.SafeCloseable;
 
 import io.netty.util.concurrent.ScheduledFuture;
 
@@ -237,7 +237,7 @@ public abstract class ConcurrencyLimitingClient<I extends Request, O extends Res
                 }
             }
 
-            try (PushHandle ignored = RequestContext.push(ctx)) {
+            try (SafeCloseable ignored = RequestContext.push(ctx)) {
                 try {
                     final O actualRes = delegate().execute(ctx, req);
                     actualRes.closeFuture().whenCompleteAsync((unused, cause) -> {

--- a/core/src/main/java/com/linecorp/armeria/common/logging/MessageLogConsumerInvoker.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/MessageLogConsumerInvoker.java
@@ -20,7 +20,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.linecorp.armeria.common.RequestContext;
-import com.linecorp.armeria.common.RequestContext.PushHandle;
+import com.linecorp.armeria.common.util.SafeCloseable;
 
 /**
  * Utility methods that invokes the callback methods of {@link MessageLogConsumer} safely.
@@ -35,7 +35,7 @@ public final class MessageLogConsumerInvoker {
      * Invokes {@link MessageLogConsumer#onRequest(RequestContext, RequestLog)}.
      */
     public static void invokeOnRequest(MessageLogConsumer consumer, RequestContext ctx, RequestLog req) {
-        try (PushHandle ignored = RequestContext.push(ctx)) {
+        try (SafeCloseable ignored = RequestContext.push(ctx)) {
             consumer.onRequest(ctx, req);
         } catch (Throwable e) {
             logger.warn("onRequest() failed with an exception: {}", e);
@@ -46,7 +46,7 @@ public final class MessageLogConsumerInvoker {
      * Invokes {@link MessageLogConsumer#onResponse(RequestContext, ResponseLog)}.
      */
     public static void invokeOnResponse(MessageLogConsumer consumer, RequestContext ctx, ResponseLog res) {
-        try (PushHandle ignored = RequestContext.push(ctx)) {
+        try (SafeCloseable ignored = RequestContext.push(ctx)) {
             consumer.onResponse(ctx, res);
         } catch (Throwable e) {
             logger.warn("onResponse() failed with an exception: {}", e);

--- a/core/src/main/java/com/linecorp/armeria/common/util/SafeCloseable.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/SafeCloseable.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common.util;
+
+/**
+ * An {@link AutoCloseable} whose {@link #close()} method does not throw an exception.
+ */
+@FunctionalInterface
+public interface SafeCloseable extends AutoCloseable {
+    @Override
+    void close();
+}

--- a/core/src/main/java/com/linecorp/armeria/server/composition/AbstractCompositeService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/composition/AbstractCompositeService.java
@@ -25,8 +25,8 @@ import java.util.List;
 
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.RequestContext;
-import com.linecorp.armeria.common.RequestContext.PushHandle;
 import com.linecorp.armeria.common.Response;
+import com.linecorp.armeria.common.util.SafeCloseable;
 import com.linecorp.armeria.server.PathMapped;
 import com.linecorp.armeria.server.PathMapping;
 import com.linecorp.armeria.server.PathMappings;
@@ -127,7 +127,7 @@ public abstract class AbstractCompositeService<I extends Request, O extends Resp
         }
 
         final ServiceRequestContext newCtx = new CompositeServiceRequestContext(ctx, mapped.mappedPath());
-        try (PushHandle ignored = RequestContext.push(newCtx, false)) {
+        try (SafeCloseable ignored = RequestContext.push(newCtx, false)) {
             return mapped.value().serve(newCtx, req);
         }
     }

--- a/core/src/main/java/com/linecorp/armeria/server/http/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/HttpServerHandler.java
@@ -36,7 +36,6 @@ import com.google.common.net.MediaType;
 
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.RequestContext;
-import com.linecorp.armeria.common.RequestContext.PushHandle;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.http.AggregatedHttpMessage;
 import com.linecorp.armeria.common.http.HttpData;
@@ -50,6 +49,7 @@ import com.linecorp.armeria.common.logging.RequestLogBuilder;
 import com.linecorp.armeria.common.stream.ClosedPublisherException;
 import com.linecorp.armeria.common.util.CompletionActions;
 import com.linecorp.armeria.common.util.Exceptions;
+import com.linecorp.armeria.common.util.SafeCloseable;
 import com.linecorp.armeria.internal.http.AbstractHttp2ConnectionHandler;
 import com.linecorp.armeria.internal.http.ArmeriaHttpUtil;
 import com.linecorp.armeria.internal.http.Http1ObjectEncoder;
@@ -287,7 +287,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
 
         final RequestLogBuilder reqLogBuilder = reqCtx.requestLogBuilder();
         final HttpResponse res;
-        try (PushHandle ignored = RequestContext.push(reqCtx)) {
+        try (SafeCloseable ignored = RequestContext.push(reqCtx)) {
             req.init(reqCtx);
             res = service.serve(reqCtx, req);
         } catch (Throwable cause) {

--- a/core/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
@@ -47,7 +47,6 @@ import com.google.common.collect.Sets;
 import com.google.common.net.MediaType;
 
 import com.linecorp.armeria.common.RequestContext;
-import com.linecorp.armeria.common.RequestContext.PushHandle;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.http.AggregatedHttpMessage;
 import com.linecorp.armeria.common.http.HttpData;
@@ -64,6 +63,7 @@ import com.linecorp.armeria.common.thrift.ThriftCall;
 import com.linecorp.armeria.common.thrift.ThriftProtocolFactories;
 import com.linecorp.armeria.common.thrift.ThriftReply;
 import com.linecorp.armeria.common.util.CompletionActions;
+import com.linecorp.armeria.common.util.SafeCloseable;
 import com.linecorp.armeria.internal.thrift.ThriftFunction;
 import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceRequestContext;
@@ -566,7 +566,7 @@ public class THttpService extends AbstractHttpService {
         final ThriftReply reply;
         ctx.requestLogBuilder().attr(RequestLog.RPC_REQUEST).set(call);
 
-        try (PushHandle ignored = RequestContext.push(ctx)) {
+        try (SafeCloseable ignored = RequestContext.push(ctx)) {
             reply = delegate.serve(ctx, call);
             ctx.responseLogBuilder().attr(ResponseLog.RPC_RESPONSE).set(reply);
         } catch (Throwable cause) {

--- a/core/src/test/java/com/linecorp/armeria/common/RequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/RequestContextTest.java
@@ -43,12 +43,12 @@ import org.mockito.junit.MockitoRule;
 
 import com.google.common.util.concurrent.MoreExecutors;
 
-import com.linecorp.armeria.common.RequestContext.PushHandle;
 import com.linecorp.armeria.common.http.DefaultHttpRequest;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.logging.RequestLogBuilder;
 import com.linecorp.armeria.common.logging.ResponseLog;
 import com.linecorp.armeria.common.logging.ResponseLogBuilder;
+import com.linecorp.armeria.common.util.SafeCloseable;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFutureListener;
@@ -181,7 +181,7 @@ public class RequestContextTest {
     @Test
     public void contextPropagationSameContextAlreadySet() {
         final RequestContext context = createContext();
-        try (PushHandle ignored = RequestContext.push(context, false)) {
+        try (SafeCloseable ignored = RequestContext.push(context, false)) {
             context.makeContextAware(() -> {
                 assertEquals(context, RequestContext.current());
                 // Context was already correct, so handlers were not run (in real code they would already be
@@ -196,7 +196,7 @@ public class RequestContextTest {
         final RequestContext context = createContext();
         final RequestContext context2 = createContext();
 
-        try (PushHandle ignored = RequestContext.push(context2)) {
+        try (SafeCloseable ignored = RequestContext.push(context2)) {
             thrown.expect(IllegalStateException.class);
             context.makeContextAware((Runnable) Assert::fail).run();
         }

--- a/core/src/test/java/com/linecorp/armeria/it/thrift/ThriftThreadLocalHttpHeaderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/it/thrift/ThriftThreadLocalHttpHeaderTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.it.thrift;
+
+import static com.linecorp.armeria.common.http.HttpHeaderNames.AUTHORIZATION;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.thrift.TException;
+import org.apache.thrift.async.AsyncMethodCallback;
+import org.junit.Test;
+
+import com.linecorp.armeria.client.Clients;
+import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.common.http.HttpHeaders;
+import com.linecorp.armeria.common.http.HttpRequest;
+import com.linecorp.armeria.common.util.SafeCloseable;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.thrift.THttpService;
+import com.linecorp.armeria.service.test.thrift.main.HelloService;
+import com.linecorp.armeria.service.test.thrift.main.HelloService.Iface;
+import com.linecorp.armeria.test.AbstractServerTest;
+
+/**
+ * Tests if Armeria decorators can alter the request/response timeout specified in Thrift call parameters.
+ */
+public class ThriftThreadLocalHttpHeaderTest extends AbstractServerTest {
+
+    private static final String SECRET = "QWxhZGRpbjpPcGVuU2VzYW1l";
+
+    private static final HelloService.AsyncIface helloService = (name, resultHandler) -> {
+        final HttpRequest httpReq = RequestContext.current().request();
+        final HttpHeaders headers = httpReq.headers();
+        if (headers.contains(AUTHORIZATION, SECRET)) {
+            resultHandler.onComplete("Hello, " + name + '!');
+        } else {
+            final String errorMessage;
+            if (headers.contains(AUTHORIZATION)) {
+                errorMessage = "not authorized: " + headers.get(AUTHORIZATION);
+            } else {
+                errorMessage = "not authorized due to missing credential";
+            }
+            resultHandler.onError(new Exception(errorMessage));
+        }
+    };
+
+    @Override
+    protected void configureServer(ServerBuilder sb) throws Exception {
+        sb.serviceAt("/hello", THttpService.of(helloService));
+    }
+
+    @Test
+    public void testSimpleManipulation() throws Exception {
+        final HelloService.Iface client = newClient();
+        try (SafeCloseable ignored = Clients.withHttpHeader(AUTHORIZATION, SECRET)) {
+            assertThat(client.hello("trustin")).isEqualTo("Hello, trustin!");
+        }
+
+        // Ensure that the header manipulator set in the thread-local variable has been cleared.
+        assertAuthorizationFailure(client, null);
+    }
+
+    @Test
+    public void testNestedManipulation() throws Exception {
+        // Split the secret into two pieces.
+        final String secretA = SECRET.substring(0, SECRET.length() >>> 1);
+        final String secretB = SECRET.substring(secretA.length());
+
+        final HelloService.Iface client = newClient();
+        try (SafeCloseable ignored = Clients.withHttpHeader(AUTHORIZATION, secretA)) {
+            // Should fail with the first half of the secret.
+            assertAuthorizationFailure(client, secretA);
+            try (SafeCloseable ignored2 = Clients.withHttpHeaders(
+                    h -> h.set(AUTHORIZATION, h.get(AUTHORIZATION) + secretB))) {
+                // Should pass if both manipulators worked.
+                assertThat(client.hello("foobar")).isEqualTo("Hello, foobar!");
+            }
+            // Should fail again with the first half of the secret.
+            assertAuthorizationFailure(client, secretA);
+        }
+
+        // Ensure that the header manipulator set in the thread-local variable has been cleared.
+        assertAuthorizationFailure(client, null);
+    }
+
+    @Test
+    public void testSimpleManipulationAsync() throws Exception {
+        final HelloService.AsyncIface client = Clients.newClient(
+                "tbinary+" + uri("/hello"), HelloService.AsyncIface.class);
+
+        final BlockingQueue<Object> result = new ArrayBlockingQueue<>(1);
+        final Callback callback = new Callback(result);
+
+        try (SafeCloseable ignored = Clients.withHttpHeader(AUTHORIZATION, SECRET)) {
+            client.hello("armeria", callback);
+        }
+
+        assertThat(result.poll(10, TimeUnit.SECONDS)).isEqualTo("Hello, armeria!");
+
+        // Ensure that the header manipulator set in the thread-local variable has been cleared.
+        client.hello("bar", callback);
+        assertThat(result.poll(10, TimeUnit.SECONDS))
+                .isInstanceOf(TException.class)
+                .matches(o -> ((Throwable) o).getMessage().contains("not authorized"),
+                         "must fail with authorization failure");
+    }
+
+    @Test
+    public void testFailedAuthorization() throws Exception {
+        assertAuthorizationFailure(newClient(), null);
+    }
+
+    private static Iface newClient() {
+        return Clients.newClient("tbinary+" + uri("/hello"), HelloService.Iface.class);
+    }
+
+    private static void assertAuthorizationFailure(Iface client, String expectedSecret) {
+        final String expectedMessage;
+        if (expectedSecret != null) {
+            expectedMessage = "not authorized: " + expectedSecret;
+        } else {
+            expectedMessage = "not authorized due to missing credential";
+        }
+        assertThatThrownBy(() -> client.hello("foo"))
+                .isInstanceOf(TException.class)
+                .hasMessageContaining(expectedMessage);
+    }
+
+    private static final class Callback implements AsyncMethodCallback<Object> {
+
+        private final BlockingQueue<Object> result;
+
+        Callback(BlockingQueue<Object> result) {
+            this.result = result;
+        }
+
+        @Override
+        public void onComplete(Object response) {
+            result.add(response);
+        }
+
+        @Override
+        public void onError(Exception exception) {
+            result.add(exception);
+        }
+    }
+}

--- a/logback/src/test/java/com/linecorp/armeria/common/logback/RequestContextExportingAppenderTest.java
+++ b/logback/src/test/java/com/linecorp/armeria/common/logback/RequestContextExportingAppenderTest.java
@@ -57,6 +57,7 @@ import com.linecorp.armeria.common.logging.ResponseLog;
 import com.linecorp.armeria.common.logging.ResponseLogBuilder;
 import com.linecorp.armeria.common.thrift.ThriftCall;
 import com.linecorp.armeria.common.thrift.ThriftReply;
+import com.linecorp.armeria.common.util.SafeCloseable;
 import com.linecorp.armeria.server.DefaultServiceRequestContext;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
@@ -222,7 +223,7 @@ public class RequestContextExportingAppenderTest {
 
         MDC.put("some-prop", "some-value");
         final ServiceRequestContext ctx = newServiceContext("/foo");
-        try (RequestContext.PushHandle ignored = RequestContext.push(ctx)) {
+        try (SafeCloseable ignored = RequestContext.push(ctx)) {
             final ILoggingEvent e = log(events);
             final Map<String, String> mdc = e.getMDCPropertyMap();
             assertThat(mdc).containsEntry("req.direction", "INBOUND")
@@ -243,7 +244,7 @@ public class RequestContextExportingAppenderTest {
         });
 
         final ServiceRequestContext ctx = newServiceContext("/foo");
-        try (RequestContext.PushHandle ignored = RequestContext.push(ctx)) {
+        try (SafeCloseable ignored = RequestContext.push(ctx)) {
             final ILoggingEvent e = log(events);
             final Map<String, String> mdc = e.getMDCPropertyMap();
             assertThat(mdc).containsEntry("local.host", "server.com")
@@ -274,7 +275,7 @@ public class RequestContextExportingAppenderTest {
         });
 
         final ServiceRequestContext ctx = newServiceContext("/foo");
-        try (RequestContext.PushHandle ignored = RequestContext.push(ctx)) {
+        try (SafeCloseable ignored = RequestContext.push(ctx)) {
             final RequestLogBuilder req = ctx.requestLogBuilder();
             final ResponseLogBuilder res = ctx.responseLogBuilder();
             req.end();
@@ -319,7 +320,7 @@ public class RequestContextExportingAppenderTest {
         });
 
         final ServiceRequestContext ctx = newServiceContext("/foo");
-        try (RequestContext.PushHandle ignored = RequestContext.push(ctx)) {
+        try (SafeCloseable ignored = RequestContext.push(ctx)) {
             final RequestLogBuilder req = ctx.requestLogBuilder();
             final ResponseLogBuilder res = ctx.responseLogBuilder();
             req.serializationFormat(SerializationFormat.THRIFT_BINARY);
@@ -413,7 +414,7 @@ public class RequestContextExportingAppenderTest {
         });
 
         final ClientRequestContext ctx = newClientContext("/foo");
-        try (RequestContext.PushHandle ignored = RequestContext.push(ctx)) {
+        try (SafeCloseable ignored = RequestContext.push(ctx)) {
             final ILoggingEvent e = log(events);
             final Map<String, String> mdc = e.getMDCPropertyMap();
             assertThat(mdc).containsEntry("local.host", "client.com")
@@ -449,7 +450,7 @@ public class RequestContextExportingAppenderTest {
         });
 
         final ClientRequestContext ctx = newClientContext("/bar");
-        try (RequestContext.PushHandle ignored = RequestContext.push(ctx)) {
+        try (SafeCloseable ignored = RequestContext.push(ctx)) {
             final RequestLogBuilder req = ctx.requestLogBuilder();
             final ResponseLogBuilder res = ctx.responseLogBuilder();
             req.serializationFormat(SerializationFormat.THRIFT_BINARY);

--- a/site/src/sphinx/client-thrift-custom-http-headers.rst
+++ b/site/src/sphinx/client-thrift-custom-http-headers.rst
@@ -1,0 +1,78 @@
+Sending custom HTTP headers with a Thrift call
+==============================================
+To send a custom HTTP header such as authentication token with a Thrift call, you can:
+
+- use the ``Clients.withHttpHeaders()`` method or
+- use the ``ClientOption.HTTP_HEADERS`` option.
+
+Using ``Clients.withHttpHeaders()``
+-----------------------------------
+
+.. code-block:: java
+
+    import static com.linecorp.armeria.common.http.HttpHeaderNames.AUTHORIZATION;
+    import com.linecorp.armeria.common.util.SafeCloseable
+    import com.linecorp.armeria.client.Clients;
+
+    HelloService.Iface client = Clients.newClient("tbinary+http://example.com/hello",
+                                                   HelloService.Iface.class);
+    try (SafeCloseable ignored = Clients.withHttpHeaders(
+            headers -> headers.set(AUTHORIZATION, credential))) {
+        client.hello("authorized personnel");
+    }
+
+If you are setting only a single header, you can use ``Clients.withHttpHeader()`` simply:
+
+.. code-block:: java
+
+    try (SafeCloseable ignored = Clients.withHttpHeader(AUTHORIZATION, credential)) {
+        client.hello("authorized personnel");
+    }
+
+You can also nest ``withHttpHeader(s)``. The following example will send both ``user-agent`` header and
+``authorization`` header when calling ``client.hello()``:
+
+.. code-block:: java
+
+    import static com.linecorp.armeria.common.http.HttpHeaderNames.USER_AGENT;
+
+    try (SafeClosedble ignored1 = Clients.withHttpHeader(USER_AGENT, myUserAgent)) {
+        for (String cred : credentials) {
+            try (SafeCloseable ignored2 = Clients.withHttpHeaders(AUTHORIZATION, cred)) {
+                client.hello("authorized personnel");
+            }
+        }
+    }
+
+Using ``ClientOption.HTTP_HEADERS``
+-----------------------------------
+If you have a custom HTTP header whose value does not change often, you can use ``ClientOption.HTTP_HEADERS``:
+
+.. code-block:: java
+
+    import static com.linecorp.armeria.common.http.HttpHeaderNames.AUTHORIZATION;
+    import com.linecorp.armeria.common.http.HttpHeaders;
+    import com.linecorp.armeria.client.ClientBuilder;
+    import com.linecorp.armeria.client.ClientOption;
+
+    ClientBuilder cb = new ClientBuilder("tbinary+http://example.com/hello");
+    cb.setHttpHeader(AUTHORIZATION, credential);
+    // or:
+    // cb.option(ClientOption.HTTP_HEADERS, HttpHeaders.of(AUTHORIZATION, credential));
+    HelloService.Iface client = cb.build(HelloService.Iface.class);
+    client.hello("authorized personnel");
+
+Although not as simple as using ``withHttpHeaders()``, you can create a derived client to add more custom
+headers to an existing client:
+
+.. code-block:: java
+
+    import com.linecorp.armeria.client.ClientOptionsBuilder;
+
+    HelloService.Iface client = ...;
+    HelloService.Iface derivedClient = Clients.newDerivedClient(client, options -> {
+        ClientOptionsBuilder builder = new ClientOptionsBuilder(options);
+        builder.decorator(...);  // Add a decorator.
+        builder.httpHeader(AUTHORIZATION, credential); // Add an HTTP header.
+        return builder.build();
+    });

--- a/site/src/sphinx/client.rst
+++ b/site/src/sphinx/client.rst
@@ -9,3 +9,4 @@ Writing a client
     client-basics
     client-http
     client-http-retrofit
+    client-thrift-custom-http-headers


### PR DESCRIPTION
Motivation:

There's no simple way for a user to specify HTTP headers when making a
Thrift call via *.Iface and *.AsyncIface clients.

Modifications:

- Add Clients.withHttpHeaders() and withHttpHeader() which allows a user
  to set a thread-local HTTP header manipulator function
- Make UserClient pick up the thread-local HTTP header manipulator
  function set by withHttpHeaders()
- Add SafeCloseable
- Remove RequestContext.PushHandle and use SafeCloseable instead

Result:

- A user can send a custom HTTP header without using decorator.