### PR TITLE
Avoid creating humongous object when armeria retrofit get large response

### DIFF
--- a/retrofit2/src/main/java/com/linecorp/armeria/client/http/retrofit2/ArmeriaCallSubscriber.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/http/retrofit2/ArmeriaCallSubscriber.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client.http.retrofit2;
+
+import java.io.IOException;
+
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import com.google.common.base.Strings;
+
+import com.linecorp.armeria.client.http.retrofit2.ArmeriaCallFactory.ArmeriaCall;
+import com.linecorp.armeria.common.http.HttpData;
+import com.linecorp.armeria.common.http.HttpHeaderNames;
+import com.linecorp.armeria.common.http.HttpHeaders;
+import com.linecorp.armeria.common.http.HttpObject;
+import com.linecorp.armeria.common.http.HttpStatusClass;
+
+import okhttp3.Callback;
+import okhttp3.MediaType;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import okio.Buffer;
+
+final class ArmeriaCallSubscriber implements Subscriber<HttpObject> {
+    private final ArmeriaCall armeriaCall;
+    private final Callback callback;
+    private final Request request;
+    private final Response.Builder responseBuilder = new Response.Builder();
+    private final Buffer responseDataBuffer = new Buffer();
+    private Subscription subscription;
+    private HttpHeaders headers;
+    private boolean callbackCalled;
+
+    ArmeriaCallSubscriber(ArmeriaCall armeriaCall, Callback callback, Request request) {
+        this.armeriaCall = armeriaCall;
+        this.callback = callback;
+        this.request = request;
+    }
+
+    @Override
+    public void onSubscribe(Subscription subscription) {
+        this.subscription = subscription;
+        if (armeriaCall.isCanceled()) {
+            safeOnFailure(newCanceledException());
+            subscription.cancel();
+            return;
+        }
+        subscription.request(Long.MAX_VALUE);
+    }
+
+    @Override
+    public void onNext(HttpObject httpObject) {
+        if (armeriaCall.isCanceled()) {
+            safeOnFailure(newCanceledException());
+            subscription.cancel();
+            return;
+        }
+        if (httpObject instanceof HttpHeaders) {
+            if (((HttpHeaders) httpObject).status().codeClass() == HttpStatusClass.INFORMATIONAL) {
+                return;
+            }
+            if (headers != null) {
+                return;
+            }
+
+            headers = (HttpHeaders) httpObject;
+            String contentType = headers.get(HttpHeaderNames.CONTENT_TYPE);
+            headers.forEach(header -> responseBuilder.addHeader(header.getKey().toString(),
+                                                                header.getValue()));
+            responseBuilder.code(headers.status().code());
+            responseBuilder.message(headers.status().reasonPhrase());
+            responseBuilder.body(ResponseBody.create(
+                    Strings.isNullOrEmpty(contentType) ? null : MediaType.parse(contentType),
+                    headers.getLong(HttpHeaderNames.CONTENT_LENGTH, -1L),
+                    responseDataBuffer));
+            return;
+        }
+        HttpData data = (HttpData) httpObject;
+        responseDataBuffer.write(data.array(), data.offset(), data.length());
+    }
+
+    @Override
+    public void onError(Throwable throwable) {
+        if (armeriaCall.tryFinish()) {
+            safeOnFailure(new IOException(throwable.getMessage(), throwable));
+        } else {
+            safeOnFailure(newCanceledException());
+        }
+    }
+
+    @Override
+    public void onComplete() {
+        if (armeriaCall.tryFinish()) {
+            responseBuilder.request(request);
+            responseBuilder.protocol(Protocol.HTTP_1_1);
+            safeOnResponse(responseBuilder.build());
+        } else {
+            safeOnFailure(newCanceledException());
+        }
+    }
+
+    private void safeOnFailure(IOException e) {
+        if (callbackCalled) {
+            return;
+        }
+        callbackCalled = true;
+        callback.onFailure(armeriaCall, e);
+    }
+
+    private void safeOnResponse(Response response) {
+        if (callbackCalled) {
+            return;
+        }
+        callbackCalled = true;
+        try {
+            callback.onResponse(armeriaCall, response);
+        } catch (IOException e) {
+            callback.onFailure(armeriaCall, e);
+        }
+    }
+
+    private static IOException newCanceledException() {
+        return new IOException("Canceled");
+    }
+}

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/http/retrofit2/CompletableCallback.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/http/retrofit2/CompletableCallback.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client.http.retrofit2;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.Response;
+
+final class CompletableCallback extends CompletableFuture<Response> implements Callback {
+
+    @Override
+    public void onFailure(Call call, IOException e) {
+        completeExceptionally(e);
+    }
+
+    @Override
+    public void onResponse(Call call, Response response) {
+        complete(response);
+    }
+}

