### PR TITLE
Do not check null on RpcRequest parameters / Easier instantiation of RpcRequest and RpcResponse

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/thrift/DefaultTHttpClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/thrift/DefaultTHttpClient.java
@@ -22,7 +22,6 @@ import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.client.ClientBuilderParams;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.UserClient;
-import com.linecorp.armeria.common.DefaultRpcRequest;
 import com.linecorp.armeria.common.DefaultRpcResponse;
 import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.RpcResponse;
@@ -45,7 +44,7 @@ final class DefaultTHttpClient extends UserClient<RpcRequest, RpcResponse> imple
     public RpcResponse executeMultiplexed(
             String path, Class<?> serviceType, String serviceName, String method, Object... args) {
         requireNonNull(serviceName, "serviceName");
-        final RpcRequest call = new DefaultRpcRequest(serviceType, method, args);
+        final RpcRequest call = RpcRequest.of(serviceType, method, args);
         return execute(call.method(), path, serviceName, call, DefaultRpcResponse::new);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/RpcRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RpcRequest.java
@@ -16,12 +16,73 @@
 
 package com.linecorp.armeria.common;
 
+import static java.util.Objects.requireNonNull;
+
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+
+import javax.annotation.Nullable;
 
 /**
  * An RPC {@link Request}.
  */
 public interface RpcRequest extends Request {
+
+    /**
+     * Creates a new instance with no parameter.
+     */
+    static RpcRequest of(Class<?> serviceType, String method) {
+        return new DefaultRpcRequest(serviceType, method, Collections.emptyList());
+    }
+
+    /**
+     * Creates a new instance with a single parameter.
+     */
+    static RpcRequest of(Class<?> serviceType, String method, @Nullable Object parameter) {
+        return new DefaultRpcRequest(serviceType, method, Collections.singletonList(parameter));
+    }
+
+    /**
+     * Creates a new instance with the specified parameters.
+     */
+    static RpcRequest of(Class<?> serviceType, String method, Iterable<?> params) {
+        requireNonNull(params, "params");
+
+        if (!(params instanceof Collection)) {
+            return new DefaultRpcRequest(serviceType, method, params);
+        }
+
+        final Collection<?> paramCollection = (Collection<?>) params;
+        switch (paramCollection.size()) {
+            case 0:
+                return of(serviceType, method);
+            case 1:
+                if (paramCollection instanceof List) {
+                    return of(serviceType, method, ((List<?>) paramCollection).get(0));
+                } else {
+                    return of(serviceType, method, paramCollection.iterator().next());
+                }
+            default:
+                return new DefaultRpcRequest(serviceType, method, paramCollection.toArray());
+        }
+    }
+
+    /**
+     * Creates a new instance with the specified parameters.
+     */
+    static RpcRequest of(Class<?> serviceType, String method, Object... params) {
+        requireNonNull(params, "params");
+        switch (params.length) {
+            case 0:
+                return of(serviceType, method);
+            case 1:
+                return of(serviceType, method, params[0]);
+            default:
+                return new DefaultRpcRequest(serviceType, method, params);
+        }
+    }
+
     /**
      * Returns the type of the service this {@link RpcRequest} is called upon.
      */

--- a/core/src/main/java/com/linecorp/armeria/common/RpcResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RpcResponse.java
@@ -25,6 +25,21 @@ import java.util.concurrent.Future;
  * call.
  */
 public interface RpcResponse extends Response, Future<Object>, CompletionStage<Object> {
+
+    /**
+     * Creates a new successfully complete {@link RpcResponse}.
+     */
+    static RpcResponse of(Object value) {
+        return new DefaultRpcResponse(value);
+    }
+
+    /**
+     * Creates a new exceptionally complete {@link RpcResponse}.
+     */
+    static RpcResponse ofFailure(Throwable cause) {
+        return new DefaultRpcResponse(cause);
+    }
+
     /**
      * Returns the cause of the failure if this {@link RpcResponse} completed exceptionally.
      *

--- a/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClientTest.java
@@ -44,8 +44,6 @@ import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.DefaultClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.circuitbreaker.KeyedCircuitBreakerMapping.KeySelector;
-import com.linecorp.armeria.common.DefaultRpcRequest;
-import com.linecorp.armeria.common.DefaultRpcResponse;
 import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.RpcResponse;
 import com.linecorp.armeria.common.SessionProtocol;
@@ -63,19 +61,19 @@ public class CircuitBreakerClientTest {
             new DefaultEventLoop(), SessionProtocol.H2C,
             Endpoint.of("dummyhost", 8080),
             "POST", "/", "", ClientOptions.DEFAULT,
-            new DefaultRpcRequest(HelloService.Iface.class, "methodA", "a", "b"));
+            RpcRequest.of(HelloService.Iface.class, "methodA", "a", "b"));
 
     private static final ClientRequestContext ctxB = new DefaultClientRequestContext(
             new DefaultEventLoop(), SessionProtocol.H2C,
             Endpoint.of("dummyhost", 8080),
             "POST", "/", "", ClientOptions.DEFAULT,
-            new DefaultRpcRequest(HelloService.Iface.class, "methodB", "c", "d"));
+            RpcRequest.of(HelloService.Iface.class, "methodB", "c", "d"));
 
     private static final RpcRequest req = ctx.request();
     private static final RpcRequest reqB = ctxB.request();
-    private static final RpcResponse successRes = new DefaultRpcResponse((Object) null);
-    private static final RpcResponse failureRes =
-            new DefaultRpcResponse(Exceptions.clearTrace(new Exception("bug")));
+    private static final RpcResponse successRes = RpcResponse.of(null);
+    private static final RpcResponse failureRes = RpcResponse.ofFailure(
+            Exceptions.clearTrace(new Exception("bug")));
 
     @Test
     public void testSingletonDecorator() throws Exception {

--- a/core/src/test/java/com/linecorp/armeria/client/thrift/ThriftOverHttpClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/thrift/ThriftOverHttpClientTest.java
@@ -324,6 +324,7 @@ public class ThriftOverHttpClientTest {
         HelloService.Iface client = Clients.newClient(clientFactory(), getURI(Handlers.HELLO),
                                                       Handlers.HELLO.iface(), clientOptions);
         assertThat(client.hello("kukuman")).isEqualTo("Hello, kukuman!");
+        assertThat(client.hello(null)).isEqualTo("Hello, null!");
 
         for (int i = 0; i < 10; i++) {
             assertThat(client.hello("kukuman" + i)).isEqualTo("Hello, kukuman" + i + '!');

--- a/core/src/test/java/com/linecorp/armeria/server/ServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServiceTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 
-import com.linecorp.armeria.common.DefaultRpcRequest;
 import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.RpcResponse;
 
@@ -33,8 +32,7 @@ public class ServiceTest {
     public void testLambdaExpressionDecorator() throws Exception {
         final FooService inner = new FooService();
         final Service<RpcRequest, RpcResponse> outer = inner.decorate((delegate, ctx, req) -> {
-            RpcRequest newReq = new DefaultRpcRequest(
-                    req.serviceType(), "new_" + req.method(), req.params());
+            RpcRequest newReq = RpcRequest.of(req.serviceType(), "new_" + req.method(), req.params());
             return delegate.serve(ctx, newReq);
         });
 

--- a/core/src/test/java/com/linecorp/armeria/server/thrift/ThriftServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/thrift/ThriftServiceTest.java
@@ -174,6 +174,35 @@ public class ThriftServiceTest {
     }
 
     @Test
+    public void testSync_HelloService_hello_with_null() throws Exception {
+        HelloService.Client client = new HelloService.Client.Factory().getClient(inProto, outProto);
+        client.send_hello(null);
+        assertThat(out.length(), is(greaterThan(0)));
+
+        THttpService service = THttpService.of(
+                (HelloService.Iface) name -> String.valueOf(name != null), defaultSerializationFormat);
+
+        invoke(service);
+
+        assertThat(client.recv_hello(), is("false"));
+    }
+
+    @Test
+    public void testAsync_HelloService_hello_with_null() throws Exception {
+        HelloService.Client client = new HelloService.Client.Factory().getClient(inProto, outProto);
+        client.send_hello(null);
+        assertThat(out.length(), is(greaterThan(0)));
+
+        THttpService service = THttpService.of(
+                (HelloService.AsyncIface) (name, resultHandler) ->
+                        resultHandler.onComplete(String.valueOf(name != null)), defaultSerializationFormat);
+
+        invoke(service);
+
+        assertThat(client.recv_hello(), is("false"));
+    }
+
+    @Test
     public void testIdentity_HelloService_hello() throws Exception {
         HelloService.Client client = new HelloService.Client.Factory().getClient(inProto, outProto);
         client.send_hello(FOO);

--- a/zipkin/src/test/java/com/linecorp/armeria/client/tracing/TracingClientTest.java
+++ b/zipkin/src/test/java/com/linecorp/armeria/client/tracing/TracingClientTest.java
@@ -40,8 +40,6 @@ import com.linecorp.armeria.client.ClientOptions;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.DefaultClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
-import com.linecorp.armeria.common.DefaultRpcRequest;
-import com.linecorp.armeria.common.DefaultRpcResponse;
 import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.RpcResponse;
 import com.linecorp.armeria.common.SessionProtocol;
@@ -103,8 +101,8 @@ public class TracingClientTest {
                 .build();
 
         // prepare parameters
-        final RpcRequest req = new DefaultRpcRequest(HelloService.Iface.class, "hello", "Armeria");
-        final RpcResponse res = new DefaultRpcResponse("Hello, Armeria!");
+        final RpcRequest req = RpcRequest.of(HelloService.Iface.class, "hello", "Armeria");
+        final RpcResponse res = RpcResponse.of("Hello, Armeria!");
         final ClientRequestContext ctx = new DefaultClientRequestContext(
                 new DefaultEventLoop(), SessionProtocol.H2C, Endpoint.of("localhost", 8080),
                 "POST", "/", "", ClientOptions.DEFAULT, req);

--- a/zipkin/src/test/java/com/linecorp/armeria/server/tracing/TracingServiceTest.java
+++ b/zipkin/src/test/java/com/linecorp/armeria/server/tracing/TracingServiceTest.java
@@ -37,8 +37,6 @@ import com.github.kristofa.brave.Sampler;
 import com.github.kristofa.brave.SpanId;
 import com.github.kristofa.brave.TraceData;
 
-import com.linecorp.armeria.common.DefaultRpcRequest;
-import com.linecorp.armeria.common.DefaultRpcResponse;
 import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.RpcResponse;
 import com.linecorp.armeria.common.SessionProtocol;
@@ -112,7 +110,7 @@ public class TracingServiceTest {
         TracingServiceImpl stub = new TracingServiceImpl(delegate, brave, traceData);
 
         final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
-        final RpcRequest req = new DefaultRpcRequest(HelloService.Iface.class, "hello", "trustin");
+        final RpcRequest req = RpcRequest.of(HelloService.Iface.class, "hello", "trustin");
         final DefaultRequestLog log = new DefaultRequestLog(ctx);
         log.startRequest(mock(Channel.class), SessionProtocol.H2C, "localhost", TEST_METHOD, "/");
         log.endRequest();
@@ -124,7 +122,7 @@ public class TracingServiceTest {
         ctx.onEnter(ArgumentMatchers.isA(Runnable.class));
         ctx.onExit(ArgumentMatchers.isA(Runnable.class));
 
-        RpcResponse res = new DefaultRpcResponse("Hello, trustin!");
+        RpcResponse res = RpcResponse.of("Hello, trustin!");
         when(delegate.serve(ctx, req)).thenReturn(res);
 
         // do invoke


### PR DESCRIPTION
Related issue: #350

Motivation:

- Attempting to send a null parameter fails since 0.33.0 due to the use
  of ImmutableList.copyOf() and GuavaCollectors.toImmutableList(), which
  does null checks on elements.
- We could make users' lives easier by adding some static factory
  methods to RpcRequest and RpcResponse

Modifications:

- Do not use ImmutableList.copyOf() and
  GuavaCollectors.toImmutableList() when constructing the RPC parameter
  list
- Add various static factory methods to RpcRequest and RpcResponse
- Add more convenience constructors to DefaultRpcRequest

Result:

- Fixes #350, the regression introduced in 0.33.0
- A user can instantiate RpcRequest and RpcResponse more easily.