### PR TITLE
Do not pop the current RequestContext too early when a Service throws an unexpected exception

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,9 @@ configure(javaProjects) {
             // AssertJ
             dependency "org.assertj:assertj-core:${ext.versionOf('assertj')}"
 
+            // FastUtil
+            dependency "it.unimi.dsi:fastutil:${ext.versionOf('fastutil')}"
+
             // gRPC
             dependencySet(group: 'io.grpc', version: ext.versionOf('grpc')) {
                 entry('grpc-core') {

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,7 @@ inceptionYear=2015
 
 assertj.version=3.5.2
 brave.version=3.14.1
+fastutil.version=7.0.13
 grpc.version=1.0.1
 guava.version=19.0
 hamcrest.version=1.3

--- a/logback/build.gradle
+++ b/logback/build.gradle
@@ -1,6 +1,9 @@
 dependencies {
     compile project(':core')
 
+    // FastUtil
+    compile 'it.unimi.dsi:fastutil'
+
     // Logback
     compile 'ch.qos.logback:logback-classic'
 }


### PR DESCRIPTION
Motivation:

When a Service throws an unexpected exception in its `service()` method,
HttpServerHandler.handleRequest() will log the exception at WARN level.

When the exception is logged, the thread-local RequestContext must be
set so that RequestContextExportingAppender picks it up.

However, we currently pop the RequestContext too early, and thus
RequestContextExportingAppender does not see the thread local
RequestContext.

Modifications

- Pop the current RequestContext as late as possible
- Fix potential race condition in RequestContextExportingAppender

Result:

- An unexpected exception from a Service will be logged with more
  information.
- RequestContextExportingAppender will not cause other Appender to throw
  ConcurrentModificationException by making a copy