### PR TITLE
Add support for slow JSON GRPC marshalling.

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/common/grpc/GrpcSerializationFormats.java
+++ b/grpc/src/main/java/com/linecorp/armeria/common/grpc/GrpcSerializationFormats.java
@@ -75,6 +75,14 @@ public final class GrpcSerializationFormats {
     }
 
     /**
+     * Is a json-based GRPC serialization format.
+     */
+    public static boolean isJson(SerializationFormat format) {
+        requireNonNull(format, "format");
+        return format == JSON || format == JSON_WEB;
+    }
+
+    /**
      * Returns whether the specified {@link SerializationFormat} is GRPC-web, the subset of GRPC that supports
      * browsers.
      */

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
@@ -20,18 +20,16 @@ import static java.util.Objects.requireNonNull;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Set;
 
 import javax.annotation.Nullable;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.collect.ImmutableList;
-
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.SerializationFormat;
-import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
 import com.linecorp.armeria.common.http.HttpHeaderNames;
 import com.linecorp.armeria.common.http.HttpHeaders;
 import com.linecorp.armeria.common.http.HttpRequest;
@@ -67,9 +65,6 @@ public final class GrpcService extends AbstractHttpService {
 
     private static final Logger logger = LoggerFactory.getLogger(GrpcService.class);
 
-    private static final List<SerializationFormat> SUPPORTED_SERIALIZATION_FORMATS =
-            ImmutableList.of(GrpcSerializationFormats.PROTO, GrpcSerializationFormats.PROTO_WEB);
-
     static final int NO_MAX_INBOUND_MESSAGE_SIZE = -1;
 
     private static final Metadata EMPTY_METADATA = new Metadata();
@@ -77,6 +72,7 @@ public final class GrpcService extends AbstractHttpService {
     private final HandlerRegistry registry;
     private final DecompressorRegistry decompressorRegistry;
     private final CompressorRegistry compressorRegistry;
+    private final Set<SerializationFormat> supportedSerializationFormats;
     private final int maxOutboundMessageSizeBytes;
 
     private int maxInboundMessageSizeBytes;
@@ -84,11 +80,13 @@ public final class GrpcService extends AbstractHttpService {
     GrpcService(HandlerRegistry registry,
                 DecompressorRegistry decompressorRegistry,
                 CompressorRegistry compressorRegistry,
+                Set<SerializationFormat> supportedSerializationFormats,
                 int maxOutboundMessageSizeBytes,
                 int maxInboundMessageSizeBytes) {
         this.registry = requireNonNull(registry, "registry");
         this.decompressorRegistry = requireNonNull(decompressorRegistry, "decompressorRegistry");
         this.compressorRegistry = requireNonNull(compressorRegistry, "compressorRegistry");
+        this.supportedSerializationFormats = supportedSerializationFormats;
         this.maxOutboundMessageSizeBytes = maxOutboundMessageSizeBytes;
         this.maxInboundMessageSizeBytes = maxInboundMessageSizeBytes;
     }
@@ -199,7 +197,7 @@ public final class GrpcService extends AbstractHttpService {
             return null;
         }
 
-        for (SerializationFormat format : SUPPORTED_SERIALIZATION_FORMATS) {
+        for (SerializationFormat format : supportedSerializationFormats) {
             if (format.isAccepted(mediaType)) {
                 return format;
             }

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
@@ -20,8 +20,14 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
+import java.util.Set;
+
 import javax.annotation.Nullable;
 
+import com.google.common.collect.ImmutableSet;
+
+import com.linecorp.armeria.common.SerializationFormat;
+import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
 import com.linecorp.armeria.common.http.HttpRequest;
 import com.linecorp.armeria.common.http.HttpResponse;
 import com.linecorp.armeria.internal.grpc.ArmeriaMessageFramer;
@@ -38,14 +44,18 @@ import io.grpc.ServerServiceDefinition;
  */
 public final class GrpcServiceBuilder {
 
-    private final HandlerRegistry.Builder registryBuilder =
-            new HandlerRegistry.Builder();
+    private static final Set<SerializationFormat> DEFAULT_SUPPORTED_SERIALIZATION_FORMATS =
+            ImmutableSet.of(GrpcSerializationFormats.PROTO, GrpcSerializationFormats.PROTO_WEB);
+
+    private final HandlerRegistry.Builder registryBuilder = new HandlerRegistry.Builder();
 
     @Nullable
     private DecompressorRegistry decompressorRegistry;
 
     @Nullable
     private CompressorRegistry compressorRegistry;
+
+    private Set<SerializationFormat> supportedSerializationFormats = DEFAULT_SUPPORTED_SERIALIZATION_FORMATS;
 
     private int maxInboundMessageSizeBytes = GrpcService.NO_MAX_INBOUND_MESSAGE_SIZE;
 
@@ -85,6 +95,33 @@ public final class GrpcServiceBuilder {
      */
     public GrpcServiceBuilder compressorRegistry(CompressorRegistry registry) {
         compressorRegistry = requireNonNull(registry, "registry");
+        return this;
+    }
+
+    /**
+     * Sets the {@link SerializationFormat}s supported by this server. If not set, defaults to supporting binary
+     * protobuf formats. JSON formats are currently very inefficient and not recommended for use in production.
+     *
+     * <p>TODO(anuraaga): Use faster JSON marshalling.
+     */
+    public GrpcServiceBuilder supportedSerializationFormats(SerializationFormat... formats) {
+        return supportedSerializationFormats(ImmutableSet.copyOf(requireNonNull(formats, "formats")));
+    }
+
+    /**
+     * Sets the {@link SerializationFormat}s supported by this server. If not set, defaults to supporting binary
+     * protobuf formats. JSON formats are currently very inefficient and not recommended for use in production.
+     *
+     * <p>TODO(anuraaga): Use faster JSON marshalling.
+     */
+    public GrpcServiceBuilder supportedSerializationFormats(Iterable<SerializationFormat> formats) {
+        requireNonNull(formats, "formats");
+        for (SerializationFormat format : formats) {
+            if (!GrpcSerializationFormats.isGrpc(format)) {
+                throw new IllegalArgumentException("Not a GRPC serialization format: " + format);
+            }
+        }
+        supportedSerializationFormats = ImmutableSet.copyOf(formats);
         return this;
     }
 
@@ -145,7 +182,7 @@ public final class GrpcServiceBuilder {
                 registryBuilder.build(),
                 firstNonNull(decompressorRegistry, DecompressorRegistry.getDefaultInstance()),
                 firstNonNull(compressorRegistry, CompressorRegistry.getDefaultInstance()),
-                maxOutboundMessageSizeBytes,
+                supportedSerializationFormats, maxOutboundMessageSizeBytes,
                 maxInboundMessageSizeBytes);
         return enableUnframedRequests ? grpcService.decorate(UnframedGrpcService::new) : grpcService;
     }


### PR DESCRIPTION
I want to add fast JSON too for allowing REST services to be migrated to GRPC (hint, hint ;) ), but in the meantime slow JSON is useful to enable the debug form in a following PR.