### PR TITLE
Migrate main tests from ArmeriaServerCall to server tests.

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -38,6 +38,7 @@ io.grpc:
     exclusions:
     - io.netty:netty-codec-http2
     - com.google.guava:guava-jdk5
+  grpc-okhttp: { version: *GRPC_VERSION }
   grpc-protobuf: { version: *GRPC_VERSION }
   grpc-stub: { version: *GRPC_VERSION }
   grpc-testing: { version: *GRPC_VERSION }

--- a/grpc/build.gradle
+++ b/grpc/build.gradle
@@ -15,6 +15,7 @@ managedDependencies {
         compile "io.grpc:$it"
     }
 
+    testCompile 'io.grpc:grpc-okhttp'
     testCompile 'io.grpc:grpc-testing'
 }
 

--- a/grpc/src/main/java/com/linecorp/armeria/common/grpc/GrpcSerializationFormatProvider.java
+++ b/grpc/src/main/java/com/linecorp/armeria/common/grpc/GrpcSerializationFormatProvider.java
@@ -32,9 +32,10 @@ public final class GrpcSerializationFormatProvider extends SerializationFormatPr
     @Override
     protected Set<Entry> entries() {
         return ImmutableSet.of(
-                new Entry("gproto", create("application", "grpc+proto")),
+                new Entry("gproto", create("application", "grpc+proto"), create("application", "grpc")),
                 new Entry("gjson", create("application", "grpc+json")),
-                new Entry("gproto-web", create("application", "grpc-web+proto")),
+                new Entry("gproto-web", create("application", "grpc-web+proto"),
+                          create("application", "grpc-web")),
                 new Entry("gjson-web", create("application", "grpc-web+json")));
     }
 }

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/ArmeriaServerCallTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/ArmeriaServerCallTest.java
@@ -18,63 +18,38 @@ package com.linecorp.armeria.server.grpc;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
-
-import java.nio.charset.StandardCharsets;
-import java.util.zip.GZIPInputStream;
-import java.util.zip.GZIPOutputStream;
 
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.reactivestreams.Subscription;
 
-import com.google.common.base.Strings;
-import com.google.common.io.ByteStreams;
-import com.google.protobuf.ByteString;
-
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
-import com.linecorp.armeria.common.http.HttpData;
-import com.linecorp.armeria.common.http.HttpHeaderNames;
 import com.linecorp.armeria.common.http.HttpHeaders;
-import com.linecorp.armeria.common.http.HttpObject;
 import com.linecorp.armeria.common.http.HttpResponseWriter;
 import com.linecorp.armeria.common.http.HttpStatus;
 import com.linecorp.armeria.common.logging.DefaultRequestLog;
-import com.linecorp.armeria.grpc.testing.Messages.Payload;
 import com.linecorp.armeria.grpc.testing.Messages.SimpleRequest;
 import com.linecorp.armeria.grpc.testing.Messages.SimpleResponse;
 import com.linecorp.armeria.grpc.testing.TestServiceGrpc;
 import com.linecorp.armeria.internal.grpc.ArmeriaMessageDeframer.ByteBufOrStream;
 import com.linecorp.armeria.internal.grpc.GrpcHeaderNames;
 import com.linecorp.armeria.internal.grpc.GrpcTestUtil;
-import com.linecorp.armeria.internal.http.ByteBufHttpData;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
 import io.grpc.CompressorRegistry;
 import io.grpc.DecompressorRegistry;
-import io.grpc.Metadata;
 import io.grpc.ServerCall;
 import io.grpc.Status;
-import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.ByteBufInputStream;
-import io.netty.buffer.ByteBufOutputStream;
-import io.netty.buffer.ByteBufUtil;
-import io.netty.buffer.UnpooledByteBufAllocator;
-import io.netty.channel.DefaultEventLoop;
 import io.netty.util.AsciiString;
-import io.netty.util.concurrent.DefaultEventExecutor;
 
 // TODO(anuraag): Currently only grpc-protobuf has been published so we only test proto here.
 // Once grpc-thrift is published, add tests for thrift stubs which will not go through the
@@ -128,39 +103,6 @@ public class ArmeriaServerCallTest {
     }
 
     @Test
