### PR TITLE
Implement HTTP authorization decorator service

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/http/auth/AuthTokenExtractors.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/auth/AuthTokenExtractors.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.http.auth;
+
+import java.util.function.Function;
+
+import com.linecorp.armeria.common.http.HttpHeaders;
+
+/**
+ * A utility class that provides singleton instances of authorization token extractor functions.
+ */
+public final class AuthTokenExtractors {
+
+    /**
+     * A {@link BasicToken} extractor function instance.
+     */
+    public static final Function<HttpHeaders, BasicToken> BASIC = new BasicTokenExtractor();
+
+    /**
+     * An {@link OAuth1aToken} extractor function instance.
+     */
+    public static final Function<HttpHeaders, OAuth1aToken> OAUTH1A = new OAuth1aTokenExtractor();
+
+    /**
+     * An {@link OAuth2Token} extractor function instance.
+     */
+    public static final Function<HttpHeaders, OAuth2Token> OAUTH2 = new OAuth2TokenExtractor();
+
+    private AuthTokenExtractors() {}
+}

--- a/core/src/main/java/com/linecorp/armeria/server/http/auth/BasicToken.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/auth/BasicToken.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.http.auth;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Objects;
+
+import com.google.common.base.MoreObjects;
+
+/**
+ * The bearer token of <a href="https://en.wikipedia.org/wiki/Basic_access_authentication">HTTP basic access authentication</a>.
+ */
+public final class BasicToken {
+
+    /**
+     * Creates a new {@link BasicToken} from the given {@code username} and {@code password}.
+     */
+    public static BasicToken of(String username, String password) {
+        return new BasicToken(username, password);
+    }
+
+    private final String username;
+    private final String password;
+
+    private BasicToken(String username, String password) {
+        this.username = requireNonNull(username, "username");
+        this.password = requireNonNull(password, "password");
+    }
+
+    public String username() {
+        return username;
+    }
+
+    public String password() {
+        return password;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        BasicToken that = (BasicToken) o;
+        return username.equals(that.username()) && password.equals(that.password());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(username, password);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("username", username)
+                          .add("password", "****")
+                          .toString();
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/http/auth/BasicTokenExtractor.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/auth/BasicTokenExtractor.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.http.auth;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Base64.Decoder;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Strings;
+
+import com.linecorp.armeria.common.http.HttpHeaderNames;
+import com.linecorp.armeria.common.http.HttpHeaders;
+
+/**
+ * Extracts {@link BasicToken} from {@link HttpHeaders}, in order to be used by {@link HttpAuthServiceBuilder}.
+ */
+final class BasicTokenExtractor implements Function<HttpHeaders, BasicToken> {
+
+    private static final Logger logger = LoggerFactory.getLogger(BasicTokenExtractor.class);
+
+    private static final Pattern AUTHORIZATION_HEADER_PATTERN = Pattern.compile(
+            "\\s*(?i)basic\\s+(?<encoded>\\S+)\\s*");
+    private static final Decoder BASE64_DECODER = Base64.getDecoder();
+
+    @Override
+    public BasicToken apply(HttpHeaders headers) {
+        String authorization = headers.get(HttpHeaderNames.AUTHORIZATION);
+        if (Strings.isNullOrEmpty(authorization)) {
+            return null;
+        }
+
+        Matcher matcher = AUTHORIZATION_HEADER_PATTERN.matcher(authorization);
+        if (!matcher.matches()) {
+            logger.warn("Invalid authorization header: {}", authorization);
+            return null;
+        }
+
+        String base64 = matcher.group("encoded");
+        byte[] decoded;
+        try {
+            decoded = BASE64_DECODER.decode(base64);
+        } catch (IllegalArgumentException e) {
+            logger.warn("Base64 decoding failed: {}", base64);
+            return null;
+        }
+
+        String credential = new String(decoded, StandardCharsets.UTF_8);
+        int sep = credential.indexOf(':');
+        if (sep == -1) {
+            logger.warn("Invalid credential: {}", credential);
+            return null;
+        }
+        String username = credential.substring(0, sep);
+        String password = credential.substring(sep + 1);
+
+        return BasicToken.of(username, password);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/http/auth/HttpAuthService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/auth/HttpAuthService.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.http.auth;
+
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import com.google.common.collect.Iterables;
+
+import com.linecorp.armeria.common.http.DefaultHttpResponse;
+import com.linecorp.armeria.common.http.HttpHeaders;
+import com.linecorp.armeria.common.http.HttpRequest;
+import com.linecorp.armeria.common.http.HttpResponse;
+import com.linecorp.armeria.common.http.HttpStatus;
+import com.linecorp.armeria.server.DecoratingService;
+import com.linecorp.armeria.server.Service;
+import com.linecorp.armeria.server.ServiceRequestContext;
+
+/**
+ * A {@link DecoratingService} that provides HTTP authorization functionality.
+ */
+public abstract class HttpAuthService
+        extends DecoratingService<HttpRequest, HttpResponse, HttpRequest, HttpResponse> {
+
+    /**
+     * Creates a new HTTP authorization {@link Service} decorator using the specified
+     * {@code predicates}.
+     *
+     * @param predicates {@link Iterable} authorization predicates
+     */
+    public static Function<Service<? super HttpRequest, ? extends HttpResponse>,
+            HttpAuthService> newDecorator(Iterable<? extends Predicate<? super HttpHeaders>> predicates) {
+        Predicate<? super HttpHeaders>[] array = Iterables.toArray(predicates, Predicate.class);
+        return newDecorator(array);
+    }
+
+    /**
+     * Creates a new HTTP authorization {@link Service} decorator using the specified
+     * {@code predicates}.
+     *
+     * @param predicates the array of authorization predicates
+     */
+    public static Function<Service<? super HttpRequest, ? extends HttpResponse>,
+            HttpAuthService> newDecorator(Predicate<? super HttpHeaders>... predicates) {
+        return service -> new HttpAuthServiceImpl(service, predicates);
+    }
+
+    /**
+     * Creates a new instance that provides HTTP authorization functionality to {@code delegate}.
+     */
+    protected HttpAuthService(Service<? super HttpRequest, ? extends HttpResponse> delegate) {
+        super(delegate);
+    }
+
+    /**
+     * Authorize {@code headers}. In other words, determine if it is successful or not.
+     */
+    protected abstract boolean authorize(HttpHeaders headers);
+
+    /**
+     * Invoked when {@code req} is successful. By default, this method delegates the specified {@code req} to
+     * the {@link #delegate()} of this service.
+     */
+    protected HttpResponse onSuccess(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+        return delegate().serve(ctx, req);
+    }
+
+    /**
+     * Invoked when {@code req} is failed. By default, this method responds with the
+     * {@link HttpStatus#UNAUTHORIZED} status.
+     */
+    protected HttpResponse onFailure(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+        final DefaultHttpResponse res = new DefaultHttpResponse();
+        res.respond(HttpStatus.UNAUTHORIZED);
+        return res;
+    }
+
+    @Override
+    public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+        if (authorize(req.headers())) {
+            return onSuccess(ctx, req);
+        } else {
+            return onFailure(ctx, req);
+        }
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/http/auth/HttpAuthServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/auth/HttpAuthServiceBuilder.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.http.auth;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+
+import com.linecorp.armeria.common.http.HttpHeaders;
+import com.linecorp.armeria.common.http.HttpRequest;
+import com.linecorp.armeria.common.http.HttpResponse;
+import com.linecorp.armeria.server.Service;
+
+/**
+ * Builds a new {@link HttpAuthService}.
+ */
+public final class HttpAuthServiceBuilder {
+
+    private final List<Predicate<? super HttpHeaders>> predicates = new ArrayList<>();
+
+    /**
+     * Adds an authorization predicate.
+     */
+    public HttpAuthServiceBuilder add(Predicate<? super HttpHeaders> predicate) {
+        predicates.add(predicate);
+        return this;
+    }
+
+    /**
+     * Adds multiple authorization predicates.
+     */
+    public HttpAuthServiceBuilder add(Iterable<? extends Predicate<? super HttpHeaders>> predicates) {
+        this.predicates.addAll(Lists.newArrayList(predicates));
+        return this;
+    }
+
+    /**
+     * Adds an HTTP basic authorization predicate.
+     */
+    public HttpAuthServiceBuilder addBasicAuth(Predicate<? super BasicToken> predicate) {
+        this.predicates.add(new Predicate<HttpHeaders>() {
+            private final Function<HttpHeaders, BasicToken> extractor = AuthTokenExtractors.BASIC;
+
+            @Override
+            public boolean test(HttpHeaders headers) {
+                BasicToken token = extractor.apply(headers);
+                return token != null ? predicate.test(token) : false;
+            }
+        });
+        return this;
+    }
+
+    /**
+     * Adds an OAuth1a authorization predicate.
+     */
+    public HttpAuthServiceBuilder addOAuth1a(Predicate<? super OAuth1aToken> predicate) {
+        this.predicates.add(new Predicate<HttpHeaders>() {
+            private final Function<HttpHeaders, OAuth1aToken> extractor = AuthTokenExtractors.OAUTH1A;
+
+            @Override
+            public boolean test(HttpHeaders headers) {
+                OAuth1aToken token = extractor.apply(headers);
+                return token != null ? predicate.test(token) : false;
+            }
+        });
+        return this;
+    }
+
+    /**
+     * Adds an OAuth2 authorization predicate.
+     */
+    public HttpAuthServiceBuilder addOAuth2(Predicate<? super OAuth2Token> predicate) {
+        this.predicates.add(new Predicate<HttpHeaders>() {
+            private final Function<HttpHeaders, OAuth2Token> extractor = AuthTokenExtractors.OAUTH2;
+
+            @Override
+            public boolean test(HttpHeaders headers) {
+                OAuth2Token token = extractor.apply(headers);
+                return token != null ? predicate.test(token) : false;
+            }
+        });
+        return this;
+    }
+
+    /**
+     * Creates a new {@link HttpAuthService} instance with the given {@code delegate} and all of the
+     * authorization {@link Predicate}s.
+     */
+    public HttpAuthService build(Service<? super HttpRequest, ? extends HttpResponse> delegate) {
+        return new HttpAuthServiceImpl(delegate, Iterables.toArray(predicates, Predicate.class));
+    }
+
+    /**
+     * Creates a new {@link HttpAuthService} {@link Service} decorator that supports all of the given
+     * authorization {@link Predicate}s.
+     */
+    public Function<Service<? super HttpRequest, ? extends HttpResponse>, HttpAuthService> newDecorator() {
+        return HttpAuthService.newDecorator(predicates);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/http/auth/HttpAuthServiceImpl.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/auth/HttpAuthServiceImpl.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.http.auth;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.function.Predicate;
+
+import com.google.common.base.MoreObjects;
+
+import com.linecorp.armeria.common.http.HttpHeaders;
+import com.linecorp.armeria.common.http.HttpRequest;
+import com.linecorp.armeria.common.http.HttpResponse;
+import com.linecorp.armeria.server.Service;
+
+/**
+ * A default implementation of {@link HttpAuthService}.
+ */
+final class HttpAuthServiceImpl extends HttpAuthService {
+
+    private final Predicate<? super HttpHeaders>[] predicates;
+
+    HttpAuthServiceImpl(Service<? super HttpRequest, ? extends HttpResponse> delegate,
+                        Predicate<? super HttpHeaders>... predicates) {
+        super(delegate);
+        for (Predicate<? super HttpHeaders> predicate : predicates) {
+            requireNonNull(predicate);
+        }
+        this.predicates = predicates;
+    }
+
+    @Override
+    public boolean authorize(HttpHeaders headers) {
+        for (Predicate<? super HttpHeaders> predicate : predicates) {
+            if (predicate.test(headers)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).addValue(predicates).toString();
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/http/auth/OAuth1aToken.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/auth/OAuth1aToken.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.http.auth;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+
+/**
+ * The bearer token of <a href="https://oauth.net/core/1.0a/#anchor12">OAuth 1.0a authentication</a>.
+ */
+public final class OAuth1aToken {
+
+    /**
+     * realm parameter. (optional)
+     */
+    private static final String REALM = "realm";
+
+    /**
+     * oauth_consumer_key parameter.
+     */
+    private static final String OAUTH_CONSUMER_KEY = "oauth_consumer_key";
+
+    /**
+     * oauth_token parameter.
+     */
+    private static final String OAUTH_TOKEN = "oauth_token";
+
+    /**
+     * oauth_signature_method parameter.
+     */
+    private static final String OAUTH_SIGNATURE_METHOD = "oauth_signature_method";
+
+    /**
+     * oauth_signature parameter.
+     */
+    private static final String OAUTH_SIGNATURE = "oauth_signature";
+
+    /**
+     * oauth_timestamp parameter.
+     */
+    private static final String OAUTH_TIMESTAMP = "oauth_timestamp";
+
+    /**
+     * oauth_nonce parameter.
+     */
+    private static final String OAUTH_NONCE = "oauth_nonce";
+
+    /**
+     * version parameter. (optional)
+     * If not set, the default value is 1.0.
+     */
+    private static final String OAUTH_VERSION = "version";
+
+    /**
+     * Set of required parameters.
+     */
+    private static final Set<String> REQUIRED_PARAM_KEYS = ImmutableSet.of(OAUTH_CONSUMER_KEY, OAUTH_TOKEN,
+                                                                           OAUTH_SIGNATURE_METHOD,
+                                                                           OAUTH_SIGNATURE, OAUTH_TIMESTAMP,
+                                                                           OAUTH_NONCE);
+
+    /**
+     * Set of optional parameters.
+     */
+    private static final Set<String> OPTIONAL_PARAM_KEYS = ImmutableSet.of(REALM, OAUTH_VERSION);
+
+    /**
+     * Set of defined parameters, regardless of it is required or not.
+     */
+    private static final Set<String> DEFINED_PARAM_KEYS = Sets.union(REQUIRED_PARAM_KEYS, OPTIONAL_PARAM_KEYS);
+
+    /**
+     * Creates a new {@link OAuth1aToken} from the given arguments.
+     */
+    public static OAuth1aToken of(Map<String, String> params) {
+        return new OAuth1aToken(params);
+    }
+
+    private final Map<String, String> params;
+
+    private OAuth1aToken(Map<String, String> params) {
+        // Map builder with default version value.
+        ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+
+        for (Entry<String, String> param : params.entrySet()) {
+            String key = param.getKey();
+            String value = param.getValue();
+
+            // Empty values are ignored.
+            if (!Strings.isNullOrEmpty(value)) {
+                String lowerCased = key.toLowerCase(Locale.US);
+                if (DEFINED_PARAM_KEYS.contains(lowerCased)) {
+                    // If given parameter is defined by Oauth1a protocol, add with lower-cased key.
+                    builder.put(lowerCased, value);
+                } else {
+                    // Otherwise, just add.
+                    builder.put(key, value);
+                }
+            }
+        }
+
+        this.params = builder.build();
+
+        if (!this.params.keySet().containsAll(REQUIRED_PARAM_KEYS)) {
+            Set<String> missing = Sets.difference(REQUIRED_PARAM_KEYS, this.params.keySet());
+            throw new IllegalArgumentException("Missing OAuth1a parameter exists: " + missing);
+        }
+
+        try {
+            Long.parseLong(this.params.get(OAUTH_TIMESTAMP));
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(
+                    "Illegal " + OAUTH_TIMESTAMP + " value: " + this.params.get(OAUTH_TIMESTAMP));
+        }
+    }
+
+    public String realm() {
+        return params.get(REALM);
+    }
+
+    public String consumerKey() {
+        return params.get(OAUTH_CONSUMER_KEY);
+    }
+
+    public String token() {
+        return params.get(OAUTH_TOKEN);
+    }
+
+    public String signatureMethod() {
+        return params.get(OAUTH_SIGNATURE_METHOD);
+    }
+
+    public String signature() {
+        return params.get(OAUTH_SIGNATURE);
+    }
+
+    public String timestamp() {
+        return params.get(OAUTH_TIMESTAMP);
+    }
+
+    public String nonce() {
+        return params.get(OAUTH_NONCE);
+    }
+
+    /**
+     * Returns version. If not set, returns default value (1.0).
+     */
+    public String version() {
+        return params.getOrDefault(OAUTH_VERSION, "1.0");
+    }
+
+    /**
+     * Returns additional (or, user-defined) parameters.
+     */
+    public Map<String, String> additionals() {
+        ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+        for (String key : params.keySet()) {
+            if (!DEFINED_PARAM_KEYS.contains(key)) {
+                builder.put(key, params.get(key));
+            }
+        }
+        return builder.build();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OAuth1aToken that = (OAuth1aToken) o;
+        return params.equals(that.params);
+    }
+
+    @Override
+    public int hashCode() {
+        return params.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("realm", realm())
+                          .add("consumerKey", consumerKey())
+                          .add("token", "****")
+                          .add("signatureMethod", signatureMethod())
+                          .add("signature", signature())
+                          .add("timestamp", timestamp())
+                          .add("nonce", nonce())
+                          .add("version", version())
+                          .add("additionals", additionals())
+                          .toString();
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/http/auth/OAuth1aTokenExtractor.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/auth/OAuth1aTokenExtractor.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.http.auth;
+
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
+
+import com.linecorp.armeria.common.http.HttpHeaderNames;
+import com.linecorp.armeria.common.http.HttpHeaders;
+
+/**
+ * Extracts {@link OAuth1aToken} from {@link HttpHeaders}, in order to be used by
+ * {@link HttpAuthServiceBuilder}.
+ */
+final class OAuth1aTokenExtractor implements Function<HttpHeaders, OAuth1aToken> {
+
+    private static final Logger logger = LoggerFactory.getLogger(OAuth1aTokenExtractor.class);
+    private static final Pattern AUTHORIZATION_HEADER_PATTERN = Pattern.compile(
+            "\\s*(?i)oauth\\s+(?<parameters>\\S+)\\s*");
+
+    @Override
+    public OAuth1aToken apply(HttpHeaders headers) {
+        String authorization = headers.get(HttpHeaderNames.AUTHORIZATION);
+        if (Strings.isNullOrEmpty(authorization)) {
+            return null;
+        }
+
+        Matcher matcher = AUTHORIZATION_HEADER_PATTERN.matcher(authorization);
+        if (!matcher.matches()) {
+            logger.warn("Invalid authorization header: " + authorization);
+            return null;
+        }
+
+        ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+        for (String token : matcher.group("parameters").split(",")) {
+            int sep = token.indexOf('=');
+            if (sep == -1 || token.charAt(sep + 1) != '"' || token.charAt(token.length() - 1) != '"') {
+                logger.warn("Invalid token: " + token);
+                return null;
+            }
+            String key = token.substring(0, sep);
+            String value = token.substring(sep + 2, token.length() - 1);
+            builder.put(key, value);
+        }
+
+        return OAuth1aToken.of(builder.build());
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/http/auth/OAuth2Token.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/auth/OAuth2Token.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.http.auth;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * The bearer token of <a href="https://tools.ietf.org/html/rfc6750">OAuth 2.0 authentication</a>.
+ */
+public final class OAuth2Token {
+
+    /**
+     * Creates a new {@link OAuth2Token} from the given {@code accessToken}.
+     */
+    public static OAuth2Token of(String accessToken) {
+        return new OAuth2Token(accessToken);
+    }
+
+    private final String accessToken;
+
+    private OAuth2Token(String accessToken) {
+        this.accessToken = requireNonNull(accessToken, "accessToken");
+    }
+
+    public String accessToken() {
+        return accessToken;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OAuth2Token that = (OAuth2Token) o;
+        return accessToken.equals(that.accessToken);
+    }
+
+    @Override
+    public int hashCode() {
+        return accessToken.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "OAuth2Token(****)";
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/http/auth/OAuth2TokenExtractor.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/auth/OAuth2TokenExtractor.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.http.auth;
+
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Strings;
+
+import com.linecorp.armeria.common.http.HttpHeaderNames;
+import com.linecorp.armeria.common.http.HttpHeaders;
+
+/**
+ * Extracts {@link OAuth2Token} from {@link HttpHeaders}, in order to be used by {@link HttpAuthServiceBuilder}.
+ */
+final class OAuth2TokenExtractor implements Function<HttpHeaders, OAuth2Token> {
+
+    private static final Logger logger = LoggerFactory.getLogger(OAuth2TokenExtractor.class);
+    private static final Pattern AUTHORIZATION_HEADER_PATTERN = Pattern.compile(
+            "\\s*(?i)bearer\\s+(?<accessToken>\\S+)\\s*");
+
+    @Override
+    public OAuth2Token apply(HttpHeaders headers) {
+        String authorization = headers.get(HttpHeaderNames.AUTHORIZATION);
+        if (Strings.isNullOrEmpty(authorization)) {
+            return null;
+        }
+
+        Matcher matcher = AUTHORIZATION_HEADER_PATTERN.matcher(authorization);
+        if (!matcher.matches()) {
+            logger.warn("Invalid authorization header: " + authorization);
+            return null;
+        }
+
+        return OAuth2Token.of(matcher.group("accessToken"));
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/http/auth/package-info.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/auth/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * HTTP authorization service.
+ */
+package com.linecorp.armeria.server.http.auth;

--- a/core/src/test/java/com/linecorp/armeria/server/http/auth/AuthServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/http/auth/AuthServiceTest.java
@@ -1,0 +1,315 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.http.auth;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Base64.Encoder;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.function.Predicate;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.assertj.core.util.Strings;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+import com.linecorp.armeria.common.http.HttpHeaderNames;
+import com.linecorp.armeria.common.http.HttpHeaders;
+import com.linecorp.armeria.common.http.HttpRequest;
+import com.linecorp.armeria.common.http.HttpResponseWriter;
+import com.linecorp.armeria.common.http.HttpStatus;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.http.AbstractHttpService;
+import com.linecorp.armeria.server.http.HttpService;
+import com.linecorp.armeria.server.logging.LoggingService;
+import com.linecorp.armeria.test.AbstractServerTest;
+
+public class AuthServiceTest extends AbstractServerTest {
+
+    private static final Encoder BASE64_ENCODER = Base64.getEncoder();
+
+    @Override
+    protected void configureServer(ServerBuilder sb) throws Exception {
+        // Auth with arbitrary predicate
+        Predicate<HttpHeaders> predicate = (HttpHeaders headers) -> {
+            return "unit test".equals(headers.get(HttpHeaderNames.AUTHORIZATION));
+        };
+        sb.serviceAt(
+                "/",
+                new AbstractHttpService() {
+                    @Override
+                    protected void doGet(
+                            ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) {
+                        res.respond(HttpStatus.OK);
+                    }
+                }.decorate(HttpAuthService.newDecorator(predicate))
+                 .decorate(LoggingService::new));
+
+        // Auth with HTTP basic
+        final Map<String, String> usernameToPassword = ImmutableMap.of("brown", "cony", "pangyo", "choco");
+        Predicate<BasicToken> httpBasicPredicate = (BasicToken token) -> {
+            String username = token.username();
+            String password = token.password();
+            return password.equals(usernameToPassword.get(username));
+        };
+        sb.serviceAt(
+                "/basic",
+                new AbstractHttpService() {
+                    @Override
+                    protected void doGet(
+                            ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) {
+                        res.respond(HttpStatus.OK);
+                    }
+                }.decorate(new HttpAuthServiceBuilder().addBasicAuth(httpBasicPredicate).newDecorator())
+                 .decorate(LoggingService::new));
+
+        // Auth with OAuth1a
+        Predicate<OAuth1aToken> oAuth1aPredicate = (OAuth1aToken token) -> {
+            return "dummy_signature".equals(token.signature());
+        };
+        sb.serviceAt(
+                "/oauth1a",
+                new AbstractHttpService() {
+                    @Override
+                    protected void doGet(
+                            ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) {
+                        res.respond(HttpStatus.OK);
+                    }
+                }.decorate(new HttpAuthServiceBuilder().addOAuth1a(oAuth1aPredicate).newDecorator())
+                 .decorate(LoggingService::new));
+
+        // Auth with OAuth2
+        Predicate<OAuth2Token> oAuth2aPredicate = (OAuth2Token token) -> {
+            return "dummy_oauth2_token".equals(token.accessToken());
+        };
+        sb.serviceAt(
+                "/oauth2",
+                new AbstractHttpService() {
+                    @Override
+                    protected void doGet(
+                            ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) {
+                        res.respond(HttpStatus.OK);
+                    }
+                }.decorate(new HttpAuthServiceBuilder().addOAuth2(oAuth2aPredicate).newDecorator())
+                 .decorate(LoggingService::new));
+
+        // Auth with all predicates above!
+        HttpService compositeService = new AbstractHttpService() {
+            @Override
+            protected void doGet(
+                    ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) {
+                res.respond(HttpStatus.OK);
+            }
+        };
+        HttpAuthService compositeAuth = new HttpAuthServiceBuilder()
+                .add(predicate)
+                .addBasicAuth(httpBasicPredicate)
+                .addOAuth1a(oAuth1aPredicate)
+                .addOAuth2(oAuth2aPredicate)
+                .build(compositeService);
+        sb.serviceAt(
+                "/composite", compositeAuth.decorate(LoggingService::new));
+    }
+
+    @Test
+    public void testAuth() throws Exception {
+        try (CloseableHttpClient hc = HttpClients.createMinimal()) {
+            try (CloseableHttpResponse res = hc.execute(
+                    getRequest("/", "unit test"))) {
+                assertThat(res.getStatusLine().toString(), is("HTTP/1.1 200 OK"));
+            }
+            try (CloseableHttpResponse res = hc.execute(
+                    getRequest("/", "UNIT TEST"))) {
+                assertThat(res.getStatusLine().toString(), is("HTTP/1.1 401 Unauthorized"));
+            }
+        }
+    }
+
+    @Test
+    public void testBasicAuth() throws Exception {
+        try (CloseableHttpClient hc = HttpClients.createMinimal()) {
+            try (CloseableHttpResponse res = hc.execute(
+                    basicGetRequest("/basic", BasicToken.of("brown", "cony")))) {
+                assertThat(res.getStatusLine().toString(), is("HTTP/1.1 200 OK"));
+            }
+            try (CloseableHttpResponse res = hc.execute(
+                    basicGetRequest("/basic", BasicToken.of("pangyo", "choco")))) {
+                assertThat(res.getStatusLine().toString(), is("HTTP/1.1 200 OK"));
+            }
+            try (CloseableHttpResponse res = hc.execute(new HttpGet(uri("/basic")))) {
+                assertThat(res.getStatusLine().toString(), is("HTTP/1.1 401 Unauthorized"));
+            }
+            try (CloseableHttpResponse res = hc.execute(
+                    basicGetRequest("/basic", BasicToken.of("choco", "pangyo")))) {
+                assertThat(res.getStatusLine().toString(), is("HTTP/1.1 401 Unauthorized"));
+            }
+        }
+    }
+
+    @Test
+    public void testOAuth1a() throws Exception {
+        try (CloseableHttpClient hc = HttpClients.createMinimal()) {
+            Map<String, String> passToken = ImmutableMap.<String, String>builder()
+                    .put("realm", "dummy_realm")
+                    .put("oauth_consumer_key", "dummy_consumer_key")
+                    .put("oauth_token", "dummy_oauth1a_token")
+                    .put("oauth_signature_method", "dummy")
+                    .put("oauth_signature", "dummy_signature")
+                    .put("oauth_timestamp", "0")
+                    .put("oauth_nonce", "dummy_nonce")
+                    .put("version", "1.0")
+                    .build();
+            try (CloseableHttpResponse res = hc.execute(
+                    oauth1aGetRequest("/oauth1a", OAuth1aToken.of(passToken)))) {
+                assertThat(res.getStatusLine().toString(), is("HTTP/1.1 200 OK"));
+            }
+            Map<String, String> failToken = ImmutableMap.<String, String>builder()
+                    .put("realm", "dummy_realm")
+                    .put("oauth_consumer_key", "dummy_consumer_key")
+                    .put("oauth_token", "dummy_oauth1a_token")
+                    .put("oauth_signature_method", "dummy")
+                    .put("oauth_signature", "DUMMY_signature")
+                    .put("oauth_timestamp", "0")
+                    .put("oauth_nonce", "dummy_nonce")
+                    .put("version", "1.0")
+                    .build();
+            try (CloseableHttpResponse res = hc.execute(
+                    oauth1aGetRequest("/oauth1a", OAuth1aToken.of(failToken)))) {
+                assertThat(res.getStatusLine().toString(), is("HTTP/1.1 401 Unauthorized"));
+            }
+        }
+    }
+
+    @Test
+    public void testOAuth2() throws Exception {
+        try (CloseableHttpClient hc = HttpClients.createMinimal()) {
+            try (CloseableHttpResponse res = hc.execute(
+                    oauth2GetRequest("/oauth2", OAuth2Token.of("dummy_oauth2_token")))) {
+                assertThat(res.getStatusLine().toString(), is("HTTP/1.1 200 OK"));
+            }
+            try (CloseableHttpResponse res = hc.execute(
+                    oauth2GetRequest("/oauth2", OAuth2Token.of("DUMMY_oauth2_token")))) {
+                assertThat(res.getStatusLine().toString(), is("HTTP/1.1 401 Unauthorized"));
+            }
+        }
+    }
+
+    @Test
+    public void testCompositeAuth() throws Exception {
+        try (CloseableHttpClient hc = HttpClients.createMinimal()) {
+            try (CloseableHttpResponse res = hc.execute(
+                    getRequest("/composite", "unit test"))) {
+                assertThat(res.getStatusLine().toString(), is("HTTP/1.1 200 OK"));
+            }
+            try (CloseableHttpResponse res = hc.execute(
+                    basicGetRequest("/composite", BasicToken.of("brown", "cony")))) {
+                assertThat(res.getStatusLine().toString(), is("HTTP/1.1 200 OK"));
+            }
+            Map<String, String> passToken = ImmutableMap.<String, String>builder()
+                    .put("realm", "dummy_realm")
+                    .put("oauth_consumer_key", "dummy_consumer_key")
+                    .put("oauth_token", "dummy_oauth1a_token")
+                    .put("oauth_signature_method", "dummy")
+                    .put("oauth_signature", "dummy_signature")
+                    .put("oauth_timestamp", "0")
+                    .put("oauth_nonce", "dummy_nonce")
+                    .put("version", "1.0")
+                    .build();
+            try (CloseableHttpResponse res = hc.execute(
+                    oauth1aGetRequest("/composite", OAuth1aToken.of(passToken)))) {
+                assertThat(res.getStatusLine().toString(), is("HTTP/1.1 200 OK"));
+            }
+            try (CloseableHttpResponse res = hc.execute(
+                    oauth2GetRequest("/composite", OAuth2Token.of("dummy_oauth2_token")))) {
+                assertThat(res.getStatusLine().toString(), is("HTTP/1.1 200 OK"));
+            }
+            try (CloseableHttpResponse res = hc.execute(new HttpGet(uri("/composite")))) {
+                assertThat(res.getStatusLine().toString(), is("HTTP/1.1 401 Unauthorized"));
+            }
+            try (CloseableHttpResponse res = hc.execute(
+                    basicGetRequest("/composite", BasicToken.of("choco", "pangyo")))) {
+                assertThat(res.getStatusLine().toString(), is("HTTP/1.1 401 Unauthorized"));
+            }
+        }
+    }
+
+    private static HttpRequestBase getRequest(String path, String authorization) {
+        HttpGet request = new HttpGet(uri(path));
+        request.addHeader("Authorization", authorization);
+        return request;
+    }
+
+    private static HttpRequestBase basicGetRequest(String path, BasicToken basicToken) {
+        HttpGet request = new HttpGet(uri(path));
+        request.addHeader("Authorization", "Basic " +
+                                           BASE64_ENCODER.encodeToString(
+                                                   (basicToken.username() + ':' + basicToken.password())
+                                                           .getBytes(StandardCharsets.US_ASCII)));
+        return request;
+    }
+
+    private static HttpRequestBase oauth1aGetRequest(String path, OAuth1aToken oAuth1aToken) {
+        HttpGet request = new HttpGet(uri(path));
+        StringBuilder authorization = new StringBuilder("OAuth ");
+        String realm = oAuth1aToken.realm();
+        if (!Strings.isNullOrEmpty(realm)) {
+            authorization.append("realm=\"");
+            authorization.append(realm);
+            authorization.append("\",");
+        }
+        authorization.append("oauth_consumer_key=\"");
+        authorization.append(oAuth1aToken.consumerKey());
+        authorization.append("\",oauth_token=\"");
+        authorization.append(oAuth1aToken.token());
+        authorization.append("\",oauth_signature_method=\"");
+        authorization.append(oAuth1aToken.signatureMethod());
+        authorization.append("\",oauth_signature=\"");
+        authorization.append(oAuth1aToken.signature());
+        authorization.append("\",oauth_timestamp=\"");
+        authorization.append(oAuth1aToken.timestamp());
+        authorization.append("\",oauth_nonce=\"");
+        authorization.append(oAuth1aToken.nonce());
+        authorization.append("\",version=\"");
+        authorization.append(oAuth1aToken.version());
+        authorization.append("\"");
+        for (Entry<String, String> entry : oAuth1aToken.additionals().entrySet()) {
+            authorization.append("\",");
+            authorization.append(entry.getKey());
+            authorization.append("=\"");
+            authorization.append(entry.getValue());
+            authorization.append("\"");
+        }
+        request.addHeader("Authorization", authorization.toString());
+        return request;
+    }
+
+    private static HttpRequestBase oauth2GetRequest(String path, OAuth2Token oAuth2Token) {
+        HttpGet request = new HttpGet(uri(path));
+        request.addHeader("Authorization", "Bearer " + oAuth2Token.accessToken());
+        return request;
+    }
+}


### PR DESCRIPTION
Hello. Here is a concept-proof commit which resolves #259 and #258.

Here is my approach: Http Authorization routine, including rate-limiting routine, can be represented in the form of Predicate of Authorization Token with its internal state (e.g., Set of valid tokens, API usage rate, etc.). So, I implemented a helper method in HttpAuthSevice which creates DecoratingServiceFunction<HttpRequest, HttpResponse> with given Predicate. For example, HttpAuthService#basic returns a DecoratingServiceFunction which inspects authorization header and handle the request to delegate.

This commit only includes basic authorization. If you agree with my approach, I will continue on the other authorization methods like Oauth1.0a, Oauth2, and so on. Thanks.