### PR TITLE
Cancel context-aware callbacks if the context has already been timed …

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/http/HttpSessionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/http/HttpSessionHandler.java
@@ -134,7 +134,7 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
                                             responseTimeoutMillis, maxContentLength);
         req.subscribe(
                 new HttpRequestSubscriber(channel, requestEncoder,
-                                          numRequestsSent, req, wrappedRes, ctx.logBuilder(),
+                                          numRequestsSent, req, wrappedRes, ctx,
                                           writeTimeoutMillis),
                 channel.eventLoop());
 

--- a/core/src/main/java/com/linecorp/armeria/common/AbstractRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AbstractRequestContext.java
@@ -17,6 +17,7 @@
 package com.linecorp.armeria.common;
 
 import java.util.concurrent.Callable;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
@@ -24,11 +25,17 @@ import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
+import javax.annotation.Nullable;
+
+import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.common.util.SafeCloseable;
 
 import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.DefaultChannelPromise;
 import io.netty.channel.EventLoop;
+import io.netty.util.concurrent.DefaultPromise;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
 import io.netty.util.concurrent.GenericFutureListener;
@@ -38,6 +45,11 @@ import io.netty.util.concurrent.Promise;
  * A skeletal {@link RequestContext} implementation.
  */
 public abstract class AbstractRequestContext implements RequestContext {
+
+    private static final CancellationException CANCELLATION_EXCEPTION =
+            Exceptions.clearTrace(new CancellationException());
+
+    private boolean timedOut;
 
     @Override
     public final EventLoop contextAwareEventLoop() {
@@ -53,6 +65,7 @@ public abstract class AbstractRequestContext implements RequestContext {
     public final <T> Callable<T> makeContextAware(Callable<T> callable) {
         return () -> {
             try (SafeCloseable ignored = propagateContextIfNotPresent()) {
+                cancelIfTimedOut();
                 return callable.call();
             }
         };
@@ -62,6 +75,7 @@ public abstract class AbstractRequestContext implements RequestContext {
     public final Runnable makeContextAware(Runnable runnable) {
         return () -> {
             try (SafeCloseable ignored = propagateContextIfNotPresent()) {
+                cancelIfTimedOut();
                 runnable.run();
             }
         };
@@ -71,6 +85,7 @@ public abstract class AbstractRequestContext implements RequestContext {
     public final <T, R> Function<T, R> makeContextAware(Function<T, R> function) {
         return t -> {
             try (SafeCloseable ignored = propagateContextIfNotPresent()) {
+                cancelIfTimedOut();
                 return function.apply(t);
             }
         };
@@ -80,6 +95,7 @@ public abstract class AbstractRequestContext implements RequestContext {
     public final <T, U, V> BiFunction<T, U, V> makeContextAware(BiFunction<T, U, V> function) {
         return (t, u) -> {
             try (SafeCloseable ignored = propagateContextIfNotPresent()) {
+                cancelIfTimedOut();
                 return function.apply(t, u);
             }
         };
@@ -89,6 +105,7 @@ public abstract class AbstractRequestContext implements RequestContext {
     public final <T> Consumer<T> makeContextAware(Consumer<T> action) {
         return t -> {
             try (SafeCloseable ignored = propagateContextIfNotPresent()) {
+                cancelIfTimedOut();
                 action.accept(t);
             }
         };
@@ -98,6 +115,7 @@ public abstract class AbstractRequestContext implements RequestContext {
     public final <T, U> BiConsumer<T, U> makeContextAware(BiConsumer<T, U> action) {
         return (t, u) -> {
             try (SafeCloseable ignored = propagateContextIfNotPresent()) {
+                cancelIfTimedOut();
                 action.accept(t, u);
             }
         };
@@ -105,18 +123,19 @@ public abstract class AbstractRequestContext implements RequestContext {
 
     @Override
     public final <T> FutureListener<T> makeContextAware(FutureListener<T> listener) {
-        return future -> invokeOperationComplete(listener, future);
+        return future -> invokeOperationComplete(listener, future, () -> new DefaultPromise<>(eventLoop()));
     }
 
     @Override
     public final ChannelFutureListener makeContextAware(ChannelFutureListener listener) {
-        return future -> invokeOperationComplete(listener, future);
+        return future -> invokeOperationComplete(
+                listener, future, () -> new DefaultChannelPromise(future.channel()));
     }
 
     @Override
     public final <T extends Future<?>> GenericFutureListener<T>
     makeContextAware(GenericFutureListener<T> listener) {
-        return future -> invokeOperationComplete(listener, future);
+        return future -> invokeOperationComplete(listener, future, null);
     }
 
     @Override
@@ -124,7 +143,9 @@ public abstract class AbstractRequestContext implements RequestContext {
         final CompletableFuture<T> future = new RequestContextAwareCompletableFuture<>(this);
         stage.whenComplete((result, cause) -> {
             try (SafeCloseable ignored = propagateContextIfNotPresent()) {
-                if (cause != null) {
+                if (timedOut) {
+                    future.cancel(true);
+                } else if (cause != null) {
                     future.completeExceptionally(cause);
                 } else {
                     future.complete(result);
@@ -139,10 +160,22 @@ public abstract class AbstractRequestContext implements RequestContext {
         return RequestContext.super.makeContextAware(future);
     }
 
-    private <T extends Future<?>> void invokeOperationComplete(
-            GenericFutureListener<T> listener, T future) throws Exception {
+    /**
+     * Marks this {@link RequestContext} as having been timed out. Any callbacks created with
+     * {code makeContextAware} that are run after this will be failed with {@link CancellationException}.
+     */
+    public void setTimedOut() {
+        timedOut = true;
+    }
 
+    private <T extends Future<?>> void invokeOperationComplete(
+            GenericFutureListener<T> listener, T future, @Nullable Supplier<T> futureCreator) throws Exception {
         try (SafeCloseable ignored = propagateContextIfNotPresent()) {
+            if (timedOut && futureCreator != null) {
+                T cancelledFuture = futureCreator.get();
+                cancelledFuture.cancel(true);
+                future = cancelledFuture;
+            }
             listener.operationComplete(future);
         }
     }
@@ -179,5 +212,12 @@ public abstract class AbstractRequestContext implements RequestContext {
     @Override
     public final boolean equals(Object obj) {
         return super.equals(obj);
+    }
+
+    private void cancelIfTimedOut() {
+        if (timedOut) {
+            throw Exceptions.isVerbose() ?
+                  new CancellationException(CANCELLATION_EXCEPTION.getMessage()) : CANCELLATION_EXCEPTION;
+        }
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/NonWrappingRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/common/NonWrappingRequestContext.java
@@ -43,6 +43,7 @@ public abstract class NonWrappingRequestContext extends AbstractRequestContext {
     private final Object request;
     private List<Runnable> onEnterCallbacks;
     private List<Runnable> onExitCallbacks;
+    private boolean timedOut;
 
     /**
      * Creates a new instance.

--- a/core/src/main/java/com/linecorp/armeria/common/RequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestContext.java
@@ -307,8 +307,8 @@ public interface RequestContext extends AttributeMap {
 
     /**
      * Returns a {@link GenericFutureListener} that makes sure the current {@link RequestContext} is set and
-     * then invokes the input {@code listener}.
-     *
+     * then invokes the input {@code listener}. Unlike other versions of {@code makeContextAware}, this one will
+     * invoke the listener with the future's result even if the context has already been timed out.
      * @deprecated Use {@link CompletableFuture} instead.
      */
     @Deprecated

--- a/core/src/main/java/com/linecorp/armeria/server/http/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/HttpResponseSubscriber.java
@@ -123,6 +123,7 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject>, RequestTim
 
     private void onTimeout() {
         if (state != State.DONE) {
+            reqCtx.setTimedOut();
             failAndRespond(RequestTimeoutException.get(),
                            HttpStatus.SERVICE_UNAVAILABLE, Http2Error.INTERNAL_ERROR);
         }


### PR DESCRIPTION
…out.

Currently, even if a request has timed out, the entire request will still be executed to completion, including any series of callbacks that may be wired together. For context-aware callbacks, it makes sense to cancel them if the context corresponds to a request that already timed out.