### PR TITLE
Allow 'charset=utf-8' parameter in 'content-type' and 'accept' headers of Thrift requests

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/MediaTypeSet.java
+++ b/core/src/main/java/com/linecorp/armeria/common/MediaTypeSet.java
@@ -233,28 +233,34 @@ public final class MediaTypeSet extends AbstractSet<MediaType> {
                containsAllParameters(range.parameters(), candidate.parameters());
     }
 
-    private static boolean containsAllParameters(Map<String, List<String>> requiredParameters,
+    /**
+     * Returns {@code true} if {@code actualParameters} contains all entries of {@code expectedParameters}.
+     * Note that this method does *not* require {@code actualParameters} to contain *only* the entries of
+     * {@code expectedParameters}. i.e. {@code actualParameters} can contain an entry that's non-existent
+     * in {@code expectedParameters}.
+     */
+    private static boolean containsAllParameters(Map<String, List<String>> expectedParameters,
                                                  Map<String, List<String>> actualParameters) {
-        if (requiredParameters.isEmpty()) {
+        if (expectedParameters.isEmpty()) {
             return true;
         }
 
-        for (Entry<String, List<String>> requiredEntry : requiredParameters.entrySet()) {
-            final String requiredName = requiredEntry.getKey();
-            final List<String> requiredValues = requiredEntry.getValue();
-            if (Q.equals(requiredName)) {
+        for (Entry<String, List<String>> requiredEntry : expectedParameters.entrySet()) {
+            final String expectedName = requiredEntry.getKey();
+            final List<String> expectedValues = requiredEntry.getValue();
+            if (Q.equals(expectedName)) {
                 continue;
             }
 
-            final List<String> actualValues = actualParameters.get(requiredName);
+            final List<String> actualValues = actualParameters.get(expectedName);
 
-            assert !requiredValues.isEmpty();
+            assert !expectedValues.isEmpty();
             if (actualValues == null || actualValues.isEmpty()) {
                 // Does not contain any required values.
                 return false;
             }
 
-            if (!containsAllRequiredValues(requiredValues, actualValues)) {
+            if (!containsAllValues(expectedValues, actualValues)) {
                 return false;
             }
         }
@@ -262,20 +268,20 @@ public final class MediaTypeSet extends AbstractSet<MediaType> {
         return true;
     }
 
-    private static boolean containsAllRequiredValues(List<String> requiredValues, List<String> actualValues) {
-        final int numRequiredValues = requiredValues.size();
+    private static boolean containsAllValues(List<String> expectedValues, List<String> actualValues) {
+        final int numRequiredValues = expectedValues.size();
         for (int i = 0; i < numRequiredValues; i++) {
-            if (!containsRequiredValue(requiredValues.get(i), actualValues)) {
+            if (!containsValue(expectedValues.get(i), actualValues)) {
                 return false;
             }
         }
         return true;
     }
 
-    private static boolean containsRequiredValue(String requiredValue, List<String> actualValues) {
+    private static boolean containsValue(String expectedValue, List<String> actualValues) {
         final int numActualValues = actualValues.size();
         for (int i = 0; i < numActualValues; i++) {
-            if (Ascii.equalsIgnoreCase(requiredValue, actualValues.get(i))) {
+            if (Ascii.equalsIgnoreCase(expectedValue, actualValues.get(i))) {
                 return true;
             }
         }

--- a/thrift/src/main/java/com/linecorp/armeria/common/thrift/ThriftSerializationFormatProvider.java
+++ b/thrift/src/main/java/com/linecorp/armeria/common/thrift/ThriftSerializationFormatProvider.java
@@ -16,12 +16,13 @@
 
 package com.linecorp.armeria.common.thrift;
 
-import static com.linecorp.armeria.common.MediaType.create;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.util.Set;
 
 import com.google.common.collect.ImmutableSet;
 
+import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.SerializationFormatProvider;
 
@@ -33,16 +34,28 @@ public final class ThriftSerializationFormatProvider extends SerializationFormat
     protected Set<Entry> entries() {
         return ImmutableSet.of(
                 new Entry("tbinary",
-                          create("application", "x-thrift").withParameter("protocol", "TBINARY"),
-                          create("application", "vnd.apache.thrift.binary")),
+                          create("x-thrift", "TBINARY"),
+                          create("vnd.apache.thrift.binary")),
                 new Entry("tcompact",
-                          create("application", "x-thrift").withParameter("protocol", "TCOMPACT"),
-                          create("application", "vnd.apache.thrift.compact")),
+                          create("x-thrift", "TCOMPACT"),
+                          create("vnd.apache.thrift.compact")),
                 new Entry("tjson",
-                          create("application", "x-thrift").withParameter("protocol", "TJSON"),
-                          create("application", "vnd.apache.thrift.json")),
+                          create("x-thrift", "TJSON"),
+                          create("x-thrift", "TJSON").withCharset(UTF_8),
+                          create("vnd.apache.thrift.json"),
+                          create("vnd.apache.thrift.json").withCharset(UTF_8)),
                 new Entry("ttext",
-                          create("application", "x-thrift").withParameter("protocol", "TTEXT"),
-                          create("application", "vnd.apache.thrift.text")));
+                          create("x-thrift", "TTEXT"),
+                          create("x-thrift", "TTEXT").withCharset(UTF_8),
+                          create("vnd.apache.thrift.text"),
+                          create("vnd.apache.thrift.text").withCharset(UTF_8)));
+    }
+
+    private static MediaType create(String subtype) {
+        return MediaType.create("application", subtype);
+    }
+
+    private static MediaType create(String subtype, String protocol) {
+        return create(subtype).withParameter("protocol", protocol);
     }
 }

--- a/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftSerializationFormatsTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftSerializationFormatsTest.java
@@ -52,7 +52,27 @@ public class ThriftSerializationFormatsTest extends AbstractServerTest {
         assertThat(find(parse("application/x-thrift; protocol=tbinary"))).containsSame(BINARY);
         assertThat(find(parse("application/x-thrift;protocol=TCompact"))).containsSame(COMPACT);
         assertThat(find(parse("application/x-thrift ; protocol=\"TjSoN\""))).containsSame(JSON);
+
+        // An unknown parameter ('version' in this case) should not be accepted.
         assertThat(find(parse("application/x-thrift ; version=3;protocol=ttext"))).isEmpty();
+
+        // 'charset=utf-8' parameter should be accepted for TJSON and TTEXT.
+        assertThat(find(parse("application/x-thrift; protocol=tjson; charset=utf-8"))).containsSame(JSON);
+        assertThat(find(parse("application/vnd.apache.thrift.json; charset=utf-8"))).containsSame(JSON);
+        assertThat(find(parse("application/x-thrift; protocol=ttext; charset=utf-8"))).containsSame(TEXT);
+        assertThat(find(parse("application/vnd.apache.thrift.text; charset=utf-8"))).containsSame(TEXT);
+
+        // .. but neither non-UTF-8 charsets:
+        assertThat(find(parse("application/x-thrift; protocol=tjson; charset=us-ascii"))).isEmpty();
+        assertThat(find(parse("application/vnd.apache.thrift.json; charset=us-ascii"))).isEmpty();
+        assertThat(find(parse("application/x-thrift; protocol=ttext; charset=us-ascii"))).isEmpty();
+        assertThat(find(parse("application/vnd.apache.thrift.text; charset=us-ascii"))).isEmpty();
+
+        // .. nor binary/compact formats:
+        assertThat(find(parse("application/x-thrift; protocol=tbinary; charset=utf-8"))).isEmpty();
+        assertThat(find(parse("application/vnd.apache.thrift.binary; charset=utf-8"))).isEmpty();
+        assertThat(find(parse("application/x-thrift; protocol=tcompact; charset=utf-8"))).isEmpty();
+        assertThat(find(parse("application/vnd.apache.thrift.compact; charset=utf-8"))).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
Motivation:

Some clients seem to append the 'charset=utf-8' parameter to the media
types/ranges specified in the 'content-type' and 'accept' headers of a
Thrift request. This leads the THttpService to respond with '415
Unsupported Media Type' which may be confusing to a user.

Modifications:

- Add the media types with the 'charset=utf-8' parameter to
  ThriftSerializationFormatProvider
- Clean up MediaTypeSet.containsAllParameters for clarity

Result:

- Fixes #473
- THttpService now accepts the media types with the 'charset=utf-8'
  parameter.