### PR TITLE
Add MediaTypeSet and handle 'accept' header properly in THttpService

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/MediaTypeSet.java
+++ b/core/src/main/java/com/linecorp/armeria/common/MediaTypeSet.java
@@ -1,0 +1,384 @@
+/*
+ *  Copyright 2017 LINE Corporation
+ *
+ *  LINE Corporation licenses this file to you under the Apache License,
+ *  version 2.0 (the "License"); you may not use this file except in compliance
+ *  with the License. You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations
+ *  under the License.
+ */
+package com.linecorp.armeria.common;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+import java.util.AbstractSet;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.Set;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Ascii;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterators;
+
+/**
+ * An immutable {@link Set} of {@link MediaType}s which provides useful methods for content negotiation.
+ *
+ * <p>This {@link Set} provides {@link #match(MediaType...)} and {@link #matchHeaders(CharSequence...)}
+ * so that a user can find the preferred {@link MediaType} that matches the specified media ranges. For example:
+ * <pre>{@code
+ * MediaTypeSet set = new MediaTypeSet(MediaType.HTML_UTF_8, MediaType.PLAIN_TEXT_UTF_8);
+ *
+ * Optional<MediaType> negotiated1 = set.matchHeaders("text/html; q=0.5, text/plain");
+ * assert negotiated1.isPresent();
+ * assert negotiated1.get().equals(MediaType.PLAIN_TEXT_UTF_8);
+ *
+ * Optional<MediaType> negotiated2 = set.matchHeaders("audio/*, text/*");
+ * assert negotiated2.isPresent();
+ * assert negotiated2.get().equals(MediaType.HTML_UTF_8);
+ *
+ * Optional<MediaType> negotiated3 = set.matchHeaders("video/webm");
+ * assert !negotiated3.isPresent();
+ * }</pre>
+ */
+public final class MediaTypeSet extends AbstractSet<MediaType> {
+
+    private static final String WILDCARD = MediaType.ANY_TYPE.type();
+    private static final String Q = "q";
+
+    private final MediaType[] mediaTypes;
+
+    /**
+     * Creates a new instance.
+     */
+    public MediaTypeSet(MediaType... mediaTypes) {
+        this(ImmutableList.copyOf(requireNonNull(mediaTypes, "mediaTypes")));
+    }
+
+    /**
+     * Creates a new instance.
+     */
+    public MediaTypeSet(Iterable<MediaType> mediaTypes) {
+        final Set<MediaType> mediaTypesCopy = new LinkedHashSet<>(); // Using a Set to deduplicate
+        for (MediaType mediaType : requireNonNull(mediaTypes, "mediaTypes")) {
+            requireNonNull(mediaType, "mediaTypes contains null.");
+            checkArgument(!mediaType.hasWildcard(),
+                          "mediaTypes contains a wildcard media type: %s", mediaType);
+
+            // Ensure qvalue does not exists.
+            final List<String> otherQValues = mediaType.parameters().get(Q);
+            checkArgument(otherQValues == null || otherQValues.isEmpty(),
+                          "mediaTypes contains a media type with a q-value parameter: %s", mediaType);
+
+            mediaTypesCopy.add(mediaType);
+        }
+
+        this.mediaTypes = mediaTypesCopy.toArray(new MediaType[mediaTypesCopy.size()]);
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        if (!(o instanceof MediaType)) {
+            return false;
+        }
+
+        for (MediaType e : mediaTypes) {
+            if (e.equals(o)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    @Override
+    public Iterator<MediaType> iterator() {
+        return Iterators.forArray(mediaTypes);
+    }
+
+    @Override
+    public int size() {
+        return mediaTypes.length;
+    }
+
+    /**
+     * Finds the {@link MediaType} in this {@link List} that matches one of the media ranges specified in the
+     * specified string.
+     *
+     * @param acceptHeaders the values of the {@code "accept"} header, as defined in
+     *        <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html">the section 14.1, RFC2616</a>
+     * @return the most preferred {@link MediaType} that matches one of the specified media ranges.
+     *         {@link Optional#empty()} if there are no matches or {@code acceptHeaders} does not contain
+     *         any valid ranges.
+     */
+    public Optional<MediaType> matchHeaders(Iterable<? extends CharSequence> acceptHeaders) {
+        requireNonNull(acceptHeaders, "acceptHeaders");
+
+        final List<MediaType> ranges = new ArrayList<>(4);
+        for (CharSequence acceptHeader : acceptHeaders) {
+            addRanges(ranges, acceptHeader);
+        }
+        return match(ranges);
+    }
+
+    /**
+     * Finds the {@link MediaType} in this {@link List} that matches one of the media ranges specified in the
+     * specified string.
+     *
+     * @param acceptHeaders the values of the {@code "accept"} header, as defined in
+     *        <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html">the section 14.1, RFC2616</a>
+     * @return the most preferred {@link MediaType} that matches one of the specified media ranges.
+     *         {@link Optional#empty()} if there are no matches or {@code acceptHeaders} does not contain
+     *         any valid ranges.
+     */
+    public Optional<MediaType> matchHeaders(CharSequence... acceptHeaders) {
+        requireNonNull(acceptHeaders, "acceptHeaders");
+
+        final List<MediaType> ranges = new ArrayList<>(4);
+        for (CharSequence acceptHeader : acceptHeaders) {
+            addRanges(ranges, acceptHeader);
+        }
+        return match(ranges);
+    }
+
+    /**
+     * Finds the {@link MediaType} in this {@link List} that matches one of the specified media ranges.
+     *
+     * @return the most preferred {@link MediaType} that matches one of the specified media ranges.
+     *         {@link Optional#empty()} if there are no matches or {@code ranges} does not contain
+     *         any valid ranges.
+     */
+    public Optional<MediaType> match(MediaType... ranges) {
+        return match(Arrays.asList(requireNonNull(ranges, "ranges")));
+    }
+
+    /**
+     * Finds the {@link MediaType} in this {@link List} that matches one of the specified media ranges.
+     *
+     * @return the most preferred {@link MediaType} that matches one of the specified media ranges.
+     *         {@link Optional#empty()} if there are no matches or {@code ranges} does not contain
+     *         any valid ranges.
+     */
+    public Optional<MediaType> match(Iterable<MediaType> ranges) {
+        requireNonNull(ranges, "ranges");
+
+        MediaType match = null;
+        float matchQ = Float.NEGATIVE_INFINITY;    // higher = better
+        int matchNumWildcards = Integer.MAX_VALUE; // lower = better
+        int matchNumParams = Integer.MIN_VALUE;    // higher = better
+        for (MediaType range : ranges) {
+            requireNonNull(range, "ranges contains null.");
+            for (MediaType candidate : mediaTypes) {
+                if (!matches(range, candidate)) {
+                    continue;
+                }
+
+                float qValue = qValue(range);
+                final int numWildcards = numWildcards(range);
+                final int numParams;
+                if (qValue < 0) {
+                    // qvalue does not exist; use the default value of 1.0.
+                    qValue = 1.0f;
+                    numParams = range.parameters().size();
+                } else {
+                    // Do not count the qvalue.
+                    numParams = range.parameters().size() - 1;
+                }
+
+                final boolean isBetter;
+                if (qValue > matchQ) {
+                    isBetter = true;
+                } else if (Math.copySign(qValue - matchQ, 1.0f) <= 0.0001f) {
+                    if (matchNumWildcards > numWildcards) {
+                        isBetter = true;
+                    } else if (matchNumWildcards == numWildcards) {
+                        isBetter = numParams > matchNumParams;
+                    } else {
+                        isBetter = false;
+                    }
+                } else {
+                    isBetter = false;
+                }
+
+                if (isBetter) {
+                    match = candidate;
+                    matchQ = qValue;
+                    matchNumWildcards = numWildcards;
+                    matchNumParams = numParams;
+                }
+            }
+        }
+
+        return Optional.ofNullable(match);
+    }
+
+    private static boolean matches(MediaType range, MediaType candidate) {
+        // Similar to what MediaType.is(MediaType) does except that this one
+        // compares the parameters case-insensitively and excludes 'q' parameter.
+        return (WILDCARD.equals(range.type()) || range.type().equals(candidate.type())) &&
+               (WILDCARD.equals(range.subtype()) || range.subtype().equals(candidate.subtype())) &&
+               containsAllParameters(range.parameters(), candidate.parameters());
+    }
+
+    private static boolean containsAllParameters(Map<String, List<String>> requiredParameters,
+                                                 Map<String, List<String>> actualParameters) {
+        if (requiredParameters.isEmpty()) {
+            return true;
+        }
+
+        for (Entry<String, List<String>> requiredEntry : requiredParameters.entrySet()) {
+            final String requiredName = requiredEntry.getKey();
+            final List<String> requiredValues = requiredEntry.getValue();
+            if (Q.equals(requiredName)) {
+                continue;
+            }
+
+            final List<String> actualValues = actualParameters.get(requiredName);
+
+            assert !requiredValues.isEmpty();
+            if (actualValues == null || actualValues.isEmpty()) {
+                // Does not contain any required values.
+                return false;
+            }
+
+            if (!containsAllRequiredValues(requiredValues, actualValues)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static boolean containsAllRequiredValues(List<String> requiredValues, List<String> actualValues) {
+        final int numRequiredValues = requiredValues.size();
+        for (int i = 0; i < numRequiredValues; i++) {
+            if (!containsRequiredValue(requiredValues.get(i), actualValues)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean containsRequiredValue(String requiredValue, List<String> actualValues) {
+        final int numActualValues = actualValues.size();
+        for (int i = 0; i < numActualValues; i++) {
+            if (Ascii.equalsIgnoreCase(requiredValue, actualValues.get(i))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static float qValue(MediaType range) {
+        // Find 'q' or 'Q'.
+        final List<String> qValues = range.parameters().get(Q);
+        if (qValues == null || qValues.isEmpty()) {
+            // qvalue does not exist.
+            return Float.NEGATIVE_INFINITY;
+        }
+
+        try {
+            // Parse the qvalue. Make sure it's within the range of [0, 1].
+            return Math.max(Math.min(Float.parseFloat(qValues.get(0)), 1.0f), 0.0f);
+        } catch (NumberFormatException e) {
+            // The range with a malformed qvalue gets the lowest possible preference.
+            return 0.0f;
+        }
+    }
+
+    private static int numWildcards(MediaType candidate) {
+        int numWildcards = 0;
+        if (WILDCARD.equals(candidate.type())) {
+            numWildcards++;
+        }
+        if (WILDCARD.equals(candidate.subtype())) {
+            numWildcards++;
+        }
+        return numWildcards;
+    }
+
+    private static final int ST_SKIP_LEADING_WHITESPACES = 0;
+    private static final int ST_READ_QDTEXT = 1;
+    private static final int ST_READ_QUOTED_STRING = 2;
+    private static final int ST_READ_QUOTED_STRING_ESCAPED = 3;
+
+    @VisibleForTesting
+    @SuppressWarnings("checkstyle:FallThrough")
+    static void addRanges(List<MediaType> ranges, CharSequence header) {
+        final int length = header.length();
+        int state = ST_SKIP_LEADING_WHITESPACES;
+        int firstCharIdx = 0;
+        int lastCharIdx = -1;
+        for (int i = 0; i < length; i++) {
+            final char ch = header.charAt(i);
+            switch (state) {
+                case ST_SKIP_LEADING_WHITESPACES:
+                    if (!Character.isWhitespace(ch)) {
+                        state = ST_READ_QDTEXT;
+                        firstCharIdx = i;
+                        lastCharIdx = -1;
+                    } else {
+                        break;
+                    }
+                case ST_READ_QDTEXT:
+                    if (Character.isWhitespace(ch)) {
+                        break;
+                    }
+                    switch (ch) {
+                        case '"':
+                            state = ST_READ_QUOTED_STRING;
+                            break;
+                        case ',':
+                            addRange(ranges, header, firstCharIdx, lastCharIdx);
+                            state = ST_SKIP_LEADING_WHITESPACES;
+                            break;
+                        default:
+                            lastCharIdx = i;
+                    }
+                    break;
+                case ST_READ_QUOTED_STRING:
+                    switch (ch) {
+                        case '\\':
+                            state = ST_READ_QUOTED_STRING_ESCAPED;
+                            break;
+                        case '"':
+                            state = ST_READ_QDTEXT;
+                            lastCharIdx = i;
+                            break;
+                    }
+                    break;
+                case ST_READ_QUOTED_STRING_ESCAPED:
+                    state = ST_READ_QUOTED_STRING;
+                    break;
+            }
+        }
+
+        if (state == ST_READ_QDTEXT) {
+            addRange(ranges, header, firstCharIdx, lastCharIdx);
+        }
+    }
+
+    private static void addRange(
+            List<MediaType> ranges, CharSequence header, int firstCharIdx, int lastCharIdx) {
+        if (lastCharIdx >= 0) {
+            try {
+                ranges.add(MediaType.parse(header.subSequence(firstCharIdx, lastCharIdx + 1).toString()));
+            } catch (IllegalArgumentException e) {
+                // Ignore the malformed media range.
+            }
+        }
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/common/SerializationFormatProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/common/SerializationFormatProvider.java
@@ -22,7 +22,7 @@ import java.util.Set;
 
 import com.google.common.base.Ascii;
 import com.google.common.base.MoreObjects;
-import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableList;
 
 /**
  * Registers the {@link SerializationFormat}s dynamically via Java SPI (Service Provider Interface).
@@ -40,7 +40,7 @@ public abstract class SerializationFormatProvider {
     protected static final class Entry implements Comparable<Entry> {
         final String uriText;
         final MediaType primaryMediaType;
-        final Set<MediaType> allMediaTypes;
+        final MediaTypeSet mediaTypes;
 
         /**
          * Creates a new instance.
@@ -48,9 +48,10 @@ public abstract class SerializationFormatProvider {
         public Entry(String uriText, MediaType primaryMediaType, MediaType... alternativeMediaTypes) {
             this.uriText = Ascii.toLowerCase(requireNonNull(uriText, "uriText"));
             this.primaryMediaType = requireNonNull(primaryMediaType, "primaryMediaType");
-            allMediaTypes = ImmutableSet.<MediaType>builder()
+            mediaTypes = new MediaTypeSet(ImmutableList.<MediaType>builder()
                     .add(primaryMediaType)
-                    .add(requireNonNull(alternativeMediaTypes, "alternativeMediaTypes")).build();
+                    .add(requireNonNull(alternativeMediaTypes, "alternativeMediaTypes"))
+                    .build());
         }
 
         @Override
@@ -75,7 +76,7 @@ public abstract class SerializationFormatProvider {
         public String toString() {
             return MoreObjects.toStringHelper(this)
                               .add("uriText", uriText)
-                              .add("mediaTypes", allMediaTypes).toString();
+                              .add("mediaTypes", mediaTypes).toString();
         }
 
         @Override

--- a/core/src/test/java/com/linecorp/armeria/common/MediaTypeSetTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/MediaTypeSetTest.java
@@ -1,0 +1,171 @@
+/*
+ *  Copyright 2017 LINE Corporation
+ *
+ *  LINE Corporation licenses this file to you under the Apache License,
+ *  version 2.0 (the "License"); you may not use this file except in compliance
+ *  with the License. You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package com.linecorp.armeria.common;
+
+import static com.linecorp.armeria.common.MediaType.ANY_AUDIO_TYPE;
+import static com.linecorp.armeria.common.MediaType.ANY_TYPE;
+import static com.linecorp.armeria.common.MediaType.HTML_UTF_8;
+import static com.linecorp.armeria.common.MediaType.PLAIN_TEXT_UTF_8;
+import static com.linecorp.armeria.common.MediaType.WEBM_VIDEO;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+
+public class MediaTypeSetTest {
+
+    @Test
+    public void getters() {
+        final MediaTypeSet set = new MediaTypeSet(HTML_UTF_8, PLAIN_TEXT_UTF_8);
+        assertThat(set).containsOnly(HTML_UTF_8, PLAIN_TEXT_UTF_8).hasSize(2);
+    }
+
+    @Test
+    public void matchList() {
+        final MediaTypeSet set = new MediaTypeSet(HTML_UTF_8, PLAIN_TEXT_UTF_8);
+
+        // No ranges
+        assertThat(set.match(ImmutableList.of())).isEmpty();
+
+        // More than one range
+        assertThat(set.match(HTML_UTF_8.withParameter("q", "0.5"), PLAIN_TEXT_UTF_8))
+                .contains(PLAIN_TEXT_UTF_8);
+
+        // Wildcard match
+        assertThat(set.match(ANY_AUDIO_TYPE, ANY_TYPE)).contains(HTML_UTF_8);
+
+        // No matches
+        assertThat(set.match(WEBM_VIDEO)).isEmpty();
+    }
+
+    @Test
+    public void matchHeaders() {
+        final MediaTypeSet set = new MediaTypeSet(HTML_UTF_8, PLAIN_TEXT_UTF_8);
+
+        // No ranges
+        assertThat(set.matchHeaders()).isEmpty();
+        assertThat(set.matchHeaders("")).isEmpty();
+        assertThat(set.matchHeaders(ImmutableList.of())).isEmpty();
+
+        // More than one range
+        assertThat(set.matchHeaders("text/html; q=0.5, text/plain")).contains(PLAIN_TEXT_UTF_8);
+        assertThat(set.matchHeaders(ImmutableList.of("text/html, text/plain; q=0.5")))
+                .contains(HTML_UTF_8);
+
+        // Wildcard match
+        assertThat(set.matchHeaders("audio/*, */*")).contains(HTML_UTF_8);
+
+        // No matches
+        assertThat(set.matchHeaders("video/webm")).isEmpty();
+    }
+
+    @Test
+    public void moreSpecificRangeWins() {
+        final MediaType HTML_UTF_8_LEVEL_1 = HTML_UTF_8.withParameter("level", "1");
+        final MediaTypeSet set = new MediaTypeSet(WEBM_VIDEO,
+                                                  PLAIN_TEXT_UTF_8,
+                                                  HTML_UTF_8,
+                                                  HTML_UTF_8_LEVEL_1);
+
+        assertThat(set.matchHeaders("*/*")).contains(WEBM_VIDEO);
+        assertThat(set.matchHeaders("*/*, text/*")).contains(PLAIN_TEXT_UTF_8);
+        assertThat(set.matchHeaders("text/*, text/html")).contains(HTML_UTF_8);
+        assertThat(set.matchHeaders("text/html, text/html; level=0")).contains(HTML_UTF_8);
+        assertThat(set.matchHeaders("text/html, text/html; level=1")).contains(HTML_UTF_8_LEVEL_1);
+    }
+
+    @Test
+    public void invalidRange() {
+        final MediaTypeSet set = new MediaTypeSet(HTML_UTF_8);
+        assertThat(set.matchHeaders("foo, */*")).contains(HTML_UTF_8);
+    }
+
+    @Test
+    public void invalidQValue() {
+        final MediaTypeSet set = new MediaTypeSet(HTML_UTF_8, PLAIN_TEXT_UTF_8);
+
+        // A bad qvalue is interpreted as 0.
+        assertThat(set.matchHeaders("text/*; q=bad, text/plain; q=0.5")).contains(PLAIN_TEXT_UTF_8);
+    }
+
+    @Test
+    public void parameterMatching() {
+        final MediaType HTML_US_ASCII = HTML_UTF_8.withCharset(StandardCharsets.US_ASCII);
+        final MediaTypeSet set = new MediaTypeSet(HTML_UTF_8, HTML_US_ASCII);
+
+        assertThat(set.matchHeaders("*/*")).contains(HTML_UTF_8);
+
+        // Parameter requirement must be respected.
+        assertThat(set.matchHeaders("*/*; charset=UTF-8")).contains(HTML_UTF_8);
+        assertThat(set.matchHeaders("*/*; charset=US-ASCII")).contains(HTML_US_ASCII);
+
+        // Case-insensitive comparison
+        assertThat(set.matchHeaders("*/*; charset=utf-8")).contains(HTML_UTF_8);
+        assertThat(set.matchHeaders("*/*; charset=us-ascii")).contains(HTML_US_ASCII);
+
+        // Parameter requirements did not meet.
+        assertThat(set.matchHeaders("*/*; charset=UTF-8; mode=foo")).isEmpty();
+    }
+
+    @Test
+    public void testAddRanges() {
+        List<MediaType> ranges = new ArrayList<>();
+
+        // Single element without whitespaces
+        MediaTypeSet.addRanges(ranges, "text/plain");
+        assertThat(ranges).containsExactly(MediaType.parse("text/plain"));
+        ranges.clear();
+
+        // Multiple elements without whitespaces
+        MediaTypeSet.addRanges(ranges, "text/plain,text/html");
+        assertThat(ranges).containsExactly(MediaType.parse("text/plain"),
+                                           MediaType.parse("text/html"));
+        ranges.clear();
+
+        // Single element with whitespaces
+        MediaTypeSet.addRanges(ranges, " text/plain ");
+        assertThat(ranges).containsExactly(MediaType.parse("text/plain"));
+        ranges.clear();
+
+        // Multiple elements with whitespaces
+        MediaTypeSet.addRanges(ranges, " text/plain , text/html ");
+        assertThat(ranges).containsExactly(MediaType.parse("text/plain"),
+                                           MediaType.parse("text/html"));
+        ranges.clear();
+
+        // Quoted strings
+        MediaTypeSet.addRanges(ranges, "text/plain; foo=\"b\\\"a,r\", text/html; bar=\"b\\a\\z\"");
+        assertThat(ranges).containsExactly(MediaType.parse("text/plain; foo=\"b\\\"a,r\""),
+                                           MediaType.parse("text/html; bar=baz"));
+        ranges.clear();
+
+        // Empty elements
+        MediaTypeSet.addRanges(ranges, ",,,");
+        assertThat(ranges).isEmpty();
+        ranges.clear();
+
+        // Empty elements with whitespaces
+        MediaTypeSet.addRanges(ranges, " , , , ");
+        assertThat(ranges).isEmpty();
+        ranges.clear();
+    }
+}

--- a/thrift/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
+++ b/thrift/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
@@ -453,23 +453,14 @@ public class THttpService extends AbstractHttpService {
             serializationFormat = defaultSerializationFormat;
         }
 
-        final String accept = headers.get(HttpHeaderNames.ACCEPT);
-        if (accept != null) {
-            // If accept header is present, make sure it is sane. Currently, we do not support accept
-            // headers with a different format than the content type header.
-            SerializationFormat outputSerializationFormat;
-            try {
-                outputSerializationFormat =
-                        SerializationFormat.find(MediaType.parse(accept)).orElse(serializationFormat);
-            } catch (IllegalArgumentException e) {
-                logger.debug("Failed to parse the 'accept' header: {}", accept, e);
-                outputSerializationFormat = null;
-            }
-            if (outputSerializationFormat != serializationFormat) {
-                res.respond(HttpStatus.NOT_ACCEPTABLE,
-                            MediaType.PLAIN_TEXT_UTF_8, ACCEPT_THRIFT_PROTOCOL_MUST_MATCH_CONTENT_TYPE);
-                return null;
-            }
+        // If accept header is present, make sure it is sane. Currently, we do not support accept
+        // headers with a different format than the content type header.
+        final List<String> acceptHeaders = headers.getAll(HttpHeaderNames.ACCEPT);
+        if (!acceptHeaders.isEmpty() &&
+            !serializationFormat.mediaTypes().matchHeaders(acceptHeaders).isPresent()) {
+            res.respond(HttpStatus.NOT_ACCEPTABLE,
+                        MediaType.PLAIN_TEXT_UTF_8, ACCEPT_THRIFT_PROTOCOL_MUST_MATCH_CONTENT_TYPE);
+            return null;
         }
 
         return serializationFormat;

--- a/thrift/src/test/java/com/linecorp/armeria/server/thrift/THttp2Client.java
+++ b/thrift/src/test/java/com/linecorp/armeria/server/thrift/THttp2Client.java
@@ -48,6 +48,7 @@ import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpClientUpgradeHandler;
 import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http2.DefaultHttp2Connection;
@@ -84,12 +85,14 @@ final class THttp2Client extends TTransport {
     private final String host;
     private final int port;
     private final String path;
+    private final HttpHeaders defaultHeaders;
 
     private TMemoryInputTransport in;
     private final TMemoryBuffer out = new TMemoryBuffer(128);
 
-    THttp2Client(String uriStr) throws TTransportException {
+    THttp2Client(String uriStr, HttpHeaders defaultHeaders) throws TTransportException {
         uri = URI.create(uriStr);
+        this.defaultHeaders = defaultHeaders;
 
         int port;
         switch (uri.getScheme()) {
@@ -215,6 +218,7 @@ final class THttp2Client extends TTransport {
                     Unpooled.wrappedBuffer(out.getArray(), 0, out.length()));
             request.headers().add(HttpHeaderNames.HOST, host);
             request.headers().set(ExtensionHeaderNames.SCHEME.text(), uri.getScheme());
+            request.headers().add(defaultHeaders);
             ch.writeAndFlush(request).sync();
 
             // Wait until the Thrift response is received.

--- a/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftOverHttp2Test.java
+++ b/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftOverHttp2Test.java
@@ -18,9 +18,15 @@ package com.linecorp.armeria.server.thrift;
 import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
 
+import com.linecorp.armeria.common.http.HttpHeaders;
+
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+
 public class ThriftOverHttp2Test extends AbstractThriftOverHttpTest {
     @Override
-    protected TTransport newTransport(String uri) throws TTransportException {
-        return new THttp2Client(uri);
+    protected TTransport newTransport(String uri, HttpHeaders headers) throws TTransportException {
+        final io.netty.handler.codec.http.HttpHeaders nettyDefaultHeaders = new DefaultHttpHeaders();
+        headers.names().forEach(name -> nettyDefaultHeaders.set(name, headers.getAll(name)));
+        return new THttp2Client(uri, nettyDefaultHeaders);
     }
 }

--- a/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftSerializationFormatsTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftSerializationFormatsTest.java
@@ -44,7 +44,7 @@ public class ThriftSerializationFormatsTest extends AbstractServerTest {
         assertThat(find(parse("application/x-thrift; protocol=tbinary"))).containsSame(BINARY);
         assertThat(find(parse("application/x-thrift;protocol=TCompact"))).containsSame(COMPACT);
         assertThat(find(parse("application/x-thrift ; protocol=\"TjSoN\""))).containsSame(JSON);
-        assertThat(find(parse("application/x-thrift ; version=3;protocol=ttext"))).containsSame(TEXT);
+        assertThat(find(parse("application/x-thrift ; version=3;protocol=ttext"))).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
Motivation:

THttpService fails to handle the 'accept' HTTP header whose value
contains:

- comma-separated media ranges
- a wildcard range
- a range with a qvalue parameter

Modifications:

- Add MediaTypeSet which provides the utility methods for content
  negotiation
- Make SerializationFormat.find() accept media ranges
- Change the return type of SerializationFormat.mediaTypes() from Set to
  MediaTypeSet
- Fix THttpService to handle the 'accept' HTTP header correctly

Result:

- Fixes #443