### PR TITLE
Notify all Endpoint list change to listners correctly

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/EndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/EndpointGroup.java
@@ -17,19 +17,27 @@
 package com.linecorp.armeria.client.endpoint;
 
 import java.util.List;
+import java.util.function.Consumer;
 
 import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.common.util.Listenable;
 import com.linecorp.armeria.common.util.SafeCloseable;
 
 /**
  * A list of {@link Endpoint}s.
  */
 @FunctionalInterface
-public interface EndpointGroup extends SafeCloseable {
+public interface EndpointGroup extends Listenable<List<Endpoint>>, SafeCloseable {
     /**
      * Return the endpoints held by this {@link EndpointGroup}.
      */
     List<Endpoint> endpoints();
+
+    @Override
+    default void addListener(Consumer<? super List<Endpoint>> listener) {}
+
+    @Override
+    default void removeListener(Consumer<?> listener) {}
 
     @Override
     default void close() {}

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/OrElseEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/OrElseEndpointGroup.java
@@ -22,7 +22,6 @@ import java.util.List;
 
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.common.util.AbstractListenable;
-import com.linecorp.armeria.common.util.Listenable;
 
 final class OrElseEndpointGroup extends AbstractListenable<List<Endpoint>> implements EndpointGroup {
     private final EndpointGroup first;
@@ -31,16 +30,8 @@ final class OrElseEndpointGroup extends AbstractListenable<List<Endpoint>> imple
     OrElseEndpointGroup(EndpointGroup first, EndpointGroup second) {
         this.first = requireNonNull(first, "first");
         this.second = requireNonNull(second, "second");
-        if (first instanceof Listenable) {
-            @SuppressWarnings("unchecked")
-            Listenable<List<Endpoint>> listenable = (Listenable<List<Endpoint>>) first;
-            listenable.addListener(unused -> notifyListeners(endpoints()));
-        }
-        if (second instanceof Listenable) {
-            @SuppressWarnings("unchecked")
-            Listenable<List<Endpoint>> listenable = (Listenable<List<Endpoint>>) second;
-            listenable.addListener(unused -> notifyListeners(endpoints()));
-        }
+        first.addListener(unused -> notifyListeners(endpoints()));
+        second.addListener(unused -> notifyListeners(endpoints()));
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/OrElseEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/OrElseEndpointGroup.java
@@ -21,14 +21,26 @@ import static java.util.Objects.requireNonNull;
 import java.util.List;
 
 import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.common.util.AbstractListenable;
+import com.linecorp.armeria.common.util.Listenable;
 
-final class OrElseEndpointGroup implements EndpointGroup {
+final class OrElseEndpointGroup extends AbstractListenable<List<Endpoint>> implements EndpointGroup {
     private final EndpointGroup first;
     private final EndpointGroup second;
 
     OrElseEndpointGroup(EndpointGroup first, EndpointGroup second) {
         this.first = requireNonNull(first, "first");
         this.second = requireNonNull(second, "second");
+        if (first instanceof Listenable) {
+            @SuppressWarnings("unchecked")
+            Listenable<List<Endpoint>> listenable = (Listenable<List<Endpoint>>) first;
+            listenable.addListener(unused -> notifyListeners(endpoints()));
+        }
+        if (second instanceof Listenable) {
+            @SuppressWarnings("unchecked")
+            Listenable<List<Endpoint>> listenable = (Listenable<List<Endpoint>>) second;
+            listenable.addListener(unused -> notifyListeners(endpoints()));
+        }
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/util/AbstractListenable.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/AbstractListenable.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.util;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.function.Consumer;
+
+/**
+ * A skeletal {@link Listenable} implementation.
+ */
+public abstract class AbstractListenable<T> implements Listenable<T> {
+    private final Set<Consumer<? super T>> updateListeners = new CopyOnWriteArraySet<>();
+
+    /**
+     * Notify the new value changes to the listeners added via {@link #addListener(Consumer)}.
+     */
+    protected final void notifyListeners(T latestValue) {
+        for (Consumer<? super T> listener : updateListeners) {
+            listener.accept(latestValue);
+        }
+    }
+
+    @Override
+    public final void addListener(Consumer<? super T> listener) {
+        requireNonNull(listener, "listener");
+        updateListeners.add(listener);
+    }
+
+    @Override
+    public final void removeListener(Consumer<?> listener) {
+        requireNonNull(listener, "listener");
+        updateListeners.remove(listener);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/common/util/Listenable.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/Listenable.java
@@ -1,0 +1,18 @@
+package com.linecorp.armeria.common.util;
+
+import java.util.function.Consumer;
+
+/**
+ * An interface that accepts item change listeners.
+ */
+public interface Listenable<T> {
+    /**
+     * Adds a {@link Consumer} that will be invoked when a {@link Listenable} changes its value.
+     */
+    void addListener(Consumer<? super T> listener);
+
+    /**
+     * Remove a listener.
+     */
+    void removeListener(Consumer<?> listener);
+}

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/OrElseEndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/OrElseEndpointGroupTest.java
@@ -1,0 +1,64 @@
+package com.linecorp.armeria.client.endpoint;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.client.Endpoint;
+
+public class OrElseEndpointGroupTest {
+    @Test
+    public void updateFirstEndpoints() {
+        DynamicEndpointGroup firstEndpointGroup = new DynamicEndpointGroup();
+        DynamicEndpointGroup secondEndpointGroup = new DynamicEndpointGroup();
+        EndpointGroup endpointGroup = new OrElseEndpointGroup(firstEndpointGroup, secondEndpointGroup);
+
+        firstEndpointGroup.setEndpoints(ImmutableList.of(Endpoint.of("127.0.0.1", 1111),
+                                                         Endpoint.of("127.0.0.1", 2222)));
+        assertThat(endpointGroup.endpoints()).isEqualTo(ImmutableList.of(Endpoint.of("127.0.0.1", 1111),
+                                                                         Endpoint.of("127.0.0.1", 2222)));
+
+        firstEndpointGroup.addEndpoint(Endpoint.of("127.0.0.1", 3333));
+        assertThat(endpointGroup.endpoints()).isEqualTo(ImmutableList.of(Endpoint.of("127.0.0.1", 1111),
+                                                                         Endpoint.of("127.0.0.1", 2222),
+                                                                         Endpoint.of("127.0.0.1", 3333)));
+
+        firstEndpointGroup.removeEndpoint(Endpoint.of("127.0.0.1", 2222));
+        assertThat(endpointGroup.endpoints()).isEqualTo(ImmutableList.of(Endpoint.of("127.0.0.1", 1111),
+                                                                         Endpoint.of("127.0.0.1", 3333)));
+    }
+
+    @Test
+    public void updateSecondEndpoints() {
+        DynamicEndpointGroup firstEndpointGroup = new DynamicEndpointGroup();
+        DynamicEndpointGroup secondEndpointGroup = new DynamicEndpointGroup();
+        EndpointGroup endpointGroup = new OrElseEndpointGroup(firstEndpointGroup, secondEndpointGroup);
+
+        secondEndpointGroup.setEndpoints(ImmutableList.of(Endpoint.of("127.0.0.1", 1111),
+                                                          Endpoint.of("127.0.0.1", 2222)));
+
+        secondEndpointGroup.addEndpoint(Endpoint.of("127.0.0.1", 3333));
+        assertThat(endpointGroup.endpoints()).isEqualTo(ImmutableList.of(Endpoint.of("127.0.0.1", 1111),
+                                                                         Endpoint.of("127.0.0.1", 2222),
+                                                                         Endpoint.of("127.0.0.1", 3333)));
+
+        secondEndpointGroup.removeEndpoint(Endpoint.of("127.0.0.1", 2222));
+        assertThat(endpointGroup.endpoints()).isEqualTo(ImmutableList.of(Endpoint.of("127.0.0.1", 1111),
+                                                                         Endpoint.of("127.0.0.1", 3333)));
+
+        firstEndpointGroup.addEndpoint(Endpoint.of("127.0.0.1", 4444));
+        assertThat(endpointGroup.endpoints()).isEqualTo(ImmutableList.of(Endpoint.of("127.0.0.1", 4444)));
+
+        // Use firstEndpointGroup's endpoint list even if secondEndpointGroup has change.
+        secondEndpointGroup.addEndpoint(Endpoint.of("127.0.0.1", 5555));
+        assertThat(endpointGroup.endpoints()).isEqualTo(ImmutableList.of(Endpoint.of("127.0.0.1", 4444)));
+
+        // Fallback to secondEndpointGroup if firstEndpointGroup has no endpoints.
+        firstEndpointGroup.removeEndpoint(Endpoint.of("127.0.0.1", 4444));
+        assertThat(endpointGroup.endpoints()).isEqualTo(ImmutableList.of(Endpoint.of("127.0.0.1", 1111),
+                                                                         Endpoint.of("127.0.0.1", 3333),
+                                                                         Endpoint.of("127.0.0.1", 5555)));
+    }
+}


### PR DESCRIPTION
Motivations:
- A EndpointGroup that has delegated Endpoint (for example, OrElseEndpointGroup) does not notify endpoint list
  change to listners (#498)

Modifications:
- All subclass of EndpointGroup extends DynamicEndpointGroup
- Merge DynamicEndpointGroup to EndpointGroup

Results:
- Endpoint list changes are notified to listers correctly