### PR TITLE
[WIP] Add Prometheus request metrics to armeria-core

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -16,6 +16,10 @@ managedDependencies {
     // Metrics
     compile 'io.dropwizard.metrics:metrics-core'
 
+    // Prometheus
+    compile 'io.prometheus:simpleclient_common'
+    compile 'io.prometheus:simpleclient_dropwizard'
+
     // Netty
     [ 'netty-transport', 'netty-codec-http2', 'netty-resolver-dns' ].each {
         compile "io.netty:$it"

--- a/core/src/main/java/com/linecorp/armeria/common/logging/MetricLabel.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/MetricLabel.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.logging;
+
+import java.util.List;
+
+public interface MetricLabel<V> {
+    List<String> getTokenizedName();
+    String getDescription();
+    V getValue();
+}

--- a/core/src/main/java/com/linecorp/armeria/common/logging/PrometheusMetricRequestDecorator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/PrometheusMetricRequestDecorator.java
@@ -1,0 +1,326 @@
+/**
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.logging;
+
+import java.beans.BeanInfo;
+import java.beans.IntrospectionException;
+import java.beans.Introspector;
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import com.linecorp.armeria.client.Client;
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.DecoratingClientFunction;
+import com.linecorp.armeria.common.Request;
+import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.common.Response;
+import com.linecorp.armeria.common.RpcResponse;
+import com.linecorp.armeria.common.http.HttpSessionProtocols;
+import com.linecorp.armeria.server.DecoratingServiceFunction;
+import com.linecorp.armeria.server.Service;
+import com.linecorp.armeria.server.ServiceRequestContext;
+
+import io.prometheus.client.Collector;
+import io.prometheus.client.Counter;
+import io.prometheus.client.Gauge;
+import io.prometheus.client.Summary;
+
+public final class PrometheusMetricRequestDecorator<I extends Request, O extends Response>
+        implements DecoratingServiceFunction<I, O>, DecoratingClientFunction<I, O> {
+
+    private static class MetricAdapter {
+        private AtomicReference<MetricAdapter> initialized;
+
+        private Summary timer;
+        private Counter success;
+        private Counter failure;
+        private Gauge activeRequests;
+        private Summary requestBytes;
+        private Summary responseBytes;
+
+        private List<Method> metricLabelValueMethods;
+
+        public MetricAdapter() {
+            initialized = new AtomicReference<>();
+        }
+
+        public MetricAdapter initialize(MetricLabel<?> namingFunction,
+                                        PrometheusRegistryWrapper collectorRegistry) {
+            if (initialized.compareAndSet(null, this)) {
+                BeanInfo metricLabelValueBeanInfo;
+
+                try {
+                    metricLabelValueBeanInfo = Introspector.getBeanInfo(namingFunction.getValue().getClass());
+                } catch (IntrospectionException e) {
+                    throw new RuntimeException(e);
+                }
+
+                String[] labels = Arrays.asList(metricLabelValueBeanInfo.getPropertyDescriptors())
+                                        .stream()
+                                        .skip(1)
+                                        .map(PropertyDescriptor::getName)
+                                        .map(Collector::sanitizeMetricName)
+                                        .toArray(String[]::new);
+
+                String sanitizedName = namingFunction.getTokenizedName()
+                                                     .stream()
+                                                     .collect(Collectors.joining("_"));
+
+                metricLabelValueMethods = Arrays.asList(metricLabelValueBeanInfo.getPropertyDescriptors())
+                                                .stream()
+                                                .skip(1)
+                                                .map(PropertyDescriptor::getReadMethod)
+                                                .collect(Collectors.toList());
+
+                timer = create(sanitizedName + "_timer",
+                               collectorRegistry,
+                               name -> Summary.build()
+                                              .quantile(.5, .01)
+                                              .quantile(.75, .01)
+                                              .quantile(.95, .01)
+                                              .quantile(.98, .01)
+                                              .quantile(.99, .01)
+                                              .quantile(.999, .01)
+                                              .name(name)
+                                              .labelNames(labels)
+                                              .help(namingFunction.getDescription())
+                                              .create());
+                success = create(sanitizedName + "_success",
+                                 collectorRegistry,
+                                 name -> Counter.build().name(name)
+                                                .labelNames(labels)
+                                                .help(namingFunction.getDescription())
+                                                .create());
+                failure = create(sanitizedName + "_failure",
+                                 collectorRegistry,
+                                 name -> Counter.build().name(name)
+                                                .labelNames(labels)
+                                                .help(namingFunction.getDescription())
+                                                .create());
+                activeRequests = create(sanitizedName + "_activeRequests",
+                                        collectorRegistry,
+                                        name -> Gauge.build().name(name)
+                                                     .labelNames(labels)
+                                                     .help(namingFunction.getDescription())
+                                                     .create());
+                requestBytes = create(sanitizedName + "_requestBytes",
+                                      collectorRegistry,
+                                      name -> Summary.build()
+                                                     .quantile(.5, .01)
+                                                     .quantile(.75, .01)
+                                                     .quantile(.95, .01)
+                                                     .quantile(.98, .01)
+                                                     .quantile(.99, .01)
+                                                     .quantile(.999, .01)
+                                                     .name(name)
+                                                     .labelNames(labels)
+                                                     .help(namingFunction.getDescription())
+                                                     .create());
+                responseBytes = create(sanitizedName + "_responseBytes",
+                                       collectorRegistry,
+                                       name -> Summary.build()
+                                                      .quantile(.5, .01)
+                                                      .quantile(.75, .01)
+                                                      .quantile(.95, .01)
+                                                      .quantile(.98, .01)
+                                                      .quantile(.99, .01)
+                                                      .quantile(.999, .01)
+                                                      .name(name)
+                                                      .labelNames(labels)
+
+                                                      .help(namingFunction.getDescription())
+                                                      .create());
+
+            }
+            return this;
+        }
+
+        private <T extends Collector> T create(String name,
+                                               PrometheusRegistryWrapper collectorRegistry,
+                                               Function<String, T> ifAbsent) {
+            return collectorRegistry.create(name, ifAbsent);
+        }
+
+        private <T> String[] getValues(MetricLabel<T> label) {
+            BiFunction<Method, T, Object> callMethod = (method, obj) -> {
+                try {
+                    return method.invoke(obj);
+                } catch (Throwable t) {
+                    throw new RuntimeException(t);
+                }
+            };
+
+            return metricLabelValueMethods.stream()
+                                          .map(method -> callMethod.apply(method, label.getValue()))
+                                          .map(Objects::toString)
+                                          .toArray(String[]::new);
+        }
+
+        public MetricAdapter time(MetricLabel<?> label, long time) throws Exception {
+            check(timer).labels(getValues(label)).observe(time);
+            return this;
+        }
+
+        public MetricAdapter success(MetricLabel<?> label) {
+            check(success).labels(getValues(label)).inc();
+            return this;
+        }
+
+        public MetricAdapter failure(MetricLabel<?> label) {
+            check(failure).labels(getValues(label)).inc();
+            return this;
+        }
+
+        public MetricAdapter incActiveRequests(MetricLabel<?> label) {
+            check(activeRequests).labels(getValues(label)).inc();
+            return this;
+        }
+
+        public MetricAdapter decActiveRequests(MetricLabel<?> label) {
+            check(activeRequests).labels(getValues(label)).dec();
+            return this;
+        }
+
+        public MetricAdapter requestBytes(MetricLabel<?> label, RequestLog log) {
+            check(requestBytes).labels(getValues(label)).observe(log.requestLength());
+            return this;
+        }
+
+        public MetricAdapter responseBytes(MetricLabel<?> label, RequestLog log) {
+            check(responseBytes).labels(getValues(label)).observe(log.responseLength());
+            return this;
+        }
+
+        private <T> T check(T metric) {
+            if (Objects.isNull(metric)) {
+                throw new IllegalStateException(MetricAdapter.class.getCanonicalName() + "not initialized");
+            }
+            return metric;
+        }
+    }
+
+    private PrometheusRegistryWrapper collectorRegistry;
+    private Function<RequestLog, MetricLabel> labelingFunction;
+    private MetricAdapter metricAdapter;
+
+    /**
+     * Creates a new instance that decorates the specified {@link Service}.
+     */
+    private PrometheusMetricRequestDecorator(PrometheusRegistryWrapper collectorRegistry,
+                                             Function<RequestLog, MetricLabel> labelingFunction) {
+        this.collectorRegistry = collectorRegistry;
+        this.labelingFunction = labelingFunction;
+        this.metricAdapter = new MetricAdapter();
+    }
+
+    @FunctionalInterface
+    private interface ThrowsBiFunction<C, I, O> {
+        O apply(C c, I i) throws Exception;
+    }
+
+    private <C extends RequestContext> O request(ThrowsBiFunction<C, I, O> function, C ctx, I req)
+            throws Exception {
+        ctx.log().addListener(
+                log -> {
+                    MetricLabel<?> label = labelingFunction.apply(log);
+                    metricAdapter.initialize(label, collectorRegistry)
+                                 .incActiveRequests(label);
+                }, RequestLogAvailability.REQUEST_ENVELOPE, RequestLogAvailability.REQUEST_CONTENT);
+
+        ctx.log().addListener(
+                log -> {
+                    MetricLabel<?> label = labelingFunction.apply(log);
+                    metricAdapter.initialize(label, collectorRegistry)
+                                 .requestBytes(label, log);
+                    if (log.requestCause() != null) {
+                        metricAdapter.failure(label)
+                                     .decActiveRequests(label);
+                    }
+                }, RequestLogAvailability.REQUEST_END);
+
+        ctx.log().addListener(
+                log -> {
+                    if (log.requestCause() != null) {
+                        return;
+                    }
+                    MetricLabel<?> label = labelingFunction.apply(log);
+                    metricAdapter.initialize(label, collectorRegistry)
+                                 .time(label, log.totalDurationNanos())
+                                 .responseBytes(label, log)
+                                 .decActiveRequests(label);
+
+                    if (isSuccess(log)) {
+                        metricAdapter.success(label);
+                    } else {
+                        metricAdapter.failure(label);
+                    }
+                }, RequestLogAvailability.COMPLETE);
+        return function.apply(ctx, req);
+    }
+
+    @Override
+    public O serve(Service<I, O> delegate, ServiceRequestContext ctx, I req) throws Exception {
+        return request(delegate::serve, ctx, req);
+    }
+
+    @Override
+    public O execute(Client<I, O> delegate, ClientRequestContext ctx, I req) throws Exception {
+        return request(delegate::execute, ctx, req);
+    }
+
+    public static <I extends Request, O extends Response> DecoratingServiceFunction<I, O> decorateService(
+            PrometheusRegistryWrapper collectorRegistry,
+            Function<RequestLog, MetricLabel> labelingFunction) {
+        return new PrometheusMetricRequestDecorator<>(collectorRegistry, labelingFunction);
+    }
+
+    public static <I extends Request, O extends Response> DecoratingClientFunction<I, O> decorateClient(
+            PrometheusRegistryWrapper collectorRegistry,
+            Function<RequestLog, MetricLabel> labelingFunction) {
+        return new PrometheusMetricRequestDecorator<>(collectorRegistry, labelingFunction);
+    }
+
+    private static boolean isSuccess(RequestLog log) {
+        if (log.responseCause() != null) {
+            return false;
+        }
+
+        if (HttpSessionProtocols.isHttp(log.sessionProtocol())) {
+            if (log.statusCode() >= 400) {
+                return false;
+            }
+        } else {
+            if (log.statusCode() != 0) {
+                return false;
+            }
+        }
+
+        final Object responseContent = log.responseContent();
+        if (responseContent instanceof RpcResponse) {
+            return !((RpcResponse) responseContent).isCompletedExceptionally();
+        }
+
+        return true;
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/common/logging/PrometheusRegistryWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/PrometheusRegistryWrapper.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.logging;
+
+import java.util.Enumeration;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Function;
+
+import io.prometheus.client.Collector;
+import io.prometheus.client.Collector.MetricFamilySamples;
+import io.prometheus.client.CollectorRegistry;
+
+public class PrometheusRegistryWrapper {
+    private CollectorRegistry collectorRegistry;
+    private ConcurrentMap<String, ? extends Collector> names;
+
+    public PrometheusRegistryWrapper() {
+        collectorRegistry = new CollectorRegistry();
+        names = new ConcurrentHashMap<>();
+    }
+
+    public <T extends Collector> T create(String name, Function<String, T> ifAbsent) {
+        ConcurrentMap<String, T> map = (ConcurrentMap<String, T>) names;
+        Function<T, T> registerIfAbsent = collector -> {
+            collectorRegistry.register(collector);
+            return collector;
+        };
+        return map.computeIfAbsent(name, registerIfAbsent.compose((ifAbsent)));
+    }
+
+    public Enumeration<MetricFamilySamples> metricFamilySamples() {
+        return collectorRegistry.metricFamilySamples();
+    }
+
+}

--- a/core/src/main/java/com/linecorp/armeria/server/http/metric/PrometheusExporterHttpService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/metric/PrometheusExporterHttpService.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.http.metric;
+
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStreamWriter;
+
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.http.HttpRequest;
+import com.linecorp.armeria.common.http.HttpResponseWriter;
+import com.linecorp.armeria.common.http.HttpStatus;
+import com.linecorp.armeria.common.logging.PrometheusRegistryWrapper;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.http.AbstractHttpService;
+
+import io.prometheus.client.exporter.common.TextFormat;
+
+public class PrometheusExporterHttpService extends AbstractHttpService {
+
+    private final PrometheusRegistryWrapper collectorRegistry;
+
+    /**
+     * Constructor.
+     * @param collectorRegistry Prometheus collector registry.
+     */
+    public PrometheusExporterHttpService(PrometheusRegistryWrapper collectorRegistry) {
+        this.collectorRegistry = collectorRegistry;
+    }
+
+    @Override
+    protected void doGet(ServiceRequestContext ctx, HttpRequest req,
+                         HttpResponseWriter res) throws Exception {
+        try (ByteArrayOutputStream stream = new ByteArrayOutputStream();
+             OutputStreamWriter writer = new OutputStreamWriter(stream)) {
+            TextFormat.write004(writer, collectorRegistry.metricFamilySamples());
+            writer.flush();
+            res.respond(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, stream.toByteArray());
+        }
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/http/metric/package-info.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/metric/package-info.java
@@ -1,0 +1,5 @@
+/*
+ * Copyright (c) 2016 LINE Corporation. All rights reserved.
+ * LINE Corporation PROPRIETARY/CONFIDENTIAL. Use is subject to license terms.
+ */
+package com.linecorp.armeria.server.http.metric;

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -49,6 +49,10 @@ io.netty:
   netty-transport-native-epoll: { version: *NETTY_VERSION }
   netty-tcnative-boringssl-static: { version: 2.0.0.Final }
 
+io.prometheus:
+  simpleclient_common: { version: 0.0.21 }
+  simpleclient_dropwizard: { version: 0.0.21 }
+
 io.zipkin.brave:
   brave-core: { version: &BRAVE_VERSION 4.0.6 }
   brave-http: { version: *BRAVE_VERSION }

--- a/thrift/src/test/java/com/linecorp/armeria/it/metrics/PrometheusMetricsIntegrationTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/metrics/PrometheusMetricsIntegrationTest.java
@@ -1,0 +1,315 @@
+/**
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.it.metrics;
+
+import static com.linecorp.armeria.common.thrift.ThriftSerializationFormats.BINARY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.BufferedReader;
+import java.io.StringReader;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+
+import org.apache.thrift.TException;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.client.ClientBuilder;
+import com.linecorp.armeria.client.ClientFactory;
+import com.linecorp.armeria.client.Clients;
+import com.linecorp.armeria.client.http.HttpClient;
+import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.common.RpcRequest;
+import com.linecorp.armeria.common.RpcResponse;
+import com.linecorp.armeria.common.http.AggregatedHttpMessage;
+import com.linecorp.armeria.common.http.HttpHeaderNames;
+import com.linecorp.armeria.common.http.HttpHeaders;
+import com.linecorp.armeria.common.http.HttpMethod;
+import com.linecorp.armeria.common.logging.MetricLabel;
+import com.linecorp.armeria.common.logging.PrometheusMetricRequestDecorator;
+import com.linecorp.armeria.common.logging.PrometheusRegistryWrapper;
+import com.linecorp.armeria.common.logging.RequestLog;
+import com.linecorp.armeria.common.logging.RequestLogAvailability;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.http.metric.PrometheusExporterHttpService;
+import com.linecorp.armeria.server.thrift.THttpService;
+import com.linecorp.armeria.service.test.thrift.main.HelloService.Iface;
+import com.linecorp.armeria.testing.server.ServerRule;
+
+public class PrometheusMetricsIntegrationTest {
+    private static final PrometheusRegistryWrapper collectorRegistry = new PrometheusRegistryWrapper();
+
+    private static volatile CountDownLatch latch;
+
+    @ClassRule
+    public static final ServerRule server = new ServerRule() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.serviceAt("/thrift", THttpService.of((Iface) name -> {
+                if ("world".equals(name)) {
+                    return "success";
+                }
+                throw new IllegalArgumentException("bad argument");
+            }).decorate((delegate, ctx, req) -> {
+                ctx.log().addListener(log -> latch.countDown(),
+                                      RequestLogAvailability.COMPLETE);
+                return delegate.serve(ctx, req);
+            }).decorate(
+                    PrometheusMetricRequestDecorator
+                            .decorateService(collectorRegistry,
+                                             log -> defaultMetricName(log, "HelloService",
+                                                                      serviceMetricName()))))
+              .serviceAt("/internal/prometheus/metrics-v2",
+                         new PrometheusExporterHttpService(collectorRegistry));
+        }
+    };
+
+    private static void makeRequest(String name) throws TException {
+        Iface client = new ClientBuilder(server.uri(BINARY, "/thrift"))
+                .decorator(RpcRequest.class, RpcResponse.class,
+                           (delegate, ctx, req) -> {
+                               ctx.log().addListener(unused -> latch.countDown(),
+                                                     RequestLogAvailability.COMPLETE);
+                               return delegate.execute(ctx, req);
+                           })
+                .decorator(RpcRequest.class, RpcResponse.class,
+                           PrometheusMetricRequestDecorator
+                                   .decorateClient(collectorRegistry,
+                                                   log -> defaultMetricName(log,
+                                                                            "HelloService",
+                                                                            clientMetricName())))
+                .build(Iface.class);
+        try {
+            client.hello(name);
+        } catch (Throwable t) {
+
+        }
+    }
+
+    private static AggregatedHttpMessage makeMetricsRequest() throws ExecutionException,
+                                                                     InterruptedException {
+        HttpClient client = Clients.newClient(ClientFactory.DEFAULT,
+                                              "none+http://127.0.0.1:" + server.httpPort(),
+                                              HttpClient.class);
+        return client.execute(
+                HttpHeaders.of(HttpMethod.GET, "/internal/prometheus/metrics-v2")
+                           .set(HttpHeaderNames.ACCEPT, "utf-8")).aggregate().get();
+
+    }
+
+    private static MetricLabel defaultMetricName(RequestLog log,
+                                                 String serviceName,
+                                                 String[] metricNamePrefix) {
+
+        final RequestContext ctx = log.context();
+        final Object requestEnvelope = log.requestEnvelope();
+        final Object requestContent = log.requestContent();
+
+        String pathAsMetricName = null;
+        String methodName = null;
+
+        if (requestEnvelope instanceof HttpHeaders) {
+            pathAsMetricName = ctx.path();
+            methodName = ((HttpHeaders) requestEnvelope).method().name();
+        }
+
+        if (requestContent instanceof RpcRequest) {
+            methodName = ((RpcRequest) requestContent).method();
+        }
+
+        pathAsMetricName = MoreObjects.firstNonNull(pathAsMetricName, "__UNKNOWN_PATH__");
+
+        if (methodName == null) {
+            methodName = MoreObjects.firstNonNull(log.method(), "__UNKNOWN_METHOD__");
+        }
+
+        return new MyMetricLabel(metricNamePrefix,
+                                 "Armeria client/server request metric",
+                                 new MyMetricValue(serviceName, methodName, pathAsMetricName));
+    }
+
+    /**
+     * Returns the name of the service metric.
+     */
+    public static String[] serviceMetricName() {
+        return new String[] { "armeria", "server" };
+    }
+
+    /**
+     * Returns the name of the client metric.
+     */
+    public static String[] clientMetricName() {
+        return new String[] { "armeria", "client" };
+    }
+
+    public static class MyMetricValue {
+        private String handler;
+        private String method;
+        private String path;
+
+        public MyMetricValue(String handler, String method, String path) {
+            this.handler = handler;
+            this.method = method;
+            this.path = path;
+        }
+
+        public String getHandler() {
+            return handler;
+        }
+
+        public String getMethod() {
+            return method;
+        }
+
+        public String getPath() {
+            return path;
+        }
+    }
+
+    public static class MyMetricLabel implements MetricLabel<MyMetricValue> {
+
+        private String[] metricNamePrefix;
+        private String description;
+        private MyMetricValue myMetricValue;
+
+        public MyMetricLabel(String[] metricNamePrefix, String description, MyMetricValue myMetricValue) {
+            this.metricNamePrefix = metricNamePrefix;
+            this.description = description;
+            this.myMetricValue = myMetricValue;
+        }
+
+        @Override
+        public List<String> getTokenizedName() {
+            return ImmutableList.<String>builder().add(metricNamePrefix).build();
+        }
+
+        @Override
+        public String getDescription() {
+            return description;
+        }
+
+        @Override
+        public MyMetricValue getValue() {
+            return myMetricValue;
+        }
+    }
+
+    @Test(timeout = 10000L)
+    public void normal() throws Exception {
+        latch = new CountDownLatch(14);
+
+        makeRequest("world");
+        makeRequest("world");
+        makeRequest("space");
+        makeRequest("world");
+        makeRequest("space");
+        makeRequest("space");
+        makeRequest("world");
+
+        //Wait until all RequestLogs are collected.
+        latch.await();
+
+        String content = makeMetricsRequest().content().toStringUtf8();
+        String helloServiceMethod = "{handler=\"HelloService\",method=\"hello\",path=\"/thrift\",}";
+
+        //Server entry count check
+        assertThat(new BufferedReader(new StringReader(content))
+                           .lines()
+                           .map(String::trim)
+                           .filter(line -> line.startsWith("armeria_server_timer_count"))
+                           .filter(line -> line.contains(helloServiceMethod))
+                           .anyMatch(line -> line.endsWith("7.0"))).isTrue();
+        assertThat(new BufferedReader(new StringReader(content))
+                           .lines()
+                           .map(String::trim)
+                           .filter(line -> line.startsWith("armeria_server_responseBytes_count"))
+                           .filter(line -> line.contains(helloServiceMethod))
+                           .anyMatch(line -> line.endsWith("7.0"))).isTrue();
+        assertThat(new BufferedReader(new StringReader(content))
+                           .lines()
+                           .map(String::trim)
+                           .filter(line -> line.startsWith("armeria_server_requestBytes_count"))
+                           .filter(line -> line.contains(helloServiceMethod))
+                           .anyMatch(line -> line.endsWith("7.0"))).isTrue();
+
+        //Client entry count check
+        assertThat(new BufferedReader(new StringReader(content))
+                           .lines()
+                           .map(String::trim)
+                           .filter(line -> line.startsWith("armeria_client_timer_count"))
+                           .filter(line -> line.contains(helloServiceMethod))
+                           .anyMatch(line -> line.endsWith("7.0"))).isTrue();
+        assertThat(new BufferedReader(new StringReader(content))
+                           .lines()
+                           .map(String::trim)
+                           .filter(line -> line.startsWith("armeria_client_responseBytes_count"))
+                           .filter(line -> line.contains(helloServiceMethod))
+                           .anyMatch(line -> line.endsWith("7.0"))).isTrue();
+        assertThat(new BufferedReader(new StringReader(content))
+                           .lines()
+                           .map(String::trim)
+                           .filter(line -> line.startsWith("armeria_client_requestBytes_count"))
+                           .filter(line -> line.contains(helloServiceMethod))
+                           .anyMatch(line -> line.endsWith("7.0"))).isTrue();
+
+        //Failure count
+        assertThat(new BufferedReader(new StringReader(content))
+                           .lines()
+                           .map(String::trim)
+                           .filter(line -> line.startsWith("armeria_server_failure"))
+                           .filter(line -> line.contains(helloServiceMethod))
+                           .anyMatch(line -> line.endsWith("3.0"))).isTrue();
+        assertThat(new BufferedReader(new StringReader(content))
+                           .lines()
+                           .map(String::trim)
+                           .filter(line -> line.startsWith("armeria_client_failure"))
+                           .filter(line -> line.contains(helloServiceMethod))
+                           .anyMatch(line -> line.endsWith("3.0"))).isTrue();
+
+        //Success count
+        assertThat(new BufferedReader(new StringReader(content))
+                           .lines()
+                           .map(String::trim)
+                           .filter(line -> line.startsWith("armeria_server_success"))
+                           .filter(line -> line.contains(helloServiceMethod))
+                           .anyMatch(line -> line.endsWith("4.0"))).isTrue();
+        assertThat(new BufferedReader(new StringReader(content))
+                           .lines()
+                           .map(String::trim)
+                           .filter(line -> line.startsWith("armeria_client_success"))
+                           .filter(line -> line.contains(helloServiceMethod))
+                           .anyMatch(line -> line.endsWith("4.0"))).isTrue();
+
+        //Active Requests 0
+        assertThat(new BufferedReader(new StringReader(content))
+                           .lines()
+                           .map(String::trim)
+                           .filter(line -> line.startsWith("armeria_server_activeRequests"))
+                           .filter(line -> line.contains(helloServiceMethod))
+                           .anyMatch(line -> line.endsWith("0.0"))).isTrue();
+        assertThat(new BufferedReader(new StringReader(content))
+                           .lines()
+                           .map(String::trim)
+                           .filter(line -> line.startsWith("armeria_client_activeRequests"))
+                           .filter(line -> line.contains(helloServiceMethod))
+                           .anyMatch(line -> line.endsWith("0.0"))).isTrue();
+    }
+}


### PR DESCRIPTION
Motivation:

We would like Armeria to record and export Prometheus metrics.

Modifications:

- Add Prometheus dependencies
- Add service and client decorator (combined)
- Add wrapper for registry for concurrent access
- Add Prometheus HTTP exporter