### PR TITLE
Fix AssertionError in ThriftDocServicePlugin.toTypeSignature()

### DIFF
--- a/thrift/src/main/java/com/linecorp/armeria/server/thrift/ThriftDocServicePlugin.java
+++ b/thrift/src/main/java/com/linecorp/armeria/server/thrift/ThriftDocServicePlugin.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.server.thrift;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static java.util.Objects.requireNonNull;
@@ -329,7 +330,8 @@ public class ThriftDocServicePlugin implements DocServicePlugin {
                              typeSignature);
     }
 
-    private static TypeSignature toTypeSignature(FieldValueMetaData fieldValueMetaData) {
+    @VisibleForTesting
+    static TypeSignature toTypeSignature(FieldValueMetaData fieldValueMetaData) {
         if (fieldValueMetaData instanceof StructMetaData) {
             return TypeSignature.ofNamed(((StructMetaData) fieldValueMetaData).structClass);
         }
@@ -374,8 +376,14 @@ public class ThriftDocServicePlugin implements DocServicePlugin {
                 return STRING;
         }
 
-        assert fieldValueMetaData.isTypedef();
-        return TypeSignature.ofUnresolved(fieldValueMetaData.getTypedefName());
+        final String unresolvedName;
+        if (fieldValueMetaData.isTypedef()) {
+            unresolvedName = fieldValueMetaData.getTypedefName();
+        } else {
+            unresolvedName = null;
+        }
+
+        return TypeSignature.ofUnresolved(firstNonNull(unresolvedName, "unknown"));
     }
 
     private static FieldRequirement convertRequirement(byte value) {

--- a/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftDocServicePluginTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftDocServicePluginTest.java
@@ -22,6 +22,7 @@ import static com.linecorp.armeria.server.thrift.ThriftDocServicePlugin.newExcep
 import static com.linecorp.armeria.server.thrift.ThriftDocServicePlugin.newFieldInfo;
 import static com.linecorp.armeria.server.thrift.ThriftDocServicePlugin.newServiceInfo;
 import static com.linecorp.armeria.server.thrift.ThriftDocServicePlugin.newStructInfo;
+import static com.linecorp.armeria.server.thrift.ThriftDocServicePlugin.toTypeSignature;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
@@ -243,5 +244,11 @@ public class ThriftDocServicePluginTest {
 
         final StructInfo fooStruct = newStructInfo(FooStruct.class);
         assertThat(fooStruct).isEqualTo(new StructInfo(FooStruct.class.getName(), fields));
+    }
+
+    @Test
+    public void incompleteStructMetadata() throws Exception {
+        assertThat(toTypeSignature(new FieldValueMetaData(TType.STRUCT)))
+                .isEqualTo(TypeSignature.ofUnresolved("unknown"));
     }
 }


### PR DESCRIPTION
Motivation:

Thrift compiler seems to have a bug that generates a weird field value
metadata such as:

    new FieldValueMetadata(TType.STRUCT)

.. which doesn't make much sense because the metadata of a struct should
be represented as StructMetadata and should have a name.

Because we can't change this behavior, we need to implement a workaround
for this problem.

Modifications:

- Handle the case mentioned in the 'motivation' section
  - An offending metadata is translated into
    TypeSignature.ofUnresolved("unknown")

Result:

Robustness