### PR TITLE
Replace MessageLog.start/endTimeNanos() with durationNanos()

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
@@ -33,7 +33,6 @@ import io.netty.util.Attribute;
 public final class DefaultRequestLog
         extends AbstractMessageLog<RequestLog> implements RequestLog, RequestLogBuilder {
 
-    private long startTimeMillis;
     private Channel channel;
     private SessionProtocol sessionProtocol;
     private SerializationFormat serializationFormat = SerializationFormat.NONE;
@@ -60,20 +59,6 @@ public final class DefaultRequestLog
         this.host = host;
         this.method = method;
         this.path = path;
-    }
-
-    @Override
-    protected boolean setStartTime() {
-        boolean isSet = super.setStartTime();
-        if (isSet) {
-            startTimeMillis = System.currentTimeMillis();
-        }
-        return isSet;
-    }
-
-    @Override
-    public long startTimeMillis() {
-        return startTimeMillis;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultResponseLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultResponseLog.java
@@ -18,6 +18,8 @@ package com.linecorp.armeria.common.logging;
 
 import java.util.concurrent.CompletableFuture;
 
+import com.linecorp.armeria.common.util.TextFormatter;
+
 import io.netty.util.Attribute;
 
 /**
@@ -26,16 +28,16 @@ import io.netty.util.Attribute;
 public final class DefaultResponseLog
         extends AbstractMessageLog<ResponseLog> implements ResponseLog, ResponseLogBuilder {
 
-    private final RequestLog request;
+    private final DefaultRequestLog request;
     private final CompletableFuture<?> requestLogFuture;
     private int statusCode;
 
     /**
      * Creates a new instance.
      *
-     * @param request the {@link RequestLog} of the corresponding request
+     * @param request the {@link DefaultRequestLog} of the corresponding request
      */
-    public DefaultResponseLog(RequestLog request, CompletableFuture<?> requestLogFuture) {
+    public DefaultResponseLog(DefaultRequestLog request, CompletableFuture<?> requestLogFuture) {
         this.request = request;
         this.requestLogFuture = requestLogFuture;
     }
@@ -48,6 +50,11 @@ public final class DefaultResponseLog
     @Override
     public RequestLog request() {
         return request;
+    }
+
+    @Override
+    public long responseTimeNanos() {
+        return endTimeNanos() - request.startTimeNanos();
     }
 
     @Override
@@ -66,6 +73,8 @@ public final class DefaultResponseLog
 
     @Override
     protected void appendProperties(StringBuilder buf) {
+        buf.append(", responseTime=");
+        TextFormatter.appendElapsed(buf, responseTimeNanos());
         buf.append(", statusCode=").append(statusCode);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/logging/MessageLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/MessageLog.java
@@ -37,14 +37,14 @@ public interface MessageLog extends AttributeMap {
     long contentLength();
 
     /**
-     * Returns the {@link System#nanoTime() nanoTime} of when the processing of the message started.
+     * Returns the time when the processing of the message started, in millis since the epoch.
      */
-    long startTimeNanos();
+    long startTimeMillis();
 
     /**
-     * Returns the {@link System#nanoTime() nanoTime} of when the processing of the message ended.
+     * Returns the duration that was taken to consume or produce the message completely, in nanoseconds.
      */
-    long endTimeNanos();
+    long durationNanos();
 
     /**
      * Returns the cause of message processing failure.

--- a/core/src/main/java/com/linecorp/armeria/common/logging/MessageLogBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/MessageLogBuilder.java
@@ -36,14 +36,14 @@ public interface MessageLogBuilder extends AttributeMap {
     void contentLength(long contentLength);
 
     /**
-     * Sets {@link MessageLog#endTimeNanos()} and finishes the collection of the information, completing
+     * Sets {@link MessageLog#durationNanos()} and finishes the collection of the information, completing
      * {@link RequestContext#requestLogFuture()} or {@link RequestContext#responseLogFuture()} successfully.
      * This method will do nothing if called twice.
      */
     void end();
 
     /**
-     * Sets {@link MessageLog#endTimeNanos()} and finishes the collection of the information, completing
+     * Sets {@link MessageLog#durationNanos()} and finishes the collection of the information, completing
      * {@link RequestContext#requestLogFuture()} or {@link RequestContext#responseLogFuture()} exceptionally.
      * This method will do nothing if called twice.
      */

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestLog.java
@@ -54,11 +54,6 @@ public interface RequestLog extends MessageLog {
     AttributeKey<Object> RAW_RPC_REQUEST = AttributeKey.valueOf(RequestLog.class, "RAW_RPC_REQUEST");
 
     /**
-     * Returns the {@link System#currentTimeMillis()} of when the processing of the message started.
-     */
-    long startTimeMillis();
-
-    /**
      * Returns the Netty {@link Channel} which handled the {@link Request}.
      */
     Channel channel();

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogBuilder.java
@@ -28,7 +28,6 @@ public interface RequestLogBuilder extends MessageLogBuilder {
     /**
      * Starts the collection of information. This method will update the following properties:
      * <ul>
-     *   <li>{@link MessageLog#startTimeNanos()}</li>
      *   <li>{@link RequestLog#scheme()} with {@link SerializationFormat#UNKNOWN}</li>
      *   <li>{@link RequestLog#host()}</li>
      *   <li>{@link RequestLog#method()}</li>

--- a/core/src/main/java/com/linecorp/armeria/common/logging/ResponseLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/ResponseLog.java
@@ -59,6 +59,12 @@ public interface ResponseLog extends MessageLog {
     RequestLog request();
 
     /**
+     * Returns the amount of time taken since the {@link Request} processing started and until the
+     * {@link Response} processing ended.
+     */
+    long responseTimeNanos();
+
+    /**
      * Returns the status code specific to the current {@link SessionProtocol}.
      */
     int statusCode();

--- a/core/src/main/java/com/linecorp/armeria/common/logging/ResponseLogBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/ResponseLogBuilder.java
@@ -60,8 +60,7 @@ public interface ResponseLogBuilder extends MessageLogBuilder {
     };
 
     /**
-     * Starts the collection of information. This method will update the {@link MessageLog#startTimeNanos()}
-     * property. This method will do nothing if called twice.
+     * Starts the collection of information. This method will do nothing if called twice.
      */
     void start();
 

--- a/core/src/main/java/com/linecorp/armeria/internal/logging/DropwizardMetricConsumer.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/logging/DropwizardMetricConsumer.java
@@ -67,7 +67,7 @@ public final class DropwizardMetricConsumer implements MessageLogConsumer {
     public void onResponse(RequestContext ctx, ResponseLog res) {
         final RequestLog req = res.request();
         final DropwizardRequestMetrics metrics = getRequestMetrics(ctx, req);
-        metrics.updateTime(res.endTimeNanos() - req.startTimeNanos());
+        metrics.updateTime(res.responseTimeNanos());
         if (isSuccess(res)) {
             metrics.markSuccess();
         } else {

--- a/core/src/main/java/com/linecorp/armeria/server/logging/structured/StructuredLog.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/structured/StructuredLog.java
@@ -49,7 +49,7 @@ public abstract class StructuredLog {
         RequestLog reqLog = resLog.request();
 
         timestampMillis = reqLog.startTimeMillis();
-        responseTimeNanos = reqLog.endTimeNanos() - reqLog.startTimeNanos();
+        responseTimeNanos = resLog.responseTimeNanos();
 
         requestSize = reqLog.contentLength();
         responseSize = resLog.contentLength();

--- a/logback/src/main/java/com/linecorp/armeria/common/logback/RequestContextExporter.java
+++ b/logback/src/main/java/com/linecorp/armeria/common/logback/RequestContextExporter.java
@@ -304,7 +304,7 @@ final class RequestContextExporter {
     private static void exportElapsedNanos(Map<String, String> out, @Nullable RequestLog req,
                                            @Nullable ResponseLog res) {
         if (req != null && res != null) {
-            out.put(ELAPSED_NANOS.mdcKey, String.valueOf(res.endTimeNanos() - req.startTimeNanos()));
+            out.put(ELAPSED_NANOS.mdcKey, String.valueOf(res.responseTimeNanos()));
         }
     }
 


### PR DESCRIPTION
Motivation:

MessageLog.startTimeNanos() and startTimeMillis() may misleads a user
think startTimeNanos = startTimeMillis * 1000000, which is not correct.

Modifications:

- Replace start/endTimeNanos() with durationNanos()
- Add ResponseLog.responseTimeNanos()

Result:

Less confusion