### PR TITLE
Add a decorator that allows GRPC services to be served without framin…

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/internal/grpc/GrpcRequestUtil.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/grpc/GrpcRequestUtil.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.grpc;
+
+import javax.annotation.Nullable;
+
+import com.linecorp.armeria.server.ServiceRequestContext;
+
+/**
+ * Utilities for introspecting a GRPC request.
+ */
+public final class GrpcRequestUtil {
+
+    @Nullable
+    public static String determineMethod(ServiceRequestContext ctx) {
+        // Remove the leading slash of the path and get the fully qualified method name
+        String path = ctx.mappedPath();
+        if (path.charAt(0) != '/') {
+            return null;
+        }
+        return path.substring(1, path.length());
+    }
+
+    private GrpcRequestUtil() {}
+}

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcRequestUtil.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcRequestUtil.java
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-package com.linecorp.armeria.internal.grpc;
+package com.linecorp.armeria.server.grpc;
 
 import javax.annotation.Nullable;
 
@@ -23,7 +23,7 @@ import com.linecorp.armeria.server.ServiceRequestContext;
 /**
  * Utilities for introspecting a GRPC request.
  */
-public final class GrpcRequestUtil {
+final class GrpcRequestUtil {
 
     @Nullable
     public static String determineMethod(ServiceRequestContext ctx) {

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcRequestUtil.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcRequestUtil.java
@@ -26,7 +26,7 @@ import com.linecorp.armeria.server.ServiceRequestContext;
 final class GrpcRequestUtil {
 
     @Nullable
-    public static String determineMethod(ServiceRequestContext ctx) {
+    static String determineMethod(ServiceRequestContext ctx) {
         // Remove the leading slash of the path and get the fully qualified method name
         String path = ctx.mappedPath();
         if (path.charAt(0) != '/') {

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
@@ -30,7 +30,6 @@ import com.linecorp.armeria.common.http.HttpRequest;
 import com.linecorp.armeria.common.http.HttpResponseWriter;
 import com.linecorp.armeria.common.http.HttpStatus;
 import com.linecorp.armeria.internal.grpc.GrpcHeaderNames;
-import com.linecorp.armeria.internal.grpc.GrpcRequestUtil;
 import com.linecorp.armeria.internal.grpc.TimeoutHeaderUtil;
 import com.linecorp.armeria.server.ServiceConfig;
 import com.linecorp.armeria.server.ServiceRequestContext;

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
@@ -21,8 +21,6 @@ import static java.util.Objects.requireNonNull;
 import java.time.Duration;
 import java.util.List;
 
-import javax.annotation.Nullable;
-
 import com.google.common.annotations.VisibleForTesting;
 
 import com.linecorp.armeria.common.MediaType;
@@ -32,6 +30,7 @@ import com.linecorp.armeria.common.http.HttpRequest;
 import com.linecorp.armeria.common.http.HttpResponseWriter;
 import com.linecorp.armeria.common.http.HttpStatus;
 import com.linecorp.armeria.internal.grpc.GrpcHeaderNames;
+import com.linecorp.armeria.internal.grpc.GrpcRequestUtil;
 import com.linecorp.armeria.internal.grpc.TimeoutHeaderUtil;
 import com.linecorp.armeria.server.ServiceConfig;
 import com.linecorp.armeria.server.ServiceRequestContext;
@@ -90,12 +89,12 @@ public final class GrpcService extends AbstractHttpService {
     @Override
     protected void doPost(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) throws Exception {
         if (!verifyContentType(req.headers())) {
-            res.respond(HttpStatus.BAD_REQUEST,
+            res.respond(HttpStatus.UNSUPPORTED_MEDIA_TYPE,
                         MediaType.PLAIN_TEXT_UTF_8,
                         "Missing or invalid Content-Type header.");
             return;
         }
-        String methodName = determineMethod(ctx);
+        String methodName = GrpcRequestUtil.determineMethod(ctx);
         if (methodName == null) {
             res.respond(HttpStatus.BAD_REQUEST,
                         MediaType.PLAIN_TEXT_UTF_8,
@@ -156,16 +155,6 @@ public final class GrpcService extends AbstractHttpService {
     private boolean verifyContentType(HttpHeaders headers) throws Http2Exception {
         String contentType = headers.get(HttpHeaderNames.CONTENT_TYPE);
         return contentType != null && isGrpcContentType(contentType);
-    }
-
-    @Nullable
-    private String determineMethod(ServiceRequestContext ctx) throws Http2Exception {
-        // Remove the leading slash of the path and get the fully qualified method name
-        String path = ctx.mappedPath();
-        if (path.charAt(0) != '/') {
-            return null;
-        }
-        return path.substring(1, path.length());
     }
 
     private static boolean isGrpcContentType(String contentType) {

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcService.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.grpc;
+
+import java.util.Map;
+import java.util.function.Function;
+
+import com.google.common.collect.ImmutableMap;
+
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.SerializationFormat;
+import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
+import com.linecorp.armeria.common.http.AggregatedHttpMessage;
+import com.linecorp.armeria.common.http.DefaultHttpRequest;
+import com.linecorp.armeria.common.http.DefaultHttpResponse;
+import com.linecorp.armeria.common.http.HttpData;
+import com.linecorp.armeria.common.http.HttpHeaderNames;
+import com.linecorp.armeria.common.http.HttpHeaders;
+import com.linecorp.armeria.common.http.HttpRequest;
+import com.linecorp.armeria.common.http.HttpResponse;
+import com.linecorp.armeria.common.http.HttpStatus;
+import com.linecorp.armeria.internal.grpc.ArmeriaMessageDeframer;
+import com.linecorp.armeria.internal.grpc.ArmeriaMessageDeframer.ByteBufOrStream;
+import com.linecorp.armeria.internal.grpc.ArmeriaMessageDeframer.Listener;
+import com.linecorp.armeria.internal.grpc.ArmeriaMessageFramer;
+import com.linecorp.armeria.internal.grpc.GrpcHeaderNames;
+import com.linecorp.armeria.internal.grpc.GrpcRequestUtil;
+import com.linecorp.armeria.internal.http.ByteBufHttpData;
+import com.linecorp.armeria.server.Service;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.SimpleDecoratingService;
+
+import io.grpc.Codec.Identity;
+import io.grpc.MethodDescriptor;
+import io.grpc.MethodDescriptor.MethodType;
+import io.grpc.ServerMethodDefinition;
+import io.grpc.Status;
+import io.netty.buffer.ByteBuf;
+
+/**
+ * A {@link SimpleDecoratingService} which allows {@link GrpcService} to serve requests without the framing
+ * specified by the GRPC wire protocol. This can be useful for serving both legacy systems and GRPC clients with
+ * the same business logic.
+ *
+ * <p>Limitations:
+ * <ul>
+ *     <li>Only unary methods (single request, single response) are supported.</li>
+ *     <li>
+ *         Message compression is not supported.
+ *         {@link com.linecorp.armeria.server.http.encoding.HttpEncodingService} should be used instead for
+ *         transport level encoding.
+ *     </li>
+ * </ul>
+ */
+public class UnframedGrpcService extends SimpleDecoratingService<HttpRequest, HttpResponse> {
+
+    private final Map<String, MethodDescriptor<?, ?>> methodsByName;
+
+    /**
+     * Creates a new instance that decorates the specified {@link Service}.
+     */
+    public UnframedGrpcService(Service<? super HttpRequest, ? extends HttpResponse> delegate) {
+        super(delegate);
+        GrpcService grpcService =
+                delegate.as(GrpcService.class)
+                        .orElseThrow(
+                                () -> new IllegalArgumentException("Decorated service must be a GrpcService."));
+        methodsByName = grpcService.services()
+                                   .stream()
+                                   .flatMap(service ->  service.getMethods().stream())
+                                   .map(ServerMethodDefinition::getMethodDescriptor)
+                                   .collect(ImmutableMap.toImmutableMap(MethodDescriptor::getFullMethodName,
+                                                                        Function.identity()));
+    }
+
+    @Override
+    public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+        final HttpHeaders clientHeaders = req.headers();
+        final String contentType = clientHeaders.get(HttpHeaderNames.CONTENT_TYPE);
+        if (contentType == null) {
+            // All GRPC requests, whether framed or non-framed, must have content-type. If it's not sent, let
+            // the delegate return its usual error message.
+            return delegate().serve(ctx, req);
+        }
+
+        MediaType mediaType = MediaType.parse(contentType);
+        for (SerializationFormat format : GrpcSerializationFormats.values()) {
+            if (format.isAccepted(mediaType)) {
+                // Framed request, so just delegate.
+                return delegate().serve(ctx, req);
+            }
+        }
+
+        String methodName = GrpcRequestUtil.determineMethod(ctx);
+        MethodDescriptor<?, ?> method = methodName != null ? methodsByName.get(methodName) : null;
+        if (method == null) {
+            // Unknown method, let the delegate return a usual error.
+            return delegate().serve(ctx, req);
+        }
+
+        DefaultHttpResponse res = new DefaultHttpResponse();
+
+        if (method.getType() != MethodType.UNARY) {
+            res.respond(HttpStatus.BAD_REQUEST,
+                        MediaType.PLAIN_TEXT_UTF_8,
+                        "Only unary methods can be used with non-framed requests.");
+            return res;
+        }
+
+        HttpHeaders grpcHeaders = HttpHeaders.copyOf(clientHeaders);
+
+        if (mediaType.is(MediaType.PROTOBUF)) {
+            grpcHeaders.set(
+                    HttpHeaderNames.CONTENT_TYPE, GrpcSerializationFormats.PROTO.mediaType().toString());
+        } else {
+            res.respond(HttpStatus.UNSUPPORTED_MEDIA_TYPE,
+                        MediaType.PLAIN_TEXT_UTF_8,
+                        "Unsupported media type. Only application/protobuf is supported.");
+            return res;
+        }
+
+        if (grpcHeaders.get(GrpcHeaderNames.GRPC_ENCODING) != null) {
+            res.respond(HttpStatus.UNSUPPORTED_MEDIA_TYPE,
+                        MediaType.PLAIN_TEXT_UTF_8,
+                        "GRPC encoding is not supported for non-framed requests.");
+        }
+
+        // All clients support no encoding, and we don't support GRPC encoding for non-framed requests, so just
+        // clear the header if it's present.
+        grpcHeaders.remove(GrpcHeaderNames.GRPC_ACCEPT_ENCODING);
+
+        req.aggregate().whenCompleteAsync(
+                (clientRequest, t) -> {
+                    if (t != null) {
+                        res.close(t);
+                    } else {
+                        frameAndServe(ctx, grpcHeaders, clientRequest, res);
+                    }
+                },
+                ctx.eventLoop());
+
+        return res;
+    }
+
+    private void frameAndServe(
+            ServiceRequestContext ctx,
+            HttpHeaders grpcHeaders,
+            AggregatedHttpMessage clientRequest,
+            DefaultHttpResponse res) {
+        final ArmeriaMessageFramer framer = new ArmeriaMessageFramer(
+                ctx.alloc(), ArmeriaMessageFramer.NO_MAX_OUTBOUND_MESSAGE_SIZE);
+
+        HttpData content = clientRequest.content();
+        ByteBuf message = ctx.alloc().buffer(content.length());
+        message.writeBytes(content.array(), content.offset(), content.length());
+
+        HttpData frame = framer.writePayload(message);
+        DefaultHttpRequest grpcRequest = new DefaultHttpRequest(grpcHeaders);
+        grpcRequest.write(frame);
+        grpcRequest.close();
+
+        final HttpResponse grpcResponse;
+        try {
+            grpcResponse = delegate().serve(ctx, grpcRequest);
+        } catch (Exception e) {
+            res.close(e);
+            return;
+        }
+
+        grpcResponse.aggregate().whenCompleteAsync(
+                (framedResponse, t) -> {
+                    if (t != null) {
+                        res.close(t);
+                    } else {
+                        deframeAndRespond(ctx, framedResponse, res);
+                    }
+                },
+                ctx.eventLoop());
+    }
+
+    private void deframeAndRespond(
+            ServiceRequestContext ctx, AggregatedHttpMessage grpcResponse, DefaultHttpResponse res) {
+        HttpHeaders trailers = !grpcResponse.trailingHeaders().isEmpty() ?
+                               grpcResponse.trailingHeaders() : grpcResponse.headers();
+        String grpcStatusCode = trailers.get(GrpcHeaderNames.GRPC_STATUS);
+        Status grpcStatus = Status.fromCodeValue(Integer.parseInt(grpcStatusCode));
+
+        if (!grpcStatus.getCode().equals(Status.OK.getCode())) {
+            StringBuilder message = new StringBuilder("grpc-status: " + grpcStatusCode);
+            String grpcMessage = trailers.get(GrpcHeaderNames.GRPC_MESSAGE);
+            if (grpcMessage != null) {
+                message.append(", ").append(grpcMessage);
+            }
+            res.respond(HttpStatus.INTERNAL_SERVER_ERROR,
+                        MediaType.PLAIN_TEXT_UTF_8,
+                        message.toString());
+            return;
+        }
+
+        MediaType grpcMediaType = MediaType.parse(
+                grpcResponse.headers().get(HttpHeaderNames.CONTENT_TYPE));
+        HttpHeaders unframedHeaders = HttpHeaders.copyOf(grpcResponse.headers());
+        if (grpcMediaType.is(GrpcSerializationFormats.PROTO.mediaType())) {
+            unframedHeaders.set(HttpHeaderNames.CONTENT_TYPE, MediaType.PROTOBUF.toString());
+        }
+
+        ArmeriaMessageDeframer deframer = new ArmeriaMessageDeframer(
+                new Listener() {
+                    @Override
+                    public void messageRead(ByteBufOrStream message) {
+                        // We know there is only one message in total, so don't bother with checking endOfStream
+                        // We also know that we don't support compression, so this is always a ByteBuffer.
+                        HttpData unframedContent = new ByteBufHttpData(message.buf(), true);
+                        res.respond(AggregatedHttpMessage.of(
+                                unframedHeaders, unframedContent));
+                    }
+
+                    @Override
+                    public void endOfStream() {}
+                },
+                Identity.NONE,
+                // Max outbound message size is handled by the GrpcService, so we don't need to set it here.
+                Integer.MAX_VALUE,
+                ctx.alloc());
+        deframer.request(1);
+        deframer.deframe(grpcResponse.content(), true);
+    }
+}

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcService.java
@@ -66,14 +66,14 @@ import io.netty.buffer.ByteBuf;
  *     </li>
  * </ul>
  */
-public class UnframedGrpcService extends SimpleDecoratingService<HttpRequest, HttpResponse> {
+class UnframedGrpcService extends SimpleDecoratingService<HttpRequest, HttpResponse> {
 
     private final Map<String, MethodDescriptor<?, ?>> methodsByName;
 
     /**
      * Creates a new instance that decorates the specified {@link Service}.
      */
-    public UnframedGrpcService(Service<? super HttpRequest, ? extends HttpResponse> delegate) {
+    UnframedGrpcService(Service<? super HttpRequest, ? extends HttpResponse> delegate) {
         super(delegate);
         GrpcService grpcService =
                 delegate.as(GrpcService.class)

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcService.java
@@ -38,7 +38,6 @@ import com.linecorp.armeria.internal.grpc.ArmeriaMessageDeframer.ByteBufOrStream
 import com.linecorp.armeria.internal.grpc.ArmeriaMessageDeframer.Listener;
 import com.linecorp.armeria.internal.grpc.ArmeriaMessageFramer;
 import com.linecorp.armeria.internal.grpc.GrpcHeaderNames;
-import com.linecorp.armeria.internal.grpc.GrpcRequestUtil;
 import com.linecorp.armeria.internal.http.ByteBufHttpData;
 import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceRequestContext;

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.grpc;
+
+import static com.linecorp.armeria.common.http.HttpSessionProtocols.HTTP;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import com.linecorp.armeria.client.http.HttpClient;
+import com.linecorp.armeria.client.http.HttpClientFactory;
+import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
+import com.linecorp.armeria.common.http.AggregatedHttpMessage;
+import com.linecorp.armeria.common.http.HttpHeaderNames;
+import com.linecorp.armeria.common.http.HttpHeaders;
+import com.linecorp.armeria.common.http.HttpMethod;
+import com.linecorp.armeria.common.http.HttpStatus;
+import com.linecorp.armeria.grpc.testing.TestServiceGrpc;
+import com.linecorp.armeria.grpc.testing.TestServiceGrpc.TestServiceImplBase;
+import com.linecorp.armeria.internal.grpc.GrpcHeaderNames;
+import com.linecorp.armeria.internal.grpc.GrpcTestUtil;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.testing.server.ServerRule;
+
+import come.linecorp.armeria.grpc.testing.Messages.EchoStatus;
+import come.linecorp.armeria.grpc.testing.Messages.SimpleRequest;
+import come.linecorp.armeria.grpc.testing.Messages.SimpleResponse;
+import come.linecorp.armeria.grpc.testing.Messages.StreamingOutputCallRequest;
+import come.linecorp.armeria.grpc.testing.Messages.StreamingOutputCallResponse;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.StreamObserver;
+
+public class GrpcServiceServerTest {
+
+    private static class TestServiceImpl extends TestServiceImplBase {
+
+        @Override
+        public void unaryCall(SimpleRequest request, StreamObserver<SimpleResponse> responseObserver) {
+            if (request.hasResponseStatus()) {
+                throw new StatusRuntimeException(Status.fromCodeValue(request.getResponseStatus().getCode()));
+            }
+            responseObserver.onNext(GrpcTestUtil.RESPONSE_MESSAGE);
+            responseObserver.onCompleted();
+        }
+
+        @Override
+        public void streamingOutputCall(StreamingOutputCallRequest request,
+                                        StreamObserver<StreamingOutputCallResponse> responseObserver) {
+            responseObserver.onNext(
+                    StreamingOutputCallResponse.newBuilder()
+                                               .setPayload(request.getPayload())
+                                               .build());
+            responseObserver.onCompleted();
+        }
+    }
+
+    @ClassRule
+    public static ServerRule server = new ServerRule() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.numWorkers(1);
+            sb.port(0, HTTP);
+
+            sb.serviceUnder("/", new GrpcServiceBuilder()
+                    .addService(new TestServiceImpl())
+                    .build()
+                    .decorate(UnframedGrpcService::new));
+        }
+    };
+
+    @Test
+    public void unframed() throws Exception {
+        HttpClient client = HttpClientFactory.DEFAULT
+                .newClient("none+" + server.httpUri("/"),
+                           HttpClient.class);
+        AggregatedHttpMessage response = client.execute(
+                HttpHeaders.of(HttpMethod.POST, TestServiceGrpc.METHOD_UNARY_CALL.getFullMethodName())
+                           .set(HttpHeaderNames.CONTENT_TYPE, "application/protobuf"),
+                GrpcTestUtil.REQUEST_MESSAGE.toByteArray()).aggregate().get();
+        SimpleResponse message = SimpleResponse.parseFrom(response.content().array());
+        assertThat(message).isEqualTo(GrpcTestUtil.RESPONSE_MESSAGE);
+    }
+
+    @Test
+    public void unframed_acceptEncoding() throws Exception {
+        HttpClient client = HttpClientFactory.DEFAULT
+                .newClient("none+" + server.httpUri("/"),
+                           HttpClient.class);
+        AggregatedHttpMessage response = client.execute(
+                HttpHeaders.of(HttpMethod.POST, TestServiceGrpc.METHOD_UNARY_CALL.getFullMethodName())
+                           .set(HttpHeaderNames.CONTENT_TYPE, "application/protobuf")
+                           .set(GrpcHeaderNames.GRPC_ACCEPT_ENCODING, "gzip,none"),
+                GrpcTestUtil.REQUEST_MESSAGE.toByteArray()).aggregate().get();
+        SimpleResponse message = SimpleResponse.parseFrom(response.content().array());
+        assertThat(message).isEqualTo(GrpcTestUtil.RESPONSE_MESSAGE);
+    }
+
+    @Test
+    public void unframed_streamingApi() throws Exception {
+        HttpClient client = HttpClientFactory.DEFAULT
+                .newClient("none+" + server.httpUri("/"),
+                           HttpClient.class);
+        AggregatedHttpMessage response = client.execute(
+                HttpHeaders.of(HttpMethod.POST,
+                               TestServiceGrpc.METHOD_STREAMING_OUTPUT_CALL.getFullMethodName())
+                           .set(HttpHeaderNames.CONTENT_TYPE, "application/protobuf"),
+                StreamingOutputCallRequest.getDefaultInstance().toByteArray()).aggregate().get();
+        assertThat(response.status()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    public void unframed_noContentType() throws Exception {
+        HttpClient client = HttpClientFactory.DEFAULT
+                .newClient("none+" + server.httpUri("/"),
+                           HttpClient.class);
+        AggregatedHttpMessage response = client.execute(
+                HttpHeaders.of(HttpMethod.POST,
+                               TestServiceGrpc.METHOD_UNARY_CALL.getFullMethodName()),
+                GrpcTestUtil.REQUEST_MESSAGE.toByteArray()).aggregate().get();
+        assertThat(response.status()).isEqualTo(HttpStatus.UNSUPPORTED_MEDIA_TYPE);
+    }
+
+    @Test
+    public void unframed_grpcEncoding() throws Exception {
+        HttpClient client = HttpClientFactory.DEFAULT
+                .newClient("none+" + server.httpUri("/"),
+                           HttpClient.class);
+        AggregatedHttpMessage response = client.execute(
+                HttpHeaders.of(HttpMethod.POST,
+                               TestServiceGrpc.METHOD_UNARY_CALL.getFullMethodName())
+                           .set(HttpHeaderNames.CONTENT_TYPE, "application/protobuf")
+                           .set(GrpcHeaderNames.GRPC_ENCODING, "gzip"),
+                GrpcTestUtil.REQUEST_MESSAGE.toByteArray()).aggregate().get();
+        assertThat(response.status()).isEqualTo(HttpStatus.UNSUPPORTED_MEDIA_TYPE);
+    }
+
+    @Test
+    public void unframed_serviceError() throws Exception {
+        HttpClient client = HttpClientFactory.DEFAULT
+                .newClient("none+" + server.httpUri("/"),
+                           HttpClient.class);
+        AggregatedHttpMessage response = client.execute(
+                HttpHeaders.of(HttpMethod.POST,
+                               TestServiceGrpc.METHOD_UNARY_CALL.getFullMethodName())
+                           .set(HttpHeaderNames.CONTENT_TYPE, "application/protobuf"),
+                SimpleRequest.newBuilder()
+                             .setResponseStatus(
+                                     EchoStatus.newBuilder()
+                                               .setCode(Status.DEADLINE_EXCEEDED.getCode().value()))
+                             .build().toByteArray()).aggregate().get();
+        assertThat(response.status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    // TODO(anuraag): Replace with an actual grpc client after armeria supports one.
+    @Test
+    public void framed() throws Exception {
+        HttpClient client = HttpClientFactory.DEFAULT
+                .newClient("none+" + server.httpUri("/"),
+                           HttpClient.class);
+        AggregatedHttpMessage response = client.execute(
+                HttpHeaders.of(HttpMethod.POST,
+                               TestServiceGrpc.METHOD_UNARY_CALL.getFullMethodName())
+                           .set(HttpHeaderNames.CONTENT_TYPE,
+                                GrpcSerializationFormats.PROTO.mediaType().toString()),
+                GrpcTestUtil.uncompressedFrame(GrpcTestUtil.requestByteBuf())).aggregate().get();
+        assertThat(response.content().array())
+                .containsExactly(GrpcTestUtil.uncompressedResponseBytes());
+    }
+
+}

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
@@ -79,8 +79,8 @@ public class GrpcServiceServerTest {
 
             sb.serviceUnder("/", new GrpcServiceBuilder()
                     .addService(new TestServiceImpl())
-                    .build()
-                    .decorate(UnframedGrpcService::new));
+                    .enableUnframedRequests(true)
+                    .build());
         }
     };
 

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceTest.java
@@ -56,7 +56,7 @@ public class GrpcServiceTest {
     @Before
     public void setUp() {
         response = new DefaultHttpResponse();
-        grpcService = new GrpcServiceBuilder()
+        grpcService = (GrpcService) new GrpcServiceBuilder()
                 .addService(mock(TestServiceImplBase.class))
                 .build();
     }

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceTest.java
@@ -68,7 +68,7 @@ public class GrpcServiceTest {
                 HttpRequest.of(HttpHeaders.of(HttpMethod.POST, "/grpc.testing.TestService.UnaryCall")),
                 response);
         assertThat(response.aggregate().get()).isEqualTo(AggregatedHttpMessage.of(
-                HttpHeaders.of(HttpStatus.BAD_REQUEST)
+                HttpHeaders.of(HttpStatus.UNSUPPORTED_MEDIA_TYPE)
                            .set(HttpHeaderNames.CONTENT_TYPE, "text/plain; charset=utf-8"),
                 HttpData.ofUtf8("Missing or invalid Content-Type header.")));
     }
@@ -81,7 +81,7 @@ public class GrpcServiceTest {
                                           .set(HttpHeaderNames.CONTENT_TYPE, "application/json")),
                 response);
         assertThat(response.aggregate().get()).isEqualTo(AggregatedHttpMessage.of(
-                HttpHeaders.of(HttpStatus.BAD_REQUEST)
+                HttpHeaders.of(HttpStatus.UNSUPPORTED_MEDIA_TYPE)
                            .set(HttpHeaderNames.CONTENT_TYPE, "text/plain; charset=utf-8"),
                 HttpData.ofUtf8("Missing or invalid Content-Type header.")));
     }


### PR DESCRIPTION
…g for interaction with legacy clients. After adding JSON support, this can allow a GRPC service to be simultaneously GRPC and REST.

Also changes error message in GrpcService from BAD_REQUEST to UNSUPPORTED_MEDIA_TYPE for requests with the wrong content type. This seems more appropriate, and it doesn't seem to be standardized (grpc-java just resets the HTTP2 stream).

Part of #255 