### PR TITLE
[WIP] Make Armeria retrofit can handle full url like @Url annotation

### DIFF
--- a/retrofit2/src/test/java/com/linecorp/armeria/client/http/retrofit2/ArmeriaRetrofitTest.java
+++ b/retrofit2/src/test/java/com/linecorp/armeria/client/http/retrofit2/ArmeriaRetrofitTest.java
@@ -16,7 +16,6 @@
 package com.linecorp.armeria.client.http.retrofit2;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.net.URI;
 
@@ -25,45 +24,36 @@ import org.junit.Test;
 import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.http.HttpClient;
 
+import retrofit2.Retrofit;
+
 public class ArmeriaRetrofitTest {
     @Test
     public void convertToOkHttpUrl() throws Exception {
-        URI uri = Clients.newClient(URI.create("none+http://example.com:8080/a/b/c"), HttpClient.class).uri();
-        assertThat(String.valueOf(ArmeriaRetrofit.convertToOkHttpUrl(uri)))
-                .isEqualTo("http://example.com:8080/a/b/c");
+        Retrofit retrofit = ArmeriaRetrofit.builder(
+                Clients.newClient(URI.create("none+http://example.com:8080/a/b/c/"), HttpClient.class)).build();
+        assertThat(retrofit.baseUrl().toString())
+                .isEqualTo("http://example.com:8080/a/b/c/");
     }
 
     @Test
     public void convertToOkHttpUrl_sessionProtocol() throws Exception {
-        assertThat(String.valueOf(ArmeriaRetrofit.convertToOkHttpUrl(URI.create("h1c://example.com:8080/"))))
+        assertThat(ArmeriaRetrofit.builder(URI.create("h1c://example.com:8080/")).build().baseUrl().toString())
                 .isEqualTo("http://example.com:8080/");
-        assertThat(String.valueOf(ArmeriaRetrofit.convertToOkHttpUrl(URI.create("h2c://example.com:8080/"))))
+        assertThat(ArmeriaRetrofit.builder(URI.create("h2c://example.com:8080/")).build().baseUrl().toString())
                 .isEqualTo("http://example.com:8080/");
-        assertThat(String.valueOf(ArmeriaRetrofit.convertToOkHttpUrl(URI.create("h1://example.com:8080/"))))
+        assertThat(ArmeriaRetrofit.builder(URI.create("h1://example.com:8080/")).build().baseUrl().toString())
                 .isEqualTo("https://example.com:8080/");
-        assertThat(String.valueOf(ArmeriaRetrofit.convertToOkHttpUrl(URI.create("h2://example.com:8080/"))))
+        assertThat(ArmeriaRetrofit.builder(URI.create("h2://example.com:8080/")).build().baseUrl().toString())
                 .isEqualTo("https://example.com:8080/");
-        assertThat(String.valueOf(ArmeriaRetrofit.convertToOkHttpUrl(URI.create("https://example.com:8080/"))))
-                .isEqualTo("https://example.com:8080/");
-    }
-
-    @Test
-    public void convertToOkHttpUrl_wrongSessionProtocol() throws Exception {
-        assertThatThrownBy(() -> ArmeriaRetrofit.convertToOkHttpUrl(URI.create("foo://example.com:8080/")))
-                .isInstanceOf(IllegalArgumentException.class);
-    }
-
-    @Test
-    public void convertToOkHttpUrl_noSerializationFormat() throws Exception {
-        URI uri = URI.create("http://example.com:8080/");
-        assertThat(String.valueOf(ArmeriaRetrofit.convertToOkHttpUrl(uri)))
-                .isEqualTo("http://example.com:8080/");
+        assertThat(ArmeriaRetrofit.builder(URI.create("https://example.com:8080/")).build().baseUrl()
+                                  .toString()).isEqualTo("https://example.com:8080/");
     }
 
     @Test
     public void convertToOkHttpUrl_convertOkhttpNotSupportedAuthority() throws Exception {
-        URI uri = URI.create("http://group:myGroup/path");
-        assertThat(String.valueOf(ArmeriaRetrofit.convertToOkHttpUrl(uri)))
-                .isEqualTo("http://group_mygroup/path"); // NB: lower-cased by OkHttp
+        assertThat(ArmeriaRetrofit.builder(URI.create("http://group:myGroup/path/")).build().baseUrl()
+                                  .toString())
+                // NB: lower-cased by OkHttp
+                .isEqualTo("http://group_mygroup/path/");
     }
 }


### PR DESCRIPTION
Apply this change will make armeria retrofit easier to use.

Modifications:
* Lazy creation of HttpClient
* Support retrofit's @Url
* Currently group only allow ^[.-_0-9a-z]*$, so remove unused replacement