### PR TITLE
Rename HttpResponse.ofFailed() to ofFailure()

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/http/DefaultHttpClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/http/DefaultHttpClient.java
@@ -55,7 +55,7 @@ final class DefaultHttpClient extends UserClient<HttpRequest, HttpResponse> impl
         final String[] pathAndQuery = splitPathAndQuery(concatPaths);
         if (pathAndQuery == null) {
             req.abort();
-            return HttpResponse.ofFailed(new IllegalArgumentException("invalid path: " + concatPaths));
+            return HttpResponse.ofFailure(new IllegalArgumentException("invalid path: " + concatPaths));
         }
 
         return execute(eventLoop, req.method(), pathAndQuery[0], pathAndQuery[1], null, req, cause -> {

--- a/core/src/main/java/com/linecorp/armeria/client/http/HttpClientDelegate.java
+++ b/core/src/main/java/com/linecorp/armeria/client/http/HttpClientDelegate.java
@@ -75,7 +75,7 @@ final class HttpClientDelegate implements Client<HttpRequest, HttpResponse> {
         autoFillHeaders(ctx, endpoint, req);
         if (!sanitizePath(req)) {
             req.abort();
-            return HttpResponse.ofFailed(new IllegalArgumentException("invalid path: " + req.path()));
+            return HttpResponse.ofFailure(new IllegalArgumentException("invalid path: " + req.path()));
         }
 
         final PoolKey poolKey = new PoolKey(

--- a/core/src/main/java/com/linecorp/armeria/common/http/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/http/HttpResponse.java
@@ -42,10 +42,18 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
     /**
      * Creates a new failed instance.
      */
-    static HttpResponse ofFailed(Throwable cause) {
+    static HttpResponse ofFailure(Throwable cause) {
         final DefaultHttpResponse res = new DefaultHttpResponse();
         res.close(cause);
         return res;
+    }
+
+    /**
+     * @deprecated Use {@link #ofFailure(Throwable)} instead.
+     */
+    @Deprecated
+    static HttpResponse ofFailed(Throwable cause) {
+        return ofFailure(cause);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/http/dynamic/MappedDynamicFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/dynamic/MappedDynamicFunction.java
@@ -34,7 +34,7 @@ final class MappedDynamicFunction extends AbstractHttpService {
     public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
         final Object ret = function.serve(ctx, req, args);
         if (!(ret instanceof CompletionStage)) {
-            return HttpResponse.ofFailed(new IllegalStateException(
+            return HttpResponse.ofFailure(new IllegalStateException(
                     "illegal return type: " + ret.getClass().getSimpleName()));
         }
 


### PR DESCRIPTION
Motivation:

HttpResponse has ofFailed() while RpcResponse has ofFailure(). We need
consistency here.

Modifications:

- Rename HttpResponse.ofFailed() to ofFailure()
- Add back HttpResponse.ofFailed() and deprecate it

Result:

Consistency