### PR TITLE
Cleaner build output

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -702,12 +702,10 @@ configure(javaProjects) {
                      dependsOn: tasks.publishToMavenLocal)
     }
 
-    // Print only interesting test results and progress, except when running from IntelliJ IDEA which has
-    // its own output listener.
+    // Print interesting test results, except when running from IntelliJ IDEA which has its own output listener.
     if (System.getProperty('idea.no.launcher') == null) {
         test {
             def buf = new StringBuilder()
-            def printedProgress = false
 
             // Record the test output.
             onOutput { TestDescriptor td, TestOutputEvent toe ->
@@ -716,16 +714,33 @@ configure(javaProjects) {
 
             // Print the test output when the test failed or the test output contains an Exception or an Error.
             afterTest { TestDescriptor td, TestResult tr ->
-                if (tr.resultType == TestResult.ResultType.FAILURE || buf =~ /(?:Exception|Error|Throwable|LEAK):/) {
-                    def simpleClassName = td.className.substring(td.className.lastIndexOf('.') + 1)
+                def printBuffer
+                if (tr.resultType == TestResult.ResultType.FAILURE) {
+                    printBuffer = true
+                } else {
+                    def lines = buf.readLines().findAll { it =~ /(?:Exception|Error|Throwable|LEAK):/ }
 
-                    // Add an empty line if the test progress dots were printed.
-                    if (printedProgress) {
-                        println()
-                        println()
-                        printedProgress = false
+                    // Ignore the expected exceptions.
+                    lines.removeIf { it.matches(/.*Anticipated(?:Exception|Error|Throwable):.*/) }
+
+                    // Ignore known false positives.
+                    lines.removeIf { it.contains('Only supported on Linux') }
+                    switch (td.className) {
+                        case 'com.linecorp.armeria.server.http.HttpServiceTest':
+                            lines.removeIf { it.contains('InvocationTargetException') }
+                            lines.removeIf { it.contains("Can't deserialize fourty-two to type int") }
+                            lines.removeIf { it.contains('For input string: "fourty-two"') }
+                            break
+                        case 'com.linecorp.armeria.client.zookeeper.EndpointGroupTest':
+                            lines.removeIf { it.contains('ServerCnxn$EndOfStreamException') }
+                            break
                     }
 
+                    printBuffer = !lines.isEmpty()
+                }
+
+                if (printBuffer) {
+                    def simpleClassName = td.className.substring(td.className.lastIndexOf('.') + 1)
                     def subject = "${simpleClassName}.${td.name}: ${tr.resultType}"
                     println subject
 
@@ -736,27 +751,9 @@ configure(javaProjects) {
                             println()
                         }
                     }
-                } else {
-                    // Print the progress dots.
-                    print '.'
-                    System.out.flush()
-                    printedProgress = true
                 }
 
                 buf.length = 0
-            }
-
-            afterSuite { TestDescriptor td, TestResult tr ->
-                if (printedProgress) {
-                    print ' '
-                    System.out.flush()
-                }
-            }
-
-            doLast {
-                if (printedProgress) {
-                    println()
-                }
             }
         }
     }

--- a/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClientTest.java
@@ -49,6 +49,7 @@ import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.RpcResponse;
 import com.linecorp.armeria.common.http.HttpMethod;
 import com.linecorp.armeria.common.util.Exceptions;
+import com.linecorp.armeria.testing.common.AnticipatedException;
 
 import io.netty.channel.DefaultEventLoop;
 
@@ -152,7 +153,7 @@ public class CircuitBreakerClientTest {
         when(delegate.execute(any(), any())).thenReturn(successRes);
 
         CircuitBreakerMapping mapping = (ctx, req) -> {
-            throw Exceptions.clearTrace(new IllegalArgumentException("bug!"));
+            throw Exceptions.clearTrace(new AnticipatedException("bug!"));
         };
         CircuitBreakerClient<RpcRequest, RpcResponse> stub = new CircuitBreakerClient<>(delegate, mapping);
 

--- a/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/NonBlockingCircuitBreakerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/NonBlockingCircuitBreakerTest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 import com.google.common.testing.FakeTicker;
 
 import com.linecorp.armeria.common.util.Exceptions;
+import com.linecorp.armeria.testing.common.AnticipatedException;
 
 public class NonBlockingCircuitBreakerTest {
 
@@ -192,7 +193,7 @@ public class NonBlockingCircuitBreakerTest {
     public void testFailureOfExceptionFilter() {
         NonBlockingCircuitBreaker cb = (NonBlockingCircuitBreaker) new CircuitBreakerBuilder()
                 .exceptionFilter(cause -> {
-                    throw Exceptions.clearTrace(new Exception("exception filter failed"));
+                    throw Exceptions.clearTrace(new AnticipatedException("exception filter failed"));
                 })
                 .ticker(ticker)
                 .build();

--- a/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
@@ -53,6 +53,7 @@ import com.linecorp.armeria.common.util.CompletionActions;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.server.http.AbstractHttpService;
 import com.linecorp.armeria.server.logging.LoggingService;
+import com.linecorp.armeria.testing.common.AnticipatedException;
 import com.linecorp.armeria.testing.server.ServerRule;
 
 import io.netty.handler.codec.http.HttpStatusClass;
@@ -100,7 +101,7 @@ public class ServerTest {
                 protected void doPost(ServiceRequestContext ctx,
                                       HttpRequest req, HttpResponseWriter res) throws Exception {
 
-                    throw Exceptions.clearTrace(new Exception("bug!"));
+                    throw Exceptions.clearTrace(new AnticipatedException("bug!"));
                 }
             }.decorate(LoggingService.newDecorator());
 

--- a/core/src/test/java/com/linecorp/armeria/server/http/HttpServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/http/HttpServiceTest.java
@@ -62,6 +62,7 @@ import com.linecorp.armeria.server.http.dynamic.Path;
 import com.linecorp.armeria.server.http.dynamic.PathParam;
 import com.linecorp.armeria.server.http.dynamic.Post;
 import com.linecorp.armeria.server.logging.LoggingService;
+import com.linecorp.armeria.testing.common.AnticipatedException;
 
 public class HttpServiceTest {
 
@@ -244,7 +245,7 @@ public class HttpServiceTest {
         @Get
         @Path("/exception/:var")
         public int exception(@PathParam("var") int var) {
-            throw new IllegalArgumentException("bad var!");
+            throw new AnticipatedException("bad var!");
         }
 
         // Throws an exception asynchronously
@@ -252,7 +253,7 @@ public class HttpServiceTest {
         @Path("/exception-async/:var")
         public CompletableFuture<Integer> exceptionAsync(@PathParam("var") int var) {
             CompletableFuture<Integer> future = new CompletableFuture<>();
-            future.completeExceptionally(new IllegalArgumentException("bad var!"));
+            future.completeExceptionally(new AnticipatedException("bad var!"));
             return future;
         }
     }

--- a/core/src/test/java/com/linecorp/armeria/server/http/auth/HttpAuthServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/http/auth/HttpAuthServiceTest.java
@@ -49,6 +49,7 @@ import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.http.AbstractHttpService;
 import com.linecorp.armeria.server.http.HttpService;
 import com.linecorp.armeria.server.logging.LoggingService;
+import com.linecorp.armeria.testing.common.AnticipatedException;
 import com.linecorp.armeria.testing.server.ServerRule;
 
 public class HttpAuthServiceTest {
@@ -118,7 +119,7 @@ public class HttpAuthServiceTest {
             sb.serviceAt(
                     "/authorizer_exception",
                     ok.decorate(new HttpAuthServiceBuilder().add((ctx, data) -> {
-                        throw new RuntimeException("bug!");
+                        throw new AnticipatedException("bug!");
                     }).newDecorator())
                       .decorate(LoggingService.newDecorator()));
 
@@ -134,7 +135,7 @@ public class HttpAuthServiceTest {
 
                         @Override
                         protected HttpResponse onSuccess(ServiceRequestContext ctx, HttpRequest req) {
-                            throw new RuntimeException("bug!");
+                            throw new AnticipatedException("bug!");
                         }
                     }).decorate(LoggingService.newDecorator()));
         }

--- a/shaded-test/build.gradle
+++ b/shaded-test/build.gradle
@@ -1,3 +1,5 @@
+import com.google.common.base.CaseFormat
+
 ext {
     requiredProjects = rootProject.ext.publishedJavaProjects + project(':testing')
 }
@@ -125,5 +127,5 @@ private static Collection<Configuration> testConfigurations(Project project) {
 }
 
 private static String shadedName(Project project, String suffix = '') {
-    return "shaded${project.name.capitalize()}${suffix}"
+    return "shaded${CaseFormat.LOWER_HYPHEN.to(CaseFormat.UPPER_CAMEL, project.name)}${suffix}"
 }

--- a/testing/src/main/java/com/linecorp/armeria/testing/common/AnticipatedException.java
+++ b/testing/src/main/java/com/linecorp/armeria/testing/common/AnticipatedException.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.testing.common;
+
+/**
+ * A {@link RuntimeException} which is expected to be raised during a test.
+ */
+public class AnticipatedException extends RuntimeException {
+
+    private static final long serialVersionUID = -3303479723421632825L;
+
+    /**
+     * Creates a new instance.
+     */
+    public AnticipatedException() {}
+
+    /**
+     * Creates a new instance.
+     */
+    public AnticipatedException(String message) {
+        super(message);
+    }
+
+    /**
+     * Creates a new instance.
+     */
+    public AnticipatedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Creates a new instance.
+     */
+    public AnticipatedException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Creates a new instance.
+     */
+    protected AnticipatedException(String message, Throwable cause, boolean enableSuppression,
+                                   boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/testing/src/main/java/com/linecorp/armeria/testing/common/package-info.java
+++ b/testing/src/main/java/com/linecorp/armeria/testing/common/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Common testing utilities.
+ */
+package com.linecorp.armeria.testing.common;

--- a/thrift/src/test/java/com/linecorp/armeria/server/thrift/AbstractThriftOverHttpTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/server/thrift/AbstractThriftOverHttpTest.java
@@ -50,7 +50,6 @@ import com.linecorp.armeria.common.logging.RequestLogAvailability;
 import com.linecorp.armeria.common.thrift.ThriftCall;
 import com.linecorp.armeria.common.thrift.ThriftProtocolFactories;
 import com.linecorp.armeria.common.thrift.ThriftReply;
-import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.Service;
@@ -60,6 +59,7 @@ import com.linecorp.armeria.server.logging.LoggingService;
 import com.linecorp.armeria.service.test.thrift.main.HelloService;
 import com.linecorp.armeria.service.test.thrift.main.HelloService.AsyncIface;
 import com.linecorp.armeria.service.test.thrift.main.SleepService;
+import com.linecorp.armeria.testing.common.AnticipatedException;
 
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 
@@ -111,7 +111,7 @@ public abstract class AbstractThriftOverHttpTest {
 
             sb.serviceAt("/exception", THttpService.of(
                     (AsyncIface) (name, resultHandler) ->
-                            resultHandler.onError(Exceptions.clearTrace(new Exception(name)))));
+                            resultHandler.onError(new AnticipatedException(name))));
 
             sb.serviceAt("/hellochild", THttpService.of(new HelloServiceChild()));
 


### PR DESCRIPTION
Motivation:

- The dot (.) progress display interferes with the progress output of
  Gradle 3.5, resulting in ugly terminal.
- Some test outputs printed are not very interesting because they
  contain only expected exceptions
- The tasks created by 'shaded-test' look ugly when a project name
  contains a hyphen (-). e.g. testSpring-boot should be testSpringBoot.

Modifications:

- Do not print the progress dots
- Add a new exception called 'ExpectedException' and use it for expected
  exceptions
- Do not print the test output if it contains only ExpectedExceptions
- Do not print the test output if it contains a false positive
- Fix task name generation in 'shaded-test'

Result:

- Cleaner build output