### PR TITLE
Revive the 'example HTTP headers' support for DocService

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/http/HttpHeaders.java
+++ b/core/src/main/java/com/linecorp/armeria/common/http/HttpHeaders.java
@@ -16,8 +16,13 @@
 
 package com.linecorp.armeria.common.http;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.Iterator;
 import java.util.Map.Entry;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 import io.netty.handler.codec.Headers;
 import io.netty.util.AsciiString;
@@ -25,12 +30,21 @@ import io.netty.util.AsciiString;
 /**
  * HTTP/2 headers.
  */
+@JsonSerialize(using = HttpHeadersJsonSerializer.class)
+@JsonDeserialize(using = HttpHeadersJsonDeserializer.class)
 public interface HttpHeaders extends HttpObject, Headers<AsciiString, String, HttpHeaders> {
 
     /**
      * An immutable empty HTTP/2 headers.
      */
     HttpHeaders EMPTY_HEADERS = new DefaultHttpHeaders(false, 0).asImmutable();
+
+    /**
+     * Returns new empty HTTP headers.
+     */
+    static HttpHeaders of() {
+        return new DefaultHttpHeaders();
+    }
 
     /**
      * Returns new HTTP request headers.
@@ -85,6 +99,13 @@ public interface HttpHeaders extends HttpObject, Headers<AsciiString, String, Ht
 
         return new DefaultHttpHeaders().add(name1, value1).add(name2, value2)
                                        .add(name3, value3).add(name4, value4);
+    }
+
+    /**
+     * Returns a copy of the specified {@link HttpHeaders}.
+     */
+    static HttpHeaders copyOf(HttpHeaders headers) {
+        return of().set(requireNonNull(headers, "headers"));
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/http/HttpHeadersJsonDeserializer.java
+++ b/core/src/main/java/com/linecorp/armeria/common/http/HttpHeadersJsonDeserializer.java
@@ -1,0 +1,87 @@
+/*
+ *  Copyright 2017 LINE Corporation
+ *
+ *  LINE Corporation licenses this file to you under the Apache License,
+ *  version 2.0 (the "License"); you may not use this file except in compliance
+ *  with the License. You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package com.linecorp.armeria.common.http;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Map.Entry;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import io.netty.util.AsciiString;
+
+/**
+ * Jackson {@link JsonDeserializer} for {@link HttpHeaders}.
+ */
+public class HttpHeadersJsonDeserializer extends StdDeserializer<HttpHeaders> {
+
+    private static final long serialVersionUID = 6308506823069217145L;
+
+    /**
+     * Creates a new instance.
+     */
+    public HttpHeadersJsonDeserializer() {
+        super(HttpHeaders.class);
+    }
+
+    @Override
+    public HttpHeaders deserialize(JsonParser p, DeserializationContext ctx)
+            throws IOException {
+        final JsonNode tree = p.getCodec().readTree(p);
+        if (!tree.isObject()) {
+            ctx.reportMappingException("HTTP headers must be an object.");
+            return null;
+        }
+
+        final ObjectNode obj = (ObjectNode) tree;
+        final HttpHeaders headers = HttpHeaders.of();
+
+        for (Iterator<Entry<String, JsonNode>> i = obj.fields(); i.hasNext();) {
+            final Entry<String, JsonNode> e = i.next();
+            final AsciiString name = HttpHeaderNames.of(e.getKey());
+            final JsonNode values = e.getValue();
+            if (!values.isArray()) {
+                // Values is a single item, so add it directly.
+                addHeader(ctx, headers, name, values);
+            } else {
+                final int numValues = values.size();
+                for (int j = 0; j < numValues; j++) {
+                    final JsonNode v = values.get(j);
+                    addHeader(ctx, headers, name, v);
+                }
+            }
+        }
+
+        return headers.asImmutable();
+    }
+
+    private static void addHeader(DeserializationContext ctx, HttpHeaders headers,
+                                  AsciiString name, JsonNode valueNode) throws JsonMappingException {
+        if (!valueNode.isTextual()) {
+            ctx.reportMappingException("HTTP header '%s' contains %s (%s); only strings are allowed.",
+                                       name, valueNode.getNodeType(), valueNode);
+        }
+
+        headers.add(name, valueNode.asText());
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/common/http/HttpHeadersJsonSerializer.java
+++ b/core/src/main/java/com/linecorp/armeria/common/http/HttpHeadersJsonSerializer.java
@@ -1,0 +1,65 @@
+/*
+ *  Copyright 2017 LINE Corporation
+ *
+ *  LINE Corporation licenses this file to you under the Apache License,
+ *  version 2.0 (the "License"); you may not use this file except in compliance
+ *  with the License. You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package com.linecorp.armeria.common.http;
+
+import java.io.IOException;
+import java.util.List;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import io.netty.util.AsciiString;
+
+/**
+ * Jackson {@link JsonSerializer} for {@link HttpHeaders}.
+ */
+public class HttpHeadersJsonSerializer extends StdSerializer<HttpHeaders> {
+
+    private static final long serialVersionUID = 4459242879396343114L;
+
+    /**
+     * Creates a new instance.
+     */
+    public HttpHeadersJsonSerializer() {
+        super(HttpHeaders.class);
+    }
+
+    @Override
+    public void serialize(HttpHeaders headers, JsonGenerator gen, SerializerProvider serializers)
+            throws IOException {
+
+        gen.writeStartObject();
+
+        for (AsciiString name : headers.names()) {
+            gen.writeFieldName(name.toString());
+            final List<String> values = headers.getAll(name);
+            if (values.size() == 1) {
+                gen.writeString(values.get(0));
+            } else {
+                gen.writeStartArray();
+                for (String value : values) {
+                    gen.writeString(value);
+                }
+                gen.writeEndArray();
+            }
+        }
+
+        gen.writeEndObject();
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/docs/ServiceInfo.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/ServiceInfo.java
@@ -16,11 +16,13 @@
 
 package com.linecorp.armeria.server.docs;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSortedMap.toImmutableSortedMap;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
@@ -30,6 +32,7 @@ import javax.annotation.Nullable;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.Streams;
 
+import com.linecorp.armeria.common.http.HttpHeaders;
 import com.linecorp.armeria.server.Service;
 
 /**
@@ -42,7 +45,7 @@ public final class ServiceInfo {
     private final Map<String, ClassInfo> classes;
     private final Map<String, EndpointInfo> endpoints;
     private final String docString;
-    private final String sampleHttpHeaders;
+    private final List<HttpHeaders> exampleHttpHeaders;
 
     /**
      * Creates a new instance.
@@ -52,7 +55,7 @@ public final class ServiceInfo {
                        Iterable<ClassInfo> classes,
                        Iterable<EndpointInfo> endpoints,
                        @Nullable String docString,
-                       @Nullable String sampleHttpHeaders) {
+                       Iterable<HttpHeaders> exampleHttpHeaders) {
 
         this.name = requireNonNull(name, "name");
 
@@ -71,7 +74,10 @@ public final class ServiceInfo {
                                                               e -> e.hostnamePattern() + ':' + e.path(),
                                                               Function.identity()));
         this.docString = docString;
-        this.sampleHttpHeaders = sampleHttpHeaders;
+        this.exampleHttpHeaders = Streams.stream(requireNonNull(exampleHttpHeaders, "exampleHttpHeaders"))
+                                         .map(HttpHeaders::copyOf)
+                                         .map(HttpHeaders::asImmutable)
+                                         .collect(toImmutableList());
     }
 
     /**
@@ -123,11 +129,11 @@ public final class ServiceInfo {
     }
 
     /**
-     * Returns the sample HTTP headers of the service, serialized in JSON format.
+     * Returns the example HTTP headers of the service.
      */
     @JsonProperty
-    public String sampleHttpHeaders() {
-        return sampleHttpHeaders;
+    public List<HttpHeaders> exampleHttpHeaders() {
+        return exampleHttpHeaders;
     }
 
     @Override
@@ -160,7 +166,7 @@ public final class ServiceInfo {
                ", classes=" + classes() +
                ", endpoints=" + endpoints() +
                ", docString=" + docString() +
-               ", sampleHttpHeaders=" + sampleHttpHeaders() +
+               ", exampleHttpHeaders=" + exampleHttpHeaders() +
                '}';
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/docs/ServiceSpecificationGenerator.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/ServiceSpecificationGenerator.java
@@ -18,6 +18,9 @@ package com.linecorp.armeria.server.docs;
 
 import java.util.Set;
 
+import com.google.common.collect.ListMultimap;
+
+import com.linecorp.armeria.common.http.HttpHeaders;
 import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceConfig;
 
@@ -36,6 +39,9 @@ public interface ServiceSpecificationGenerator {
      *
      * @param serviceConfigs the {@link ServiceConfig}s of the {@link Service}s that are instances of the
      *                       {@link #supportedServiceTypes()}
+     * @param exampleHeaders the {@link ListMultimap} of the example {@link HttpHeaders} whose key is the
+     *                       type of the relevant services
      */
-    ServiceSpecification generate(Iterable<ServiceConfig> serviceConfigs);
+    ServiceSpecification generate(Set<ServiceConfig> serviceConfigs,
+                                  ListMultimap<Class<?>, HttpHeaders> exampleHeaders);
 }

--- a/core/src/main/resources/com/linecorp/armeria/server/docs/assets/js/armeria.js
+++ b/core/src/main/resources/com/linecorp/armeria/server/docs/assets/js/armeria.js
@@ -186,7 +186,13 @@ $(function () {
       debugHttpHeadersSticky.prop('checked', true);
       debugHttpHeadersText.val(oldDebugHttpHeadersText.val());
     } else {
-      debugHttpHeadersText.val(serviceInfo.sampleHttpHeaders);
+      var exampleHttpHeaders = serviceInfo.exampleHttpHeaders;
+      if (exampleHttpHeaders.length > 0) {
+        // TODO(trustin): Allow choosing from the example list.
+        debugHttpHeadersText.val(JSON.stringify(serviceInfo.exampleHttpHeaders[0], null, 2));
+      } else {
+        debugHttpHeadersText.val('');
+      }
     }
     var debugResponse = functionContainer.find('.debug-response code');
 
@@ -245,7 +251,17 @@ $(function () {
         type: 'POST',
         url: serviceInfo.debugPath,
         data: request,
-        headers: httpHeaders,
+        beforeSend: function (xhr) {
+          Object.keys(httpHeaders).forEach(function (name) {
+            var values = httpHeaders[name];
+            if (!Array.isArray(values)) {
+              // Values is a single item, so set it directly.
+              xhr.setRequestHeader(name, values);
+            } else {
+              xhr.setRequestHeader(name, values.join());
+            }
+          });
+        },
         contentType: TTEXT_MIME_TYPE,
         success: function (response) {
           var result = response.length > 0 ? response : "Request sent to one-way function";

--- a/core/src/test/java/com/linecorp/armeria/common/http/HttpHeadersJsonDeserializerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/http/HttpHeadersJsonDeserializerTest.java
@@ -1,0 +1,86 @@
+/*
+ *  Copyright 2017 LINE Corporation
+ *
+ *  LINE Corporation licenses this file to you under the Apache License,
+ *  version 2.0 (the "License"); you may not use this file except in compliance
+ *  with the License. You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package com.linecorp.armeria.common.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.netty.util.AsciiString;
+
+public class HttpHeadersJsonDeserializerTest {
+
+    private static final AsciiString NAME = AsciiString.of("a");
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    public void singleString() throws IOException {
+        assertThat(mapper.readValue("{\"a\":\"0\"}", HttpHeaders.class))
+                .isEqualTo(HttpHeaders.of(NAME, "0"));
+    }
+
+    @Test
+    public void multipleValues() throws IOException {
+        final HttpHeaders expected = new DefaultHttpHeaders();
+        expected.set(NAME, "foo", "bar", "baz");
+        assertThat(mapper.readValue("{\"a\":[\"foo\",\"bar\",\"baz\"]}", HttpHeaders.class))
+                .isEqualTo(expected);
+    }
+
+    @Test
+    public void failOnNonObject() {
+        assertThatThrownBy(() -> mapper.readValue("[]", HttpHeaders.class))
+                .isInstanceOf(JsonMappingException.class);
+    }
+
+    @Test
+    public void failOnNullValue1() {
+        assertThatThrownBy(() -> mapper.readValue("{\"a\":null}", HttpHeaders.class))
+                .isInstanceOf(JsonMappingException.class);
+    }
+
+    @Test
+    public void failOnNullValue2() {
+        assertThatThrownBy(() -> mapper.readValue("{\"a\":[null]}", HttpHeaders.class))
+                .isInstanceOf(JsonMappingException.class);
+    }
+
+    @Test
+    public void failOnNestedArray() {
+        assertThatThrownBy(() -> mapper.readValue("{\"a\":[[]]}", HttpHeaders.class))
+                .isInstanceOf(JsonMappingException.class);
+    }
+
+    @Test
+    public void failOnNumberValue() throws IOException {
+        assertThatThrownBy(() -> mapper.readValue("{\"a\":3.14}", HttpHeaders.class))
+                .isInstanceOf(JsonMappingException.class);
+    }
+
+    @Test
+    public void failOnBooleanValue() throws IOException {
+        assertThatThrownBy(() -> mapper.readValue("{\"a\":true}", HttpHeaders.class))
+                .isInstanceOf(JsonMappingException.class);
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/common/http/HttpHeadersJsonSerializerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/http/HttpHeadersJsonSerializerTest.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright 2017 LINE Corporation
+ *
+ *  LINE Corporation licenses this file to you under the Apache License,
+ *  version 2.0 (the "License"); you may not use this file except in compliance
+ *  with the License. You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package com.linecorp.armeria.common.http;
+
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.netty.util.AsciiString;
+
+public class HttpHeadersJsonSerializerTest {
+
+    private static final AsciiString NAME = AsciiString.of("a");
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    public void singleValue() {
+        assertThatJson(mapper.valueToTree(HttpHeaders.of(NAME, "0"))).isEqualTo("{\"a\":\"0\"}");
+    }
+
+    @Test
+    public void multipleValues() {
+        final HttpHeaders headers = new DefaultHttpHeaders();
+        headers.add(NAME, "0");
+        headers.add(NAME, "1");
+        assertThatJson(mapper.valueToTree(headers)).isEqualTo("{\"a\":[\"0\",\"1\"]}");
+    }
+}

--- a/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftDocServiceTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftDocServiceTest.java
@@ -21,10 +21,9 @@ import static com.linecorp.armeria.common.thrift.ThriftSerializationFormats.TEXT
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
@@ -35,22 +34,30 @@ import org.apache.http.util.EntityUtils;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ListMultimap;
 
+import com.linecorp.armeria.common.SerializationFormat;
+import com.linecorp.armeria.common.http.HttpHeaders;
 import com.linecorp.armeria.common.thrift.ThriftSerializationFormats;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.docs.DocService;
 import com.linecorp.armeria.server.docs.EndpointInfo;
 import com.linecorp.armeria.server.logging.LoggingService;
+import com.linecorp.armeria.server.thrift.ThriftServiceSpecificationGenerator.Entry;
+import com.linecorp.armeria.server.thrift.ThriftServiceSpecificationGenerator.EntryBuilder;
 import com.linecorp.armeria.service.test.thrift.cassandra.Cassandra;
 import com.linecorp.armeria.service.test.thrift.hbase.Hbase;
 import com.linecorp.armeria.service.test.thrift.main.FooService;
 import com.linecorp.armeria.service.test.thrift.main.HelloService;
-import com.linecorp.armeria.service.test.thrift.main.HelloService.hello_args;
 import com.linecorp.armeria.service.test.thrift.main.OnewayHelloService;
 import com.linecorp.armeria.service.test.thrift.main.SleepService;
 import com.linecorp.armeria.test.AbstractServerTest;
+
+import io.netty.util.AsciiString;
 
 public class ThriftDocServiceTest extends AbstractServerTest {
 
@@ -60,10 +67,9 @@ public class ThriftDocServiceTest extends AbstractServerTest {
     private static final SleepService.AsyncIface SLEEP_SERVICE_HANDLER =
             (duration, resultHandler) -> resultHandler.onComplete(duration);
 
-    private static final hello_args SAMPLE_HELLO = new hello_args().setName("sample user");
-    private static final Map<Class<?>, Map<String, String>> SAMPLE_HTTP_HEADERS = ImmutableMap.of(
-            HelloService.class, ImmutableMap.of("foobar", "barbaz"),
-            FooService.class, ImmutableMap.of("barbaz", "barbar"));
+    private static final ListMultimap<Class<?>, HttpHeaders> EXAMPLE_HTTP_HEADERS = ImmutableListMultimap.of(
+            HelloService.class, HttpHeaders.of(AsciiString.of("foobar"), "barbaz"),
+            FooService.class, HttpHeaders.of(AsciiString.of("barbaz"), "barbar"));
 
     @Override
     protected void configureServer(ServerBuilder sb) {
@@ -86,35 +92,45 @@ public class ThriftDocServiceTest extends AbstractServerTest {
         sb.serviceAt("/hbase", hbaseService);
         sb.serviceAt("/oneway", onewayHelloService);
 
-        sb.serviceUnder("/docs/", new DocService().decorate(LoggingService::new));
-        // FIXME(trustin): Bring this back
-        //new DocService(ImmutableList.of(SAMPLE_HELLO), SAMPLE_HTTP_HEADERS)
-        //        .decorate(LoggingService::new));
+        sb.serviceUnder("/docs/", new DocService(EXAMPLE_HTTP_HEADERS).decorate(LoggingService::new));
+        // FIXME(trustin): Bring the example requests back.
     }
 
     @Test
     public void testOk() throws Exception {
-        final Map<Class<?>, Iterable<EndpointInfo>> serviceMap = new HashMap<>();
-        serviceMap.put(HelloService.class, Collections.singletonList(
-                new EndpointInfo("*", "/", "hello", BINARY, ThriftSerializationFormats.values())));
-        serviceMap.put(SleepService.class, Collections.singletonList(
-                new EndpointInfo("*", "/", "sleep", BINARY, ThriftSerializationFormats.values())));
-        serviceMap.put(FooService.class, Collections.singletonList(
-                new EndpointInfo("*", "/foo", "", COMPACT, ImmutableSet.of(COMPACT))));
-        serviceMap.put(Cassandra.class, Arrays.asList(
-                new EndpointInfo("*", "/cassandra", "", BINARY, ImmutableSet.of(BINARY)),
-                new EndpointInfo("*", "/cassandra/debug", "", TEXT, ImmutableSet.of(TEXT))));
-        serviceMap.put(Hbase.class, Collections.singletonList(
-                new EndpointInfo("*", "/hbase", "", BINARY, ThriftSerializationFormats.values())));
-        serviceMap.put(OnewayHelloService.class, Collections.singletonList(
-                new EndpointInfo("*", "/oneway", "", BINARY, ThriftSerializationFormats.values())));
+        final Set<SerializationFormat> allThriftFormats = ThriftSerializationFormats.values();
+        final List<Entry> entries = ImmutableList.of(
+                new EntryBuilder(HelloService.class)
+                        .endpoint(new EndpointInfo("*", "/", "hello", BINARY, allThriftFormats))
+                        .exampleHttpHeaders(EXAMPLE_HTTP_HEADERS.get(HelloService.class))
+                        .build(),
+                new EntryBuilder(SleepService.class)
+                        .endpoint(new EndpointInfo("*", "/", "sleep", BINARY, allThriftFormats))
+                        .exampleHttpHeaders(EXAMPLE_HTTP_HEADERS.get(SleepService.class))
+                        .build(),
+                new EntryBuilder(FooService.class)
+                        .endpoint(new EndpointInfo("*", "/foo", "", COMPACT, ImmutableSet.of(COMPACT)))
+                        .exampleHttpHeaders(EXAMPLE_HTTP_HEADERS.get(FooService.class))
+                        .build(),
+                new EntryBuilder(Cassandra.class)
+                        .endpoint(new EndpointInfo("*", "/cassandra", "", BINARY, ImmutableSet.of(BINARY)))
+                        .endpoint(new EndpointInfo("*", "/cassandra/debug", "", TEXT, ImmutableSet.of(TEXT)))
+                        .exampleHttpHeaders(EXAMPLE_HTTP_HEADERS.get(Cassandra.class))
+                        .build(),
+                new EntryBuilder(Hbase.class)
+                        .endpoint(new EndpointInfo("*", "/hbase", "", BINARY, allThriftFormats))
+                        .exampleHttpHeaders(EXAMPLE_HTTP_HEADERS.get(Hbase.class))
+                        .build(),
+                new EntryBuilder(OnewayHelloService.class)
+                        .endpoint(new EndpointInfo("*", "/oneway", "", BINARY, allThriftFormats))
+                        .exampleHttpHeaders(EXAMPLE_HTTP_HEADERS.get(OnewayHelloService.class))
+                        .build());
 
         final ObjectMapper mapper = new ObjectMapper();
         final String expectedJson = mapper.writeValueAsString(
-                ThriftServiceSpecificationGenerator.generate(serviceMap));
+                ThriftServiceSpecificationGenerator.generate(entries));
         // FIXME(trustin): Bring this back.
-        //ImmutableMap.of(hello_args.class, SAMPLE_HELLO),
-        //SAMPLE_HTTP_HEADERS));
+        //ImmutableMap.of(hello_args.class, SAMPLE_HELLO)
 
         try (CloseableHttpClient hc = HttpClients.createMinimal()) {
             final HttpGet req = new HttpGet(specificationUri());

--- a/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftServiceSpecificationGeneratorTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftServiceSpecificationGeneratorTest.java
@@ -46,9 +46,11 @@ import org.apache.thrift.protocol.TType;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
+import com.linecorp.armeria.common.http.HttpHeaders;
 import com.linecorp.armeria.common.thrift.ThriftSerializationFormats;
 import com.linecorp.armeria.server.PathMapping;
 import com.linecorp.armeria.server.ServiceConfig;
@@ -74,6 +76,9 @@ import com.linecorp.armeria.service.test.thrift.main.FooServiceException;
 import com.linecorp.armeria.service.test.thrift.main.FooStruct;
 import com.linecorp.armeria.service.test.thrift.main.FooUnion;
 import com.linecorp.armeria.service.test.thrift.main.HelloService;
+import com.linecorp.armeria.service.test.thrift.main.HelloService.AsyncIface;
+
+import io.netty.util.AsciiString;
 
 public class ThriftServiceSpecificationGeneratorTest {
 
@@ -81,29 +86,39 @@ public class ThriftServiceSpecificationGeneratorTest {
 
     @Test
     public void servicesTest() throws Exception {
-        final ServiceSpecification specification = generator.generate(ImmutableList.of(
-                new ServiceConfig(
-                        new VirtualHostBuilder().build(),
-                        PathMapping.ofExact("/hello"),
-                        THttpService.of(mock(HelloService.AsyncIface.class))),
-                new ServiceConfig(
-                        new VirtualHostBuilder().build(),
-                        PathMapping.ofExact("/foo"),
-                        THttpService.ofFormats(mock(FooService.AsyncIface.class),
-                                               ThriftSerializationFormats.COMPACT))));
+        final ServiceConfig helloService = new ServiceConfig(
+                new VirtualHostBuilder().build(),
+                PathMapping.ofExact("/hello"),
+                THttpService.of(mock(AsyncIface.class)));
+
+        final HttpHeaders helloExampleHeaders = HttpHeaders.of(AsciiString.of("hello"), "world");
+
+        final ServiceConfig fooService = new ServiceConfig(
+                new VirtualHostBuilder().build(),
+                PathMapping.ofExact("/foo"),
+                THttpService.ofFormats(mock(FooService.AsyncIface.class), ThriftSerializationFormats.COMPACT));
+
+        final HttpHeaders fooExampleHeaders = HttpHeaders.of(AsciiString.of("foo"), "bar");
+
+        final ServiceSpecification specification = generator.generate(
+                ImmutableSet.of(helloService, fooService),
+                ImmutableListMultimap.of(HelloService.class, helloExampleHeaders,
+                                         FooService.class, fooExampleHeaders));
 
         final Map<String, ServiceInfo> services = specification.services();
-        assertThat(services).containsOnlyKeys(HelloService.class.getName(),
-                                              FooService.class.getName());
+        assertThat(services).containsOnlyKeys(HelloService.class.getName(), FooService.class.getName());
 
-        assertThat(services.get(HelloService.class.getName()).endpoints())
+        final ServiceInfo helloServiceInfo = services.get(HelloService.class.getName());
+        assertThat(helloServiceInfo.endpoints())
                 .containsExactly(new EndpointInfo("*", "/hello", "", ThriftSerializationFormats.BINARY,
                                                   ThriftSerializationFormats.values()));
+        assertThat(helloServiceInfo.exampleHttpHeaders()).containsExactly(helloExampleHeaders);
 
-        assertThat(services.containsKey(FooService.class.getName())).isTrue();
-        assertThat(services.get(FooService.class.getName()).endpoints())
+        final ServiceInfo fooServiceInfo = services.get(FooService.class.getName());
+        assertThat(fooServiceInfo.endpoints())
                 .containsExactly(new EndpointInfo("*", "/foo", "", ThriftSerializationFormats.COMPACT,
                                                   ImmutableSet.of(ThriftSerializationFormats.COMPACT)));
+        assertThat(fooServiceInfo.exampleHttpHeaders()).containsExactly(fooExampleHeaders);
     }
 
     @Test
@@ -148,13 +163,13 @@ public class ThriftServiceSpecificationGeneratorTest {
     public void testNewServiceInfo() throws Exception {
         final ServiceInfo service =
                 newServiceInfo(FooService.class,
-                               Arrays.asList(
+                               ImmutableList.of(
                                        new EndpointInfo("*", "/foo", "a", ThriftSerializationFormats.BINARY,
                                                         ImmutableSet.of(ThriftSerializationFormats.BINARY)),
                                        new EndpointInfo("*", "/debug/foo", "b", ThriftSerializationFormats.TEXT,
                                                         ImmutableSet.of(ThriftSerializationFormats.TEXT))),
                                ImmutableMap.of(bar3_args.class, new bar3_args().setIntVal(10)),
-                               ImmutableMap.of("foobar", "barbaz"));
+                               ImmutableList.of(HttpHeaders.of(AsciiString.of("foobar"), "barbaz")));
 
         assertThat(service.endpoints()).hasSize(2);
         // Should be sorted alphabetically
@@ -203,9 +218,8 @@ public class ThriftServiceSpecificationGeneratorTest {
         assertThat(bar5.exceptions()).hasSize(1);
         assertThat(bar5.sampleJsonRequest()).isEmpty();
 
-        final String sampleHttpHeaders = service.sampleHttpHeaders();
-        assertThat(sampleHttpHeaders).isNotNull();
-        assertThatJson(sampleHttpHeaders).isEqualTo("{ \"foobar\": \"barbaz\" }");
+        final List<HttpHeaders> exampleHttpHeaders = service.exampleHttpHeaders();
+        assertThat(exampleHttpHeaders).containsExactly(HttpHeaders.of(AsciiString.of("foobar"), "barbaz"));
     }
 
     @Test


### PR DESCRIPTION
Motivation:

Since the separation of armeria-thrift from the core, a user was not
able to specify example HTTP headers. We should implement it again.

Modifications:

- Add a new DocService constructor that accepts a Multimap of
  HttpHeaders whose key is the type of the relevant service
  - Unlike the old implementation, it is possible to specify more than
    one example HTTP headers.
- Replace sampleHttpHeaders which is a Map of Strings with
  exampleHttpHeaders which is a List of HttpHeaders
- Add Jackson (de)serializer implementation for HttpHeaders
- Change the signature or ServiceSpecificationGenerator.generate() to
  support the example HTTP headers
- Update the frontend-side implementation to handle the example HTTP
  headers properly
- Miscellaneous:
  - Add HttpHeaders.of() convenience method
  - Add HttpHeaders.copyOf(HttpHeaders) convenience method

Result:

- The example HTTP headers support is back.
- TODOs:
  - Allow choosing from multiple example HTTP headers from the
    DocService debug form