### PR TITLE
Fix a bug where Response is not completed when timeout is disabled dynamically

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/http/HttpRequestSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/client/http/HttpRequestSubscriber.java
@@ -285,6 +285,7 @@ final class HttpRequestSubscriber implements Subscriber<HttpObject>, ChannelFutu
             return true;
         }
 
+        this.timeoutFuture = null;
         return timeoutFuture.cancel(false);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/http/HttpResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/http/HttpResponseDecoder.java
@@ -218,6 +218,8 @@ abstract class HttpResponseDecoder {
             if (responseTimeoutFuture == null) {
                 return true;
             }
+
+            this.responseTimeoutFuture = null;
             return responseTimeoutFuture.cancel(false);
         }
 

--- a/core/src/main/java/com/linecorp/armeria/server/http/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/HttpResponseSubscriber.java
@@ -333,6 +333,7 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject>, RequestTim
             return true;
         }
 
+        this.timeoutFuture = null;
         return timeoutFuture.cancel(false);
     }
 


### PR DESCRIPTION
Motivation:

When a user disables the timeout dynamically by calling
ServiceRequestContext.setRequestTimeoutMillis(0), the response stream is
never marked as completed because HttpResponseSubscriber.cancelTimeout()
will always return false, preventing HttpResponseSubscriber.onComplete()
from sending the 'end of stream'.

Modifications:

- Set the timeoutFuture to null when canceling it so that
  cancelTimeout() returns true
- Add the test case for the bug to ThriftDynamicTimeoutTest

Result:

One less bugs