--- a/retrofit2/src/test/java/com/linecorp/armeria/client/http/retrofit2/ArmeriaCallSubscriberTest.java
+++ b/retrofit2/src/test/java/com/linecorp/armeria/client/http/retrofit2/ArmeriaCallSubscriberTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client.http.retrofit2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.reactivestreams.Subscription;
+
+import com.linecorp.armeria.client.http.retrofit2.ArmeriaCallFactory.ArmeriaCall;
+import com.linecorp.armeria.common.http.HttpData;
+import com.linecorp.armeria.common.http.HttpHeaders;
+
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.Request;
+import okhttp3.Response;
+
+public class ArmeriaCallSubscriberTest {
+
+    private static class ManualMockCallback implements Callback {
+        private int callbackCallingCount;
+        private Response response;
+        private IOException exception;
+
+        @Override
+        public void onFailure(Call call, IOException e) {
+            callbackCallingCount++;
+            this.exception = e;
+        }
+
+        @Override
+        public void onResponse(Call call, Response response) throws IOException {
+            callbackCallingCount++;
+            this.response = response;
+        }
+    }
+
+    @Mock
+    ArmeriaCall armeriaCall;
+
+    @Mock
+    Subscription subscription;
+
+    @Rule
+    public MockitoRule mockingRule = MockitoJUnit.rule();
+
+    @Test
+    public void completeNormally() throws Exception {
+
+        when(armeriaCall.tryFinish()).thenReturn(true);
+
+        ManualMockCallback callback = new ManualMockCallback();
+        ArmeriaCallSubscriber subscriber = new ArmeriaCallSubscriber(armeriaCall,
+                                                                     callback,
+                                                                     new Request.Builder().url("http://foo.com")
+                                                                                          .build());
+        subscriber.onSubscribe(subscription);
+        subscriber.onNext(HttpHeaders.of(200));
+        subscriber.onNext(HttpData.ofUtf8("{\"name\":\"foo\"}"));
+        subscriber.onComplete();
+
+        verify(subscription).request(Long.MAX_VALUE);
+        assertThat(callback.callbackCallingCount).isEqualTo(1);
+        assertThat(callback.response.body().string()).isEqualTo("{\"name\":\"foo\"}");
+    }
+
+    @Test
+    public void cancel() throws Exception {
+
+        when(armeriaCall.tryFinish()).thenReturn(false);
+        when(armeriaCall.isCanceled()).thenReturn(false, false, true);
+
+        ManualMockCallback callback = new ManualMockCallback();
+        ArmeriaCallSubscriber subscriber = new ArmeriaCallSubscriber(armeriaCall,
+                                                                     callback,
+                                                                     new Request.Builder().url("http://foo.com")
+                                                                                          .build());
+        subscriber.onSubscribe(subscription);
+        subscriber.onNext(HttpHeaders.of(200));
+        subscriber.onNext(HttpData.ofUtf8("{\"name\":\"foo\"}"));
+        subscriber.onComplete();
+
+        verify(subscription).request(Long.MAX_VALUE);
+        assertThat(callback.callbackCallingCount).isEqualTo(1);
+        assertThat(callback.exception.getMessage()).isEqualTo("Canceled");
+    }
+}


### PR DESCRIPTION
Motivation:

- Original armeria-retrofit will convert huge response body to single byte[].

Modifications:

- Using subscriber to add response data to okio.Buffer which creates multiple.

Result:

- Avoid humongous object creation which is not good for memory management.