### PR TITLE
Improve randomized backoff

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/retry/AbstractBackoff.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/AbstractBackoff.java
@@ -1,0 +1,40 @@
+/*
+ *  Copyright 2017 LINE Corporation
+ *
+ *  LINE Corporation licenses this file to you under the Apache License,
+ *  version 2.0 (the "License"); you may not use this file except in compliance
+ *  with the License. You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package com.linecorp.armeria.client.retry;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+/**
+ * A skeletal {@link Backoff} implementation.
+ */
+public abstract class AbstractBackoff implements Backoff {
+
+    static void validateNumAttemptsSoFar(int numAttemptsSoFar) {
+        checkArgument(numAttemptsSoFar > 0, "numAttemptsSoFar: %s (expected: > 0)", numAttemptsSoFar);
+    }
+
+    @Override
+    public final long nextIntervalMillis(int numAttemptsSoFar) {
+        validateNumAttemptsSoFar(numAttemptsSoFar);
+        return doNextIntervalMillis(numAttemptsSoFar);
+    }
+
+    /**
+     * Invoked by {@link #nextIntervalMillis(int)} after {@code numAttemptsSoFar} is validated.
+     */
+    protected abstract long doNextIntervalMillis(int numAttemptsSoFar);
+}

--- a/core/src/main/java/com/linecorp/armeria/client/retry/AttemptLimitingBackoff.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/AttemptLimitingBackoff.java
@@ -16,6 +16,7 @@
 package com.linecorp.armeria.client.retry;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.linecorp.armeria.client.retry.AbstractBackoff.validateNumAttemptsSoFar;
 
 import com.google.common.base.MoreObjects;
 
