### PR TITLE
Add debug form support for gRPC. Currently only supports unframed req…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/docs/DocService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/DocService.java
@@ -177,7 +177,6 @@ public class DocService extends AbstractCompositeService<HttpRequest, HttpRespon
                 service.methods().stream()
                        .map(method -> addMethodDocStrings(service, method, docStrings))
                        .collect(toImmutableList()),
-                service.endpoints(),
                 service.exampleHttpHeaders(),
                 docString(service.name(), service.docString(), docStrings));
     }
@@ -190,6 +189,7 @@ public class DocService extends AbstractCompositeService<HttpRequest, HttpRespon
                                     .map(field -> addParameterDocString(service, method, field, docStrings))
                                     .collect(toImmutableList()),
                               method.exceptionTypeSignatures(),
+                              method.endpoints(),
                               method.exampleHttpHeaders(),
                               method.exampleRequests(),
                               docString(service.name() + '/' + method.name(), method.docString(), docStrings));
@@ -270,12 +270,11 @@ public class DocService extends AbstractCompositeService<HttpRequest, HttpRespon
                 // Reconstruct MethodInfos with the examples.
                 service.methods().stream().map(m -> new MethodInfo(
                         m.name(), m.returnTypeSignature(), m.parameters(), m.exceptionTypeSignatures(),
-                        Iterables.concat(m.exampleHttpHeaders(),
-                                         exampleHttpHeaders.get(m.name())),
+                        m.endpoints(), Iterables.concat(m.exampleHttpHeaders(),
+                                                        exampleHttpHeaders.get(m.name())),
                         Iterables.concat(m.exampleRequests(),
                                          exampleRequests.get(m.name())),
                         m.docString()))::iterator,
-                service.endpoints(),
                 Iterables.concat(service.exampleHttpHeaders(),
                                  exampleHttpHeaders.get("")),
                 service.docString());

--- a/core/src/main/java/com/linecorp/armeria/server/docs/DocServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/DocServiceBuilder.java
@@ -168,10 +168,10 @@ public final class DocServiceBuilder {
      * exampleRequest(serviceType.getName(), exampleRequests);
      * }</pre>
      */
