### PR TITLE
Ignore flaky zookeeper test for now.

### DIFF
--- a/zookeeper/src/test/java/com/linecorp/armeria/server/zookeeper/ZooKeeperRegistrationTest.java
+++ b/zookeeper/src/test/java/com/linecorp/armeria/server/zookeeper/ZooKeeperRegistrationTest.java
@@ -27,6 +27,7 @@ import org.apache.zookeeper.ZooKeeper;
 import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import com.linecorp.armeria.client.Endpoint;
@@ -117,6 +118,7 @@ public class ZooKeeperRegistrationTest extends TestBase implements ZooKeeperAsse
         }
     }
 
+    @Ignore  // https://github.com/line/armeria/issues/477
     @Test
     public void testConnectionRecovery() throws Exception {
         ZooKeeperRegistration zkConnector = zkConnectors.get(0);

--- a/zookeeper/src/test/java/com/linecorp/armeria/server/zookeeper/ZooKeeperRegistrationTest.java
+++ b/zookeeper/src/test/java/com/linecorp/armeria/server/zookeeper/ZooKeeperRegistrationTest.java
@@ -118,7 +118,7 @@ public class ZooKeeperRegistrationTest extends TestBase implements ZooKeeperAsse
         }
     }
 
-    @Ignore  // https://github.com/line/armeria/issues/477
+    @Ignore  // FIXME: https://github.com/line/armeria/issues/477
     @Test
     public void testConnectionRecovery() throws Exception {
         ZooKeeperRegistration zkConnector = zkConnectors.get(0);


### PR DESCRIPTION
I get this failure a lot so propose disabling for now. Maybe we can remove it too - does armeria do anything special for connection recovery vs the standard zookeeper client?