### PR TITLE
Add SampledLoggingService

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -65,6 +65,11 @@ by Adobe Systems Incorporated:
 Modified redistributions
 ========================
 
+This product contains a modified part of Brave, distributed by Zipkin.io:
+
+  * License: licenses/LICENSE.brave.al20.txt (Apache License v2.0)
+  * Homepage: https://github.com/openzipkin/brave/
+
 This product contains a modified part of GRPC, distributed by Google:
 
   * License: licenses/LICENSE.grpc.bsd.txt (New BSD License)

--- a/core/src/main/java/com/linecorp/armeria/server/logging/CountingSampler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/CountingSampler.java
@@ -63,7 +63,7 @@ final class CountingSampler extends Sampler {
     };
 
     private final BitSet sampleDecisions;
-    private int i; // guarded by this
+    private int counter; // guarded by this
 
     /** Fills a bitset with decisions according to the supplied rate. */
     private CountingSampler(float rate) {
@@ -73,7 +73,7 @@ final class CountingSampler extends Sampler {
 
     /**
      * @param rate 0 means never sample, 1 means always sample. Otherwise minimum sample rate is 0.01,
-     * or 1% of traces
+     *             or 1% of traces
      */
     public static Sampler create(final float rate) {
         if (rate == 0) {
@@ -88,7 +88,6 @@ final class CountingSampler extends Sampler {
 
     /**
      * Reservoir sampling algorithm borrowed from Stack Overflow.
-     *
      * http://stackoverflow.com/questions/12817946/generate-a-random-bitset-with-n-1s
      */
     private static BitSet randomBitSet(int size, int cardinality, Random rnd) {
@@ -116,9 +115,9 @@ final class CountingSampler extends Sampler {
      */
     @Override
     public synchronized boolean isSampled() {
-        boolean result = sampleDecisions.get(i++);
-        if (i == 100) {
-            i = 0;
+        boolean result = sampleDecisions.get(counter++);
+        if (counter == 100) {
+            counter = 0;
         }
         return result;
     }

--- a/core/src/main/java/com/linecorp/armeria/server/logging/CountingSampler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/CountingSampler.java
@@ -12,8 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations
  * under the License.
- */
-/*
+ *
  * Copyright 2013 <kristofa@github.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,8 +24,8 @@
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package com.linecorp.armeria.server.logging;
 
@@ -49,19 +48,6 @@ import java.util.Random;
  * <p>Forked from brave-core.
  */
 final class CountingSampler extends Sampler {
-    private static final Sampler ALWAYS_SAMPLE = new Sampler() {
-        @Override
-        boolean isSampled() {
-            return true;
-        }
-    };
-    private static final Sampler NEVER_SAMPLE = new Sampler() {
-        @Override
-        boolean isSampled() {
-            return false;
-        }
-    };
-
     private final BitSet sampleDecisions;
     private int counter; // guarded by this
 

--- a/core/src/main/java/com/linecorp/armeria/server/logging/CountingSampler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/CountingSampler.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright 2013 <kristofa@github.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+package com.linecorp.armeria.server.logging;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.util.BitSet;
+import java.util.Random;
+
+/**
+ * This sampler is appropriate for low-traffic instrumentation (ex servers that each receive <100K
+ * requests), or those who do not provision random trace ids. It not appropriate for collectors as
+ * the sampling decision isn't idempotent (consistent based on trace id).
+ *
+ * <h3>Implementation</h3>
+ *
+ * <p>This initializes a random bitset of size 100 (corresponding to 1% granularity). This means
+ * that it is accurate in units of 100 traces. At runtime, this loops through the bitset, returning
+ * the value according to a counter.
+ *
+ * <p>Forked from brave-core.
+ */
+final class CountingSampler extends Sampler {
+    private static final Sampler ALWAYS_SAMPLE = new Sampler() {
+        @Override
+        boolean isSampled() {
+            return true;
+        }
+    };
+    private static final Sampler NEVER_SAMPLE = new Sampler() {
+        @Override
+        boolean isSampled() {
+            return false;
+        }
+    };
+
+    private final BitSet sampleDecisions;
+    private int i; // guarded by this
+
+    /** Fills a bitset with decisions according to the supplied rate. */
+    private CountingSampler(float rate) {
+        int outOf100 = (int) (rate * 100.0f);
+        sampleDecisions = randomBitSet(100, outOf100, new Random());
+    }
+
+    /**
+     * @param rate 0 means never sample, 1 means always sample. Otherwise minimum sample rate is 0.01,
+     * or 1% of traces
+     */
+    public static Sampler create(final float rate) {
+        if (rate == 0) {
+            return NEVER_SAMPLE;
+        }
+        if (rate == 1.0) {
+            return ALWAYS_SAMPLE;
+        }
+        checkArgument(rate >= 0.01f && rate < 1, "rate should be between 0.01 and 1: was %s", rate);
+        return new CountingSampler(rate);
+    }
+
+    /**
+     * Reservoir sampling algorithm borrowed from Stack Overflow.
+     *
+     * http://stackoverflow.com/questions/12817946/generate-a-random-bitset-with-n-1s
+     */
+    private static BitSet randomBitSet(int size, int cardinality, Random rnd) {
+        BitSet result = new BitSet(size);
+        int[] chosen = new int[cardinality];
+        int i;
+        for (i = 0; i < cardinality; ++i) {
+            chosen[i] = i;
+            result.set(i);
+        }
+        for (; i < size; ++i) {
+            int j = rnd.nextInt(i + 1);
+            if (j < cardinality) {
+                result.clear(chosen[j]);
+                result.set(i);
+                chosen[j] = i;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Returns true if the trace ID should be measured.
+     * Loops over the pre-canned decisions, resetting to zero when it gets to the end.
+     */
+    @Override
+    public synchronized boolean isSampled() {
+        boolean result = sampleDecisions.get(i++);
+        if (i == 100) {
+            i = 0;
+        }
+        return result;
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/logging/LoggingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/LoggingService.java
@@ -65,7 +65,9 @@ public class LoggingService<I extends Request, O extends Response> extends Decor
         return delegate().serve(ctx, req);
     }
 
-    // FIXME(trustin): Format properly.
+    /**
+     * Logs a stringified request of {@link RequestLog}.
+     */
     protected void logRequest(RequestLog log) {
         final Logger logger = ((ServiceRequestContext) log.context()).logger();
         if (level.isEnabled(logger)) {
@@ -73,6 +75,9 @@ public class LoggingService<I extends Request, O extends Response> extends Decor
         }
     }
 
+    /**
+     * Logs a stringified response of {@link RequestLog}.
+     */
     protected void logResponse(RequestLog log) {
         final Logger logger = ((ServiceRequestContext) log.context()).logger();
         if (level.isEnabled(logger)) {

--- a/core/src/main/java/com/linecorp/armeria/server/logging/LoggingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/LoggingService.java
@@ -65,16 +65,15 @@ public class LoggingService<I extends Request, O extends Response> extends Decor
         return delegate().serve(ctx, req);
     }
 
-
     // FIXME(trustin): Format properly.
-    private void logRequest(RequestLog log) {
+    protected void logRequest(RequestLog log) {
         final Logger logger = ((ServiceRequestContext) log.context()).logger();
         if (level.isEnabled(logger)) {
             level.log(logger, REQUEST_FORMAT, log.toStringRequestOnly());
         }
     }
 
-    private void logResponse(RequestLog log) {
+    protected void logResponse(RequestLog log) {
         final Logger logger = ((ServiceRequestContext) log.context()).logger();
         if (level.isEnabled(logger)) {
             level.log(logger, RESPONSE_FORMAT, log.toStringResponseOnly());

--- a/core/src/main/java/com/linecorp/armeria/server/logging/SampledLoggingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/SampledLoggingService.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.logging;
+
+import java.util.function.Function;
+
+import com.linecorp.armeria.common.Request;
+import com.linecorp.armeria.common.Response;
+import com.linecorp.armeria.common.logging.LogLevel;
+import com.linecorp.armeria.common.logging.RequestLogAvailability;
+import com.linecorp.armeria.server.Service;
+import com.linecorp.armeria.server.ServiceRequestContext;
+
+/**
+ * Decorates a {@link Service} to log {@link Request}s and {@link Response}s.
+ * Same as {@link LoggingService} but can configure what kind of data will be logging.
+ *
+ * @param <I> the {@link Request} type
+ * @param <O> the {@link Response} type
+ */
+public class SampledLoggingService<I extends Request, O extends Response> extends LoggingService<I, O> {
+    private final boolean logRequest;
+    private final boolean logResponse;
+    private final Sampler sampler;
+
+    /**
+     * Creates a new instance that logs {@link Request}s and {@link Response}s at {@link LogLevel#INFO}.
+     */
+    public static <I extends Request, O extends Response> Function<Service<I, O>, SampledLoggingService<I, O>>
+    newDecorator() {
+        return newDecorator(true, true, 1.0f);
+    }
+
+    /**
+     * Creates a new instance that logs {@link Request}s at {@link LogLevel#INFO} if {@code logRequest} is
+     * {@code true} and logs {@link Response}s at {@link LogLevel#INFO} if {@code logRequest} is {@code true}.
+     */
+    public static <I extends Request, O extends Response> Function<Service<I, O>, SampledLoggingService<I, O>>
+    newDecorator(boolean logRequest, boolean logResponse, float logSamplingRate) {
+        return service -> new SampledLoggingService<>(service, LogLevel.INFO, logRequest, logResponse,
+                                                      logSamplingRate);
+    }
+
+    /**
+     * Creates a new instance that logs {@link Request}s and {@link Response}s at the specified
+     * {@link LogLevel}.
+     */
+    public SampledLoggingService(Service<? super I, ? extends O> delegate, LogLevel level,
+                                 boolean logRequest, boolean logResponse, float logSamplingRate) {
+        super(delegate, level);
+        this.logRequest = logRequest;
+        this.logResponse = logResponse;
+        sampler = CountingSampler.create(logSamplingRate);
+    }
+
+    @Override
+    public O serve(ServiceRequestContext ctx, I req) throws Exception {
+        if (sampler.isSampled()) {
+            if (logRequest) {
+                ctx.log().addListener(this::logRequest, RequestLogAvailability.REQUEST_END);
+            }
+            if (logResponse) {
+                ctx.log().addListener(this::logResponse, RequestLogAvailability.COMPLETE);
+            }
+        }
+        return delegate().serve(ctx, req);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/logging/Sampler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/Sampler.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.logging;
+
+/**
+ * Sampler is responsible for deciding if a particular log should be "sampled".
+ */
+abstract class Sampler {
+    /**
+     * Returns true if a log should be recorded.
+     */
+    abstract boolean isSampled();
+}

--- a/core/src/main/java/com/linecorp/armeria/server/logging/Sampler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/Sampler.java
@@ -12,15 +12,77 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations
  * under the License.
+ *
+ * Copyright 2013 <kristofa@github.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package com.linecorp.armeria.server.logging;
 
 /**
- * Sampler is responsible for deciding if a particular log should be "sampled".
+ * Sampler is responsible for deciding if a particular trace should be "sampled", i.e. whether the
+ * overhead of tracing will occur and/or if a trace will be reported to the collection tier.
+ *
+ * <p>Zipkin v1 uses before-the-fact sampling. This means that the decision to keep or drop the
+ * trace is made before any work is measured, or annotations are added. As such, the input parameter
+ * to zipkin v1 samplers is the trace ID (64-bit random number).
+ *
+ * <p>The instrumentation sampling decision happens once, at the root of the trace, and is
+ * propagated downstream. For this reason, the decision needn't be consistent based on trace ID.
+ *
+ * <p>Forked from brave-core.
  */
+// abstract for factory-method support on Java language level 7
 abstract class Sampler {
+
+    static final Sampler ALWAYS_SAMPLE = new Sampler() {
+        @Override
+        public boolean isSampled() {
+            return true;
+        }
+
+        @Override
+        public String toString() {
+            return "AlwaysSample";
+        }
+    };
+
+    static final Sampler NEVER_SAMPLE = new Sampler() {
+        @Override
+        public boolean isSampled() {
+            return false;
+        }
+
+        @Override
+        public String toString() {
+            return "NeverSample";
+        }
+    };
+
     /**
-     * Returns true if a log should be recorded.
+     *  Returns true if a log should be recorded.
      */
     abstract boolean isSampled();
+
+    /**
+     * Returns a sampler, given a rate expressed as a percentage.
+     *
+     * <p>The sampler returned is good for low volumes of traffic (<100K requests), as it is precise.
+     * If you have high volumes of traffic, consider {@code BoundarySampler}.
+     *
+     * @param rate minimum sample rate is 0.01, or 1% of traces
+     */
+    static Sampler create(float rate) {
+        return CountingSampler.create(rate);
+    }
 }


### PR DESCRIPTION
When a server receives many requests, we cannot records all logs
through LoggingService due to server resource limitation. To adjust
this, sample logs.