### PR TITLE
Fix health check metrics not correctly represent the state.

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/EndpointHealthStateGaugeSet.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/EndpointHealthStateGaugeSet.java
@@ -49,9 +49,9 @@ class EndpointHealthStateGaugeSet implements MetricSet {
     public Map<String, Metric> getMetrics() {
         return ImmutableMap.of(
                 METRIC_NAME_PREFIX + metricName + ".all.count",
-                (Gauge<Integer>) endpointGroup.allServers::size,
+                (Gauge<Integer>) () -> endpointGroup.allServers.size(),
                 METRIC_NAME_PREFIX + metricName + ".healthy.count",
-                (Gauge<Integer>) endpointGroup.endpoints()::size,
+                (Gauge<Integer>) () -> endpointGroup.endpoints().size(),
                 METRIC_NAME_PREFIX + metricName + ".healthy.endpoints",
                 (Gauge<Set<String>>) () -> ImmutableSet.copyOf(endpointGroup.endpoints())
                                                        .stream()

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroupTest.java
@@ -79,6 +79,10 @@ public class HttpHealthCheckedEndpointGroupTest {
                                            "127.0.0.1:" + serverTwo.httpPort()));
         assertThat(metricRegistry.getGauges().get("endpointHealth.metric.unhealthy.endpoints").getValue())
                 .isEqualTo(ImmutableSet.of());
+
+        serverTwo.stop().get();
+        assertThat(metricRegistry.getGauges().get("endpointHealth.metric.healthy.count").getValue())
+                .isEqualTo(1);
     }
 
     @Test


### PR DESCRIPTION
Apply this change will fix healthy count not correct problem. Method
reference & lambda version have different bytecode. check

https://gist.github.com/kojilin/c09062812c1f76699f5567bdcd984cac#file-bytecode1-L105-L113
and
https://gist.github.com/kojilin/c09062812c1f76699f5567bdcd984cac#file-bytecode2-L98-L106