### PR TITLE
Update the dependencies

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/http/Http2ResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/http/Http2ResponseDecoder.java
@@ -68,15 +68,6 @@ final class Http2ResponseDecoder extends HttpResponseDecoder implements Http2Con
     public void onStreamRemoved(Http2Stream stream) {}
 
     @Override
-    public void onPriorityTreeParentChanged(Http2Stream stream, Http2Stream oldParent) {}
-
-    @Override
-    public void onPriorityTreeParentChanging(Http2Stream stream, Http2Stream newParent) {}
-
-    @Override
-    public void onWeightChanged(Http2Stream stream, short oldWeight) {}
-
-    @Override
     public void onGoAwaySent(int lastStreamId, long errorCode, ByteBuf debugData) {}
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/http/HttpSessionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/http/HttpSessionHandler.java
@@ -43,7 +43,9 @@ import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.socket.ChannelInputShutdownReadComplete;
 import io.netty.handler.codec.http2.Http2ConnectionHandler;
+import io.netty.handler.codec.http2.Http2ConnectionPrefaceWrittenEvent;
 import io.netty.handler.codec.http2.Http2Settings;
 import io.netty.handler.ssl.SslCloseCompletionEvent;
 import io.netty.util.ReferenceCountUtil;
@@ -197,7 +199,7 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
             final SessionProtocol protocol = (SessionProtocol) evt;
             this.protocol = protocol;
             if (protocol == H1 || protocol == H1C) {
-                requestEncoder = new Http1ObjectEncoder(false);
+                requestEncoder = new Http1ObjectEncoder(false, protocol.isTls());
                 responseDecoder = ctx.pipeline().get(Http1ResponseDecoder.class);
             } else if (protocol == H2 || protocol == H2C) {
                 final Http2ConnectionHandler handler = ctx.pipeline().get(Http2ConnectionHandler.class);
@@ -221,7 +223,10 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
             return;
         }
 
-        if (evt instanceof SslCloseCompletionEvent) {
+        if (evt instanceof Http2ConnectionPrefaceWrittenEvent ||
+            evt instanceof SslCloseCompletionEvent ||
+            evt instanceof ChannelInputShutdownReadComplete) {
+            // Expected events
             return;
         }
 

--- a/core/src/main/java/com/linecorp/armeria/server/http/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/HttpServerHandler.java
@@ -76,6 +76,7 @@ import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.EventLoop;
+import io.netty.channel.socket.ChannelInputShutdownReadComplete;
 import io.netty.handler.codec.http2.Http2ConnectionHandler;
 import io.netty.handler.codec.http2.Http2Settings;
 import io.netty.handler.ssl.SslCloseCompletionEvent;
@@ -175,7 +176,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
 
         this.protocol = requireNonNull(protocol, "protocol");
         if (protocol == H1 || protocol == H1C) {
-            responseEncoder = new Http1ObjectEncoder(true);
+            responseEncoder = new Http1ObjectEncoder(true, protocol.isTls());
         }
     }
 
@@ -534,7 +535,9 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
 
     @Override
     public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
