### PR TITLE
Use awaitality for HttpHealthCheckedEndpointGroupTest to try to avoid…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -206,6 +206,7 @@ configure(javaProjects) {
         testCompile 'junit:junit'
         testCompile 'net.javacrumbs.json-unit:json-unit'
         testCompile 'net.javacrumbs.json-unit:json-unit-fluent'
+        testCompile 'org.awaitility:awaitility'
         testCompile 'org.hamcrest:hamcrest-library'
         testCompile 'org.assertj:assertj-core'
         testCompile 'org.mockito:mockito-core'

--- a/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/SlidingWindowCounterTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/SlidingWindowCounterTest.java
@@ -17,6 +17,7 @@
 package com.linecorp.armeria.client.circuitbreaker;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -131,9 +132,7 @@ public class SlidingWindowCounterTest {
             thread.join();
         }
 
-        Thread.sleep(Duration.ofMillis(10).toMillis());
-
-        assertThat(counter.onFailure()).isPresent();
+        await().until(() -> assertThat(counter.onFailure()).isPresent());
         assertThat(counter.count()).isEqualTo(new EventCount(success.get(), failure.get()));
     }
 

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroupTest.java
@@ -17,6 +17,7 @@
 package com.linecorp.armeria.client.endpoint.healthcheck;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -66,10 +67,10 @@ public class HttpHealthCheckedEndpointGroupTest {
                 HEALTH_CHECK_PATH);
         metricRegistry.registerAll(endpointGroup.newMetricSet("metric"));
 
-        Thread.sleep(4000); // Wait until updating server list.
-        assertThat(endpointGroup.endpoints()).containsExactly(
-                Endpoint.of("127.0.0.1", serverOne.httpPort()),
-                Endpoint.of("127.0.0.1", serverTwo.httpPort()));
+        await().until(
+                () -> assertThat(endpointGroup.endpoints()).containsExactly(
+                        Endpoint.of("127.0.0.1", serverOne.httpPort()),
+                        Endpoint.of("127.0.0.1", serverTwo.httpPort())));
         assertThat(metricRegistry.getGauges().get("endpointHealth.metric.all.count").getValue())
                 .isEqualTo(2);
         assertThat(metricRegistry.getGauges().get("endpointHealth.metric.healthy.count").getValue())
@@ -81,8 +82,10 @@ public class HttpHealthCheckedEndpointGroupTest {
                 .isEqualTo(ImmutableSet.of());
 
         serverTwo.stop().get();
-        assertThat(metricRegistry.getGauges().get("endpointHealth.metric.healthy.count").getValue())
-                .isEqualTo(1);
+        await().until(
+                () ->assertThat(
+                        metricRegistry.getGauges().get("endpointHealth.metric.healthy.count").getValue())
+                        .isEqualTo(1));
     }
 
     @Test
@@ -93,10 +96,12 @@ public class HttpHealthCheckedEndpointGroupTest {
                         Endpoint.of("127.0.0.1", serverOne.httpPort()),
                         Endpoint.of("127.0.0.1", 2345)),
                 HEALTH_CHECK_PATH);
-        Thread.sleep(4000); // Wait until updating server list.
 
         metricRegistry.registerAll(endpointGroup.newMetricSet("metric"));
-        assertThat(endpointGroup.endpoints()).containsOnly(Endpoint.of("127.0.0.1", serverOne.httpPort()));
+
+        await().until(
+                () -> assertThat(endpointGroup.endpoints())
+                        .containsOnly(Endpoint.of("127.0.0.1", serverOne.httpPort())));
         assertThat(metricRegistry.getGauges().get("endpointHealth.metric.all.count").getValue())
                 .isEqualTo(2);
         assertThat(metricRegistry.getGauges().get("endpointHealth.metric.healthy.count").getValue())
@@ -116,10 +121,12 @@ public class HttpHealthCheckedEndpointGroupTest {
                         Endpoint.of("127.0.0.1", serverOne.httpPort()),
                         Endpoint.of("127.0.0.1", serverOne.httpPort())),
                 HEALTH_CHECK_PATH);
-        Thread.sleep(4000); // Wait until updating server list.
 
         metricRegistry.registerAll(endpointGroup.newMetricSet("metric"));
-        assertThat(endpointGroup.endpoints()).containsOnly(Endpoint.of("127.0.0.1", serverOne.httpPort()));
+
+        await().until(
+                () -> assertThat(endpointGroup.endpoints())
+                        .containsOnly(Endpoint.of("127.0.0.1", serverOne.httpPort())));
         assertThat(metricRegistry.getGauges().get("endpointHealth.metric.all.count").getValue())
                 .isEqualTo(3);
         assertThat(metricRegistry.getGauges().get("endpointHealth.metric.healthy.count").getValue())

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroupTest.java
@@ -83,7 +83,7 @@ public class HttpHealthCheckedEndpointGroupTest {
 
         serverTwo.stop().get();
         await().until(
-                () ->assertThat(
+                () -> assertThat(
                         metricRegistry.getGauges().get("endpointHealth.metric.healthy.count").getValue())
                         .isEqualTo(1));
     }

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -96,6 +96,9 @@ org.apache.zookeeper:
 org.assertj:
   assertj-core: { version: 3.6.2 }
 
+org.awaitility:
+  awaitility: { version: 2.0.0 }
+
 org.dmonix.junit:
   zookeeper-junit: { version: !!str 1.2 }
 


### PR DESCRIPTION
… flakiness.

I think the reason we see flakiness in this test is there's no ```Thread.sleep()``` after ```server2.stop()```. But I think we've had enough of latches and sleeping.

This PR introduces awaitility, which in concept allows assertions to block until they're satisfied. The assertion is polled every 100ms by default, up to a max of 10s. By using an await assertion at fence points, we don't have to worry about manually synchronization during tests anymore. If fence points aren't obvious, there's no harm in awaiting every assertion.

Also uses it in SlidingWindowCounterTest which happened to fail when testing this PR :)

https://github.com/awaitility/awaitility/wiki/Usage

Probably fixes #497 