### PR TITLE
Rearrange callbacks for server error case to match GRPC semantics.

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaClientCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaClientCall.java
@@ -44,8 +44,8 @@ import com.linecorp.armeria.internal.grpc.ArmeriaMessageFramer;
 import com.linecorp.armeria.internal.grpc.GrpcHeaderNames;
 import com.linecorp.armeria.internal.grpc.GrpcMessageMarshaller;
 import com.linecorp.armeria.internal.grpc.HttpStreamReader;
-import com.linecorp.armeria.internal.grpc.StatusListener;
 import com.linecorp.armeria.internal.grpc.TimeoutHeaderUtil;
+import com.linecorp.armeria.internal.grpc.TransportStatusListener;
 
 import io.grpc.CallOptions;
 import io.grpc.ClientCall;
@@ -63,7 +63,7 @@ import io.netty.buffer.ByteBuf;
  * from the server, passing to business logic via {@link ClientCall.Listener}.
  */
 class ArmeriaClientCall<I, O> extends ClientCall<I, O>
-        implements ArmeriaMessageDeframer.Listener, StatusListener {
+        implements ArmeriaMessageDeframer.Listener, TransportStatusListener {
 
     private static final Runnable NO_OP = () -> { };
 
@@ -230,7 +230,7 @@ class ArmeriaClientCall<I, O> extends ClientCall<I, O>
     }
 
     @Override
-    public void onError(Status status) {
+    public void transportReportStatus(Status status) {
         responseReader.cancel();
         try (SafeCloseable ignored = RequestContext.push(ctx)) {
             listener.onClose(status, EMPTY_METADATA);

--- a/grpc/src/main/java/com/linecorp/armeria/internal/grpc/GrpcStatus.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/grpc/GrpcStatus.java
@@ -45,7 +45,7 @@ public final class GrpcStatus {
         }
         if (t instanceof StreamException) {
             StreamException streamException = (StreamException) t;
-            if (streamException.getMessage().contains("RST_STREAM")) {
+            if (streamException.getMessage() != null && streamException.getMessage().contains("RST_STREAM")) {
                 return Status.CANCELLED;
             }
         }

--- a/grpc/src/main/java/com/linecorp/armeria/internal/grpc/TransportStatusListener.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/grpc/TransportStatusListener.java
@@ -22,6 +22,6 @@ import io.grpc.Status;
  * A listener of GRPC {@link Status}s. Any errors occuring within the armeria will be returned to GRPC business
  * logic through this listener, and for clients the final response {@link Status} is also returned.
  */
-public interface StatusListener {
-    void onError(Status status);
+public interface TransportStatusListener {
+    void transportReportStatus(Status status);
 }

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
@@ -61,6 +61,11 @@ import io.grpc.Status;
  *         {@link Metadata} - use armeria's HttpHeaders and decorators for accessing custom metadata sent from
  *         the client. Any usages of {@link Metadata} in the server will be silently ignored.
  *     </li>
+ *     <li>
+ *         There are some differences in the HTTP/2 error code returned from an Armeria server vs GRPC server
+ *         when dealing with transport errors and deadlines. Generally, the client will see an UNKNOWN status
+ *         when the official server may have returned CANCELED.
+ *     </li>
  * </ul>
  */
 public final class GrpcService extends AbstractHttpService {

--- a/grpc/src/test/java/com/linecorp/armeria/internal/grpc/HttpStreamReaderTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/internal/grpc/HttpStreamReaderTest.java
@@ -45,7 +45,7 @@ public class HttpStreamReaderTest {
     public MockitoRule mocks = MockitoJUnit.rule();
 
     @Mock
-    private StatusListener statusListener;
+    private TransportStatusListener transportStatusListener;
 
     @Mock
     private ArmeriaMessageDeframer deframer;
@@ -57,7 +57,8 @@ public class HttpStreamReaderTest {
 
     @Before
     public void setUp() {
-        reader = new HttpStreamReader(DecompressorRegistry.getDefaultInstance(), deframer, statusListener);
+        reader = new HttpStreamReader(DecompressorRegistry.getDefaultInstance(), deframer,
+                                      transportStatusListener);
     }
 
     @Test
@@ -97,7 +98,7 @@ public class HttpStreamReaderTest {
         reader.onSubscribe(subscription);
         reader.onNext(DATA);
         verify(deframer).deframe(DATA, false);
-        verify(statusListener).onError(Status.INTERNAL);
+        verify(transportStatusListener).transportReportStatus(Status.INTERNAL);
         verify(deframer).close();
     }
 
@@ -106,7 +107,7 @@ public class HttpStreamReaderTest {
         doThrow(Status.INTERNAL.asRuntimeException())
                 .when(deframer).deframe(isA(HttpData.class), anyBoolean());
         doThrow(new IllegalStateException())
-                .when(statusListener).onError(isA(Status.class));
+                .when(transportStatusListener).transportReportStatus(isA(Status.class));
         reader.onSubscribe(subscription);
         assertThatThrownBy(() -> reader.onNext(DATA)).isInstanceOf(IllegalStateException.class);
         verify(deframer).close();

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/ArmeriaServerCallTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/ArmeriaServerCallTest.java
@@ -39,12 +39,12 @@ import com.linecorp.armeria.grpc.testing.Messages.SimpleRequest;
 import com.linecorp.armeria.grpc.testing.Messages.SimpleResponse;
 import com.linecorp.armeria.grpc.testing.TestServiceGrpc;
 import com.linecorp.armeria.internal.grpc.ArmeriaMessageDeframer.ByteBufOrStream;
-import com.linecorp.armeria.internal.grpc.GrpcHeaderNames;
 import com.linecorp.armeria.internal.grpc.GrpcTestUtil;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
 import io.grpc.CompressorRegistry;
 import io.grpc.DecompressorRegistry;
+import io.grpc.Metadata;
 import io.grpc.ServerCall;
 import io.grpc.Status;
 import io.netty.buffer.ByteBufAllocator;
@@ -104,7 +104,7 @@ public class ArmeriaServerCallTest {
 
     @Test
     public void messageReadAfterClose_byteBuf() throws Exception {
-        call.close(Status.ABORTED);
+        call.close(Status.ABORTED, new Metadata());
 
         call.messageRead(new ByteBufOrStream(GrpcTestUtil.requestByteBuf()));
 
@@ -113,7 +113,7 @@ public class ArmeriaServerCallTest {
 
     @Test
     public void messageReadAfterClose_stream() throws Exception {
-        call.close(Status.ABORTED);
+        call.close(Status.ABORTED, new Metadata());
 
         call.messageRead(new ByteBufOrStream(new ByteBufInputStream(GrpcTestUtil.requestByteBuf(), true)));
 
@@ -129,21 +129,7 @@ public class ArmeriaServerCallTest {
     @Test
     public void notReadyAfterClose() {
         assertThat(call.isReady()).isTrue();
-        call.close(Status.OK);
+        call.close(Status.OK, new Metadata());
         assertThat(call.isReady()).isFalse();
     }
-
-    private ArmeriaServerCall<SimpleRequest, SimpleResponse> responseCompressionCall() {
-        return new ArmeriaServerCall<>(
-                HttpHeaders.of().set(GrpcHeaderNames.GRPC_ACCEPT_ENCODING, "pied-piper, gzip"),
-                TestServiceGrpc.METHOD_UNARY_CALL,
-                CompressorRegistry.getDefaultInstance(),
-                DecompressorRegistry.getDefaultInstance(),
-                res,
-                MAX_MESSAGE_BYTES,
-                MAX_MESSAGE_BYTES,
-                ctx,
-                GrpcSerializationFormats.PROTO);
-    }
-
 }


### PR DESCRIPTION
While examining error handling, I realized that GRPC server does not actually send an error response to the client in cases of transport errors (request too large / invalid, deadline) - it just resets the stream with HTTP/2 CANCEL. Note, this doesn't mean I don't need #521 as I would still like to be able to notify the server's business logic of cancellation and clear up stream resources.

This PR makes sure that non-business-logic exceptions are not returned to the client, but just result in a reset. It also renames to transportStatus and closeListener to match the naming of upstream grpc-java to make comparing the implementations simpler. 

Also:
- Use same translation of netty error codes to status as grpc
- Remove unused method
- Adds DisableOnDebug to test timeout. My previous attempt at this, if you remember it, failed since it doesn't affect `Test(timeout = ` pattern, but for this test I'm only using a global timeout. This is probably a good pattern to use generally in armeria since it makes debugging much easier and removes some of the noise on timeouts.