-    public void nonStreamProtoMessage() throws Exception {
-        ByteBuf request = GrpcTestUtil.requestByteBuf();
-        assertThat(request.refCnt()).isEqualTo(1);
-        call.messageRead(new ByteBufOrStream(request));
-        call.messageReader().onComplete();
-        verify(listener).onMessage(GrpcTestUtil.REQUEST_MESSAGE);
-        assertThat(request.refCnt()).isEqualTo(0);
-    }
-
-    @Test
-    public void streamProtoMessage() throws Exception {
-        ByteBuf uncompressed = GrpcTestUtil.requestByteBuf();
-
-        ByteBuf request = UnpooledByteBufAllocator.DEFAULT.buffer();
-
-        // While any InputStream would be fine, let's go ahead and make sure a closed gzip
-        // stream releases the buffer.
-        try (ByteBufInputStream is = new ByteBufInputStream(uncompressed, true);
-             GZIPOutputStream os = new GZIPOutputStream(new ByteBufOutputStream(request))) {
-            ByteStreams.copy(is, os);
-        }
-
-        assertThat(uncompressed.refCnt()).isEqualTo(0);
-        assertThat(request.refCnt()).isEqualTo(1);
-
-        call.messageRead(new ByteBufOrStream(
-                new GZIPInputStream(new ByteBufInputStream(request, true))));
-        call.messageReader().onComplete();
-        verify(listener).onMessage(GrpcTestUtil.REQUEST_MESSAGE);
-        assertThat(request.refCnt()).isEqualTo(0);
-    }
-
-    @Test
     public void messageReadAfterClose_byteBuf() throws Exception {
         call.close(Status.ABORTED);
 
@@ -189,328 +131,6 @@ public class ArmeriaServerCallTest {
         assertThat(call.isReady()).isTrue();
         call.close(Status.OK);
         assertThat(call.isReady()).isFalse();
-    }
-
-    @Test
-    public void headers_defaults() throws Exception {
-        call.messageReader().cancel();
-        call.sendHeaders(new Metadata());
-        HttpHeaders expectedHeaders = DEFAULT_RESPONSE_HEADERS;
-        verify(res).write(expectedHeaders);
-        verifyNoMoreInteractions(res);
-    }
-
-    @Test
-    public void headers_noDecompressors() throws Exception {
-        call.messageReader().cancel();
-        call = new ArmeriaServerCall<>(
-                HttpHeaders.of(),
-                TestServiceGrpc.METHOD_UNARY_CALL,
-                CompressorRegistry.getDefaultInstance(),
-                DecompressorRegistry.emptyInstance(),
-                res,
-                MAX_MESSAGE_BYTES,
-                MAX_MESSAGE_BYTES,
-                ctx,
-                GrpcSerializationFormats.PROTO);
-        call.messageReader().cancel();
-        call.sendHeaders(new Metadata());
-        HttpHeaders expectedHeaders =
-                HttpHeaders.of(HttpStatus.OK)
-                           .set(AsciiString.of("content-type"), "application/grpc+proto")
-                           .set(AsciiString.of("grpc-encoding"), "identity");
-        verify(res).write(expectedHeaders);
-        verifyNoMoreInteractions(res);
-    }
-
-    @Test
-    public void headers_callCompressionClientNoAccepts() throws Exception {
-        call.messageReader().cancel();
-        call.setCompression("gzip");
-        call.setMessageCompression(true);
-        call.sendHeaders(new Metadata());
-        HttpHeaders expectedHeaders =
-                HttpHeaders.of(HttpStatus.OK)
-                           .set(AsciiString.of("content-type"), "application/grpc+proto")
-                           .set(AsciiString.of("grpc-encoding"), "identity")
-                           .set(AsciiString.of("grpc-accept-encoding"),
-                                DecompressorRegistry.getDefaultInstance().getAdvertisedMessageEncodings());
-        verify(res).write(expectedHeaders);
-        verifyNoMoreInteractions(res);
-    }
-
-    @Test
-    public void headers_callCompressionClientNoMatch() throws Exception {
-        call.messageReader().cancel();
-        call = new ArmeriaServerCall<>(
-                HttpHeaders.of().set(GrpcHeaderNames.GRPC_ACCEPT_ENCODING, "pied-piper,quantum"),
-                TestServiceGrpc.METHOD_UNARY_CALL,
-                CompressorRegistry.getDefaultInstance(),
-                DecompressorRegistry.getDefaultInstance(),
-                res,
-                MAX_MESSAGE_BYTES,
-                MAX_MESSAGE_BYTES,
-                ctx,
-                GrpcSerializationFormats.PROTO);
-        call.messageReader().cancel();
-        call.setCompression("gzip");
-        call.setMessageCompression(true);
-        call.sendHeaders(new Metadata());
-        HttpHeaders expectedHeaders =
-                HttpHeaders.of(HttpStatus.OK)
-                           .set(AsciiString.of("content-type"), "application/grpc+proto")
-                           .set(AsciiString.of("grpc-encoding"), "identity")
-                           .set(AsciiString.of("grpc-accept-encoding"),
-                                DecompressorRegistry.getDefaultInstance().getAdvertisedMessageEncodings());
-        verify(res).write(expectedHeaders);
-        verifyNoMoreInteractions(res);
-    }
-
-    @Test
-    public void headers_callCompressionClientMatch() throws Exception {
-        call.messageReader().cancel();
-        call = responseCompressionCall();
-        call.messageReader().cancel();
-        call.setCompression("gzip");
-        call.setMessageCompression(true);
-        call.sendHeaders(new Metadata());
-        HttpHeaders expectedHeaders =
-                HttpHeaders.of(HttpStatus.OK)
-                           .set(AsciiString.of("content-type"), "application/grpc+proto")
-                           .set(AsciiString.of("grpc-encoding"), "gzip")
-                           .set(AsciiString.of("grpc-accept-encoding"),
-                                DecompressorRegistry.getDefaultInstance().getAdvertisedMessageEncodings());
-        verify(res).write(expectedHeaders);
-        verifyNoMoreInteractions(res);
-    }
-
-    @Test
-    public void sendMessage() throws Exception {
-        call.messageReader().cancel();
-        call.sendHeaders(new Metadata());
-        call.sendMessage(GrpcTestUtil.RESPONSE_MESSAGE);
-
-        verify(res).write(isA(HttpHeaders.class));
-        verify(res).write(HttpData.of(GrpcTestUtil.uncompressedResponseBytes()));
-        verifyNoMoreInteractions(res);
-
-        verify(listener, times(1)).onReady();
-        verifyNoMoreInteractions(listener);
-    }
-
-    @Test
-    public void sendCompressedMessage() throws Exception {
-        call.messageReader().cancel();
-        call = responseCompressionCall();
-        call.messageReader().cancel();
-        call.setListener(listener);
-        call.setCompression("gzip");
-        call.setMessageCompression(true);
-        call.sendHeaders(new Metadata());
-        call.sendMessage(GrpcTestUtil.RESPONSE_MESSAGE);
-
-        verify(res).write(isA(HttpHeaders.class));
-        verify(res).write(HttpData.of(GrpcTestUtil.compressedResponseBytes()));
-        verifyNoMoreInteractions(res);
-
-        verify(listener, times(1)).onReady();
-        verifyNoMoreInteractions(listener);
-    }
-
-    @Test
-    public void error_noMessage() throws Exception {
-        call.onError(Status.ABORTED);
-        HttpHeaders expectedHeaders =
-                HttpHeaders.of(HttpStatus.OK)
-                           .set(AsciiString.of("content-type"), "application/grpc+proto")
-                           .set(AsciiString.of("grpc-status"), "10");
-        verify(res).write(expectedHeaders);
-        verify(res).close();
-        verifyNoMoreInteractions(res);
-        verify(listener).onCancel();
-        verify(subscription).cancel();
-    }
-
-    @Test
-    public void error_withMessage() throws Exception {
-        call.onError(Status.ABORTED.withDescription("aborted call"));
-        HttpHeaders expectedHeaders =
-                HttpHeaders.of(HttpStatus.OK)
-                           .set(AsciiString.of("content-type"), "application/grpc+proto")
-                           .set(AsciiString.of("grpc-status"), "10")
-                           .set(AsciiString.of("grpc-message"), "aborted call");
-        verify(res).write(expectedHeaders);
-        verify(res).close();
-        verifyNoMoreInteractions(res);
-        verify(listener).onCancel();
-        verify(subscription).cancel();
-    }
-
-    @Test
-    public void fullCall_success() throws Exception {
-        when(ctx.eventLoop()).thenReturn(new DefaultEventLoop(new DefaultEventExecutor()));
-        call.request(2);
-        ctx.eventLoop().shutdownGracefully().get();
-        call.messageReader().onNext(HttpData.of(GrpcTestUtil.uncompressedFrame(GrpcTestUtil.requestByteBuf())));
-        verify(listener).onMessage(GrpcTestUtil.REQUEST_MESSAGE);
-        call.messageReader().onComplete();
-        verify(listener).onHalfClose();
-        call.sendHeaders(new Metadata());
-        call.sendMessage(GrpcTestUtil.RESPONSE_MESSAGE);
-        verify(listener).onReady();
-        call.close(Status.OK);
-        verify(listener).onComplete();
-        verifyNoMoreInteractions(listener);
-
-        verify(res).write(DEFAULT_RESPONSE_HEADERS);
-        verify(res).write(HttpData.of(GrpcTestUtil.uncompressedResponseBytes()));
-        verify(res).write(HttpHeaders.of().set(AsciiString.of("grpc-status"), "0"));
-        verify(res).close();
-        verifyNoMoreInteractions(res);
-    }
-
-    @Test
-    public void fullCall_error() throws Exception {
-        when(ctx.eventLoop()).thenReturn(new DefaultEventLoop(new DefaultEventExecutor()));
-        call.request(2);
-        ctx.eventLoop().shutdownGracefully().get();
-        call.messageReader().onNext(HttpData.of(GrpcTestUtil.uncompressedFrame(GrpcTestUtil.requestByteBuf())));
-        verify(listener).onMessage(GrpcTestUtil.REQUEST_MESSAGE);
-        call.messageReader().onComplete();
-        verify(listener).onHalfClose();
-        call.sendHeaders(new Metadata());
-        call.sendMessage(GrpcTestUtil.RESPONSE_MESSAGE);
-        verify(listener).onReady();
-        call.close(Status.ABORTED);
-        verify(listener).onCancel();
-        verifyNoMoreInteractions(listener);
-
-        verify(res).write(DEFAULT_RESPONSE_HEADERS);
-        verify(res).write(HttpData.of(GrpcTestUtil.uncompressedResponseBytes()));
-        verify(res).write(HttpHeaders.of().set(AsciiString.of("grpc-status"), "10"));
-        verify(res).close();
-        verifyNoMoreInteractions(res);
-
-        // Error happened after client stream ended.
-        verify(subscription, never()).cancel();
-    }
-
-    @Test
-    public void tooLargeRequest() throws Exception {
-        when(ctx.eventLoop()).thenReturn(new DefaultEventLoop(new DefaultEventExecutor()));
-        SimpleRequest request =
-                SimpleRequest.newBuilder()
-                             .setPayload(Payload.newBuilder()
-                                                .setBody(ByteString.copyFromUtf8(
-                                                        Strings.repeat("a", 1024))))
-                             .build();
-        call.request(2);
-        ctx.eventLoop().shutdownGracefully().get();
-        call.messageReader().onNext(
-                HttpData.of(GrpcTestUtil.uncompressedFrame(GrpcTestUtil.protoByteBuf(request))));
-        verify(res).write(HttpHeaders.of(HttpStatus.OK)
-                                     .set(HttpHeaderNames.CONTENT_TYPE, "application/grpc+proto")
-                                     .set(AsciiString.of("grpc-status"),
-                                          Integer.toString(Status.RESOURCE_EXHAUSTED.getCode().value()))
-                                     .set(AsciiString.of("grpc-message"),
-                                          "com.linecorp.armeria.internal.grpc.ArmeriaMessageDeframer: " +
-                                          "Frame size 1030 exceeds maximum: 1024. "));
-        verify(res).close();
-        verifyNoMoreInteractions(res);
-        verify(listener).onCancel();
-        verifyNoMoreInteractions(listener);
-
-        assertThat(call.messageReader().deframer.isClosed()).isTrue();
-        verify(subscription).cancel();
-    }
-
-    @Test
-    public void tooLargeRequestCompressed() throws Exception {
-        when(ctx.eventLoop()).thenReturn(new DefaultEventLoop(new DefaultEventExecutor()));
-        call.messageReader().cancel();
-        reset(subscription);
-        call = new ArmeriaServerCall<>(
-                HttpHeaders.of().set(GrpcHeaderNames.GRPC_ENCODING, "gzip"),
-                TestServiceGrpc.METHOD_UNARY_CALL,
-                CompressorRegistry.getDefaultInstance(),
-                DecompressorRegistry.getDefaultInstance(), res,
-                MAX_MESSAGE_BYTES,
-                MAX_MESSAGE_BYTES,
-                ctx,
-                GrpcSerializationFormats.PROTO);
-        call.messageReader().onSubscribe(subscription);
-        call.setListener(listener);
-        call.setCompression("gzip");
-        call.setMessageCompression(true);
-        SimpleRequest request =
-                SimpleRequest.newBuilder()
-                             .setPayload(Payload.newBuilder()
-                                                .setBody(ByteString.copyFromUtf8(
-                                                        Strings.repeat("a", 1024))))
-                             .build();
-        call.request(2);
-        ctx.eventLoop().shutdownGracefully().get();
-        call.messageReader().onNext(
-                HttpData.of(GrpcTestUtil.compressedFrame(GrpcTestUtil.protoByteBuf(request))));
-        verify(res).write(
-                HttpHeaders.of(HttpStatus.OK)
-                           .set(HttpHeaderNames.CONTENT_TYPE, "application/grpc+proto")
-                           .set(AsciiString.of("grpc-status"), "13")
-                           .set(AsciiString.of("grpc-message"),
-                                "com.linecorp.armeria.internal.grpc.ArmeriaMessageDeframer: " +
-                                "Compressed frame exceeds maximum frame size: 1024. Bytes read: 1030. "));
-        verify(res).close();
-        verifyNoMoreInteractions(res);
-        verify(listener).onCancel();
-        verifyNoMoreInteractions(listener);
-
-        assertThat(call.messageReader().deframer.isClosed()).isTrue();
-        verify(subscription).cancel();
-    }
-
-    @Test
-    public void grpcWeb() throws Exception {
-        call.messageReader().cancel();
-        call = new ArmeriaServerCall<>(
-                HttpHeaders.of(),
-                TestServiceGrpc.METHOD_UNARY_CALL,
-                CompressorRegistry.getDefaultInstance(),
-                DecompressorRegistry.getDefaultInstance(),
-                res,
-                MAX_MESSAGE_BYTES,
-                MAX_MESSAGE_BYTES,
-                ctx,
-                GrpcSerializationFormats.PROTO_WEB);
-        call.setListener(listener);
-        call.messageReader().onSubscribe(subscription);
-        when(ctx.eventLoop()).thenReturn(new DefaultEventLoop(new DefaultEventExecutor()));
-        call.request(2);
-        ctx.eventLoop().shutdownGracefully().get();
-        call.messageReader().onNext(HttpData.of(GrpcTestUtil.uncompressedFrame(GrpcTestUtil.requestByteBuf())));
-        call.messageReader().onComplete();
-        call.sendHeaders(new Metadata());
-        call.sendMessage(GrpcTestUtil.RESPONSE_MESSAGE);
-        call.close(Status.OK);
-
-        ArgumentCaptor<HttpObject> trailersCaptor = ArgumentCaptor.forClass(HttpObject.class);
-        verify(res, times(3)).write(trailersCaptor.capture());
-        assertThat(trailersCaptor.getAllValues().get(0))
-                .isEqualTo(
-                        HttpHeaders.copyOf(DEFAULT_RESPONSE_HEADERS)
-                                   .set(HttpHeaderNames.CONTENT_TYPE,
-                                        GrpcSerializationFormats.PROTO_WEB.mediaType().toString()));
-        assertThat(trailersCaptor.getAllValues().get(1))
-                .isEqualTo(HttpData.of(GrpcTestUtil.uncompressedResponseBytes()));
-        ByteBufHttpData data = (ByteBufHttpData) trailersCaptor.getAllValues().get(2);
-        assertThat(data.buf().getByte(0)).isEqualTo(ArmeriaServerCall.TRAILERS_FRAME_HEADER);
-        String expectedHeader = "grpc-status: 0\r\n";
-        int length = data.buf().getInt(1);
-        assertThat(length).isEqualTo(expectedHeader.length());
-        assertThat(new String(ByteBufUtil.getBytes(data.buf(), 5, length), StandardCharsets.US_ASCII))
-                .isEqualTo(expectedHeader);
-        verify(res).close();
-        verifyNoMoreInteractions(res);
-        data.buf().release();
     }
 
     private ArmeriaServerCall<SimpleRequest, SimpleResponse> responseCompressionCall() {

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
@@ -17,60 +17,112 @@
 package com.linecorp.armeria.server.grpc;
 
 import static com.linecorp.armeria.common.http.HttpSessionProtocols.HTTP;
+import static com.linecorp.armeria.internal.grpc.GrpcTestUtil.REQUEST_MESSAGE;
+import static com.linecorp.armeria.internal.grpc.GrpcTestUtil.RESPONSE_MESSAGE;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
-import com.linecorp.armeria.client.Clients;
+import com.google.common.base.Strings;
+import com.google.common.primitives.Bytes;
+import com.google.common.primitives.Ints;
+import com.google.protobuf.ByteString;
+
 import com.linecorp.armeria.client.http.HttpClient;
 import com.linecorp.armeria.client.http.HttpClientFactory;
-import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
 import com.linecorp.armeria.common.http.AggregatedHttpMessage;
 import com.linecorp.armeria.common.http.HttpHeaderNames;
 import com.linecorp.armeria.common.http.HttpHeaders;
 import com.linecorp.armeria.common.http.HttpMethod;
 import com.linecorp.armeria.common.http.HttpStatus;
 import com.linecorp.armeria.grpc.testing.Messages.EchoStatus;
+import com.linecorp.armeria.grpc.testing.Messages.Payload;
 import com.linecorp.armeria.grpc.testing.Messages.SimpleRequest;
 import com.linecorp.armeria.grpc.testing.Messages.SimpleResponse;
 import com.linecorp.armeria.grpc.testing.Messages.StreamingOutputCallRequest;
-import com.linecorp.armeria.grpc.testing.Messages.StreamingOutputCallResponse;
-import com.linecorp.armeria.grpc.testing.TestServiceGrpc;
-import com.linecorp.armeria.grpc.testing.TestServiceGrpc.TestServiceBlockingStub;
-import com.linecorp.armeria.grpc.testing.TestServiceGrpc.TestServiceImplBase;
+import com.linecorp.armeria.grpc.testing.UnitTestServiceGrpc;
+import com.linecorp.armeria.grpc.testing.UnitTestServiceGrpc.UnitTestServiceBlockingStub;
+import com.linecorp.armeria.grpc.testing.UnitTestServiceGrpc.UnitTestServiceImplBase;
+import com.linecorp.armeria.grpc.testing.UnitTestServiceGrpc.UnitTestServiceStub;
 import com.linecorp.armeria.internal.grpc.GrpcHeaderNames;
 import com.linecorp.armeria.internal.grpc.GrpcTestUtil;
+import com.linecorp.armeria.internal.grpc.StreamRecorder;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.testing.server.ServerRule;
 
+import io.grpc.Codec;
+import io.grpc.DecompressorRegistry;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
 import io.grpc.Status;
+import io.grpc.Status.Code;
 import io.grpc.StatusRuntimeException;
+import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
+import io.netty.util.AsciiString;
 
 public class GrpcServiceServerTest {
 
-    private static class TestServiceImpl extends TestServiceImplBase {
+    private static final int MAX_MESSAGE_SIZE = 16 * 1024 * 1024;
+
+    private static final AsciiString LARGE_PAYLOAD = AsciiString.of(Strings.repeat("a", MAX_MESSAGE_SIZE + 1));
+
+    private static class UnitTestServiceImpl extends UnitTestServiceImplBase {
 
         @Override
-        public void unaryCall(SimpleRequest request, StreamObserver<SimpleResponse> responseObserver) {
-            if (request.hasResponseStatus()) {
-                responseObserver.onError(
-                        new StatusRuntimeException(
-                                Status.fromCodeValue(request.getResponseStatus().getCode())));
+        public void staticUnaryCall(SimpleRequest request, StreamObserver<SimpleResponse> responseObserver) {
+            if (!request.equals(REQUEST_MESSAGE)) {
+                responseObserver.onError(new IllegalArgumentException("Unexpected request: " + request));
                 return;
             }
-            responseObserver.onNext(GrpcTestUtil.RESPONSE_MESSAGE);
+            responseObserver.onNext(RESPONSE_MESSAGE);
             responseObserver.onCompleted();
         }
 
         @Override
-        public void streamingOutputCall(StreamingOutputCallRequest request,
-                                        StreamObserver<StreamingOutputCallResponse> responseObserver) {
-            responseObserver.onNext(
-                    StreamingOutputCallResponse.newBuilder()
-                                               .setPayload(request.getPayload())
-                                               .build());
+        public void staticStreamedOutputCall(SimpleRequest request,
+                                             StreamObserver<SimpleResponse> responseObserver) {
+            if (!request.equals(REQUEST_MESSAGE)) {
+                responseObserver.onError(new IllegalArgumentException("Unexpected request: " + request));
+                return;
+            }
+            responseObserver.onNext(RESPONSE_MESSAGE);
+            responseObserver.onNext(RESPONSE_MESSAGE);
+            responseObserver.onCompleted();
+        }
+
+        @Override
+        public void errorNoMessage(SimpleRequest request, StreamObserver<SimpleResponse> responseObserver) {
+            responseObserver.onError(Status.ABORTED.asException());
+        }
+
+        @Override
+        public void errorWithMessage(SimpleRequest request, StreamObserver<SimpleResponse> responseObserver) {
+            responseObserver.onError(Status.ABORTED.withDescription("aborted call").asException());
+        }
+
+        @Override
+        public void staticUnaryCallSetsMessageCompression(SimpleRequest request,
+                                                          StreamObserver<SimpleResponse> responseObserver) {
+            if (!request.equals(REQUEST_MESSAGE)) {
+                responseObserver.onError(new IllegalArgumentException("Unexpected request: " + request));
+                return;
+            }
+            ServerCallStreamObserver<SimpleResponse> callObserver =
+                    (ServerCallStreamObserver<SimpleResponse>) responseObserver;
+            callObserver.setCompression("gzip");
+            callObserver.setMessageCompression(true);
+            responseObserver.onNext(RESPONSE_MESSAGE);
             responseObserver.onCompleted();
         }
     }
@@ -83,11 +135,103 @@ public class GrpcServiceServerTest {
             sb.port(0, HTTP);
 
             sb.serviceUnder("/", new GrpcServiceBuilder()
-                    .addService(new TestServiceImpl())
+                    .setMaxInboundMessageSizeBytes(MAX_MESSAGE_SIZE)
+                    .addService(new UnitTestServiceImpl())
                     .enableUnframedRequests(true)
                     .build());
         }
     };
+
+    @Rule
+    public Timeout globalTimeout = new Timeout(10, TimeUnit.SECONDS);
+
+    private static ManagedChannel channel;
+
+    private UnitTestServiceBlockingStub blockingClient;
+    private UnitTestServiceStub streamingClient;
+
+    @BeforeClass
+    public static void setUpChannel() {
+        channel = ManagedChannelBuilder.forAddress("127.0.0.1", server.httpPort())
+                                       .usePlaintext(true)
+                                       .build();
+    }
+
+    @AfterClass
+    public static void tearDownChannel() {
+        channel.shutdownNow();
+    }
+
+    @Before
+    public void setUp() {
+        blockingClient = UnitTestServiceGrpc.newBlockingStub(channel);
+        streamingClient = UnitTestServiceGrpc.newStub(channel);
+    }
+
+    @Test
+    public void unary_normal() throws Exception {
+        assertThat(blockingClient.staticUnaryCall(REQUEST_MESSAGE)).isEqualTo(RESPONSE_MESSAGE);
+    }
+
+    @Test
+    public void streamedOutput_normal() throws Exception {
+        StreamRecorder<SimpleResponse> recorder = StreamRecorder.create();
+        streamingClient.staticStreamedOutputCall(REQUEST_MESSAGE, recorder);
+        recorder.awaitCompletion();
+        assertThat(recorder.getValues()).containsExactly(RESPONSE_MESSAGE, RESPONSE_MESSAGE);
+    }
+
+    @Test
+    public void tooLargeRequest_uncompressed() throws Exception {
+        SimpleRequest request = SimpleRequest.newBuilder()
+                                             .setPayload(
+                                                     Payload.newBuilder()
+                                                            .setBody(ByteString.copyFrom(
+                                                                    LARGE_PAYLOAD.toByteArray())))
+                                             .build();
+        StatusRuntimeException t =
+                (StatusRuntimeException) catchThrowable(
+                        () -> blockingClient.staticUnaryCall(request));
+        assertThat(t.getStatus().getCode()).isEqualTo(Code.RESOURCE_EXHAUSTED);
+        assertThat(t.getMessage()).contains("Frame size 16777227 exceeds maximum: 16777216");
+    }
+
+    @Test
+    public void tooLargeRequest_compressed() throws Exception {
+        SimpleRequest request = SimpleRequest.newBuilder()
+                                             .setPayload(
+                                                     Payload.newBuilder()
+                                                            .setBody(ByteString.copyFrom(
+                                                                    LARGE_PAYLOAD.toByteArray())))
+                                             .build();
+        StatusRuntimeException t =
+                (StatusRuntimeException) catchThrowable(
+                        () -> blockingClient.withCompression("gzip").staticUnaryCall(request));
+        assertThat(t.getStatus().getCode()).isEqualTo(Code.INTERNAL);
+        assertThat(t.getMessage())
+                .contains("Compressed frame exceeds maximum frame size: 16777216. Bytes read: 16777227.");
+    }
+
+    @Test
+    public void uncompressedClient_compressedEndpoint() throws Exception {
+        ManagedChannel nonDecompressingChannel =
+                ManagedChannelBuilder.forAddress("127.0.0.1", server.httpPort())
+                                     .decompressorRegistry(
+                                             DecompressorRegistry.emptyInstance()
+                                                                 .with(Codec.Identity.NONE, false))
+                                     .usePlaintext(true)
+                                     .build();
+        UnitTestServiceBlockingStub client = UnitTestServiceGrpc.newBlockingStub(nonDecompressingChannel);
+        assertThat(client.staticUnaryCallSetsMessageCompression(REQUEST_MESSAGE))
+                .isEqualTo(RESPONSE_MESSAGE);
+        nonDecompressingChannel.shutdownNow();
+    }
+
+    @Test
+    public void compressedClient_compressedEndpoint() throws Exception {
+        assertThat(blockingClient.staticUnaryCallSetsMessageCompression(REQUEST_MESSAGE))
+                .isEqualTo(RESPONSE_MESSAGE);
+    }
 
     @Test
     public void unframed() throws Exception {
@@ -95,11 +239,12 @@ public class GrpcServiceServerTest {
                 .newClient("none+" + server.httpUri("/"),
                            HttpClient.class);
         AggregatedHttpMessage response = client.execute(
-                HttpHeaders.of(HttpMethod.POST, TestServiceGrpc.METHOD_UNARY_CALL.getFullMethodName())
+                HttpHeaders.of(HttpMethod.POST,
+                               UnitTestServiceGrpc.METHOD_STATIC_UNARY_CALL.getFullMethodName())
                            .set(HttpHeaderNames.CONTENT_TYPE, "application/protobuf"),
-                GrpcTestUtil.REQUEST_MESSAGE.toByteArray()).aggregate().get();
+                REQUEST_MESSAGE.toByteArray()).aggregate().get();
         SimpleResponse message = SimpleResponse.parseFrom(response.content().array());
-        assertThat(message).isEqualTo(GrpcTestUtil.RESPONSE_MESSAGE);
+        assertThat(message).isEqualTo(RESPONSE_MESSAGE);
     }
 
     @Test
@@ -108,12 +253,13 @@ public class GrpcServiceServerTest {
                 .newClient("none+" + server.httpUri("/"),
                            HttpClient.class);
         AggregatedHttpMessage response = client.execute(
-                HttpHeaders.of(HttpMethod.POST, TestServiceGrpc.METHOD_UNARY_CALL.getFullMethodName())
+                HttpHeaders.of(HttpMethod.POST,
+                               UnitTestServiceGrpc.METHOD_STATIC_UNARY_CALL.getFullMethodName())
                            .set(HttpHeaderNames.CONTENT_TYPE, "application/protobuf")
                            .set(GrpcHeaderNames.GRPC_ACCEPT_ENCODING, "gzip,none"),
-                GrpcTestUtil.REQUEST_MESSAGE.toByteArray()).aggregate().get();
+                REQUEST_MESSAGE.toByteArray()).aggregate().get();
         SimpleResponse message = SimpleResponse.parseFrom(response.content().array());
-        assertThat(message).isEqualTo(GrpcTestUtil.RESPONSE_MESSAGE);
+        assertThat(message).isEqualTo(RESPONSE_MESSAGE);
     }
 
     @Test
@@ -123,7 +269,7 @@ public class GrpcServiceServerTest {
                            HttpClient.class);
         AggregatedHttpMessage response = client.execute(
                 HttpHeaders.of(HttpMethod.POST,
-                               TestServiceGrpc.METHOD_STREAMING_OUTPUT_CALL.getFullMethodName())
+                               UnitTestServiceGrpc.METHOD_STATIC_STREAMED_OUTPUT_CALL.getFullMethodName())
                            .set(HttpHeaderNames.CONTENT_TYPE, "application/protobuf"),
                 StreamingOutputCallRequest.getDefaultInstance().toByteArray()).aggregate().get();
         assertThat(response.status()).isEqualTo(HttpStatus.BAD_REQUEST);
@@ -136,8 +282,8 @@ public class GrpcServiceServerTest {
                            HttpClient.class);
         AggregatedHttpMessage response = client.execute(
                 HttpHeaders.of(HttpMethod.POST,
-                               TestServiceGrpc.METHOD_UNARY_CALL.getFullMethodName()),
-                GrpcTestUtil.REQUEST_MESSAGE.toByteArray()).aggregate().get();
+                               UnitTestServiceGrpc.METHOD_STATIC_UNARY_CALL.getFullMethodName()),
+                REQUEST_MESSAGE.toByteArray()).aggregate().get();
         assertThat(response.status()).isEqualTo(HttpStatus.UNSUPPORTED_MEDIA_TYPE);
     }
 
@@ -148,10 +294,10 @@ public class GrpcServiceServerTest {
                            HttpClient.class);
         AggregatedHttpMessage response = client.execute(
                 HttpHeaders.of(HttpMethod.POST,
-                               TestServiceGrpc.METHOD_UNARY_CALL.getFullMethodName())
+                               UnitTestServiceGrpc.METHOD_STATIC_UNARY_CALL.getFullMethodName())
                            .set(HttpHeaderNames.CONTENT_TYPE, "application/protobuf")
                            .set(GrpcHeaderNames.GRPC_ENCODING, "gzip"),
-                GrpcTestUtil.REQUEST_MESSAGE.toByteArray()).aggregate().get();
+                REQUEST_MESSAGE.toByteArray()).aggregate().get();
         assertThat(response.status()).isEqualTo(HttpStatus.UNSUPPORTED_MEDIA_TYPE);
     }
 
