### PR TITLE
Fix NoSuchMethodError in UnmanagedTomcatServiceTest.createTomcat()

### DIFF
--- a/tomcat/src/test/java/com/linecorp/armeria/server/http/tomcat/UnmanagedTomcatServiceTest.java
+++ b/tomcat/src/test/java/com/linecorp/armeria/server/http/tomcat/UnmanagedTomcatServiceTest.java
@@ -54,7 +54,7 @@ public class UnmanagedTomcatServiceTest extends AbstractServerTest {
 
         tomcatWithWebApp.addWebapp(
                 "", (docBaseB.exists() ? docBaseB : docBaseA).getAbsolutePath());
-        tomcatWithWebApp.getService().getContainer().setName("tomcatWithWebApp");
+        TomcatUtil.engine(tomcatWithWebApp.getService()).setName("tomcatWithWebApp");
 
         tomcatWithoutWebApp = new Tomcat();
         tomcatWithoutWebApp.setPort(0);


### PR DESCRIPTION
- Use TomcatUtil.engine(Service) to make UnmanagedTomcatServiceTest work
  for different Tomcat versions