### PR TITLE
Update weight dynamicaly

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/EndpointSelectionStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/EndpointSelectionStrategy.java
@@ -25,6 +25,11 @@ import com.linecorp.armeria.client.Endpoint;
 public interface EndpointSelectionStrategy {
 
     /**
+     * Simple round-robin strategy.
+     */
+    EndpointSelectionStrategy ROUND_ROBIN = new RoundRobinStrategy();
+
+    /**
      * Weighted round-robin strategy.
      */
     EndpointSelectionStrategy WEIGHTED_ROUND_ROBIN = new WeightedRoundRobinStrategy();

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/RoundRobinStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/RoundRobinStrategy.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.endpoint;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.linecorp.armeria.client.Endpoint;
+
+final class RoundRobinStrategy implements EndpointSelectionStrategy {
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public EndpointSelector newSelector(EndpointGroup endpointGroup) {
+        return new RoundRobinSelector(endpointGroup);
+    }
+
+    /**
+     * A round robin select strategy.
+     *
+     * <p>For example, with node a, b and c, then select result is abc abc ...
+     */
+    static class RoundRobinSelector implements EndpointSelector {
+        private final EndpointGroup endpointGroup;
+
+        private final AtomicInteger sequence = new AtomicInteger();
+
+        RoundRobinSelector(EndpointGroup endpointGroup) {
+            this.endpointGroup = requireNonNull(endpointGroup, "endpointGroup");
+        }
+
+        @Override
+        public EndpointGroup group() {
+            return endpointGroup;
+        }
+
+        @Override
+        public EndpointSelectionStrategy strategy() {
+            return ROUND_ROBIN;
+        }
+
+        @Override
+        public Endpoint select() {
+            List<Endpoint> endpoints = endpointGroup.endpoints();
+            long currentSequence = sequence.getAndIncrement();
+
+            if (endpoints.isEmpty()) {
+                throw new EndpointGroupException(endpointGroup + " is empty");
+            }
+            return endpoints.get((int) (Math.abs(currentSequence) % endpoints.size()));
+        }
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/RoundRobinStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/RoundRobinStrategy.java
@@ -58,12 +58,12 @@ final class RoundRobinStrategy implements EndpointSelectionStrategy {
         @Override
         public Endpoint select() {
             List<Endpoint> endpoints = endpointGroup.endpoints();
-            long currentSequence = sequence.getAndIncrement();
+            int currentSequence = sequence.getAndIncrement();
 
             if (endpoints.isEmpty()) {
                 throw new EndpointGroupException(endpointGroup + " is empty");
             }
-            return endpoints.get((int) (Math.abs(currentSequence) % endpoints.size()));
+            return endpoints.get(Math.abs(currentSequence % endpoints.size()));
         }
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightedRoundRobinStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightedRoundRobinStrategy.java
@@ -99,7 +99,7 @@ final class WeightedRoundRobinStrategy implements EndpointSelectionStrategy {
                     }
                 }
             }
-            return endpoints.get((int) (Math.abs(currentSequence) % endpoints.size()));
+            return endpoints.get((int) Math.abs(currentSequence % endpoints.size()));
         }
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/RoundRobinStrategyTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/RoundRobinStrategyTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.endpoint;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.linecorp.armeria.client.Endpoint;
+
+public class RoundRobinStrategyTest {
+    private static final EndpointGroup ENDPOINT_GROUP = new StaticEndpointGroup(Endpoint.of("localhost:1234"),
+                                                                                Endpoint.of("localhost:2345"));
+    private static final EndpointGroup EMPTY_ENDPOINT_GROUP = new StaticEndpointGroup();
+
+    private final RoundRobinStrategy strategy = new RoundRobinStrategy();
+
+    @Before
+    public void setup() {
+        EndpointGroupRegistry.register("endpoint", ENDPOINT_GROUP, strategy);
+        EndpointGroupRegistry.register("empty", EMPTY_ENDPOINT_GROUP, strategy);
+    }
+
+    @Test
+    public void select_empty() {
+        assertThat(EndpointGroupRegistry.selectNode("endpoint")).isEqualTo(ENDPOINT_GROUP.endpoints().get(0));
+        assertThat(EndpointGroupRegistry.selectNode("endpoint")).isEqualTo(ENDPOINT_GROUP.endpoints().get(1));
+        assertThat(EndpointGroupRegistry.selectNode("endpoint")).isEqualTo(ENDPOINT_GROUP.endpoints().get(0));
+        assertThat(EndpointGroupRegistry.selectNode("endpoint")).isEqualTo(ENDPOINT_GROUP.endpoints().get(1));
+    }
+
+    @Test
+    public void select() {
+        assertThat(EndpointGroupRegistry.selectNode("endpoint")).isNotNull();
+
+        assertThat(catchThrowable(() -> EndpointGroupRegistry.selectNode("empty")))
+                .isInstanceOf(EndpointGroupException.class);
+    }
+
+}


### PR DESCRIPTION
Motivation:
- WeightedRoundRobinStrategy does not refresh min/max/sumWeight even if endpointGroup return different endpoint lists.

Modifications:
- Calculate min/max/sumWeight everytime
- Add RoundRobinStrategy

Results:
- Endpoint's weight are applied correctly