### PR TITLE
Make DynamicHttpService asynchronous.

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/http/dynamic/Deserializers.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/dynamic/Deserializers.java
@@ -16,11 +16,6 @@
 
 package com.linecorp.armeria.server.http.dynamic;
 
-import java.util.Map;
-import java.util.function.Function;
-
-import com.google.common.collect.ImmutableMap;
-
 /**
  * Provides deserializing functionality for reflection.
  *
@@ -30,37 +25,36 @@ import com.google.common.collect.ImmutableMap;
  */
 final class Deserializers {
 
-    private static final Map<Class<?>, Function<String, Object>> FUNCTIONS =
-            ImmutableMap.<Class<?>, Function<String, Object>>builder()
-                    .put(Byte.TYPE, Byte::parseByte)
-                    .put(Short.TYPE, Short::parseShort)
-                    .put(Integer.TYPE, Integer::parseInt)
-                    .put(Long.TYPE, Long::parseLong)
-                    .put(Float.TYPE, Float::parseFloat)
-                    .put(Double.TYPE, Double::parseDouble)
-                    .put(String.class, s -> s)
-                    .build();
-
     /**
      * Deserialize given {@code str} to {@code T} type object. e.g., "42" -> 42.
      *
      * @throws IllegalArgumentException if {@code str} can't be deserialized to {@code T} type object.
      */
-    public static <T> T deserialize(String str, Class<T> clazz) {
-        if (!canDeserialize(clazz)) {
-            throw new IllegalArgumentException("Class " + clazz.getSimpleName() + " can't be deserialized.");
-        }
-        Function<String, Object> function = FUNCTIONS.get(clazz);
+    @SuppressWarnings("unchecked")
+    static <T> T deserialize(String str, Class<T> clazz) {
         try {
-            return (T) function.apply(str);
+            if (clazz == Byte.TYPE) {
+                return (T) Byte.valueOf(str);
+            } else if (clazz == Short.TYPE) {
+                return (T) Short.valueOf(str);
+            } else if (clazz == Integer.TYPE) {
+                return (T) Integer.valueOf(str);
+            } else if (clazz == Long.TYPE) {
+                return (T) Long.valueOf(str);
+            } else if (clazz == Float.TYPE) {
+                return (T) Float.valueOf(str);
+            } else if (clazz == Double.TYPE) {
+                return (T) Double.valueOf(str);
+            } else if (clazz == String.class) {
+                return (T) str;
+            } else {
+                throw new IllegalArgumentException(
+                        "Class " + clazz.getSimpleName() + " can't be deserialized.");
+            }
         } catch (Exception e) {
             throw new IllegalArgumentException(
                     "Can't deserialize " + str + " to type " + clazz.getSimpleName(), e);
         }
-    }
-
-    private static boolean canDeserialize(Class<?> clazz) {
-        return FUNCTIONS.containsKey(clazz);
     }
 
     private Deserializers() {}

--- a/core/src/main/java/com/linecorp/armeria/server/http/dynamic/DynamicHttpFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/dynamic/DynamicHttpFunction.java
@@ -6,7 +6,8 @@ import com.linecorp.armeria.common.http.HttpRequest;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
 /**
- * Path variable-enabled function.
+ * Path variable-enabled function. When implementing, make sure to run logic inside
+ * {@code ctx.blockingCodeExecutor()} if it may block.
  *
  * <p>Mapped path variables are passed via arguments parameter.
  */

--- a/core/src/main/java/com/linecorp/armeria/server/http/dynamic/DynamicHttpFunctionEntry.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/dynamic/DynamicHttpFunctionEntry.java
@@ -18,8 +18,8 @@ package com.linecorp.armeria.server.http.dynamic;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.EnumSet;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Nullable;
 
@@ -36,7 +36,7 @@ final class DynamicHttpFunctionEntry {
     /**
      * EnumSet of HTTP Method, e.g., GET, POST, PUT, ...
      */
-    private final EnumSet<HttpMethod> methods;
+    private final Set<HttpMethod> methods;
 
     /**
      * Path with placeholders, e.g., "/const1/{var1}/{var2}/const2"
@@ -52,8 +52,8 @@ final class DynamicHttpFunctionEntry {
     /**
      * Creates a new instance.
      */
-    DynamicHttpFunctionEntry(EnumSet<HttpMethod> methods, DynamicPath path, DynamicHttpFunction function) {
-        this.methods = EnumSet.copyOf(requireNonNull(methods, "methods"));
+    DynamicHttpFunctionEntry(Set<HttpMethod> methods, DynamicPath path, DynamicHttpFunction function) {
+        this.methods = Sets.immutableEnumSet(requireNonNull(methods, "methods"));
         this.path = requireNonNull(path, "path");
         this.function = requireNonNull(function, "function");
     }

--- a/core/src/main/java/com/linecorp/armeria/server/http/dynamic/DynamicHttpService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/dynamic/DynamicHttpService.java
@@ -16,8 +16,10 @@
 
 package com.linecorp.armeria.server.http.dynamic;
 
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Maps;
+import java.util.Collections;
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.common.http.DefaultHttpResponse;
 import com.linecorp.armeria.common.http.HttpMethod;
@@ -33,18 +35,17 @@ import com.linecorp.armeria.server.http.HttpService;
  */
 public class DynamicHttpService extends AbstractHttpService {
 
-    private final DynamicHttpFunctionEntry[] entries;
+    private final List<DynamicHttpFunctionEntry> entries;
 
     /**
      * Create a {@link DynamicHttpService} instance.
      */
     protected DynamicHttpService() {
-        this.entries = Iterables.toArray(Methods.entries(this, Maps.newHashMap()),
-                                         DynamicHttpFunctionEntry.class);
+        this.entries = ImmutableList.copyOf(Methods.entries(this, Collections.emptyMap()));
     }
 
-    DynamicHttpService(DynamicHttpFunctionEntry[] entries) {
-        this.entries = entries;
+    DynamicHttpService(Iterable<DynamicHttpFunctionEntry> entries) {
+        this.entries = ImmutableList.copyOf(entries);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/http/dynamic/DynamicHttpServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/dynamic/DynamicHttpServiceBuilder.java
@@ -70,7 +70,7 @@ public final class DynamicHttpServiceBuilder {
                                                 DynamicHttpFunction function) {
         DynamicHttpFunction f = DynamicHttpFunctions.of(function, converters);
         DynamicHttpFunctionEntry entry = new DynamicHttpFunctionEntry(
-                Sets.newEnumSet(methods, HttpMethod.class), DynamicPath.of(path), f);
+                Sets.immutableEnumSet(methods), DynamicPath.of(path), f);
         validate(entry);
         entries.add(entry);
         return this;
@@ -121,6 +121,6 @@ public final class DynamicHttpServiceBuilder {
      * Creates a new {@link DynamicHttpService} with the configuration properties set so far.
      */
     public DynamicHttpService build() {
-        return new DynamicHttpService(entries.toArray(new DynamicHttpFunctionEntry[entries.size()]));
+        return new DynamicHttpService(entries);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/http/dynamic/DynamicPath.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/dynamic/DynamicPath.java
@@ -16,16 +16,18 @@
 
 package com.linecorp.armeria.server.http.dynamic;
 
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.StringJoiner;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import javax.annotation.Nullable;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
 /**
@@ -151,11 +153,7 @@ final class DynamicPath {
             return null;
         }
 
-        ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
-        for (String variable : variables) {
-            String value = matcher.group(variable);
-            builder.put(variable, value);
-        }
-        return builder.build();
+        return variables.stream()
+                        .collect(toImmutableMap(Function.identity(), matcher::group));
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/http/dynamic/MappedDynamicFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/dynamic/MappedDynamicFunction.java
@@ -3,14 +3,11 @@ package com.linecorp.armeria.server.http.dynamic;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Map;
+import java.util.concurrent.CompletionStage;
 
-import com.linecorp.armeria.common.http.AggregatedHttpMessage;
-import com.linecorp.armeria.common.http.DefaultHttpResponse;
-import com.linecorp.armeria.common.http.HttpHeaderNames;
-import com.linecorp.armeria.common.http.HttpHeaders;
+import com.linecorp.armeria.common.http.DeferredHttpResponse;
 import com.linecorp.armeria.common.http.HttpRequest;
 import com.linecorp.armeria.common.http.HttpResponse;
-import com.linecorp.armeria.common.http.HttpStatus;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.http.AbstractHttpService;
 
@@ -36,25 +33,23 @@ final class MappedDynamicFunction extends AbstractHttpService {
 
     @Override
     public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
-        final DefaultHttpResponse res = new DefaultHttpResponse();
-        ctx.blockingTaskExecutor().execute(() -> {
-            try {
-                Object ret = function.serve(ctx, req, args);
-                if (!(ret instanceof HttpResponse)) {
-                    throw new IllegalStateException("Illegal return type: " + ret.getClass().getSimpleName());
-                }
-                AggregatedHttpMessage msg = ((HttpResponse) ret).aggregate().get();
-                res.write(msg.headers());
-                res.write(msg.content());
-            } catch (Throwable e) {
-                final long current = System.currentTimeMillis();
-                HttpHeaders headers = HttpHeaders.of(HttpStatus.INTERNAL_SERVER_ERROR)
-                                                 .setTimeMillis(HttpHeaderNames.DATE, current);
-                res.write(headers);
-            } finally {
-                res.close();
+        final DeferredHttpResponse res = new DeferredHttpResponse();
+        try {
+            Object ret = function.serve(ctx, req, args);
+            if (!(ret instanceof CompletionStage)) {
+                throw new IllegalStateException("Illegal return type: " + ret.getClass().getSimpleName());
             }
-        });
+            ((CompletionStage<HttpResponse>) ret)
+                    .whenComplete((httpResponse, t) -> {
+                        if (t != null) {
+                            res.close(t);
+                        } else {
+                            res.delegate(httpResponse);
+                        }
+                    });
+        } catch (Throwable e) {
+            res.close(e);
+        }
         return res;
     }
 }


### PR DESCRIPTION
With this change, automatic execution of methods in the blocking executor is moved into a feature of reflection-based methods, where the only arguments are the Java types. Methods defined directly as implementations of DynamicHttpFunction (dunno if anyone will ever do this...) should take care of using the executor themselves as appropriate (simple since ServiceInvocationContext is provided).

Methods are run in the blocking executor if their return type is not CompletionStage (future) or HttpResponse (published stream). 

Also applied some cleanups while going through the code, let me know if you'd like to move any or all from this behavior-changing PR.

- Replace map dispatch with if/else since almost same amount of code but should be a bit faster/simpler
- Use immutable lists / sets for function definitions
- Switch some manual list buildups to stream/map
- Prefer list to array
- Don't return in a finally block after a catch