### PR TITLE
Set RequestLog.statusCode when failing a response

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/http/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/HttpResponseSubscriber.java
@@ -299,6 +299,7 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject>, RequestTim
 
     private void failAndRespond(Throwable cause, HttpStatus status, Http2Error error) {
         final State state = this.state;
+        logBuilder().statusCode(status.code());
         fail(cause);
 
         final int id = req.id();


### PR DESCRIPTION
Motivation:

HttpResponseSubscriber.failAndResponse does not set RequestLog.statusCode
when failing a request, resulting in '-1' status code.

Modifications:

- Set RequestLog.statusCode in failAndResponse()

Result:

- RequestLog.statusCode is set to 404, 500 or 503 when the request is
  failed by HttpResponseSubscriber