### PR TITLE
Make the test coverage of SlidingWindowCounter consistent

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/SlidingWindowCounter.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/SlidingWindowCounter.java
@@ -88,7 +88,9 @@ final class SlidingWindowCounter implements EventCounter {
             event.increment(bucket);
             reservoir.offer(bucket);
             return Optional.empty();
-        } else if (tickerNanos < currentBucket.timestamp() + updateIntervalNanos) {
+        }
+
+        if (tickerNanos < currentBucket.timestamp() + updateIntervalNanos) {
             // increments the current bucket since it is exactly latest
             event.increment(currentBucket);
             return Optional.empty();

--- a/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/SlidingWindowCounterTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/SlidingWindowCounterTest.java
@@ -16,14 +16,14 @@
 
 package com.linecorp.armeria.client.circuitbreaker;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.junit.Test;
@@ -40,7 +40,7 @@ public class SlidingWindowCounterTest {
         SlidingWindowCounter counter = new SlidingWindowCounter(ticker, Duration.ofSeconds(10),
                                                                 Duration.ofSeconds(1));
 
-        assertThat(counter.count(), is(new EventCount(0, 0)));
+        assertThat(counter.count()).isEqualTo(new EventCount(0, 0));
     }
 
     @Test
@@ -48,12 +48,11 @@ public class SlidingWindowCounterTest {
         SlidingWindowCounter counter = new SlidingWindowCounter(ticker, Duration.ofSeconds(10),
                                                                 Duration.ofSeconds(1));
 
-        counter.onSuccess();
+        assertThat(counter.onSuccess()).isEmpty();
 
-        ticker.advance(Duration.ofSeconds(1).toNanos());
-        counter.onFailure();
-
-        assertThat(counter.count(), is(new EventCount(1, 0)));
+        ticker.advance(1, TimeUnit.SECONDS);
+        assertThat(counter.onFailure()).contains(new EventCount(1, 0));
+        assertThat(counter.count()).isEqualTo(new EventCount(1, 0));
     }
 
     @Test
@@ -61,12 +60,11 @@ public class SlidingWindowCounterTest {
         SlidingWindowCounter counter = new SlidingWindowCounter(ticker, Duration.ofSeconds(10),
                                                                 Duration.ofSeconds(1));
 
-        counter.onFailure();
+        assertThat(counter.onFailure()).isEmpty();
 
-        ticker.advance(Duration.ofSeconds(1).toNanos());
-        counter.onFailure();
-
-        assertThat(counter.count(), is(new EventCount(0, 1)));
+        ticker.advance(1, TimeUnit.SECONDS);
+        assertThat(counter.onFailure()).contains(new EventCount(0, 1));
+        assertThat(counter.count()).isEqualTo(new EventCount(0, 1));
     }
 
     @Test
@@ -74,18 +72,16 @@ public class SlidingWindowCounterTest {
         SlidingWindowCounter counter = new SlidingWindowCounter(ticker, Duration.ofSeconds(10),
                                                                 Duration.ofSeconds(1));
 
-        counter.onSuccess();
-        counter.onFailure();
+        assertThat(counter.onSuccess()).isEmpty();
+        assertThat(counter.onFailure()).isEmpty();
 
-        ticker.advance(Duration.ofSeconds(1).toNanos());
-        counter.onFailure();
+        ticker.advance(1, TimeUnit.SECONDS);
+        assertThat(counter.onFailure()).contains(new EventCount(1, 1));
+        assertThat(counter.count()).isEqualTo(new EventCount(1, 1));
 
-        assertThat(counter.count(), is(new EventCount(1, 1)));
-
-        ticker.advance(Duration.ofSeconds(11).toNanos());
-        counter.onFailure();
-
-        assertThat(counter.count(), is(new EventCount(0, 0)));
+        ticker.advance(11, TimeUnit.SECONDS);
+        assertThat(counter.onFailure()).contains(new EventCount(0, 0));
+        assertThat(counter.count()).isEqualTo(new EventCount(0, 0));
     }
 
     @Test
@@ -118,8 +114,6 @@ public class SlidingWindowCounterTest {
                         } else if (r > 0.2) {
                             counter.onFailure();
                             f++;
-                        } else {
-                            counter.count();
                         }
                     }
                     success.addAndGet(s);
@@ -138,8 +132,19 @@ public class SlidingWindowCounterTest {
         }
 
         Thread.sleep(Duration.ofMillis(10).toMillis());
-        counter.onFailure();
 
-        assertThat(counter.count(), is(new EventCount(success.get(), failure.get())));
+        assertThat(counter.onFailure()).isPresent();
+        assertThat(counter.count()).isEqualTo(new EventCount(success.get(), failure.get()));
     }
+
+    @Test
+    public void testLateBucket() {
+        SlidingWindowCounter counter = new SlidingWindowCounter(ticker, Duration.ofSeconds(10),
+                                                                Duration.ofSeconds(1));
+
+        ticker.advance(-1, TimeUnit.SECONDS);
+        assertThat(counter.onSuccess()).isEmpty();
+        assertThat(counter.count()).isEqualTo(new EventCount(0, 0));
+    }
+
 }


### PR DESCRIPTION
Motivation:

The test coverage of SlidingWindowCounter seems inconsistent because
SlidingWindowCounterTest does not test the case where ticker goes
backward explicitly.

Modifications:

- Add a test that reproduces the case where time ticker goes backward
- Migrate from Hamcrest to AssertJ

Result:

- More consistent test coverage value (CI will complain less.)