### PR TITLE
Add RequestContext.onChild() and more onEnter/Exit() variants

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/AbstractRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AbstractRequestContext.java
@@ -191,7 +191,17 @@ public abstract class AbstractRequestContext implements RequestContext {
                         "sure you are not saving callbacks into shared state.");
             }
             return () -> { /* no-op */ };
-        }, () -> RequestContext.push(this, true));
+        }, () -> RequestContext.push(this));
+    }
+
+    @Override
+    public final void onEnter(Runnable callback) {
+        RequestContext.super.onEnter(callback);
+    }
+
+    @Override
+    public final void onExit(Runnable callback) {
+        RequestContext.super.onExit(callback);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/RequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestContextWrapper.java
@@ -20,6 +20,8 @@ import static java.util.Objects.requireNonNull;
 
 import java.net.SocketAddress;
 import java.util.Iterator;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLSession;
@@ -113,13 +115,18 @@ public abstract class RequestContextWrapper<T extends RequestContext> extends Ab
     }
 
     @Override
-    public void onEnter(Runnable callback) {
+    public void onEnter(Consumer<? super RequestContext> callback) {
         delegate().onEnter(callback);
     }
 
     @Override
-    public void onExit(Runnable callback) {
+    public void onExit(Consumer<? super RequestContext> callback) {
         delegate().onExit(callback);
+    }
+
+    @Override
+    public void onChild(BiConsumer<? super RequestContext, ? super RequestContext> callback) {
+        delegate().onChild(callback);
     }
 
     @Override
@@ -130,6 +137,11 @@ public abstract class RequestContextWrapper<T extends RequestContext> extends Ab
     @Override
     public void invokeOnExitCallbacks() {
         delegate().invokeOnExitCallbacks();
+    }
+
+    @Override
+    public void invokeOnChildCallbacks(RequestContext newCtx) {
+        delegate().invokeOnChildCallbacks(newCtx);
     }
 
     @Override

--- a/zipkin/src/main/java/com/linecorp/armeria/server/tracing/AbstractTracingService.java
+++ b/zipkin/src/main/java/com/linecorp/armeria/server/tracing/AbstractTracingService.java
@@ -68,8 +68,8 @@ public abstract class AbstractTracingService<I extends Request, O extends Respon
         final ServerSpan serverSpan = serverInterceptor.openSpan(requestAdapter);
         try {
             if (serverSpan != null) {
-                ctx.onEnter(() -> serverInterceptor.setSpan(serverSpan));
-                ctx.onExit(serverInterceptor::clearSpan);
+                ctx.onEnter(unused -> serverInterceptor.setSpan(serverSpan));
+                ctx.onExit(unused -> serverInterceptor.clearSpan());
                 if (serverSpan.getSample()) {
                     ctx.log().addListener(log -> closeSpan(ctx, serverSpan, log),
                                           RequestLogAvailability.COMPLETE);

--- a/zipkin/src/test/java/com/linecorp/armeria/server/tracing/TracingServiceTest.java
+++ b/zipkin/src/test/java/com/linecorp/armeria/server/tracing/TracingServiceTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.when;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import org.junit.Test;
@@ -119,8 +120,8 @@ public class TracingServiceTest {
         when(ctx.method()).thenReturn("POST");
         when(ctx.log()).thenReturn(log);
         when(ctx.logBuilder()).thenReturn(log);
-        ctx.onEnter(isA(Runnable.class));
-        ctx.onExit(isA(Runnable.class));
+        ctx.onEnter(isA(Consumer.class));
+        ctx.onExit(isA(Consumer.class));
 
         RpcResponse res = RpcResponse.of("Hello, trustin!");
         when(delegate.serve(ctx, req)).thenReturn(res);


### PR DESCRIPTION
Motivation:

- There's currently no way for a user to add a callback to the context
  that is not created and pushed yet. A user may want such a callback
  mechanism so that he or she can implement attribute inheritance when
  contexts are nested. e.g. Sending a request while serving a request
- RequestContext.onEnter/Exit() uses a Runnable as a callback. This
  removes the chance of optimization when a user has a callback that
  accesses the current context. e.g.

    // A new Runnable is always created.
    ctx.onEnter(() -> ctx.attr(...));
    // One Consumer instance could be reused if:
    ctx.onEnter(myCtx -> myCtx.attr(...));

Modifications:

- Add RequestContext.onChild(BiConsumer) which allows a user to add a
  callback to the context that's not created yet
- Add onEnter(Consumer) and onExit(Consumer)
  - onEnter(Runnable) and onExit(Runnable) now delegates to
    onEnter(Consumer) and onExit(Runnable).
- Deprecate onEnter(Runnable) and onExit(Runnable)
- Add a test case to RequestContextTest
  - Convert to AssertJ

Result:

- Fixes #455