### PR TITLE
Add EndpointGroup.orElse(EndpointGroup)

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/client/routing/EndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/routing/EndpointGroupTest.java
@@ -1,0 +1,21 @@
+package com.linecorp.armeria.client.routing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+import com.linecorp.armeria.client.Endpoint;
+
+public class EndpointGroupTest {
+    @Test
+    public void orElse() throws Exception {
+        EndpointGroup emptyEndpointGroup = new StaticEndpointGroup();
+        EndpointGroup endpointGroup1 = new StaticEndpointGroup(Endpoint.of("127.0.0.1", 1234));
+        EndpointGroup endpointGroup2 = new StaticEndpointGroup(Endpoint.of("127.0.0.1", 2345));
+
+        assertThat(emptyEndpointGroup.orElse(endpointGroup2).endpoints())
+                .isEqualTo(endpointGroup2.endpoints());
+        assertThat(endpointGroup1.orElse(endpointGroup2).endpoints())
+                .isEqualTo(endpointGroup1.endpoints());
+    }
+}


### PR DESCRIPTION
Motivations:

It is often useful to provide some endpoints in one EndpointGroup and
other endpoints in the other EndpointGroup. And there is no way to bind
such two EndpointGroup under the same endpoint group name.

Modifications:

- Add EndpointGroup.orElse

Results:

A user can combine two EndpointGroup

```
EndpointGroupRegistry.register(
    "myGroup",
    new StaticEndpointGroup().orElse(new StaticEndpointGroup()),
    WEIGHTED_ROUND_ROBIN);
```