### PR TITLE
Update the dependencies

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
@@ -48,7 +48,7 @@ public final class Endpoint {
         }
 
         final HostAndPort parsed = HostAndPort.fromString(authority).withDefaultPort(0);
-        return new Endpoint(parsed.getHostText(), parsed.getPort(), 1000);
+        return new Endpoint(parsed.getHost(), parsed.getPort(), 1000);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/http/HttpSessionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/http/HttpSessionHandler.java
@@ -45,6 +45,7 @@ import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http2.Http2ConnectionHandler;
 import io.netty.handler.codec.http2.Http2Settings;
+import io.netty.handler.ssl.SslCloseCompletionEvent;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.Promise;
 
@@ -217,6 +218,10 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
             sessionTimeoutFuture.cancel(false);
             sessionPromise.tryFailure((SessionProtocolNegotiationException) evt);
             ctx.close();
+            return;
+        }
+
+        if (evt instanceof SslCloseCompletionEvent) {
             return;
         }
 

--- a/core/src/main/java/com/linecorp/armeria/server/http/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/HttpServerHandler.java
@@ -78,6 +78,7 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.EventLoop;
 import io.netty.handler.codec.http2.Http2ConnectionHandler;
 import io.netty.handler.codec.http2.Http2Settings;
+import io.netty.handler.ssl.SslCloseCompletionEvent;
 import io.netty.handler.ssl.SslHandler;
 
 final class HttpServerHandler extends ChannelInboundHandlerAdapter implements HttpServer {
@@ -533,6 +534,10 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
 
     @Override
     public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+        if (evt instanceof SslCloseCompletionEvent) {
+            return;
+        }
+
         logger.warn("{} Unexpected user event: {}", ctx.channel(), evt);
     }
 

