### PR TITLE
Return RequestContextAwareEventLoop itself for next()

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/RequestContextAwareEventLoop.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestContextAwareEventLoop.java
@@ -48,7 +48,7 @@ final class RequestContextAwareEventLoop extends RequestContextAwareExecutorServ
 
     @Override
     public EventLoop next() {
-        return delegate().next();
+        return this;
     }
 
     @Override


### PR DESCRIPTION
... to propagate current request context to next event loop

https://github.com/line/armeria/pull/364#discussion_r103172395
> Also, the next() actually loses the context (I guess it may be a bug in RequestContextAwareEventLoop where next() should wrap the result in a ContextAwareEventLoop);