### PR TITLE
Add AggregatedHttpMessage.toHttpRequest/Response()

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/http/DefaultHttpClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/http/DefaultHttpClient.java
@@ -25,11 +25,7 @@ import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.UserClient;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.http.AggregatedHttpMessage;
-import com.linecorp.armeria.common.http.DefaultHttpRequest;
 import com.linecorp.armeria.common.http.DefaultHttpResponse;
-import com.linecorp.armeria.common.http.HttpData;
-import com.linecorp.armeria.common.http.HttpHeaderNames;
-import com.linecorp.armeria.common.http.HttpHeaders;
 import com.linecorp.armeria.common.http.HttpRequest;
 import com.linecorp.armeria.common.http.HttpResponse;
 
@@ -71,23 +67,6 @@ final class DefaultHttpClient extends UserClient<HttpRequest, HttpResponse> impl
     }
 
     HttpResponse execute(EventLoop eventLoop, AggregatedHttpMessage aggregatedReq) {
-        final HttpHeaders headers = aggregatedReq.headers();
-        final DefaultHttpRequest req = new DefaultHttpRequest(headers);
-        final HttpData content = aggregatedReq.content();
-
-        // Add content if not empty.
-        if (!content.isEmpty()) {
-            headers.setInt(HttpHeaderNames.CONTENT_LENGTH, content.length());
-            req.write(content);
-        }
-
-        // Add trailing headers if not empty.
-        final HttpHeaders trailingHeaders = aggregatedReq.trailingHeaders();
-        if (!trailingHeaders.isEmpty()) {
-            req.write(trailingHeaders);
-        }
-
-        req.close();
-        return execute(eventLoop, req);
+        return execute(eventLoop, aggregatedReq.toHttpRequest());
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/http/AggregatedHttpMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/http/AggregatedHttpMessage.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.common.http;
 
+import static com.linecorp.armeria.common.http.HttpHeaderNames.CONTENT_LENGTH;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Collections;
@@ -54,6 +55,19 @@ public interface AggregatedHttpMessage {
     }
 
     /**
+     * Creates a new HTTP request.
+     *
+     * @param method the HTTP method of the request
+     * @param path the path of the request
+     * @param content the content of the request
+     * @param trailingHeaders the trailing HTTP headers
+     */
+    static AggregatedHttpMessage of(HttpMethod method, String path,
+                                    HttpData content, HttpHeaders trailingHeaders) {
+        return of(HttpHeaders.of(method, path), content, trailingHeaders);
+    }
+
+    /**
      * Creates a new HTTP response with empty content.
      *
      * @param statusCode the HTTP status code
@@ -79,6 +93,17 @@ public interface AggregatedHttpMessage {
      */
     static AggregatedHttpMessage of(HttpStatus status, HttpData content) {
         return of(HttpHeaders.of(status), content);
+    }
+
+    /**
+     * Creates a new HTTP response.
+     *
+     * @param status the HTTP status
+     * @param content the content of the HTTP response
+     * @param trailingHeaders the trailing HTTP headers
+     */
+    static AggregatedHttpMessage of(HttpStatus status, HttpData content, HttpHeaders trailingHeaders) {
+        return of(HttpHeaders.of(status), content, trailingHeaders);
     }
 
     /**
@@ -127,12 +152,19 @@ public interface AggregatedHttpMessage {
         requireNonNull(content, "content");
         requireNonNull(trailingHeaders, "trailingHeaders");
 
-        // Set the 'content-length' header if possible, but do not overwrite because a response to
-        // a HEAD request will have no content but still have non-zero content-length header.
+        // Set the 'content-length' header if possible.
         final HttpStatus status = headers.status();
-        if (status != null && !ArmeriaHttpUtil.isContentAlwaysEmpty(status)) {
-            if (!headers.contains(HttpHeaderNames.CONTENT_LENGTH)) {
-                headers.setInt(HttpHeaderNames.CONTENT_LENGTH, content.length());
+        if (status != null) { // Response
+            // But do not overwrite the 'content-length' header because a response to a HEAD request
+            // will have no content even if it has non-zero content-length header.
+            if (!ArmeriaHttpUtil.isContentAlwaysEmpty(status) && !headers.contains(CONTENT_LENGTH)) {
+                headers.setInt(CONTENT_LENGTH, content.length());
+            }
+        } else { // Request
+            if (content.isEmpty()) {
+                headers.remove(CONTENT_LENGTH);
+            } else {
+                headers.setInt(CONTENT_LENGTH, content.length());
             }
         }
 
@@ -204,5 +236,78 @@ public interface AggregatedHttpMessage {
      */
     default HttpStatus status() {
         return headers().status();
+    }
+
+    /**
+     * Converts this message into a new complete {@link HttpRequest}.
+     *
+     * @return the converted {@link HttpRequest} whose stream is complete
+     * @throws IllegalStateException if this message is not a request
+     */
+    default HttpRequest toHttpRequest() {
+        final HttpHeaders headers = headers();
+
+        // From the section 8.1.2.3 of RFC 7540:
+        //// All HTTP/2 requests MUST include exactly one valid value for the :method, :scheme, and :path
+        //// pseudo-header fields, unless it is a CONNECT request (Section 8.3)
+        // NB: ':scheme' will be filled when a request is written.
+        if (headers.method() == null) {
+            throw new IllegalStateException("not a request (missing :method)");
+        }
+        if (headers.path() == null) {
+            throw new IllegalStateException("not a request (missing :path)");
+        }
+
+        final DefaultHttpRequest req = new DefaultHttpRequest(headers);
+        final HttpData content = content();
+        if (!content.isEmpty()) {
+            req.write(content);
+        }
+
+        final HttpHeaders trailingHeaders = trailingHeaders();
+        if (!trailingHeaders.isEmpty()) {
+            req.write(trailingHeaders);
+        }
+
+        req.close();
+        return req;
+    }
+
+    /**
+     * Converts this message into a new complete {@link HttpResponse}.
+     *
+     * @return the converted {@link HttpResponse} whose stream is complete
+     * @throws IllegalStateException if this message is not a response.
+     */
+    default HttpResponse toHttpResponse() {
+        final DefaultHttpResponse res = new DefaultHttpResponse();
+        final List<HttpHeaders> informationals = informationals();
+        final HttpHeaders headers = headers();
+
+        // From the section 8.1.2.4 of RFC 7540:
+        //// For HTTP/2 responses, a single :status pseudo-header field is defined that carries the HTTP status
+        //// code field (see [RFC7231], Section 6). This pseudo-header field MUST be included in all responses;
+        //// otherwise, the response is malformed (Section 8.1.2.6).
+        if (headers.status() == null) {
+            throw new IllegalStateException("not a response (missing :status)");
+        }
+
+        if (!informationals.isEmpty()) {
+            informationals.forEach(res::write);
+        }
+
+        res.write(headers);
+
+        final HttpData content = content();
+        if (!content.isEmpty()) {
+            res.write(content);
+        }
+
+        final HttpHeaders trailingHeaders = trailingHeaders();
+        if (!trailingHeaders.isEmpty()) {
+            res.write(trailingHeaders);
+        }
+        res.close();
+        return res;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/http/HttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/http/HttpRequest.java
@@ -41,7 +41,7 @@ public interface HttpRequest extends Request, StreamMessage<HttpObject> {
     }
 
     /**
-     * Returns a new {@link HttpRequest} with empty content.
+     * Creates a new {@link HttpRequest} with empty content.
      */
     static HttpRequest of(HttpHeaders headers) {
         // TODO(trustin): Use no-op Queue implementation for QueueBasedPublisher?

--- a/core/src/main/java/com/linecorp/armeria/server/http/dynamic/DynamicHttpFunctions.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/dynamic/DynamicHttpFunctions.java
@@ -21,7 +21,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 import com.linecorp.armeria.common.http.AggregatedHttpMessage;
-import com.linecorp.armeria.common.http.DefaultHttpResponse;
 import com.linecorp.armeria.common.http.HttpRequest;
 import com.linecorp.armeria.common.http.HttpResponse;
 import com.linecorp.armeria.internal.Types;
@@ -76,7 +75,7 @@ final class DynamicHttpFunctions {
         if (object instanceof HttpResponse) {
             return (HttpResponse) object;
         } else if (object instanceof AggregatedHttpMessage) {
-            return convert((AggregatedHttpMessage) object);
+            return ((AggregatedHttpMessage) object).toHttpResponse();
         } else {
             ResponseConverter converter = converter(object.getClass(), converters);
             try {
@@ -96,7 +95,7 @@ final class DynamicHttpFunctions {
         if (object instanceof HttpResponse) {
             return (HttpResponse) object;
         } else if (object instanceof AggregatedHttpMessage) {
-            return convert((AggregatedHttpMessage) object);
+            return ((AggregatedHttpMessage) object).toHttpResponse();
         } else {
             try {
                 return converter.convert(object);
@@ -104,15 +103,6 @@ final class DynamicHttpFunctions {
                 throw new IllegalStateException("Exception occurred during ResponseConverter#convert", e);
             }
         }
-    }
-
-    /**
-     * Converts {@link AggregatedHttpMessage} object into {@link HttpResponse}.
-     */
-    private static HttpResponse convert(AggregatedHttpMessage aggregatedMessage) {
-        DefaultHttpResponse response = new DefaultHttpResponse();
-        response.respond(aggregatedMessage);
-        return response;
     }
 
     /**

--- a/core/src/test/java/com/linecorp/armeria/common/http/DefaultAggregatedHttpMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/http/DefaultAggregatedHttpMessageTest.java
@@ -1,0 +1,176 @@
+/*
+ *  Copyright 2017 LINE Corporation
+ *
+ *  LINE Corporation licenses this file to you under the Apache License,
+ *  version 2.0 (the "License"); you may not use this file except in compliance
+ *  with the License. You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package com.linecorp.armeria.common.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.common.stream.StreamMessage;
+
+public class DefaultAggregatedHttpMessageTest {
+
+    @Test
+    public void toHttpRequest() throws Exception {
+        final AggregatedHttpMessage aReq = AggregatedHttpMessage.of(
+                HttpMethod.POST, "/foo", HttpData.of(StandardCharsets.US_ASCII, "bar"));
+        final HttpRequest req = aReq.toHttpRequest();
+        final List<HttpObject> unaggregated = unaggregate(req);
+
+        assertThat(req.headers()).isEqualTo(HttpHeaders.of(HttpMethod.POST, "/foo")
+                                                       .setInt(HttpHeaderNames.CONTENT_LENGTH, 3));
+        assertThat(unaggregated).containsExactly(HttpData.of(StandardCharsets.US_ASCII, "bar"));
+    }
+
+    @Test
+    public void toHttpRequestWithoutContent() throws Exception {
+        final AggregatedHttpMessage aReq = AggregatedHttpMessage.of(HttpMethod.GET, "/bar");
+        final HttpRequest req = aReq.toHttpRequest();
+        final List<HttpObject> unaggregated = unaggregate(req);
+
+        assertThat(req.headers()).isEqualTo(HttpHeaders.of(HttpMethod.GET, "/bar"));
+        assertThat(unaggregated).isEmpty();
+    }
+
+    @Test
+    public void toHttpRequestWithTrailingHeaders() throws Exception {
+        final AggregatedHttpMessage aReq = AggregatedHttpMessage.of(
+                HttpMethod.PUT, "/baz", HttpData.of(StandardCharsets.US_ASCII, "bar"),
+                HttpHeaders.of(HttpHeaderNames.CONTENT_MD5, "37b51d194a7513e45b56f6524f2d51f2"));
+        final HttpRequest req = aReq.toHttpRequest();
+        final List<HttpObject> unaggregated = unaggregate(req);
+
+        assertThat(req.headers()).isEqualTo(HttpHeaders.of(HttpMethod.PUT, "/baz")
+                                                       .setInt(HttpHeaderNames.CONTENT_LENGTH, 3));
+        assertThat(unaggregated).containsExactly(
+                HttpData.of(StandardCharsets.US_ASCII, "bar"),
+                HttpHeaders.of(HttpHeaderNames.CONTENT_MD5, "37b51d194a7513e45b56f6524f2d51f2"));
+    }
+
+    @Test
+    public void toHttpRequestAgainstResponse() {
+        final AggregatedHttpMessage aRes = AggregatedHttpMessage.of(200);
+        assertThatThrownBy(aRes::toHttpRequest).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void toHttpRequestWithoutPath() {
+        // Method only
+        assertThatThrownBy(() -> AggregatedHttpMessage.of(HttpHeaders.of(HttpHeaderNames.METHOD, "GET"))
+                                                      .toHttpRequest())
+                .isInstanceOf(IllegalStateException.class);
+
+        // Path only
+        assertThatThrownBy(() -> AggregatedHttpMessage.of(HttpHeaders.of(HttpHeaderNames.PATH, "/charlie"))
+                                                      .toHttpRequest())
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void toHttpResponse() throws Exception {
+        final AggregatedHttpMessage aRes = AggregatedHttpMessage.of(
+                HttpStatus.OK, HttpData.of(StandardCharsets.US_ASCII, "alice"));
+        final HttpResponse res = aRes.toHttpResponse();
+        final List<HttpObject> unaggregated = unaggregate(res);
+
+        assertThat(unaggregated).containsExactly(
+                HttpHeaders.of(HttpStatus.OK)
+                           .setInt(HttpHeaderNames.CONTENT_LENGTH, 5),
+                HttpData.of(StandardCharsets.US_ASCII, "alice"));
+    }
+
+    @Test
+    public void toHttpResponseWithoutContent() throws Exception {
+        final AggregatedHttpMessage aRes = AggregatedHttpMessage.of(HttpStatus.OK);
+        final HttpResponse res = aRes.toHttpResponse();
+        final List<HttpObject> unaggregated = unaggregate(res);
+
+        assertThat(unaggregated).containsExactly(
+                HttpHeaders.of(HttpStatus.OK)
+                           .setInt(HttpHeaderNames.CONTENT_LENGTH, 0));
+    }
+
+    @Test
+    public void toHttpResponseWithTrailingHeaders() throws Exception {
+        final AggregatedHttpMessage aRes = AggregatedHttpMessage.of(
+                HttpStatus.OK, HttpData.of(StandardCharsets.US_ASCII, "bob"),
+                HttpHeaders.of(HttpHeaderNames.CONTENT_MD5, "9f9d51bc70ef21ca5c14f307980a29d8"));
+        final HttpResponse res = aRes.toHttpResponse();
+        final List<HttpObject> unaggregated = unaggregate(res);
+
+        assertThat(unaggregated).containsExactly(
+                HttpHeaders.of(HttpStatus.OK)
+                           .setInt(HttpHeaderNames.CONTENT_LENGTH, 3),
+                HttpData.of(StandardCharsets.US_ASCII, "bob"),
+                HttpHeaders.of(HttpHeaderNames.CONTENT_MD5, "9f9d51bc70ef21ca5c14f307980a29d8"));
+    }
+
+    @Test
+    public void toHttpResponseWithInformationals() throws Exception {
+        final AggregatedHttpMessage aRes = AggregatedHttpMessage.of(
+                ImmutableList.of(HttpHeaders.of(HttpStatus.CONTINUE)),
+                HttpHeaders.of(HttpStatus.OK), HttpData.EMPTY_DATA, HttpHeaders.EMPTY_HEADERS);
+
+        final HttpResponse res = aRes.toHttpResponse();
+        final List<HttpObject> unaggregated = unaggregate(res);
+
+        assertThat(unaggregated).containsExactly(
+                HttpHeaders.of(HttpStatus.CONTINUE),
+                HttpHeaders.of(HttpStatus.OK)
+                           .setInt(HttpHeaderNames.CONTENT_LENGTH, 0));
+    }
+
+    @Test
+    public void toHttpResponseAgainstRequest() {
+        final AggregatedHttpMessage aReq = AggregatedHttpMessage.of(HttpMethod.GET, "/qux");
+        assertThatThrownBy(aReq::toHttpResponse).isInstanceOf(IllegalStateException.class);
+    }
+
+    private static List<HttpObject> unaggregate(StreamMessage<HttpObject> req) throws Exception {
+        final List<HttpObject> unaggregated = new ArrayList<>();
+        req.subscribe(new Subscriber<HttpObject>() {
+            @Override
+            public void onSubscribe(Subscription s) {
+                s.request(Long.MAX_VALUE);
+            }
+
+            @Override
+            public void onNext(HttpObject httpObject) {
+                unaggregated.add(httpObject);
+            }
+
+            @Override
+            public void onError(Throwable t) {}
+
+            @Override
+            public void onComplete() {}
+        });
+
+        req.closeFuture().get(10, TimeUnit.SECONDS);
+        return unaggregated;
+    }
+}

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcService.java
@@ -237,7 +237,9 @@ class UnframedGrpcService extends SimpleDecoratingService<HttpRequest, HttpRespo
                         // We also know that we don't support compression, so this is always a ByteBuffer.
                         HttpData unframedContent = new ByteBufHttpData(message.buf(), true);
                         unframedHeaders.setInt(HttpHeaderNames.CONTENT_LENGTH, unframedContent.length());
-                        res.respond(AggregatedHttpMessage.of(unframedHeaders, unframedContent));
+                        res.write(unframedHeaders);
+                        res.write(unframedContent);
+                        res.close();
                     }
 
                     @Override


### PR DESCRIPTION
.. so that a user can write more concise code:

    // Before:
    AggregatedHttpMessage aReq = ...;
    DefaultHttpRequest req = new DefaultHttpRequest(aReq.headers());
    req.write(aReq.content());
    req.close();

    AggregatedHttpResponse aRes = ...;
    DefaultHttpResponse res = new DefaultHttpResponse();
    res.respond(aRes);

    // After:
    AggregatedHttpMessage aReq = ...;
    HttpRequest req = aReq.toHttpRequest();

    AggregatedHttpResponse aRes = ...;
    HttpResponse res = aRes.toHttpResponse();

This commit also makes the following additional changes:

- Add more variants of AggregatedHttpMessages.of() for convenience
- Use AggregatedHttpMessage.toHttpRequest/Response() where possible

Result:

- Fixes #575