### PR TITLE
Add makeContextAware for CompletableFuture

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/RequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestContext.java
@@ -20,6 +20,7 @@ import java.net.SocketAddress;
 import java.util.Iterator;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Function;
@@ -285,6 +286,20 @@ public interface RequestContext extends AttributeMap {
      */
     @Deprecated
     <T extends Future<?>> GenericFutureListener<T> makeContextAware(GenericFutureListener<T> listener);
+
+    /**
+     * Returns a {@link CompletionStage} that makes sure the current {@link CompletionStage} is set and
+     * then invokes the input {@code stage}.
+     */
+    <T> CompletionStage<T> makeContextAware(CompletionStage<T> stage);
+
+    /**
+     * Returns a {@link CompletableFuture} that makes sure the current {@link CompletableFuture} is set and
+     * then invokes the input {@code future}.
+     */
+    default <T> CompletableFuture<T> makeContextAware(CompletableFuture<T> future) {
+        return makeContextAware((CompletionStage<T>) future).toCompletableFuture();
+    }
 
     /**
      * Registers {@code callback} to be run when re-entering this {@link RequestContext}, usually when using

--- a/core/src/test/java/com/linecorp/armeria/common/RequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/RequestContextTest.java
@@ -18,16 +18,22 @@ package com.linecorp.armeria.common;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -173,6 +179,65 @@ public class RequestContextTest {
             assertTrue(entered.get());
         }));
         promise.setSuccess(null);
+    }
+
+    @Test
+    public void makeContextAwareCompletableFutureInSameThread() throws Exception {
+        RequestContext context = createContext();
+        CompletableFuture<String> originalFuture = new CompletableFuture<>();
+        CompletableFuture<String> contextAwareFuture = context.makeContextAware(originalFuture);
+        CompletableFuture<String> resultFuture = contextAwareFuture.whenComplete((result, cause) -> {
+            assertEquals("success", result);
+            assertNull(cause);
+            assertEquals(context, RequestContext.current());
+            assertTrue(entered.get());
+        });
+        originalFuture.complete("success");
+        assertFalse(entered.get());
+        resultFuture.get(); // this will propagate assertions.
+    }
+
+    @Test
+    public void makeContextAwareCompletableFutureWithExecutor() throws Exception {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            RequestContext context = createContext();
+            Thread testMainThread = Thread.currentThread();
+            AtomicReference<Thread> callbackThread = new AtomicReference<>();
+            CountDownLatch latch = new CountDownLatch(1);
+
+            CompletableFuture<String> originalFuture = CompletableFuture.supplyAsync(() -> {
+                try {
+                    // In CompletableFuture chaining, if previous callback was already completed,
+                    // next chained callback will run in same thread instead of executor's thread.
+                    // We should add callbacks before they were completed. This latch is for preventing it.
+                    latch.await();
+                } catch (InterruptedException e) {
+                    throw new IllegalStateException(e);
+                }
+                final Thread currentThread = Thread.currentThread();
+                callbackThread.set(currentThread);
+                assertNotEquals(testMainThread, currentThread);
+                return "success";
+            }, executor);
+
+            CompletableFuture<String> contextAwareFuture = context.makeContextAware(originalFuture);
+
+            CompletableFuture<String> resultFuture = contextAwareFuture.whenComplete((result, cause) -> {
+                final Thread currentThread = Thread.currentThread();
+                assertNotEquals(testMainThread, currentThread);
+                assertEquals(callbackThread.get(), currentThread);
+                assertEquals("success", result);
+                assertNull(cause);
+                assertEquals(context, RequestContext.current());
+                assertTrue(entered.get());
+            });
+
+            latch.countDown();
+            resultFuture.get(); // this will wait and propagate assertions.
+        } finally {
+            executor.shutdown();
+        }
     }
 
     @Test


### PR DESCRIPTION
Motivation:

- `RequestContext` is not propagate when users use `CompletableFuture` asynchronously.

Modifications:

- Add `RequestContext#makeContextAware` for `CompletableFuture`.

Result:

- Fixes #365