### PR TITLE
Fix armeria-retrofit throws IllegalArgumentException when using armer…

### DIFF
--- a/retrofit2/src/main/java/com/linecorp/armeria/client/http/retrofit2/ArmeriaRetrofit.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/http/retrofit2/ArmeriaRetrofit.java
@@ -25,6 +25,7 @@ import com.google.common.escape.Escapers;
 
 import com.linecorp.armeria.client.http.HttpClient;
 import com.linecorp.armeria.common.Scheme;
+import com.linecorp.armeria.common.SessionProtocol;
 
 import okhttp3.HttpUrl;
 import retrofit2.Retrofit;
@@ -70,9 +71,12 @@ public final class ArmeriaRetrofit {
     static HttpUrl convertToOkHttpUrl(URI uri) {
         requireNonNull(uri.getScheme(), "uri does not contain the scheme component.");
 
-        String protocol = Scheme.tryParse(uri.getScheme())
-                                .map(scheme -> scheme.sessionProtocol().uriText())
-                                .orElse(uri.getScheme());
+        SessionProtocol sessionProtocol =
+                Scheme.tryParse(uri.getScheme())
+                      .map(Scheme::sessionProtocol)
+                      .orElseGet(() -> SessionProtocol.valueOf(uri.getScheme().toUpperCase()));
+
+        String protocol = sessionProtocol.isTls() ? "https" : "http";
         String authority = uri.getAuthority();
         String path = uri.getPath();
         final HttpUrl okHttpUrl = HttpUrl.parse(protocol + "://" + authority + path);

--- a/retrofit2/src/test/java/com/linecorp/armeria/client/http/retrofit2/ArmeriaRetrofitTest.java
+++ b/retrofit2/src/test/java/com/linecorp/armeria/client/http/retrofit2/ArmeriaRetrofitTest.java
@@ -16,6 +16,7 @@
 package com.linecorp.armeria.client.http.retrofit2;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.net.URI;
 
@@ -30,6 +31,26 @@ public class ArmeriaRetrofitTest {
         URI uri = Clients.newClient(URI.create("none+http://example.com:8080/a/b/c"), HttpClient.class).uri();
         assertThat(String.valueOf(ArmeriaRetrofit.convertToOkHttpUrl(uri)))
                 .isEqualTo("http://example.com:8080/a/b/c");
+    }
+
+    @Test
+    public void convertToOkHttpUrl_sessionProtocol() throws Exception {
+        assertThat(String.valueOf(ArmeriaRetrofit.convertToOkHttpUrl(URI.create("h1c://example.com:8080/"))))
+                .isEqualTo("http://example.com:8080/");
+        assertThat(String.valueOf(ArmeriaRetrofit.convertToOkHttpUrl(URI.create("h2c://example.com:8080/"))))
+                .isEqualTo("http://example.com:8080/");
+        assertThat(String.valueOf(ArmeriaRetrofit.convertToOkHttpUrl(URI.create("h1://example.com:8080/"))))
+                .isEqualTo("https://example.com:8080/");
+        assertThat(String.valueOf(ArmeriaRetrofit.convertToOkHttpUrl(URI.create("h2://example.com:8080/"))))
+                .isEqualTo("https://example.com:8080/");
+        assertThat(String.valueOf(ArmeriaRetrofit.convertToOkHttpUrl(URI.create("https://example.com:8080/"))))
+                .isEqualTo("https://example.com:8080/");
+    }
+
+    @Test
+    public void convertToOkHttpUrl_wrongSessionProtocol() throws Exception {
+        assertThatThrownBy(() -> ArmeriaRetrofit.convertToOkHttpUrl(URI.create("foo://example.com:8080/")))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test


### PR DESCRIPTION
…ia specific session protocol

Motivations:

Currently, retrofit only allows supports http(s) protocol string, so using h1(c)/h2(c) will throw IllegalArgumentException at retrofit parsing phase.
Modifications:

Convert h1(c)/h2(c) to http(s).
Results:
Make aremria-retrofit won't throw IllegalArgumentException when using h1(c)/h2(c) in url.