### PR TITLE
Allow catch-all mapping to expose prefix for DocService.

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/CatchAllPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/CatchAllPathMapping.java
@@ -43,6 +43,11 @@ final class CatchAllPathMapping extends AbstractPathMapping {
     }
 
     @Override
+    public Optional<String> prefix() {
+        return PREFIX_PATH_OPT;
+    }
+
+    @Override
     public String toString() {
         return "catchAll";
     }

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcDocServiceTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcDocServiceTest.java
@@ -89,9 +89,6 @@ public class GrpcDocServiceTest {
                     .supportedSerializationFormats(GrpcSerializationFormats.values())
                     .enableUnframedRequests(true)
                     .build());
-            sb.serviceUnder("/reconnect", new GrpcServiceBuilder()
-                    .addService(mock(ReconnectServiceImplBase.class))
-                    .build());
             sb.serviceUnder(
                     "/docs/",
                     new DocServiceBuilder()
@@ -105,6 +102,9 @@ public class GrpcDocServiceTest {
                                                  .build())
                             .build()
                             .decorate(LoggingService::new));
+            sb.serviceUnder("/", new GrpcServiceBuilder()
+                    .addService(mock(ReconnectServiceImplBase.class))
+                    .build());
         }
     };
 
@@ -131,7 +131,7 @@ public class GrpcDocServiceTest {
                         RECONNECT_SERVICE_DESCRIPTOR,
                         ImmutableList.of(new EndpointInfo(
                                 "*",
-                                "/reconnect/armeria.grpc.testing.ReconnectService/",
+                                "/armeria.grpc.testing.ReconnectService/",
                                 "",
                                 GrpcSerializationFormats.PROTO,
                                 ImmutableSet.of(


### PR DESCRIPTION
Without this, doc service does not handle endpoints for services mounted `serviceUnder("/"`, common for gRPC. It was actually almost implemented already...