### PR TITLE
Switch example headers from keying on Class to keying on String.

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/docs/DocService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/DocService.java
@@ -67,7 +67,7 @@ public class DocService extends AbstractCompositeService<HttpRequest, HttpRespon
 
     private static final ObjectMapper mapper = new ObjectMapper();
 
-    private final ListMultimap<Class<?>, HttpHeaders> exampleHeaders;
+    private final ListMultimap<String, HttpHeaders> exampleHeaders;
     private Server server;
 
     /**
@@ -80,19 +80,19 @@ public class DocService extends AbstractCompositeService<HttpRequest, HttpRespon
     /**
      * Creates a new instance with example HTTP headers.
      *
-     * @param exampleHeaders a {@link Map} of example {@link HttpHeaders} whose key is the type of
-     *                       a service. Use the key {@code Object.class} to add the example HTTP headers
+     * @param exampleHeaders a {@link Map} of example {@link HttpHeaders} whose key is the full name of
+     *                       a service. Use the empty string to add the example HTTP headers
      *                       to all services.
      */
-    public DocService(Map<Class<?>, ? extends Iterable<HttpHeaders>> exampleHeaders) {
+    public DocService(Map<String, ? extends Iterable<HttpHeaders>> exampleHeaders) {
         super(ofExact("/specification.json", HttpFileService.forVfs(new DocServiceVfs())),
               ofCatchAll(HttpFileService.forClassPath(DocService.class.getClassLoader(),
                                                       "com/linecorp/armeria/server/docs")));
 
         requireNonNull(exampleHeaders, "exampleHeaders");
-        final ImmutableListMultimap.Builder<Class<?>, HttpHeaders> builder = ImmutableListMultimap.builder();
-        for (Entry<Class<?>, ? extends Iterable<HttpHeaders>> e : exampleHeaders.entrySet()) {
-            final Class<?> k = e.getKey();
+        final ImmutableListMultimap.Builder<String, HttpHeaders> builder = ImmutableListMultimap.builder();
+        for (Entry<String, ? extends Iterable<HttpHeaders>> e : exampleHeaders.entrySet()) {
+            final String k = e.getKey();
             for (HttpHeaders v : e.getValue()) {
                 builder.put(k, HttpHeaders.copyOf(v).asImmutable());
             }
@@ -142,8 +142,8 @@ public class DocService extends AbstractCompositeService<HttpRequest, HttpRespon
     private ServiceSpecification generate(ServiceSpecificationGenerator gen, List<ServiceConfig> services) {
         final Set<ServiceConfig> supportedServices = findSupportedServices(gen, services);
         @SuppressWarnings({ "unchecked", "rawtypes" })
-        final Map<Class<?>, List<HttpHeaders>> exampleHeaders =
-                (Map<Class<?>, List<HttpHeaders>>) (Map) this.exampleHeaders.asMap();
+        final Map<String, List<HttpHeaders>> exampleHeaders =
+                (Map<String, List<HttpHeaders>>) (Map) this.exampleHeaders.asMap();
         return gen.generate(supportedServices, exampleHeaders);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/docs/ServiceSpecificationGenerator.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/ServiceSpecificationGenerator.java
@@ -40,8 +40,8 @@ public interface ServiceSpecificationGenerator {
      * @param serviceConfigs the {@link ServiceConfig}s of the {@link Service}s that are instances of the
      *                       {@link #supportedServiceTypes()}
      * @param exampleHeaders the {@link Map} of the example {@link HttpHeaders} whose key is the
-     *                       type of the relevant services
+     *                       fully specified name of the relevant services
      */
     ServiceSpecification generate(Set<ServiceConfig> serviceConfigs,
-                                  Map<Class<?>, List<HttpHeaders>> exampleHeaders);
+                                  Map<String, List<HttpHeaders>> exampleHeaders);
 }

--- a/thrift/src/main/java/com/linecorp/armeria/server/thrift/ThriftServiceSpecificationGenerator.java
+++ b/thrift/src/main/java/com/linecorp/armeria/server/thrift/ThriftServiceSpecificationGenerator.java
@@ -86,7 +86,7 @@ public class ThriftServiceSpecificationGenerator implements ServiceSpecification
 
     @Override
     public ServiceSpecification generate(Set<ServiceConfig> serviceConfigs,
-                                         Map<Class<?>, List<HttpHeaders>> exampleHeaders) {
+                                         Map<String, List<HttpHeaders>> exampleHeaders) {
 
         final Map<Class<?>, EntryBuilder> map = new LinkedHashMap<>();
 
@@ -105,8 +105,8 @@ public class ThriftServiceSpecificationGenerator implements ServiceSpecification
                                     service.defaultSerializationFormat(),
                                     service.allowedSerializationFormats())));
 
-                    exampleHeaders.forEach((type, headersList) -> {
-                        if (serviceClass.isAssignableFrom(type)) {
+                    exampleHeaders.forEach((name, headersList) -> {
+                        if (serviceClass.getName().equals(name)) {
                             builder.exampleHttpHeaders(headersList);
                         }
                     });

--- a/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftDocServiceTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftDocServiceTest.java
@@ -67,9 +67,9 @@ public class ThriftDocServiceTest extends AbstractServerTest {
     private static final SleepService.AsyncIface SLEEP_SERVICE_HANDLER =
             (duration, resultHandler) -> resultHandler.onComplete(duration);
 
-    private static final ListMultimap<Class<?>, HttpHeaders> EXAMPLE_HTTP_HEADERS = ImmutableListMultimap.of(
-            HelloService.class, HttpHeaders.of(AsciiString.of("foobar"), "barbaz"),
-            FooService.class, HttpHeaders.of(AsciiString.of("barbaz"), "barbar"));
+    private static final ListMultimap<String, HttpHeaders> EXAMPLE_HTTP_HEADERS = ImmutableListMultimap.of(
+            HelloService.class.getName(), HttpHeaders.of(AsciiString.of("foobar"), "barbaz"),
+            FooService.class.getName(), HttpHeaders.of(AsciiString.of("barbaz"), "barbar"));
 
     @Override
     protected void configureServer(ServerBuilder sb) {
@@ -102,28 +102,29 @@ public class ThriftDocServiceTest extends AbstractServerTest {
         final List<Entry> entries = ImmutableList.of(
                 new EntryBuilder(HelloService.class)
                         .endpoint(new EndpointInfo("*", "/", "hello", BINARY, allThriftFormats))
-                        .exampleHttpHeaders(EXAMPLE_HTTP_HEADERS.get(HelloService.class))
+                        .exampleHttpHeaders(EXAMPLE_HTTP_HEADERS.get(HelloService.class.getName()))
                         .build(),
                 new EntryBuilder(SleepService.class)
                         .endpoint(new EndpointInfo("*", "/", "sleep", BINARY, allThriftFormats))
-                        .exampleHttpHeaders(EXAMPLE_HTTP_HEADERS.get(SleepService.class))
+                        .exampleHttpHeaders(EXAMPLE_HTTP_HEADERS.get(SleepService.class.getName()))
                         .build(),
                 new EntryBuilder(FooService.class)
                         .endpoint(new EndpointInfo("*", "/foo", "", COMPACT, ImmutableSet.of(COMPACT)))
-                        .exampleHttpHeaders(EXAMPLE_HTTP_HEADERS.get(FooService.class))
+                        .exampleHttpHeaders(EXAMPLE_HTTP_HEADERS.get(FooService.class.getName()))
                         .build(),
                 new EntryBuilder(Cassandra.class)
                         .endpoint(new EndpointInfo("*", "/cassandra", "", BINARY, ImmutableSet.of(BINARY)))
                         .endpoint(new EndpointInfo("*", "/cassandra/debug", "", TEXT, ImmutableSet.of(TEXT)))
-                        .exampleHttpHeaders(EXAMPLE_HTTP_HEADERS.get(Cassandra.class))
+                        .exampleHttpHeaders(EXAMPLE_HTTP_HEADERS.get(Cassandra.class.getName()))
                         .build(),
                 new EntryBuilder(Hbase.class)
                         .endpoint(new EndpointInfo("*", "/hbase", "", BINARY, allThriftFormats))
-                        .exampleHttpHeaders(EXAMPLE_HTTP_HEADERS.get(Hbase.class))
+                        .exampleHttpHeaders(EXAMPLE_HTTP_HEADERS.get(Hbase.class.getName()))
                         .build(),
                 new EntryBuilder(OnewayHelloService.class)
                         .endpoint(new EndpointInfo("*", "/oneway", "", BINARY, allThriftFormats))
-                        .exampleHttpHeaders(EXAMPLE_HTTP_HEADERS.get(OnewayHelloService.class))
+                        .exampleHttpHeaders(EXAMPLE_HTTP_HEADERS.get(
+                                OnewayHelloService.class.getName()))
                         .build());
 
         final ObjectMapper mapper = new ObjectMapper();

--- a/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftServiceSpecificationGeneratorTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftServiceSpecificationGeneratorTest.java
@@ -101,8 +101,8 @@ public class ThriftServiceSpecificationGeneratorTest {
 
         final ServiceSpecification specification = generator.generate(
                 ImmutableSet.of(helloService, fooService),
-                ImmutableMap.of(HelloService.class, ImmutableList.of(helloExampleHeaders),
-                                FooService.class,   ImmutableList.of(fooExampleHeaders)));
+                ImmutableMap.of(HelloService.class.getName(), ImmutableList.of(helloExampleHeaders),
+                                FooService.class.getName(),   ImmutableList.of(fooExampleHeaders)));
 
         final Map<String, ServiceInfo> services = specification.services();
         assertThat(services).containsOnlyKeys(HelloService.class.getName(), FooService.class.getName());


### PR DESCRIPTION
Not all RPC protocols have the concept of a class (in the end, RPC is just a bunch of methods) so this is more widely appliable.

Hmm - I was hoping to find a better "full service name" for a thrift service than the class canonical name. Any suggestion or does it look ok?