### PR TITLE
Add support for subscribing to StreamMessage with or without pooled o…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/stream/FilteredStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/FilteredStreamMessage.java
@@ -90,9 +90,23 @@ public abstract class FilteredStreamMessage<T, U> implements StreamMessage<U> {
     }
 
     @Override
+    public void subscribe(Subscriber<? super U> subscriber, boolean withPooledObjects) {
+        requireNonNull(subscriber, "subscriber");
+        delegate.subscribe(new FilteringSubscriber(subscriber), withPooledObjects);
+    }
+
+    @Override
     public void subscribe(Subscriber<? super U> subscriber, Executor executor) {
         requireNonNull(subscriber, "subscriber");
+        requireNonNull(executor, "executor");
         delegate.subscribe(new FilteringSubscriber(subscriber), executor);
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super U> subscriber, Executor executor, boolean withPooledObjects) {
+        requireNonNull(subscriber, "subscriber");
+        requireNonNull(executor, "executor");
+        delegate.subscribe(new FilteringSubscriber(subscriber), executor, withPooledObjects);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/stream/PublisherBasedStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/PublisherBasedStreamMessage.java
@@ -74,18 +74,28 @@ public class PublisherBasedStreamMessage<T> implements StreamMessage<T> {
 
     @Override
     public void subscribe(Subscriber<? super T> subscriber) {
+        subscribe(subscriber, false);
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super T> subscriber, boolean withPooledObjects) {
         requireNonNull(subscriber, "subscriber");
-        subscribe0(subscriber, null);
+        subscribe0(subscriber, null, withPooledObjects);
     }
 
     @Override
     public void subscribe(Subscriber<? super T> subscriber, Executor executor) {
-        requireNonNull(subscriber, "subscriber");
-        requireNonNull(executor, "executor");
-        subscribe0(subscriber, executor);
+        subscribe(subscriber, executor, false);
     }
 
-    private void subscribe0(Subscriber<? super T> subscriber, Executor executor) {
+    @Override
+    public void subscribe(Subscriber<? super T> subscriber, Executor executor, boolean withPooledObjects) {
+        requireNonNull(subscriber, "subscriber");
+        requireNonNull(executor, "executor");
+        subscribe0(subscriber, executor, withPooledObjects);
+    }
+
+    private void subscribe0(Subscriber<? super T> subscriber, Executor executor, boolean withPooledObjects) {
         final SubscriberWrapper s = new SubscriberWrapper(this, subscriber, executor);
         if (!subscriberUpdater.compareAndSet(this, null, s)) {
             if (this.subscriber == ABORTED_SUBSCRIBER) {

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -78,12 +78,31 @@ public interface StreamMessage<T> extends Publisher<T> {
     void subscribe(Subscriber<? super T> s);
 
     /**
+     * Requests to start streaming data to the specified {@link Subscriber}, receiving pooled objects as is.
+     * Ownership of all pooled objects is transferred to the {@link Subscriber}, which must release them when
+     * finished. If you don't know what this means, use {@link StreamMessage#subscribe(Subscriber)}.
+     *
+     * @throws IllegalStateException if there is a {@link Subscriber} who subscribed to this stream already
+     */
+    void subscribe(Subscriber<? super T> s, boolean withPooledObjects);
+
+    /**
      * Requests to start streaming data, invoking the specified {@link Subscriber} from the specified
      * {@link Executor}.
      *
      * @throws IllegalStateException if there is a {@link Subscriber} who subscribed to this stream already
      */
     void subscribe(Subscriber<? super T> s, Executor executor);
+
+    /**
+     * Requests to start streaming data, invoking the specified {@link Subscriber} from the specified
+     * {@link Executor}, receiving pooled objects as is. Ownership of all pooled objects is transferred to the
+     * {@link Subscriber}, which must release them when finished. If you don't know what this means, use
+     * {@link StreamMessage#subscribe(Subscriber, Executor)}.
+     *
+     * @throws IllegalStateException if there is a {@link Subscriber} who subscribed to this stream already
+     */
+    void subscribe(Subscriber<? super T> s, Executor executor, boolean withPooledObjects);
 
     /**
      * Cancels the {@link Subscription} if any and closes this publisher.

--- a/core/src/main/java/com/linecorp/armeria/server/http/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/HttpServerHandler.java
@@ -337,7 +337,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
             final HttpResponseSubscriber resSubscriber =
                     new HttpResponseSubscriber(ctx, responseEncoder, reqCtx, req);
             reqCtx.setRequestTimeoutChangeListener(resSubscriber);
-            res.subscribe(resSubscriber, eventLoop);
+            res.subscribe(resSubscriber, eventLoop, true);
         }
     }
 

--- a/core/src/test/java/com/linecorp/armeria/client/http/HttpClientIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/http/HttpClientIntegrationTest.java
@@ -20,6 +20,7 @@ import static com.linecorp.armeria.common.http.HttpSessionProtocols.HTTP;
 import static com.linecorp.armeria.common.util.Functions.voidFunction;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
@@ -498,7 +499,7 @@ public class HttpClientIntegrationTest {
 
         assertEquals(HttpStatus.OK, response.headers().status());
         assertThat(response.content().toStringUtf8()).isEqualTo("pooled content");
-        assertThat(releasedByteBuf.get().refCnt()).isZero();
+        await().untilAsserted(() -> assertThat(releasedByteBuf.get().refCnt()).isZero());
     }
 
     @Test
@@ -511,7 +512,7 @@ public class HttpClientIntegrationTest {
 
         assertEquals(HttpStatus.OK, response.headers().status());
         assertThat(response.content().toStringUtf8()).isEqualTo("pooled content");
-        assertThat(releasedByteBuf.get().refCnt()).isZero();
+        await().untilAsserted(() -> assertThat(releasedByteBuf.get().refCnt()).isZero());
     }
 
     @Test
@@ -524,6 +525,6 @@ public class HttpClientIntegrationTest {
 
         assertEquals(HttpStatus.OK, response.headers().status());
         assertThat(response.content().toStringUtf8()).isEqualTo("pooled content");
-        assertThat(releasedByteBuf.get().refCnt()).isZero();
+        await().untilAsserted(() -> assertThat(releasedByteBuf.get().refCnt()).isZero());
     }
 }

--- a/thrift/build.gradle
+++ b/thrift/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id 'me.champeau.gradle.jmh' version '0.3.1'
+}
+
 managedDependencies {
     // Thrift
     compile 'org.apache.thrift:libthrift'
@@ -17,3 +21,7 @@ tasks.shadedJar.doLast {
                 includes: 'com/linecorp/armeria/common/thrift/ThriftListenableFuture*')
     }
 }
+
+configurations.jmh.extendsFrom configurations.testRuntimeClasspath
+
+tasks.checkstyleJmh.enabled = false

--- a/thrift/src/jmh/java/com/linecorp/armeria/server/thrift/PooledResponseBufferBenchmark.java
+++ b/thrift/src/jmh/java/com/linecorp/armeria/server/thrift/PooledResponseBufferBenchmark.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.thrift;
+
+import static com.linecorp.armeria.common.http.HttpSessionProtocols.HTTP;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.infra.Blackhole;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import com.linecorp.armeria.client.ClientFactory;
+import com.linecorp.armeria.client.thrift.THttpClientFactory;
+import com.linecorp.armeria.common.http.DefaultHttpResponse;
+import com.linecorp.armeria.common.http.HttpObject;
+import com.linecorp.armeria.common.http.HttpRequest;
+import com.linecorp.armeria.common.http.HttpResponse;
+import com.linecorp.armeria.common.http.HttpSessionProtocols;
+import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.ServerPort;
+import com.linecorp.armeria.server.Service;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.SimpleDecoratingService;
+import com.linecorp.armeria.service.test.thrift.main.HelloService;
+import com.linecorp.armeria.service.test.thrift.main.HelloService.AsyncIface;
+
+import joptsimple.internal.Strings;
+
+/**
+ * Compare performance of pooled vs unpooled {@link Service} response buffers.
+ *
+ * <p>20170511 Macbook Pro 2016 2.9 GHz Intel Core i5
+ * <pre>
+ * # Run complete. Total time: 00:19:32
+ *
+ * Benchmark                                Mode  Cnt    Score   Error  Units
+ * PooledResponseBufferBenchmark.pooled    thrpt  200  562.800 ± 4.447  ops/s
+ * PooledResponseBufferBenchmark.unpooled  thrpt  200  521.167 ± 4.445  ops/s
+ * </pre>
+ */
+@State(Scope.Benchmark)
+public class PooledResponseBufferBenchmark {
+
+    private static final int RESPONSE_SIZE = 500 * 1024;
+    private static final String RESPONSE = Strings.repeat('a', RESPONSE_SIZE);
+
+    private static final class PooledDecoratingService
+            extends SimpleDecoratingService<HttpRequest, HttpResponse> {
+
+        private PooledDecoratingService(
+                Service<? super HttpRequest, ? extends HttpResponse> delegate) {
+            super(delegate);
+        }
+
+        @Override
+        public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+            HttpResponse res = delegate().serve(ctx, req);
+            DefaultHttpResponse decorated = new DefaultHttpResponse();
+            res.subscribe(new Subscriber<HttpObject>() {
+                @Override
+                public void onSubscribe(Subscription s) {
+                    s.request(Long.MAX_VALUE);
+                }
+
+                @Override
+                public void onNext(HttpObject httpObject) {
+                    decorated.write(httpObject);
+                }
+
+                @Override
+                public void onError(Throwable t) {
+                    decorated.close(t);
+                }
+
+                @Override
+                public void onComplete() {
+                    decorated.close();
+                }
+            }, true);
+            return decorated;
+        }
+    }
+
+    private static final class UnpooledDecoratingService
+            extends SimpleDecoratingService<HttpRequest, HttpResponse> {
+
+        private UnpooledDecoratingService(
+                Service<? super HttpRequest, ? extends HttpResponse> delegate) {
+            super(delegate);
+        }
+
+        @Override
+        public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+            HttpResponse res = delegate().serve(ctx, req);
+            DefaultHttpResponse decorated = new DefaultHttpResponse();
+            res.subscribe(new Subscriber<HttpObject>() {
+                @Override
+                public void onSubscribe(Subscription s) {
+                    s.request(Long.MAX_VALUE);
+                }
+
+                @Override
+                public void onNext(HttpObject httpObject) {
+                    decorated.write(httpObject);
+                }
+
+                @Override
+                public void onError(Throwable t) {
+                    decorated.close(t);
+                }
+
+                @Override
+                public void onComplete() {
+                    decorated.close();
+                }
+            }, false);
+            return decorated;
+        }
+    }
+
+    private Server server;
+    private HelloService.Iface pooledClient;
+    private HelloService.Iface unpooledClient;
+
+    @Setup
+    public void startServer() throws Exception {
+        ServerBuilder sb = new ServerBuilder()
+                .port(0, HttpSessionProtocols.HTTP)
+                .serviceAt("/a", THttpService.of(
+                        (AsyncIface) (name, resultHandler) ->
+                                resultHandler.onComplete(RESPONSE))
+                                                  .decorate(PooledDecoratingService::new))
+                .serviceAt("/b", THttpService.of(
+                        (AsyncIface) (name, resultHandler) ->
+                                resultHandler.onComplete(RESPONSE))
+                                             .decorate(UnpooledDecoratingService::new));
+        server = sb.build();
+        server.start().join();
+
+        ServerPort httpPort = server.activePorts().values().stream()
+                                    .filter(p1 -> p1.protocol() == HTTP).findAny()
+                                    .get();
+        pooledClient = new THttpClientFactory(ClientFactory.DEFAULT).newClient(
+                "tbinary+http://127.0.0.1:" + httpPort.localAddress().getPort() + "/a",
+                HelloService.Iface.class);
+        unpooledClient = new THttpClientFactory(ClientFactory.DEFAULT).newClient(
+                "tbinary+http://127.0.0.1:" + httpPort.localAddress().getPort() + "/b",
+                HelloService.Iface.class);
+    }
+
+    @TearDown
+    public void stopServer() throws Exception {
+        server.stop().join();
+    }
+
+    @Benchmark
+    public void pooled(Blackhole bh) throws Exception {
+        bh.consume(pooledClient.hello("hello"));
+    }
+
+    @Benchmark
+    public void unpooled(Blackhole bh) throws Exception {
+        bh.consume(unpooledClient.hello("hello"));
+    }
+}


### PR DESCRIPTION
…bjects.

Currently, it is possible for decorators to subscribe to a response and return a different one without releasing pooled objects. This makes the default behavior of subscription do a copy from pooled to unpooled to protect unknowing decorators from memory leaks. As modifying the response content in a decorator is quite rare, this copy should rarely happen in practice.

Also adds a simple benchmark of pooled vs unpooled of medium size buffers.