### PR TITLE
Dedup endpoint health check metric and converts healthcheck metrics t…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/EndpointHealthStateGaugeSet.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/EndpointHealthStateGaugeSet.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client.endpoint.healthcheck;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Map;
+import java.util.Set;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricSet;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.internal.guava.stream.GuavaCollectors;
+
+/**
+ * {@link Metric}s for a {@link HealthCheckedEndpointGroup}.
+ */
+class EndpointHealthStateGaugeSet implements MetricSet {
+    private static final String METRIC_NAME_PREFIX = "healthcheck.";
+    private final HealthCheckedEndpointGroup endpointGroup;
+    private final String metricName;
+
+    EndpointHealthStateGaugeSet(HealthCheckedEndpointGroup endpointGroup,
+                                String metricName) {
+        this.endpointGroup = requireNonNull(endpointGroup, "endpointGroup");
+        this.metricName = requireNonNull(metricName, "metricName");
+    }
+
+    @Override
+    public Map<String, Metric> getMetrics() {
+        return ImmutableMap.of(
+                METRIC_NAME_PREFIX + metricName + ".all.server.count",
+                (Gauge<Integer>) endpointGroup.allServers::size,
+                METRIC_NAME_PREFIX + metricName + ".healthy.server.count",
+                (Gauge<Integer>) endpointGroup.healthyEndpoints::size,
+                METRIC_NAME_PREFIX + metricName + ".healthy.servers",
+                (Gauge<Set<String>>) () -> ImmutableSet.copyOf(endpointGroup.healthyEndpoints)
+                                                       .stream()
+                                                       .map(Endpoint::authority)
+                                                       .collect(GuavaCollectors.toImmutableSet()));
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/EndpointHealthStateGaugeSet.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/EndpointHealthStateGaugeSet.java
@@ -52,12 +52,12 @@ class EndpointHealthStateGaugeSet implements MetricSet {
                 (Gauge<Integer>) endpointGroup.allServers::size,
                 METRIC_NAME_PREFIX + metricName + ".healthy.count",
                 (Gauge<Integer>) endpointGroup.healthyEndpoints::size,
-                METRIC_NAME_PREFIX + metricName + ".healthy.servers",
+                METRIC_NAME_PREFIX + metricName + ".healthy.endpoints",
                 (Gauge<Set<String>>) () -> ImmutableSet.copyOf(endpointGroup.healthyEndpoints)
                                                        .stream()
                                                        .map(Endpoint::authority)
                                                        .collect(GuavaCollectors.toImmutableSet()),
-                METRIC_NAME_PREFIX + metricName + ".unhealthy.servers",
+                METRIC_NAME_PREFIX + metricName + ".unhealthy.endpoints",
                 (Gauge<Set<String>>) () -> {
                     Set<String> all = ImmutableSet.copyOf(endpointGroup.allServers)
                                                   .stream()

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
@@ -76,10 +76,9 @@ public abstract class HealthCheckedEndpointGroup implements EndpointGroup {
     }
 
     private void scheduleCheckAndUpdateHealthyServers() {
-        clientFactory.eventLoopGroup()
-                     .schedule(() -> checkAndUpdateHealthyServers()
-                                       .thenRun(this::scheduleCheckAndUpdateHealthyServers),
-                               healthCheckRetryInterval.toMillis(), TimeUnit.MILLISECONDS);
+        clientFactory.eventLoopGroup().schedule(
+                () -> checkAndUpdateHealthyServers().thenRun(this::scheduleCheckAndUpdateHealthyServers),
+                healthCheckRetryInterval.toMillis(), TimeUnit.MILLISECONDS);
     }
 
     private CompletableFuture<Void> checkAndUpdateHealthyServers() {
@@ -130,7 +129,7 @@ public abstract class HealthCheckedEndpointGroup implements EndpointGroup {
     /**
      * Creates healthcheck {@link MetricSet} for this {@link HealthCheckedEndpointGroup}.
      */
-    public MetricSet metricSet(String metricName) {
+    public MetricSet newMetricSet(String metricName) {
         return new EndpointHealthStateGaugeSet(this, metricName);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroup.java
@@ -20,8 +20,6 @@ import static java.util.Objects.requireNonNull;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 
-import com.codahale.metrics.MetricRegistry;
-
 import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.Endpoint;
@@ -39,19 +37,17 @@ public final class HttpHealthCheckedEndpointGroup extends HealthCheckedEndpointG
      * Creates a new {@link HttpHealthCheckedEndpointGroup} instance.
      */
     public static HttpHealthCheckedEndpointGroup of(EndpointGroup delegate,
-                                                    MetricRegistry metricRegistry,
                                                     String healthCheckPath) {
-        return of(delegate, metricRegistry, healthCheckPath, DEFAULT_HEALTHCHECK_RETRY_INTERVAL);
+        return of(delegate, healthCheckPath, DEFAULT_HEALTHCHECK_RETRY_INTERVAL);
     }
 
     /**
      * Creates a new {@link HttpHealthCheckedEndpointGroup} instance.
      */
     public static HttpHealthCheckedEndpointGroup of(EndpointGroup delegate,
-                                                    MetricRegistry metricRegistry,
                                                     String healthCheckPath,
                                                     Duration healthCheckRetryInterval) {
-        return of(ClientFactory.DEFAULT, delegate, metricRegistry, healthCheckPath, healthCheckRetryInterval);
+        return of(ClientFactory.DEFAULT, delegate, healthCheckPath, healthCheckRetryInterval);
     }
 
     /**
@@ -59,12 +55,10 @@ public final class HttpHealthCheckedEndpointGroup extends HealthCheckedEndpointG
      */
     public static HttpHealthCheckedEndpointGroup of(ClientFactory clientFactory,
                                                     EndpointGroup delegate,
-                                                    MetricRegistry metricRegistry,
                                                     String healthCheckPath,
                                                     Duration healthCheckRetryInterval) {
         return new HttpHealthCheckedEndpointGroup(clientFactory,
                                                   delegate,
-                                                  metricRegistry,
                                                   healthCheckPath,
                                                   healthCheckRetryInterval);
     }
@@ -74,10 +68,9 @@ public final class HttpHealthCheckedEndpointGroup extends HealthCheckedEndpointG
      */
     private HttpHealthCheckedEndpointGroup(ClientFactory clientFactory,
                                            EndpointGroup delegate,
-                                           MetricRegistry metricRegistry,
                                            String healthCheckPath,
                                            Duration healthCheckRetryInterval) {
-        super(clientFactory, delegate, metricRegistry, healthCheckRetryInterval);
+        super(clientFactory, delegate, healthCheckRetryInterval);
         this.healthCheckPath = requireNonNull(healthCheckPath, "healthCheckPath");
         init();
     }

--- a/core/src/main/resources/com/linecorp/armeria/server/docs/index.html
+++ b/core/src/main/resources/com/linecorp/armeria/server/docs/index.html
@@ -78,7 +78,7 @@
 
       <div id="function" class="content">
         <script id="function-template" type="text/x-handlebars-template">
-          <h1 class="page-header"><code title="{{serviceName}}.{{function.name}}()">{{serviceSimpleName}}.{{function.name}}()</code></h1>
+          <h1 class="page-header"><code title="{{groupName}}.{{function.name}}()">{{serviceSimpleName}}.{{function.name}}()</code></h1>
 
           <div class="description">{{{function.docString}}}</div>
 

--- a/core/src/main/resources/com/linecorp/armeria/server/docs/index.html
+++ b/core/src/main/resources/com/linecorp/armeria/server/docs/index.html
@@ -78,7 +78,7 @@
 
       <div id="function" class="content">
         <script id="function-template" type="text/x-handlebars-template">
-          <h1 class="page-header"><code title="{{groupName}}.{{function.name}}()">{{serviceSimpleName}}.{{function.name}}()</code></h1>
+          <h1 class="page-header"><code title="{{serviceName}}.{{function.name}}()">{{serviceSimpleName}}.{{function.name}}()</code></h1>
 
           <div class="description">{{{function.docString}}}</div>
 

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroupTest.java
@@ -94,9 +94,9 @@ public class HttpHealthCheckedEndpointGroupTest {
                 .isEqualTo(2);
         assertThat(metricRegistry.getGauges().get("endpointHealth.metric.healthy.count").getValue())
                 .isEqualTo(2);
-        assertThat(metricRegistry.getGauges().get("endpointHealth.metric.healthy.servers").getValue())
+        assertThat(metricRegistry.getGauges().get("endpointHealth.metric.healthy.endpoints").getValue())
                 .isEqualTo(ImmutableSet.of("127.0.0.1:" + serverOne.port(), "127.0.0.1:" + serverTwo.port()));
-        assertThat(metricRegistry.getGauges().get("endpointHealth.metric.unhealthy.servers").getValue())
+        assertThat(metricRegistry.getGauges().get("endpointHealth.metric.unhealthy.endpoints").getValue())
                 .isEqualTo(ImmutableSet.of());
         serverOne.stop();
         serverTwo.stop();
@@ -120,9 +120,9 @@ public class HttpHealthCheckedEndpointGroupTest {
                 .isEqualTo(2);
         assertThat(metricRegistry.getGauges().get("endpointHealth.metric.healthy.count").getValue())
                 .isEqualTo(1);
-        assertThat(metricRegistry.getGauges().get("endpointHealth.metric.healthy.servers").getValue())
+        assertThat(metricRegistry.getGauges().get("endpointHealth.metric.healthy.endpoints").getValue())
                 .isEqualTo(ImmutableSet.of("127.0.0.1:" + serverOne.port()));
-        assertThat(metricRegistry.getGauges().get("endpointHealth.metric.unhealthy.servers").getValue())
+        assertThat(metricRegistry.getGauges().get("endpointHealth.metric.unhealthy.endpoints").getValue())
                 .isEqualTo(ImmutableSet.of("127.0.0.1:2345"));
         serverOne.stop();
     }
@@ -146,9 +146,9 @@ public class HttpHealthCheckedEndpointGroupTest {
                 .isEqualTo(3);
         assertThat(metricRegistry.getGauges().get("endpointHealth.metric.healthy.count").getValue())
                 .isEqualTo(3);
-        assertThat(metricRegistry.getGauges().get("endpointHealth.metric.healthy.servers").getValue())
+        assertThat(metricRegistry.getGauges().get("endpointHealth.metric.healthy.endpoints").getValue())
                 .isEqualTo(ImmutableSet.of("127.0.0.1:" + serverOne.port()));
-        assertThat(metricRegistry.getGauges().get("endpointHealth.metric.unhealthy.servers").getValue())
+        assertThat(metricRegistry.getGauges().get("endpointHealth.metric.unhealthy.endpoints").getValue())
                 .isEqualTo(ImmutableSet.of());
         serverOne.stop();
     }


### PR DESCRIPTION
…o metricsSet

Motivation:
When a user creates a HealthCheckedEndpointGroup with duplicated
endpoint list, it throws IllegalStateException because it registers
duplicated metric to MetricRegistry.

Modifications:
- Add EndpointHealthStateGaugeSet
- Expose number of servers registered to endpoing group,
  health servers, and health server sets as Gauge metrics