### PR TITLE
Fix NPE when resolving a hostname

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/NonDecoratingClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/NonDecoratingClientFactory.java
@@ -41,8 +41,8 @@ import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioDatagramChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.resolver.AddressResolverGroup;
+import io.netty.resolver.dns.DefaultDnsServerAddressStreamProvider;
 import io.netty.resolver.dns.DnsAddressResolverGroup;
-import io.netty.resolver.dns.DnsServerAddressStreamProviders;
 import io.netty.util.concurrent.DefaultThreadFactory;
 
 /**
@@ -128,7 +128,9 @@ public abstract class NonDecoratingClientFactory extends AbstractClientFactory {
         return options.addressResolverGroup().orElseGet(
                 () -> new DnsAddressResolverGroup(
                         datagramChannelType(eventLoopGroup),
-                        DnsServerAddressStreamProviders.platformDefault()));
+                        // TODO(trustin): Use DnsServerAddressStreamProviders.platformDefault()
+                        //                once Netty fixes its bug: https://github.com/netty/netty/issues/6736
+                        DefaultDnsServerAddressStreamProvider.INSTANCE));
     }
 
     private static Class<? extends SocketChannel> channelType(EventLoopGroup eventLoopGroup) {

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -43,7 +43,7 @@ io.grpc:
   grpc-testing: { version: *GRPC_VERSION }
 
 io.netty:
-  netty-codec-http2: { version: &NETTY_VERSION 4.1.10.Final }
+  netty-codec-http2: { version: &NETTY_VERSION 4.1.11.Final }
   netty-handler: { version: *NETTY_VERSION }
   netty-resolver-dns: { version: *NETTY_VERSION }
   netty-transport: { version: *NETTY_VERSION }


### PR DESCRIPTION
Motivation:

A bug in Netty's UnixResolverDnsServerAddressStreamProvider causes
domain name resolution fails with a NullPointerException.

Modifications:

- Avoid using UnixResolverDnsServerAddressStreamProvider
  - Use DefaultDnsServerAddressStreamProvider instead
- Update Netty to 4.1.11

Result:

- NPE is gone.