### PR TITLE
Make AbstractPathMapping#loggerName protected instead of package private.

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/AbstractPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AbstractPathMapping.java
@@ -84,7 +84,7 @@ public abstract class AbstractPathMapping implements PathMapping {
         return "__UNKNOWN__";
     }
 
-    static String loggerName(String pathish) {
+    protected static String loggerName(String pathish) {
         if (pathish == null) {
             return "__UNKNOWN__";
         }


### PR DESCRIPTION
It seems like it's intended to be usable by any child, which doesn't have to be in the same package (AbstractPathMapping is Public).