### PR TITLE
More fine-grained classpath generation for shaded-test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ ext {
     publishedJavaProjects = javaProjects.findAll { it.name != 'it' && it.name != 'shaded-test' }
 
     // The list of backward-compatibility Java projects which have the namespace conflicts with other projects.
-    backwardCompatProjects = publishedJavaProjects.findAll { it.name in [ 'thrift0.9' ] }
+    backwardCompatProjects = publishedJavaProjects.findAll { it.name in [ 'thrift0.9', 'tomcat8.0' ] }
 
     // The list of Gradle task names specified in the startup parameters.
     requestedTaskNames = gradle.startParameter.taskRequests.inject([]) { a, b -> a + b.args }

--- a/shaded-test/build.gradle
+++ b/shaded-test/build.gradle
@@ -3,18 +3,9 @@ rootProject.ext.publishedJavaProjects.each {
     evaluationDependsOn it.path
 }
 
-ext {
-    getTestConfigurations = { testProject -> testProject.configurations.findAll { cfg ->
-        cfg.name in ['compile', 'runtime', 'testCompile', 'testRuntime']
-    }}
-    testConfigurations = getTestConfigurations(project)
-
-    // Exclude the projects with conflicting dependency versions.
-    testedProjects = rootProject.ext.publishedJavaProjects - rootProject.ext.backwardCompatProjects
-}
-// Clear the common dependencies set by the root project to make sure we do not pull the unshaded projects.
-ext.testConfigurations.each { it.dependencies.clear() }
-ext.testConfigurations.each { assert it.dependencies.empty } // Make sure we did not clear the copy.
+// Clear the common dependencies set by the root project because we don't use them at all.
+configurations.each { it.dependencies.clear() }
+configurations.each { assert it.dependencies.empty } // Make sure we did not clear the copy.
 
 // Clear the common source sets set by the root project to make sure we do not compile anything additionally.
 sourceSets.findAll().each { set ->
@@ -27,37 +18,11 @@ sourceSets.findAll().each { set ->
     assert set.resources.srcDirs.empty
 }
 
-dependencies {
-    def addShaded = { Project testProject ->
-        if (testProject.tasks.findByName('trimShadedJar')) {
-            assert testProject.name == 'core'
-            testRuntime files(testProject.tasks.trimShadedJar.outJarFiles)
-        } else {
-            assert testProject.name != 'core'
-            testRuntime files(testProject.tasks.shadedJar.archivePath)
-        }
-
-        // Collect all dependencies of the project.
-        def allDeps = project.ext.getTestConfigurations(testProject).inject([]) { a, b -> a + b.dependencies }
-        allDeps.each { dep ->
-            // Do not pull the the shaded dependencies in.
-            if ("${dep.group}:${dep.name}".toString() in relocations.collect { it[0] }) {
-                return
-            }
-            if (dep instanceof ProjectDependency) {
-                owner.call(dep.dependencyProject) // Recurse.
-            } else {
-                testRuntime dep
-            }
-        }
-    }
-
-    // Pull all shaded JARs and their dependencies in.
-    project.ext.testedProjects.each { addShaded it }
-}
+// Pull all shaded JARs and their dependencies in.
+rootProject.ext.publishedJavaProjects.each { addDependencies(it) }
 
 task allShadedJars {
-    project.ext.testedProjects.each { testProject ->
+    rootProject.ext.publishedJavaProjects.each { testProject ->
         dependsOn testProject.tasks.assemble
     }
 }
@@ -66,8 +31,8 @@ task shadedTest(group: 'Verification',
                 description: 'Runs the unit tests with the shaded JARs.')
 tasks.test.dependsOn tasks.shadedTest
 
-project.ext.testedProjects.each { testProject ->
-    def shadedTestJarExtractTask = tasks.create("shaded${testProject.name.capitalize()}TestJarExtract", Copy) {
+rootProject.ext.publishedJavaProjects.each { testProject ->
+    def shadedTestJarExtractTask = tasks.create(shadedName(testProject, 'TestJarExtract'), Copy) {
         def shadedTestJarTask = testProject.tasks.shadedTestJar
         dependsOn shadedTestJarTask
 
@@ -80,7 +45,9 @@ project.ext.testedProjects.each { testProject ->
         into file("${sourceSets.test.output.classesDir.parent}/test-${testProject.name}")
     }
 
-    def shadedTestTask = tasks.create("shaded${testProject.name.capitalize()}Test", Test) {
+    def shadedTestTask = tasks.create(shadedName(testProject, 'Test'), Test) {
+        Configuration cfg = configurations.getByName(shadedName(testProject))
+        dependsOn cfg
         dependsOn tasks.allShadedJars
         dependsOn tasks.copyJavaAgents
         dependsOn shadedTestJarExtractTask
@@ -91,7 +58,7 @@ project.ext.testedProjects.each { testProject ->
         }
 
         testClassesDir = shadedTestJarExtractTask.destinationDir
-        classpath = files(testClassesDir) + classpath
+        classpath = files(testClassesDir) + files(cfg.files)
 
         exclude('**/internal/shaded/**')
 
@@ -107,4 +74,46 @@ jacocoTestReport {
     reports {
         xml.enabled false
     }
+}
+
+/**
+ * Finds the dependencies of {@code initialProject} recursively and adds the found dependencies to
+ * the configuration named as {@code "shaded${initialProject.name}"}.
+ */
+private void addDependencies(Project initialProject, Project recursedProject = initialProject) {
+
+    def configName = shadedName(initialProject)
+    project.configurations.maybeCreate(configName)
+
+    if (recursedProject.tasks.findByName('trimShadedJar')) {
+        assert recursedProject.name == 'core'
+        project.dependencies.add(configName, files(recursedProject.tasks.trimShadedJar.outJarFiles))
+    } else {
+        assert recursedProject.name != 'core'
+        project.dependencies.add(configName, files(recursedProject.tasks.shadedJar.archivePath))
+    }
+
+    // Collect all dependencies of the project.
+    def allDeps = testConfigurations(recursedProject).inject([]) { a, b -> a + b.dependencies }
+    allDeps.each { dep ->
+        // Do not pull the the shaded dependencies in.
+        if ("${dep.group}:${dep.name}".toString() in relocations.collect { it[0] }) {
+            return
+        }
+        if (dep instanceof ProjectDependency) {
+            addDependencies(initialProject, dep.dependencyProject) // Recurse.
+        } else {
+            project.dependencies.add(configName, dep)
+        }
+    }
+}
+
+private static Collection<Configuration> testConfigurations(Project project) {
+    return project.configurations.findAll { cfg ->
+        cfg.name in ['compile', 'runtime', 'testCompile', 'testRuntime']
+    }
+}
+
+private static String shadedName(Project project, String suffix = '') {
+    return "shaded${project.name.capitalize()}${suffix}"
 }


### PR DESCRIPTION
Motivation:

The tests in the 'shaded-test' module uses one big merged classpath for
all test tasks. It works in most cases but it cannot test the backward
compatibility projects like 'thrift0.9' and 'tomcat8.0'.

Modifications:

- Create a dedicated configuration for each project so that the projects
  with conflicting dependencies (e.g. 'thrift' and 'thrift0.9') can
  coexist
- Make 'shaded-test' run the tests for 'backwardCompatProjects' as well
- Add 'tomcat8.0' to 'backwardCompatProject', which is going to be added
  in the near future

Result:

- The backward-compat projects are also tested properly.
- './gradlew shaded-test:dependencies' shows the dependency graphs for
  all shaded projects