### PR TITLE
Fix RequestLogAvailabilitySet.of(int)

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogAvailabilitySet.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogAvailabilitySet.java
@@ -47,7 +47,7 @@ final class RequestLogAvailabilitySet extends AbstractSet<RequestLogAvailability
             int flags = 0;
             for (RequestLogAvailability v : values) {
                 if ((i & 1 << v.ordinal()) != 0) {
-                    flags |= v.getterFlags();
+                    flags |= v.setterFlags();
                 }
             }
 
@@ -73,7 +73,7 @@ final class RequestLogAvailabilitySet extends AbstractSet<RequestLogAvailability
 
         final List<RequestLogAvailability> values = new ArrayList<>();
         for (RequestLogAvailability v : RequestLogAvailability.values()) {
-            if ((flags & v.getterFlags()) == flags) {
+            if ((flags & v.getterFlags()) == v.getterFlags()) {
                 values.add(v);
             }
         }

--- a/core/src/test/java/com/linecorp/armeria/common/logging/RequestLogAvailabilitySetTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/logging/RequestLogAvailabilitySetTest.java
@@ -1,0 +1,59 @@
+/*
+ *  Copyright 2017 LINE Corporation
+ *
+ *  LINE Corporation licenses this file to you under the Apache License,
+ *  version 2.0 (the "License"); you may not use this file except in compliance
+ *  with the License. You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package com.linecorp.armeria.common.logging;
+
+import static com.linecorp.armeria.common.logging.RequestLogAvailability.REQUEST_CONTENT;
+import static com.linecorp.armeria.common.logging.RequestLogAvailability.REQUEST_START;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+import com.google.common.math.IntMath;
+
+public class RequestLogAvailabilitySetTest {
+
+    @Test
+    public void allGetterFlagsAreAccepted() {
+        final RequestLogAvailability[] values = RequestLogAvailability.values();
+        final int end = IntMath.pow(2, values.length);
+        for (int i = 0; i < end; i++) {
+            int flags = 0;
+            for (RequestLogAvailability v : values) {
+                if ((i & 1 << v.ordinal()) != 0) {
+                    flags |= v.getterFlags();
+                }
+            }
+
+            if (flags != 0) {
+                assertThat(RequestLogAvailabilitySet.of(flags)).isNotEmpty();
+            }
+        }
+    }
+
+    @Test
+    public void requestContentAfterRequestStart() {
+        assertThat(RequestLogAvailabilitySet.of(REQUEST_START.setterFlags())).containsExactly(REQUEST_START);
+        assertThat(RequestLogAvailabilitySet.of(REQUEST_START.setterFlags() | REQUEST_CONTENT.setterFlags()))
+                .containsExactly(REQUEST_START, REQUEST_CONTENT);
+    }
+
+    @Test
+    public void requestContentBeforeRequestStart() {
+        // Should not return anything because the getter flag of REQUEST_CONTENT does not match.
+        assertThat(RequestLogAvailabilitySet.of(REQUEST_CONTENT.setterFlags())).isEmpty();
+    }
+}


### PR DESCRIPTION
Motivation:

RequestLogAvailabilitySet.of(int) returns a wrong RequestLogAvailibilitySet
or null because of a bug in its instance prepopulation logic.

Modifications:

- Fix the broken logic and add a test case

Result:

RequestLogListener is notified correctly.