### PR TITLE
More convenient deferred construction of RpcResponse and HttpResponse

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingHttpClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingHttpClient.java
@@ -70,8 +70,9 @@ public final class ConcurrencyLimitingHttpClient
 
     @Override
     protected Deferred<HttpResponse> defer(ClientRequestContext ctx, HttpRequest req) throws Exception {
-        final DeferredHttpResponse res = new DeferredHttpResponse();
         return new Deferred<HttpResponse>() {
+            private final DeferredHttpResponse res = new DeferredHttpResponse();
+
             @Override
             public HttpResponse response() {
                 return res;

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultRpcResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultRpcResponse.java
@@ -22,6 +22,8 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
+import javax.annotation.Nullable;
+
 import com.google.common.base.MoreObjects;
 
 import com.linecorp.armeria.common.util.Exceptions;
@@ -48,7 +50,7 @@ public class DefaultRpcResponse extends CompletableFuture<Object> implements Rpc
      *
      * @param result the result or an RPC call
      */
-    public DefaultRpcResponse(Object result) {
+    public DefaultRpcResponse(@Nullable Object result) {
         complete(result);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/RpcResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RpcResponse.java
@@ -16,9 +16,13 @@
 
 package com.linecorp.armeria.common;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Future;
+
+import javax.annotation.Nullable;
 
 /**
  * An RPC {@link Response}. It is a {@link CompletionStage} whose result signifies the return value of an RPC
@@ -29,7 +33,7 @@ public interface RpcResponse extends Response, Future<Object>, CompletionStage<O
     /**
      * Creates a new successfully complete {@link RpcResponse}.
      */
-    static RpcResponse of(Object value) {
+    static RpcResponse of(@Nullable Object value) {
         return new DefaultRpcResponse(value);
     }
 
@@ -39,6 +43,39 @@ public interface RpcResponse extends Response, Future<Object>, CompletionStage<O
     static RpcResponse ofFailure(Throwable cause) {
         return new DefaultRpcResponse(cause);
     }
+
+    /**
+     * Creates a new {@link RpcResponse} that is completed successfully or exceptionally based on the
+     * completion of the specified {@link CompletionStage}.
+     */
+    static RpcResponse from(CompletionStage<?> stage) {
+        requireNonNull(stage, "stage");
+        final DefaultRpcResponse res = new DefaultRpcResponse();
+        stage.whenComplete((value, cause) -> {
+            if (cause != null) {
+                res.completeExceptionally(cause);
+            } else {
+                res.complete(value);
+            }
+        });
+        return res;
+    }
+
+    /**
+     * Returns the result value if completed successfully or
+     * throws an unchecked exception if completed exceptionally.
+     *
+     * @see CompletableFuture#join()
+     */
+    Object join();
+
+    /**
+     * Returns the specified {@code valueIfAbsent} when not complete, or
+     * returns the result value or throws an exception when complete.
+     *
+     * @see CompletableFuture#getNow(Object)
+     */
+    Object getNow(Object valueIfAbsent);
 
     /**
      * Returns the cause of the failure if this {@link RpcResponse} completed exceptionally.

--- a/core/src/main/java/com/linecorp/armeria/common/http/DeferredHttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/http/DeferredHttpResponse.java
@@ -31,7 +31,7 @@ import com.linecorp.armeria.common.stream.DeferredStreamMessage;
  *         // Delay all requests by 3 seconds.
  *         DeferredHttpResponse res = new DeferredHttpResponse();
  *         ctx.eventLoop().schedule(() -> {
- *             res.setDelegate(delegate().serve(ctx, req));
+ *             res.delegate(delegate().serve(ctx, req));
  *         }, 3, TimeUnit.SECONDS);
  *         return res;
  *     }

--- a/core/src/main/java/com/linecorp/armeria/common/util/Exceptions.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/Exceptions.java
@@ -20,6 +20,9 @@ import static java.util.Objects.requireNonNull;
 
 import java.io.IOException;
 import java.nio.channels.ClosedChannelException;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
 import org.slf4j.Logger;
@@ -167,6 +170,39 @@ public final class Exceptions {
         requireNonNull(exception, "exception");
         exception.setStackTrace(EMPTY_STACK_TRACE);
         return exception;
+    }
+
+    /**
+     * Throws the specified exception violating the {@code throws} clause of the enclosing method.
+     * This method is useful when you need to rethrow a checked exception in {@link Function}, {@link Consumer},
+     * {@link Supplier} and {@link Runnable}, only if you are sure that the rethrown exception will be handled
+     * as a {@link Throwable} or an {@link Exception}. For example:
+     * <pre>{@code
+     * CompletableFuture.supplyAsync(() -> {
+     *     try (FileInputStream fin = new FileInputStream(...)) {
+     *         ....
+     *         return someValue;
+     *     } catch (IOException e) {
+     *         // 'throw e;' won't work because Runnable.run() does not allow any checked exceptions.
+     *         return Exceptions.throwUnsafely(e);
+     *     }
+     * }).exceptionally(CompletionActions::log);
+     * }</pre>
+     *
+     * @return This method never returns because it always throws an exception. However, combined with an
+     *         arbitrary return clause, you can terminate any non-void function with a single statement.
+     *         e.g. {@code return Exceptions.throwUnsafely(...);} vs.
+     *              {@code Exceptions.throwUnsafely(...); return null;}
+     */
+    public static <T> T throwUnsafely(Throwable cause) {
+        doThrowUnsafely(requireNonNull(cause, "cause"));
+        return null;
+    }
+
+    // This black magic causes the Java compiler to believe E is an unchecked exception type.
+    @SuppressWarnings("unchecked")
+    private static <E extends Throwable> void doThrowUnsafely(Throwable cause) throws E {
+        throw (E) cause;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/http/auth/HttpAuthService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/auth/HttpAuthService.java
@@ -27,10 +27,10 @@ import org.slf4j.LoggerFactory;
 import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.common.http.DefaultHttpResponse;
-import com.linecorp.armeria.common.http.DeferredHttpResponse;
 import com.linecorp.armeria.common.http.HttpRequest;
 import com.linecorp.armeria.common.http.HttpResponse;
 import com.linecorp.armeria.common.http.HttpStatus;
+import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.server.DecoratingService;
 import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceRequestContext;
@@ -101,20 +101,16 @@ public abstract class HttpAuthService extends SimpleDecoratingService<HttpReques
 
     @Override
     public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
-        DeferredHttpResponse res = new DeferredHttpResponse();
-
-        authorize(req, ctx).whenCompleteAsync((result, t) -> {
+        return HttpResponse.from(authorize(req, ctx).handleAsync((result, t) -> {
             try {
                 if (t != null || !result) {
-                    res.delegate(onFailure(ctx, req, t));
+                    return onFailure(ctx, req, t);
                 } else {
-                    res.delegate(onSuccess(ctx, req));
+                    return onSuccess(ctx, req);
                 }
-            } catch (Throwable cause) {
-                res.close(cause);
+            } catch (Exception e) {
+                return Exceptions.throwUnsafely(e);
             }
-        }, ctx.contextAwareEventLoop());
-
-        return res;
+        }, ctx.contextAwareEventLoop()));
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/common/RpcResponseTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/RpcResponseTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+import org.junit.Test;
+
+import com.linecorp.armeria.common.util.Exceptions;
+
+public class RpcResponseTest {
+
+    private static final Object RESULT = new Object();
+    private static final Throwable CAUSE = Exceptions.clearTrace(new Throwable());
+
+    @Test
+    public void successfulFrom() {
+        final CompletableFuture<Object> future = new CompletableFuture<>();
+        final RpcResponse res = RpcResponse.from(future);
+        assertThat(res.isDone()).isFalse();
+        future.complete(RESULT);
+        assertThat(res.isDone()).isTrue();
+        assertThat(res.join()).isSameAs(RESULT);
+    }
+
+    @Test
+    public void failedFrom() {
+        final CompletableFuture<Object> future = new CompletableFuture<>();
+        final RpcResponse res = RpcResponse.from(future);
+        assertThat(res.isDone()).isFalse();
+        future.completeExceptionally(CAUSE);
+        assertThat(res.isDone()).isTrue();
+        assertThatThrownBy(res::join).isInstanceOf(CompletionException.class).hasCause(CAUSE);
+    }
+}


### PR DESCRIPTION
Motivation:

A user often ends up with quite verbose code when he or she wants to
defer the construction of a RpcResponse or an HttpResponse. For example:

    // RpcResponse
    DefaultRpcResponse res = new DefaultRpcResponse();
    CompletableFuture<Object> future = doAsync();
    future.whenComplete((value, cause) -> {
        if (cause != null) {
            res.completeExceptionally(cause);
        } else {
            res.complete(value);
        }
    });
    return res;

    // HttpResponse
    DeferredHttpResponse res = new DeferredHttpResponse();
    CompletableFuture<HttpResponse> future = doAsync();
    future.whenComplete((actualRes, cause) -> {
        if (cause != null) {
            res.close(cause);
        } else {
            res.delegate(actualRes);
        }
    });
    return res;

This pull request simplifies the code above into:

    // RpcResponse
    return RpcResponse.from(doAsync());

    // HttpResponse
    return HttpResponse.from(doAsync());

Modifications:

- Add RpcResponse.from(CompletionStage<?>)
- Add RpcResponseTest to test from()
- Add HttpResponse.from(CompletionStage<? extends HttpResponse>)
- Use HttpResponse.from() where possible
- Improve HttpAuthServiceTest so that the use of HttpResponse.from() is
  tested better
- Miscellaneous:
  - Add RpcResponse.join() and getNow()
  - Add HttpResponse.ofFailed(Throwable)
  - Fix the broken example in DeferredHttpResponse
  - Add Exceptions.throwUnsafely()
  - Rename AuthServiceTest to HttpAuthServiceTest

Result:

- Better user experience