### PR TITLE
Add appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,21 @@
+version: "{branch}.{build}"
+
+init:
+  - git config --global core.autocrlf true
+
+build:
+  verbosity: detailed
+
+build_script:
+  - gradlew.bat --no-daemon --stacktrace checkstyle build test
+
+cache:
+  - %USERPROFILE%\.gradle
+
+environment:
+  matrix:
+  - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
+  - JAVA_HOME: C:\Program Files (x86)\Java\jdk1.8.0
+
+matrix:
+  fast_finish: true


### PR DESCRIPTION
Motivations:
 - Sometimes windows build is broken
- ~~When I tried to build armeria on windows system, checkstyle was failed with following errors.~~
```
[ant:checkstyle] [ERROR] C:\projects\armeria\core\src\main\java\com\linecorp\armeria\client\endpoint\StaticEndpointGroup.java:0: File does not end with a newline. [NewlineAtEndOfFile]
```
~~(See [link](https://ci.appveyor.com/project/imasahiro/armeria/build/app%20110/job/4icgnpgnr6y1ndug) for detail log)~~

Modifications:
- Add appveyor setting
- ~~Add LF checkstyle config~~

Results:
 - Detect windows build failure more easily
- ~~Fix checkstyle failure~~