@@ -162,7 +308,7 @@ public class GrpcServiceServerTest {
                            HttpClient.class);
         AggregatedHttpMessage response = client.execute(
                 HttpHeaders.of(HttpMethod.POST,
-                               TestServiceGrpc.METHOD_UNARY_CALL.getFullMethodName())
+                               UnitTestServiceGrpc.METHOD_STATIC_UNARY_CALL.getFullMethodName())
                            .set(HttpHeaderNames.CONTENT_TYPE, "application/protobuf"),
                 SimpleRequest.newBuilder()
                              .setResponseStatus(
@@ -173,11 +319,24 @@ public class GrpcServiceServerTest {
     }
 
     @Test
-    public void framed() throws Exception {
-        TestServiceBlockingStub stub = Clients.newClient(
-                server.httpUri(GrpcSerializationFormats.PROTO, "/"),
-                TestServiceBlockingStub.class);
-        assertThat(stub.unaryCall(GrpcTestUtil.REQUEST_MESSAGE)).isEqualTo(GrpcTestUtil.RESPONSE_MESSAGE);
+    public void grpcWeb() throws Exception {
+        HttpClient client = HttpClientFactory.DEFAULT
+                .newClient("none+" + server.httpUri("/"),
+                           HttpClient.class);
+        AggregatedHttpMessage response = client.execute(
+                HttpHeaders.of(HttpMethod.POST,
+                               UnitTestServiceGrpc.METHOD_STATIC_UNARY_CALL.getFullMethodName())
+                           .set(HttpHeaderNames.CONTENT_TYPE, "application/grpc-web"),
+                GrpcTestUtil.uncompressedFrame(GrpcTestUtil.requestByteBuf())).aggregate().get();
+        byte[] serializedStatusHeader = "grpc-status: 0\r\n".getBytes(StandardCharsets.US_ASCII);
+        byte[] serializedTrailers = Bytes.concat(
+                new byte[] { ArmeriaServerCall.TRAILERS_FRAME_HEADER },
+                Ints.toByteArray(serializedStatusHeader.length),
+                serializedStatusHeader);
+        assertThat(response.content().array()).containsExactly(
+                Bytes.concat(
+                        GrpcTestUtil.uncompressedFrame(
+                                GrpcTestUtil.protoByteBuf(GrpcTestUtil.RESPONSE_MESSAGE)),
+                        serializedTrailers));
     }
-
 }

--- a/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/test.proto
+++ b/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/test.proto
@@ -89,6 +89,27 @@ service TestService {
   rpc UnimplementedCall(armeria.grpc.testing.Empty) returns (armeria.grpc.testing.Empty);
 }
 
+// A service for use in unit tests with methods for fine-grained test conditions.
+service UnitTestService {
+
+    // A unary call which always expects a standard request message and always returns a standard response.
+    rpc StaticUnaryCall(SimpleRequest) returns (SimpleResponse);
+
+    // A streaming output call which always expects a standard request message and always returns a standard
+    // streamed response.
+    rpc StaticStreamedOutputCall(SimpleRequest) returns (stream SimpleResponse);
+
+    // A call that always returns an error with no message.
+    rpc ErrorNoMessage(SimpleRequest) returns (SimpleResponse);
+
+    // A call that always returns an error with a message.
+    rpc ErrorWithMessage(SimpleRequest) returns (SimpleResponse);
+
+    // A unary call which always expects a standard request message and always turns on message compression and
+    // returns a standard response.
+    rpc StaticUnaryCallSetsMessageCompression(SimpleRequest) returns (SimpleResponse);
+}
+
 // A simple service NOT implemented at servers so clients can test for
 // that case.
 service UnimplementedService {


### PR DESCRIPTION
ArmeriaServerCallTest are very hard to maintain and reason about since they require running many different callbacks in precise order. While the speed of unit tests is nice, these aren't very useful, so we migrate them to normal client/server tests.

Also defines a separate stub interface for fine-grained unit testing. The copy of the upstream one will still be used for interopability tests, but this should be easier to maintain for unit tests. I don't like how in the upstream ones, many different cases are handled by request parameters which are somewhat opaque.

Also follows AbstractThriftOverHttpTest pattern by using the upstream client to test server behavior and interopability in one go. Uses grpc-okhttp instead of grpc-netty to prevent netty version conflicts so this should be reasonably stable unlike the netty interop tests (I'll probably migrate the ignored integration test at some point to okhttp).

Also allows non-qualified content types for proto since many clients (like okhttp, grpc-web) don't specify `+proto` (hopefully grpc doesn't end up in content-type hell like thrift did...).