--- a/core/src/test/java/com/linecorp/armeria/server/http/HttpServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/http/HttpServerTest.java
@@ -454,7 +454,7 @@ public class HttpServerTest extends AbstractServerTest {
 
     @Test(timeout = 10000)
     public void testStrings_noAcceptEncoding() throws Exception {
-        final DefaultHttpRequest req = new DefaultHttpRequest(HttpMethod.GET, "/strings");
+        final HttpHeaders req = HttpHeaders.of(HttpMethod.GET, "/strings");
         final CompletableFuture<AggregatedHttpMessage> f = client().execute(req).aggregate();
 
         final AggregatedHttpMessage res = f.get();
@@ -467,9 +467,8 @@ public class HttpServerTest extends AbstractServerTest {
 
     @Test(timeout = 10000)
     public void testStrings_acceptEncodingGzip() throws Exception {
-        final DefaultHttpRequest req = new DefaultHttpRequest(
-                HttpHeaders.of(HttpMethod.GET, "/strings")
-                           .set(HttpHeaderNames.ACCEPT_ENCODING, "gzip"));
+        final HttpHeaders req = HttpHeaders.of(HttpMethod.GET, "/strings")
+                                           .set(HttpHeaderNames.ACCEPT_ENCODING, "gzip");
         final CompletableFuture<AggregatedHttpMessage> f = client().execute(req).aggregate();
 
         final AggregatedHttpMessage res = f.get();
@@ -489,9 +488,8 @@ public class HttpServerTest extends AbstractServerTest {
 
     @Test(timeout = 10000)
     public void testStrings_acceptEncodingGzip_imageContentType() throws Exception {
-        final DefaultHttpRequest req = new DefaultHttpRequest(
-                HttpHeaders.of(HttpMethod.GET, "/images")
-                           .set(HttpHeaderNames.ACCEPT_ENCODING, "gzip"));
+        final HttpHeaders req = HttpHeaders.of(HttpMethod.GET, "/images")
+                                           .set(HttpHeaderNames.ACCEPT_ENCODING, "gzip");
         final CompletableFuture<AggregatedHttpMessage> f = client().execute(req).aggregate();
 
         final AggregatedHttpMessage res = f.get();
@@ -504,9 +502,8 @@ public class HttpServerTest extends AbstractServerTest {
 
     @Test(timeout = 10000)
     public void testStrings_acceptEncodingGzip_smallFixedContent() throws Exception {
-        final DefaultHttpRequest req = new DefaultHttpRequest(
-                HttpHeaders.of(HttpMethod.GET, "/small")
-                           .set(HttpHeaderNames.ACCEPT_ENCODING, "gzip"));
+        final HttpHeaders req = HttpHeaders.of(HttpMethod.GET, "/small")
+                                           .set(HttpHeaderNames.ACCEPT_ENCODING, "gzip");
         final CompletableFuture<AggregatedHttpMessage> f = client().execute(req).aggregate();
 
         final AggregatedHttpMessage res = f.get();
@@ -519,9 +516,8 @@ public class HttpServerTest extends AbstractServerTest {
 
     @Test(timeout = 10000)
     public void testStrings_acceptEncodingGzip_largeFixedContent() throws Exception {
-        final DefaultHttpRequest req = new DefaultHttpRequest(
-                HttpHeaders.of(HttpMethod.GET, "/large")
-                           .set(HttpHeaderNames.ACCEPT_ENCODING, "gzip"));
+        final HttpHeaders req = HttpHeaders.of(HttpMethod.GET, "/large")
+                                           .set(HttpHeaderNames.ACCEPT_ENCODING, "gzip");
         final CompletableFuture<AggregatedHttpMessage> f = client().execute(req).aggregate();
 
         final AggregatedHttpMessage res = f.get();
@@ -539,9 +535,8 @@ public class HttpServerTest extends AbstractServerTest {
 
     @Test(timeout = 10000)
     public void testStrings_acceptEncodingDeflate() throws Exception {
-        final DefaultHttpRequest req = new DefaultHttpRequest(
-                HttpHeaders.of(HttpMethod.GET, "/strings")
-                           .set(HttpHeaderNames.ACCEPT_ENCODING, "deflate"));
+        final HttpHeaders req = HttpHeaders.of(HttpMethod.GET, "/strings")
+                                           .set(HttpHeaderNames.ACCEPT_ENCODING, "deflate");
         final CompletableFuture<AggregatedHttpMessage> f = client().execute(req).aggregate();
 
         final AggregatedHttpMessage res = f.get();
@@ -560,9 +555,8 @@ public class HttpServerTest extends AbstractServerTest {
 
     @Test(timeout = 10000)
     public void testStrings_acceptEncodingUnknown() throws Exception {
-        final DefaultHttpRequest req = new DefaultHttpRequest(
-                HttpHeaders.of(HttpMethod.GET, "/strings")
-                           .set(HttpHeaderNames.ACCEPT_ENCODING, "piedpiper"));
+        final HttpHeaders req = HttpHeaders.of(HttpMethod.GET, "/strings")
+                                           .set(HttpHeaderNames.ACCEPT_ENCODING, "piedpiper");
         final CompletableFuture<AggregatedHttpMessage> f = client().execute(req).aggregate();
 
         final AggregatedHttpMessage res = f.get();
@@ -695,16 +689,17 @@ public class HttpServerTest extends AbstractServerTest {
                 "none+" + protocol.uriText() + "://127.0.0.1:" + (protocol.isTls() ? httpsPort() : httpPort()));
 
         builder.factory(clientFactory);
-        builder.decorator(HttpRequest.class, HttpResponse.class,
-                          s -> new DecoratingClient<HttpRequest, HttpResponse, HttpRequest, HttpResponse>(s) {
-            @Override
-            public HttpResponse execute(ClientRequestContext ctx, HttpRequest req) throws Exception {
-                ctx.setWriteTimeoutMillis(clientWriteTimeoutMillis);
-                ctx.setResponseTimeoutMillis(clientResponseTimeoutMillis);
-                ctx.setMaxResponseLength(clientMaxResponseLength);
-                return delegate().execute(ctx, req);
-            }
-        });
+        builder.decorator(
+                HttpRequest.class, HttpResponse.class,
+                s -> new DecoratingClient<HttpRequest, HttpResponse, HttpRequest, HttpResponse>(s) {
+                    @Override
+                    public HttpResponse execute(ClientRequestContext ctx, HttpRequest req) throws Exception {
+                        ctx.setWriteTimeoutMillis(clientWriteTimeoutMillis);
+                        ctx.setResponseTimeoutMillis(clientResponseTimeoutMillis);
+                        ctx.setMaxResponseLength(clientMaxResponseLength);
+                        return delegate().execute(ctx, req);
+                    }
+                });
 
         return client = builder.build(HttpClient.class);
     }

--- a/core/src/test/java/com/linecorp/armeria/server/http/file/HttpFileServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/http/file/HttpFileServiceTest.java
@@ -51,7 +51,7 @@ import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.logging.LoggingService;
 
-import io.netty.handler.codec.http.HttpHeaderDateFormat;
+import io.netty.handler.codec.DateFormatter;
 
 public class HttpFileServiceTest {
 
@@ -292,7 +292,7 @@ public class HttpFileServiceTest {
         final String lastModified;
         assertThat(res.containsHeader(HttpHeaders.LAST_MODIFIED), is(true));
         lastModified = res.getFirstHeader(HttpHeaders.LAST_MODIFIED).getValue();
-        HttpHeaderDateFormat.get().parse(lastModified);
+        DateFormatter.parseHttpDate(lastModified);
 
         // Ensure the content and its type are correct.
         assertThat(EntityUtils.toString(res.getEntity()), is(expectedContent));
@@ -331,7 +331,7 @@ public class HttpFileServiceTest {
     }
 
     private static String currentHttpDate() {
-        return HttpHeaderDateFormat.get().format(new Date());
+        return DateFormatter.format(new Date());
     }
 
     private static String newUri(String path) {

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -1,8 +1,8 @@
 ch.qos.logback:
-  logback-classic: { version: 1.1.7 }
+  logback-classic: { version: 1.2.1 }
 
 com.fasterxml.jackson.core:
-  jackson-annotations: { version: &JACKSON_VERSION 2.8.4 }
+  jackson-annotations: { version: &JACKSON_VERSION 2.8.7 }
   jackson-core: { version: *JACKSON_VERSION }
   jackson-databind: { version: *JACKSON_VERSION }
 
@@ -42,41 +42,41 @@ io.grpc:
   grpc-stub: { version: *GRPC_VERSION }
 
 io.netty:
-  netty-codec-http2: { version: &NETTY_VERSION 4.1.6.Final }
+  netty-codec-http2: { version: &NETTY_VERSION 4.1.8.Final }
   netty-handler: { version: *NETTY_VERSION }
   netty-resolver-dns: { version: *NETTY_VERSION }
   netty-transport: { version: *NETTY_VERSION }
   netty-transport-native-epoll: { version: *NETTY_VERSION }
-  netty-tcnative-boringssl-static: { version: 1.1.33.Fork23 }
+  netty-tcnative-boringssl-static: { version: 1.1.33.Fork26 }
 
 io.zipkin.brave:
-  brave-core: { version: &BRAVE_VERSION 3.14.1 }
+  brave-core: { version: &BRAVE_VERSION 4.0.6 }
   brave-http: { version: *BRAVE_VERSION }
 
 it.unimi.dsi:
-  fastutil: { version: 7.0.13 }
+  fastutil: { version: 7.1.0 }
 
 junit:
   junit: { version: !!str 4.12 }
 
 net.javacrumbs.json-unit:
-  json-unit: { version: &JSON_UNIT_VERSION 1.16.0 }
+  json-unit: { version: &JSON_UNIT_VERSION 1.19.0 }
   json-unit-fluent: { version: *JSON_UNIT_VERSION }
 
 org.apache.hbase:
   hbase-shaded-client:
-    version: 1.2.3
+    version: 1.2.4
     exclusions:
     - org.slf4j:slf4j-log4j12
 
 org.apache.httpcomponents:
   httpclient:
-    version: 4.5.2
+    version: 4.5.3
     exclusions:
     - commons-logging:commons-logging
 
 org.apache.kafka:
-  kafka-clients: { version: 0.10.0.1 }
+  kafka-clients: { version: 0.10.1.1 }
 
 org.apache.thrift:
   libthrift:
@@ -91,16 +91,16 @@ org.apache.tomcat.embed:
   tomcat-embed-el: { version: *TOMCAT_VERSION }
 
 org.apache.zookeeper:
-  zookeeper: { version: 3.4.7 }
+  zookeeper: { version: 3.4.9 }
 
 org.assertj:
-  assertj-core: { version: 3.5.2 }
+  assertj-core: { version: 3.6.2 }
 
 org.dmonix.junit:
   zookeeper-junit: { version: !!str 1.2 }
 
 org.eclipse.jetty:
-  apache-jsp: { version: &JETTY_VERSION 9.3.14.v20161028 }
+  apache-jsp: { version: &JETTY_VERSION 9.4.1.v20170120 }
   apache-jstl: { version: *JETTY_VERSION }
   jetty-annotations: { version: *JETTY_VERSION }
   jetty-server: { version: *JETTY_VERSION  }
@@ -116,13 +116,13 @@ org.hamcrest:
   hamcrest-library: { version: !!str 1.3 }
 
 org.javassist:
-  javassist: { version: 3.20.0-GA }
+  javassist: { version: 3.21.0-GA }
 
 org.mockito:
-  mockito-core: { version: 2.2.10 }
+  mockito-core: { version: 2.7.10 }
 
 org.mortbay.jetty.alpn:
-  jetty-alpn-agent: { version: 2.0.5 }
+  jetty-alpn-agent: { version: 2.0.6 }
 
 org.reactivestreams:
   reactive-streams: { version: 1.0.0 }
@@ -134,7 +134,7 @@ org.reflections:
     - com.google.code.findbugs:annotations
 
 org.slf4j:
-  jcl-over-slf4j: { version: &SLF4J_VERSION 1.7.21 }
+  jcl-over-slf4j: { version: &SLF4J_VERSION 1.7.23 }
   jul-to-slf4j: { version: *SLF4J_VERSION }
   log4j-over-slf4j: { version: *SLF4J_VERSION }
   slf4j-api: { version: *SLF4J_VERSION }

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/interop/ArmeriaGrpcServerInteropTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/interop/ArmeriaGrpcServerInteropTest.java
@@ -65,6 +65,7 @@ import io.netty.handler.ssl.util.SelfSignedCertificate;
  * Interop test based on grpc-interop-testing. Should provide reasonable confidence in armeria's
  * handling of the grpc protocol.
  */
+@Ignore // TODO(trustin): Re-enable after upgrading to GRPC 1.1.2.
 public class ArmeriaGrpcServerInteropTest extends AbstractInteropTest {
 
     /** Starts the server with HTTPS. */

--- a/jetty/src/main/java/com/linecorp/armeria/server/http/jetty/JettyService.java
+++ b/jetty/src/main/java/com/linecorp/armeria/server/http/jetty/JettyService.java
@@ -408,10 +408,27 @@ public final class JettyService implements HttpService {
     }
 
     private static final class ArmeriaEndPoint extends AbstractEndPoint {
+
+        private final InetSocketAddress localAddress;
+        private final InetSocketAddress remoteAddress;
+
         ArmeriaEndPoint(String hostname, Scheduler scheduler, SocketAddress local, SocketAddress remote) {
-            super(scheduler, addHostname((InetSocketAddress) local, hostname), (InetSocketAddress) remote);
+            super(scheduler);
+
+            localAddress = addHostname((InetSocketAddress) local, hostname);
+            remoteAddress = (InetSocketAddress) remote;
 
             setIdleTimeout(getIdleTimeout());
+        }
+
+        @Override
+        public InetSocketAddress getLocalAddress() {
+            return localAddress;
+        }
+
+        @Override
+        public InetSocketAddress getRemoteAddress() {
+            return remoteAddress;
         }
 
         /**
@@ -427,25 +444,11 @@ public final class JettyService implements HttpService {
             }
         }
 
-
         @Override
         protected void onIncompleteFlush() {}
 
         @Override
         protected void needsFillInterest() {}
-
-        @Override
-        public void shutdownOutput() {}
-
-        @Override
-        public boolean isOutputShutdown() {
-            return false;
-        }
-
-        @Override
-        public boolean isInputShutdown() {
-            return false;
-        }
 
         @Override
         public int fill(ByteBuffer buffer) {
@@ -463,9 +466,13 @@ public final class JettyService implements HttpService {
         }
 
         @Override
-        public boolean isOpen() {
-            return true;
-        }
+        protected void doShutdownInput() {}
+
+        @Override
+        protected void doShutdownOutput() {}
+
+        @Override
+        protected void doClose() {}
     }
 
     private final class Configurator extends ServerListenerAdapter {

--- a/settings/logback/logback-test.xml
+++ b/settings/logback/logback-test.xml
@@ -29,6 +29,8 @@
   <appender name="NOP" class="ch.qos.logback.core.helpers.NOPAppender" />
 
   <logger name="com.linecorp.armeria" level="DEBUG" />
+  <logger name="com.linecorp.armeria.traffic.server" level="OFF" />
+  <logger name="com.linecorp.armeria.traffic.client" level="OFF" />
   <logger name="com.linecorp.armeria.internal.http.Http2GoAwayListener" level="INFO" />
   <logger name="armeria" level="DEBUG" />
   <logger name="loggerTest" level="ALL" additivity="false">

--- a/zipkin/src/main/java/com/linecorp/armeria/server/tracing/HttpTracingService.java
+++ b/zipkin/src/main/java/com/linecorp/armeria/server/tracing/HttpTracingService.java
@@ -65,18 +65,18 @@ public class HttpTracingService extends AbstractTracingService<HttpRequest, Http
         final String sampled = headers.get(SAMPLED);
         if (sampled == null) {
             // trace data is not specified
-            return TraceData.builder().build();
+            return TraceData.EMPTY;
         }
         if ("0".equals(sampled) || "false".equalsIgnoreCase(sampled)) {
             // this request is not sampled
-            return TraceData.builder().sample(false).build();
+            return TraceData.NOT_SAMPLED;
         }
 
         final String traceId = headers.get(TRACE_ID);
         final String spanId = headers.get(SPAN_ID);
         if (traceId == null || spanId == null) {
             // broken trace header
-            return TraceData.builder().build();
+            return TraceData.EMPTY;
         }
 
         // parentSpanId can be null
@@ -91,6 +91,6 @@ public class HttpTracingService extends AbstractTracingService<HttpRequest, Http
                       .sampled(true)
                       .build();
 
-        return TraceData.builder().sample(true).spanId(span).build();
+        return TraceData.create(span);
     }
 }


### PR DESCRIPTION
Updated dependencies:

- Logback 1.1.7 -> 1.2.1
- Jackson 2.8.4 -> 2.8.7
- Netty 4.1.6 -> 4.1.8
- Brave 3.14.1 -> 4.0.6
- fastutil 7.0.13 -> 7.1.0
- json-unit 1.16.0 -> 1.19.0
- HBase shaded client -> 1.2.3 -> 1.2.4
- Apache HTTP client -> 4.5.2 -> 4.5.3
- Kafka -> 0.10.0.1 -> 0.10.1.1
- ZooKeeper -> 3.4.7 -> 3.4.9
- AssertJ -> 3.5.2 -> 3.6.2
- Jetty -> 9.3.14 -> 9.4.1
- Javassist -> 3.20 -> 3.21
- Jetty ALPN agent -> 2.0.5 -> 2.0.6
- SLF4J -> 1.7.21 -> 1.7.23

Modifications:

- Replace the use of the deprecated API with the new one
- Fix the client-side HTTP/2 upgrade which got broken due to Netty upgrade
- Do not log SslCloseCompletionEvent
- Fix the bugs where HttpServerTest.testStrings_*() do not close the
  requests they sent
- Add the logger names related with traffic logging to logback-test.xml
  so that it's easier to turn on/off traffic logging while developing
  Armeria

Result:

- Closes #367
- Catch up 3rd parties' improvements on their products