### PR TITLE
Close all zookeeper connections opened in test code.

### DIFF
--- a/zookeeper/src/test/java/com/linecorp/armeria/client/zookeeper/TestBase.java
+++ b/zookeeper/src/test/java/com/linecorp/armeria/client/zookeeper/TestBase.java
@@ -15,8 +15,6 @@
  */
 package com.linecorp.armeria.client.zookeeper;
 
-import static org.junit.Assert.fail;
-
 import java.time.Duration;
 import java.util.Set;
 
@@ -41,7 +39,7 @@ public class TestBase {
     protected static final Set<Endpoint> sampleEndpoints = ImmutableSet.of(Endpoint.of("127.0.0.1", 1234, 2),
                                                                            Endpoint.of("127.0.0.1", 2345, 4),
                                                                            Endpoint.of("127.0.0.1", 3456, 2));
-    private static final Duration duration = Duration.ofSeconds(5);
+    private static final Duration duration = Duration.ofSeconds(10);
     @ClassRule
     public static final TemporaryFolder ROOT_FOLDER = new TemporaryFolder();
     private static ZKInstance zkInstance;
@@ -52,7 +50,7 @@ public class TestBase {
             zkInstance = ZKFactory.apply().withRootDir(ROOT_FOLDER.newFolder("zookeeper")).create();
             zkInstance.start().result(duration);
         } catch (Throwable throwable) {
-            fail();
+            throw new IllegalStateException(throwable);
         }
     }
 

--- a/zookeeper/src/test/java/com/linecorp/armeria/server/zookeeper/ZooKeeperRegistrationTest.java
+++ b/zookeeper/src/test/java/com/linecorp/armeria/server/zookeeper/ZooKeeperRegistrationTest.java
@@ -45,6 +45,7 @@ import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.http.AbstractHttpService;
 
 import junitextensions.OptionAssert;
+import zookeeperjunit.CloseableZooKeeper;
 import zookeeperjunit.ZooKeeperAssert;
 
 public class ZooKeeperRegistrationTest extends TestBase implements ZooKeeperAssert, OptionAssert {
@@ -86,7 +87,7 @@ public class ZooKeeperRegistrationTest extends TestBase implements ZooKeeperAsse
         //all servers start and with zNode created
         sampleEndpoints.forEach(
                 endpoint -> assertExists(zNode + '/' + endpoint.host() + '_' + endpoint.port()));
-        instance().connect().forEach(zkClient -> {
+        try (CloseableZooKeeper zkClient = connection()) {
             try {
                 sampleEndpoints.forEach(endpoint -> {
                     try {
@@ -113,7 +114,7 @@ public class ZooKeeperRegistrationTest extends TestBase implements ZooKeeperAsse
             } catch (Throwable throwable) {
                 fail(throwable.getMessage());
             }
-        });
+        }
     }
 
     @Test


### PR DESCRIPTION
Fixes #431 

This is an alternative to #432 which removes log spam from non-closed zookeeper clients by making sure to close all clients.

Additional changes:
- Raises the zookeeper startup timeout a little, it was too fast for my Mac
- Creates child node data persistently instead of ephemereally. This was probably intended, and only happened to work because the connection wasn't closed.
- Adds a sync after updating endpoints in zookeeper, the watcher would run too slow without it. I'm not sure if this is idiomatic.