### PR TITLE
Switch to protobuf-jackson for json marshalling.

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -119,6 +119,9 @@ org.assertj:
 org.awaitility:
   awaitility: { version: '3.0.0' }
 
+org.curioswitch.curiostack:
+  protobuf-jackson: { version: '0.1.0' }
+
 org.dmonix.junit:
   zookeeper-junit: { version: '1.2' }
 

--- a/grpc/build.gradle
+++ b/grpc/build.gradle
@@ -15,6 +15,8 @@ managedDependencies {
         compile "io.grpc:$it"
     }
 
+    compile 'org.curioswitch.curiostack:protobuf-jackson'
+
     testCompile 'io.grpc:grpc-okhttp'
     testCompile 'io.grpc:grpc-testing'
 }

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaChannel.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaChannel.java
@@ -18,6 +18,8 @@ package com.linecorp.armeria.client.grpc;
 
 import java.net.URI;
 
+import javax.annotation.Nullable;
+
 import org.curioswitch.common.protobuf.json.MessageMarshaller;
 
 import com.linecorp.armeria.client.Client;
@@ -70,7 +72,7 @@ class ArmeriaChannel extends Channel implements ClientBuilderParams {
                    SessionProtocol sessionProtocol,
                    Endpoint endpoint,
                    SerializationFormat serializationFormat,
-                   MessageMarshaller jsonMarshaller) {
+                   @Nullable MessageMarshaller jsonMarshaller) {
         this.params = params;
         this.httpClient = httpClient;
         this.sessionProtocol = sessionProtocol;

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaChannel.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaChannel.java
@@ -18,6 +18,8 @@ package com.linecorp.armeria.client.grpc;
 
 import java.net.URI;
 
+import org.curioswitch.common.protobuf.json.MessageMarshaller;
+
 import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.client.ClientBuilderParams;
 import com.linecorp.armeria.client.ClientFactory;
@@ -61,17 +63,20 @@ class ArmeriaChannel extends Channel implements ClientBuilderParams {
     private final SessionProtocol sessionProtocol;
     private final Endpoint endpoint;
     private final SerializationFormat serializationFormat;
+    private final MessageMarshaller jsonMarshaller;
 
     ArmeriaChannel(ClientBuilderParams params,
                    Client<HttpRequest, HttpResponse> httpClient,
                    SessionProtocol sessionProtocol,
                    Endpoint endpoint,
-                   SerializationFormat serializationFormat) {
+                   SerializationFormat serializationFormat,
+                   MessageMarshaller jsonMarshaller) {
         this.params = params;
         this.httpClient = httpClient;
         this.sessionProtocol = sessionProtocol;
         this.endpoint = endpoint;
         this.serializationFormat = serializationFormat;
+        this.jsonMarshaller = jsonMarshaller;
     }
 
     @Override
@@ -99,7 +104,9 @@ class ArmeriaChannel extends Channel implements ClientBuilderParams {
                                 (long) DEFAULT_MAX_INBOUND_MESSAGE_SIZE).intValue()),
                 callOptions,
                 CompressorRegistry.getDefaultInstance(),
-                DecompressorRegistry.getDefaultInstance());
+                DecompressorRegistry.getDefaultInstance(),
+                serializationFormat,
+                jsonMarshaller);
     }
 
     @Override

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaClientCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaClientCall.java
@@ -25,13 +25,14 @@ import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nullable;
 
+import org.curioswitch.common.protobuf.json.MessageMarshaller;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.common.RequestContext;
-import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
+import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.http.DefaultHttpRequest;
 import com.linecorp.armeria.common.http.HttpData;
 import com.linecorp.armeria.common.http.HttpHeaders;
@@ -98,7 +99,9 @@ class ArmeriaClientCall<I, O> extends ClientCall<I, O>
             int maxInboundMessageSizeBytes,
             CallOptions callOptions,
             CompressorRegistry compressorRegistry,
