### PR TITLE
Allow the lazy instantiation of Jetty SessionIdManager

### DIFF
--- a/jetty/src/main/java/com/linecorp/armeria/server/http/jetty/JettyService.java
+++ b/jetty/src/main/java/com/linecorp/armeria/server/http/jetty/JettyService.java
@@ -113,7 +113,8 @@ public final class JettyService implements HttpService {
 
             config.handler().ifPresent(server::setHandler);
             config.requestLog().ifPresent(server::setRequestLog);
-            config.sessionIdManager().ifPresent(server::setSessionIdManager);
+            config.sessionIdManagerFactory().ifPresent(
+                    factory -> server.setSessionIdManager(factory.apply(server)));
 
             config.handlerWrappers().forEach(server::insertHandler);
             config.attrs().forEach(server::setAttribute);


### PR DESCRIPTION
Motivation:

Since Jetty 9.4, DefaultSessionIdManager requires a Jetty Server
instance as a constructor parameter, which means a user cannot create it
until a Server instance is actually created. It is currently impossible
to achieve this with JettyService because JettyServiceBuilder requires
a SessionIdManager instance rather than its factory.

Modifications:

- Add JettyServiceBuilder.sessionIdManagerFactory() so that a user can
  create a SessionIdManager lazily

Result:

Better customizability of Jetty Server