### PR TITLE
Add RequestContextAwareCompletableFuture for async chaining

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/AbstractRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AbstractRequestContext.java
@@ -20,6 +20,10 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 import com.linecorp.armeria.common.util.SafeCloseable;
 
@@ -64,6 +68,42 @@ public abstract class AbstractRequestContext implements RequestContext {
     }
 
     @Override
+    public final <T, R> Function<T, R> makeContextAware(Function<T, R> function) {
+        return t -> {
+            try (SafeCloseable ignored = propagateContextIfNotPresent()) {
+                return function.apply(t);
+            }
+        };
+    }
+
+    @Override
+    public final <T, U, V> BiFunction<T, U, V> makeContextAware(BiFunction<T, U, V> function) {
+        return (t, u) -> {
+            try (SafeCloseable ignored = propagateContextIfNotPresent()) {
+                return function.apply(t, u);
+            }
+        };
+    }
+
+    @Override
+    public final <T> Consumer<T> makeContextAware(Consumer<T> action) {
+        return t -> {
+            try (SafeCloseable ignored = propagateContextIfNotPresent()) {
+                action.accept(t);
+            }
+        };
+    }
+
+    @Override
+    public final <T, U> BiConsumer<T, U> makeContextAware(BiConsumer<T, U> action) {
+        return (t, u) -> {
+            try (SafeCloseable ignored = propagateContextIfNotPresent()) {
+                action.accept(t, u);
+            }
+        };
+    }
+
+    @Override
     public final <T> FutureListener<T> makeContextAware(FutureListener<T> listener) {
         return future -> invokeOperationComplete(listener, future);
     }
