### PR TITLE
Fix to throw EndpointGroupException instead of ArithmeticException wh…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/routing/WeightedRoundRobinStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/routing/WeightedRoundRobinStrategy.java
@@ -102,6 +102,9 @@ final class WeightedRoundRobinStrategy implements EndpointSelectionStrategy {
                     }
                 }
             }
+            if (endpoints.isEmpty()) {
+                throw new EndpointGroupException(endpointGroup + " is empty");
+            }
             //endpoints weight equal
             return endpoints.get((int) (currentSequence % endpoints.size()));
         }

--- a/core/src/test/java/com/linecorp/armeria/client/routing/WeightedRoundRobinStrategyTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/routing/WeightedRoundRobinStrategyTest.java
@@ -1,0 +1,32 @@
+package com.linecorp.armeria.client.routing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.linecorp.armeria.client.Endpoint;
+
+public class WeightedRoundRobinStrategyTest {
+    private static final EndpointGroup ENDPOINT_GROUP = new StaticEndpointGroup(Endpoint.of("localhost:1234"),
+                                                                                Endpoint.of("localhost:2345"));
+    private static final EndpointGroup EMPTY_ENDPOINT_GROUP = new StaticEndpointGroup();
+
+    private final WeightedRoundRobinStrategy strategy = new WeightedRoundRobinStrategy();
+
+    @Before
+    public void setup() {
+        EndpointGroupRegistry.register("endpoint", ENDPOINT_GROUP, strategy);
+        EndpointGroupRegistry.register("empty", EMPTY_ENDPOINT_GROUP, strategy);
+    }
+
+    @Test
+    public void select() {
+        assertThat(EndpointGroupRegistry.selectNode("endpoint")).isNotNull();
+
+        assertThat(catchThrowable(() -> EndpointGroupRegistry.selectNode("empty")))
+                .isInstanceOf(EndpointGroupException.class);
+    }
+
+}


### PR DESCRIPTION
…en endpoints is empty

Motivations:

When EndpointGroup#endpoints() returns empty list, RoundRobinSelector do 'divide by zero' and throws ArithmeticException.

Modifications:

- Add empty check and throw EndpointGroupException if empty.

Result:

No more ArithmeticException