-    public DocServiceBuilder exampleRequest(Class<?> serviceType, String methodName,
-                                            Object... exampleRequests) {
+    public DocServiceBuilder exampleRequestForMethod(Class<?> serviceType, String methodName,
+                                                     Object... exampleRequests) {
         requireNonNull(exampleRequests, "exampleRequests");
-        return exampleRequest(serviceType, methodName, ImmutableList.copyOf(exampleRequests));
+        return exampleRequestForMethod(serviceType, methodName, ImmutableList.copyOf(exampleRequests));
     }
 
     /**
@@ -181,26 +181,26 @@ public final class DocServiceBuilder {
      * exampleRequest(serviceType.getName(), exampleRequests);
      * }</pre>
      */
-    public DocServiceBuilder exampleRequest(Class<?> serviceType, String methodName,
-                                            Iterable<?> exampleRequests) {
+    public DocServiceBuilder exampleRequestForMethod(Class<?> serviceType, String methodName,
+                                                     Iterable<?> exampleRequests) {
         requireNonNull(serviceType, "serviceType");
-        return exampleRequest(serviceType.getName(), methodName, exampleRequests);
+        return exampleRequestForMethod(serviceType.getName(), methodName, exampleRequests);
     }
 
     /**
      * Adds the example requests for the method with the specified service and method name.
      */
-    public DocServiceBuilder exampleRequest(String serviceName, String methodName,
-                                            Object... exampleRequests) {
+    public DocServiceBuilder exampleRequestForMethod(String serviceName, String methodName,
+                                                     Object... exampleRequests) {
         requireNonNull(exampleRequests, "exampleRequests");
-        return exampleRequest(serviceName, methodName, ImmutableList.copyOf(exampleRequests));
+        return exampleRequestForMethod(serviceName, methodName, ImmutableList.copyOf(exampleRequests));
     }
 
     /**
      * Adds the example requests for the method with the specified service and method name.
      */
-    public DocServiceBuilder exampleRequest(String serviceName, String methodName,
-                                            Iterable<?> exampleRequests) {
+    public DocServiceBuilder exampleRequestForMethod(String serviceName, String methodName,
+                                                     Iterable<?> exampleRequests) {
         requireNonNull(serviceName, "serviceName");
         requireNonNull(methodName, "methodName");
         requireNonNull(exampleRequests, "exampleRequests");

--- a/core/src/main/java/com/linecorp/armeria/server/docs/EndpointInfo.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/EndpointInfo.java
@@ -16,7 +16,6 @@
 
 package com.linecorp.armeria.server.docs;
 
-import static com.google.common.collect.ImmutableSortedSet.toImmutableSortedSet;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Comparator;
@@ -30,6 +29,7 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Streams;
 
 import com.linecorp.armeria.common.MediaType;
@@ -53,15 +53,24 @@ public final class EndpointInfo {
      */
     public EndpointInfo(String hostnamePattern, String path, @Nullable String fragment,
                         SerializationFormat defaultFormat, Iterable<SerializationFormat> availableFormats) {
+        this(hostnamePattern, path, fragment, defaultFormat.mediaType(),
+             Streams.stream(availableFormats).map(SerializationFormat::mediaType)::iterator);
+    }
+
+    /**
+     * Creates a new instance.
+     */
+    public EndpointInfo(String hostnamePattern, String path, @Nullable String fragment,
+                        MediaType defaultMimeType, Iterable<MediaType> availableMimeTypes) {
 
         this.hostnamePattern = requireNonNull(hostnamePattern, "hostnamePattern");
         this.path = requireNonNull(path, "path");
         this.fragment = Strings.emptyToNull(fragment);
-        defaultMimeType = requireNonNull(defaultFormat, "defaultFormat").mediaType();
+        this.defaultMimeType = requireNonNull(defaultMimeType, "defaultFormat");
 
-        availableMimeTypes = Streams.stream(availableFormats)
-                                    .map(SerializationFormat::mediaType)
-                                    .collect(toImmutableSortedSet(Comparator.comparing(MediaType::toString)));
+        this.availableMimeTypes = ImmutableSortedSet.copyOf(
+                Comparator.comparing(MediaType::toString),
+                requireNonNull(availableMimeTypes, "availableMimeTypes"));
     }
 
     /**

--- a/core/src/main/resources/com/linecorp/armeria/server/docs/assets/js/armeria.js
+++ b/core/src/main/resources/com/linecorp/armeria/server/docs/assets/js/armeria.js
@@ -430,6 +430,14 @@ $(function () {
           methodInfo.debugPath == undefined) {
         methodInfo.debugPath = endpointInfo.path;
         methodInfo.debugMimeType = mimeType;
+        if (mimeType === TTEXT_MIME_TYPE) {
+          methodInfo.debugFormatLink =
+            '<a href="https://github.com/line/armeria/blob/13b0510205a84e1a3cd17509e7d39116d050b6b3/' +
+            'src/main/java/com/linecorp/armeria/common/thrift/text/TTextProtocol.java">TText</a>';
+        } else if (mimeType === UNFRAMED_GRPC_JSON_TYPE) {
+          methodInfo.debugFormatLink =
+            '<a href="https://developers.google.com/protocol-buffers/docs/proto3#json">Protobuf</a>';
+        }
         if (typeof endpointInfo.fragment === 'string') {
           methodInfo.debugFragment = endpointInfo.fragment;
         } else {

--- a/core/src/main/resources/com/linecorp/armeria/server/docs/index.html
+++ b/core/src/main/resources/com/linecorp/armeria/server/docs/index.html
@@ -191,7 +191,7 @@
               <div>
                 <label>
                   Arguments as a
-                  <a href="https://github.com/line/armeria/blob/13b0510205a84e1a3cd17509e7d39116d050b6b3/src/main/java/com/linecorp/armeria/common/thrift/text/TTextProtocol.java">TText</a>
+                  {{{ method.debugFormatLink }}}
                   JSON object:
                 </label>
                 <textarea class="debug-textarea form-control code">{&#10;&#32;&#32;"": ""&#10;}&#10;</textarea>

--- a/core/src/main/resources/com/linecorp/armeria/server/docs/index.html
+++ b/core/src/main/resources/com/linecorp/armeria/server/docs/index.html
@@ -154,7 +154,7 @@
           </div>
           {{/if}}
 
-          {{#if service.endpoints.length}}
+          {{#if method.endpoints.length}}
           <h2 class="sub-header">Endpoints</h2>
           <div class="table-responsive">
             <table class="table table-striped table-condensed">
@@ -166,7 +166,7 @@
               </tr>
               </thead>
               <tbody>
-              {{#each service.endpoints}}
+              {{#each method.endpoints}}
               <tr>
                 <td><code>{{{hostnamePattern}}}</code></td>
                 <td><code>{{{path}}}{{#if fragment}}#{{fragment}}{{/if}}</code></td>
@@ -184,7 +184,7 @@
           </div>
           {{/if}}
 
-          {{#if service.debugPath}}
+          {{#if method.debugPath}}
           <h2 class="sub-header">Debug</h2>
           <div class="row">
             <div class="col-sm-6">
@@ -209,7 +209,7 @@
                 </div>
               </div>
               <div>
-                <button class="debug-submit btn btn-primary">Submit to: <code>{{{service.debugPath}}}</code></button>
+                <button class="debug-submit btn btn-primary">Submit to: <code>{{{method.debugPath}}}</code></button>
               </div>
             </div>
             <div class="col-sm-6">

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcDocServicePlugin.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcDocServicePlugin.java
@@ -116,8 +116,8 @@ public class GrpcDocServicePlugin implements DocServicePlugin {
             final GrpcService grpcService = serviceConfig.service().as(GrpcService.class).get();
             ImmutableSet.Builder<MediaType> supportedMediaTypesBuilder = ImmutableSet.builder();
             supportedMediaTypesBuilder.addAll(grpcService.supportedSerializationFormats()
-                                                  .stream()
-                                                  .map(SerializationFormat::mediaType)::iterator);
+                                                         .stream()
+                                                         .map(SerializationFormat::mediaType)::iterator);
             if (serviceConfig.service().as(UnframedGrpcService.class).isPresent()) {
                 if (grpcService.supportedSerializationFormats().contains(GrpcSerializationFormats.PROTO)) {
                     // Normal clients of a GrpcService are not required to set a protocol when using unframed
@@ -154,7 +154,7 @@ public class GrpcDocServicePlugin implements DocServicePlugin {
                                     new EndpointInfo(
                                             serviceConfig.virtualHost().hostnamePattern(),
                                             // Only the URL prefix, each method is served at a different path.
-                                            path + serviceName + "/",
+                                            path + serviceName + '/',
                                             "",
                                             // No default mime type for GRPC, so just pick arbitrarily for now.
                                             // TODO(anuraag): Consider allowing default mime type to be null.

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
@@ -188,6 +188,10 @@ public final class GrpcService extends AbstractHttpService {
         return registry.services();
     }
 
+    Set<SerializationFormat> supportedSerializationFormats() {
+        return supportedSerializationFormats;
+    }
+
     @Nullable
     private SerializationFormat findSerializationFormat(@Nullable String contentType) {
         if (contentType == null) {

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientTest.java
@@ -20,6 +20,7 @@ import static com.linecorp.armeria.common.http.HttpSessionProtocols.HTTP;
 import static com.linecorp.armeria.grpc.testing.Messages.PayloadType.COMPRESSABLE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
@@ -370,7 +371,7 @@ public class GrpcClientTest {
         StreamObserver<StreamingOutputCallRequest> requestObserver
                 = asyncStub.fullDuplexCall(responseObserver);
         requestObserver.onNext(request);
-        assertThat(responseObserver.firstValue().get()).isEqualTo(goldenResponse);
+        await().untilAsserted(() -> assertThat(responseObserver.firstValue().get()).isEqualTo(goldenResponse));
         requestObserver.onError(new RuntimeException());
         responseObserver.awaitCompletion(operationTimeoutMillis(), TimeUnit.MILLISECONDS);
         assertThat(responseObserver.getValues()).hasSize(1);

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcDocServiceTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcDocServiceTest.java
@@ -71,15 +71,10 @@ public class GrpcDocServiceTest {
 
         @Override
         public void unaryCall(SimpleRequest request, StreamObserver<SimpleResponse> responseObserver) {
+            ByteString body = ByteString.copyFromUtf8("hello " + request.getPayload().getBody().toStringUtf8());
             responseObserver.onNext(
                     SimpleResponse.newBuilder()
-                                  .setPayload(
-                                          Payload.newBuilder()
-                                                 .setBody(
-                                                         ByteString.copyFromUtf8(
-                                                                 "hello" +
-                                                                 request.getPayload().getBody()
-                                                                        .toStringUtf8())))
+                                  .setPayload(Payload.newBuilder().setBody(body))
                                   .build());
             responseObserver.onCompleted();
         }

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcDocServiceTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcDocServiceTest.java
@@ -190,10 +190,10 @@ public class GrpcDocServiceTest {
                 final ArrayNode exampleRequests = (ArrayNode) method.get("exampleRequests");
                 if (TestServiceGrpc.SERVICE_NAME.equals(serviceName) &&
                         "UnaryCall".equals(methodName)) {
-                    exampleRequests.add('{' + System.lineSeparator() +
-                                        "  \"payload\": {" + System.lineSeparator() +
-                                        "    \"body\": \"d29ybGQ=\"" + System.lineSeparator() +
-                                        "  }" + System.lineSeparator() +
+                    exampleRequests.add("{\n" +
+                                        "  \"payload\": {\n" +
+                                        "    \"body\": \"d29ybGQ=\"\n" +
+                                        "  }\n" +
                                         '}');
                 }
             });

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
@@ -256,6 +256,8 @@ public class GrpcServiceServerTest {
                 REQUEST_MESSAGE.toByteArray()).aggregate().get();
         SimpleResponse message = SimpleResponse.parseFrom(response.content().array());
         assertThat(message).isEqualTo(RESPONSE_MESSAGE);
+        assertThat(response.headers().getInt(HttpHeaderNames.CONTENT_LENGTH))
+                .isEqualTo(response.content().length());
     }
 
     @Test
@@ -271,6 +273,8 @@ public class GrpcServiceServerTest {
                 REQUEST_MESSAGE.toByteArray()).aggregate().get();
         SimpleResponse message = SimpleResponse.parseFrom(response.content().array());
         assertThat(message).isEqualTo(RESPONSE_MESSAGE);
+        assertThat(response.headers().getInt(HttpHeaderNames.CONTENT_LENGTH))
+                .isEqualTo(response.content().length());
     }
 
     @Test

--- a/thrift/src/main/java/com/linecorp/armeria/server/thrift/ThriftDocServicePlugin.java
+++ b/thrift/src/main/java/com/linecorp/armeria/server/thrift/ThriftDocServicePlugin.java
@@ -151,12 +151,10 @@ public class ThriftDocServicePlugin implements DocServicePlugin {
         }
         final Method[] methods = interfaceClass.getDeclaredMethods();
 
-        return new ServiceInfo(name,
-                               Arrays.stream(methods).map(ThriftDocServicePlugin::newMethodInfo)::iterator,
-                               endpoints);
+        return new ServiceInfo(name, Arrays.stream(methods).map(m -> newMethodInfo(m, endpoints))::iterator);
     }
 
-    private static MethodInfo newMethodInfo(Method method) {
+    private static MethodInfo newMethodInfo(Method method, Iterable<EndpointInfo> endpoints) {
         requireNonNull(method, "method");
 
         final String methodName = method.getName();
@@ -188,7 +186,8 @@ public class ThriftDocServicePlugin implements DocServicePlugin {
         final MethodInfo methodInfo =
                 newMethodInfo(methodName, argsClass,
                               (Class<? extends TBase<?, ?>>) resultClass,
-                              (Class<? extends TException>[]) method.getExceptionTypes());
+                              (Class<? extends TException>[]) method.getExceptionTypes(),
+                              endpoints);
         return methodInfo;
     }
 
@@ -196,10 +195,12 @@ public class ThriftDocServicePlugin implements DocServicePlugin {
     private static MethodInfo newMethodInfo(String name,
                                             Class<? extends TBase<?, ?>> argsClass,
                                             @Nullable Class<? extends TBase<?, ?>> resultClass,
-                                            Class<? extends TException>[] exceptionClasses) {
+                                            Class<? extends TException>[] exceptionClasses,
+                                            Iterable<EndpointInfo> endpoints) {
         requireNonNull(name, "name");
         requireNonNull(argsClass, "argsClass");
         requireNonNull(exceptionClasses, "exceptionClasses");
+        requireNonNull(endpoints, "endpoints");
 
         final List<FieldInfo> parameters =
                 FieldMetaData.getStructMetaDataMap(argsClass).values().stream()
@@ -233,7 +234,7 @@ public class ThriftDocServicePlugin implements DocServicePlugin {
                       .map(TypeSignature::ofNamed)
                       .collect(toImmutableList());
 
-        return new MethodInfo(name, returnTypeSignature, parameters, exceptionTypeSignatures);
+        return new MethodInfo(name, returnTypeSignature, parameters, exceptionTypeSignatures, endpoints);
     }
 
     private static NamedTypeInfo newNamedTypeInfo(TypeSignature typeSignature) {

--- a/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftDocServicePluginTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftDocServicePluginTest.java
@@ -95,15 +95,9 @@ public class ThriftDocServicePluginTest {
 
         // Ensure each service contains all endpoints and example HTTP headers.
         final ServiceInfo helloServiceInfo = services.get(HelloService.class.getName());
-        assertThat(helloServiceInfo.endpoints())
-                .containsExactly(new EndpointInfo("*", "/hello", "", ThriftSerializationFormats.BINARY,
-                                                  ThriftSerializationFormats.values()));
         assertThat(helloServiceInfo.exampleHttpHeaders()).isEmpty();
 
         final ServiceInfo fooServiceInfo = services.get(FooService.class.getName());
-        assertThat(fooServiceInfo.endpoints())
-                .containsExactly(new EndpointInfo("*", "/foo", "", ThriftSerializationFormats.COMPACT,
-                                                  ImmutableSet.of(ThriftSerializationFormats.COMPACT)));
         assertThat(fooServiceInfo.exampleHttpHeaders()).isEmpty();
 
         // Ensure the example request exists as well.
@@ -114,6 +108,9 @@ public class ThriftDocServicePluginTest {
         assertThat(methods).containsKey("bar4");
         final MethodInfo bar4 = methods.get("bar4");
         assertThat(bar4.exampleRequests()).isEmpty();
+        assertThat(bar4.endpoints())
+                .containsExactly(new EndpointInfo("*", "/foo", "", ThriftSerializationFormats.COMPACT,
+                                                  ImmutableSet.of(ThriftSerializationFormats.COMPACT)));
     }
 
     @Test
@@ -147,14 +144,6 @@ public class ThriftDocServicePluginTest {
                         new EndpointInfo("*", "/debug/foo", "b", ThriftSerializationFormats.TEXT,
                                          ImmutableSet.of(ThriftSerializationFormats.TEXT))));
 
-        assertThat(service.endpoints()).hasSize(2);
-        // Should be sorted alphabetically
-        assertThat(service.endpoints()).containsExactlyInAnyOrder(
-                new EndpointInfo("*", "/debug/foo", "b", ThriftSerializationFormats.TEXT,
-                                 ImmutableSet.of(ThriftSerializationFormats.TEXT)),
-                new EndpointInfo("*", "/foo", "a", ThriftSerializationFormats.BINARY,
-                                 ImmutableSet.of(ThriftSerializationFormats.BINARY)));
-
         final Map<String, MethodInfo> methods =
                 service.methods().stream().collect(toImmutableMap(MethodInfo::name, Function.identity()));
         assertThat(methods).hasSize(6);
@@ -164,6 +153,11 @@ public class ThriftDocServicePluginTest {
         assertThat(bar1.returnTypeSignature()).isEqualTo(TypeSignature.ofBase("void"));
         assertThat(bar1.exceptionTypeSignatures()).hasSize(1);
         assertThat(bar1.exampleRequests().isEmpty());
+        assertThat(bar1.endpoints()).containsExactlyInAnyOrder(
+                new EndpointInfo("*", "/debug/foo", "b", ThriftSerializationFormats.TEXT,
+                                 ImmutableSet.of(ThriftSerializationFormats.TEXT)),
+                new EndpointInfo("*", "/foo", "a", ThriftSerializationFormats.BINARY,
+                                 ImmutableSet.of(ThriftSerializationFormats.BINARY)));
 
         final TypeSignature string = TypeSignature.ofBase("string");
         final MethodInfo bar2 = methods.get("bar2");


### PR DESCRIPTION
…uests.

I will add grpc-web support at some point to be able to use streaming responses, but it will require quite a lot of refactoring in armeria.js to allow pluggable transports. The large majority of APIs are unary, so this should be quite fine for now.

And before that, I'd probably send a PR to make armeria.js less thrift, and now grpc, specific.

- Moves endpoints to methods from services, as they really do correspond to a method and are used by methods. Allows gRPC to work where methods have different endpoints.
- Adds a constructor to be able to copy EndpointInfo
- Allows armeria.js to recognize and send gRPC unframed json
- Fixes argument clash in DocServiceBuilder which has a method that accepts `Object...`
- Fixes bug where UnframedGrpcService didn't return the correct content length
- Small code style tweaks (`ImmutableSortedSet.copyOf`, direct `equals` check for non-null fields, toString)
- Try to fix flaky test using awaitility