### PR TITLE
Change the behavior of DynamicHttpFunctionEntry.bind() to allow no-variable path

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/http/PathParamExtractor.java
+++ b/core/src/main/java/com/linecorp/armeria/common/http/PathParamExtractor.java
@@ -19,7 +19,6 @@ package com.linecorp.armeria.common.http;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static java.util.Objects.requireNonNull;
 
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -144,12 +143,12 @@ public final class PathParamExtractor {
 
     /**
      * Returns extracting results with given {@code path}.
-     * If the {@code path} does not match, returns an empty {@link Map}.
+     * If the {@code path} does not match, returns {@code null}.
      */
     public Map<String, String> extract(String path) {
         Matcher matcher = pattern.matcher(path);
         if (!matcher.matches()) {
-            return Collections.emptyMap();
+            return null;
         }
 
         return variables.stream()

--- a/core/src/main/java/com/linecorp/armeria/server/http/dynamic/DynamicHttpFunctionEntry.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/dynamic/DynamicHttpFunctionEntry.java
@@ -75,12 +75,12 @@ final class DynamicHttpFunctionEntry {
      */
     @Nullable
     MappedDynamicFunction bind(HttpMethod method, String mappedPath) {
-        if (!this.methods.contains(method)) {
+        if (!methods.contains(method)) {
             return null;
         }
 
         Map<String, String> args = pathParamExtractor.extract(mappedPath);
-        if (args.isEmpty()) {
+        if (args == null) {
             return null;
         }
 

--- a/core/src/test/java/com/linecorp/armeria/common/http/PathParamExtractorTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/http/PathParamExtractorTest.java
@@ -34,12 +34,12 @@ public class PathParamExtractorTest {
     }
 
     @Test
-    public void givenNoMatchingPathParam_whenExtract_thenReturnsEmptyMap() throws Exception {
+    public void givenNoMatchingPathParam_whenExtract_thenReturnsNull() throws Exception {
         PathParamExtractor ppe = new PathParamExtractor("/service/{value}");
 
         Map<String, String> values = ppe.extract("/service2/hello");
 
-        assertThat(values).isEmpty();
+        assertThat(values).isNull();
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/server/http/HttpServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/http/HttpServiceTest.java
@@ -302,6 +302,12 @@ public class HttpServiceTest {
         public String returnString(@PathParam("var") String var) {
             return var;
         }
+
+        @Get
+        @Path("/no-path-param")
+        public String noPathParam() {
+            return "no-path-param";
+        }
     }
 
     @BeforeClass
@@ -466,6 +472,10 @@ public class HttpServiceTest {
             try (CloseableHttpResponse res = hc.execute(new HttpGet(newUri("/dynamic4/string/blah")))) {
                 assertThat(res.getStatusLine().toString(), is("HTTP/1.1 200 OK"));
                 assertThat(EntityUtils.toString(res.getEntity()), is("String[blah]"));
+            }
+            try (CloseableHttpResponse res = hc.execute(new HttpGet(newUri("/dynamic4/no-path-param")))) {
+                assertThat(res.getStatusLine().toString(), is("HTTP/1.1 200 OK"));
+                assertThat(EntityUtils.toString(res.getEntity()), is("String[no-path-param]"));
             }
             try (CloseableHttpResponse res = hc.execute(new HttpGet(newUri("/dynamic4/undefined")))) {
                 assertThat(res.getStatusLine().toString(), is("HTTP/1.1 405 Method Not Allowed"));


### PR DESCRIPTION
Related #553 

Motivation:
- The current `DynamicHttpService` doesn't handle the path which doesn't include a path variable. However some API might get data from the request's body instead of its path, e.g, content type of `application/x-www-form-urlencoded`.
- This might be fixed via #553 in another way. But I need to use this fix before #553 merged.

Modifications:
- `PathParamExtractor.extract` would return `null` instead of an empty map when there's no matched path.
- `DynamicHttpFunctionEntry` might return `MappedDynamicFunction` with empty arguments map.