### PR TITLE
Use ipv4 addresses instead of ipv6 anycast in socket tests.

### DIFF
--- a/core/src/test/java-shared/com/linecorp/armeria/test/AbstractServerTest.java
+++ b/core/src/test/java-shared/com/linecorp/armeria/test/AbstractServerTest.java
@@ -19,6 +19,7 @@ import static com.linecorp.armeria.common.http.HttpSessionProtocols.HTTP;
 import static com.linecorp.armeria.common.http.HttpSessionProtocols.HTTPS;
 import static java.util.Objects.requireNonNull;
 
+import java.net.InetSocketAddress;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -119,6 +120,12 @@ public abstract class AbstractServerTest {
         }
 
         return "https://127.0.0.1:" + httpsPort + path;
+    }
+
+    protected static InetSocketAddress ipv4SocketAddress() {
+        return new InetSocketAddress(
+                "127.0.0.1",
+                server().activePort().get().localAddress().getPort());
     }
 
     private static void validatePath(String path) {

--- a/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
@@ -185,7 +185,7 @@ public class ServerTest extends AbstractServerTest {
     public void testIdleTimeoutByNoContentSent() throws Exception {
         try (Socket socket = new Socket()) {
             socket.setSoTimeout((int) (idleTimeoutMillis * 4));
-            socket.connect(server().activePort().get().localAddress());
+            socket.connect(ipv4SocketAddress());
             long connectedNanos = System.nanoTime();
             //read until EOF
             while (socket.getInputStream().read() != -1) {
@@ -201,7 +201,7 @@ public class ServerTest extends AbstractServerTest {
     public void testIdleTimeoutByContentSent() throws Exception {
         try (Socket socket = new Socket()) {
             socket.setSoTimeout((int) (idleTimeoutMillis * 4));
-            socket.connect(server().activePort().get().localAddress());
+            socket.connect(ipv4SocketAddress());
             PrintWriter outWriter = new PrintWriter(socket.getOutputStream(), false);
             outWriter.print("POST / HTTP/1.1\r\n");
             outWriter.print("Connection: Keep-Alive\r\n");
@@ -228,7 +228,7 @@ public class ServerTest extends AbstractServerTest {
     public void testBuggyService() throws Exception {
         try (Socket socket = new Socket()) {
             socket.setSoTimeout((int) (idleTimeoutMillis * 4));
-            socket.connect(server().activePort().get().localAddress());
+            socket.connect(ipv4SocketAddress());
             PrintWriter outWriter = new PrintWriter(socket.getOutputStream(), false);
 
             // Send a request to a buggy service whose invoke() raises an exception.
@@ -272,7 +272,7 @@ public class ServerTest extends AbstractServerTest {
 
         try (Socket socket = new Socket()) {
             socket.setSoTimeout((int) (idleTimeoutMillis * 4));
-            socket.connect(server().activePort().get().localAddress());
+            socket.connect(ipv4SocketAddress());
             PrintWriter outWriter = new PrintWriter(socket.getOutputStream(), false);
 
             outWriter.print(reqLine);


### PR DESCRIPTION
On Mac (at least my mac), the ipv6 lookups in ServerTest take a ridiculously long time (several seconds). Tests with a timeout less than that fail all the time. One alternative would be to raise the timeout, but there doesn't seem to be a real reason to use ipv6 so switched to using ipv4 addresses which resolve fast.

Result: Tests work on my mac, and ServerTest runs much faster than before.

Fixes #403 