@@ -30,6 +31,7 @@ final class AttemptLimitingBackoff extends BackoffWrapper {
 
     @Override
     public long nextIntervalMillis(int numAttemptsSoFar) {
+        validateNumAttemptsSoFar(numAttemptsSoFar);
         if (numAttemptsSoFar >= maxAttempts) {
             return -1;
         }

--- a/core/src/main/java/com/linecorp/armeria/client/retry/Backoff.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/Backoff.java
@@ -55,9 +55,15 @@ public interface Backoff {
     }
 
     /**
-     * Returns the amount of time to wait before attempting a retry, in milliseconds.
+     * Returns the number of milliseconds to wait for before attempting a retry.
+     *
      * @param numAttemptsSoFar the number of attempts made by a client so far, including the first attempt and
      *                         its following retries.
+     *
+     * @return the number of milliseconds to wait for before attempting a retry,
+     *         or a negative value if no further retry has to be made.
+     *
+     * @throws IllegalArgumentException if {@code numAttemptsSoFar} is equal to or less than {@code 0}
      */
     long nextIntervalMillis(int numAttemptsSoFar);
 

--- a/core/src/main/java/com/linecorp/armeria/client/retry/ExponentialBackoff.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/ExponentialBackoff.java
@@ -19,7 +19,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.base.MoreObjects;
 
-final class ExponentialBackoff implements Backoff {
+final class ExponentialBackoff extends AbstractBackoff {
     private long currentIntervalMillis;
     private final long maxIntervalMillis;
     private final double multiplier;
@@ -35,7 +35,7 @@ final class ExponentialBackoff implements Backoff {
     }
 
     @Override
-    public long nextIntervalMillis(int numAttemptsSoFar) {
+    protected long doNextIntervalMillis(int numAttemptsSoFar) {
         if (currentIntervalMillis >= maxIntervalMillis) {
             return maxIntervalMillis;
         }

--- a/core/src/main/java/com/linecorp/armeria/client/retry/FixedBackoff.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/FixedBackoff.java
@@ -19,7 +19,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.base.MoreObjects;
 
-final class FixedBackoff implements Backoff {
+final class FixedBackoff extends AbstractBackoff {
     static final Backoff NO_DELAY = new FixedBackoff(0);
 
     private final long intervalMillis;
@@ -30,7 +30,7 @@ final class FixedBackoff implements Backoff {
     }
 
     @Override
-    public long nextIntervalMillis(int numAttemptsSoFar) {
+    protected long doNextIntervalMillis(int numAttemptsSoFar) {
         return intervalMillis;
     }
 

--- a/core/src/test/java/com/linecorp/armeria/client/retry/BackoffTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/BackoffTest.java
@@ -25,49 +25,48 @@ public class BackoffTest {
     @Test
     public void withoutDelay() throws Exception {
         Backoff backoff = Backoff.withoutDelay();
-        assertThat(backoff.nextIntervalMillis(0)).isEqualTo(0);
         assertThat(backoff.nextIntervalMillis(1)).isEqualTo(0);
         assertThat(backoff.nextIntervalMillis(2)).isEqualTo(0);
+        assertThat(backoff.nextIntervalMillis(3)).isEqualTo(0);
     }
 
     @Test
     public void fixed() throws Exception {
         Backoff backoff = Backoff.fixed(100);
-        assertThat(backoff.nextIntervalMillis(0)).isEqualTo(100);
         assertThat(backoff.nextIntervalMillis(1)).isEqualTo(100);
         assertThat(backoff.nextIntervalMillis(2)).isEqualTo(100);
+        assertThat(backoff.nextIntervalMillis(3)).isEqualTo(100);
     }
 
     @Test
     public void exponential() throws Exception {
         Backoff backoff = Backoff.exponential(10, 50);
-        assertThat(backoff.nextIntervalMillis(0)).isEqualTo(10);
-        assertThat(backoff.nextIntervalMillis(1)).isEqualTo(20);
-        assertThat(backoff.nextIntervalMillis(2)).isEqualTo(40);
-        assertThat(backoff.nextIntervalMillis(3)).isEqualTo(50);
+        assertThat(backoff.nextIntervalMillis(1)).isEqualTo(10);
+        assertThat(backoff.nextIntervalMillis(2)).isEqualTo(20);
+        assertThat(backoff.nextIntervalMillis(3)).isEqualTo(40);
         assertThat(backoff.nextIntervalMillis(4)).isEqualTo(50);
+        assertThat(backoff.nextIntervalMillis(5)).isEqualTo(50);
 
         backoff = Backoff.exponential(10, 120, 3.0);
-        assertThat(backoff.nextIntervalMillis(0)).isEqualTo(10);
-        assertThat(backoff.nextIntervalMillis(1)).isEqualTo(30);
-        assertThat(backoff.nextIntervalMillis(2)).isEqualTo(90);
-        assertThat(backoff.nextIntervalMillis(3)).isEqualTo(120);
+        assertThat(backoff.nextIntervalMillis(1)).isEqualTo(10);
+        assertThat(backoff.nextIntervalMillis(2)).isEqualTo(30);
+        assertThat(backoff.nextIntervalMillis(3)).isEqualTo(90);
         assertThat(backoff.nextIntervalMillis(4)).isEqualTo(120);
+        assertThat(backoff.nextIntervalMillis(5)).isEqualTo(120);
     }
 
     @Test
     public void withJitter() throws Exception {
         Random random = new Random(1);
-        Backoff backoff = Backoff.fixed(100).withJitter(10, 20, () -> random);
-        assertThat(backoff.nextIntervalMillis(0)).isEqualTo(116);
-        assertThat(backoff.nextIntervalMillis(1)).isEqualTo(113);
-        assertThat(backoff.nextIntervalMillis(2)).isEqualTo(118);
+        Backoff backoff = Backoff.fixed(100).withJitter(-50, 50, () -> random);
+        assertThat(backoff.nextIntervalMillis(1)).isEqualTo(120);
+        assertThat(backoff.nextIntervalMillis(2)).isEqualTo(139);
+        assertThat(backoff.nextIntervalMillis(3)).isEqualTo(94);
     }
 
     @Test
     public void withMaxAttempts() throws Exception {
         Backoff backoff = Backoff.fixed(100).withMaxAttempts(2);
-        assertThat(backoff.nextIntervalMillis(0)).isEqualTo(100);
         assertThat(backoff.nextIntervalMillis(1)).isEqualTo(100);
         assertThat(backoff.nextIntervalMillis(2)).isEqualTo(-1);
         assertThat(backoff.nextIntervalMillis(3)).isEqualTo(-1);

--- a/core/src/test/java/com/linecorp/armeria/client/retry/ExponentialBackoffTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/ExponentialBackoffTest.java
@@ -24,17 +24,17 @@ public class ExponentialBackoffTest {
     @Test
     public void test() {
         Backoff backoff = new ExponentialBackoff(10, 120, 3.0);
-        assertThat(backoff.nextIntervalMillis(0)).isEqualTo(10);
-        assertThat(backoff.nextIntervalMillis(1)).isEqualTo(30);
-        assertThat(backoff.nextIntervalMillis(2)).isEqualTo(90);
-        assertThat(backoff.nextIntervalMillis(3)).isEqualTo(120);
+        assertThat(backoff.nextIntervalMillis(1)).isEqualTo(10);
+        assertThat(backoff.nextIntervalMillis(2)).isEqualTo(30);
+        assertThat(backoff.nextIntervalMillis(3)).isEqualTo(90);
+        assertThat(backoff.nextIntervalMillis(4)).isEqualTo(120);
     }
 
     @Test
     public void testOverflow() {
         Backoff backoff = new ExponentialBackoff(Long.MAX_VALUE / 3, Long.MAX_VALUE, 2.0);
-        assertThat(backoff.nextIntervalMillis(0)).isEqualTo(Long.MAX_VALUE / 3);
-        assertThat(backoff.nextIntervalMillis(1)).isEqualTo((long) (Long.MAX_VALUE / 3 * 2.0));
-        assertThat(backoff.nextIntervalMillis(2)).isEqualTo(Long.MAX_VALUE);
+        assertThat(backoff.nextIntervalMillis(1)).isEqualTo(Long.MAX_VALUE / 3);
+        assertThat(backoff.nextIntervalMillis(2)).isEqualTo((long) (Long.MAX_VALUE / 3 * 2.0));
+        assertThat(backoff.nextIntervalMillis(3)).isEqualTo(Long.MAX_VALUE);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RandomBackoffTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RandomBackoffTest.java
@@ -16,6 +16,7 @@
 package com.linecorp.armeria.client.retry;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 
@@ -26,10 +27,23 @@ public class RandomBackoffTest {
     public void nextIntervalMillis() throws Exception {
         Random r = new Random(1);
         Backoff backoff = new RandomBackoff(10, 100, () -> r);
-        assertThat(backoff.nextIntervalMillis(0)).isEqualTo(46);
-        assertThat(backoff.nextIntervalMillis(0)).isEqualTo(13);
-        assertThat(backoff.nextIntervalMillis(0)).isEqualTo(28);
-        assertThat(backoff.nextIntervalMillis(0)).isEqualTo(40);
+        assertThat(backoff.nextIntervalMillis(1)).isEqualTo(18);
+        assertThat(backoff.nextIntervalMillis(1)).isEqualTo(93);
+        assertThat(backoff.nextIntervalMillis(1)).isEqualTo(12);
+        assertThat(backoff.nextIntervalMillis(1)).isEqualTo(95);
     }
 
+    @Test
+    public void validation() {
+        // Negative minIntervalMillis
+        assertThatThrownBy(() -> new RandomBackoff(-1, 1, Random::new))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        // minIntervalMillis > maxIntervalMillis
+        assertThatThrownBy(() -> new RandomBackoff(2, 1, Random::new))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        // Should not fail for 0-interval:
+        new RandomBackoff(0, 0, Random::new);
+    }
 }


### PR DESCRIPTION
Related: #513 #514

Motivation:

- There's off-by-one validation error in RandomBackoff
- RandomBackoff uses Random.longs() which is expensive to create
- Backoff.withJitter() doesn't accept negative jitters

Modifications:

- Add AbstractBackoff that performs validation on numAttemptsSoFar
- Do not make JitterAddingBackoff delegate to RandomBackoff
- Fix the validation error in RandomBackoff
- Make RandomBackoff not create a LongSupplier every time when
  generating a random number

Result:

- Fixes #513
- Fixes #514
- Efficiency