### PR TITLE
Allow numeric characters in EndpointGroup names

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/EndpointGroupRegistry.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/EndpointGroupRegistry.java
@@ -30,7 +30,7 @@ import com.linecorp.armeria.client.Endpoint;
  */
 public final class EndpointGroupRegistry {
 
-    private static final Pattern GROUP_NAME_PATTERN = Pattern.compile("^[-_.a-z]+$");
+    private static final Pattern GROUP_NAME_PATTERN = Pattern.compile("^[-_.0-9a-z]+$");
     private static final Map<String, EndpointSelector> serverGroups = new ConcurrentHashMap<>();
 
     /**
@@ -38,7 +38,7 @@ public final class EndpointGroupRegistry {
      * specified {@code groupName}, this method will replace it with the new one.
      *
      * @param groupName the case-insensitive name of the {@link EndpointGroup} that matches
-     *                  the regular expression {@code /^[-_.a-zA-Z]+$/}
+     *                  the regular expression {@code /^[-_.0-9a-zA-Z]+$/}
      * @param endpointGroup the {@link EndpointGroup} to register
      * @param endpointSelectionStrategy the {@link EndpointSelectionStrategy} of the registered group
      *

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/EndpointGroupRegistryTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/EndpointGroupRegistryTest.java
@@ -39,23 +39,23 @@ public class EndpointGroupRegistryTest {
     @Test
     public void testRegistration() throws Exception {
         // Unregister a non-existent group.
-        assertThat(EndpointGroupRegistry.unregister("foo")).isFalse();
+        assertThat(EndpointGroupRegistry.unregister("foo3")).isFalse();
 
         final EndpointGroup group1 = new StaticEndpointGroup(Endpoint.of("a.com"));
         final EndpointGroup group2 = new StaticEndpointGroup(Endpoint.of("b.com"));
 
         // Register a new group.
-        assertThat(EndpointGroupRegistry.register("foo", group1, WEIGHTED_ROUND_ROBIN)).isTrue();
-        assertThat(EndpointGroupRegistry.get("foo")).isSameAs(group1);
-        assertThat(EndpointGroupRegistry.get("fOO")).isSameAs(group1); // Ensure case-insensitivity
+        assertThat(EndpointGroupRegistry.register("foo3", group1, WEIGHTED_ROUND_ROBIN)).isTrue();
+        assertThat(EndpointGroupRegistry.get("foo3")).isSameAs(group1);
+        assertThat(EndpointGroupRegistry.get("fOO3")).isSameAs(group1); // Ensure case-insensitivity
 
         // Replace the group.
-        assertThat(EndpointGroupRegistry.register("Foo", group2, WEIGHTED_ROUND_ROBIN)).isFalse();
-        assertThat(EndpointGroupRegistry.get("foo")).isSameAs(group2);
+        assertThat(EndpointGroupRegistry.register("Foo3", group2, WEIGHTED_ROUND_ROBIN)).isFalse();
+        assertThat(EndpointGroupRegistry.get("foo3")).isSameAs(group2);
 
         // Unregister the group.
-        assertThat(EndpointGroupRegistry.unregister("FOO")).isTrue();
-        assertThat(EndpointGroupRegistry.get("foo")).isNull();
+        assertThat(EndpointGroupRegistry.unregister("FOO3")).isTrue();
+        assertThat(EndpointGroupRegistry.get("foo3")).isNull();
     }
 
     @Test


### PR DESCRIPTION
.. which were mistakenly dropped in the previous commit.