-            DecompressorRegistry decompressorRegistry) {
+            DecompressorRegistry decompressorRegistry,
+            SerializationFormat serializationFormat,
+            MessageMarshaller jsonMarshaller) {
         this.ctx = ctx;
         this.httpClient = httpClient;
         this.req = req;
@@ -106,7 +109,8 @@ class ArmeriaClientCall<I, O> extends ClientCall<I, O>
         this.compressorRegistry = compressorRegistry;
         this.decompressorRegistry = decompressorRegistry;
         this.messageFramer = new ArmeriaMessageFramer(ctx.alloc(), maxOutboundMessageSizeBytes);
-        this.marshaller = new GrpcMessageMarshaller<>(ctx.alloc(), GrpcSerializationFormats.PROTO, method);
+        this.marshaller = new GrpcMessageMarshaller<>(
+                ctx.alloc(), serializationFormat, method, jsonMarshaller);
         responseReader = new HttpStreamReader(
                 decompressorRegistry,
                 new ArmeriaMessageDeframer(this, maxInboundMessageSizeBytes, ctx.alloc()),

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaClientCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaClientCall.java
@@ -101,7 +101,7 @@ class ArmeriaClientCall<I, O> extends ClientCall<I, O>
             CompressorRegistry compressorRegistry,
             DecompressorRegistry decompressorRegistry,
             SerializationFormat serializationFormat,
-            MessageMarshaller jsonMarshaller) {
+            @Nullable MessageMarshaller jsonMarshaller) {
         this.ctx = ctx;
         this.httpClient = httpClient;
         this.req = req;

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientFactory.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientFactory.java
@@ -30,6 +30,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import org.curioswitch.common.protobuf.json.MessageMarshaller;
+
 import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.client.ClientBuilderParams;
 import com.linecorp.armeria.client.ClientFactory;
@@ -118,13 +120,15 @@ public class GrpcClientFactory extends DecoratingClientFactory {
 
         Client<HttpRequest, HttpResponse> httpClient = newHttpClient(uri, scheme, options);
 
+        MessageMarshaller jsonMarshaller = GrpcSerializationFormats.isJson(serializationFormat) ?
+                                           GrpcJsonUtil.jsonMarshaller(stubMethods(stubClass)) : null;
         ArmeriaChannel channel = new ArmeriaChannel(
                 new DefaultClientBuilderParams(this, uri, clientType, options),
                 httpClient,
                 scheme.sessionProtocol(),
                 newEndpoint(uri),
                 serializationFormat,
-                GrpcJsonUtil.jsonMarshaller(stubMethods(stubClass)));
+                jsonMarshaller);
 
         try {
             // Verified createClientMethod.getReturnType == clientType

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientFactory.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientFactory.java
@@ -16,13 +16,17 @@
 
 package com.linecorp.armeria.client.grpc;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.util.Objects.requireNonNull;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -39,8 +43,10 @@ import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
 import com.linecorp.armeria.common.http.HttpRequest;
 import com.linecorp.armeria.common.http.HttpResponse;
 import com.linecorp.armeria.common.http.HttpSessionProtocols;
+import com.linecorp.armeria.internal.grpc.GrpcJsonUtil;
 
 import io.grpc.Channel;
+import io.grpc.MethodDescriptor;
 import io.grpc.stub.AbstractStub;
 
 /**
@@ -55,8 +61,6 @@ public class GrpcClientFactory extends DecoratingClientFactory {
                     .flatMap(p -> GrpcSerializationFormats
                             .values()
                             .stream()
-                            // TODO(anuraag): Remove this line after JSON support is added.
-                            .filter(f -> f.equals(GrpcSerializationFormats.PROTO))
                             .map(f -> Scheme.of(f, p)))
                     .collect(toImmutableSet());
 
@@ -119,7 +123,8 @@ public class GrpcClientFactory extends DecoratingClientFactory {
                 httpClient,
                 scheme.sessionProtocol(),
                 newEndpoint(uri),
-                serializationFormat);
+                serializationFormat,
+                GrpcJsonUtil.jsonMarshaller(stubMethods(stubClass)));
 
         try {
             // Verified createClientMethod.getReturnType == clientType
@@ -153,6 +158,21 @@ public class GrpcClientFactory extends DecoratingClientFactory {
         }
 
         return httpClientFactory;
+    }
+
+    private static List<MethodDescriptor<?, ?>> stubMethods(Class<?> stubClass) {
+        return Arrays.stream(stubClass.getDeclaredFields())
+                     .filter(field -> ((field.getModifiers() & Modifier.PUBLIC) != 0) &&
+                                      ((field.getModifiers() & Modifier.STATIC) != 0) &&
+                                      MethodDescriptor.class.isAssignableFrom(field.getType()))
+                     .map(field -> {
+                         try {
+                             return (MethodDescriptor<?, ?>) field.get(null);
+                         } catch (IllegalAccessException e) {
+                             throw new IllegalStateException("Modifier is public so can't happen.");
+                         }
+                     })
+                     .collect(toImmutableList());
     }
 
     private Client<HttpRequest, HttpResponse> newHttpClient(URI uri, Scheme scheme, ClientOptions options) {

--- a/grpc/src/main/java/com/linecorp/armeria/internal/grpc/GrpcJsonUtil.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/grpc/GrpcJsonUtil.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.grpc;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.curioswitch.common.protobuf.json.MessageMarshaller;
+
+import com.google.protobuf.Message;
+
+import io.grpc.MethodDescriptor;
+import io.grpc.MethodDescriptor.Marshaller;
+import io.grpc.MethodDescriptor.PrototypeMarshaller;
+
+/**
+ * Utilities for dealing with JSON marshalling in server/client.
+ */
+public final class GrpcJsonUtil {
+
+    /**
+     * Returns a {@link MessageMarshaller} with the request/response {@link Message}s of all the {@code methods}
+     * registered.
+     */
+    public static MessageMarshaller jsonMarshaller(List<MethodDescriptor<?, ?>> methods) {
+        MessageMarshaller.Builder builder = MessageMarshaller.builder()
+                                                             .omittingInsignificantWhitespace(true)
+                                                             .ignoringUnknownFields(true);
+        for (MethodDescriptor<?, ?> method : methods) {
+            marshallerPrototype(method.getRequestMarshaller()).ifPresent(builder::register);
+            marshallerPrototype(method.getResponseMarshaller()).ifPresent(builder::register);
+        }
+        return builder.build();
+    }
+
+    private static Optional<Message> marshallerPrototype(Marshaller<?> marshaller) {
+        if (marshaller instanceof PrototypeMarshaller) {
+            Object prototype = ((PrototypeMarshaller) marshaller).getMessagePrototype();
+            if (prototype instanceof Message) {
+                return Optional.of((Message) prototype);
+            }
+        }
+        return Optional.empty();
+    }
+
+    private GrpcJsonUtil() {}
+}

--- a/grpc/src/main/java/com/linecorp/armeria/internal/grpc/GrpcMessageMarshaller.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/grpc/GrpcMessageMarshaller.java
@@ -16,10 +16,13 @@
 
 package com.linecorp.armeria.internal.grpc;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 import java.io.IOException;
 import java.io.InputStream;
+
+import javax.annotation.Nullable;
 
 import org.curioswitch.common.protobuf.json.MessageMarshaller;
 
@@ -64,11 +67,13 @@ public class GrpcMessageMarshaller<I, O> {
     public GrpcMessageMarshaller(ByteBufAllocator alloc,
                                  SerializationFormat serializationFormat,
                                  MethodDescriptor<I, O> method,
-                                 MessageMarshaller jsonMarshaller) {
+                                 @Nullable MessageMarshaller jsonMarshaller) {
         this.alloc = requireNonNull(alloc, "alloc");
         this.serializationFormat = requireNonNull(serializationFormat, "serializationFormat");
         this.method = requireNonNull(method, "method");
-        this.jsonMarshaller = requireNonNull(jsonMarshaller, "jsonMarshaller");
+        checkArgument(!GrpcSerializationFormats.isJson(serializationFormat) || jsonMarshaller != null,
+                      "jsonMarshaller must be non-null when serializationFormat is JSON.");
+        this.jsonMarshaller = jsonMarshaller;
         requestType = marshallerType(method.getRequestMarshaller());
         responseType = marshallerType(method.getResponseMarshaller());
     }

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
@@ -29,6 +29,7 @@ import java.util.Map;
 
 import javax.annotation.Nullable;
 
+import org.curioswitch.common.protobuf.json.MessageMarshaller;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -127,7 +128,8 @@ class ArmeriaServerCall<I, O> extends ServerCall<I, O>
                       int maxInboundMessageSizeBytes,
                       int maxOutboundMessageSizeBytes,
                       ServiceRequestContext ctx,
-                      SerializationFormat serializationFormat) {
+                      SerializationFormat serializationFormat,
+                      MessageMarshaller jsonMarshaller) {
         requireNonNull(clientHeaders, "clientHeaders");
         this.method = requireNonNull(method, "method");
         this.ctx = requireNonNull(ctx, "ctx");
@@ -146,7 +148,7 @@ class ArmeriaServerCall<I, O> extends ServerCall<I, O>
         this.clientAcceptEncoding =
                 Strings.emptyToNull(clientHeaders.get(GrpcHeaderNames.GRPC_ACCEPT_ENCODING));
         this.decompressorRegistry = requireNonNull(decompressorRegistry, "decompressorRegistry");
-        marshaller = new GrpcMessageMarshaller<>(ctx.alloc(), serializationFormat, method);
+        marshaller = new GrpcMessageMarshaller<>(ctx.alloc(), serializationFormat, method, jsonMarshaller);
     }
 
     @Override

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
@@ -100,9 +100,7 @@ public final class GrpcServiceBuilder {
 
     /**
      * Sets the {@link SerializationFormat}s supported by this server. If not set, defaults to supporting binary
-     * protobuf formats. JSON formats are currently very inefficient and not recommended for use in production.
-     *
-     * <p>TODO(anuraaga): Use faster JSON marshalling.
+     * protobuf formats. Enabling JSON can be useful, e.g., when migrating existing JSON services to gRPC.
      */
     public GrpcServiceBuilder supportedSerializationFormats(SerializationFormat... formats) {
         return supportedSerializationFormats(ImmutableSet.copyOf(requireNonNull(formats, "formats")));

--- a/grpc/src/test/java/com/linecorp/armeria/internal/grpc/GrpcMessageMarshallerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/internal/grpc/GrpcMessageMarshallerTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayInputStream;
 
+import org.curioswitch.common.protobuf.json.MessageMarshaller;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -43,7 +44,11 @@ public class GrpcMessageMarshallerTest {
         marshaller = new GrpcMessageMarshaller<>(
                 ByteBufAllocator.DEFAULT,
                 GrpcSerializationFormats.PROTO,
-                TestServiceGrpc.METHOD_UNARY_CALL);
+                TestServiceGrpc.METHOD_UNARY_CALL,
+                MessageMarshaller.builder()
+                                 .register(SimpleRequest.getDefaultInstance())
+                                 .register(SimpleResponse.getDefaultInstance())
+                                 .build());
     }
 
     @Test

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/ArmeriaServerCallTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/ArmeriaServerCallTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import org.curioswitch.common.protobuf.json.MessageMarshaller;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -95,7 +96,8 @@ public class ArmeriaServerCallTest {
                 MAX_MESSAGE_BYTES,
                 MAX_MESSAGE_BYTES,
                 ctx,
-                GrpcSerializationFormats.PROTO);
+                GrpcSerializationFormats.PROTO,
+                MessageMarshaller.builder().build());
         call.setListener(listener);
         call.messageReader().onSubscribe(subscription);
         when(ctx.logBuilder()).thenReturn(new DefaultRequestLog(ctx));


### PR DESCRIPTION
Also adds support for JSON to armeria grpc client. It's unlikely this would be used in practice, but is useful for unit tests. Switches the JSON test to use the armeria client.