### PR TITLE
Notify HTTP message aggregation future even on abortion

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/http/HttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/http/HttpRequest.java
@@ -134,7 +134,9 @@ public interface HttpRequest extends Request, StreamMessage<HttpObject> {
      */
     default CompletableFuture<AggregatedHttpMessage> aggregate() {
         final CompletableFuture<AggregatedHttpMessage> future = new CompletableFuture<>();
-        subscribe(new HttpRequestAggregator(this, future));
+        final HttpRequestAggregator aggregator = new HttpRequestAggregator(this, future);
+        closeFuture().whenComplete(aggregator);
+        subscribe(aggregator);
         return future;
     }
 
@@ -144,7 +146,9 @@ public interface HttpRequest extends Request, StreamMessage<HttpObject> {
      */
     default CompletableFuture<AggregatedHttpMessage> aggregate(Executor executor) {
         final CompletableFuture<AggregatedHttpMessage> future = new CompletableFuture<>();
-        subscribe(new HttpRequestAggregator(this, future), executor);
+        final HttpRequestAggregator aggregator = new HttpRequestAggregator(this, future);
+        closeFuture().whenCompleteAsync(aggregator, executor);
+        subscribe(aggregator, executor);
         return future;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/http/HttpRequestAggregator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/http/HttpRequestAggregator.java
@@ -30,28 +30,17 @@ final class HttpRequestAggregator extends HttpMessageAggregator {
     }
 
     @Override
-    public void onNext(HttpObject o) {
-        if (o instanceof HttpHeaders) {
-            trailingHeaders = (HttpHeaders) o;
-        } else {
-            add((HttpData) o);
-        }
+    protected void onHeaders(HttpHeaders headers) {
+        trailingHeaders = headers;
     }
 
     @Override
-    public void onError(Throwable t) {
-        clear();
-        future().completeExceptionally(t);
+    protected AggregatedHttpMessage onSuccess(HttpData content) {
+        return AggregatedHttpMessage.of(request.headers(), content, trailingHeaders);
     }
 
     @Override
-    protected void doClear() {
+    protected void onFailure() {
         trailingHeaders = HttpHeaders.EMPTY_HEADERS;
-    }
-
-    @Override
-    public void onComplete() {
-        final HttpData content = finish();
-        future().complete(AggregatedHttpMessage.of(request.headers(), content, trailingHeaders));
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/http/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/http/HttpResponse.java
@@ -77,7 +77,9 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
      */
     default CompletableFuture<AggregatedHttpMessage> aggregate() {
         final CompletableFuture<AggregatedHttpMessage> future = new CompletableFuture<>();
-        subscribe(new HttpResponseAggregator(future));
+        final HttpResponseAggregator aggregator = new HttpResponseAggregator(future);
+        closeFuture().whenComplete(aggregator);
+        subscribe(aggregator);
         return future;
     }
 
@@ -87,7 +89,9 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
      */
     default CompletableFuture<AggregatedHttpMessage> aggregate(Executor executor) {
         final CompletableFuture<AggregatedHttpMessage> future = new CompletableFuture<>();
-        subscribe(new HttpResponseAggregator(future), executor);
+        final HttpResponseAggregator aggregator = new HttpResponseAggregator(future);
+        closeFuture().whenCompleteAsync(aggregator, executor);
+        subscribe(aggregator, executor);
         return future;
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/common/http/DefaultHttpRequestTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/http/DefaultHttpRequestTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.DisableOnDebug;
+import org.junit.rules.TestRule;
+import org.junit.rules.Timeout;
+
+import com.linecorp.armeria.common.stream.CancelledSubscriptionException;
+
+public class DefaultHttpRequestTest {
+
+    @Rule
+    public TestRule globalTimeout = new DisableOnDebug(new Timeout(10, TimeUnit.SECONDS));
+
+    /**
+     * The aggregation future must be completed even if the request being aggregated has been aborted.
+     */
+    @Test
+    public void abortedAggregationWithoutExecutor() {
+        final Thread mainThread = Thread.currentThread();
+        final DefaultHttpRequest req = new DefaultHttpRequest(HttpHeaders.of(HttpMethod.GET, "/foo"));
+        final CompletableFuture<AggregatedHttpMessage> future = req.aggregate();
+        final AtomicReference<Thread> callbackThread = new AtomicReference<>();
+
+        future.whenComplete((unused, cause) -> {
+            callbackThread.set(Thread.currentThread());
+            assertThat(cause).isInstanceOf(CancelledSubscriptionException.class);
+        });
+
+        req.abort();
+        assertThat(future).isCompletedExceptionally();
+        assertThat(callbackThread.get()).isSameAs(mainThread);
+    }
+
+    /**
+     * Same with {@link #abortedAggregationWithoutExecutor()} but with an {@link Executor}.
+     */
+    @Test
+    public void abortedAggregationWithExecutor() {
+        final ExecutorService executor = Executors.newSingleThreadExecutor();
+        final Thread mainThread = Thread.currentThread();
+        try {
+            final DefaultHttpRequest req = new DefaultHttpRequest(HttpHeaders.of(HttpMethod.GET, "/foo"));
+            final CompletableFuture<AggregatedHttpMessage> future = req.aggregate(executor);
+            final AtomicReference<Thread> callbackThread = new AtomicReference<>();
+            final AtomicReference<Throwable> callbackCause = new AtomicReference<>();
+
+            future.whenComplete((unused, cause) -> {
+                callbackCause.set(cause);
+                callbackThread.set(Thread.currentThread());
+            });
+
+            req.abort();
+            await().until(() -> callbackThread.get() != null);
+
+            assertThat(callbackThread.get()).isNotSameAs(mainThread);
+            assertThat(callbackCause.get()).isInstanceOf(CancelledSubscriptionException.class);
+            assertThat(future).isCompletedExceptionally();
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/common/http/DefaultHttpResponseTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/http/DefaultHttpResponseTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.DisableOnDebug;
+import org.junit.rules.TestRule;
+import org.junit.rules.Timeout;
+
+import com.linecorp.armeria.common.stream.CancelledSubscriptionException;
+
+public class DefaultHttpResponseTest {
+
+    @Rule
+    public TestRule globalTimeout = new DisableOnDebug(new Timeout(10, TimeUnit.SECONDS));
+
+    /**
+     * The aggregation future must be completed even if the response being aggregated has been aborted.
+     */
+    @Test
+    public void abortedAggregationWithoutExecutor() {
+        final Thread mainThread = Thread.currentThread();
+        final DefaultHttpResponse res = new DefaultHttpResponse();
+        final CompletableFuture<AggregatedHttpMessage> future = res.aggregate();
+        final AtomicReference<Thread> callbackThread = new AtomicReference<>();
+
+        future.whenComplete((unused, cause) -> {
+            callbackThread.set(Thread.currentThread());
+            assertThat(cause).isInstanceOf(CancelledSubscriptionException.class);
+        });
+
+        res.abort();
+        assertThat(future).isCompletedExceptionally();
+        assertThat(callbackThread.get()).isSameAs(mainThread);
+    }
+
+    /**
+     * Same with {@link #abortedAggregationWithoutExecutor()} but with an {@link Executor}.
+     */
+    @Test
+    public void abortedAggregationWithExecutor() {
+        final ExecutorService executor = Executors.newSingleThreadExecutor();
+        final Thread mainThread = Thread.currentThread();
+        try {
+            final DefaultHttpResponse res = new DefaultHttpResponse();
+            final CompletableFuture<AggregatedHttpMessage> future = res.aggregate(executor);
+            final AtomicReference<Thread> callbackThread = new AtomicReference<>();
+            final AtomicReference<Throwable> callbackCause = new AtomicReference<>();
+
+            future.whenComplete((unused, cause) -> {
+                callbackCause.set(cause);
+                callbackThread.set(Thread.currentThread());
+            });
+
+            res.abort();
+            await().until(() -> callbackThread.get() != null);
+
+            assertThat(callbackThread.get()).isNotSameAs(mainThread);
+            assertThat(callbackCause.get()).isInstanceOf(CancelledSubscriptionException.class);
+            assertThat(future).isCompletedExceptionally();
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

HttpMessageAggregator and its subtypes were relying on
Subscriber.onError() and onComplete() to get notified when an HTTP
message stream is closed. However, they are not invoked when the message
is aborted or cancelled due to timeout, leaving the future returned by
aggregate() never fulfilled.

Modifications:

- Use StreamMessage.closeFuture() to always get notified when a stream
  being aggregated is closed
- Overall clean-up
  - Move the common code up from HttpRequest/ResponseAggregator to
    HttpMessageAggregator
  - Make most methods in HttpMessageAggregator final
- Add test cases

Result:

- Fixes #571