### PR TITLE
Fix NPE in ArmeriaCallFactory

### DIFF
--- a/retrofit2/src/main/java/com/linecorp/armeria/client/http/retrofit2/ArmeriaCallFactory.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/http/retrofit2/ArmeriaCallFactory.java
@@ -29,7 +29,9 @@ import com.linecorp.armeria.common.http.HttpResponse;
 
 import okhttp3.Call;
 import okhttp3.Callback;
+import okhttp3.MediaType;
 import okhttp3.Request;
+import okhttp3.RequestBody;
 import okhttp3.Response;
 import okio.Buffer;
 
@@ -112,10 +114,15 @@ public class ArmeriaCallFactory implements Call.Factory {
             }
             request.headers().toMultimap().forEach(
                     (key, values) -> headers.add(HttpHeaderNames.of(key), values));
-            if (request.body() != null) {
-                headers.set(HttpHeaderNames.CONTENT_TYPE, request.body().contentType().toString());
+            final RequestBody body = request.body();
+            if (body != null) {
+                final MediaType contentType = body.contentType();
+                if (contentType != null) {
+                    headers.set(HttpHeaderNames.CONTENT_TYPE, contentType.toString());
+                }
+
                 try (Buffer contentBuffer = new Buffer()) {
-                    request.body().writeTo(contentBuffer);
+                    body.writeTo(contentBuffer);
 
                     return httpClient.execute(headers, contentBuffer.readByteArray());
                 } catch (IOException e) {


### PR DESCRIPTION
When a client request does not contain the 'content-type' information,
NullPointerException would be raised.