### PR TITLE
Fix flakiness in ThriftOverHttpClientTServletIntegrationTest

### DIFF
--- a/thrift/src/test/java/com/linecorp/armeria/client/thrift/ThriftOverHttpClientTServletIntegrationTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/client/thrift/ThriftOverHttpClientTServletIntegrationTest.java
@@ -204,18 +204,12 @@ public class ThriftOverHttpClientTServletIntegrationTest {
 
         assertEquals("Hello, old world!", client.hello("old world"));
         assertThat(sessionProtocol.get(), is(H1C));
-    }
 
-    /**
-     * When an upgrade request is rejected with 'Connection: close', the client should retry the connection
-     * attempt silently with explicit H1C.
-     */
-    @Test
-    public void sendHelloViaHttp1WithConnectionClose() throws Exception {
+        // When an upgrade request is rejected with 'Connection: close', the client should retry the connection
+        // attempt silently with explicit H1C.
+
+        sessionProtocol.set(null);
         sendConnectionClose.set(true);
-
-        final AtomicReference<SessionProtocol> sessionProtocol = new AtomicReference<>();
-        final HelloService.Iface client = newSchemeCapturingClient(http1uri(HTTP), sessionProtocol);
 
         assertEquals("Hello, ancient world!", client.hello("ancient world"));
         assertThat(sessionProtocol.get(), is(H1C));


### PR DESCRIPTION
Motivation:

sendHelloViaHttp1() often fails with ClosedSessionException when a build
runs on Appveyor. It is possible that sendHelloViaHttp1() picks up a
connection closed by sendHelloViaHttp1WithConnectionClose().

Modifications:

- Merge sendHelloViaHttp1WithConnectionClose() into sendHelloViaHttp1()
  so that the disconnection never occurs before the HTTP/1 test

Result:

- Less flakiness