### PR TITLE
Make header names case-insensitive

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/http/ArmeriaHttpUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/http/ArmeriaHttpUtil.java
@@ -72,7 +72,7 @@ import io.netty.util.HashingStrategy;
 public final class ArmeriaHttpUtil {
 
     /**
-     * The default case-sensitive {@link AsciiString} hasher and comparator for HTTP/2 headers.
+     * The default case-insensitive {@link AsciiString} hasher and comparator for HTTP/2 headers.
      */
     public static final HashingStrategy<AsciiString> HTTP2_HEADER_NAME_HASHER =
             new HashingStrategy<AsciiString>() {
@@ -83,7 +83,7 @@ public final class ArmeriaHttpUtil {
 
                 @Override
                 public boolean equals(AsciiString a, AsciiString b) {
-                    return a.equals(b);
+                    return a.contentEqualsIgnoreCase(b);
                 }
             };
 

--- a/core/src/test/java/com/linecorp/armeria/common/http/HttpHeadersTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/http/HttpHeadersTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.http;
+
+import static io.netty.util.AsciiString.of;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+import io.netty.util.AsciiString;
+
+public class HttpHeadersTest {
+
+    @Test
+    public void testCaseInsensitiveHeaderNames() throws Exception {
+        final HttpHeaders headers = HttpHeaders.of(of("header1"), "value1",
+                                                   of("HEADER2"), "value2",
+                                                   of("Header3"), "VALUE3");
+
+        assertThat(headers.get(of("HeAdEr1")), is("value1"));
+        assertThat(headers.get(of("header2")), is("value2"));
+        assertThat(headers.get(of("HEADER3")), is("VALUE3"));
+
+        assertThat(headers.names(), containsInAnyOrder(of("header1"), of("header2"), of("header3")));
+    }
+
+    @Test
+    public void testInvalidHeaderName() throws Exception {
+        assertThatThrownBy(() -> HttpHeaders.of((AsciiString) null, "value1"))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        assertThatThrownBy(() -> HttpHeaders.of(AsciiString.of(""), "value1"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}


### PR DESCRIPTION
Motivation:

HTTP/2 header field names are compared in case-insensitive fashion.

Modification:

- Make `HTTP2_HEADER_NAME_HASHER` case-insensitive
- Lowercase header name when adding new header

Result:

- Users do not worry case-sensitivity for header names