### PR TITLE
Make leak test work

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -716,7 +716,7 @@ configure(javaProjects) {
 
             // Print the test output when the test failed or the test output contains an Exception or an Error.
             afterTest { TestDescriptor td, TestResult tr ->
-                if (tr.resultType == TestResult.ResultType.FAILURE || buf =~ /(?:Exception|Error|Throwable):/) {
+                if (tr.resultType == TestResult.ResultType.FAILURE || buf =~ /(?:Exception|Error|Throwable|LEAK):/) {
                     def simpleClassName = td.className.substring(td.className.lastIndexOf('.') + 1)
 
                     // Add an empty line if the test progress dots were printed.

--- a/core/src/test/java/com/linecorp/armeria/server/http/HttpServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/http/HttpServerTest.java
@@ -105,6 +105,8 @@ import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import io.netty.util.AsciiString;
+import io.netty.util.ResourceLeakDetector;
+import io.netty.util.ResourceLeakDetector.Level;
 import io.netty.util.concurrent.GlobalEventExecutor;
 
 @RunWith(Parameterized.class)
@@ -122,7 +124,9 @@ public class HttpServerTest {
                                                                : new NioEventLoopGroup(1))));
 
     private static final long MAX_CONTENT_LENGTH = 65536;
-    private static final long STREAMING_CONTENT_LENGTH = Runtime.getRuntime().maxMemory() * 2;
+    // Stream as much as twice of the heap. Stream less to avoid OOME when leak detection is enabled.
+    private static final long STREAMING_CONTENT_LENGTH =
+            Runtime.getRuntime().maxMemory() * 2 / (ResourceLeakDetector.getLevel() == Level.PARANOID ? 8 : 1);
     private static final int STREAMING_CONTENT_CHUNK_LENGTH =
             (int) Math.min(Integer.MAX_VALUE, STREAMING_CONTENT_LENGTH / 8);
 


### PR DESCRIPTION
Motivation:

- './gradlew -Pleak test' does not work due to OutOfMemoryError.
- Test tasks do not output the leak error messages when Netty logs it.

Modifications:

- Adjust the heap usage of HttpServerTest when leak detection level is
  'paranoid' so that OOME is not raised
- Print the output when the output contains 'LEAK:'

Result:

A developer can easily check if Armeria has any buffer leak.