### PR TITLE
Prefer Ascii.toLower/UpperCase() and equalsIgnoreCase()

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/EndpointGroupRegistry.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/EndpointGroupRegistry.java
@@ -18,10 +18,11 @@ package com.linecorp.armeria.client.endpoint;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
+
+import com.google.common.base.Ascii;
 
 import com.linecorp.armeria.client.Endpoint;
 
@@ -115,7 +116,7 @@ public final class EndpointGroupRegistry {
     }
 
     private static String normalizeGroupName(String groupName) {
-        return requireNonNull(groupName, "groupName").toLowerCase(Locale.ENGLISH);
+        return Ascii.toLowerCase(requireNonNull(groupName, "groupName"));
     }
 
     private EndpointGroupRegistry() {}

--- a/core/src/main/java/com/linecorp/armeria/client/http/HttpClientPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/client/http/HttpClientPipelineConfigurator.java
@@ -36,6 +36,8 @@ import org.reactivestreams.Subscription;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Ascii;
+
 import com.linecorp.armeria.client.SessionOptions;
 import com.linecorp.armeria.client.SessionProtocolNegotiationCache;
 import com.linecorp.armeria.client.SessionProtocolNegotiationException;
@@ -437,10 +439,10 @@ class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
                 // The server rejected the upgrade request and sent its response in HTTP/1.
                 ReferenceCountUtil.release(msg);
                 assert upgradeEvt == UPGRADE_REJECTED;
-                onUpgradeResponse(
-                        ctx, false,
-                        "close".equalsIgnoreCase(
-                                ((FullHttpResponse) msg).headers().get(HttpHeaderNames.CONNECTION)));
+
+                final String connection = ((FullHttpResponse) msg).headers().get(HttpHeaderNames.CONNECTION);
+                onUpgradeResponse(ctx, false,
+                                  connection != null && Ascii.equalsIgnoreCase("close", connection));
                 return;
             }
 

