### PR TITLE
Simplify client and service decoration

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/AbstractClientOptionsBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/AbstractClientOptionsBuilder.java
@@ -104,7 +104,7 @@ class AbstractClientOptionsBuilder<B extends AbstractClientOptionsBuilder<?>> {
         final ClientOption<?> opt = optionValue.option();
         if (opt == ClientOption.DECORATION) {
             final ClientDecoration d = (ClientDecoration) optionValue.value();
-            d.entries().forEach(e -> decorator((Class) e.requestType(), e.responseType(),
+            d.entries().forEach(e -> decorator(e.requestType(), e.responseType(),
                                                (Function) e.decorator()));
         } else if (opt == ClientOption.HTTP_HEADERS) {
             final HttpHeaders h = (HttpHeaders) optionValue.value();
@@ -163,10 +163,33 @@ class AbstractClientOptionsBuilder<B extends AbstractClientOptionsBuilder<?>> {
 
     /**
      * Adds the specified {@code decorator}.
+     *
+     * @param requestType the type of the {@link Request} that the {@code decorator} is interested in
+     * @param responseType the type of the {@link Response} that the {@code decorator} is interested in
+     * @param decorator the {@link Function} that transforms a {@link Client} to another
+     * @param <T> the type of the {@link Client} being decorated
+     * @param <R> the type of the {@link Client} produced by the {@code decorator}
+     * @param <I> the {@link Request} type of the {@link Client} being decorated
+     * @param <O> the {@link Response} type of the {@link Client} being decorated
      */
     public <T extends Client<? super I, ? extends O>, R extends Client<I, O>,
             I extends Request, O extends Response>
     B decorator(Class<I> requestType, Class<O> responseType, Function<T, R> decorator) {
+        decoration.add(requestType, responseType, decorator);
+        return self();
+    }
+
+    /**
+     * Adds the specified {@code decorator}.
+     *
+     * @param requestType the type of the {@link Request} that the {@code decorator} is interested in
+     * @param responseType the type of the {@link Response} that the {@code decorator} is interested in
+     * @param decorator the {@link DecoratingClientFunction} that intercepts an invocation
+     * @param <I> the {@link Request} type of the {@link Client} being decorated
+     * @param <O> the {@link Response} type of the {@link Client} being decorated
+     */
+    public <I extends Request, O extends Response>
+    B decorator(Class<I> requestType, Class<O> responseType, DecoratingClientFunction<I, O> decorator) {
         decoration.add(requestType, responseType, decorator);
         return self();
     }

--- a/core/src/main/java/com/linecorp/armeria/client/ClientDecorationBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientDecorationBuilder.java
@@ -41,6 +41,8 @@ public final class ClientDecorationBuilder {
      * @param decorator the {@link Function} that transforms a {@link Client} to another
      * @param <T> the type of the {@link Client} being decorated
      * @param <R> the type of the {@link Client} produced by the {@code decorator}
+     * @param <I> the {@link Request} type of the {@link Client} being decorated
+     * @param <O> the {@link Response} type of the {@link Client} being decorated
      */
     public <T extends Client<? super I, ? extends O>, R extends Client<I, O>,
             I extends Request, O extends Response>
@@ -51,6 +53,27 @@ public final class ClientDecorationBuilder {
         requireNonNull(decorator, "decorator");
 
         entries.add(new Entry<>(requestType, responseType, decorator));
+        return this;
+    }
+
+    /**
+     * Adds a new {@link DecoratingClientFunction}.
+     *
+     * @param requestType the type of the {@link Request} that the {@code decorator} is interested in
+     * @param responseType the type of the {@link Response} that the {@code decorator} is interested in
+     * @param decorator the {@link DecoratingClientFunction} that intercepts an invocation
+     * @param <I> the {@link Request} type of the {@link Client} being decorated
+     * @param <O> the {@link Response} type of the {@link Client} being decorated
+     */
+    public <I extends Request, O extends Response> ClientDecorationBuilder add(
+            Class<I> requestType, Class<O> responseType, DecoratingClientFunction<I, O> decorator) {
+
+        requireNonNull(requestType, "requestType");
+        requireNonNull(responseType, "responseType");
+        requireNonNull(decorator, "decorator");
+
+        entries.add(new Entry<>(requestType, responseType,
+                                delegate -> new FunctionalDecoratingClient<>(delegate, decorator)));
         return this;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/DecoratingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DecoratingClient.java
@@ -22,7 +22,9 @@ import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
 
 /**
- * Decorates a {@link Client}.
+ * Decorates a {@link Client}. Use {@link SimpleDecoratingClient} or
+ * {@link ClientBuilder#decorator(Class, Class, DecoratingClientFunction)} if your {@link Client} has the same
+ * {@link Request} and {@link Response} type with the {@link Client} being decorated.
  *
  * @param <T_I> the {@link Request} type of the {@link Client} being decorated
  * @param <T_O> the {@link Response} type of the {@link Client} being decorated

--- a/core/src/main/java/com/linecorp/armeria/client/DecoratingClientFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DecoratingClientFunction.java
@@ -1,0 +1,42 @@
+/*
+ *  Copyright 2017 LINE Corporation
+ *
+ *  LINE Corporation licenses this file to you under the Apache License,
+ *  version 2.0 (the "License"); you may not use this file except in compliance
+ *  with the License. You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import com.linecorp.armeria.common.Request;
+import com.linecorp.armeria.common.Response;
+
+/**
+ * A functional interface that enables building a {@link SimpleDecoratingClient} with
+ * {@link ClientBuilder#decorator(Class, Class, DecoratingClientFunction)}.
+ *
+ * @param <I> the {@link Request} type
+ * @param <O> the {@link Response} type
+ */
+@FunctionalInterface
+public interface DecoratingClientFunction<I extends Request, O extends Response> {
+    /**
+     * Sends a {@link Request} to a remote {@link Endpoint}, as specified in
+     * {@link ClientRequestContext#endpoint()}.
+     *
+     * @param delegate the {@link Client} being decorated by this function
+     * @param ctx the context of the {@link Request} being sent
+     * @param req the {@link Request} being sent
+     *
+     * @return the {@link Response} to be received
+     */
+    O execute(Client<I, O> delegate, ClientRequestContext ctx, I req) throws Exception;
+}

--- a/core/src/main/java/com/linecorp/armeria/client/FunctionalDecoratingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/FunctionalDecoratingClient.java
@@ -1,0 +1,53 @@
+/*
+ *  Copyright 2017 LINE Corporation
+ *
+ *  LINE Corporation licenses this file to you under the Apache License,
+ *  version 2.0 (the "License"); you may not use this file except in compliance
+ *  with the License. You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import static java.util.Objects.requireNonNull;
+
+import com.linecorp.armeria.common.Request;
+import com.linecorp.armeria.common.Response;
+
+/**
+ * A decorating {@link Client} which implements its {@link #execute(ClientRequestContext, Request)} method
+ * using a given function.
+ *
+ * @see ClientBuilder#decorator(Class, Class, DecoratingClientFunction)
+ */
+final class FunctionalDecoratingClient<I extends Request, O extends Response>
+        extends SimpleDecoratingClient<I, O> {
+
+    private final DecoratingClientFunction<? super I, ? extends O> function;
+
+    /**
+     * Creates a new instance with the specified function.
+     */
+    FunctionalDecoratingClient(Client<? super I, ? extends O> delegate,
+                               DecoratingClientFunction<? super I, ? extends O> function) {
+        super(delegate);
+        this.function = requireNonNull(function, "function");
+    }
+
+    @Override
+    public O execute(ClientRequestContext ctx, I req) throws Exception {
+        return function.execute(delegate(), ctx, req);
+    }
+
+    @Override
+    public String toString() {
+        return FunctionalDecoratingClient.class.getSimpleName() + '(' + delegate() + ", " + function + ')';
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/client/SimpleDecoratingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/SimpleDecoratingClient.java
@@ -1,0 +1,39 @@
+/*
+ *  Copyright 2017 LINE Corporation
+ *
+ *  LINE Corporation licenses this file to you under the Apache License,
+ *  version 2.0 (the "License"); you may not use this file except in compliance
+ *  with the License. You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import com.linecorp.armeria.common.Request;
+import com.linecorp.armeria.common.Response;
+import com.linecorp.armeria.server.Service;
+
+/**
+ * Decorates a {@link Client}. Use {@link DecoratingClient} if your {@link Service} has different
+ * {@link Request} or {@link Response} type from the {@link Client} being decorated.
+ *
+ * @param <I> the {@link Request} type of the {@link Client} being decorated
+ * @param <O> the {@link Response} type of the {@link Client} being decorated
+ */
+public abstract class SimpleDecoratingClient<I extends Request, O extends Response>
+        extends DecoratingClient<I, O, I, O> {
+
+    /**
+     * Creates a new instance that decorates the specified {@link Client}.
+     */
+    protected SimpleDecoratingClient(Client<? super I, ? extends O> delegate) {
+        super(delegate);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClient.java
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
 
 import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.client.ClientRequestContext;
-import com.linecorp.armeria.client.DecoratingClient;
+import com.linecorp.armeria.client.SimpleDecoratingClient;
 import com.linecorp.armeria.client.circuitbreaker.KeyedCircuitBreakerMapping.KeySelector;
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
@@ -39,7 +39,7 @@ import com.linecorp.armeria.common.util.CompletionActions;
  * @param <O> the {@link Response} type
  */
 public final class CircuitBreakerClient<I extends Request, O extends Response>
-        extends DecoratingClient<I, O, I, O> {
+        extends SimpleDecoratingClient<I, O> {
 
     private static final Logger logger = LoggerFactory.getLogger(CircuitBreakerClient.class);
 

--- a/core/src/main/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingClient.java
@@ -26,8 +26,8 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.client.ClientRequestContext;
-import com.linecorp.armeria.client.DecoratingClient;
 import com.linecorp.armeria.client.ResponseTimeoutException;
+import com.linecorp.armeria.client.SimpleDecoratingClient;
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.Response;
@@ -48,7 +48,7 @@ import io.netty.util.concurrent.ScheduledFuture;
  * @param <O> the {@link Response} type
  */
 public abstract class ConcurrencyLimitingClient<I extends Request, O extends Response>
-        extends DecoratingClient<I, O, I, O> {
+        extends SimpleDecoratingClient<I, O> {
 
     private static final long DEFAULT_TIMEOUT_MILLIS = 10000L;
 

--- a/core/src/main/java/com/linecorp/armeria/client/logging/DropwizardMetricCollectingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/logging/DropwizardMetricCollectingClient.java
@@ -25,7 +25,7 @@ import com.google.common.base.MoreObjects;
 
 import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.client.ClientRequestContext;
-import com.linecorp.armeria.client.DecoratingClient;
+import com.linecorp.armeria.client.SimpleDecoratingClient;
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
 import com.linecorp.armeria.common.RpcRequest;
@@ -55,7 +55,7 @@ import com.linecorp.armeria.internal.logging.DropwizardMetricCollector;
  * @param <O> the response type
  */
 public final class DropwizardMetricCollectingClient<I extends Request, O extends Response>
-        extends DecoratingClient<I, O, I, O> {
+        extends SimpleDecoratingClient<I, O> {
 
     /**
      * Returns a {@link Client} decorator that tracks request stats using the Dropwizard metrics library.

--- a/core/src/main/java/com/linecorp/armeria/client/logging/LoggingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/logging/LoggingClient.java
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
 
 import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.client.ClientRequestContext;
-import com.linecorp.armeria.client.DecoratingClient;
+import com.linecorp.armeria.client.SimpleDecoratingClient;
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
 import com.linecorp.armeria.common.logging.LogLevel;
@@ -36,7 +36,7 @@ import com.linecorp.armeria.common.logging.RequestLogAvailability;
  * @param <I> the {@link Request} type
  * @param <O> the {@link Response} type
  */
-public final class LoggingClient<I extends Request, O extends Response> extends DecoratingClient<I, O, I, O> {
+public final class LoggingClient<I extends Request, O extends Response> extends SimpleDecoratingClient<I, O> {
 
     private static final Logger logger = LoggerFactory.getLogger(LoggingClient.class);
 

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
@@ -20,7 +20,7 @@ import static java.util.Objects.requireNonNull;
 import java.util.function.Supplier;
 
 import com.linecorp.armeria.client.Client;
-import com.linecorp.armeria.client.DecoratingClient;
+import com.linecorp.armeria.client.SimpleDecoratingClient;
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
 
@@ -31,7 +31,7 @@ import com.linecorp.armeria.common.Response;
  * @param <O> the {@link Response} type
  */
 public abstract class RetryingClient<I extends Request, O extends Response>
-        extends DecoratingClient<I, O, I, O> {
+        extends SimpleDecoratingClient<I, O> {
     private final Supplier<? extends Backoff> backoffSupplier;
     private final RetryRequestStrategy<I, O> retryStrategy;
 

--- a/core/src/main/java/com/linecorp/armeria/server/DecoratingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DecoratingService.java
@@ -19,14 +19,14 @@ package com.linecorp.armeria.server;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Optional;
-import java.util.function.Function;
 
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
 
 /**
- * A {@link Service} that decorates another {@link Service}. Do not use this class unless you want to define
- * a new dedicated {@link Service} type by extending this class; prefer {@link Service#decorate(Function)}.
+ * A {@link Service} that decorates another {@link Service}. Use {@link SimpleDecoratingService} or
+ * {@link Service#decorate(DecoratingServiceFunction)} if your {@link Service} has the same {@link Request}
+ * and {@link Response} type with the {@link Service} being decorated.
  *
  * @param <T_I> the {@link Request} type of the {@link Service} being decorated
  * @param <T_O> the {@link Response} type of the {@link Service} being decorated

--- a/core/src/main/java/com/linecorp/armeria/server/DecoratingServiceFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DecoratingServiceFunction.java
@@ -20,7 +20,7 @@ import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
 
 /**
- * A functional interface that enables building a {@link DecoratingService} with
+ * A functional interface that enables building a {@link SimpleDecoratingService} with
  * {@link Service#decorate(DecoratingServiceFunction)}.
  *
  * @param <I> the {@link Request} type

--- a/core/src/main/java/com/linecorp/armeria/server/FunctionalDecoratingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/FunctionalDecoratingService.java
@@ -28,7 +28,7 @@ import com.linecorp.armeria.common.Response;
  * @see Service#decorate(DecoratingServiceFunction)
  */
 final class FunctionalDecoratingService<I extends Request, O extends Response>
-        extends DecoratingService<I, O, I, O> {
+        extends SimpleDecoratingService<I, O> {
 
     private final DecoratingServiceFunction<? super I, ? extends O> function;
 

--- a/core/src/main/java/com/linecorp/armeria/server/SimpleDecoratingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/SimpleDecoratingService.java
@@ -1,0 +1,41 @@
+/*
+ *  Copyright 2017 LINE Corporation
+ *
+ *  LINE Corporation licenses this file to you under the Apache License,
+ *  version 2.0 (the "License"); you may not use this file except in compliance
+ *  with the License. You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import com.linecorp.armeria.common.Request;
+import com.linecorp.armeria.common.Response;
+
+/**
+ * A {@link Service} that decorates another {@link Service}. Use {@link DecoratingService} if your
+ * {@link Service} has different {@link Request} or {@link Response} type from the {@link Service} being
+ * decorated.
+ *
+ * @param <I> the {@link Request} type of the {@link Service} being decorated
+ * @param <O> the {@link Response} type of the {@link Service} being decorated
+ *
+ * @see Service#decorate(DecoratingServiceFunction)
+ */
+public abstract class SimpleDecoratingService<I extends Request, O extends Response>
+        extends DecoratingService<I, O, I, O> {
+
+    /**
+     * Creates a new instance that decorates the specified {@link Service}.
+     */
+    protected SimpleDecoratingService(Service<? super I, ? extends O> delegate) {
+        super(delegate);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/http/auth/HttpAuthService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/auth/HttpAuthService.java
@@ -34,12 +34,12 @@ import com.linecorp.armeria.common.http.HttpStatus;
 import com.linecorp.armeria.server.DecoratingService;
 import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.SimpleDecoratingService;
 
 /**
  * A {@link DecoratingService} that provides HTTP authorization functionality.
  */
-public abstract class HttpAuthService
-        extends DecoratingService<HttpRequest, HttpResponse, HttpRequest, HttpResponse> {
+public abstract class HttpAuthService extends SimpleDecoratingService<HttpRequest, HttpResponse> {
 
     private static final Logger logger = LoggerFactory.getLogger(HttpAuthService.class);
 

--- a/core/src/main/java/com/linecorp/armeria/server/http/encoding/HttpEncodingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/encoding/HttpEncodingService.java
@@ -27,6 +27,7 @@ import com.linecorp.armeria.common.http.HttpResponse;
 import com.linecorp.armeria.server.DecoratingService;
 import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.SimpleDecoratingService;
 import com.linecorp.armeria.server.http.HttpService;
 
 /**
@@ -35,7 +36,7 @@ import com.linecorp.armeria.server.http.HttpService;
  * type to encode, and the response either has no fixed content length or the length is larger than 1KB.
  */
 public class HttpEncodingService
-        extends DecoratingService<HttpRequest, HttpResponse, HttpRequest, HttpResponse> {
+        extends SimpleDecoratingService<HttpRequest, HttpResponse> {
 
     private static final Predicate<MediaType> DEFAULT_ENCODABLE_CONTENT_TYPE_PREDICATE =
             contentType -> Stream.of(MediaType.ANY_TEXT_TYPE,

--- a/core/src/main/java/com/linecorp/armeria/server/logging/DropwizardMetricCollectingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/DropwizardMetricCollectingService.java
@@ -30,9 +30,9 @@ import com.linecorp.armeria.common.http.HttpHeaders;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.logging.RequestLogAvailability;
 import com.linecorp.armeria.internal.logging.DropwizardMetricCollector;
-import com.linecorp.armeria.server.DecoratingService;
 import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.SimpleDecoratingService;
 
 /**
  * Decorates a {@link Service} to collect metrics into Dropwizard {@link MetricRegistry}.
@@ -55,7 +55,7 @@ import com.linecorp.armeria.server.ServiceRequestContext;
  * @param <O> the {@link Response} type
  */
 public final class DropwizardMetricCollectingService<I extends Request, O extends Response>
-        extends DecoratingService<I, O, I, O> {
+        extends SimpleDecoratingService<I, O> {
 
     /**
      * Returns a new {@link Service} decorator that tracks request stats using the Dropwizard metrics

--- a/core/src/main/java/com/linecorp/armeria/server/logging/LoggingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/LoggingService.java
@@ -25,9 +25,9 @@ import com.linecorp.armeria.common.Response;
 import com.linecorp.armeria.common.logging.LogLevel;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.logging.RequestLogAvailability;
-import com.linecorp.armeria.server.DecoratingService;
 import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.SimpleDecoratingService;
 
 /**
  * Decorates a {@link Service} to log {@link Request}s and {@link Response}s.
@@ -35,7 +35,7 @@ import com.linecorp.armeria.server.ServiceRequestContext;
  * @param <I> the {@link Request} type
  * @param <O> the {@link Response} type
  */
-public class LoggingService<I extends Request, O extends Response> extends DecoratingService<I, O, I, O> {
+public class LoggingService<I extends Request, O extends Response> extends SimpleDecoratingService<I, O> {
 
     private static final String REQUEST_FORMAT = "Request: {}";
     private static final String RESPONSE_FORMAT = "Response: {}";

--- a/core/src/main/java/com/linecorp/armeria/server/logging/structured/StructuredLoggingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/structured/StructuredLoggingService.java
@@ -22,12 +22,12 @@ import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.logging.RequestLogAvailability;
-import com.linecorp.armeria.server.DecoratingService;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerListenerAdapter;
 import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceConfig;
 import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.SimpleDecoratingService;
 
 /**
  * A decorating service which provides support of structured and optionally externalized request/response
@@ -38,7 +38,7 @@ import com.linecorp.armeria.server.ServiceRequestContext;
  * @param <L> the type of the structured log representation
  */
 public abstract class StructuredLoggingService<I extends Request, O extends Response, L>
-        extends DecoratingService<I, O, I, O> {
+        extends SimpleDecoratingService<I, O> {
 
     private final StructuredLogBuilder<L> logBuilder;
     private Server associatedServer;

--- a/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
@@ -108,7 +108,7 @@ public class ServerTest extends AbstractServerTest {
 
         // Disable request timeout for '/timeout-not' only.
         final Function<Service<HttpRequest, HttpResponse>, Service<HttpRequest, HttpResponse>> decorator =
-                s -> new DecoratingService<HttpRequest, HttpResponse, HttpRequest, HttpResponse>(s) {
+                s -> new SimpleDecoratingService<HttpRequest, HttpResponse>(s) {
                     @Override
                     public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
                         ctx.setRequestTimeoutMillis(

--- a/thrift/src/test/java/com/linecorp/armeria/it/thrift/ThriftDynamicTimeoutTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/thrift/ThriftDynamicTimeoutTest.java
@@ -33,14 +33,14 @@ import com.google.common.base.Stopwatch;
 import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.client.ClientBuilder;
 import com.linecorp.armeria.client.ClientRequestContext;
-import com.linecorp.armeria.client.DecoratingClient;
+import com.linecorp.armeria.client.SimpleDecoratingClient;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.RpcResponse;
-import com.linecorp.armeria.server.DecoratingService;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.SimpleDecoratingService;
 import com.linecorp.armeria.server.thrift.THttpService;
 import com.linecorp.armeria.server.thrift.ThriftCallService;
 import com.linecorp.armeria.service.test.thrift.main.SleepService;
@@ -115,8 +115,7 @@ public class ThriftDynamicTimeoutTest extends AbstractServerTest {
         client.sleep(30000);
     }
 
-    private static final class DynamicTimeoutService
-            extends DecoratingService<RpcRequest, RpcResponse, RpcRequest, RpcResponse> {
+    private static final class DynamicTimeoutService extends SimpleDecoratingService<RpcRequest, RpcResponse> {
 
         DynamicTimeoutService(Service<? super RpcRequest, ? extends RpcResponse> delegate) {
             super(delegate);
@@ -132,7 +131,7 @@ public class ThriftDynamicTimeoutTest extends AbstractServerTest {
 
 
     private static final class TimeoutDisablingService
-            extends DecoratingService<RpcRequest, RpcResponse, RpcRequest, RpcResponse> {
+            extends SimpleDecoratingService<RpcRequest, RpcResponse> {
 
         TimeoutDisablingService(Service<? super RpcRequest, ? extends RpcResponse> delegate) {
             super(delegate);
@@ -146,7 +145,7 @@ public class ThriftDynamicTimeoutTest extends AbstractServerTest {
     }
 
     private static final class DynamicTimeoutClient
-            extends DecoratingClient<RpcRequest, RpcResponse, RpcRequest, RpcResponse> {
+            extends SimpleDecoratingClient<RpcRequest, RpcResponse> {
 
         DynamicTimeoutClient(Client<? super RpcRequest, ? extends RpcResponse> delegate) {
             super(delegate);
@@ -161,7 +160,7 @@ public class ThriftDynamicTimeoutTest extends AbstractServerTest {
     }
 
     private static final class TimeoutDisablingClient
-            extends DecoratingClient<RpcRequest, RpcResponse, RpcRequest, RpcResponse> {
+            extends SimpleDecoratingClient<RpcRequest, RpcResponse> {
 
         TimeoutDisablingClient(Client<? super RpcRequest, ? extends RpcResponse> delegate) {
             super(delegate);

--- a/thrift/src/test/java/com/linecorp/armeria/server/thrift/AbstractThriftOverHttpTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/server/thrift/AbstractThriftOverHttpTest.java
@@ -49,11 +49,11 @@ import com.linecorp.armeria.common.thrift.ThriftCall;
 import com.linecorp.armeria.common.thrift.ThriftProtocolFactories;
 import com.linecorp.armeria.common.thrift.ThriftReply;
 import com.linecorp.armeria.common.util.Exceptions;
-import com.linecorp.armeria.server.DecoratingService;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.SimpleDecoratingService;
 import com.linecorp.armeria.server.logging.LoggingService;
 import com.linecorp.armeria.service.test.thrift.main.HelloService;
 import com.linecorp.armeria.service.test.thrift.main.HelloService.AsyncIface;
@@ -121,7 +121,7 @@ public abstract class AbstractThriftOverHttpTest {
 
             final Function<Service<HttpRequest, HttpResponse>,
                            Service<HttpRequest, HttpResponse>> logCollectingDecorator =
-                    s -> new DecoratingService<HttpRequest, HttpResponse, HttpRequest, HttpResponse>(s) {
+                    s -> new SimpleDecoratingService<HttpRequest, HttpResponse>(s) {
                         @Override
                         public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
                             if (recordMessageLogs) {

--- a/zipkin/src/main/java/com/linecorp/armeria/client/tracing/AbstractTracingClient.java
+++ b/zipkin/src/main/java/com/linecorp/armeria/client/tracing/AbstractTracingClient.java
@@ -34,6 +34,7 @@ import com.twitter.zipkin.gen.Span;
 import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.DecoratingClient;
+import com.linecorp.armeria.client.SimpleDecoratingClient;
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
 import com.linecorp.armeria.common.RpcRequest;
@@ -50,7 +51,7 @@ import com.linecorp.armeria.common.logging.RequestLogAvailability;
  * @param <O> the {@link Response} type
  */
 public abstract class AbstractTracingClient<I extends Request, O extends Response>
-        extends DecoratingClient<I, O, I, O> {
+        extends SimpleDecoratingClient<I, O> {
 
     private final ClientTracingInterceptor clientInterceptor;
 

--- a/zipkin/src/main/java/com/linecorp/armeria/server/tracing/AbstractTracingService.java
+++ b/zipkin/src/main/java/com/linecorp/armeria/server/tracing/AbstractTracingService.java
@@ -36,6 +36,7 @@ import com.linecorp.armeria.common.logging.RequestLogAvailability;
 import com.linecorp.armeria.server.DecoratingService;
 import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.SimpleDecoratingService;
 
 /**
  * An abstract {@link DecoratingService} that traces incoming {@link Request}s.
@@ -47,7 +48,7 @@ import com.linecorp.armeria.server.ServiceRequestContext;
  * @param <O> the {@link Response} type
  */
 public abstract class AbstractTracingService<I extends Request, O extends Response>
-        extends DecoratingService<I, O, I, O> {
+        extends SimpleDecoratingService<I, O> {
 
     private final ServerTracingInterceptor serverInterceptor;
 


### PR DESCRIPTION
Motivation:

Decoration of Clients and Services is not simple enough yet.

Modifications:

- Add SimpleDecoratingService/Client which requires only two type
  parameters
- Add DecoratingClientFunction which is similar to DecoratingServiceFunction
  - Add Client(Decoration)Builder.decorator() that accepts DecoratingClientFunction
- Use SimpleDecoratingService/Client or DecoratingClient/ServiceFunction
  wherever possible

Result:

Tad bit easier to write a decorator