### PR TITLE
Make authorization predicates asynchronous and allow them to manipula…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/http/auth/Authorizer.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/auth/Authorizer.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.http.auth;
+
+import java.util.concurrent.CompletionStage;
+
+import com.linecorp.armeria.server.ServiceRequestContext;
+
+/**
+ * Determines whether a given {@code data} is authorized for the service registered in.
+ * {@code ctx} can be used for storing authorization information about the request for use in
+ * business logic. {@code data} is usually a {@link com.linecorp.armeria.common.http.HttpRequest}
+ * or token extracted from it.
+ */
+@FunctionalInterface
+public interface Authorizer<T> {
+    /**
+     * Authorizes the given {@code data}.
+     *
+     * @return a {@link CompletionStage} that will resolve to {@code true} if the request is
+     *     authorized of {@code false} otherwise. If the future resolves exceptionally, the request
+     *     will not be authorized.
+     */
+    CompletionStage<Boolean> authorize(ServiceRequestContext ctx, T data);
+}

--- a/core/src/main/java/com/linecorp/armeria/server/http/auth/Authorizer.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/auth/Authorizer.java
@@ -32,7 +32,7 @@ public interface Authorizer<T> {
      * Authorizes the given {@code data}.
      *
      * @return a {@link CompletionStage} that will resolve to {@code true} if the request is
-     *     authorized of {@code false} otherwise. If the future resolves exceptionally, the request
+     *     authorized, or {@code false} otherwise. If the future resolves exceptionally, the request
      *     will not be authorized.
      */
     CompletionStage<Boolean> authorize(ServiceRequestContext ctx, T data);

--- a/core/src/main/java/com/linecorp/armeria/server/http/auth/HttpAuthService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/auth/HttpAuthService.java
@@ -74,7 +74,7 @@ public abstract class HttpAuthService
 
     /**
      * Determine if {@code request} is authorized for this service. If the result resolves to
-     * {@code true} if the request is authorized of {@code false} otherwise. If the future
+     * {@code true}, the request is authorized, or {@code false} otherwise. If the future
      * resolves exceptionally, the request will not be authorized.
      */
     protected abstract CompletionStage<Boolean> authorize(HttpRequest request, ServiceRequestContext ctx);
@@ -91,9 +91,9 @@ public abstract class HttpAuthService
      * Invoked when {@code req} is failed. By default, this method responds with the
      * {@link HttpStatus#UNAUTHORIZED} status.
      */
-    protected HttpResponse onFailure(ServiceRequestContext ctx, HttpRequest req, @Nullable Throwable t)
+    protected HttpResponse onFailure(ServiceRequestContext ctx, HttpRequest req, @Nullable Throwable cause)
             throws Exception {
-        logger.warn("Unexpected exception during authorization.", t);
+        logger.warn("Unexpected exception during authorization:", cause);
         final DefaultHttpResponse res = new DefaultHttpResponse();
         res.respond(HttpStatus.UNAUTHORIZED);
         return res;
@@ -110,8 +110,8 @@ public abstract class HttpAuthService
                 } else {
                     res.delegate(onSuccess(ctx, req));
                 }
-            } catch (Exception e) {
-                res.close(e);
+            } catch (Throwable cause) {
+                res.close(cause);
             }
         }, ctx.contextAwareEventLoop());
 

--- a/core/src/main/java/com/linecorp/armeria/server/http/auth/HttpAuthService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/auth/HttpAuthService.java
@@ -16,13 +16,18 @@
 
 package com.linecorp.armeria.server.http.auth;
 
+import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
-import java.util.function.Predicate;
 
-import com.google.common.collect.Iterables;
+import javax.annotation.Nullable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.common.http.DefaultHttpResponse;
-import com.linecorp.armeria.common.http.HttpHeaders;
+import com.linecorp.armeria.common.http.DeferredHttpResponse;
 import com.linecorp.armeria.common.http.HttpRequest;
 import com.linecorp.armeria.common.http.HttpResponse;
 import com.linecorp.armeria.common.http.HttpStatus;
