### PR TITLE
Change ZooKeeper test rootDir from target to build/zookeeper

### DIFF
--- a/zookeeper/src/test/java/com/linecorp/armeria/client/endpoint/zookeeper/ZooKeeperEndpointGroupTest.java
+++ b/zookeeper/src/test/java/com/linecorp/armeria/client/endpoint/zookeeper/ZooKeeperEndpointGroupTest.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.client.endpoint.zookeeper;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
+import java.io.File;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -48,17 +49,22 @@ import zookeeperjunit.ZooKeeperAssert;
 public class ZooKeeperEndpointGroupTest implements ZooKeeperAssert, OptionAssert {
     private static final Logger logger = LoggerFactory.getLogger(ZooKeeperEndpointGroup.class);
 
+    private static final File ROOT_DIR = new File("build" + File.separator + "zookeeper");
+
+    static {
+        ROOT_DIR.mkdirs();
+    }
+
     private static final Duration duration = Duration.ofSeconds(5);
-    private static final ZKInstance zkInstance = ZKFactory.apply().create();
+    private static final ZKInstance zkInstance = ZKFactory.apply().withRootDir(ROOT_DIR).create();
     private static final String zNode = "/testEndPoints";
     private static final int sessionTimeout = 3000;
     private ZooKeeperEndpointGroup zkEndpointGroup;
     private static final List<Endpoint> initializedEndpointGroupList = new ArrayList<>();
-    private static final KeeperState[] expectedStates =
-            {
-                    KeeperState.SyncConnected, KeeperState.Disconnected, KeeperState.Expired,
-                    KeeperState.SyncConnected
-            };
+    private static final KeeperState[] expectedStates = {
+            KeeperState.SyncConnected, KeeperState.Disconnected,
+            KeeperState.Expired, KeeperState.SyncConnected
+    };
 
     @Override
     public ZKInstance instance() {


### PR DESCRIPTION
Motivation:

ZooKeeperEndpointGroupTest creates the ZooKeeper work directory under
'target' dierctory. Gradle uses 'build' as the build output directory
unlike Maven. As a result, the offending test case leaves the cruft
files outside the 'build' directory.

Modifications:

- Change the rootDir from 'target' to 'build/zookeeper'

Result:

No more untracked files reported by Git after a build

Assigned to @imasahiro since he reviewed the original PR by @jonefeewang 