### PR TITLE
Add an option to enable/disable HTTP/1 pipelining and fix related bugs

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/SessionOption.java
+++ b/core/src/main/java/com/linecorp/armeria/client/SessionOption.java
@@ -89,6 +89,12 @@ public final class SessionOption<T> extends AbstractOption<T> {
     public static final SessionOption<Boolean> USE_HTTP2_PREFACE = valueOf("USE_HTTP2_PREFACE");
 
     /**
+     * Whether to use <a href="https://en.wikipedia.org/wiki/HTTP_pipelining">HTTP pipelining</a> for HTTP/1
+     * connections. This does not affect HTTP/2 connections. This option is enabled by default.
+     */
+    public static final SessionOption<Boolean> USE_HTTP1_PIPELINING = valueOf("USE_HTTP1_PIPELINING");
+
+    /**
      * Returns the {@link SessionOption} of the specified name.
      */
     @SuppressWarnings("unchecked")

--- a/core/src/main/java/com/linecorp/armeria/client/SessionOptions.java
+++ b/core/src/main/java/com/linecorp/armeria/client/SessionOptions.java
@@ -21,6 +21,7 @@ import static com.linecorp.armeria.client.SessionOption.EVENT_LOOP_GROUP;
 import static com.linecorp.armeria.client.SessionOption.IDLE_TIMEOUT;
 import static com.linecorp.armeria.client.SessionOption.POOL_HANDLER_DECORATOR;
 import static com.linecorp.armeria.client.SessionOption.TRUST_MANAGER_FACTORY;
+import static com.linecorp.armeria.client.SessionOption.USE_HTTP1_PIPELINING;
 import static com.linecorp.armeria.client.SessionOption.USE_HTTP2_PREFACE;
 import static java.util.Objects.requireNonNull;
 
@@ -53,6 +54,8 @@ public final class SessionOptions extends AbstractOptions {
     private static final Duration DEFAULT_IDLE_TIMEOUT = Duration.ofSeconds(10);
     private static final Boolean DEFAULT_USE_HTTP2_PREFACE =
             "true".equals(System.getProperty("com.linecorp.armeria.defaultUseHttp2Preface", "false"));
+    private static final Boolean DEFAULT_USE_HTTP1_PIPELINING =
+            "true".equals(System.getProperty("com.linecorp.armeria.defaultUseHttp1Pipelining", "true"));
 
     static {
         logger.info("defaultUseHttp2Preface: {}", DEFAULT_USE_HTTP2_PREFACE);
@@ -267,5 +270,12 @@ public final class SessionOptions extends AbstractOptions {
      */
     public boolean useHttp2Preface() {
         return getOrElse(USE_HTTP2_PREFACE, DEFAULT_USE_HTTP2_PREFACE);
+    }
+
+    /**
+     * Returns whether {@link SessionOption#USE_HTTP1_PIPELINING} is enabled or not.
+     */
+    public boolean useHttp1Pipelining() {
+        return getOrElse(USE_HTTP1_PIPELINING, DEFAULT_USE_HTTP1_PIPELINING);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/http/HttpSessionChannelFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/http/HttpSessionChannelFactory.java
@@ -48,7 +48,7 @@ class HttpSessionChannelFactory implements Function<PoolKey, Future<Channel>> {
     private final Map<SessionProtocol, Bootstrap> bootstrapMap;
     private final SessionOptions options;
 
-    HttpSessionChannelFactory(Bootstrap bootstrap,SessionOptions options) {
+    HttpSessionChannelFactory(Bootstrap bootstrap, SessionOptions options) {
         baseBootstrap = requireNonNull(bootstrap);
         eventLoop = (EventLoop) bootstrap.config().group();
 

--- a/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
@@ -450,6 +450,9 @@ public class DefaultStreamMessage<T> implements StreamMessage<T>, StreamWriter<T
                                                : CANCELLED_CLOSE;
 
                 publisher.pushObject(closeEvent);
+            } else {
+                // Ensure the closeFuture is notified if not notified yet.
+                publisher.notifySubscriber();
             }
         }
 

--- a/core/src/test/java/com/linecorp/armeria/client/http/HttpClientPipeliningTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/http/HttpClientPipeliningTest.java
@@ -1,0 +1,178 @@
+/*
+ *  Copyright 2017 LINE Corporation
+ *
+ *  LINE Corporation licenses this file to you under the Apache License,
+ *  version 2.0 (the "License"); you may not use this file except in compliance
+ *  with the License. You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package com.linecorp.armeria.client.http;
+
+import static com.linecorp.armeria.common.util.Functions.voidFunction;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.linecorp.armeria.client.AllInOneClientFactory;
+import com.linecorp.armeria.client.ClientFactory;
+import com.linecorp.armeria.client.Clients;
+import com.linecorp.armeria.client.SessionOption;
+import com.linecorp.armeria.client.SessionOptions;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.http.HttpRequest;
+import com.linecorp.armeria.common.http.HttpResponse;
+import com.linecorp.armeria.common.http.HttpResponseWriter;
+import com.linecorp.armeria.common.http.HttpStatus;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.http.AbstractHttpService;
+import com.linecorp.armeria.test.AbstractServerTest;
+
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+
+public class HttpClientPipeliningTest extends AbstractServerTest {
+
+    private static EventLoopGroup eventLoopGroup;
+    private static ClientFactory factoryWithPipelining;
+    private static ClientFactory factoryWithoutPipelining;
+
+    @BeforeClass
+    public static void init() {
+        // Ensure only a single event loop is used so that there's only one connection pool.
+        // Note: Each event loop has its own connection pool.
+        eventLoopGroup = new NioEventLoopGroup(1);
+        factoryWithPipelining = new AllInOneClientFactory(
+                SessionOptions.of(SessionOption.EVENT_LOOP_GROUP.newValue(eventLoopGroup),
+                                  SessionOption.USE_HTTP1_PIPELINING.newValue(true)));
+
+        factoryWithoutPipelining = new AllInOneClientFactory(
+                SessionOptions.of(SessionOption.EVENT_LOOP_GROUP.newValue(eventLoopGroup),
+                                  SessionOption.USE_HTTP1_PIPELINING.newValue(false)));
+
+    }
+
+    @AfterClass
+    public static void destroy() {
+        ForkJoinPool.commonPool().execute(() -> {
+            factoryWithPipelining.close();
+            factoryWithoutPipelining.close();
+            eventLoopGroup.shutdownGracefully();
+        });
+    }
+
+    private final Semaphore semaphore = new Semaphore(0);
+    private final Lock lock = new ReentrantLock();
+    private final Condition condition = lock.newCondition();
+    private volatile boolean connectionReturnedToPool;
+
+    @Before
+    public void resetState() {
+        semaphore.drainPermits();
+        connectionReturnedToPool = false;
+    }
+
+    @Override
+    protected void configureServer(ServerBuilder sb) throws Exception {
+        // Bind a service that returns the remote address of the connection to determine
+        // if the same connection was used to handle more than one request.
+        sb.serviceAt("/", new AbstractHttpService() {
+            @Override
+            protected void doGet(ServiceRequestContext ctx,
+                                 HttpRequest req, HttpResponseWriter res) throws Exception {
+                // Consume the request completely so that the connection can be returned to the pool.
+                req.aggregate().handle(voidFunction((unused1, unused2) -> {
+                    // Signal the main thread that the connection has been returned to the pool.
+                    // Note that this is true only when pipelining is enabled. The connection is returned
+                    // after response is fully sent if pipelining is disabled.
+                    lock.lock();
+                    try {
+                        connectionReturnedToPool = true;
+                        condition.signal();
+                    } finally {
+                        lock.unlock();
+                    }
+
+                    semaphore.acquireUninterruptibly();
+                    try {
+                        res.respond(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8,
+                                    String.valueOf(ctx.remoteAddress()));
+                    } finally {
+                        semaphore.release();
+                    }
+                }));
+            }
+        });
+    }
+
+    @Test
+    public void withoutPipelining() throws Exception {
+        final HttpClient client = Clients.newClient(factoryWithoutPipelining,
+                                                    "none+h1c://127.0.0.1:" + httpPort(), HttpClient.class);
+
+        final HttpResponse res1 = client.get("/");
+        final HttpResponse res2 = client.get("/");
+
+        // At this point, the two requests have acquired two different connections from the pool
+        // because pipelining is disabled and thus the connection of the first request will not
+        // be returned to the pool until its response is fully received.
+
+        // Give two permits to the Semaphore so that the two requests get their responses.
+        semaphore.release(2);
+
+        // Two requests should go through two different connections.
+        final String remoteAddress1 = res1.aggregate().get().content().toStringUtf8();
+        final String remoteAddress2 = res2.aggregate().get().content().toStringUtf8();
+        assertThat(remoteAddress1).isNotEqualTo(remoteAddress2);
+    }
+
+    @Test
+    public void withPipelining() throws Exception {
+        final HttpClient client = Clients.newClient(factoryWithPipelining,
+                                                    "none+h1c://127.0.0.1:" + httpPort(), HttpClient.class);
+        final HttpResponse res1;
+        lock.lock();
+        try {
+            res1 = client.get("/");
+            // Wait until the connection used by res1 is returned to the pool,
+            // so that the next request reuses the connection.
+            while (!connectionReturnedToPool) {
+                condition.await();
+            }
+        } finally {
+            lock.unlock();
+        }
+
+        // At this point, we are sure the connection of the first request has been returned to the pool,
+        // because pipelining is enabled and thus the connection will be returned to the pool once
+        // the request has been fully sent.
+
+        // Now, send the second request so that the client reuses the connection.
+        final HttpResponse res2 = client.get("/");
+
+        // Give two permits to the Semaphore so that the two requests get their responses.
+        semaphore.release(2);
+
+        // Two requests should go through one same connection.
+        final String remoteAddress1 = res1.aggregate().get().content().toStringUtf8();
+        final String remoteAddress2 = res2.aggregate().get().content().toStringUtf8();
+        assertThat(remoteAddress1).isEqualTo(remoteAddress2);
+    }
+}


### PR DESCRIPTION
Motivation:

Some users want to disable HTTP/1 pipelining which is enabled by
default.

Modifications:

- Add SessionOption.USE_HTTP1_PIPELINING which enables or disables
  HTTP/1 pipelining (default: enabled)
- Update HttpClientDelegate so that it respects USE_HTTP1_PIPELINING
- Add HttpClientPipeliningTest that tests both pipelined and
  non-pipelined requests
  - Fix various bugs uncovered by the test
    - Fix a bug where NonDecoratingClientFactory chooses wrong Channel
      types without respecting the EVENT_LOOP_GROUP option
    - Fix a bug where DefaultStreamMessage.closeFuture() is sometimes
      not completed at all when its subscription is cancelled
    - Fix a potential bug where HttpClientDelegate may not return a
      Channel back to its pool
    - Fix a bug where Http1ObjectEncoder does not write LastHttpContent
      in a certain case
    - Fix a bug where Http1ObjectEncoder sets the 'endOfStream' flag on
      a wrong PendingWrites

Result:

- A user can disable HTTP/1 pipelining if he or she really wants to,
  most likely due to a buggy server.
- Stability, thanks to the fixes for the HTTP/1 bugs reproduced by the
  pipelining test