### PR TITLE
More strict naming rule for EndpointGroup

### DIFF
--- a/retrofit2/src/main/java/com/linecorp/armeria/client/http/retrofit2/ArmeriaRetrofit.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/http/retrofit2/ArmeriaRetrofit.java
@@ -62,25 +62,24 @@ public final class ArmeriaRetrofit {
      */
     public static Retrofit.Builder builder(HttpClient httpClient) {
         return new Retrofit.Builder()
-                .baseUrl(convertToOkHttpCompatUri(httpClient.uri()))
+                .baseUrl(convertToOkHttpUrl(httpClient.uri()))
                 .callFactory(new ArmeriaCallFactory(httpClient));
     }
 
     @VisibleForTesting
-    static String convertToOkHttpCompatUri(URI uri) {
+    static HttpUrl convertToOkHttpUrl(URI uri) {
         requireNonNull(uri.getScheme(), "uri does not contain the scheme component.");
-        String uriStr = uri.toString();
 
         String protocol = Scheme.tryParse(uri.getScheme())
                                 .map(scheme -> scheme.sessionProtocol().uriText())
                                 .orElse(uri.getScheme());
         String authority = uri.getAuthority();
         String path = uri.getPath();
-        String maybeOkHttpCompatUri = protocol + "://" + authority + path;
-        if (HttpUrl.parse(maybeOkHttpCompatUri) == null) {
-            return protocol + "://" + GROUP_NAME_ESCAPER.escape(authority) + path;
+        final HttpUrl okHttpUrl = HttpUrl.parse(protocol + "://" + authority + path);
+        if (okHttpUrl == null) {
+            return HttpUrl.parse(protocol + "://" + GROUP_NAME_ESCAPER.escape(authority) + path);
         } else {
-            return maybeOkHttpCompatUri;
+            return okHttpUrl;
         }
     }
 

--- a/retrofit2/src/test/java/com/linecorp/armeria/client/http/retrofit2/ArmeriaCallFactoryTest.java
+++ b/retrofit2/src/test/java/com/linecorp/armeria/client/http/retrofit2/ArmeriaCallFactoryTest.java
@@ -84,7 +84,6 @@ public class ArmeriaCallFactoryTest extends AbstractServerTest {
 
         @Override
         public int hashCode() {
-            final int PRIME = 59;
             int result = 1;
             result = result * 31 + (name == null ? 43 : name.hashCode());
             result = result * 31 + age;
@@ -93,7 +92,7 @@ public class ArmeriaCallFactoryTest extends AbstractServerTest {
 
         @Override
         public String toString() {
-            return "Pojo[name=" + name + ", age=" + age + "]";
+            return "Pojo[name=" + name + ", age=" + age + ']';
         }
     }
 
@@ -305,10 +304,10 @@ public class ArmeriaCallFactoryTest extends AbstractServerTest {
 
     @Test
     public void respectsHttpClientUri_endpointGroup() throws Exception {
-        EndpointGroupRegistry.register("group", new StaticEndpointGroup(Endpoint.of("127.0.0.1", httpPort())),
+        EndpointGroupRegistry.register("foo", new StaticEndpointGroup(Endpoint.of("127.0.0.1", httpPort())),
                                        ROUND_ROBIN);
         Service service = ArmeriaRetrofit.builder(Clients.newClient(ClientFactory.DEFAULT,
-                                                                    "none+http://group:group/",
+                                                                    "none+http://group:foo/",
                                                                     HttpClient.class))
                                          .addConverterFactory(JacksonConverterFactory.create(OBJECT_MAPPER))
                                          .addCallAdapterFactory(GuavaCallAdapterFactory.create())
@@ -318,7 +317,7 @@ public class ArmeriaCallFactoryTest extends AbstractServerTest {
         // TODO(ide) Use the actual `host:port`. See https://github.com/line/armeria/issues/379
         assertThat(response.raw().request().url()).isEqualTo(
                 new HttpUrl.Builder().scheme("http")
-                                     .host("group_group")
+                                     .host("group_foo")
                                      .addPathSegment("postForm")
                                      .build());
     }

--- a/retrofit2/src/test/java/com/linecorp/armeria/client/http/retrofit2/ArmeriaCallSubscriberTest.java
+++ b/retrofit2/src/test/java/com/linecorp/armeria/client/http/retrofit2/ArmeriaCallSubscriberTest.java
@@ -47,7 +47,7 @@ public class ArmeriaCallSubscriberTest {
         @Override
         public void onFailure(Call call, IOException e) {
             callbackCallingCount++;
-            this.exception = e;
+            exception = e;
         }
 
         @Override

--- a/retrofit2/src/test/java/com/linecorp/armeria/client/http/retrofit2/ArmeriaRetrofitTest.java
+++ b/retrofit2/src/test/java/com/linecorp/armeria/client/http/retrofit2/ArmeriaRetrofitTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package com.linecorp.armeria.client.http.retrofit2;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -11,24 +26,23 @@ import com.linecorp.armeria.client.http.HttpClient;
 
 public class ArmeriaRetrofitTest {
     @Test
-    public void convertToOkHttpCompatUri() throws Exception {
-        URI uri = Clients.newClient(URI.create("none+http://example.com:8080/a/b/c"), HttpClient.class)
-                         .uri();
-        assertThat(ArmeriaRetrofit.convertToOkHttpCompatUri(uri))
+    public void convertToOkHttpUrl() throws Exception {
+        URI uri = Clients.newClient(URI.create("none+http://example.com:8080/a/b/c"), HttpClient.class).uri();
+        assertThat(String.valueOf(ArmeriaRetrofit.convertToOkHttpUrl(uri)))
                 .isEqualTo("http://example.com:8080/a/b/c");
     }
 
     @Test
-    public void convertToOkHttpCompatUri_noSerializationFormat() throws Exception {
+    public void convertToOkHttpUrl_noSerializationFormat() throws Exception {
         URI uri = URI.create("http://example.com:8080/");
-        assertThat(ArmeriaRetrofit.convertToOkHttpCompatUri(uri))
+        assertThat(String.valueOf(ArmeriaRetrofit.convertToOkHttpUrl(uri)))
                 .isEqualTo("http://example.com:8080/");
     }
 
     @Test
-    public void convertToOkHttpCompatUri_convertOkhttpNotSupportedAuthority() throws Exception {
+    public void convertToOkHttpUrl_convertOkhttpNotSupportedAuthority() throws Exception {
         URI uri = URI.create("http://group:myGroup/path");
-        assertThat(ArmeriaRetrofit.convertToOkHttpCompatUri(uri))
-                .isEqualTo("http://group_myGroup/path");
+        assertThat(String.valueOf(ArmeriaRetrofit.convertToOkHttpUrl(uri)))
+                .isEqualTo("http://group_mygroup/path"); // NB: lower-cased by OkHttp
     }
 }


### PR DESCRIPTION
Motivation:

An EndpointGroup name is used as a part of URI, often via simple string
concatenation:

    uri = "https://group:" + groupName + "/foo/bar";

It would be less error-prone to disallow the characters in EndpoinrGroup
names.

Modifications:

- Add extra rule for EndpointGroup names
- Make EndpointGroup names case-insensitive, because a hostname in a URI
  is case-insensitive and thus often lower-cased by other integrating
  parties such as OkHttp
- Simplify the configuration of baseUrl in armeria-retrofit2
- Fix inspection warnings in com.linecorp.armeria.client.http.retrofit2

Result:

- EndpointGroup names blend better into URI