@@ -81,7 +121,7 @@ public abstract class AbstractRequestContext implements RequestContext {
 
     @Override
     public final <T> CompletionStage<T> makeContextAware(CompletionStage<T> stage) {
-        final CompletableFuture<T> future = new CompletableFuture<>();
+        final CompletableFuture<T> future = new RequestContextAwareCompletableFuture<>(this);
         stage.whenComplete((result, cause) -> {
             try (SafeCloseable ignored = propagateContextIfNotPresent()) {
                 if (cause != null) {

--- a/core/src/main/java/com/linecorp/armeria/common/RequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestContext.java
@@ -23,6 +23,9 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -259,6 +262,30 @@ public interface RequestContext extends AttributeMap {
      * the input {@code runnable}.
      */
     Runnable makeContextAware(Runnable runnable);
+
+    /**
+     * Returns a {@link Function} that makes sure the current {@link RequestContext} is set and then invokes
+     * the input {@code function}.
+     */
+    <T, R> Function<T, R> makeContextAware(Function<T, R> function);
+
+    /**
+     * Returns a {@link BiFunction} that makes sure the current {@link RequestContext} is set and then invokes
+     * the input {@code function}.
+     */
+    <T, U, V> BiFunction<T, U, V> makeContextAware(BiFunction<T, U, V> function);
+
+    /**
+     * Returns a {@link Consumer} that makes sure the current {@link RequestContext} is set and then invokes
+     * the input {@code action}.
+     */
+    <T> Consumer<T> makeContextAware(Consumer<T> action);
+
+    /**
+     * Returns a {@link BiConsumer} that makes sure the current {@link RequestContext} is set and then invokes
+     * the input {@code action}.
+     */
+    <T, U> BiConsumer<T, U> makeContextAware(BiConsumer<T, U> action);
 
     /**
      * Returns a {@link FutureListener} that makes sure the current {@link RequestContext} is set and then

--- a/core/src/main/java/com/linecorp/armeria/common/RequestContextAwareCompletableFuture.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestContextAwareCompletableFuture.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+final class RequestContextAwareCompletableFuture<T> extends CompletableFuture<T> {
+
+    private final RequestContext ctx;
+
+    RequestContextAwareCompletableFuture(RequestContext requestContext) {
+        ctx = requestContext;
+    }
+
+    @Override
+    public <U> CompletableFuture<U> thenApply(Function<? super T,? extends U> fn) {
+        return ctx.makeContextAware(super.thenApply(ctx.makeContextAware(fn)));
+    }
+
+    @Override
+    public <U> CompletableFuture<U> thenApplyAsync(Function<? super T,? extends U> fn) {
+        return ctx.makeContextAware(super.thenApplyAsync(ctx.makeContextAware(fn)));
+    }
+
+    @Override
+    public <U> CompletableFuture<U> thenApplyAsync(Function<? super T,? extends U> fn, Executor executor) {
+        return ctx.makeContextAware(super.thenApplyAsync(ctx.makeContextAware(fn), executor));
+    }
+
+    @Override
+    public CompletableFuture<Void> thenAccept(Consumer<? super T> action) {
+        return ctx.makeContextAware(super.thenAccept(ctx.makeContextAware(action)));
+    }
+
+    @Override
+    public CompletableFuture<Void> thenAcceptAsync(Consumer<? super T> action) {
+        return ctx.makeContextAware(super.thenAcceptAsync(ctx.makeContextAware(action)));
+    }
+
+    @Override
+    public CompletableFuture<Void> thenAcceptAsync(Consumer<? super T> action, Executor executor) {
+        return ctx.makeContextAware(super.thenAcceptAsync(ctx.makeContextAware(action), executor));
+    }
+
+    @Override
+    public CompletableFuture<Void> thenRun(Runnable action) {
+        return ctx.makeContextAware(super.thenRun(ctx.makeContextAware(action)));
+    }
+
+    @Override
+    public CompletableFuture<Void> thenRunAsync(Runnable action) {
+        return ctx.makeContextAware(super.thenRunAsync(ctx.makeContextAware(action)));
+    }
+
+    @Override
+    public CompletableFuture<Void> thenRunAsync(Runnable action, Executor executor) {
+        return ctx.makeContextAware(super.thenRunAsync(ctx.makeContextAware(action), executor));
+    }
+
+    @Override
+    public <U,V> CompletableFuture<V> thenCombine(CompletionStage<? extends U> other,
+                                                  BiFunction<? super T,? super U,? extends V> fn) {
+        return ctx.makeContextAware(super.thenCombine(other, ctx.makeContextAware(fn)));
+    }
+
+    @Override
+    public <U,V> CompletableFuture<V> thenCombineAsync(CompletionStage<? extends U> other,
+                                                       BiFunction<? super T,? super U,? extends V> fn) {
+        return ctx.makeContextAware(super.thenCombineAsync(other, ctx.makeContextAware(fn)));
+    }
+
+    @Override
+    public <U,V> CompletableFuture<V> thenCombineAsync(CompletionStage<? extends U> other,
+                                                       BiFunction<? super T,? super U,? extends V> fn,
+                                                       Executor executor) {
+        return ctx.makeContextAware(super.thenCombineAsync(other, ctx.makeContextAware(fn), executor));
+    }
+
+    @Override
+    public <U> CompletableFuture<Void> thenAcceptBoth(CompletionStage<? extends U> other,
+                                                      BiConsumer<? super T, ? super U> action) {
+        return ctx.makeContextAware(super.thenAcceptBoth(other, ctx.makeContextAware(action)));
+    }
+
+    @Override
+    public <U> CompletableFuture<Void> thenAcceptBothAsync(CompletionStage<? extends U> other,
+                                                           BiConsumer<? super T, ? super U> action) {
+        return ctx.makeContextAware(super.thenAcceptBothAsync(other, ctx.makeContextAware(action)));
+    }
+
+    @Override
+    public <U> CompletableFuture<Void> thenAcceptBothAsync(CompletionStage<? extends U> other,
+                                                           BiConsumer<? super T, ? super U> action,
+                                                           Executor executor) {
+        return ctx.makeContextAware(super.thenAcceptBothAsync(other, ctx.makeContextAware(action), executor));
+    }
+
+    @Override
+    public CompletableFuture<Void> runAfterBoth(CompletionStage<?> other,
+                                                Runnable action) {
+        return ctx.makeContextAware(super.runAfterBoth(other, ctx.makeContextAware(action)));
+    }
+
+    @Override
+    public CompletableFuture<Void> runAfterBothAsync(CompletionStage<?> other,
+                                                     Runnable action) {
+        return ctx.makeContextAware(super.runAfterBothAsync(other, ctx.makeContextAware(action)));
+    }
+
+    @Override
+    public CompletableFuture<Void> runAfterBothAsync(CompletionStage<?> other,
+                                                     Runnable action,
+                                                     Executor executor) {
+        return ctx.makeContextAware(super.runAfterBothAsync(other, ctx.makeContextAware(action), executor));
+    }
+
+    @Override
+    public <U> CompletableFuture<U> applyToEither(CompletionStage<? extends T> other,
+                                                  Function<? super T, U> fn) {
+        return ctx.makeContextAware(super.applyToEither(other, ctx.makeContextAware(fn)));
+    }
+
+    @Override
+    public <U> CompletableFuture<U> applyToEitherAsync(CompletionStage<? extends T> other,
+                                                       Function<? super T, U> fn) {
+        return ctx.makeContextAware(super.applyToEitherAsync(other, ctx.makeContextAware(fn)));
+    }
+
+    @Override
+    public <U> CompletableFuture<U> applyToEitherAsync(CompletionStage<? extends T> other,
+                                                       Function<? super T, U> fn,
+                                                       Executor executor) {
+        return ctx.makeContextAware(super.applyToEitherAsync(other, ctx.makeContextAware(fn), executor));
+    }
+
+    @Override
+    public CompletableFuture<Void> acceptEither(CompletionStage<? extends T> other,
+                                                Consumer<? super T> action) {
+        return ctx.makeContextAware(super.acceptEither(other, ctx.makeContextAware(action)));
+    }
+
+    @Override
+    public CompletableFuture<Void> acceptEitherAsync(CompletionStage<? extends T> other,
+                                                     Consumer<? super T> action) {
+        return ctx.makeContextAware(super.acceptEitherAsync(other, ctx.makeContextAware(action)));
+    }
+
+    @Override
+    public CompletableFuture<Void> acceptEitherAsync(CompletionStage<? extends T> other,
+                                                     Consumer<? super T> action,
+                                                     Executor executor) {
+        return ctx.makeContextAware(super.acceptEitherAsync(other, ctx.makeContextAware(action), executor));
+    }
+
+    @Override
+    public CompletableFuture<Void> runAfterEither(CompletionStage<?> other,
+                                                  Runnable action) {
+        return ctx.makeContextAware(super.runAfterEither(other, ctx.makeContextAware(action)));
+    }
+
+    @Override
+    public CompletableFuture<Void> runAfterEitherAsync(CompletionStage<?> other,
+                                                       Runnable action) {
+        return ctx.makeContextAware(super.runAfterEitherAsync(other, ctx.makeContextAware(action)));
+    }
+
+    @Override
+    public CompletableFuture<Void> runAfterEitherAsync(CompletionStage<?> other,
+                                                       Runnable action,
+                                                       Executor executor) {
+        return ctx.makeContextAware(super.runAfterEitherAsync(other, ctx.makeContextAware(action), executor));
+    }
+
+    @Override
+    public <U> CompletableFuture<U> thenCompose(Function<? super T, ? extends CompletionStage<U>> fn) {
+        return ctx.makeContextAware(super.thenCompose(ctx.makeContextAware(fn)));
+    }
+
+    @Override
+    public <U> CompletableFuture<U> thenComposeAsync(Function<? super T, ? extends CompletionStage<U>> fn) {
+        return ctx.makeContextAware(super.thenComposeAsync(ctx.makeContextAware(fn)));
+    }
+
+    @Override
+    public <U> CompletableFuture<U> thenComposeAsync(Function<? super T, ? extends CompletionStage<U>> fn,
+                                                     Executor executor) {
+        return ctx.makeContextAware(super.thenComposeAsync(ctx.makeContextAware(fn), executor));
+    }
+
+    @Override
+    public CompletableFuture<T> whenComplete(BiConsumer<? super T, ? super Throwable> action) {
+        return ctx.makeContextAware(super.whenComplete(ctx.makeContextAware(action)));
+    }
+
+    @Override
+    public CompletableFuture<T> whenCompleteAsync(BiConsumer<? super T, ? super Throwable> action) {
+        return ctx.makeContextAware(super.whenCompleteAsync(ctx.makeContextAware(action)));
+    }
+
+    @Override
+    public CompletableFuture<T> whenCompleteAsync(BiConsumer<? super T, ? super Throwable> action,
+                                                  Executor executor) {
+        return ctx.makeContextAware(super.whenCompleteAsync(ctx.makeContextAware(action), executor));
+    }
+
+    @Override
+    public <U> CompletableFuture<U> handle(BiFunction<? super T, Throwable, ? extends U> fn) {
+        return ctx.makeContextAware(super.handle(ctx.makeContextAware(fn)));
+    }
+
+    @Override
+    public <U> CompletableFuture<U> handleAsync(BiFunction<? super T, Throwable, ? extends U> fn) {
+        return ctx.makeContextAware(super.handleAsync(ctx.makeContextAware(fn)));
+    }
+
+    @Override
+    public <U> CompletableFuture<U> handleAsync(BiFunction<? super T, Throwable, ? extends U> fn,
+                                                Executor executor) {
+        return ctx.makeContextAware(super.handleAsync(ctx.makeContextAware(fn), executor));
+    }
+
+    @Override
+    public CompletableFuture<T> exceptionally(Function<Throwable, ? extends T> fn) {
+        return ctx.makeContextAware(super.exceptionally(ctx.makeContextAware(fn)));
+    }
+
+}

--- a/core/src/test/java/com/linecorp/armeria/common/RequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/RequestContextTest.java
@@ -34,6 +34,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -235,6 +236,46 @@ public class RequestContextTest {
 
             latch.countDown();
             resultFuture.get(); // this will wait and propagate assertions.
+        } finally {
+            executor.shutdown();
+        }
+    }
+
+    @Test
+    public void makeContextAwareCompletableFutureWithAsyncChaining() throws Exception {
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            RequestContext context = createContext();
+            Thread testMainThread = Thread.currentThread();
+            CountDownLatch latch = new CountDownLatch(1);
+
+            CompletableFuture<String> originalFuture = CompletableFuture.supplyAsync(() -> {
+                try {
+                    latch.await();
+                } catch (InterruptedException e) {
+                    throw new IllegalStateException(e);
+                }
+                final Thread currentThread = Thread.currentThread();
+                assertNotEquals(testMainThread, currentThread);
+                return "success";
+            }, executor);
+
+            BiConsumer<String, Throwable> handler = (result, cause) -> {
+                final Thread currentThread = Thread.currentThread();
+                assertNotEquals(testMainThread, currentThread);
+                assertEquals("success", result);
+                assertNull(cause);
+                assertEquals(context, RequestContext.current());
+                assertTrue(entered.get());
+            };
+
+            CompletableFuture<String> contextAwareFuture = context.makeContextAware(originalFuture);
+            CompletableFuture<String> future1 = contextAwareFuture.whenCompleteAsync(handler, executor);
+            CompletableFuture<String> future2 = future1.whenCompleteAsync(handler, executor);
+
+            latch.countDown(); // fire
+
+            future2.get(); // this will propagate assertions in callbacks if it failed.
         } finally {
             executor.shutdown();
         }


### PR DESCRIPTION
Motivation:

- Current `RequestContext#makeContextAware(CompletableFuture<T> future)`
  cannot propagate `RequestContext` to chained futures.

Modifications:

- Add `RequestContextAwareCompletableFuture` for async handlers.

Result:

- Fixes #384