### PR TITLE
Cleanup most GRPC test bytebuf leaks.

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/internal/grpc/HttpStreamReader.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/grpc/HttpStreamReader.java
@@ -133,6 +133,9 @@ public class HttpStreamReader implements Subscriber<HttpObject> {
         if (subscription != null) {
             subscription.cancel();
         }
+        if (!deframer.isClosed()) {
+            deframer.close();
+        }
     }
 
     private void closeDeframer() {

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientTest.java
@@ -105,7 +105,6 @@ public class GrpcClientTest {
                     .addService(new TestServiceImpl(Executors.newSingleThreadScheduledExecutor()))
                     .setMaxInboundMessageSizeBytes(MAX_MESSAGE_SIZE)
                     .setMaxOutboundMessageSizeBytes(MAX_MESSAGE_SIZE)
-                    .enableUnframedRequests(true)
                     .build()
                     .decorate(TestServiceImpl.EchoRequestHeadersInTrailers::new)
                     .decorate((client, ctx, req) -> {

--- a/grpc/src/test/java/com/linecorp/armeria/internal/grpc/GrpcMessageMarshallerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/internal/grpc/GrpcMessageMarshallerTest.java
@@ -51,6 +51,7 @@ public class GrpcMessageMarshallerTest {
         ByteBuf serialized = marshaller.serializeRequest(GrpcTestUtil.REQUEST_MESSAGE);
         assertThat(ByteBufUtil.getBytes(serialized))
                 .containsExactly(GrpcTestUtil.REQUEST_MESSAGE.toByteArray());
+        serialized.release();
     }
 
     @Test
@@ -72,6 +73,7 @@ public class GrpcMessageMarshallerTest {
         ByteBuf serialized = marshaller.serializeResponse(GrpcTestUtil.RESPONSE_MESSAGE);
         assertThat(ByteBufUtil.getBytes(serialized))
                 .containsExactly(GrpcTestUtil.RESPONSE_MESSAGE.toByteArray());
+        serialized.release();
     }
 
     @Test

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
@@ -55,7 +55,10 @@ public class GrpcServiceServerTest {
         @Override
         public void unaryCall(SimpleRequest request, StreamObserver<SimpleResponse> responseObserver) {
             if (request.hasResponseStatus()) {
-                throw new StatusRuntimeException(Status.fromCodeValue(request.getResponseStatus().getCode()));
+                responseObserver.onError(
+                        new StatusRuntimeException(
+                                Status.fromCodeValue(request.getResponseStatus().getCode())));
+                return;
             }
             responseObserver.onNext(GrpcTestUtil.RESPONSE_MESSAGE);
             responseObserver.onCompleted();


### PR DESCRIPTION
Some real leaks, some test-specific leaks. There are still a couple of leaks reported in tests after this in error cases which will take a bit more refactoring, so want to get these out first.

- Make sure to release buffer when there is an exception before transfering ownership
- Cancel client's response reading stream if there is a client-side error like timeout
- Close deframer when stream is cancelled
- Close framer / deframer in UnframedGrpcService
- Release intermediary bytebufs and those capture by mocks in unit tests
- Close deframer in ArmeriaServerCallTest by canceling the stream for tests where the stream is ignored. I don't like ArmeriaServerCallTest much since the flow for these streaming calls is too hard to understand (and results in this somewhat hacky code). I will replace most or all of the tests with normal client/server tests in another PR