### PR TITLE
Fix DocService by handling Thrift typedefs as an UnresolvedClassInfo

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/docs/ClassInfo.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/ClassInfo.java
@@ -36,7 +36,12 @@ public interface ClassInfo extends TypeInfo {
      */
     @JsonProperty
     default String simpleName() {
-        return name().substring(name().lastIndexOf('.') + 1);
+        final int dotIdx = name().lastIndexOf('.');
+        if (dotIdx < 0) {
+            return name();
+        } else {
+            return name().substring(dotIdx + 1);
+        }
     }
 
     /**
@@ -44,7 +49,12 @@ public interface ClassInfo extends TypeInfo {
      */
     @JsonProperty
     default String packageName() {
-        return name().substring(0, name().lastIndexOf('.'));
+        final int dotIdx = name().lastIndexOf('.');
+        if (dotIdx < 0) {
+            return "";
+        } else {
+            return name().substring(0, dotIdx);
+        }
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/docs/UnresolvedClassInfo.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/UnresolvedClassInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 LINE Corporation
+ * Copyright 2017 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -18,7 +18,6 @@ package com.linecorp.armeria.server.docs;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -27,33 +26,34 @@ import javax.annotation.Nullable;
 import com.google.common.collect.ImmutableList;
 
 /**
- * Metadata about a struct type.
+ * Metadata about a struct type, an enum type or an exception whose exact type name or
+ * its {@link FieldInfo}s are not resolved.
  */
-public final class StructInfo implements ClassInfo {
+public final class UnresolvedClassInfo implements ClassInfo {
 
+    private final Type type;
     private final String name;
-    private final List<FieldInfo> fields;
     private final String docString;
 
     /**
      * Creates a new instance.
      */
-    public StructInfo(String name, Iterable<FieldInfo> fields) {
-        this(name, fields, null);
+    public UnresolvedClassInfo(Type type, String name) {
+        this(type, name, null);
     }
 
     /**
      * Creates a new instance.
      */
-    public StructInfo(String name, Iterable<FieldInfo> fields, @Nullable String docString) {
+    public UnresolvedClassInfo(Type type, String name, @Nullable String docString) {
+        this.type = requireNonNull(type, "type");
         this.name = requireNonNull(name, "name");
-        this.fields = ImmutableList.copyOf(requireNonNull(fields, "fields"));
         this.docString = docString;
     }
 
     @Override
     public Type type() {
-        return Type.STRUCT;
+        return type;
     }
 
     @Override
@@ -62,13 +62,18 @@ public final class StructInfo implements ClassInfo {
     }
 
     @Override
+    public String signature() {
+        return '?' + name;
+    }
+
+    @Override
     public List<FieldInfo> fields() {
-        return fields;
+        return ImmutableList.of();
     }
 
     @Override
     public List<Object> constants() {
-        return Collections.emptyList();
+        return ImmutableList.of();
     }
 
     @Override
@@ -86,13 +91,13 @@ public final class StructInfo implements ClassInfo {
             return false;
         }
 
-        final StructInfo that = (StructInfo) o;
-        return name.equals(that.name) && fields.equals(that.fields);
+        final UnresolvedClassInfo that = (UnresolvedClassInfo) o;
+        return type == that.type && name.equals(that.name);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(type(), name, fields);
+        return Objects.hash(type(), name);
     }
 
     @Override

--- a/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftServiceSpecificationGeneratorTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftServiceSpecificationGeneratorTest.java
@@ -67,7 +67,9 @@ import com.linecorp.armeria.server.docs.ServiceSpecification;
 import com.linecorp.armeria.server.docs.ServiceSpecificationGenerator;
 import com.linecorp.armeria.server.docs.SetInfo;
 import com.linecorp.armeria.server.docs.StructInfo;
+import com.linecorp.armeria.server.docs.Type;
 import com.linecorp.armeria.server.docs.TypeInfo;
+import com.linecorp.armeria.server.docs.UnresolvedClassInfo;
 import com.linecorp.armeria.service.test.thrift.main.FooEnum;
 import com.linecorp.armeria.service.test.thrift.main.FooService;
 import com.linecorp.armeria.service.test.thrift.main.FooService.bar3_args;
@@ -219,12 +221,25 @@ public class ThriftServiceSpecificationGeneratorTest {
 
         final FunctionInfo bar6 = functions.get("bar6");
         assertThat(bar6.parameters()).containsExactly(
-                new FieldInfo("foo1", FieldRequirement.DEFAULT, foo),
-                new FieldInfo("foo2", FieldRequirement.DEFAULT, new MapInfo(string, string)),
-                new FieldInfo("foo3", FieldRequirement.DEFAULT, new ListInfo(string)),
-                new FieldInfo("foo4", FieldRequirement.DEFAULT, new SetInfo(string)));
+                new FieldInfo("foo1", FieldRequirement.DEFAULT, TypeInfo.STRING),
+                new FieldInfo("foo2", FieldRequirement.DEFAULT,
+                              new UnresolvedClassInfo(Type.STRUCT, "TypedefedStruct")),
+                new FieldInfo("foo3", FieldRequirement.DEFAULT,
+                              new UnresolvedClassInfo(Type.ENUM, "TypedefedEnum")),
+                new FieldInfo("foo4", FieldRequirement.DEFAULT,
+                              new UnresolvedClassInfo(Type.MAP, "TypedefedMap")),
+                new FieldInfo("foo5", FieldRequirement.DEFAULT,
+                              new UnresolvedClassInfo(Type.LIST, "TypedefedList")),
+                new FieldInfo("foo6", FieldRequirement.DEFAULT,
+                              new UnresolvedClassInfo(Type.SET, "TypedefedSet")),
+                new FieldInfo("foo7", FieldRequirement.DEFAULT,
+                              new UnresolvedClassInfo(Type.LIST, "NestedTypedefedStructs")),
+                new FieldInfo("foo8", FieldRequirement.DEFAULT,
+                              new ListInfo(new ListInfo(
+                                      new UnresolvedClassInfo(Type.STRUCT, "TypedefedStruct")))));
+
         assertThat(bar6.returnTypeInfo()).isEqualTo(TypeInfo.VOID);
-        assertThat(bar6.exceptions()).hasSize(1);
+        assertThat(bar6.exceptions()).isEmpty();
         assertThat(bar6.sampleJsonRequest()).isEmpty();
 
         final List<HttpHeaders> exampleHttpHeaders = service.exampleHttpHeaders();
@@ -258,6 +273,8 @@ public class ThriftServiceSpecificationGeneratorTest {
         fields.add(new FieldInfo("mapVal", FieldRequirement.DEFAULT, new MapInfo(TypeInfo.STRING, fooEnum)));
         fields.add(new FieldInfo("setVal", FieldRequirement.DEFAULT, new SetInfo(union)));
         fields.add(new FieldInfo("listVal", FieldRequirement.DEFAULT, new ListInfo(TypeInfo.STRING)));
+        fields.add(new FieldInfo("selfRef", FieldRequirement.OPTIONAL,
+                                 new UnresolvedClassInfo(Type.STRUCT, FooStruct.class.getSimpleName())));
 
         final StructInfo fooStruct = newStructInfo(
                 new StructMetaData(TType.STRUCT, FooStruct.class), emptyMap());

--- a/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftServiceSpecificationGeneratorTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftServiceSpecificationGeneratorTest.java
@@ -179,7 +179,7 @@ public class ThriftServiceSpecificationGeneratorTest {
                                  ImmutableSet.of(ThriftSerializationFormats.BINARY)));
 
         final Map<String, FunctionInfo> functions = service.functions();
-        assertThat(functions).hasSize(5);
+        assertThat(functions).hasSize(6);
 
         final FunctionInfo bar1 = functions.get("bar1");
         assertThat(bar1.parameters()).isEmpty();
@@ -216,6 +216,16 @@ public class ThriftServiceSpecificationGeneratorTest {
         assertThat(bar5.returnTypeInfo()).isEqualTo(new MapInfo(string, foo));
         assertThat(bar5.exceptions()).hasSize(1);
         assertThat(bar5.sampleJsonRequest()).isEmpty();
+
+        final FunctionInfo bar6 = functions.get("bar6");
+        assertThat(bar6.parameters()).containsExactly(
+                new FieldInfo("foo1", FieldRequirement.DEFAULT, foo),
+                new FieldInfo("foo2", FieldRequirement.DEFAULT, new MapInfo(string, string)),
+                new FieldInfo("foo3", FieldRequirement.DEFAULT, new ListInfo(string)),
+                new FieldInfo("foo4", FieldRequirement.DEFAULT, new SetInfo(string)));
+        assertThat(bar6.returnTypeInfo()).isEqualTo(TypeInfo.VOID);
+        assertThat(bar6.exceptions()).hasSize(1);
+        assertThat(bar6.sampleJsonRequest()).isEmpty();
 
         final List<HttpHeaders> exampleHttpHeaders = service.exampleHttpHeaders();
         assertThat(exampleHttpHeaders).containsExactly(HttpHeaders.of(AsciiString.of("foobar"), "barbaz"));

--- a/thrift/src/test/thrift/main.thrift
+++ b/thrift/src/test/thrift/main.thrift
@@ -77,12 +77,16 @@ struct FooStruct {
     12: map<string, FooEnum> mapVal,
     13: set<FooUnion> setVal,
     14: list<string> listVal,
+    15: optional FooStruct selfRef
 }
 
+typedef string              TypedefedString
 typedef FooStruct           TypedefedStruct
+typedef FooEnum             TypedefedEnum
 typedef map<string, string> TypedefedMap
 typedef list<string>        TypedefedList
-typedef list<string>        TypedefedSet
+typedef set<string>         TypedefedSet
+typedef list<list<TypedefedStruct>> NestedTypedefedStructs
 
 service FooService {
     void bar1() throws (1: FooServiceException e),
@@ -90,8 +94,11 @@ service FooService {
     FooStruct bar3(1: i32 intVal, 2: FooStruct foo) throws (1: FooServiceException e),
     list<FooStruct> bar4(1: list<FooStruct> foos) throws (1: FooServiceException e),
     map<string, FooStruct> bar5(1: map<string, FooStruct> foos) throws (1: FooServiceException e),
-    void bar6(1: TypedefedStruct foo1, 2: TypedefedMap foo2, 3: TypedefedList foo3, 4: TypedefedSet foo4)
-        throws (1: FooServiceException e),
+
+    // To make sure typedefs are handled correctly.
+    void bar6(1: TypedefedString foo1, 2: TypedefedStruct foo2, 3: TypedefedEnum foo3,
+              4: TypedefedMap foo4, 5: TypedefedList foo5, 6: TypedefedSet foo6,
+              7: NestedTypedefedStructs foo7, 8: list<list<TypedefedStruct>> foo8)
 }
 
 // Tests Clients.newDerivedClient()

--- a/thrift/src/test/thrift/main.thrift
+++ b/thrift/src/test/thrift/main.thrift
@@ -79,12 +79,19 @@ struct FooStruct {
     14: list<string> listVal,
 }
 
+typedef FooStruct           TypedefedStruct
+typedef map<string, string> TypedefedMap
+typedef list<string>        TypedefedList
+typedef list<string>        TypedefedSet
+
 service FooService {
     void bar1() throws (1: FooServiceException e),
     string bar2() throws (1: FooServiceException e),
     FooStruct bar3(1: i32 intVal, 2: FooStruct foo) throws (1: FooServiceException e),
     list<FooStruct> bar4(1: list<FooStruct> foos) throws (1: FooServiceException e),
-    map<string, FooStruct> bar5(1: map<string, FooStruct> foos) throws (1: FooServiceException e)
+    map<string, FooStruct> bar5(1: map<string, FooStruct> foos) throws (1: FooServiceException e),
+    void bar6(1: TypedefedStruct foo1, 2: TypedefedMap foo2, 3: TypedefedList foo3, 4: TypedefedSet foo4)
+        throws (1: FooServiceException e),
 }
 
 // Tests Clients.newDerivedClient()


### PR DESCRIPTION
Motivation:

The FieldValueMetaData of a typedef'd field does not provide enough
information to infer its effective type. Translate typedef'd field into
a new type called UnresolvedClassInfo so that
ThriftServiceSpecificationGenerator does not fail at least.

Modifications:

- Add UnresolvedClassInfo
- Modify ThriftServiceSpecificationGenerator so that it does not fail on
  a typedef'd field
- Revise @imasahiro's test case to reflect the modification of
  ThriftServiceSpecificationGenerator

Result:

- DocService does not fail to start when typedef is used in .thrift
  files.
- Fixes #413