### PR TITLE
Add support for grpc-web draft spec.

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/common/grpc/GrpcSerializationFormatProvider.java
+++ b/grpc/src/main/java/com/linecorp/armeria/common/grpc/GrpcSerializationFormatProvider.java
@@ -33,6 +33,8 @@ public final class GrpcSerializationFormatProvider extends SerializationFormatPr
     protected Set<Entry> entries() {
         return ImmutableSet.of(
                 new Entry("gproto", create("application", "grpc+proto")),
-                new Entry("gjson", create("application", "grpc+json")));
+                new Entry("gjson", create("application", "grpc+json")),
+                new Entry("gproto-web", create("application", "grpc-web+proto")),
+                new Entry("gjson-web", create("application", "grpc-web+json")));
     }
 }

--- a/grpc/src/main/java/com/linecorp/armeria/common/grpc/GrpcSerializationFormats.java
+++ b/grpc/src/main/java/com/linecorp/armeria/common/grpc/GrpcSerializationFormats.java
@@ -39,7 +39,18 @@ public final class GrpcSerializationFormats {
      */
     public static final SerializationFormat JSON = SerializationFormat.of("gjson");
 
-    private static final Set<SerializationFormat> GRPC_FORMATS = ImmutableSet.of(PROTO, JSON);
+    /**
+     * GRPC-web protobuf serialization format.
+     */
+    public static final SerializationFormat PROTO_WEB = SerializationFormat.of("gproto-web");
+
+    /**
+     * GRPC-web JSON serialization format.
+     */
+    public static final SerializationFormat JSON_WEB = SerializationFormat.of("gjson-web");
+
+    private static final Set<SerializationFormat> GRPC_FORMATS = ImmutableSet.of(
+            PROTO, JSON, PROTO_WEB, JSON_WEB);
 
     /**
      * Returns the set of all known GRPC serialization formats.
@@ -53,6 +64,23 @@ public final class GrpcSerializationFormats {
      */
     public static boolean isGrpc(SerializationFormat format) {
         return values().contains(requireNonNull(format, "format"));
+    }
+
+    /**
+     * Is a proto-based GRPC serialization format.
+     */
+    public static boolean isProto(SerializationFormat format) {
+        requireNonNull(format, "format");
+        return format == PROTO || format == PROTO_WEB;
+    }
+
+    /**
+     * Returns whether the specified {@link SerializationFormat} is GRPC-web, the subset of GRPC that supports
+     * browsers.
+     */
+    public static boolean isGrpcWeb(SerializationFormat format) {
+        requireNonNull(format, "format");
+        return format == PROTO_WEB || format == JSON_WEB;
     }
 
     private GrpcSerializationFormats() {}

--- a/grpc/src/main/java/com/linecorp/armeria/internal/grpc/GrpcMessageMarshaller.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/grpc/GrpcMessageMarshaller.java
@@ -147,7 +147,7 @@ public class GrpcMessageMarshaller<I, O> {
     }
 
     private ByteBuf serializeProto(Message message) throws IOException {
-        if (serializationFormat.equals(GrpcSerializationFormats.PROTO)) {
+        if (GrpcSerializationFormats.isProto(serializationFormat)) {
             ByteBuf buf = alloc.buffer(message.getSerializedSize());
             boolean success = false;
             try {

--- a/grpc/src/test/java/com/linecorp/armeria/common/grpc/GrpcSerializationFormatsTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/common/grpc/GrpcSerializationFormatsTest.java
@@ -17,7 +17,9 @@
 package com.linecorp.armeria.common.grpc;
 
 import static com.linecorp.armeria.common.grpc.GrpcSerializationFormats.JSON;
+import static com.linecorp.armeria.common.grpc.GrpcSerializationFormats.JSON_WEB;
 import static com.linecorp.armeria.common.grpc.GrpcSerializationFormats.PROTO;
+import static com.linecorp.armeria.common.grpc.GrpcSerializationFormats.PROTO_WEB;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
@@ -25,6 +27,7 @@ import org.junit.Test;
 public class GrpcSerializationFormatsTest {
     @Test
     public void allFormatsAreRegistered() {
-        assertThat(GrpcSerializationFormats.values()).containsExactlyInAnyOrder(PROTO, JSON);
+        assertThat(GrpcSerializationFormats.values())
+                .containsExactlyInAnyOrder(PROTO, JSON, PROTO_WEB, JSON_WEB);
     }
 }

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceTest.java
@@ -94,7 +94,7 @@ public class GrpcServiceTest {
         grpcService.doPost(
                 ctx,
                 HttpRequest.of(HttpHeaders.of(HttpMethod.POST, "grpc.testing.TestService.UnaryCall")
-                                          .set(HttpHeaderNames.CONTENT_TYPE, GrpcService.CONTENT_TYPE_GRPC)),
+                                          .set(HttpHeaderNames.CONTENT_TYPE, "application/grpc+proto")),
                 response);
         assertThat(response.aggregate().get()).isEqualTo(AggregatedHttpMessage.of(
                 HttpHeaders.of(HttpStatus.BAD_REQUEST)
@@ -108,7 +108,7 @@ public class GrpcServiceTest {
         grpcService.doPost(
                 ctx,
                 HttpRequest.of(HttpHeaders.of(HttpMethod.POST, "/grpc.testing.TestService/FooCall")
-                                          .set(HttpHeaderNames.CONTENT_TYPE, GrpcService.CONTENT_TYPE_GRPC)),
+                                          .set(HttpHeaderNames.CONTENT_TYPE, "application/grpc+proto")),
                 response);
         assertThat(response.aggregate().get()).isEqualTo(AggregatedHttpMessage.of(
                 HttpHeaders.of(HttpStatus.OK)


### PR DESCRIPTION
Browsers cannot use normal grpc because they don't support trailers, so a grpc-web spec exists that is basically the same as grpc but encodes trailers into the response body. It also talks about decoupling the protocol from HTTP/2, but armeria already does that :D

Spec:
https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB.md

No reference implementation, but closest is at:
https://github.com/improbable-eng/grpc-web

Verified interop with the example in that repo.