### PR TITLE
Add Prometheus request metrics to armeria-core

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -16,6 +16,9 @@ managedDependencies {
     // Metrics
     compile 'io.dropwizard.metrics:metrics-core'
 
+    // Prometheus
+    compile 'io.prometheus:simpleclient_common'
+
     // Netty
     [ 'netty-transport', 'netty-codec-http2', 'netty-resolver-dns' ].each {
         compile "io.netty:$it"

--- a/core/src/main/java/com/linecorp/armeria/client/metric/DropwizardMetricCollectingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/metric/DropwizardMetricCollectingClient.java
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-package com.linecorp.armeria.client.logging;
+package com.linecorp.armeria.client.metric;
 
 import static java.util.Objects.requireNonNull;
 
@@ -32,7 +32,7 @@ import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.http.HttpHeaders;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.logging.RequestLogAvailability;
-import com.linecorp.armeria.internal.logging.DropwizardMetricCollector;
+import com.linecorp.armeria.internal.metric.DropwizardMetricCollector;
 
 /**
  * Decorates a {@link Client} to collect metrics into Dropwizard {@link MetricRegistry}.

--- a/core/src/main/java/com/linecorp/armeria/client/metric/PrometheusMetricCollectionClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/metric/PrometheusMetricCollectionClient.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.metric;
+
+import java.util.Map;
+import java.util.function.Function;
+
+import com.linecorp.armeria.client.Client;
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.SimpleDecoratingClient;
+import com.linecorp.armeria.common.Request;
+import com.linecorp.armeria.common.Response;
+import com.linecorp.armeria.common.logging.RequestLog;
+import com.linecorp.armeria.common.metric.MetricLabel;
+import com.linecorp.armeria.internal.metric.PrometheusMetricRequestDecorator;
+
+import io.prometheus.client.CollectorRegistry;
+
+/**
+ * Decorates a {@link Client} to collect metrics into Prometheus {@link CollectorRegistry}.
+ * To use, simply prepare a {@link CollectorRegistry} and add this decorator to a service specification.
+ * @param <T> {@link MetricLabel} type
+ * @param <I> {@link Request} type
+ * @param <O> {@link Response} type
+ */
+public final class PrometheusMetricCollectionClient<T extends MetricLabel<T>,
+        I extends Request, O extends Response> extends SimpleDecoratingClient<I, O> {
+
+    /**
+     * Returns a new {@link Client} decorator that tracks request stats using the Prometheus metrics  library.
+     *
+     * @param <I> Request type
+     * @param <O> Response type
+     * @param collectorRegistry Prometheus registry
+     * @param metricLabels Labels names for metrics
+     * @param labelingFunction map of labels to values
+     * @return A client decorator function
+     */
+    public static <T extends MetricLabel<T>, I extends Request, O extends Response>
+    Function<Client<? super I, ? extends O>, PrometheusMetricCollectionClient<T, I, O>>
+    newDecorator(CollectorRegistry collectorRegistry,
+                 T[] metricLabels,
+                 Function<RequestLog, Map<T, String>> labelingFunction) {
+        PrometheusMetricRequestDecorator<T, I, O> requestDecorator =
+                PrometheusMetricRequestDecorator.decorateClient(collectorRegistry,
+                                                                metricLabels,
+                                                                labelingFunction);
+        return client -> new PrometheusMetricCollectionClient<>(client, requestDecorator);
+    }
+
+    /**
+     * Returns a new {@link Client} decorator that tracks request stats using the Prometheus metrics  library.
+     *
+     * @param <I> Request type
+     * @param <O> Response type
+     * @param collectorRegistry Prometheus registry
+     * @param metricLabels Labels names for metrics
+     * @param labelingFunction map of labels to values
+     * @return A client decorator function
+     */
+    public static <T extends MetricLabel<T>, I extends Request, O extends Response>
+    Function<Client<? super I, ? extends O>, PrometheusMetricCollectionClient<T, I, O>>
+    newDecorator(CollectorRegistry collectorRegistry,
+                 Iterable<T> metricLabels,
+                 Function<RequestLog, Map<T, String>> labelingFunction) {
+        PrometheusMetricRequestDecorator<T, I, O> requestDecorator =
+                PrometheusMetricRequestDecorator.decorateClient(collectorRegistry,
+                                                                metricLabels,
+                                                                labelingFunction);
+        return client -> new PrometheusMetricCollectionClient<>(client, requestDecorator);
+    }
+
+    private final PrometheusMetricRequestDecorator<T, I, O> requestDecorator;
+
+    private PrometheusMetricCollectionClient(
+            Client<? super I, ? extends O> delegate,
+            PrometheusMetricRequestDecorator<T, I, O> requestDecorator) {
+        super(delegate);
+        this.requestDecorator = requestDecorator;
+    }
+
+    @Override
+    public O execute(ClientRequestContext ctx, I req) throws Exception {
+        return requestDecorator.execute(delegate(), ctx, req);
+    }
+
+}

--- a/core/src/main/java/com/linecorp/armeria/client/metric/package-info.java
+++ b/core/src/main/java/com/linecorp/armeria/client/metric/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 LINE Corporation
+ * Copyright 2015 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -15,6 +15,6 @@
  */
 
 /**
- * Logging client decorators.
+ * Metric-collecting client decorators.
  */
-package com.linecorp.armeria.client.logging;
+package com.linecorp.armeria.client.metric;

--- a/core/src/main/java/com/linecorp/armeria/common/metric/MetricLabel.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/MetricLabel.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.metric;
+
+/**
+ * User definable label name for metrics (ex. {@link io.prometheus.client.Collector}).
+ *
+ * <p>Example:
+ * <pre>{@code
+ * public enum MyMetricLabel implements MetricLabel<MyMetricLabel> {
+ *  path,
+ *  handler,
+ *  method,
+ * }
+ * }
+ * </pre>
+ * @param <T> the implementing class
+ */
+public interface MetricLabel<T extends MetricLabel> extends Comparable<T> {
+    /**
+     * Returns a single label name.
+     * @return label name
+     */
+    String name();
+
+    @Override
+    default int compareTo(T o) {
+        return this.name().compareTo(o.name());
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/common/metric/PrometheusRegistry.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/PrometheusRegistry.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2017 LINE Corporation
+ * <p>
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.metric;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Function;
+
+import com.linecorp.armeria.internal.metric.PrometheusMetricRequestDecorator;
+
+import io.prometheus.client.Collector;
+import io.prometheus.client.CollectorRegistry;
+
+/**
+ * Subclass {@link CollectorRegistry} that allows registering metrics with the same name.
+ */
+public class PrometheusRegistry extends CollectorRegistry {
+    private final ConcurrentMap<String, ? extends Collector> nameToCollector;
+    private final Map<String, ? extends Collector> nameToCollectorView;
+
+    /**
+     * Creates a new instance.
+     */
+    public PrometheusRegistry() {
+        nameToCollector = new ConcurrentHashMap<>();
+        nameToCollectorView = Collections.unmodifiableMap(nameToCollector);
+    }
+
+    /**
+     * Registers a {@link Collector} conditionally.
+     * Registering the same name in base {@link CollectorRegistry} will throw an exception.
+     * So this extended registry provides if-not-exists function.
+     * Allows use in multiple instances of {@link PrometheusMetricRequestDecorator}.
+     * @param name collector name
+     * @param createCollector function to generate a collector if absent
+     * @param <T> type of {@link Collector}
+     * @return existing or newly created collector.
+     */
+    public synchronized <T extends Collector> T register(String name, Function<String, T> createCollector) {
+        @SuppressWarnings("unchecked")
+        ConcurrentMap<String, T> map = (ConcurrentMap<String, T>) nameToCollector;
+        Function<T, T> register = collector -> {
+            super.register(collector);
+            return collector;
+        };
+        return map.computeIfAbsent(name, register.compose(createCollector));
+    }
+
+    @Override
+    public synchronized void unregister(Collector collector) {
+        if (nameToCollector.values().remove(collector)) {
+            super.unregister(collector);
+        }
+    }
+
+    /**
+     * Unregisters a collector by name.
+     * @param name name given to collector
+     * @return {@code true} if exists and unregistered. {@code false} otherwise.
+     */
+    public synchronized boolean unregister(String name) {
+        Collector collector = nameToCollector.remove(name);
+        if (collector == null) {
+            return false;
+        }
+        super.unregister(collector);
+        return true;
+    }
+
+    /**
+     * Immutable map of metric name to Collector.
+     * @return map of name to Collector.
+     */
+    public Map<String, ? extends Collector> asMap() {
+        return nameToCollectorView;
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/common/metric/package-info.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/package-info.java
@@ -15,6 +15,6 @@
  */
 
 /**
- * Logging client decorators.
+ * Common metric related components.
  */
-package com.linecorp.armeria.client.logging;
+package com.linecorp.armeria.common.metric;

--- a/core/src/main/java/com/linecorp/armeria/internal/metric/DropwizardMetricCollector.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/metric/DropwizardMetricCollector.java
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-package com.linecorp.armeria.internal.logging;
+package com.linecorp.armeria.internal.metric;
 
 import static java.util.Objects.requireNonNull;
 

--- a/core/src/main/java/com/linecorp/armeria/internal/metric/DropwizardRequestMetrics.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/metric/DropwizardRequestMetrics.java
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-package com.linecorp.armeria.internal.logging;
+package com.linecorp.armeria.internal.metric;
 
 import java.util.concurrent.TimeUnit;
 

--- a/core/src/main/java/com/linecorp/armeria/internal/metric/PrometheusMetricRequestDecorator.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/metric/PrometheusMetricRequestDecorator.java
@@ -1,0 +1,370 @@
+/**
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.metric;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.Iterables;
+
+import com.linecorp.armeria.client.Client;
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.common.Request;
+import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.common.Response;
+import com.linecorp.armeria.common.RpcResponse;
+import com.linecorp.armeria.common.http.HttpSessionProtocols;
+import com.linecorp.armeria.common.logging.RequestLog;
+import com.linecorp.armeria.common.logging.RequestLogAvailability;
+import com.linecorp.armeria.common.metric.MetricLabel;
+import com.linecorp.armeria.common.metric.PrometheusRegistry;
+import com.linecorp.armeria.server.Service;
+import com.linecorp.armeria.server.ServiceRequestContext;
+
+import io.prometheus.client.Collector;
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.Counter;
+import io.prometheus.client.Gauge;
+import io.prometheus.client.Summary;
+
+/**
+ * Provides request decorator functions for server and client sides. Functions will record metrics into
+ * Prometheus {@link CollectorRegistry}.
+ * @param <T> {@link MetricLabel} type
+ * @param <I> {@link Request} type
+ * @param <O> {@link Response} type
+ */
+public final class PrometheusMetricRequestDecorator<T extends MetricLabel<T>,
+        I extends Request, O extends Response> {
+
+    private static final String HELP_STRING = "Armeria client/server request metric";
+
+    /**
+     * Returns a new {@link Service} decorator that tracks request stats using the Prometheus metrics  library.
+     *
+     * @param <I> Request type
+     * @param <O> Response type
+     * @param collectorRegistry Prometheus registry
+     * @param metricLabels Labels names for metrics
+     * @param labelingFunction Must return a sorted map in natural order
+     * @return A service decorator function
+     */
+    public static <T extends MetricLabel<T>, I extends Request, O extends Response>
+    PrometheusMetricRequestDecorator<T, I, O> decorateService(
+            CollectorRegistry collectorRegistry,
+            T[] metricLabels,
+            Function<RequestLog, Map<T, String>> labelingFunction) {
+        return new PrometheusMetricRequestDecorator<>(collectorRegistry,
+                                                      metricLabels,
+                                                      labelingFunction,
+                                                      "armeria_server");
+    }
+
+    /**
+     * Returns a new {@link Service} decorator that tracks request stats using the Prometheus metrics  library.
+     *
+     * @param <I> Request type
+     * @param <O> Response type
+     * @param collectorRegistry Prometheus registry
+     * @param metricLabels Labels names for metrics
+     * @param labelingFunction Must return a sorted map in natural order
+     * @return A service decorator function
+     */
+    public static <T extends MetricLabel<T>, I extends Request, O extends Response>
+    PrometheusMetricRequestDecorator<T, I, O> decorateService(
+            CollectorRegistry collectorRegistry,
+            Iterable<T> metricLabels,
+            Function<RequestLog, Map<T, String>> labelingFunction) {
+        return new PrometheusMetricRequestDecorator<>(collectorRegistry,
+                                                      metricLabels,
+                                                      labelingFunction,
+                                                      "armeria_server");
+    }
+
+    /**
+     * Returns a new {@link Client} decorator that tracks request stats using the Prometheus metrics  library.
+     *
+     * @param <I> Request type
+     * @param <O> Response type
+     * @param collectorRegistry Prometheus registry
+     * @param metricLabels Labels names for metrics
+     * @param labelingFunction map of labels to values
+     * @return A client decorator function
+     */
+    public static <T extends MetricLabel<T>, I extends Request, O extends Response>
+    PrometheusMetricRequestDecorator<T, I, O> decorateClient(
+            CollectorRegistry collectorRegistry,
+            T[] metricLabels,
+            Function<RequestLog, Map<T, String>> labelingFunction) {
+        return new PrometheusMetricRequestDecorator<>(collectorRegistry,
+                                                      metricLabels,
+                                                      labelingFunction,
+                                                      "armeria_client");
+    }
+
+    /**
+     * Returns a new {@link Client} decorator that tracks request stats using the Prometheus metrics  library.
+     *
+     * @param <I> Request type
+     * @param <O> Response type
+     * @param collectorRegistry Prometheus registry
+     * @param metricLabels Labels names for metrics
+     * @param labelingFunction map of labels to values
+     * @return A client decorator function
+     */
+    public static <T extends MetricLabel<T>, I extends Request, O extends Response>
+    PrometheusMetricRequestDecorator<T, I, O> decorateClient(
+            CollectorRegistry collectorRegistry,
+            Iterable<T> metricLabels,
+            Function<RequestLog, Map<T, String>> labelingFunction) {
+        return new PrometheusMetricRequestDecorator<>(collectorRegistry,
+                                                      metricLabels,
+                                                      labelingFunction,
+                                                      "armeria_client");
+    }
+
+    private final Function<RequestLog, Map<T, String>> labelingFunction;
+    private final MetricAdapter<T> metricAdapter;
+
+    private PrometheusMetricRequestDecorator(
+            CollectorRegistry collectorRegistry,
+            T[] metricLabels,
+            Function<RequestLog, Map<T, String>> labelingFunction,
+            String prefix) {
+        requireNonNull(collectorRegistry, "collectorRegistry");
+        requireNonNull(metricLabels, "metricLabels");
+        T[] metricLabelsCopy = Arrays.copyOf(metricLabels, metricLabels.length);
+        for (T metricLabel : metricLabelsCopy) {
+            requireNonNull(metricLabel, "metricLabels contains null");
+        }
+        requireNonNull(labelingFunction, "labelingFunction");
+        requireNonNull(prefix, "prefix");
+
+        this.labelingFunction = labelingFunction;
+        this.metricAdapter = new MetricAdapter<>(collectorRegistry, metricLabelsCopy, prefix, HELP_STRING);
+    }
+
+    @SuppressWarnings("unchecked")
+    private PrometheusMetricRequestDecorator(
+            CollectorRegistry collectorRegistry,
+            Iterable<T> metricLabels,
+            Function<RequestLog, Map<T, String>> labelingFunction,
+            String prefix) {
+        this(collectorRegistry,
+             (T[]) Iterables.toArray(requireNonNull(metricLabels, "metricLabels"), MetricLabel.class),
+             labelingFunction,
+             prefix);
+    }
+
+    private <C extends RequestContext> O request(ThrowingBiFunction<C, I, O> function, C ctx, I req)
+            throws Exception {
+        ctx.log().addListener(
+                log -> {
+                    final String[] values = getLabelValues(log);
+                    metricAdapter.incActiveRequests(values);
+                }, RequestLogAvailability.REQUEST_ENVELOPE, RequestLogAvailability.REQUEST_CONTENT);
+
+        ctx.log().addListener(
+                log -> {
+                    final String[] values = getLabelValues(log);
+                    metricAdapter.requestBytes(values, log);
+                    if (log.requestCause() != null) {
+                        metricAdapter.failure(values)
+                                     .decActiveRequests(values);
+                    }
+                }, RequestLogAvailability.REQUEST_END);
+
+        ctx.log().addListener(
+                log -> {
+                    if (log.requestCause() != null) {
+                        return;
+                    }
+                    final String[] values = getLabelValues(log);
+                    metricAdapter.seconds(values, TimeUnit.NANOSECONDS.toSeconds(log.totalDurationNanos()))
+                                 .responseBytes(values, log)
+                                 .decActiveRequests(values);
+
+                    if (isSuccess(log)) {
+                        metricAdapter.success(values);
+                    } else {
+                        metricAdapter.failure(values);
+                    }
+                }, RequestLogAvailability.COMPLETE);
+        return function.apply(ctx, req);
+    }
+
+    public O serve(Service<I, O> delegate, ServiceRequestContext ctx, I req) throws Exception {
+        return request(delegate::serve, ctx, req);
+    }
+
+    public O execute(Client<I, O> delegate, ClientRequestContext ctx, I req) throws Exception {
+        return request(delegate::execute, ctx, req);
+    }
+
+    private String[] getLabelValues(RequestLog log) {
+        return ImmutableSortedMap.copyOf(labelingFunction.apply(log))
+                                 .values()
+                                 .stream()
+                                 .toArray(String[]::new);
+    }
+
+    private static boolean isSuccess(RequestLog log) {
+        final Object responseContent = log.responseContent();
+        if (responseContent instanceof RpcResponse) {
+            return !((RpcResponse) responseContent).isCompletedExceptionally();
+        }
+
+        if (log.responseCause() != null) {
+            return false;
+        }
+
+        if (HttpSessionProtocols.isHttp(log.sessionProtocol())) {
+            if (log.statusCode() >= 400) {
+                return false;
+            }
+        } else {
+            if (log.statusCode() != 0) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    @FunctionalInterface
+    private interface ThrowingBiFunction<C, I, O> {
+        O apply(C c, I i) throws Exception;
+    }
+
+    private static final class MetricAdapter<T extends MetricLabel<T>> {
+
+        private final Summary timer;
+        private final Counter success;
+        private final Counter failure;
+        private final Gauge activeRequests;
+        private final Summary requestBytes;
+        private final Summary responseBytes;
+
+        private MetricAdapter(CollectorRegistry collectorRegistry,
+                              T[] metricLabels,
+                              String namePrefix,
+                              String help) {
+            requireNonNull(collectorRegistry, "collectorRegistry");
+            requireNonNull(metricLabels, "metricLabels");
+            requireNonNull(namePrefix, "namePrefix");
+            requireNonNull(help, "help");
+
+            final String[] metricLabelNames = Stream.of(metricLabels)
+                                                    .sorted()
+                                                    .map(MetricLabel::name)
+                                                    .toArray(String[]::new);
+            timer = register(collectorRegistry, namePrefix + "_request_duration_seconds",
+                             name -> newSummary(Summary.build())
+                                     .name(name)
+                                     .labelNames(metricLabelNames)
+                                     .help(help)
+                                     .create());
+            success = register(collectorRegistry, namePrefix + "_request_success_total",
+                               name -> Counter.build().name(name)
+                                              .labelNames(metricLabelNames)
+                                              .help(help)
+                                              .create());
+            failure = register(collectorRegistry, namePrefix + "_request_failure_total",
+                               name -> Counter.build().name(name)
+                                              .labelNames(metricLabelNames)
+                                              .help(help)
+                                              .create());
+            activeRequests = register(collectorRegistry, namePrefix + "_request_active",
+                                      name -> Gauge.build().name(name)
+                                                   .labelNames(metricLabelNames)
+                                                   .help(help)
+                                                   .create());
+            requestBytes = register(collectorRegistry, namePrefix + "_request_size_bytes",
+                                    name -> newSummary(Summary.build())
+                                            .name(name)
+                                            .labelNames(metricLabelNames)
+                                            .help(help)
+                                            .create());
+            responseBytes = register(collectorRegistry, namePrefix + "_response_size_bytes",
+                                     name -> newSummary(Summary.build())
+                                             .name(name)
+                                             .labelNames(metricLabelNames)
+                                             .help(help)
+                                             .create());
+        }
+
+        private Summary.Builder newSummary(Summary.Builder builder) {
+            return builder.quantile(.5, .01)
+                          .quantile(.75, .01)
+                          .quantile(.95, .01)
+                          .quantile(.98, .01)
+                          .quantile(.99, .01)
+                          .quantile(.999, .01);
+        }
+
+        private MetricAdapter seconds(String[] values, double seconds) throws Exception {
+            timer.labels(values).observe(seconds);
+            return this;
+        }
+
+        private MetricAdapter success(String[] values) {
+            success.labels(values).inc();
+            return this;
+        }
+
+        private MetricAdapter failure(String[] values) {
+            failure.labels(values).inc();
+            return this;
+        }
+
+        private MetricAdapter incActiveRequests(String[] values) {
+            activeRequests.labels(values).inc();
+            return this;
+        }
+
+        private MetricAdapter decActiveRequests(String[] values) {
+            activeRequests.labels(values).dec();
+            return this;
+        }
+
+        private MetricAdapter requestBytes(String[] values, RequestLog log) {
+            requestBytes.labels(values).observe(log.requestLength());
+            return this;
+        }
+
+        private MetricAdapter responseBytes(String[] values, RequestLog log) {
+            responseBytes.labels(values).observe(log.responseLength());
+            return this;
+        }
+
+        private static <T extends Collector> T register(CollectorRegistry collectorRegistry,
+                                                        String name, Function<String, T> createCollector) {
+            if (collectorRegistry instanceof PrometheusRegistry) {
+                return ((PrometheusRegistry)collectorRegistry).register(name, createCollector);
+            }
+            T collector = createCollector.apply(name);
+            collectorRegistry.register(collector);
+            return collector;
+        }
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/internal/metric/package-info.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/metric/package-info.java
@@ -15,6 +15,7 @@
  */
 
 /**
- * Logging client decorators.
+ * Various metrics related classes used internally.
+ * Anything in this package can be changed or removed at any time.
  */
-package com.linecorp.armeria.client.logging;
+package com.linecorp.armeria.internal.metric;

--- a/core/src/main/java/com/linecorp/armeria/server/http/metric/PrometheusExporterHttpService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/metric/PrometheusExporterHttpService.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.http.metric;
+
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStreamWriter;
+import java.util.Objects;
+
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.http.HttpRequest;
+import com.linecorp.armeria.common.http.HttpResponseWriter;
+import com.linecorp.armeria.common.http.HttpStatus;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.http.AbstractHttpService;
+
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.exporter.common.TextFormat;
+
+/**
+ * Exports Prometheus metrics.
+ */
+public class PrometheusExporterHttpService extends AbstractHttpService {
+    private static final MediaType CONTENT_TYPE_004 = MediaType.parse(TextFormat.CONTENT_TYPE_004);
+
+    private final CollectorRegistry prometheusRegistry;
+
+    /**
+     * Create a {@link PrometheusExporterHttpService} instance.
+     * @param prometheusRegistry Prometheus registry
+     */
+    public PrometheusExporterHttpService(CollectorRegistry prometheusRegistry) {
+        Objects.requireNonNull(prometheusRegistry, "prometheusRegistry");
+        this.prometheusRegistry = prometheusRegistry;
+    }
+
+    @Override
+    protected void doGet(ServiceRequestContext ctx, HttpRequest req,
+                         HttpResponseWriter res) throws Exception {
+        ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        try (OutputStreamWriter writer = new OutputStreamWriter(stream)) {
+            TextFormat.write004(writer, prometheusRegistry.metricFamilySamples());
+        }
+        res.respond(HttpStatus.OK, CONTENT_TYPE_004, stream.toByteArray());
+    }
+
+    @Override
+    protected void doPost(ServiceRequestContext ctx, HttpRequest req,
+                          HttpResponseWriter res) throws Exception {
+        doGet(ctx, req, res);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/http/metric/package-info.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/metric/package-info.java
@@ -15,6 +15,6 @@
  */
 
 /**
- * Logging client decorators.
+ * Prometheus export Service.
  */
-package com.linecorp.armeria.client.logging;
+package com.linecorp.armeria.server.http.metric;

--- a/core/src/main/java/com/linecorp/armeria/server/metric/DropwizardMetricCollectingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/metric/DropwizardMetricCollectingService.java
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-package com.linecorp.armeria.server.logging;
+package com.linecorp.armeria.server.metric;
 
 import static java.util.Objects.requireNonNull;
 
@@ -29,7 +29,7 @@ import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.http.HttpHeaders;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.logging.RequestLogAvailability;
-import com.linecorp.armeria.internal.logging.DropwizardMetricCollector;
+import com.linecorp.armeria.internal.metric.DropwizardMetricCollector;
 import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.SimpleDecoratingService;

--- a/core/src/main/java/com/linecorp/armeria/server/metric/PrometheusMetricCollectionService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/metric/PrometheusMetricCollectionService.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.metric;
+
+import java.util.Map;
+import java.util.function.Function;
+
+import com.linecorp.armeria.common.Request;
+import com.linecorp.armeria.common.Response;
+import com.linecorp.armeria.common.logging.RequestLog;
+import com.linecorp.armeria.common.metric.MetricLabel;
+import com.linecorp.armeria.internal.metric.PrometheusMetricRequestDecorator;
+import com.linecorp.armeria.server.Service;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.SimpleDecoratingService;
+
+import io.prometheus.client.CollectorRegistry;
+
+/**
+ * Decorates a {@link Service} to collect metrics into Prometheus {@link CollectorRegistry}.
+ * To use, simply prepare a {@link CollectorRegistry} and add this decorator to a service specification.
+ * @param <T> {@link MetricLabel} type
+ * @param <I> {@link Request} type
+ * @param <O> {@link Response} type
+ */
+public final class PrometheusMetricCollectionService
+        <T extends MetricLabel<T>, I extends Request, O extends Response>
+        extends SimpleDecoratingService<I, O> {
+    /**
+     * Returns a new {@link Service} decorator that tracks request stats using the Prometheus metrics  library.
+     *
+     * @param <I> Request type
+     * @param <O> Response type
+     * @param collectorRegistry Wrapped Prometheus registry
+     * @param metricLabels Labels names for metrics
+     * @param labelingFunction Must return a sorted map in natural order
+     * @return A service decorator function
+     */
+    public static <T extends MetricLabel<T>, I extends Request, O extends Response>
+    Function<Service<? super I, ? extends O>, PrometheusMetricCollectionService<T, I, O>>
+    newDecorator(CollectorRegistry collectorRegistry,
+                 T[] metricLabels,
+                 Function<RequestLog, Map<T, String>> labelingFunction) {
+        PrometheusMetricRequestDecorator<T, I, O> decoratingServiceFunction =
+                PrometheusMetricRequestDecorator.decorateService(collectorRegistry, metricLabels,
+                                                                 labelingFunction);
+        return service -> new PrometheusMetricCollectionService<>(service, decoratingServiceFunction);
+    }
+
+    /**
+     * Returns a new {@link Service} decorator that tracks request stats using the Prometheus metrics  library.
+     *
+     * @param <I> Request type
+     * @param <O> Response type
+     * @param collectorRegistry Wrapped Prometheus registry
+     * @param metricLabels Labels names for metrics
+     * @param labelingFunction Must return a sorted map in natural order
+     * @return A service decorator function
+     */
+    public static <T extends MetricLabel<T>, I extends Request, O extends Response>
+    Function<Service<? super I, ? extends O>, PrometheusMetricCollectionService<T, I, O>>
+    newDecorator(CollectorRegistry collectorRegistry,
+                 Iterable<T> metricLabels,
+                 Function<RequestLog, Map<T, String>> labelingFunction) {
+        PrometheusMetricRequestDecorator<T, I, O> decoratingServiceFunction =
+                PrometheusMetricRequestDecorator.decorateService(collectorRegistry, metricLabels,
+                                                                 labelingFunction);
+        return service -> new PrometheusMetricCollectionService<>(service, decoratingServiceFunction);
+    }
+
+    private final PrometheusMetricRequestDecorator<T, I, O> requestDecorator;
+
+    private PrometheusMetricCollectionService(Service<? super I, ? extends O> delegate,
+                                              PrometheusMetricRequestDecorator<T, I, O> requestDecorator) {
+        super(delegate);
+        this.requestDecorator = requestDecorator;
+    }
+
+    @Override
+    public O serve(ServiceRequestContext ctx, I req) throws Exception {
+        return requestDecorator.serve(delegate(), ctx, req);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/metric/package-info.java
+++ b/core/src/main/java/com/linecorp/armeria/server/metric/package-info.java
@@ -15,6 +15,6 @@
  */
 
 /**
- * Logging client decorators.
+ * Metric-collecting service decorators.
  */
-package com.linecorp.armeria.client.logging;
+package com.linecorp.armeria.server.metric;

--- a/core/src/test/java/com/linecorp/armeria/common/metric/PrometheusRegistryTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/metric/PrometheusRegistryTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.metric;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import java.util.Map;
+
+import org.junit.Test;
+
+import io.prometheus.client.Collector;
+import io.prometheus.client.Counter;
+
+@SuppressWarnings("unchecked")
+public class PrometheusRegistryTest {
+    @Test
+
+    public void register_normal() {
+        PrometheusRegistry registry = new PrometheusRegistry();
+        Counter c = registry.register("test", name -> Counter.build().name(name).help("test").create());
+
+        c.inc();
+
+        assertThat((Map<String, Collector>) registry.asMap()).containsExactly(entry("test", c));
+        assertThat(registry.getSampleValue("test")).isEqualTo(1.0);
+    }
+
+    @Test
+    public void register_override_method() {
+        PrometheusRegistry registry = new PrometheusRegistry();
+        Counter c = registry.register("test", name -> Counter.build().name(name).help("test").create());
+
+        c.inc();
+
+        assertThat(registry.getSampleValue("test")).isEqualTo(1.0);
+    }
+
+    @Test
+    public void register_unregister_by_collector() {
+        PrometheusRegistry registry = new PrometheusRegistry();
+        Counter c = registry.register("test", name -> Counter.build().name(name).help("test").create());
+
+        c.inc();
+
+        assertThat((Map<String, Collector>)registry.asMap()).containsExactly(entry("test", c));
+        assertThat(registry.getSampleValue("test")).isEqualTo(1.0);
+
+        registry.unregister(c);
+
+        assertThat((Map<String, Collector>)registry.asMap()).isEmpty();
+        assertThat(registry.getSampleValue("test")).isNull();
+    }
+
+    @Test
+    public void register_unregister_by_name() {
+        PrometheusRegistry registry = new PrometheusRegistry();
+        Counter c = registry.register("test", name -> Counter.build().name(name).help("test").create());
+
+        c.inc();
+
+        assertThat(registry.getSampleValue("test")).isEqualTo(1.0);
+        assertThat(registry.unregister("test")).isTrue();
+        assertThat((Map<String, Collector>)registry.asMap()).isEmpty();
+        assertThat(registry.getSampleValue("test")).isNull();
+    }
+
+    @Test
+    public void register_unregister_by_name_not_exists() {
+        PrometheusRegistry registry = new PrometheusRegistry();
+        Counter c = registry.register("test2", name -> Counter.build().name(name).help("test2").create());
+
+        c.inc();
+
+        assertThat(registry.unregister("test")).isFalse();
+        assertThat((Map<String, Collector>) registry.asMap()).containsExactly(entry("test2", c));
+        assertThat(registry.getSampleValue("test")).isNull();
+        assertThat(registry.getSampleValue("test2")).isEqualTo(1.0);
+    }
+
+    @Test
+    public void register_unregister_by_collector_not_exists() {
+        PrometheusRegistry registry = new PrometheusRegistry();
+        Counter c = registry.register("test2", name -> Counter.build().name(name).help("test2").create());
+
+        c.inc();
+        registry.unregister(Counter.build().name("test").help("test").create());
+
+        assertThat((Map<String, Collector>) registry.asMap()).containsExactly(entry("test2", c));
+        assertThat(registry.getSampleValue("test")).isNull();
+        assertThat(registry.getSampleValue("test2")).isEqualTo(1.0);
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/internal/metric/DropwizardMetricCollectorTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/metric/DropwizardMetricCollectorTest.java
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-package com.linecorp.armeria.internal.logging;
+package com.linecorp.armeria.internal.metric;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -60,6 +60,9 @@ io.netty:
   netty-transport-native-epoll: { version: *NETTY_VERSION }
   netty-tcnative-boringssl-static: { version: '2.0.1.Final' }
 
+io.prometheus:
+  simpleclient_common: { version: 0.0.22 }
+
 io.zipkin.brave:
   brave-core: { version: &BRAVE_VERSION '4.2.0' }
   brave-http: { version: *BRAVE_VERSION }

--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/DropwizardMetricsIntegrationTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/DropwizardMetricsIntegrationTest.java
@@ -41,7 +41,7 @@ import com.linecorp.armeria.grpc.testing.TestServiceGrpc.TestServiceImplBase;
 import com.linecorp.armeria.internal.grpc.GrpcTestUtil;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.grpc.GrpcServiceBuilder;
-import com.linecorp.armeria.server.logging.DropwizardMetricCollectingService;
+import com.linecorp.armeria.server.metric.DropwizardMetricCollectingService;
 import com.linecorp.armeria.testing.server.ServerRule;
 
 import io.grpc.stub.StreamObserver;

--- a/spring-boot/autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaAutoConfiguration.java
+++ b/spring-boot/autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaAutoConfiguration.java
@@ -60,7 +60,7 @@ import com.linecorp.armeria.server.docs.DocServiceBuilder;
 import com.linecorp.armeria.server.http.AbstractHttpService;
 import com.linecorp.armeria.server.http.healthcheck.HealthChecker;
 import com.linecorp.armeria.server.http.healthcheck.HttpHealthCheckService;
-import com.linecorp.armeria.server.logging.DropwizardMetricCollectingService;
+import com.linecorp.armeria.server.metric.DropwizardMetricCollectingService;
 import com.linecorp.armeria.spring.ArmeriaSettings.Port;
 
 import io.netty.util.NetUtil;

--- a/spring-boot/autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaSettings.java
+++ b/spring-boot/autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaSettings.java
@@ -25,7 +25,7 @@ import org.springframework.validation.annotation.Validated;
 
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.server.Server;
-import com.linecorp.armeria.server.logging.DropwizardMetricCollectingService;
+import com.linecorp.armeria.server.metric.DropwizardMetricCollectingService;
 
 /**
  * Settings for armeria servers, e.g.,

--- a/thrift/src/test/java/com/linecorp/armeria/it/metrics/DropwizardMetricsIntegrationTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/metrics/DropwizardMetricsIntegrationTest.java
@@ -28,12 +28,12 @@ import org.junit.Test;
 import com.codahale.metrics.MetricRegistry;
 
 import com.linecorp.armeria.client.ClientBuilder;
-import com.linecorp.armeria.client.logging.DropwizardMetricCollectingClient;
+import com.linecorp.armeria.client.metric.DropwizardMetricCollectingClient;
 import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.RpcResponse;
 import com.linecorp.armeria.common.logging.RequestLogAvailability;
 import com.linecorp.armeria.server.ServerBuilder;
-import com.linecorp.armeria.server.logging.DropwizardMetricCollectingService;
+import com.linecorp.armeria.server.metric.DropwizardMetricCollectingService;
 import com.linecorp.armeria.server.thrift.THttpService;
 import com.linecorp.armeria.service.test.thrift.main.HelloService.Iface;
 import com.linecorp.armeria.testing.server.ServerRule;

--- a/thrift/src/test/java/com/linecorp/armeria/it/metrics/PrometheusMetricsIntegrationTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/metrics/PrometheusMetricsIntegrationTest.java
@@ -1,0 +1,424 @@
+/**
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.it.metrics;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.linecorp.armeria.common.thrift.ThriftSerializationFormats.BINARY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.given;
+
+import java.util.EnumSet;
+import java.util.SortedMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+
+import org.apache.thrift.TException;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableSortedMap;
+
+import com.linecorp.armeria.client.ClientBuilder;
+import com.linecorp.armeria.client.ClientFactory;
+import com.linecorp.armeria.client.Clients;
+import com.linecorp.armeria.client.http.HttpClient;
+import com.linecorp.armeria.client.metric.PrometheusMetricCollectionClient;
+import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.common.RpcRequest;
+import com.linecorp.armeria.common.RpcResponse;
+import com.linecorp.armeria.common.http.AggregatedHttpMessage;
+import com.linecorp.armeria.common.http.HttpHeaderNames;
+import com.linecorp.armeria.common.http.HttpHeaders;
+import com.linecorp.armeria.common.http.HttpMethod;
+import com.linecorp.armeria.common.logging.RequestLog;
+import com.linecorp.armeria.common.metric.MetricLabel;
+import com.linecorp.armeria.common.metric.PrometheusRegistry;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.http.metric.PrometheusExporterHttpService;
+import com.linecorp.armeria.server.metric.PrometheusMetricCollectionService;
+import com.linecorp.armeria.server.thrift.THttpService;
+import com.linecorp.armeria.service.test.thrift.main.HelloService.Iface;
+import com.linecorp.armeria.testing.server.ServerRule;
+
+import io.prometheus.client.CollectorRegistry;
+
+public class PrometheusMetricsIntegrationTest {
+    private static final PrometheusRegistry PROMETHEUS_REGISTRY = new PrometheusRegistry();
+    private static final CollectorRegistry COLLECTOR_REGISTRY = CollectorRegistry.defaultRegistry;
+
+    @ClassRule
+    public static final ServerRule server = new ServerRule() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.serviceAt("/thrift1", THttpService.of((Iface) name -> {
+                if ("world".equals(name)) {
+                    return "success";
+                }
+                throw new IllegalArgumentException("bad argument");
+            }).decorate(
+                    PrometheusMetricCollectionService
+                            .newDecorator(PROMETHEUS_REGISTRY,
+                                          MyMetricLabel.values(),
+                                          log -> defaultMetricName(log, "HelloService1"))))
+              .serviceAt("/thrift2", THttpService.of((Iface) name -> {
+                  if ("world".equals(name)) {
+                      return "success";
+                  }
+                  throw new IllegalArgumentException("bad argument");
+              }).decorate(
+                      PrometheusMetricCollectionService
+                              .newDecorator(PROMETHEUS_REGISTRY,
+                                            MyMetricLabel.values(),
+                                            log -> defaultMetricName(log, "HelloService2"))))
+              .serviceAt("/thrift3", THttpService.of((Iface) name -> {
+                  if ("world".equals(name)) {
+                      return "success";
+                  }
+                  throw new IllegalArgumentException("bad argument");
+              }).decorate(
+                      PrometheusMetricCollectionService
+                              .newDecorator(COLLECTOR_REGISTRY,
+                                            EnumSet.allOf(MyMetricLabel.class),
+                                            log -> defaultMetricName(log, "HelloService3"))))
+              .serviceAt("/internal/prometheus/metrics1",
+                         new PrometheusExporterHttpService(PROMETHEUS_REGISTRY))
+              .serviceAt("/internal/prometheus/metrics2",
+                       new PrometheusExporterHttpService(COLLECTOR_REGISTRY));
+        }
+    };
+
+    private static void makeRequest1(String name) throws TException {
+        final Iface client = new ClientBuilder(server.uri(BINARY, "/thrift1"))
+                .decorator(RpcRequest.class, RpcResponse.class,
+                           PrometheusMetricCollectionClient
+                                   .newDecorator(PROMETHEUS_REGISTRY,
+                                                 MyMetricLabel.values(),
+                                                 log -> defaultMetricName(log, "HelloService1")))
+                .build(Iface.class);
+        client.hello(name);
+    }
+
+    private static void makeRequest2(String name) throws TException {
+        final Iface client = new ClientBuilder(server.uri(BINARY, "/thrift2"))
+                .decorator(RpcRequest.class, RpcResponse.class,
+                           PrometheusMetricCollectionClient
+                                   .newDecorator(PROMETHEUS_REGISTRY,
+                                                 MyMetricLabel.values(),
+                                                 log -> defaultMetricName(log, "HelloService2")))
+                .build(Iface.class);
+        client.hello(name);
+    }
+
+    private static void makeRequest3(String name) throws TException {
+        final Iface client = new ClientBuilder(server.uri(BINARY, "/thrift3"))
+                .decorator(RpcRequest.class, RpcResponse.class,
+                           PrometheusMetricCollectionClient
+                                   .newDecorator(COLLECTOR_REGISTRY,
+                                                 EnumSet.allOf(MyMetricLabel.class),
+                                                 log -> defaultMetricName(log, "HelloService3")))
+                .build(Iface.class);
+        client.hello(name);
+    }
+
+    private static AggregatedHttpMessage makeMetricsRequest1() throws ExecutionException,
+                                                                      InterruptedException {
+        final HttpClient client = Clients.newClient(ClientFactory.DEFAULT,
+                                                    "none+http://127.0.0.1:" + server.httpPort(),
+                                                    HttpClient.class);
+        return client.execute(HttpHeaders.of(HttpMethod.GET, "/internal/prometheus/metrics1")
+                                         .set(HttpHeaderNames.ACCEPT, "utf-8"))
+                     .aggregate().get();
+    }
+
+    private static AggregatedHttpMessage makeMetricsRequest2() throws ExecutionException,
+                                                                      InterruptedException {
+        final HttpClient client = Clients.newClient(ClientFactory.DEFAULT,
+                                                    "none+http://127.0.0.1:" + server.httpPort(),
+                                                    HttpClient.class);
+        return client.execute(HttpHeaders.of(HttpMethod.POST, "/internal/prometheus/metrics2")
+                                         .set(HttpHeaderNames.ACCEPT, "utf-8"))
+                     .aggregate().get();
+    }
+
+    private static SortedMap<MyMetricLabel, String> defaultMetricName(RequestLog log,
+                                                                      String serviceName) {
+        final RequestContext ctx = log.context();
+        final Object requestEnvelope = log.requestEnvelope();
+        final Object requestContent = log.requestContent();
+
+        final String path;
+        final String methodName;
+
+        if (requestContent instanceof RpcRequest) {
+            methodName = ((RpcRequest) requestContent).method();
+        } else if (requestEnvelope instanceof HttpHeaders) {
+            methodName = ((HttpHeaders) requestEnvelope).method().name();
+        } else {
+            methodName = log.method();
+        }
+
+        if (requestEnvelope instanceof HttpHeaders) {
+            path = ctx.path();
+        } else {
+            path = null;
+        }
+
+        return ImmutableSortedMap.<MyMetricLabel, String>naturalOrder()
+                .put(MyMetricLabel.handler, serviceName)
+                .put(MyMetricLabel.path, firstNonNull(path, "__UNKNOWN_PATH__"))
+                .put(MyMetricLabel.method, firstNonNull(methodName, "__UNKNOWN_METHOD__"))
+                .build();
+    }
+
+    private enum MyMetricLabel implements MetricLabel<MyMetricLabel> {
+        path,
+        handler,
+        method,
+    }
+
+    private void hello_first_endpoint() throws Exception {
+
+        makeRequest1("world");
+        makeRequest1("world");
+        assertThatThrownBy(() -> makeRequest1("space"));
+        makeRequest1("world");
+        assertThatThrownBy(() -> makeRequest1("space"));
+        assertThatThrownBy(() -> makeRequest1("space"));
+        makeRequest1("world");
+
+        //Wait until all RequestLogs are collected.
+        given().atMost(10000L, TimeUnit.MILLISECONDS)
+               .ignoreExceptions()
+               .untilAsserted(() -> assertThat(makeMetricsRequest1().content().toStringUtf8())
+                       .contains("armeria_server_request_duration_seconds_count{path=\"/thrift1",
+                                 "armeria_server_request_size_bytes_count{path=\"/thrift1",
+                                 "armeria_server_response_size_bytes_count{path=\"/thrift1",
+                                 "armeria_client_request_duration_seconds_count{path=\"/thrift1",
+                                 "armeria_client_request_size_bytes_count{path=\"/thrift1",
+                                 "armeria_client_response_size_bytes_count{path=\"/thrift1",
+                                 "armeria_server_request_success_total{path=\"/thrift1",
+                                 "armeria_server_request_failure_total{path=\"/thrift1",
+                                 "armeria_client_request_success_total{path=\"/thrift1",
+                                 "armeria_client_request_failure_total{path=\"/thrift1",
+                                 "armeria_server_request_active{path=\"/thrift1",
+                                 "armeria_client_request_active{path=\"/thrift1"));
+
+        final String content = makeMetricsRequest1().content().toStringUtf8();
+
+        //Server entry count check
+        assertThat(content).containsPattern(
+                Pattern.compile("^armeria_server_request_duration_seconds_count\\{path=\\\"/thrift1\\\"," +
+                                "handler=\\\"HelloService1\\\",method=\\\"hello\\\",\\} 7.0$",
+                                Pattern.MULTILINE));
+        assertThat(content).containsPattern(
+                Pattern.compile("^armeria_server_request_size_bytes_count\\{path=\\\"/thrift1\\\"," +
+                                "handler=\\\"HelloService1\\\",method=\\\"hello\\\",\\} 7.0$",
+                                Pattern.MULTILINE));
+        assertThat(content).containsPattern(
+                Pattern.compile("^armeria_server_response_size_bytes_count\\{path=\\\"/thrift1\\\"," +
+                                "handler=\\\"HelloService1\\\",method=\\\"hello\\\",\\} 7.0$",
+                                Pattern.MULTILINE));
+        //Client entry count check
+        assertThat(content).containsPattern(
+                Pattern.compile("^armeria_client_request_duration_seconds_count\\{path=\\\"/thrift1\\\"," +
+                                "handler=\\\"HelloService1\\\",method=\\\"hello\\\",\\} 7.0$",
+                                Pattern.MULTILINE));
+        assertThat(content).containsPattern(
+                Pattern.compile("^armeria_client_request_size_bytes_count\\{path=\\\"/thrift1\\\"," +
+                                "handler=\\\"HelloService1\\\",method=\\\"hello\\\",\\} 7.0$",
+                                Pattern.MULTILINE));
+        assertThat(content).containsPattern(
+                Pattern.compile("^armeria_client_response_size_bytes_count\\{path=\\\"/thrift1\\\"," +
+                                "handler=\\\"HelloService1\\\",method=\\\"hello\\\",\\} 7.0$",
+                                Pattern.MULTILINE));
+
+        //Failure count
+        assertThat(content).containsPattern(
+                Pattern.compile("^armeria_server_request_failure_total\\{path=\\\"/thrift1\\\"," +
+                                "handler=\\\"HelloService1\\\",method=\\\"hello\\\",\\} 3.0$",
+                                Pattern.MULTILINE));
+        assertThat(content).containsPattern(
+                Pattern.compile("^armeria_client_request_failure_total\\{path=\\\"/thrift1\\\"," +
+                                "handler=\\\"HelloService1\\\",method=\\\"hello\\\",\\} 3.0$",
+                                Pattern.MULTILINE));
+
+        //Success count
+        assertThat(content).containsPattern(
+                Pattern.compile("^armeria_server_request_success_total\\{path=\\\"/thrift1\\\"," +
+                                "handler=\\\"HelloService1\\\",method=\\\"hello\\\",\\} 4.0$",
+                                Pattern.MULTILINE));
+        assertThat(content).containsPattern(
+                Pattern.compile("^armeria_client_request_success_total\\{path=\\\"/thrift1\\\"," +
+                                "handler=\\\"HelloService1\\\",method=\\\"hello\\\",\\} 4.0$",
+                                Pattern.MULTILINE));
+
+        //Active Requests 0
+        assertThat(content).containsPattern(
+                Pattern.compile("^armeria_server_request_active\\{path=\\\"/thrift1\\\"," +
+                                "handler=\\\"HelloService1\\\",method=\\\"hello\\\",\\} 0.0$",
+                                Pattern.MULTILINE));
+        assertThat(content).containsPattern(
+                Pattern.compile("^armeria_client_request_active\\{path=\\\"/thrift1\\\"," +
+                                "handler=\\\"HelloService1\\\",method=\\\"hello\\\",\\} 0.0$",
+                                Pattern.MULTILINE));
+    }
+
+    private void hello_second_endpoint_same_registry() throws Exception {
+        makeRequest2("world");
+
+        //Wait until all RequestLogs are collected.
+        given().atMost(10000L, TimeUnit.MILLISECONDS)
+               .ignoreExceptions()
+               .untilAsserted(() -> assertThat(makeMetricsRequest1().content().toStringUtf8())
+                       .contains("armeria_server_request_duration_seconds_count{path=\"/thrift2",
+                                 "armeria_server_request_size_bytes_count{path=\"/thrift2",
+                                 "armeria_server_response_size_bytes_count{path=\"/thrift2",
+                                 "armeria_client_request_duration_seconds_count{path=\"/thrift2",
+                                 "armeria_client_request_size_bytes_count{path=\"/thrift2",
+                                 "armeria_client_response_size_bytes_count{path=\"/thrift2",
+                                 "armeria_server_request_success_total{path=\"/thrift2",
+                                 "armeria_client_request_success_total{path=\"/thrift2",
+                                 "armeria_server_request_active{path=\"/thrift2",
+                                 "armeria_client_request_active{path=\"/thrift2"));
+
+        final String content = makeMetricsRequest1().content().toStringUtf8();
+
+        //Server entry count check
+        assertThat(content).containsPattern(
+                Pattern.compile("^armeria_server_request_duration_seconds_count\\{path=\\\"/thrift2\\\"," +
+                                "handler=\\\"HelloService2\\\",method=\\\"hello\\\",\\} 1.0$",
+                                Pattern.MULTILINE));
+        assertThat(content).containsPattern(
+                Pattern.compile("^armeria_server_request_size_bytes_count\\{path=\\\"/thrift2\\\"," +
+                                "handler=\\\"HelloService2\\\",method=\\\"hello\\\",\\} 1.0$",
+                                Pattern.MULTILINE));
+        assertThat(content).containsPattern(
+                Pattern.compile("^armeria_server_response_size_bytes_count\\{path=\\\"/thrift2\\\"," +
+                                "handler=\\\"HelloService2\\\",method=\\\"hello\\\",\\} 1.0$",
+                                Pattern.MULTILINE));
+        //Client entry count check
+        assertThat(content).containsPattern(
+                Pattern.compile("^armeria_client_request_duration_seconds_count\\{path=\\\"/thrift2\\\"," +
+                                "handler=\\\"HelloService2\\\",method=\\\"hello\\\",\\} 1.0$",
+                                Pattern.MULTILINE));
+        assertThat(content).containsPattern(
+                Pattern.compile("^armeria_client_request_size_bytes_count\\{path=\\\"/thrift2\\\"," +
+                                "handler=\\\"HelloService2\\\",method=\\\"hello\\\",\\} 1.0$",
+                                Pattern.MULTILINE));
+        assertThat(content).containsPattern(
+                Pattern.compile("^armeria_client_response_size_bytes_count\\{path=\\\"/thrift2\\\"," +
+                                "handler=\\\"HelloService2\\\",method=\\\"hello\\\",\\} 1.0$",
+                                Pattern.MULTILINE));
+
+        //Success count
+        assertThat(content).containsPattern(
+                Pattern.compile("^armeria_server_request_success_total\\{path=\\\"/thrift2\\\"," +
+                                "handler=\\\"HelloService2\\\",method=\\\"hello\\\",\\} 1.0$",
+                                Pattern.MULTILINE));
+        assertThat(content).containsPattern(
+                Pattern.compile("^armeria_client_request_success_total\\{path=\\\"/thrift2\\\"," +
+                                "handler=\\\"HelloService2\\\",method=\\\"hello\\\",\\} 1.0$",
+                                Pattern.MULTILINE));
+
+        //Active Requests 0
+        assertThat(content).containsPattern(
+                Pattern.compile("^armeria_server_request_active\\{path=\\\"/thrift2\\\"," +
+                                "handler=\\\"HelloService2\\\",method=\\\"hello\\\",\\} 0.0$",
+                                Pattern.MULTILINE));
+        assertThat(content).containsPattern(
+                Pattern.compile("^armeria_client_request_active\\{path=\\\"/thrift2\\\"," +
+                                "handler=\\\"HelloService2\\\",method=\\\"hello\\\",\\} 0.0$",
+                                Pattern.MULTILINE));
+    }
+
+    private void hello_third_endpoint_normal_registry() throws Exception {
+        makeRequest3("world");
+
+        //Wait until all RequestLogs are collected.
+        given().atMost(10000L, TimeUnit.MILLISECONDS)
+               .ignoreExceptions()
+               .untilAsserted(() -> assertThat(makeMetricsRequest2().content().toStringUtf8())
+                       .contains("armeria_server_request_duration_seconds_count{path=\"/thrift3",
+                                 "armeria_server_request_size_bytes_count{path=\"/thrift3",
+                                 "armeria_server_response_size_bytes_count{path=\"/thrift3",
+                                 "armeria_client_request_duration_seconds_count{path=\"/thrift3",
+                                 "armeria_client_request_size_bytes_count{path=\"/thrift3",
+                                 "armeria_client_response_size_bytes_count{path=\"/thrift3",
+                                 "armeria_server_request_success_total{path=\"/thrift3",
+                                 "armeria_client_request_success_total{path=\"/thrift3",
+                                 "armeria_server_request_active{path=\"/thrift3",
+                                 "armeria_client_request_active{path=\"/thrift3"));
+
+        final String content = makeMetricsRequest2().content().toStringUtf8();
+
+        //Server entry count check
+        assertThat(content).containsPattern(
+                Pattern.compile("^armeria_server_request_duration_seconds_count\\{path=\\\"/thrift3\\\"," +
+                                "handler=\\\"HelloService3\\\",method=\\\"hello\\\",\\} 1.0$",
+                                Pattern.MULTILINE));
+        assertThat(content).containsPattern(
+                Pattern.compile("^armeria_server_request_size_bytes_count\\{path=\\\"/thrift3\\\"," +
+                                "handler=\\\"HelloService3\\\",method=\\\"hello\\\",\\} 1.0$",
+                                Pattern.MULTILINE));
+        assertThat(content).containsPattern(
+                Pattern.compile("^armeria_server_response_size_bytes_count\\{path=\\\"/thrift3\\\"," +
+                                "handler=\\\"HelloService3\\\",method=\\\"hello\\\",\\} 1.0$",
+                                Pattern.MULTILINE));
+        //Client entry count check
+        assertThat(content).containsPattern(
+                Pattern.compile("^armeria_client_request_duration_seconds_count\\{path=\\\"/thrift3\\\"," +
+                                "handler=\\\"HelloService3\\\",method=\\\"hello\\\",\\} 1.0$",
+                                Pattern.MULTILINE));
+        assertThat(content).containsPattern(
+                Pattern.compile("^armeria_client_request_size_bytes_count\\{path=\\\"/thrift3\\\"," +
+                                "handler=\\\"HelloService3\\\",method=\\\"hello\\\",\\} 1.0$",
+                                Pattern.MULTILINE));
+        assertThat(content).containsPattern(
+                Pattern.compile("^armeria_client_response_size_bytes_count\\{path=\\\"/thrift3\\\"," +
+                                "handler=\\\"HelloService3\\\",method=\\\"hello\\\",\\} 1.0$",
+                                Pattern.MULTILINE));
+
+        //Success count
+        assertThat(content).containsPattern(
+                Pattern.compile("^armeria_server_request_success_total\\{path=\\\"/thrift3\\\"," +
+                                "handler=\\\"HelloService3\\\",method=\\\"hello\\\",\\} 1.0$",
+                                Pattern.MULTILINE));
+        assertThat(content).containsPattern(
+                Pattern.compile("^armeria_client_request_success_total\\{path=\\\"/thrift3\\\"," +
+                                "handler=\\\"HelloService3\\\",method=\\\"hello\\\",\\} 1.0$",
+                                Pattern.MULTILINE));
+
+        //Active Requests 0
+        assertThat(content).containsPattern(
+                Pattern.compile("^armeria_server_request_active\\{path=\\\"/thrift3\\\"," +
+                                "handler=\\\"HelloService3\\\",method=\\\"hello\\\",\\} 0.0$",
+                                Pattern.MULTILINE));
+        assertThat(content).containsPattern(
+                Pattern.compile("^armeria_client_request_active\\{path=\\\"/thrift3\\\"," +
+                                "handler=\\\"HelloService3\\\",method=\\\"hello\\\",\\} 0.0$",
+                                Pattern.MULTILINE));
+    }
+
+    @Test
+    public void hello_first_second_thrid_endpoint() throws Exception {
+        hello_first_endpoint();
+        hello_second_endpoint_same_registry();
+        hello_third_endpoint_normal_registry();
+    }
+}


### PR DESCRIPTION
Motivation:

We would like Armeria to record and export Prometheus metrics.

Modifications:

- Add Prometheus dependencies
- Add service and client decorator (combined)
- Add wrapper for registry for concurrent access
- Add Prometheus HTTP exporter