@@ -36,27 +41,28 @@ import com.linecorp.armeria.server.ServiceRequestContext;
 public abstract class HttpAuthService
         extends DecoratingService<HttpRequest, HttpResponse, HttpRequest, HttpResponse> {
 
+    private static final Logger logger = LoggerFactory.getLogger(HttpAuthService.class);
+
     /**
      * Creates a new HTTP authorization {@link Service} decorator using the specified
-     * {@code predicates}.
+     * {@link Authorizer}s.
      *
-     * @param predicates {@link Iterable} authorization predicates
+     * @param authorizers a list of {@link Authorizer}s.
      */
     public static Function<Service<? super HttpRequest, ? extends HttpResponse>,
-            HttpAuthService> newDecorator(Iterable<? extends Predicate<? super HttpHeaders>> predicates) {
-        Predicate<? super HttpHeaders>[] array = Iterables.toArray(predicates, Predicate.class);
-        return newDecorator(array);
+            HttpAuthService> newDecorator(Iterable<? extends Authorizer<HttpRequest>> authorizers) {
+        return service -> new HttpAuthServiceImpl(service, authorizers);
     }
 
     /**
      * Creates a new HTTP authorization {@link Service} decorator using the specified
-     * {@code predicates}.
+     * {@link Authorizer}s.
      *
-     * @param predicates the array of authorization predicates
+     * @param authorizers the array of {@link Authorizer}s.
      */
     public static Function<Service<? super HttpRequest, ? extends HttpResponse>,
-            HttpAuthService> newDecorator(Predicate<? super HttpHeaders>... predicates) {
-        return service -> new HttpAuthServiceImpl(service, predicates);
+            HttpAuthService> newDecorator(Authorizer<HttpRequest>... authorizers) {
+        return newDecorator(ImmutableList.copyOf(authorizers));
     }
 
     /**
@@ -67,9 +73,11 @@ public abstract class HttpAuthService
     }
 
     /**
-     * Authorize {@code headers}. In other words, determine if it is successful or not.
+     * Determine if {@code request} is authorized for this service. If the result resolves to
+     * {@code true} if the request is authorized of {@code false} otherwise. If the future
+     * resolves exceptionally, the request will not be authorized.
      */
-    protected abstract boolean authorize(HttpHeaders headers);
+    protected abstract CompletionStage<Boolean> authorize(HttpRequest request, ServiceRequestContext ctx);
 
     /**
      * Invoked when {@code req} is successful. By default, this method delegates the specified {@code req} to
@@ -83,7 +91,9 @@ public abstract class HttpAuthService
      * Invoked when {@code req} is failed. By default, this method responds with the
      * {@link HttpStatus#UNAUTHORIZED} status.
      */
-    protected HttpResponse onFailure(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+    protected HttpResponse onFailure(ServiceRequestContext ctx, HttpRequest req, @Nullable Throwable t)
+            throws Exception {
+        logger.warn("Unexpected exception during authorization.", t);
         final DefaultHttpResponse res = new DefaultHttpResponse();
         res.respond(HttpStatus.UNAUTHORIZED);
         return res;
@@ -91,10 +101,20 @@ public abstract class HttpAuthService
 
     @Override
     public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
-        if (authorize(req.headers())) {
-            return onSuccess(ctx, req);
-        } else {
-            return onFailure(ctx, req);
-        }
+        DeferredHttpResponse res = new DeferredHttpResponse();
+
+        authorize(req, ctx).whenCompleteAsync((result, t) -> {
+            try {
+                if (t != null || !result) {
+                    res.delegate(onFailure(ctx, req, t));
+                } else {
+                    res.delegate(onSuccess(ctx, req));
+                }
+            } catch (Exception e) {
+                res.close(e);
+            }
+        }, ctx.contextAwareEventLoop());
+
+        return res;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/http/auth/HttpAuthServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/auth/HttpAuthServiceBuilder.java
@@ -16,12 +16,13 @@
 
 package com.linecorp.armeria.server.http.auth;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
-import java.util.function.Predicate;
 
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 
 import com.linecorp.armeria.common.http.HttpHeaders;
@@ -30,89 +31,80 @@ import com.linecorp.armeria.common.http.HttpResponse;
 import com.linecorp.armeria.server.Service;
 
 /**
- * Builds a new {@link HttpAuthService}.
+ * Builds a new {@link HttpAuthService}. {@link Authorizer}s are executed without short-circuiting -
+ * all authorizers will be executed regardless of the result of any individual one.
  */
 public final class HttpAuthServiceBuilder {
 
-    private final List<Predicate<? super HttpHeaders>> predicates = new ArrayList<>();
+    private final List<Authorizer<HttpRequest>> authorizers = new ArrayList<>();
 
     /**
-     * Adds an authorization predicate.
+     * Adds an {@link Authorizer}.
      */
-    public HttpAuthServiceBuilder add(Predicate<? super HttpHeaders> predicate) {
-        predicates.add(predicate);
+    public HttpAuthServiceBuilder add(Authorizer<HttpRequest> authorizer) {
+        authorizers.add(requireNonNull(authorizer, "authorizer"));
         return this;
     }
 
     /**
-     * Adds multiple authorization predicates.
+     * Adds multiple {@link Authorizer}s.
      */
-    public HttpAuthServiceBuilder add(Iterable<? extends Predicate<? super HttpHeaders>> predicates) {
-        this.predicates.addAll(Lists.newArrayList(predicates));
+    public HttpAuthServiceBuilder add(Iterable<? extends Authorizer<HttpRequest>> authorizers) {
+        this.authorizers.addAll(Lists.newArrayList(requireNonNull(authorizers, "authorizers")));
         return this;
     }
 
     /**
-     * Adds an HTTP basic authorization predicate.
+     * Adds an HTTP basic {@link Authorizer}.
      */
-    public HttpAuthServiceBuilder addBasicAuth(Predicate<? super BasicToken> predicate) {
-        this.predicates.add(new Predicate<HttpHeaders>() {
-            private final Function<HttpHeaders, BasicToken> extractor = AuthTokenExtractors.BASIC;
-
-            @Override
-            public boolean test(HttpHeaders headers) {
-                BasicToken token = extractor.apply(headers);
-                return token != null ? predicate.test(token) : false;
-            }
-        });
+    public HttpAuthServiceBuilder addBasicAuth(Authorizer<? super BasicToken> authorizer) {
+        this.authorizers.add(
+                tokenAuthorizer(AuthTokenExtractors.BASIC, requireNonNull(authorizer, "authorizer")));
         return this;
     }
 
     /**
-     * Adds an OAuth1a authorization predicate.
+     * Adds an OAuth1a {@link Authorizer}.
      */
-    public HttpAuthServiceBuilder addOAuth1a(Predicate<? super OAuth1aToken> predicate) {
-        this.predicates.add(new Predicate<HttpHeaders>() {
-            private final Function<HttpHeaders, OAuth1aToken> extractor = AuthTokenExtractors.OAUTH1A;
-
-            @Override
-            public boolean test(HttpHeaders headers) {
-                OAuth1aToken token = extractor.apply(headers);
-                return token != null ? predicate.test(token) : false;
-            }
-        });
+    public HttpAuthServiceBuilder addOAuth1a(Authorizer<? super OAuth1aToken> authorizer) {
+        this.authorizers.add(
+                tokenAuthorizer(AuthTokenExtractors.OAUTH1A, requireNonNull(authorizer, "authorizer")));
         return this;
     }
 
     /**
-     * Adds an OAuth2 authorization predicate.
+     * Adds an OAuth2 {@link Authorizer}.
      */
-    public HttpAuthServiceBuilder addOAuth2(Predicate<? super OAuth2Token> predicate) {
-        this.predicates.add(new Predicate<HttpHeaders>() {
-            private final Function<HttpHeaders, OAuth2Token> extractor = AuthTokenExtractors.OAUTH2;
-
-            @Override
-            public boolean test(HttpHeaders headers) {
-                OAuth2Token token = extractor.apply(headers);
-                return token != null ? predicate.test(token) : false;
-            }
-        });
+    public HttpAuthServiceBuilder addOAuth2(Authorizer<? super OAuth2Token> authorizer) {
+        this.authorizers.add(
+                tokenAuthorizer(AuthTokenExtractors.OAUTH2, requireNonNull(authorizer, "authorizer")));
         return this;
     }
 
     /**
      * Creates a new {@link HttpAuthService} instance with the given {@code delegate} and all of the
-     * authorization {@link Predicate}s.
+     * authorization {@link Authorizer}s.
      */
     public HttpAuthService build(Service<? super HttpRequest, ? extends HttpResponse> delegate) {
-        return new HttpAuthServiceImpl(delegate, Iterables.toArray(predicates, Predicate.class));
+        return new HttpAuthServiceImpl(requireNonNull(delegate, "delegate"), authorizers);
     }
 
     /**
      * Creates a new {@link HttpAuthService} {@link Service} decorator that supports all of the given
-     * authorization {@link Predicate}s.
+     * authorization {@link Authorizer}s.
      */
     public Function<Service<? super HttpRequest, ? extends HttpResponse>, HttpAuthService> newDecorator() {
-        return HttpAuthService.newDecorator(predicates);
+        return HttpAuthService.newDecorator(authorizers);
+    }
+
+    private <T> Authorizer<HttpRequest> tokenAuthorizer(
+            Function<HttpHeaders, T> tokenExtractor, Authorizer<? super T> authorizer) {
+        return (ctx, req) -> {
+            T token = tokenExtractor.apply(req.headers());
+            if (token == null) {
+                return CompletableFuture.completedFuture(false);
+            }
+            return authorizer.authorize(ctx, token);
+        };
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/http/auth/HttpAuthServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/auth/HttpAuthServiceBuilder.java
@@ -31,8 +31,7 @@ import com.linecorp.armeria.common.http.HttpResponse;
 import com.linecorp.armeria.server.Service;
 
 /**
- * Builds a new {@link HttpAuthService}. {@link Authorizer}s are executed without short-circuiting -
- * all authorizers will be executed regardless of the result of any individual one.
+ * Builds a new {@link HttpAuthService}.
  */
 public final class HttpAuthServiceBuilder {
 


### PR DESCRIPTION
…te the context as needed which is fairly common.

Also loosens predicate from HttpHeaders to HttpRequest since when asynchronous, it's conceivable to use the request body during authorization.

This is API breaking for authorizer definition (needs to take ServiceRequestContext and return a future).

Fixes #370 