### PR TITLE
Fix a typo in a comment

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/http/HttpSessionProtocols.java
+++ b/core/src/main/java/com/linecorp/armeria/common/http/HttpSessionProtocols.java
@@ -55,7 +55,7 @@ public final class HttpSessionProtocols {
     public static final SessionProtocol H2 = SessionProtocol.of("h2");
 
     /**
-     * HTTP/2 - over TLS.
+     * HTTP/2 - cleartext.
      */
     public static final SessionProtocol H2C = SessionProtocol.of("h2c");
 


### PR DESCRIPTION
Change the comment on H2C from "over TLS" to "cleartext".