### PR TITLE
Fix Javadoc generation failure

### DIFF
--- a/site/build.gradle
+++ b/site/build.gradle
@@ -83,6 +83,14 @@ task javadoc(type: Javadoc,
               'https://developers.google.com/protocol-buffers/docs/reference/java/',
               'https://people.apache.org/~thejas/thrift-0.9/javadoc/',
               'http://logback.qos.ch/apidocs/'
+
+        // Add --allow-script-in-comments if available (since 1.8.0_121)
+        try {
+            if (Class.forName('com.sun.tools.doclets.formats.html.ConfigurationImpl')
+                     .newInstance().optionLength('--allow-script-in-comments') > 0) {
+                addBooleanOption('-allow-script-in-comments').value = true
+            }
+        } catch (ignored) {}
     }
 }
 


### PR DESCRIPTION
Motivation:

'./gradlew site:javadoc' fails since JDK 1.8.0_121 because it does not
allow a `<script>` tag in `-bottom` option.

Modifications:

- Add the `--allow-script-in-comments` option if available so that
  Javadoc does not fail with the `<script>` tag in the `-bottom` option
  - Note that we add this option only for `site:javadoc`. Other modules
    will not add it for improved security.

Result:

- Build does not fail with JDK 1.8.0_121