### PR TITLE
Inject AggregatedHttpMessage into a DynamicHttpFunction method automatically

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/http/dynamic/ParameterEntry.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/dynamic/ParameterEntry.java
@@ -1,5 +1,7 @@
 package com.linecorp.armeria.server.http.dynamic;
 
+import javax.annotation.Nullable;
+
 /**
  * Parameter entry, which will be used to invoke the {@link DynamicHttpFunctionEntry}.
  *
@@ -9,7 +11,7 @@ final class ParameterEntry {
     private Class<?> type;
     private String name;
 
-    ParameterEntry(Class<?> type, String name) {
+    ParameterEntry(Class<?> type, @Nullable String name) {
         this.type = type;
         this.name = name;
     }
@@ -18,6 +20,7 @@ final class ParameterEntry {
         return type;
     }
 
+    @Nullable
     String getName() {
         return name;
     }

--- a/core/src/test/java/com/linecorp/armeria/server/http/TestConverters.java
+++ b/core/src/test/java/com/linecorp/armeria/server/http/TestConverters.java
@@ -111,5 +111,22 @@ final class TestConverters {
         }
     }
 
+    public static class UnformattedStringConverter implements ResponseConverter {
+        @Override
+        public HttpResponse convert(Object resObj) throws Exception {
+            final DefaultHttpResponse res = new DefaultHttpResponse();
+            final HttpData data = HttpData.ofUtf8(resObj.toString());
+            final long current = System.currentTimeMillis();
+            HttpHeaders headers = HttpHeaders.of(HttpStatus.OK)
+                                             .setInt(HttpHeaderNames.CONTENT_LENGTH,
+                                                     data.length())
+                                             .setTimeMillis(HttpHeaderNames.DATE, current);
+            res.write(headers);
+            res.write(data);
+            res.close();
+            return res;
+        }
+    }
+
     private TestConverters() {}
 }

--- a/core/src/test/java/com/linecorp/armeria/server/http/dynamic/DynamicHttpServiceBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/http/dynamic/DynamicHttpServiceBuilderTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.http.dynamic;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.Test;
+
+import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.common.http.AggregatedHttpMessage;
+import com.linecorp.armeria.common.http.HttpRequest;
+
+public class DynamicHttpServiceBuilderTest {
+
+    @Test
+    public void testBuildingAnnotatedService_success() {
+        DynamicHttpServiceBuilder builder = new DynamicHttpServiceBuilder();
+        builder.addMappings(new Object() {
+            @Get
+            @Path("/ok/1")
+            public Object ok1(RequestContext context, AggregatedHttpMessage message) {
+                return null;
+            }
+
+            @Get
+            @Path("/ok/2")
+            public Object ok2(RequestContext context, HttpRequest request) {
+                return null;
+            }
+        });
+    }
+
+    @Test
+    public void testBuildingAnnotatedService_failure() {
+        DynamicHttpServiceBuilder builder = new DynamicHttpServiceBuilder();
+        assertThatThrownBy(() -> builder.addMappings(new Object() {
+            @Get
+            @Path("/more-then-one-request-parameter")
+            public Object moreThanOneRequestParameter(AggregatedHttpMessage message, HttpRequest request) {
+                return null;
+            }
+        })).isInstanceOf(IllegalArgumentException.class);
+    }
+}


### PR DESCRIPTION
Motivation:

AggregatedHttpMessage is useful for the most cases of restful API.
So it is better to aggregate stream messages automatically and inject the aggregated message into a DynamicHttpFunction method.

Modifications:

- Inject AggregatedHttpMessage into a DynamicHttpFunction method automatically.
- Support AggregatedHttpMessage as a return type.

Result:

Fixes #562.