### PR TITLE
Add an HTTP content decoding client decorator.

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/http/encoding/DeflateStreamDecoderFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/http/encoding/DeflateStreamDecoderFactory.java
@@ -14,12 +14,22 @@
  * under the License.
  */
 
-package com.linecorp.armeria.server.http.encoding;
+package com.linecorp.armeria.client.http.encoding;
+
+import io.netty.handler.codec.compression.ZlibWrapper;
 
 /**
- * A type of HTTP encoding, which is usually included in accept-encoding and content-encoding headers.
+ * A {@link StreamDecoderFactory} which supports the 'deflate' encoding.
  */
-enum HttpEncodingType {
-    GZIP,
-    DEFLATE;
+public class DeflateStreamDecoderFactory implements StreamDecoderFactory {
+
+    @Override
+    public String encodingHeaderValue() {
+        return "deflate";
+    }
+
+    @Override
+    public StreamDecoder newDecoder() {
+        return new ZlibStreamDecoder(ZlibWrapper.ZLIB);
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/http/encoding/GzipStreamDecoderFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/http/encoding/GzipStreamDecoderFactory.java
@@ -14,12 +14,22 @@
  * under the License.
  */
 
-package com.linecorp.armeria.server.http.encoding;
+package com.linecorp.armeria.client.http.encoding;
+
+import io.netty.handler.codec.compression.ZlibWrapper;
 
 /**
- * A type of HTTP encoding, which is usually included in accept-encoding and content-encoding headers.
+ * A {@link StreamDecoderFactory} which supports the 'gzip' encoding.
  */
-enum HttpEncodingType {
-    GZIP,
-    DEFLATE;
+public class GzipStreamDecoderFactory implements StreamDecoderFactory {
+
+    @Override
+    public String encodingHeaderValue() {
+        return "gzip";
+    }
+
+    @Override
+    public StreamDecoder newDecoder() {
+        return new ZlibStreamDecoder(ZlibWrapper.GZIP);
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/http/encoding/HttpDecodedResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/client/http/encoding/HttpDecodedResponse.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.http.encoding;
+
+import java.util.Map;
+
+import org.reactivestreams.Subscriber;
+
+import com.google.common.base.Ascii;
+
+import com.linecorp.armeria.common.http.FilteredHttpResponse;
+import com.linecorp.armeria.common.http.HttpData;
+import com.linecorp.armeria.common.http.HttpHeaderNames;
+import com.linecorp.armeria.common.http.HttpHeaders;
+import com.linecorp.armeria.common.http.HttpObject;
+import com.linecorp.armeria.common.http.HttpResponse;
+import com.linecorp.armeria.common.http.HttpStatusClass;
+
+/**
+ * @ {@link FilteredHttpResponse} that applies HTTP decoding to {@link HttpObject}s as they are published.
+ */
+class HttpDecodedResponse extends FilteredHttpResponse {
+
+    private final Map<String, StreamDecoderFactory> availableDecoders;
+
+    private StreamDecoder responseDecoder;
+    private boolean headersReceived;
+
+    HttpDecodedResponse(HttpResponse delegate, Map<String, StreamDecoderFactory> availableDecoders) {
+        super(delegate);
+        this.availableDecoders = availableDecoders;
+    }
+
+    @Override
+    protected HttpObject filter(HttpObject obj) {
+        if (obj instanceof HttpHeaders) {
+            HttpHeaders headers = (HttpHeaders) obj;
+
+            // Skip informational headers.
+            if (headers.status().codeClass() == HttpStatusClass.INFORMATIONAL) {
+                return obj;
+            }
+
+            if (headersReceived) {
+                // Trailing headers, no modification.
+                return obj;
+            }
+            headersReceived = true;
+
+            String contentEncoding = headers.get(HttpHeaderNames.CONTENT_ENCODING);
+            if (contentEncoding != null) {
+                StreamDecoderFactory decoderFactory = availableDecoders.get(Ascii.toLowerCase(contentEncoding));
+                // If the server returned an encoding we don't support (shouldn't happen since we set
+                // Accept-Encoding), decoding will be skipped which is ok.
+                if (decoderFactory != null) {
+                    responseDecoder = decoderFactory.newDecoder();
+                }
+            }
+
+            return headers;
+        }
+
+        assert obj instanceof HttpData;
+
+        return responseDecoder != null ? responseDecoder.decode((HttpData) obj) : obj;
+    }
+
+    @Override
+    protected void beforeComplete(Subscriber<? super HttpObject> subscriber) {
+        HttpData lastData = responseDecoder.finish();
+        if (!lastData.isEmpty()) {
+            subscriber.onNext(lastData);
+        }
+    }
+
+    @Override
+    protected void beforeError(Subscriber<? super HttpObject> subscriber, Throwable cause) {
+        responseDecoder.finish();
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/client/http/encoding/HttpDecodedResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/client/http/encoding/HttpDecodedResponse.java
@@ -31,7 +31,7 @@ import com.linecorp.armeria.common.http.HttpResponse;
 import com.linecorp.armeria.common.http.HttpStatusClass;
 
 /**
- * @ {@link FilteredHttpResponse} that applies HTTP decoding to {@link HttpObject}s as they are published.
+ * A {@link FilteredHttpResponse} that applies HTTP decoding to {@link HttpObject}s as they are published.
  */
 class HttpDecodedResponse extends FilteredHttpResponse {
 

--- a/core/src/main/java/com/linecorp/armeria/client/http/encoding/HttpDecodingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/http/encoding/HttpDecodingClient.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.http.encoding;
+
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+
+import java.util.Map;
+import java.util.function.Function;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Streams;
+
+import com.linecorp.armeria.client.Client;
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.DecoratingClient;
+import com.linecorp.armeria.common.http.HttpHeaderNames;
+import com.linecorp.armeria.common.http.HttpRequest;
+import com.linecorp.armeria.common.http.HttpResponse;
+
+/**
+ * A {@link DecoratingClient} that requests and decodes HTTP encoding (e.g., gzip) that has been applied to the
+ * content of a {@link HttpResponse}.
+ */
+public final class HttpDecodingClient
+        extends DecoratingClient<HttpRequest, HttpResponse, HttpRequest, HttpResponse> {
+
+    /**
+     * Creates a new {@link HttpDecodingClient} decorator with the default encodings of 'gzip' and 'deflate'.
+     */
+    public static Function<Client<HttpRequest, HttpResponse>, HttpDecodingClient> newDecorator() {
+        return client -> new HttpDecodingClient(client, ImmutableList.of(
+                new GzipStreamDecoderFactory(),
+                new DeflateStreamDecoderFactory()));
+    }
+
+    /**
+     * Creates a new {@link HttpDecodingClient} decorator with the specified {@link StreamDecoderFactory}s.
+     */
+    public static Function<Client<HttpRequest, HttpResponse>, HttpDecodingClient> newDecorator(
+            StreamDecoderFactory... decoderFactories) {
+        return client -> new HttpDecodingClient(client, ImmutableList.copyOf(decoderFactories));
+    }
+
+    /**
+     * Creates a new {@link HttpDecodingClient} decorator with the specified {@link StreamDecoderFactory}s.
+     */
+    public static Function<Client<HttpRequest, HttpResponse>, HttpDecodingClient> newDecorator(
+            Iterable<? extends StreamDecoderFactory> decoderFactories) {
+        return client -> new HttpDecodingClient(client, decoderFactories);
+    }
+
+    private final Map<String, StreamDecoderFactory> decoderFactories;
+    private final String acceptEncodingHeader;
+
+    /**
+     * Creates a new instance that decorates the specified {@link Client} with the provided decoders.
+     */
+    private HttpDecodingClient(
+            Client<? super HttpRequest, ? extends HttpResponse> delegate,
+            Iterable<? extends StreamDecoderFactory> decoderFactories) {
+        super(delegate);
+        this.decoderFactories = Streams.stream(decoderFactories)
+                                       .collect(toImmutableMap(StreamDecoderFactory::encodingHeaderValue,
+                                                               Function.identity()));
+        acceptEncodingHeader = String.join(",", this.decoderFactories.keySet());
+    }
+
+    @Override
+    public HttpResponse execute(ClientRequestContext ctx, HttpRequest req) throws Exception {
+        if (req.headers().contains(HttpHeaderNames.ACCEPT_ENCODING)) {
+            // Client specified encoding, so we don't do anything automatically.
+            return delegate().execute(ctx, req);
+        }
+        req.headers().set(HttpHeaderNames.ACCEPT_ENCODING, acceptEncodingHeader);
+        HttpResponse res = delegate().execute(ctx, req);
+        return new HttpDecodedResponse(res, decoderFactories);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/client/http/encoding/StreamDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/http/encoding/StreamDecoder.java
@@ -14,12 +14,23 @@
  * under the License.
  */
 
-package com.linecorp.armeria.server.http.encoding;
+package com.linecorp.armeria.client.http.encoding;
+
+import com.linecorp.armeria.common.http.HttpData;
 
 /**
- * A type of HTTP encoding, which is usually included in accept-encoding and content-encoding headers.
+ * An interface for objects that apply HTTP content decoding to incoming {@link HttpData}.
+ * Implement this interface to use content decoding schemes not built-in to the JDK.
  */
-enum HttpEncodingType {
-    GZIP,
-    DEFLATE;
+public interface StreamDecoder {
+
+    /**
+     * Decodes an {@link HttpData} and returns the decoded {@link HttpData}.
+     */
+    HttpData decode(HttpData obj);
+
+    /**
+     * Close the decoder and returns any decoded data that may be left over.
+     */
+    HttpData finish();
 }

--- a/core/src/main/java/com/linecorp/armeria/client/http/encoding/StreamDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/http/encoding/StreamDecoder.java
@@ -30,7 +30,7 @@ public interface StreamDecoder {
     HttpData decode(HttpData obj);
 
     /**
-     * Close the decoder and returns any decoded data that may be left over.
+     * Closes the decoder and returns any decoded data that may be left over.
      */
     HttpData finish();
 }

--- a/core/src/main/java/com/linecorp/armeria/client/http/encoding/StreamDecoderFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/http/encoding/StreamDecoderFactory.java
@@ -14,12 +14,22 @@
  * under the License.
  */
 
-package com.linecorp.armeria.server.http.encoding;
+package com.linecorp.armeria.client.http.encoding;
 
 /**
- * A type of HTTP encoding, which is usually included in accept-encoding and content-encoding headers.
+ * An interface that constructs a new {@link StreamDecoder} for a given Content-Encoding header value.
+ * A new decoder is valid for the lifetime of an {@link com.linecorp.armeria.common.http.HttpResponse}.
  */
-enum HttpEncodingType {
-    GZIP,
-    DEFLATE;
+public interface StreamDecoderFactory {
+
+    /**
+     * Returns the value of the Content-Encoding header which this factory applies to.
+     */
+    String encodingHeaderValue();
+
+    /**
+     * Construct a new {@link StreamDecoder} to use to decode an
+     * {@link com.linecorp.armeria.common.http.HttpResponse}.
+     */
+    StreamDecoder newDecoder();
 }

--- a/core/src/main/java/com/linecorp/armeria/client/http/encoding/ZlibStreamDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/http/encoding/ZlibStreamDecoder.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.http.encoding;
+
+import com.linecorp.armeria.common.http.HttpData;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.CompositeByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.compression.ZlibCodecFactory;
+import io.netty.handler.codec.compression.ZlibWrapper;
+
+/**
+ * A {@link StreamDecoder} that user zlib ('gzip' or 'deflate'). Netty implementation used to allow
+ * for incremental decoding using an {@link EmbeddedChannel}.
+ */
+class ZlibStreamDecoder implements StreamDecoder {
+
+    private final EmbeddedChannel decoder;
+
+    ZlibStreamDecoder(ZlibWrapper zlibWrapper) {
+        decoder = new EmbeddedChannel(false, ZlibCodecFactory.newZlibDecoder(zlibWrapper));
+    }
+
+    @Override
+    public HttpData decode(HttpData obj) {
+        ByteBuf compressed = Unpooled.wrappedBuffer(obj.array(), obj.offset(), obj.length());
+        decoder.writeInbound(compressed);
+        return HttpData.of(fetchDecoderOutput());
+    }
+
+    @Override
+    public HttpData finish() {
+        if (decoder.finish()) {
+            return HttpData.of(fetchDecoderOutput());
+        } else {
+            return HttpData.EMPTY_DATA;
+        }
+    }
+
+    // Mostly copied from netty's HttpContentDecoder.
+    private byte[] fetchDecoderOutput() {
+        CompositeByteBuf decoded = Unpooled.compositeBuffer();
+        for (;;) {
+            ByteBuf buf = decoder.readInbound();
+            if (buf == null) {
+                break;
+            }
+            if (!buf.isReadable()) {
+                buf.release();
+                continue;
+            }
+            decoded.addComponent(true, buf);
+        }
+        byte[] ret = ByteBufUtil.getBytes(decoded);
+        decoded.release();
+        return ret;
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/client/http/encoding/package-info.java
+++ b/core/src/main/java/com/linecorp/armeria/client/http/encoding/package-info.java
@@ -14,12 +14,7 @@
  * under the License.
  */
 
-package com.linecorp.armeria.server.http.encoding;
-
 /**
- * A type of HTTP encoding, which is usually included in accept-encoding and content-encoding headers.
+ * HTTP content decoding client.
  */
-enum HttpEncodingType {
-    GZIP,
-    DEFLATE;
-}
+package com.linecorp.armeria.client.http.encoding;


### PR DESCRIPTION
Fixes #444 

TBH, I have no idea what an EmbeddedChannel does, but I found it in Netty while looking for a solution for incremental decoding and it seems to work. Let me know if this is a bad idea. If it is, I can't find another way than collecting all the response bytes before decoding, disabling streaming functionality.

Also went ahead and made the compression algorithm extensible, can apply something similar to the server-side at some point.

Extra change: add a missing copyright header.