-        if (evt instanceof SslCloseCompletionEvent) {
+        if (evt instanceof SslCloseCompletionEvent ||
+            evt instanceof ChannelInputShutdownReadComplete) {
+            // Expected events
             return;
         }
 

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -1,5 +1,5 @@
 ch.qos.logback:
-  logback-classic: { version: 1.2.1 }
+  logback-classic: { version: 1.2.2 }
 
 com.fasterxml.jackson.core:
   jackson-annotations: { version: &JACKSON_VERSION 2.8.7 }
@@ -7,7 +7,7 @@ com.fasterxml.jackson.core:
   jackson-databind: { version: *JACKSON_VERSION }
 
 com.google.code.findbugs:
-  jsr305: { version: 3.0.1 }
+  jsr305: { version: 3.0.2 }
 
 com.google.guava:
   guava: { version: &GUAVA_VERSION !!str 21.0 }
@@ -21,12 +21,12 @@ com.spotify:
   completable-futures: { version: 0.3.0 }
 
 com.squareup.retrofit2:
-  retrofit: { version: &RETROFIT2_VERSION 2.1.0 }
+  retrofit: { version: &RETROFIT2_VERSION 2.2.0 }
   adapter-java8: { version: *RETROFIT2_VERSION }
   converter-jackson: { version: *RETROFIT2_VERSION }
 
 io.dropwizard.metrics:
-  metrics-core: { version: 3.1.2 }
+  metrics-core: { version: 3.2.2 }
 
 io.grpc:
   grpc-core:
@@ -42,12 +42,12 @@ io.grpc:
   grpc-stub: { version: *GRPC_VERSION }
 
 io.netty:
-  netty-codec-http2: { version: &NETTY_VERSION 4.1.8.Final }
+  netty-codec-http2: { version: &NETTY_VERSION 4.1.9.Final }
   netty-handler: { version: *NETTY_VERSION }
   netty-resolver-dns: { version: *NETTY_VERSION }
   netty-transport: { version: *NETTY_VERSION }
   netty-transport-native-epoll: { version: *NETTY_VERSION }
-  netty-tcnative-boringssl-static: { version: 1.1.33.Fork26 }
+  netty-tcnative-boringssl-static: { version: 2.0.0.Final }
 
 io.zipkin.brave:
   brave-core: { version: &BRAVE_VERSION 4.0.6 }
@@ -60,12 +60,12 @@ junit:
   junit: { version: !!str 4.12 }
 
 net.javacrumbs.json-unit:
-  json-unit: { version: &JSON_UNIT_VERSION 1.19.0 }
+  json-unit: { version: &JSON_UNIT_VERSION 1.21.0 }
   json-unit-fluent: { version: *JSON_UNIT_VERSION }
 
 org.apache.hbase:
   hbase-shaded-client:
-    version: 1.2.4
+    version: 1.2.5
     exclusions:
     - org.slf4j:slf4j-log4j12
 
@@ -76,7 +76,7 @@ org.apache.httpcomponents:
     - commons-logging:commons-logging
 
 org.apache.kafka:
-  kafka-clients: { version: 0.10.1.1 }
+  kafka-clients: { version: 0.10.2.0 }
 
 org.apache.thrift:
   libthrift:
@@ -86,7 +86,7 @@ org.apache.thrift:
     - org.apache.httpcomponents:httpclient
 
 org.apache.tomcat.embed:
-  tomcat-embed-core: { version: &TOMCAT_VERSION 8.5.12 }
+  tomcat-embed-core: { version: &TOMCAT_VERSION 8.5.13 }
   tomcat-embed-jasper: { version: *TOMCAT_VERSION }
   tomcat-embed-el: { version: *TOMCAT_VERSION }
 
@@ -100,7 +100,7 @@ org.dmonix.junit:
   zookeeper-junit: { version: !!str 1.2 }
 
 org.eclipse.jetty:
-  apache-jsp: { version: &JETTY_VERSION 9.4.1.v20170120 }
+  apache-jsp: { version: &JETTY_VERSION 9.4.3.v20170317 }
   apache-jstl: { version: *JETTY_VERSION }
   jetty-annotations: { version: *JETTY_VERSION }
   jetty-server: { version: *JETTY_VERSION  }
@@ -119,7 +119,7 @@ org.javassist:
   javassist: { version: 3.21.0-GA }
 
 org.mockito:
-  mockito-core: { version: 2.7.10 }
+  mockito-core: { version: 2.7.21 }
 
 org.mortbay.jetty.alpn:
   jetty-alpn-agent: { version: 2.0.6 }
@@ -129,12 +129,10 @@ org.reactivestreams:
 
 org.reflections:
   reflections:
-    version: 0.9.10
-    exclusions:
-    - com.google.code.findbugs:annotations
+    version: 0.9.11
 
 org.slf4j:
-  jcl-over-slf4j: { version: &SLF4J_VERSION 1.7.23 }
+  jcl-over-slf4j: { version: &SLF4J_VERSION 1.7.25 }
   jul-to-slf4j: { version: *SLF4J_VERSION }
   log4j-over-slf4j: { version: *SLF4J_VERSION }
   slf4j-api: { version: *SLF4J_VERSION }

--- a/it/src/test/java/com/linecorp/armeria/server/grpc/interop/ArmeriaGrpcServerInteropTest.java
+++ b/it/src/test/java/com/linecorp/armeria/server/grpc/interop/ArmeriaGrpcServerInteropTest.java
@@ -79,6 +79,7 @@ import io.netty.handler.ssl.util.SelfSignedCertificate;
  * Interop test based on grpc-interop-testing. Should provide reasonable confidence in armeria's
  * handling of the grpc protocol.
  */
+@Ignore // TODO(trustin): Unignore once GRPC upgrades to Netty 4.1.9
 public class ArmeriaGrpcServerInteropTest extends AbstractInteropTest {
 
     private static final ApplicationProtocolConfig ALPN = new ApplicationProtocolConfig(

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/http/retrofit2/ArmeriaCallFactory.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/http/retrofit2/ArmeriaCallFactory.java
@@ -188,5 +188,10 @@ public class ArmeriaCallFactory implements Call.Factory {
                                                        ExecutionState.RUNNING,
                                                        ExecutionState.FINISHED);
         }
+
+        @Override
+        public Call clone() {
+            return new ArmeriaCall(callFactory, request);
+        }
     }
 }

--- a/tomcat8.0/build.gradle
+++ b/tomcat8.0/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
     // Tomcat
     [ 'tomcat-embed-core', 'tomcat-embed-jasper', 'tomcat-embed-el' ].each {
-        compile "org.apache.tomcat.embed:$it:8.0.42"
+        compile "org.apache.tomcat.embed:$it:8.0.43"
     }
 }
 


### PR DESCRIPTION
- ch.qos.logback 1.2.1 -> 1.2.2
- com.google.code.findbugs 3.0.1 -> 3.0.2
- com.squareup.retrofit2 2.1.0 -> 2.2.0
- io.dropwizard.metrics 3.1.2 -> 3.2.2
- io.netty 4.1.8 -> 4.1.9
- net.javacrumbs.json-unit 1.19.0 -> 1.21.0
- org.apache.hbase:hbase-shaded-client 1.2.4 -> 1.2.5
- org.apache.kafka:kafka-clients 0.10.1.1 -> 0.10.2.0
- org.apache.tomcat.embed 8.5.12 -> 8.5.13 and 8.0.42 -> 8.0.43
- org.eclipse.jetty 9.4.1.v20170120 -> 9.4.3.v20170317
- org.mockito 2.7.10 -> 2.7.21
- org.reflections 0.9.10 -> 0.9.11
- org.slf4j 1.7.23 -> 1.7.25

Code changes:

- Remove the methods removed from Http2Connection.Listener
- Handle ChannelInputShutdownReadComplete user event
- Handle Http2ConnectionPrefaceWrittenEvent user event
- Implement workaround for Netty SslHandler regression in Http1ObjectEncoder
  - https://github.com/netty/netty/issues/6564
- Fix RequestContextTest failures due to a bug in the test code
  - Revealed by slight behavioral changes in Netty 4.1.9
- Disable ArmeriaGrpcServerInteropTest again until GRPC upgrade is done
- Adjust ArmeriaCallFactory to the breaking API change in Retrofit 2.2.0