--- a/core/src/main/java/com/linecorp/armeria/common/Scheme.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Scheme.java
@@ -18,10 +18,10 @@ package com.linecorp.armeria.common;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 
+import com.google.common.base.Ascii;
 import com.google.common.collect.ImmutableMap;
 
 /**
@@ -53,8 +53,8 @@ public final class Scheme implements Comparable<Scheme> {
                 final String ftxt = f.uriText();
                 final String ptxt = p.uriText();
 
-                assert ftxt.equals(ftxt.toLowerCase(Locale.US));
-                assert ptxt.equals(ptxt.toLowerCase(Locale.US));
+                assert ftxt.equals(Ascii.toLowerCase(ftxt));
+                assert ptxt.equals(Ascii.toLowerCase(ptxt));
 
                 final Scheme scheme = new Scheme(f, p);
                 schemes.put(ftxt + '+' + ptxt, scheme);
@@ -77,7 +77,7 @@ public final class Scheme implements Comparable<Scheme> {
             return Optional.empty();
         }
 
-        return Optional.ofNullable(SCHEMES.get(scheme.toLowerCase(Locale.US)));
+        return Optional.ofNullable(SCHEMES.get(Ascii.toLowerCase(scheme)));
     }
 
     /**
@@ -88,7 +88,7 @@ public final class Scheme implements Comparable<Scheme> {
      *                                  there is no such {@link Scheme} available
      */
     public static Scheme parse(String scheme) {
-        final Scheme res = SCHEMES.get(requireNonNull(scheme, "scheme").toLowerCase(Locale.US));
+        final Scheme res = SCHEMES.get(Ascii.toLowerCase(requireNonNull(scheme, "scheme")));
         if (res == null) {
             throw new IllegalArgumentException("scheme: " + scheme);
         }

--- a/core/src/main/java/com/linecorp/armeria/common/http/HttpHeaderNames.java
+++ b/core/src/main/java/com/linecorp/armeria/common/http/HttpHeaderNames.java
@@ -35,9 +35,9 @@ import static java.util.Objects.requireNonNull;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
-import java.util.Locale;
 import java.util.Map;
 
+import com.google.common.base.Ascii;
 import com.google.common.collect.ImmutableMap;
 
 import io.netty.util.AsciiString;
@@ -423,8 +423,7 @@ public final class HttpHeaderNames {
      * the allocation rate of {@link AsciiString}.
      */
     public static AsciiString of(String name) {
-        requireNonNull(name, "name");
-        name = name.toLowerCase(Locale.US);
+        name = Ascii.toLowerCase(requireNonNull(name, "name"));
         final AsciiString asciiName = map.get(name);
         return asciiName != null ? asciiName : new AsciiString(name);
     }

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHost.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHost.java
@@ -22,12 +22,13 @@ import java.net.IDN;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
+
+import com.google.common.base.Ascii;
 
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
@@ -104,7 +105,7 @@ public final class VirtualHost {
             throw new IllegalArgumentException("defaultHostname: " + defaultHostname);
         }
 
-        return defaultHostname.toLowerCase(Locale.ENGLISH);
+        return Ascii.toLowerCase(defaultHostname);
     }
 
     /**
@@ -122,7 +123,7 @@ public final class VirtualHost {
             throw new IllegalArgumentException("hostnamePattern: " + hostnamePattern);
         }
 
-        return hostnamePattern.toLowerCase(Locale.ENGLISH);
+        return Ascii.toLowerCase(hostnamePattern);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/http/auth/OAuth1aToken.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/auth/OAuth1aToken.java
@@ -16,11 +16,11 @@
 
 package com.linecorp.armeria.server.http.auth;
 
-import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import com.google.common.base.Ascii;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
@@ -110,7 +110,7 @@ public final class OAuth1aToken {
 
             // Empty values are ignored.
             if (!Strings.isNullOrEmpty(value)) {
-                String lowerCased = key.toLowerCase(Locale.US);
+                final String lowerCased = Ascii.toLowerCase(key);
                 if (DEFINED_PARAM_KEYS.contains(lowerCased)) {
                     // If given parameter is defined by Oauth1a protocol, add with lower-cased key.
                     builder.put(lowerCased, value);

--- a/core/src/main/java/com/linecorp/armeria/server/http/cors/CorsService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/cors/CorsService.java
@@ -19,13 +19,14 @@ package com.linecorp.armeria.server.http.cors;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Ascii;
 
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
@@ -196,7 +197,7 @@ public final class CorsService<I extends HttpRequest, O extends HttpResponse>
         final String origin = request.headers().get(HttpHeaderNames.ORIGIN);
         return origin == null ||
                NULL_ORIGIN.equals(origin) && config.isNullOriginAllowed() ||
-               config.origins().contains(origin.toLowerCase(Locale.ENGLISH));
+               config.origins().contains(Ascii.toLowerCase(origin));
     }
 
     /**
@@ -227,7 +228,7 @@ public final class CorsService<I extends HttpRequest, O extends HttpResponse>
                 }
                 return true;
             }
-            if (config.origins().contains(origin.toLowerCase(Locale.ENGLISH))) {
+            if (config.origins().contains(Ascii.toLowerCase(origin))) {
                 setCorsOrigin(headers, origin);
                 setCorsVaryHeader(headers);
                 return true;

--- a/core/src/main/java/com/linecorp/armeria/server/http/cors/CorsServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/cors/CorsServiceBuilder.java
@@ -24,11 +24,12 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
+
+import com.google.common.base.Ascii;
 
 import com.linecorp.armeria.common.http.HttpHeaderNames;
 import com.linecorp.armeria.common.http.HttpMethod;
@@ -97,7 +98,7 @@ public final class CorsServiceBuilder {
     CorsServiceBuilder(final String... origins) {
         final Set<String> originsCopy = new LinkedHashSet<>();
         for (String o : origins) {
-            originsCopy.add(o.toLowerCase(Locale.ENGLISH));
+            originsCopy.add(Ascii.toLowerCase(o));
         }
         this.origins = Collections.unmodifiableSet(originsCopy);
         anyOriginSupported = false;

--- a/core/src/main/java/com/linecorp/armeria/server/http/file/MimeTypeUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/file/MimeTypeUtil.java
@@ -21,11 +21,11 @@ import static java.util.Objects.requireNonNull;
 import java.net.URLConnection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Locale;
 import java.util.Map;
 
 import javax.annotation.Nullable;
 
+import com.google.common.base.Ascii;
 import com.google.common.net.MediaType;
 
 final class MimeTypeUtil {
@@ -74,7 +74,7 @@ final class MimeTypeUtil {
                             MediaType mediaType, String... extensions) {
 
         for (String e : extensions) {
-            assert e.toLowerCase(Locale.US).equals(e);
+            assert Ascii.toLowerCase(e).equals(e);
             extensionToMediaType.put(e, mediaType);
         }
     }
@@ -94,7 +94,7 @@ final class MimeTypeUtil {
             return null;
         }
 
-        final String extension = path.substring(dotIdx + 1).toLowerCase(Locale.US);
+        final String extension = Ascii.toLowerCase(path.substring(dotIdx + 1));
         final MediaType mediaType = EXTENSION_TO_MEDIA_TYPE.get(extension);
         if (mediaType != null) {
             return mediaType;

--- a/zipkin/src/main/java/com/linecorp/armeria/internal/tracing/BraveHttpHeaderNames.java
+++ b/zipkin/src/main/java/com/linecorp/armeria/internal/tracing/BraveHttpHeaderNames.java
@@ -16,8 +16,6 @@
 
 package com.linecorp.armeria.internal.tracing;
 
-import java.util.Locale;
-
 import com.github.kristofa.brave.http.BraveHttpHeaders;
 
 import io.netty.util.AsciiString;
@@ -33,7 +31,7 @@ public final class BraveHttpHeaderNames {
      * @see BraveHttpHeaders#Sampled
      */
     public static final AsciiString SAMPLED =
-            AsciiString.of(BraveHttpHeaders.Sampled.getName().toLowerCase(Locale.ENGLISH));
+            AsciiString.of(BraveHttpHeaders.Sampled.getName()).toLowerCase();
 
     /**
      * {@code "x-b3-traceid"}.
@@ -41,7 +39,7 @@ public final class BraveHttpHeaderNames {
      * @see BraveHttpHeaders#TraceId
      */
     public static final AsciiString TRACE_ID =
-            AsciiString.of(BraveHttpHeaders.TraceId.getName().toLowerCase(Locale.ENGLISH));
+            AsciiString.of(BraveHttpHeaders.TraceId.getName()).toLowerCase();
 
     /**
      * {@code "x-b3-spanid"}.
@@ -49,7 +47,7 @@ public final class BraveHttpHeaderNames {
      * @see BraveHttpHeaders#SpanId
      */
     public static final AsciiString SPAN_ID =
-            AsciiString.of(BraveHttpHeaders.SpanId.getName().toLowerCase(Locale.ENGLISH));
+            AsciiString.of(BraveHttpHeaders.SpanId.getName()).toLowerCase();
 
     /**
      * {@code "x-b3-parentspanid"}.
@@ -57,7 +55,7 @@ public final class BraveHttpHeaderNames {
      * @see BraveHttpHeaders#ParentSpanId
      */
     public static final AsciiString PARENT_SPAN_ID =
-            AsciiString.of(BraveHttpHeaders.ParentSpanId.getName().toLowerCase(Locale.ENGLISH));
+            AsciiString.of(BraveHttpHeaders.ParentSpanId.getName()).toLowerCase();
 
     private BraveHttpHeaderNames() {}
 }


### PR DESCRIPTION
Motivation:

There are many places in Armeria that performs case conversion and
case-insensitive comparisons on an ASCII string. We were using
String.toLower/UpperCase(Locale.ENGLISH) and String.equalsIgnoreCase(),
but Guava provides much better alternatives in its utility class:
com.google.common.base.Ascii.

Modifications:

- Use Ascii.toLower/UpperCase() wherever possible
- Use Ascii.equalsIgnoreCase() wherever possible

Result:

- Faster and simpler case conversion and case-insensitive comparison
- Fixes #399