### PR TITLE
Potential fix for flaky HttpServerTest.testTimeout()

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/http/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/HttpServerHandler.java
@@ -309,13 +309,18 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
             // clean up the request stream when response stream ends.
             gracefulShutdownSupport.inc();
             unfinishedRequests++;
-            res.closeFuture().handle(voidFunction((ret, cause) -> {
-                req.abort();
+
+            req.closeFuture().handle(voidFunction((ret, cause) -> {
                 if (cause == null) {
                     logBuilder.endRequest();
                 } else {
                     logBuilder.endRequest(cause);
                 }
+            })).exceptionally(CompletionActions::log);
+
+            res.closeFuture().handle(voidFunction((ret, cause) -> {
+                req.abort();
+                // NB: logBuilder.endResponse() is called by HttpResponseSubscriber below.
                 eventLoop.execute(() -> {
                     gracefulShutdownSupport.dec();
                     if (--unfinishedRequests == 0 && handledLastRequest) {

--- a/core/src/test/java/com/linecorp/armeria/internal/ConnectionLimitingHandlerIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/ConnectionLimitingHandlerIntegrationTest.java
@@ -25,7 +25,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.Socket;
 import java.net.SocketException;
-import java.util.concurrent.TimeUnit;
 
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -63,7 +62,7 @@ public class ConnectionLimitingHandlerIntegrationTest {
                 assertThat(server.server().numConnections()).isEqualTo(2);
             }
 
-            await().atMost(10, TimeUnit.SECONDS).until(() -> server.server().numConnections() == 1);
+            await().until(() -> server.server().numConnections() == 1);
 
             try (Socket s2 = newSocketAndTest()) {
                 assertThat(server.server().numConnections()).isEqualTo(2);

--- a/core/src/test/java/com/linecorp/armeria/server/http/HttpServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/http/HttpServerTest.java
@@ -22,6 +22,7 @@ import static com.linecorp.armeria.common.http.HttpSessionProtocols.H2;
 import static com.linecorp.armeria.common.http.HttpSessionProtocols.H2C;
 import static com.linecorp.armeria.common.http.HttpSessionProtocols.HTTP;
 import static com.linecorp.armeria.common.http.HttpSessionProtocols.HTTPS;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
@@ -46,11 +47,13 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.InflaterInputStream;
 
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -135,6 +138,7 @@ public class HttpServerTest {
         return ImmutableList.of(H1C, H1, H2C, H2);
     }
 
+    private static final AtomicInteger pendingRequestLogs = new AtomicInteger();
     private static final BlockingQueue<RequestLog> requestLogs = new LinkedBlockingQueue<>();
     private static volatile long serverRequestTimeoutMillis;
     private static volatile long serverMaxRequestLength;
@@ -358,9 +362,13 @@ public class HttpServerTest {
                     s -> new SimpleDecoratingService<HttpRequest, HttpResponse>(s) {
                         @Override
                         public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+                            pendingRequestLogs.incrementAndGet();
                             ctx.setRequestTimeoutMillis(serverRequestTimeoutMillis);
                             ctx.setMaxRequestLength(serverMaxRequestLength);
-                            ctx.log().addListener(requestLogs::add, RequestLogAvailability.COMPLETE);
+                            ctx.log().addListener(log -> {
+                                pendingRequestLogs.decrementAndGet();
+                                requestLogs.add(log);
+                            }, RequestLogAvailability.COMPLETE);
                             return delegate().serve(ctx, req);
                         }
                     };
@@ -383,15 +391,23 @@ public class HttpServerTest {
     }
 
     @Before
-    public void reset() {
-        requestLogs.clear();
-
+    public void resetOptions() {
         serverRequestTimeoutMillis = 10000L;
         clientWriteTimeoutMillis = 3000L;
         clientResponseTimeoutMillis = 10000L;
 
         serverMaxRequestLength = MAX_CONTENT_LENGTH;
         clientMaxResponseLength = MAX_CONTENT_LENGTH;
+    }
+
+    @After
+    public void clearRequestLogs() {
+        try {
+            await().until(() -> pendingRequestLogs.get() == 0);
+        } finally {
+            pendingRequestLogs.set(0);
+            requestLogs.clear();
+        }
     }
 
     @Test(timeout = 10000)

--- a/thrift/src/test/java/com/linecorp/armeria/it/metric/PrometheusMetricsIntegrationTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/metric/PrometheusMetricsIntegrationTest.java
@@ -20,12 +20,11 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.linecorp.armeria.common.thrift.ThriftSerializationFormats.BINARY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.awaitility.Awaitility.given;
+import static org.awaitility.Awaitility.await;
 
 import java.util.EnumSet;
 import java.util.SortedMap;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
 import org.apache.thrift.TApplicationException;
@@ -104,20 +103,19 @@ public class PrometheusMetricsIntegrationTest {
         makeRequest1("world");
 
         // Wait until all RequestLogs are collected.
-        given().atMost(10, TimeUnit.SECONDS)
-               .untilAsserted(() -> assertThat(makeMetricsRequest().content().toStringUtf8())
-                       .contains("armeria_server_request_duration_seconds_count{path=\"/thrift1",
-                                 "armeria_server_request_size_bytes_count{path=\"/thrift1",
-                                 "armeria_server_response_size_bytes_count{path=\"/thrift1",
-                                 "armeria_client_request_duration_seconds_count{path=\"/thrift1",
-                                 "armeria_client_request_size_bytes_count{path=\"/thrift1",
-                                 "armeria_client_response_size_bytes_count{path=\"/thrift1",
-                                 "armeria_server_request_success_total{path=\"/thrift1",
-                                 "armeria_server_request_failure_total{path=\"/thrift1",
-                                 "armeria_client_request_success_total{path=\"/thrift1",
-                                 "armeria_client_request_failure_total{path=\"/thrift1",
-                                 "armeria_server_request_active{path=\"/thrift1",
-                                 "armeria_client_request_active{path=\"/thrift1"));
+        await().untilAsserted(() -> assertThat(makeMetricsRequest().content().toStringUtf8())
+                .contains("armeria_server_request_duration_seconds_count{path=\"/thrift1",
+                          "armeria_server_request_size_bytes_count{path=\"/thrift1",
+                          "armeria_server_response_size_bytes_count{path=\"/thrift1",
+                          "armeria_client_request_duration_seconds_count{path=\"/thrift1",
+                          "armeria_client_request_size_bytes_count{path=\"/thrift1",
+                          "armeria_client_response_size_bytes_count{path=\"/thrift1",
+                          "armeria_server_request_success_total{path=\"/thrift1",
+                          "armeria_server_request_failure_total{path=\"/thrift1",
+                          "armeria_client_request_success_total{path=\"/thrift1",
+                          "armeria_client_request_failure_total{path=\"/thrift1",
+                          "armeria_server_request_active{path=\"/thrift1",
+                          "armeria_client_request_active{path=\"/thrift1"));
 
         final String content = makeMetricsRequest().content().toStringUtf8();
 
@@ -171,18 +169,17 @@ public class PrometheusMetricsIntegrationTest {
         makeRequest2("world");
 
         // Wait until all RequestLogs are collected.
-        given().atMost(10, TimeUnit.SECONDS)
-               .untilAsserted(() -> assertThat(makeMetricsRequest().content().toStringUtf8())
-                       .contains("armeria_server_request_duration_seconds_count{path=\"/thrift2",
-                                 "armeria_server_request_size_bytes_count{path=\"/thrift2",
-                                 "armeria_server_response_size_bytes_count{path=\"/thrift2",
-                                 "armeria_client_request_duration_seconds_count{path=\"/thrift2",
-                                 "armeria_client_request_size_bytes_count{path=\"/thrift2",
-                                 "armeria_client_response_size_bytes_count{path=\"/thrift2",
-                                 "armeria_server_request_success_total{path=\"/thrift2",
-                                 "armeria_client_request_success_total{path=\"/thrift2",
-                                 "armeria_server_request_active{path=\"/thrift2",
-                                 "armeria_client_request_active{path=\"/thrift2"));
+        await().untilAsserted(() -> assertThat(makeMetricsRequest().content().toStringUtf8())
+                .contains("armeria_server_request_duration_seconds_count{path=\"/thrift2",
+                          "armeria_server_request_size_bytes_count{path=\"/thrift2",
+                          "armeria_server_response_size_bytes_count{path=\"/thrift2",
+                          "armeria_client_request_duration_seconds_count{path=\"/thrift2",
+                          "armeria_client_request_size_bytes_count{path=\"/thrift2",
+                          "armeria_client_response_size_bytes_count{path=\"/thrift2",
+                          "armeria_server_request_success_total{path=\"/thrift2",
+                          "armeria_client_request_success_total{path=\"/thrift2",
+                          "armeria_server_request_active{path=\"/thrift2",
+                          "armeria_client_request_active{path=\"/thrift2"));
 
         final String content = makeMetricsRequest().content().toStringUtf8();
 


### PR DESCRIPTION
Motivation:

HttpServerTest.testTimeout() sometimes fails with the following
assertion failure:

    com.linecorp.armeria.server.http.HttpServerTest > testTimeout[1: h1] FAILED
        java.lang.AssertionError:
        Expected: is <503>
             but: was <200>
            at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
            at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:8)
            at com.linecorp.armeria.server.http.HttpServerTest.testTimeout(HttpServerTest.java:407)

which means the server sent the '503 Service Unavailable' response
correctly, but the RequestLog in the queue contains '200 OK'.

We clean the queue of RequestLogs before starting each test, but it is
possible that the RequestLog of the previous test is added *after* the
next test is started. i.e. '200 OK' ResponseLog may not be for the
current test.

Modifications:

- Keep the number of expected RequestLogs and wait until all RequestLogs
  are complete between each test
- Fix a bug where a RequestLog is never completed when '413 Request
  Entity Too Large' error occurs

Result:

- May fix #467. It's difficult to say this will fix the flakiness
  because it's been only reproducible in CI machines at low chance.
- RequestLog is completed even when '413 Request Entity Too Large' error
  occurs.