### PR TITLE
Provide more ways to specify a path pattern

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/AbstractVirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AbstractVirtualHostBuilder.java
@@ -200,16 +200,11 @@ abstract class AbstractVirtualHostBuilder<B extends AbstractVirtualHostBuilder> 
     }
 
     /**
-     * Binds the specified {@link Service} at the the specified path pattern. e.g.
-     * <ul>
-     *   <li>{@code /login} (no path parameters)</li>
-     *   <li>{@code /users/{userId}} (curly-brace style)</li>
-     *   <li>{@code /list/:productType/by/:ordering} (colon style)</li>
-     * </ul>
+     * @deprecated Use {@link #service(String, Service)} instead.
      */
+    @Deprecated
     public B serviceAt(String pathPattern, Service<? super HttpRequest, ? extends HttpResponse> service) {
-        service(PathMapping.of(pathPattern), service);
-        return self();
+        return service(pathPattern, service);
     }
 
     /**
@@ -217,6 +212,25 @@ abstract class AbstractVirtualHostBuilder<B extends AbstractVirtualHostBuilder> 
      */
     public B serviceUnder(String pathPrefix, Service<? super HttpRequest, ? extends HttpResponse> service) {
         service(PathMapping.ofPrefix(pathPrefix), service);
+        return self();
+    }
+
+    /**
+     * Binds the specified {@link Service} at the the specified path pattern. e.g.
+     * <ul>
+     *   <li>{@code /login} (no path parameters)</li>
+     *   <li>{@code /users/{userId}} (curly-brace style)</li>
+     *   <li>{@code /list/:productType/by/:ordering} (colon style)</li>
+     *   <li>{@code exact:/foo/bar} (exact match)</li>
+     *   <li>{@code prefix:/files} (prefix match)</li>
+     *   <li><code>glob:/~&#42;/downloads/**</code> (glob pattern)</li>
+     *   <li>{@code regex:^/files/(?<filePath>.*)$} (regular expression)</li>
+     * </ul>
+     *
+     * @throws IllegalArgumentException if the specified path pattern is invalid
+     */
+    public B service(String pathPattern, Service<? super HttpRequest, ? extends HttpResponse> service) {
+        service(PathMapping.of(pathPattern), service);
         return self();
     }
 
@@ -243,66 +257,65 @@ abstract class AbstractVirtualHostBuilder<B extends AbstractVirtualHostBuilder> 
     /**
      * Binds the specified annotated service object under the path prefix {@code "/"}.
      */
-    public B service(Object service) {
-        return service("/", service);
+    public B annotatedService(Object service) {
+        return annotatedService("/", service);
     }
 
     /**
      * Binds the specified annotated service object under the path prefix {@code "/"}.
      */
-    public B service(
+    public B annotatedService(
             Object service,
             Function<Service<HttpRequest, HttpResponse>,
                      ? extends Service<? super HttpRequest, ? extends HttpResponse>> decorator) {
-        return service("/", service, decorator);
+        return annotatedService("/", service, decorator);
     }
 
     /**
      * Binds the specified annotated service object under the path prefix {@code "/"}.
      */
-    public B service(Object service, Map<Class<?>, ResponseConverter> converters) {
-        return service("/", service, converters);
+    public B annotatedService(Object service, Map<Class<?>, ResponseConverter> converters) {
+        return annotatedService("/", service, converters);
     }
 
     /**
      * Binds the specified annotated service object under the path prefix {@code "/"}.
      */
-    public B service(
+    public B annotatedService(
             Object service, Map<Class<?>, ResponseConverter> converters,
             Function<Service<HttpRequest, HttpResponse>,
                      ? extends Service<? super HttpRequest, ? extends HttpResponse>> decorator) {
-        return service("/", service, converters, decorator);
-    }
-
-
-    /**
-     * Binds the specified annotated service object under the specified path prefix.
-     */
-    public B service(String pathPrefix, Object service) {
-        return service(pathPrefix, service, ImmutableMap.of(), Function.identity());
+        return annotatedService("/", service, converters, decorator);
     }
 
     /**
      * Binds the specified annotated service object under the specified path prefix.
      */
-    public B service(
+    public B annotatedService(String pathPrefix, Object service) {
+        return annotatedService(pathPrefix, service, ImmutableMap.of(), Function.identity());
+    }
+
+    /**
+     * Binds the specified annotated service object under the specified path prefix.
+     */
+    public B annotatedService(
             String pathPrefix, Object service,
             Function<Service<HttpRequest, HttpResponse>,
                      ? extends Service<? super HttpRequest, ? extends HttpResponse>> decorator) {
-        return service(pathPrefix, service, ImmutableMap.of(), decorator);
+        return annotatedService(pathPrefix, service, ImmutableMap.of(), decorator);
     }
 
     /**
      * Binds the specified annotated service object under the specified path prefix.
      */
-    public B service(String pathPrefix, Object service, Map<Class<?>, ResponseConverter> converters) {
-        return service(pathPrefix, service, converters, Function.identity());
+    public B annotatedService(String pathPrefix, Object service, Map<Class<?>, ResponseConverter> converters) {
+        return annotatedService(pathPrefix, service, converters, Function.identity());
     }
 
     /**
      * Binds the specified annotated service object under the specified path prefix.
      */
-    public B service(
+    public B annotatedService(
             String pathPrefix, Object service, Map<Class<?>, ResponseConverter> converters,
             Function<Service<HttpRequest, HttpResponse>,
                      ? extends Service<? super HttpRequest, ? extends HttpResponse>> decorator) {

--- a/core/src/main/java/com/linecorp/armeria/server/ExactPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ExactPathMapping.java
@@ -25,6 +25,9 @@ import com.google.common.collect.ImmutableSet;
 
 final class ExactPathMapping extends AbstractPathMapping {
 
+    static final String PREFIX = "exact:";
+    static final int PREFIX_LEN = PREFIX.length();
+
     private final String exactPath;
     private final String loggerName;
     private final Optional<String> exactPathOpt;
@@ -34,7 +37,7 @@ final class ExactPathMapping extends AbstractPathMapping {
         this.exactPath = ensureAbsolutePath(exactPath, "exactPath");
         exactPathOpt = Optional.of(exactPath);
         loggerName = loggerName(exactPath);
-        strVal = "exact: " + exactPath;
+        strVal = PREFIX + exactPath;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/GlobPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/GlobPathMapping.java
@@ -21,9 +21,13 @@ import java.util.regex.Pattern;
 
 import javax.annotation.Nullable;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 
 final class GlobPathMapping extends AbstractPathMapping {
+
+    static final String PREFIX = "glob:";
+    static final int PREFIX_LEN = PREFIX.length();
 
     private final String glob;
     private final Pattern pattern;
@@ -34,7 +38,7 @@ final class GlobPathMapping extends AbstractPathMapping {
         this.glob = glob;
         pattern = globToRegex(glob);
         loggerName = loggerName(glob);
-        strVal = "glob:" + glob;
+        strVal = PREFIX + glob;
     }
 
     @Override
@@ -58,6 +62,7 @@ final class GlobPathMapping extends AbstractPathMapping {
         return glob;
     }
 
+    @VisibleForTesting
     Pattern asRegex() {
         return pattern;
     }

--- a/core/src/main/java/com/linecorp/armeria/server/PrefixPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/PrefixPathMapping.java
@@ -25,6 +25,9 @@ import com.google.common.collect.ImmutableSet;
 
 final class PrefixPathMapping extends AbstractPathMapping {
 
+    static final String PREFIX = "prefix:";
+    static final int PREFIX_LEN = PREFIX.length();
+
     private final String prefix;
     private final String loggerName;
     private final String metricName;
@@ -39,7 +42,7 @@ final class PrefixPathMapping extends AbstractPathMapping {
         this.prefix = prefix;
         loggerName = loggerName(prefix);
         metricName = prefix + "**";
-        strVal = "prefix: " + prefix;
+        strVal = PREFIX + prefix;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/RegexPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RegexPathMapping.java
@@ -24,10 +24,14 @@ import java.util.regex.Pattern;
 
 import javax.annotation.Nullable;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
 final class RegexPathMapping extends AbstractPathMapping {
+
+    static final String PREFIX = "regex:";
+    static final int PREFIX_LEN = PREFIX.length();
 
     private static final Pattern NAMED_GROUP_PATTERN = Pattern.compile("\\(\\?<([^>]+)>");
 
@@ -40,7 +44,7 @@ final class RegexPathMapping extends AbstractPathMapping {
         this.regex = requireNonNull(regex, "regex");
         paramNames = findParamNames(regex);
         loggerName = toLoggerName(regex);
-        strVal = "regex: " + regex.pattern();
+        strVal = PREFIX + regex.pattern();
     }
 
     private static Set<String> findParamNames(Pattern regex) {
@@ -106,6 +110,11 @@ final class RegexPathMapping extends AbstractPathMapping {
     @Override
     public String metricName() {
         return strVal;
+    }
+
+    @VisibleForTesting
+    Pattern asRegex() {
+        return regex;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -56,9 +56,9 @@ import io.netty.util.concurrent.DefaultThreadFactory;
  * // Add a port to listen
  * sb.port(8080, SessionProtocol.HTTP);
  * // Build and add a virtual host.
- * sb.virtualHost(new VirtualHostBuilder("*.foo.com").serviceAt(...).build());
+ * sb.virtualHost(new VirtualHostBuilder("*.foo.com").service(...).build());
  * // Add services to the default virtual host.
- * sb.serviceAt(...);
+ * sb.service(...);
  * sb.serviceUnder(...);
  * // Build a server.
  * Server s = sb.build();
@@ -70,10 +70,10 @@ import io.netty.util.concurrent.DefaultThreadFactory;
  * Server server =
  *      sb.port(8080, SessionProtocol.HTTP) // Add a port to listen
  *      .withDefaultVirtualHost() // Add services to the default virtual host.
- *          .serviceAt(...)
+ *          .service(...)
  *          .serviceUnder(...)
  *      .and().withVirtualHost("*.foo.com") // Add a another virtual host.
- *          .serviceAt(...)
+ *          .service(...)
  *          .serviceUnder(...)
  *      .and().build(); // Build a server.
  * }</pre>
@@ -381,22 +381,12 @@ public final class ServerBuilder {
     }
 
     /**
-     * Binds the specified {@link Service} at the specified path pattern of the default {@link VirtualHost}.
-     * e.g.
-     * <ul>
-     *   <li>{@code /login} (no path parameters)</li>
-     *   <li>{@code /users/{userId}} (curly-brace style)</li>
-     *   <li>{@code /list/:productType/by/:ordering} (colon style)</li>
-     * </ul>
-     *
-     * @throws IllegalStateException if the default {@link VirtualHost} has been set via
-     *                               {@link #defaultVirtualHost(VirtualHost)} already
+     * @deprecated Use {@link #service(String, Service)} instead.
      */
+    @Deprecated
     public ServerBuilder serviceAt(String pathPattern,
                                    Service<? super HttpRequest, ? extends HttpResponse> service) {
-        defaultVirtualHostBuilderUpdated();
-        defaultVirtualHostBuilder.serviceAt(pathPattern, service);
-        return this;
+        return service(pathPattern, service);
     }
 
     /**
@@ -409,6 +399,30 @@ public final class ServerBuilder {
                                       Service<? super HttpRequest, ? extends HttpResponse> service) {
         defaultVirtualHostBuilderUpdated();
         defaultVirtualHostBuilder.serviceUnder(pathPrefix, service);
+        return this;
+    }
+
+    /**
+     * Binds the specified {@link Service} at the specified path pattern of the default {@link VirtualHost}.
+     * e.g.
+     * <ul>
+     *   <li>{@code /login} (no path parameters)</li>
+     *   <li>{@code /users/{userId}} (curly-brace style)</li>
+     *   <li>{@code /list/:productType/by/:ordering} (colon style)</li>
+     *   <li>{@code exact:/foo/bar} (exact match)</li>
+     *   <li>{@code prefix:/files} (prefix match)</li>
+     *   <li><code>glob:/~&#42;/downloads/**</code> (glob pattern)</li>
+     *   <li>{@code regex:^/files/(?<filePath>.*)$} (regular expression)</li>
+     * </ul>
+     *
+     * @throws IllegalArgumentException if the specified path pattern is invalid
+     * @throws IllegalStateException if the default {@link VirtualHost} has been set via
+     *                               {@link #defaultVirtualHost(VirtualHost)} already
+     */
+    public ServerBuilder service(String pathPattern,
+                                 Service<? super HttpRequest, ? extends HttpResponse> service) {
+        defaultVirtualHostBuilderUpdated();
+        defaultVirtualHostBuilder.service(pathPattern, service);
         return this;
     }
 
@@ -442,72 +456,72 @@ public final class ServerBuilder {
     /**
      * Binds the specified annotated service object under the path prefix {@code "/"}.
      */
-    public ServerBuilder service(Object service) {
-        return service("/", service);
+    public ServerBuilder annotatedService(Object service) {
+        return annotatedService("/", service);
     }
 
     /**
      * Binds the specified annotated service object.
      */
-    public ServerBuilder service(
+    public ServerBuilder annotatedService(
             Object service,
             Function<Service<HttpRequest, HttpResponse>,
                      ? extends Service<? super HttpRequest, ? extends HttpResponse>> decorator) {
-        return service("/", service, decorator);
+        return annotatedService("/", service, decorator);
     }
 
     /**
      * Binds the specified annotated service object under the path prefix {@code "/"}.
      */
-    public ServerBuilder service(Object service, Map<Class<?>, ResponseConverter> converters) {
-        return service("/", service, converters);
+    public ServerBuilder annotatedService(Object service, Map<Class<?>, ResponseConverter> converters) {
+        return annotatedService("/", service, converters);
     }
 
     /**
      * Binds the specified annotated service object under the path prefix {@code "/"}.
      */
-    public ServerBuilder service(
+    public ServerBuilder annotatedService(
             Object service, Map<Class<?>, ResponseConverter> converters,
             Function<Service<HttpRequest, HttpResponse>,
                      ? extends Service<? super HttpRequest, ? extends HttpResponse>> decorator) {
-        return service("/", service, converters, decorator);
+        return annotatedService("/", service, converters, decorator);
     }
 
     /**
      * Binds the specified annotated service object under the specified path prefix.
      */
-    public ServerBuilder service(String pathPrefix, Object service) {
-        return service(pathPrefix, service, ImmutableMap.of(), Function.identity());
+    public ServerBuilder annotatedService(String pathPrefix, Object service) {
+        return annotatedService(pathPrefix, service, ImmutableMap.of(), Function.identity());
     }
 
     /**
      * Binds the specified annotated service object under the specified path prefix.
      */
-    public ServerBuilder service(
+    public ServerBuilder annotatedService(
             String pathPrefix, Object service,
             Function<Service<HttpRequest, HttpResponse>,
                      ? extends Service<? super HttpRequest, ? extends HttpResponse>> decorator) {
-        return service(pathPrefix, service, ImmutableMap.of(), decorator);
+        return annotatedService(pathPrefix, service, ImmutableMap.of(), decorator);
     }
 
     /**
      * Binds the specified annotated service object under the specified path prefix.
      */
-    public ServerBuilder service(String pathPrefix, Object service,
-                                 Map<Class<?>, ResponseConverter> converters) {
-        return service(pathPrefix, service, converters, Function.identity());
+    public ServerBuilder annotatedService(String pathPrefix, Object service,
+                                          Map<Class<?>, ResponseConverter> converters) {
+        return annotatedService(pathPrefix, service, converters, Function.identity());
     }
 
     /**
      * Binds the specified annotated service object under the specified path prefix.
      */
-    public ServerBuilder service(
+    public ServerBuilder annotatedService(
             String pathPrefix, Object service, Map<Class<?>, ResponseConverter> converters,
             Function<Service<HttpRequest, HttpResponse>,
                      ? extends Service<? super HttpRequest, ? extends HttpResponse>> decorator) {
 
         defaultVirtualHostBuilderUpdated();
-        defaultVirtualHostBuilder.service(pathPrefix, service, converters, decorator);
+        defaultVirtualHostBuilder.annotatedService(pathPrefix, service, converters, decorator);
         return this;
     }
 
@@ -526,7 +540,7 @@ public final class ServerBuilder {
      *     if other default {@link VirtualHost} builder methods have been invoked already, including:
      *     <ul>
      *       <li>{@link #sslContext(SslContext)}</li>
-     *       <li>{@link #serviceAt(String, Service)}</li>
+     *       <li>{@link #service(String, Service)}</li>
      *       <li>{@link #serviceUnder(String, Service)}</li>
      *       <li>{@link #service(PathMapping, Service)}</li>
      *     </ul>

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
@@ -21,7 +21,7 @@ package com.linecorp.armeria.server;
  * <h2>Example</h2>
  * <pre>{@code
  * VirtualHostBuilder vhb = new VirtualHostBuilder("*.example.com");
- * vhb.serviceAt("/foo", new FooService())
+ * vhb.service("/foo", new FooService())
  *    .serviceUnder("/bar/", new BarService())
  *    .service(PathMapping.ofRegex("^/baz/.*", new BazService());
  *

--- a/core/src/main/java/com/linecorp/armeria/server/composition/AbstractCompositeServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/composition/AbstractCompositeServiceBuilder.java
@@ -91,7 +91,7 @@ public abstract class AbstractCompositeServiceBuilder<T extends AbstractComposit
     }
 
     /**
-     * Returns the list of the {@link CompositeServiceEntry}s added via {@link #serviceAt(String, Service)},
+     * Returns the list of the {@link CompositeServiceEntry}s added via {@link #service(String, Service)},
      * {@link #serviceUnder(String, Service)}, {@link #service(PathMapping, Service)} and
      * {@link #service(CompositeServiceEntry)}.
      */
@@ -100,10 +100,11 @@ public abstract class AbstractCompositeServiceBuilder<T extends AbstractComposit
     }
 
     /**
-     * Binds the specified {@link Service} at the specified exact path.
+     * @deprecated Use {@link #service(String, Service)} instead.
      */
-    protected T serviceAt(String exactPath, Service<? super I, ? extends O> service) {
-        return service(CompositeServiceEntry.ofExact(exactPath, service));
+    @Deprecated
+    protected T serviceAt(String pathPattern, Service<? super I, ? extends O> service) {
+        return service(pathPattern, service);
     }
 
     /**
@@ -111,6 +112,24 @@ public abstract class AbstractCompositeServiceBuilder<T extends AbstractComposit
      */
     protected T serviceUnder(String pathPrefix, Service<? super I, ? extends O> service) {
         return service(CompositeServiceEntry.ofPrefix(pathPrefix, service));
+    }
+
+    /**
+     * Binds the specified {@link Service} at the specified path pattern. e.g.
+     * <ul>
+     *   <li>{@code /login} (no path parameters)</li>
+     *   <li>{@code /users/{userId}} (curly-brace style)</li>
+     *   <li>{@code /list/:productType/by/:ordering} (colon style)</li>
+     *   <li>{@code exact:/foo/bar} (exact match)</li>
+     *   <li>{@code prefix:/files} (prefix match)</li>
+     *   <li><code>glob:/~&#42;/downloads/**</code> (glob pattern)</li>
+     *   <li>{@code regex:^/files/(?<filePath>.*)$} (regular expression)</li>
+     * </ul>
+     *
+     * @throws IllegalArgumentException if the specified path pattern is invalid
+     */
+    protected T service(String pathPattern, Service<? super I, ? extends O> service) {
+        return service(CompositeServiceEntry.of(pathPattern, service));
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/composition/SimpleCompositeServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/composition/SimpleCompositeServiceBuilder.java
@@ -33,14 +33,20 @@ public final class SimpleCompositeServiceBuilder<I extends Request, O extends Re
 
     @Override
     public SimpleCompositeServiceBuilder<I, O> serviceAt(
-            String exactPath, Service<? super I, ? extends O> service) {
-        return super.serviceAt(exactPath, service);
+            String pathPattern, Service<? super I, ? extends O> service) {
+        return super.serviceAt(pathPattern, service);
     }
 
     @Override
     public SimpleCompositeServiceBuilder<I, O> serviceUnder(
             String pathPrefix, Service<? super I, ? extends O>  service) {
         return super.serviceUnder(pathPrefix, service);
+    }
+
+    @Override
+    public SimpleCompositeServiceBuilder<I, O> service(
+            String pathPattern, Service<? super I, ? extends O> service) {
+        return super.service(pathPattern, service);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/http/healthcheck/HttpHealthCheckService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/healthcheck/HttpHealthCheckService.java
@@ -46,8 +46,8 @@ import com.linecorp.armeria.server.http.HttpService;
  * <pre>{@code
  * Server server = new ServerBuilder()
  *         .defaultVirtualHost(new VirtualHostBuilder()
- *                 .serviceAt("/rpc", new ThriftService(myHandler))
- *                 .serviceAt("/health", new HttpHealthCheckService())
+ *                 .service("/rpc", new ThriftService(myHandler))
+ *                 .service("/health", new HttpHealthCheckService())
  *                 .build())
  *         .build();
  * }</pre>
@@ -61,8 +61,8 @@ import com.linecorp.armeria.server.http.HttpService;
  * SettableHealthChecker healthChecker = new SettableHealthChecker();
  * Server server = new ServerBuilder()
  *         .defaultVirtualHost(new VirtualHostBuilder()
- *                 .serviceAt("/rpc", new ThriftService(myHandler))
- *                 .serviceAt("/health", new HttpHealthCheckService(healthChecker))
+ *                 .service("/rpc", new ThriftService(myHandler))
+ *                 .service("/health", new HttpHealthCheckService(healthChecker))
  *                 .build())
  *         .build();
  * }</pre>

--- a/core/src/main/java/com/linecorp/armeria/server/metric/DropwizardMetricCollectingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/metric/DropwizardMetricCollectingService.java
@@ -41,7 +41,7 @@ import com.linecorp.armeria.server.SimpleDecoratingService;
  * <p>Example:
  * <pre>{@code
  * MetricRegistry metricRegistry = new MetricRegistry();
- * serverBuilder.serviceAt(
+ * serverBuilder.service(
  *         "/service",
  *         ThriftService.of(handler).decorate(
  *                 DropwizardMetricCollectingService.newDecorator(metricRegistry, "services")));

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroupTest.java
@@ -43,7 +43,7 @@ public class HttpHealthCheckedEndpointGroupTest {
 
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
-            sb.serviceAt(HEALTH_CHECK_PATH, new HttpHealthCheckService());
+            sb.service(HEALTH_CHECK_PATH, new HttpHealthCheckService());
         }
     }
 

--- a/core/src/test/java/com/linecorp/armeria/client/http/HttpClientIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/http/HttpClientIntegrationTest.java
@@ -181,7 +181,7 @@ public class HttpClientIntegrationTest {
         protected void configure(ServerBuilder sb) throws Exception {
             sb.port(0, HTTP);
 
-            sb.serviceAt("/httptestbody", new AbstractHttpService() {
+            sb.service("/httptestbody", new AbstractHttpService() {
 
                 @Override
                 protected void doGet(ServiceRequestContext ctx, HttpRequest req,
@@ -229,7 +229,7 @@ public class HttpClientIntegrationTest {
                 }
             });
 
-            sb.serviceAt("/not200", new AbstractHttpService() {
+            sb.service("/not200", new AbstractHttpService() {
                 @Override
                 protected void doGet(ServiceRequestContext ctx, HttpRequest req,
                                      HttpResponseWriter res) {
@@ -237,7 +237,7 @@ public class HttpClientIntegrationTest {
                 }
             });
 
-            sb.serviceAt("/useragent", new AbstractHttpService() {
+            sb.service("/useragent", new AbstractHttpService() {
                 @Override
                 protected void doGet(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) {
                     String ua = req.headers().get(HttpHeaderNames.USER_AGENT, "undefined");
@@ -245,14 +245,14 @@ public class HttpClientIntegrationTest {
                 }
             });
 
-            sb.serviceAt("/hello/world", new AbstractHttpService() {
+            sb.service("/hello/world", new AbstractHttpService() {
                 @Override
                 protected void doGet(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) {
                     res.respond(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "success");
                 }
             });
 
-            sb.serviceAt("/encoding", new AbstractHttpService() {
+            sb.service("/encoding", new AbstractHttpService() {
                 @Override
                 protected void doGet(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res)
                         throws Exception {
@@ -263,7 +263,7 @@ public class HttpClientIntegrationTest {
                 }
             }.decorate(HttpEncodingService.class));
 
-            sb.serviceAt("/encoding-toosmall", new AbstractHttpService() {
+            sb.service("/encoding-toosmall", new AbstractHttpService() {
                 @Override
                 protected void doGet(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res)
                         throws Exception {
@@ -271,11 +271,11 @@ public class HttpClientIntegrationTest {
                 }
             }.decorate(HttpEncodingService.class));
 
-            sb.serviceAt("/pooled", new PooledContentService());
+            sb.service("/pooled", new PooledContentService());
 
-            sb.serviceAt("/pooled-aware", new PooledContentService().decorate(PoolAwareDecorator::new));
+            sb.service("/pooled-aware", new PooledContentService().decorate(PoolAwareDecorator::new));
 
-            sb.serviceAt("/pooled-unaware", new PooledContentService().decorate(PoolUnawareDecorator::new));
+            sb.service("/pooled-unaware", new PooledContentService().decorate(PoolUnawareDecorator::new));
         }
     };
 

--- a/core/src/test/java/com/linecorp/armeria/client/http/HttpClientPipeliningTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/http/HttpClientPipeliningTest.java
@@ -63,7 +63,7 @@ public class HttpClientPipeliningTest {
         protected void configure(ServerBuilder sb) throws Exception {
             // Bind a service that returns the remote address of the connection to determine
             // if the same connection was used to handle more than one request.
-            sb.serviceAt("/", new AbstractHttpService() {
+            sb.service("/", new AbstractHttpService() {
                 @Override
                 protected void doGet(ServiceRequestContext ctx,
                                      HttpRequest req, HttpResponseWriter res) throws Exception {

--- a/core/src/test/java/com/linecorp/armeria/client/http/HttpClientSniTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/http/HttpClientSniTest.java
@@ -77,8 +77,8 @@ public class HttpClientSniTest {
             final VirtualHostBuilder a = new VirtualHostBuilder("a.com");
             final VirtualHostBuilder b = new VirtualHostBuilder("b.com");
 
-            a.serviceAt("/", new SniTestService("a.com"));
-            b.serviceAt("/", new SniTestService("b.com"));
+            a.service("/", new SniTestService("a.com"));
+            b.service("/", new SniTestService("b.com"));
 
             a.sslContext(HTTPS, sscA.certificate(), sscA.privateKey());
             b.sslContext(HTTPS, sscB.certificate(), sscB.privateKey());

--- a/core/src/test/java/com/linecorp/armeria/server/ChainedVirtualHostBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ChainedVirtualHostBuilderTest.java
@@ -36,7 +36,7 @@ public class ChainedVirtualHostBuilderTest {
         assertThat(chainedVirtualHostBuilder).isEqualTo(sb.withDefaultVirtualHost());
 
         final Server server = sb.withDefaultVirtualHost()
-                                .serviceAt("/test", new TempService())
+                                .service("/test", new TempService())
                                 .and().build();
 
         assertThat(server).isNotNull();
@@ -50,7 +50,7 @@ public class ChainedVirtualHostBuilderTest {
     @Test
     public void defaultVirtualHostWithImplicitStyle() {
         final ServerBuilder sb = new ServerBuilder();
-        final Server server = sb.serviceAt("/test", new TempService()).build();
+        final Server server = sb.service("/test", new TempService()).build();
         assertThat(server).isNotNull();
 
         final VirtualHost virtualHost = server.config().defaultVirtualHost();
@@ -65,7 +65,7 @@ public class ChainedVirtualHostBuilderTest {
         assertThat(chainedVirtualHostBuilder).isNotNull();
 
         final Server server = sb.withDefaultVirtualHost()
-                                .serviceAt("/test", new TempService())
+                                .service("/test", new TempService())
                                 .and().build();
 
         assertThat(server).isNotNull();
@@ -90,7 +90,7 @@ public class ChainedVirtualHostBuilderTest {
         final ChainedVirtualHostBuilder chainedVirtualHostBuilder = sb.withVirtualHost("foo", "*");
         assertThat(chainedVirtualHostBuilder).isNotNull();
 
-        chainedVirtualHostBuilder.serviceAt("/test", new TempService());
+        chainedVirtualHostBuilder.service("/test", new TempService());
         final Server server = sb.build();
         assertThat(server).isNotNull();
 
@@ -116,7 +116,7 @@ public class ChainedVirtualHostBuilderTest {
 
         final ServerBuilder sb = new ServerBuilder();
         sb.virtualHost(h);
-        final Server server = sb.serviceAt("/test", new TempService()).build();
+        final Server server = sb.service("/test", new TempService()).build();
         assertThat(server).isNotNull();
 
         final List<VirtualHost> virtualHosts = server.config().virtualHosts();
@@ -136,8 +136,8 @@ public class ChainedVirtualHostBuilderTest {
     @Test
     public void defaultVirtalHostMixedStyle() {
         final ServerBuilder sb = new ServerBuilder();
-        sb.serviceAt("/test", new TempService())
-          .withDefaultVirtualHost().serviceAt("/test2", new TempService());
+        sb.service("/test", new TempService())
+          .withDefaultVirtualHost().service("/test2", new TempService());
 
         final Server server = sb.build();
         assertThat(server).isNotNull();
@@ -149,11 +149,11 @@ public class ChainedVirtualHostBuilderTest {
     @Test
     public void virtualHostMixedStyle() {
         final VirtualHost h =
-                new VirtualHostBuilder("bar.foo.com").serviceAt("/test", new TempService()).build();
+                new VirtualHostBuilder("bar.foo.com").service("/test", new TempService()).build();
 
         final ServerBuilder sb = new ServerBuilder();
         sb.withVirtualHost("*.some.com")
-          .serviceAt("/test2", new TempService())
+          .service("/test2", new TempService())
           .and().virtualHost(h);
 
         final Server server = sb.build();

--- a/core/src/test/java/com/linecorp/armeria/server/PathMappingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/PathMappingTest.java
@@ -1,0 +1,78 @@
+/*
+ *  Copyright 2017 LINE Corporation
+ *
+ *  LINE Corporation licenses this file to you under the Apache License,
+ *  version 2.0 (the "License"); you may not use this file except in compliance
+ *  with the License. You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.Test;
+
+public class PathMappingTest {
+
+    @Test
+    public void successfulOf() {
+        PathMapping m;
+
+        m = PathMapping.of("/foo");
+        assertThat(m).isInstanceOf(ExactPathMapping.class);
+        assertThat(m.exactPath()).contains("/foo");
+
+        m = PathMapping.of("/foo/{bar}");
+        assertThat(m).isInstanceOf(DefaultPathMapping.class);
+        assertThat(((DefaultPathMapping) m).skeleton()).isEqualTo("/foo/{}");
+
+        m = PathMapping.of("/bar/:baz");
+        assertThat(m).isInstanceOf(DefaultPathMapping.class);
+        assertThat(((DefaultPathMapping) m).skeleton()).isEqualTo("/bar/{}");
+
+        m = PathMapping.of("exact:/:foo/bar");
+        assertThat(m).isInstanceOf(ExactPathMapping.class);
+        assertThat(m.exactPath()).contains("/:foo/bar");
+
+        m = PathMapping.of("prefix:/");
+        assertThat(m).isInstanceOf(CatchAllPathMapping.class);
+
+        m = PathMapping.of("prefix:/bar/baz");
+        assertThat(m).isInstanceOf(PrefixPathMapping.class);
+        assertThat(m.prefix()).contains("/bar/baz/");
+
+        m = PathMapping.of("glob:/foo/bar");
+        assertThat(m).isInstanceOf(ExactPathMapping.class);
+        assertThat(m.exactPath()).contains("/foo/bar");
+
+        m = PathMapping.of("glob:/home/*/files/**");
+        assertThat(m).isInstanceOf(GlobPathMapping.class);
+        assertThat(((GlobPathMapping) m).asRegex().pattern()).isEqualTo("^/home/[^/]+/files/.*$");
+
+        m = PathMapping.of("glob:foo");
+        assertThat(m).isInstanceOf(GlobPathMapping.class);
+        assertThat(((GlobPathMapping) m).asRegex().pattern()).isEqualTo("^/(?:.+/)?foo$");
+
+        m = PathMapping.of("regex:^/files/(?<filePath>.*)$");
+        assertThat(m).isInstanceOf(RegexPathMapping.class);
+        assertThat(((RegexPathMapping) m).asRegex().pattern()).isEqualTo("^/files/(?<filePath>.*)$");
+    }
+
+    @Test
+    public void failedOf() {
+        assertThatThrownBy(() -> PathMapping.of("foo"))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        assertThatThrownBy(() -> PathMapping.of("foo:/bar"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
@@ -105,11 +105,11 @@ public class ServerTest {
                 }
             }.decorate(LoggingService.newDecorator());
 
-            sb.serviceAt("/", immediateResponseOnIoThread)
-              .serviceAt("/delayed", delayedResponseOnIoThread)
-              .serviceAt("/timeout", lazyResponseNotOnIoThread)
-              .serviceAt("/timeout-not", lazyResponseNotOnIoThread)
-              .serviceAt("/buggy", buggy);
+            sb.service("/", immediateResponseOnIoThread)
+              .service("/delayed", delayedResponseOnIoThread)
+              .service("/timeout", lazyResponseNotOnIoThread)
+              .service("/timeout-not", lazyResponseNotOnIoThread)
+              .service("/buggy", buggy);
 
             // Disable request timeout for '/timeout-not' only.
             final Function<Service<HttpRequest, HttpResponse>, Service<HttpRequest, HttpResponse>> decorator =

--- a/core/src/test/java/com/linecorp/armeria/server/SniServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/SniServerTest.java
@@ -73,9 +73,9 @@ public class SniServerTest {
             final VirtualHostBuilder b = new VirtualHostBuilder("b.com");
             final VirtualHostBuilder c = new VirtualHostBuilder("c.com");
 
-            a.serviceAt("/", new SniTestService("a.com"));
-            b.serviceAt("/", new SniTestService("b.com"));
-            c.serviceAt("/", new SniTestService("c.com"));
+            a.service("/", new SniTestService("a.com"));
+            b.service("/", new SniTestService("b.com"));
+            c.service("/", new SniTestService("c.com"));
 
             a.sslContext(HTTPS, sscA.certificateFile(), sscA.privateKeyFile());
             b.sslContext(HTTPS, sscB.certificateFile(), sscB.privateKeyFile());

--- a/core/src/test/java/com/linecorp/armeria/server/http/HttpServerCorsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/http/HttpServerCorsTest.java
@@ -47,7 +47,7 @@ public class HttpServerCorsTest {
     public static final ServerRule server = new ServerRule() {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
-            sb.serviceAt("/cors", new AbstractHttpService() {
+            sb.service("/cors", new AbstractHttpService() {
                 @Override
                 protected void doGet(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) {
                     res.respond(HttpStatus.OK);

--- a/core/src/test/java/com/linecorp/armeria/server/http/HttpServerPathTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/http/HttpServerPathTest.java
@@ -46,7 +46,7 @@ public class HttpServerPathTest {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
             sb.port(0, HttpSessionProtocols.HTTP);
-            sb.serviceAt("/service/foo", new AbstractHttpService() {
+            sb.service("/service/foo", new AbstractHttpService() {
                 @Override
                 protected void doGet(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) {
                     res.respond(HttpStatus.OK);

--- a/core/src/test/java/com/linecorp/armeria/server/http/HttpServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/http/HttpServerTest.java
@@ -158,7 +158,7 @@ public class HttpServerTest {
             SelfSignedCertificate ssc = new SelfSignedCertificate();
             sb.sslContext(HTTPS, ssc.certificate(), ssc.privateKey());
 
-            sb.serviceAt("/delay/{delay}", new AbstractHttpService() {
+            sb.service("/delay/{delay}", new AbstractHttpService() {
                 @Override
                 protected void doGet(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) {
                     final long delayMillis = Long.parseLong(ctx.pathParam("delay"));
@@ -167,7 +167,7 @@ public class HttpServerTest {
                 }
             });
 
-            sb.serviceAt("/informed_delay/{delay}", new AbstractHttpService() {
+            sb.service("/informed_delay/{delay}", new AbstractHttpService() {
                 @Override
                 protected void doGet(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) {
                     final long delayMillis = Long.parseLong(ctx.pathParam("delay"));
@@ -186,7 +186,7 @@ public class HttpServerTest {
                 }
             });
 
-            sb.serviceAt("/content_delay/{delay}", new AbstractHttpService() {
+            sb.service("/content_delay/{delay}", new AbstractHttpService() {
                 @Override
                 protected void doGet(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) {
                     final long delayMillis = Long.parseLong(ctx.pathParam("delay"));
@@ -227,7 +227,7 @@ public class HttpServerTest {
                 }
             });
 
-            sb.serviceAt("/echo", new AbstractHttpService() {
+            sb.service("/echo", new AbstractHttpService() {
                 @Override
                 protected void doPost(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) {
                     res.write(HttpHeaders.of(HttpStatus.OK));
@@ -261,8 +261,8 @@ public class HttpServerTest {
                 }
             });
 
-            sb.serviceAt("/count", new CountingService(false));
-            sb.serviceAt("/slow_count", new CountingService(true));
+            sb.service("/count", new CountingService(false));
+            sb.service("/slow_count", new CountingService(true));
 
             sb.serviceUnder("/zeroes", new AbstractHttpService() {
                 @Override
@@ -275,7 +275,7 @@ public class HttpServerTest {
                 }
             });
 
-            sb.serviceAt("/strings", new AbstractHttpService() {
+            sb.service("/strings", new AbstractHttpService() {
                 @Override
                 protected void doGet(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) {
                     res.write(HttpHeaders.of(HttpStatus.OK).set(HttpHeaderNames.CONTENT_TYPE, "text/plain"));
@@ -287,7 +287,7 @@ public class HttpServerTest {
                 }
             }.decorate(HttpEncodingService.class));
 
-            sb.serviceAt("/images", new AbstractHttpService() {
+            sb.service("/images", new AbstractHttpService() {
                 @Override
                 protected void doGet(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) {
                     res.write(HttpHeaders.of(HttpStatus.OK).set(HttpHeaderNames.CONTENT_TYPE, "image/png"));
@@ -299,7 +299,7 @@ public class HttpServerTest {
                 }
             }.decorate(HttpEncodingService.class));
 
-            sb.serviceAt("/small", new AbstractHttpService() {
+            sb.service("/small", new AbstractHttpService() {
                 @Override
                 protected void doGet(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) {
                     String response = Strings.repeat("a", 1023);
@@ -311,7 +311,7 @@ public class HttpServerTest {
                 }
             }.decorate(HttpEncodingService.class));
 
-            sb.serviceAt("/large", new AbstractHttpService() {
+            sb.service("/large", new AbstractHttpService() {
                 @Override
                 protected void doGet(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) {
                     String response = Strings.repeat("a", 1024);
@@ -323,7 +323,7 @@ public class HttpServerTest {
                 }
             }.decorate(HttpEncodingService.class));
 
-            sb.serviceAt("/sslsession", new AbstractHttpService() {
+            sb.service("/sslsession", new AbstractHttpService() {
                 @Override
                 protected void doGet(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) {
                     if (ctx.sessionProtocol().isTls()) {
@@ -335,7 +335,7 @@ public class HttpServerTest {
                 }
             }.decorate(HttpEncodingService.class));
 
-            sb.serviceAt("/headers", new AbstractHttpService() {
+            sb.service("/headers", new AbstractHttpService() {
                 @Override
                 protected void doGet(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) {
                     res.write(HttpHeaders.of(HttpStatus.OK).set(HttpHeaderNames.CONTENT_TYPE, "text/plain")
@@ -347,7 +347,7 @@ public class HttpServerTest {
                 }
             }.decorate(HttpEncodingService.class));
 
-            sb.serviceAt("/trailers", new AbstractHttpService() {
+            sb.service("/trailers", new AbstractHttpService() {
                 @Override
                 protected void doGet(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res)
                         throws Exception {

--- a/core/src/test/java/com/linecorp/armeria/server/http/HttpServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/http/HttpServiceTest.java
@@ -46,7 +46,7 @@ public class HttpServiceTest {
     public static final ServerRule rule = new ServerRule() {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
-            sb.serviceAt(
+            sb.service(
                     "/hello/{name}",
                     new AbstractHttpService() {
                         @Override
@@ -58,7 +58,7 @@ public class HttpServiceTest {
                         }
                     }.decorate(LoggingService.newDecorator()));
 
-            sb.serviceAt(
+            sb.service(
                     "/200",
                     new AbstractHttpService() {
                         @Override
@@ -76,7 +76,7 @@ public class HttpServiceTest {
                         }
                     }.decorate(LoggingService.newDecorator()));
 
-            sb.serviceAt(
+            sb.service(
                     "/204",
                     new AbstractHttpService() {
                         @Override

--- a/core/src/test/java/com/linecorp/armeria/server/http/auth/HttpAuthServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/http/auth/HttpAuthServiceTest.java
@@ -72,7 +72,7 @@ public class HttpAuthServiceTest {
             Authorizer<HttpRequest> authorizer = (ctx, req) ->
                     CompletableFuture.supplyAsync(
                             () -> "unit test".equals(req.headers().get(HttpHeaderNames.AUTHORIZATION)));
-            sb.serviceAt(
+            sb.service(
                     "/",
                     ok.decorate(HttpAuthService.newDecorator(authorizer))
                       .decorate(LoggingService.newDecorator()));
@@ -84,7 +84,7 @@ public class HttpAuthServiceTest {
                 String password = token.password();
                 return completedFuture(password.equals(usernameToPassword.get(username)));
             };
-            sb.serviceAt(
+            sb.service(
                     "/basic",
                     ok.decorate(new HttpAuthServiceBuilder().addBasicAuth(httpBasicAuthorizer).newDecorator())
                       .decorate(LoggingService.newDecorator()));
@@ -92,7 +92,7 @@ public class HttpAuthServiceTest {
             // Auth with OAuth1a
             Authorizer<OAuth1aToken> oAuth1aAuthorizer = (ctx, token) ->
                     completedFuture("dummy_signature".equals(token.signature()));
-            sb.serviceAt(
+            sb.service(
                     "/oauth1a",
                     ok.decorate(new HttpAuthServiceBuilder().addOAuth1a(oAuth1aAuthorizer).newDecorator())
                       .decorate(LoggingService.newDecorator()));
@@ -100,13 +100,13 @@ public class HttpAuthServiceTest {
             // Auth with OAuth2
             Authorizer<OAuth2Token> oAuth2aAuthorizer = (ctx, token) ->
                     completedFuture("dummy_oauth2_token".equals(token.accessToken()));
-            sb.serviceAt(
+            sb.service(
                     "/oauth2",
                     ok.decorate(new HttpAuthServiceBuilder().addOAuth2(oAuth2aAuthorizer).newDecorator())
                       .decorate(LoggingService.newDecorator()));
 
             // Auth with all predicates above!
-            sb.serviceAt(
+            sb.service(
                     "/composite",
                     new HttpAuthServiceBuilder().add(authorizer)
                                                 .addBasicAuth(httpBasicAuthorizer)
@@ -116,7 +116,7 @@ public class HttpAuthServiceTest {
                                                 .decorate(LoggingService.newDecorator()));
 
             // Authorizer fails with an exception.
-            sb.serviceAt(
+            sb.service(
                     "/authorizer_exception",
                     ok.decorate(new HttpAuthServiceBuilder().add((ctx, data) -> {
                         throw new AnticipatedException("bug!");
@@ -124,7 +124,7 @@ public class HttpAuthServiceTest {
                       .decorate(LoggingService.newDecorator()));
 
             // AuthService fails when building a success message.
-            sb.serviceAt(
+            sb.service(
                     "/on_success_exception",
                     ok.decorate(service -> new HttpAuthService(service) {
                         @Override

--- a/core/src/test/java/com/linecorp/armeria/server/http/healthcheck/HttpHealthCheckServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/http/healthcheck/HttpHealthCheckServiceTest.java
@@ -119,7 +119,7 @@ public class HttpHealthCheckServiceTest {
     public void testGet() throws Exception {
         final ServerBuilder builder = new ServerBuilder();
         builder.port(0, HTTP);
-        builder.serviceAt("/l7check", new HttpHealthCheckService());
+        builder.service("/l7check", new HttpHealthCheckService());
         final Server server = builder.build();
         try {
             server.start().join();
@@ -144,7 +144,7 @@ public class HttpHealthCheckServiceTest {
     public void testHead() throws Exception {
         final ServerBuilder builder = new ServerBuilder();
         builder.port(0, HTTP);
-        builder.serviceAt("/l7check", new HttpHealthCheckService());
+        builder.service("/l7check", new HttpHealthCheckService());
         final Server server = builder.build();
         try {
             server.start().join();

--- a/retrofit2/src/test/java/com/linecorp/armeria/client/http/retrofit2/ArmeriaCallFactoryTest.java
+++ b/retrofit2/src/test/java/com/linecorp/armeria/client/http/retrofit2/ArmeriaCallFactoryTest.java
@@ -150,7 +150,7 @@ public class ArmeriaCallFactoryTest {
     public static final ServerRule server = new ServerRule() {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
-            sb.serviceAt("/pojo", new AbstractHttpService() {
+            sb.service("/pojo", new AbstractHttpService() {
                 @Override
                 protected void doGet(ServiceRequestContext ctx,
                                      HttpRequest req, HttpResponseWriter res) throws Exception {
@@ -173,7 +173,7 @@ public class ArmeriaCallFactoryTest {
                       }));
                   }
               })
-              .serviceAt("/nest/pojo", new AbstractHttpService() {
+              .service("/nest/pojo", new AbstractHttpService() {
                   @Override
                   protected void doGet(ServiceRequestContext ctx,
                                        HttpRequest req, HttpResponseWriter res) throws Exception {
@@ -181,7 +181,7 @@ public class ArmeriaCallFactoryTest {
                                   "{\"name\":\"Leonard\", \"age\":21}");
                   }
               })
-              .serviceAt("/pojos", new AbstractHttpService() {
+              .service("/pojos", new AbstractHttpService() {
                   @Override
                   protected void doGet(ServiceRequestContext ctx,
                                        HttpRequest req, HttpResponseWriter res) throws Exception {
@@ -190,7 +190,7 @@ public class ArmeriaCallFactoryTest {
                                   "{\"name\":\"Leonard\", \"age\":21}]");
                   }
               })
-              .serviceAt("/queryString", new AbstractHttpService() {
+              .service("/queryString", new AbstractHttpService() {
                   @Override
                   protected void doGet(ServiceRequestContext ctx,
                                        HttpRequest req, HttpResponseWriter res) throws Exception {
@@ -203,7 +203,7 @@ public class ArmeriaCallFactoryTest {
                       }));
                   }
               })
-              .serviceAt("/post", new AbstractHttpService() {
+              .service("/post", new AbstractHttpService() {
                   @Override
                   protected void doPost(ServiceRequestContext ctx,
                                         HttpRequest req, HttpResponseWriter res) throws Exception {
@@ -229,7 +229,7 @@ public class ArmeriaCallFactoryTest {
                       }));
                   }
               })
-              .serviceAt("/postForm", new AbstractHttpService() {
+              .service("/postForm", new AbstractHttpService() {
                   @Override
                   protected void doPost(ServiceRequestContext ctx,
                                         HttpRequest req, HttpResponseWriter res) throws Exception {
@@ -249,7 +249,7 @@ public class ArmeriaCallFactoryTest {
                       }));
                   }
               })
-              .serviceAt("/postCustomContentType", new AbstractHttpService() {
+              .service("/postCustomContentType", new AbstractHttpService() {
                   @Override
                   protected void doPost(ServiceRequestContext ctx,
                                         HttpRequest req, HttpResponseWriter res) throws Exception {

--- a/site/src/sphinx/client-decorator.rst
+++ b/site/src/sphinx/client-decorator.rst
@@ -63,9 +63,6 @@ SimpleDecoratingClient_ :
 
     ClientBuilder cb = new ClientBuilder(...);
     ...
-    // Using a method reference:
-    cb.decorator(HttpRequest.class, HttpResponse.class,
-                 AuditClient::new);
     // Using a lambda expression:
     cb.decorator(HttpRequest.class, HttpResponse.class,
                  delegate -> new AuditClient(delegate));

--- a/site/src/sphinx/client-grpc.rst
+++ b/site/src/sphinx/client-grpc.rst
@@ -133,7 +133,7 @@ You can also use the builder pattern for client construction:
 
     HelloServiceBlockingStub helloService = new ClientBuilder("gproto+http://127.0.0.1:8080/")
             .defaultResponseTimeoutMillis(10000)
-            .decorator(HttpRequest.class, HttpResponse.class, LoggingClient::new)
+            .decorator(HttpRequest.class, HttpResponse.class, LoggingClient.newDecorator())
             .build(HelloServiceBlockingStub.class); // or HelloServiceFutureStub.class or HelloServiceStub.class
 
     HelloRequest request = HelloRequest.newBuilder().setName("Armerian World").build();

--- a/site/src/sphinx/client-thrift.rst
+++ b/site/src/sphinx/client-thrift.rst
@@ -75,7 +75,7 @@ You can also use the builder pattern for client construction:
 
     HelloService.Iface helloService = new ClientBuilder("tbinary+http://127.0.0.1:8080/hello")
             .defaultResponseTimeoutMillis(10000)
-            .decorator(HttpRequest.class, HttpResponse.class, LoggingClient::new)
+            .decorator(HttpRequest.class, HttpResponse.class, LoggingClient.newDecorator())
             .build(HelloService.Iface.class); // or AsyncIface.class
 
     String greeting = helloService.hello("Armerian World");

--- a/site/src/sphinx/server-decorator.rst
+++ b/site/src/sphinx/server-decorator.rst
@@ -76,12 +76,10 @@ SimpleDecoratingService_ :
     }
 
     ServerBuilder sb = new ServerBuilder();
-    // Using a method reference:
-    sb.serviceUnder("/web", service.decorate(AuthService::new));
-    // Using reflection:
-    sb.serviceUnder("/web", service.decorate(AuthService.class));
     // Using a lambda expression:
     sb.serviceUnder("/web", service.decorate(delegate -> new AuthService(delegate)));
+    // Using reflection:
+    sb.serviceUnder("/web", service.decorate(AuthService.class));
 
 Extending DecoratingService_
 ----------------------------

--- a/site/src/sphinx/server-docservice.rst
+++ b/site/src/sphinx/server-docservice.rst
@@ -21,7 +21,7 @@ First, add DocService_ to the ServerBuilder_:
     ServerBuilder sb = new ServerBuilder();
     sb.port(8080, "http");
     // Add some RPC services.
-    sb.serviceAt("/hello", THttpService.of(new MyHelloService());
+    sb.service("/hello", THttpService.of(new MyHelloService());
     // Add DocService.
     sb.serviceUnder("/docs", new DocService());
     Server server = sb.build();

--- a/site/src/sphinx/server-thrift.rst
+++ b/site/src/sphinx/server-thrift.rst
@@ -70,7 +70,7 @@ to the `ServerBuilder`_:
 
     ServerBuilder sb = new ServerBuilder();
     ...
-    sb.serviceAt("/hello", THttpService.of(new MyHelloService()));
+    sb.service("/hello", THttpService.of(new MyHelloService()));
     ...
     Server server = sb.build();
     server.start();
@@ -109,8 +109,8 @@ To change the default serialization format from TBINARY to something else, speci
 
     ServerBuilder sb = new ServerBuilder();
     // Use TCOMACT as the default serialization format.
-    sb.serviceAt("/hello", THttpService.of(new MyHelloService(),
-                                           ThriftSerializationFormats.COMPACT));
+    sb.service("/hello", THttpService.of(new MyHelloService(),
+                                         ThriftSerializationFormats.COMPACT));
 
 You can also choose the list of allowed serialization formats:
 
@@ -119,9 +119,9 @@ You can also choose the list of allowed serialization formats:
     ServerBuilder sb = new ServerBuilder();
     // Use TBINARY as the default serialization format.
     // Allow TBINARY and TCOMPACT only.
-    sb.serviceAt("/hello", THttpService.of(new MyHelloService(),
-                                           ThriftSerializationFormats.BINARY,
-                                           ThriftSerializationFormats.COMPACT));
+    sb.service("/hello", THttpService.of(new MyHelloService(),
+                                         ThriftSerializationFormats.BINARY,
+                                         ThriftSerializationFormats.COMPACT));
 
 .. note::
    TTEXT is not designed for efficiency and is recommended to be only used for debugging.
@@ -140,7 +140,7 @@ Service multiplexing
     // Use MyHelloService for non-multiplexed requests.
     impls.put("", new MyHelloService());
 
-    sb.serviceAt("/thrift", THttpService.of(impls));
+    sb.service("/thrift", THttpService.of(impls));
 
 See also
 --------

--- a/spring-boot/autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaAutoConfiguration.java
+++ b/spring-boot/autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaAutoConfiguration.java
@@ -126,7 +126,7 @@ public class ArmeriaAutoConfiguration {
                                 metricRegistry, serviceMetricName(bean.getServiceName())));
             }
 
-            server.serviceAt(bean.getPath(), service);
+            server.service(bean.getPath(), service);
             docServiceRequests.addAll(bean.getExampleRequests());
             bean.getService().as(THttpService.class).ifPresent(
                     beanService -> beanService.entries().forEach((serviceName, entry) -> {
@@ -150,9 +150,9 @@ public class ArmeriaAutoConfiguration {
         }));
 
         if (!Strings.isNullOrEmpty(armeriaSettings.getHealthCheckPath())) {
-            server.serviceAt(armeriaSettings.getHealthCheckPath(),
-                             new HttpHealthCheckService(healthCheckers.orElseGet(Collections::emptyList)
-                                                                      .toArray(EMPTY_HEALTH_CHECKERS)));
+            server.service(armeriaSettings.getHealthCheckPath(),
+                           new HttpHealthCheckService(healthCheckers.orElseGet(Collections::emptyList)
+                                                                    .toArray(EMPTY_HEALTH_CHECKERS)));
         }
 
         if (!Strings.isNullOrEmpty(armeriaSettings.getDocsPath())) {
@@ -170,7 +170,7 @@ public class ArmeriaAutoConfiguration {
                     .registerModule(new MetricsModule(TimeUnit.SECONDS,
                                                       TimeUnit.MILLISECONDS,
                                                       true));
-            server.serviceAt(
+            server.service(
                     armeriaSettings.getMetricsPath(),
                     new AbstractHttpService() {
                         @Override

--- a/thrift/src/jmh/java/com/linecorp/armeria/server/thrift/PooledResponseBufferBenchmark.java
+++ b/thrift/src/jmh/java/com/linecorp/armeria/server/thrift/PooledResponseBufferBenchmark.java
@@ -144,12 +144,12 @@ public class PooledResponseBufferBenchmark {
     @Setup
     public void startServer() throws Exception {
         ServerBuilder sb = new ServerBuilder()
-                .port(0, HttpSessionProtocols.HTTP)
-                .serviceAt("/a", THttpService.of(
+                .port(0, HTTP)
+                .service("/a", THttpService.of(
                         (AsyncIface) (name, resultHandler) ->
                                 resultHandler.onComplete(RESPONSE))
                                                   .decorate(PooledDecoratingService::new))
-                .serviceAt("/b", THttpService.of(
+                .service("/b", THttpService.of(
                         (AsyncIface) (name, resultHandler) ->
                                 resultHandler.onComplete(RESPONSE))
                                              .decorate(UnpooledDecoratingService::new));

--- a/thrift/src/test/java/com/linecorp/armeria/client/thrift/ThriftOverHttpClientTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/client/thrift/ThriftOverHttpClientTest.java
@@ -199,7 +199,7 @@ public class ThriftOverHttpClientTest {
                     if (ENABLE_LOGGING_DECORATORS) {
                         service = service.decorate(LoggingService.newDecorator());
                     }
-                    sb.serviceAt(h.path(defaultSerializationFormat), service);
+                    sb.service(h.path(defaultSerializationFormat), service);
                 }
             }
         } catch (Exception e) {

--- a/thrift/src/test/java/com/linecorp/armeria/it/client/endpoint/StaticEndpointGroupIntegrationTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/client/endpoint/StaticEndpointGroupIntegrationTest.java
@@ -111,7 +111,7 @@ public class StaticEndpointGroupIntegrationTest {
 
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
-            sb.serviceAt("/serverIp", THttpService.of(handler));
+            sb.service("/serverIp", THttpService.of(handler));
         }
     }
 }

--- a/thrift/src/test/java/com/linecorp/armeria/it/client/retry/RetryingRpcClientTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/client/retry/RetryingRpcClientTest.java
@@ -52,7 +52,7 @@ public class RetryingRpcClientTest {
     public final ServerRule server = new ServerRule() {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
-            sb.serviceAt("/thrift", THttpService.of(serviceHandler));
+            sb.service("/thrift", THttpService.of(serviceHandler));
         }
     };
 

--- a/thrift/src/test/java/com/linecorp/armeria/it/metric/DropwizardMetricsIntegrationTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/metric/DropwizardMetricsIntegrationTest.java
@@ -48,7 +48,7 @@ public class DropwizardMetricsIntegrationTest {
     public static final ServerRule server = new ServerRule() {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
-            sb.serviceAt("/helloservice", THttpService.of((Iface) name -> {
+            sb.service("/helloservice", THttpService.of((Iface) name -> {
                 if ("world".equals(name)) {
                     return "success";
                 }

--- a/thrift/src/test/java/com/linecorp/armeria/it/metric/PrometheusMetricsIntegrationTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/metric/PrometheusMetricsIntegrationTest.java
@@ -72,17 +72,17 @@ public class PrometheusMetricsIntegrationTest {
                 throw new IllegalArgumentException("bad argument");
             });
 
-            sb.serviceAt("/thrift1", helloService.decorate(
+            sb.service("/thrift1", helloService.decorate(
                     PrometheusMetricCollectingService
                             .newDecorator(registry, MyMetricLabel.values(),
                                           log -> defaultMetricName(log, "HelloService1"))));
 
-            sb.serviceAt("/thrift2", helloService.decorate(
+            sb.service("/thrift2", helloService.decorate(
                     PrometheusMetricCollectingService
                             .newDecorator(registry, EnumSet.allOf(MyMetricLabel.class),
                                           log -> defaultMetricName(log, "HelloService2"))));
 
-            sb.serviceAt("/internal/prometheus/metrics",
+            sb.service("/internal/prometheus/metrics",
                          new PrometheusExporterHttpService(registry));
         }
     };

--- a/thrift/src/test/java/com/linecorp/armeria/it/server/GracefulShutdownIntegrationTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/server/GracefulShutdownIntegrationTest.java
@@ -49,7 +49,7 @@ public class GracefulShutdownIntegrationTest {
             sb.gracefulShutdownTimeout(1000L, 2000L);
             sb.defaultRequestTimeoutMillis(0); // Disable RequestTimeoutException.
 
-            sb.serviceAt("/sleep", THttpService.of(
+            sb.service("/sleep", THttpService.of(
                     (AsyncIface) (milliseconds, resultHandler) ->
                             RequestContext.current().eventLoop().schedule(
                                     () -> resultHandler.onComplete(milliseconds), milliseconds, MILLISECONDS)));

--- a/thrift/src/test/java/com/linecorp/armeria/it/thrift/TMultiplexedProtocolIntegrationTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/thrift/TMultiplexedProtocolIntegrationTest.java
@@ -49,7 +49,7 @@ public class TMultiplexedProtocolIntegrationTest {
     public static final ServerRule server = new ServerRule() {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
-            sb.serviceAt(
+            sb.service(
                     "/",
                     THttpService.of(ImmutableMap.of("", (Iface) name -> "none:" + name,
                                                     "foo", name -> "foo:" + name,

--- a/thrift/src/test/java/com/linecorp/armeria/it/thrift/ThriftDynamicTimeoutTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/thrift/ThriftDynamicTimeoutTest.java
@@ -79,13 +79,13 @@ public class ThriftDynamicTimeoutTest {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
             // Used for testing if changing the timeout dynamically works.
-            sb.serviceAt("/sleep", ThriftCallService.of(sleepService)
-                                                    .decorate(DynamicTimeoutService::new)
-                                                    .decorate(THttpService.newDecorator()));
+            sb.service("/sleep", ThriftCallService.of(sleepService)
+                                                  .decorate(DynamicTimeoutService::new)
+                                                  .decorate(THttpService.newDecorator()));
             // Used for testing if disabling the timeout dynamically works.
-            sb.serviceAt("/fakeSleep", ThriftCallService.of(fakeSleepService)
-                                                        .decorate(TimeoutDisablingService::new)
-                                                        .decorate(THttpService.newDecorator()));
+            sb.service("/fakeSleep", ThriftCallService.of(fakeSleepService)
+                                                      .decorate(TimeoutDisablingService::new)
+                                                      .decorate(THttpService.newDecorator()));
             sb.defaultRequestTimeout(Duration.ofSeconds(1));
         }
     };

--- a/thrift/src/test/java/com/linecorp/armeria/it/thrift/ThriftStructuredLoggingTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/thrift/ThriftStructuredLoggingTest.java
@@ -80,7 +80,7 @@ public class ThriftStructuredLoggingTest {
         protected void configure(ServerBuilder sb) throws Exception {
             loggingService = new MockedStructuredLoggingService<>(
                     THttpService.of((HelloService.Iface) name -> "Hello " + name));
-            sb.serviceAt("/hello", loggingService);
+            sb.service("/hello", loggingService);
         }
     };
 

--- a/thrift/src/test/java/com/linecorp/armeria/it/thrift/ThriftThreadLocalHttpHeaderTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/thrift/ThriftThreadLocalHttpHeaderTest.java
@@ -67,7 +67,7 @@ public class ThriftThreadLocalHttpHeaderTest {
     public static final ServerRule server = new ServerRule() {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
-            sb.serviceAt("/hello", THttpService.of(helloService));
+            sb.service("/hello", THttpService.of(helloService));
         }
     };
 

--- a/thrift/src/test/java/com/linecorp/armeria/server/thrift/AbstractThriftOverHttpTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/server/thrift/AbstractThriftOverHttpTest.java
@@ -104,25 +104,25 @@ public abstract class AbstractThriftOverHttpTest {
             ssc = new SelfSignedCertificate("127.0.0.1");
             sb.sslContext(HTTPS, ssc.certificate(), ssc.privateKey());
 
-            sb.serviceAt("/hello", THttpService.of(
+            sb.service("/hello", THttpService.of(
                     (AsyncIface) (name, resultHandler) -> resultHandler.onComplete("Hello, " + name + '!')));
 
-            sb.serviceAt("/hellochild", THttpService.of(new HelloServiceChild()));
+            sb.service("/hellochild", THttpService.of(new HelloServiceChild()));
 
-            sb.serviceAt("/exception", THttpService.of(
+            sb.service("/exception", THttpService.of(
                     (AsyncIface) (name, resultHandler) ->
                             resultHandler.onError(new AnticipatedException(name))));
 
-            sb.serviceAt("/hellochild", THttpService.of(new HelloServiceChild()));
+            sb.service("/hellochild", THttpService.of(new HelloServiceChild()));
 
-            sb.serviceAt("/sleep", THttpService.of(
+            sb.service("/sleep", THttpService.of(
                     (SleepService.AsyncIface) (milliseconds, resultHandler) ->
                             RequestContext.current().eventLoop().schedule(
                                     () -> resultHandler.onComplete(milliseconds),
                                     milliseconds, TimeUnit.MILLISECONDS)));
 
             // Response larger than a h1 TLS record
-            sb.serviceAt("/large", THttpService.of(
+            sb.service("/large", THttpService.of(
                     (AsyncIface) (name, resultHandler) -> resultHandler.onComplete(LARGER_THAN_TLS)));
 
             sb.decorator(LoggingService::new);

--- a/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftDocServiceTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftDocServiceTest.java
@@ -93,12 +93,12 @@ public class ThriftDocServiceTest {
             final THttpService hbaseService = THttpService.of(mock(Hbase.AsyncIface.class));
             final THttpService onewayHelloService = THttpService.of(mock(OnewayHelloService.AsyncIface.class));
 
-            sb.serviceAt("/", helloAndSleepService);
-            sb.serviceAt("/foo", fooService);
-            sb.serviceAt("/cassandra", cassandraService);
-            sb.serviceAt("/cassandra/debug", cassandraServiceDebug);
-            sb.serviceAt("/hbase", hbaseService);
-            sb.serviceAt("/oneway", onewayHelloService);
+            sb.service("/", helloAndSleepService);
+            sb.service("/foo", fooService);
+            sb.service("/cassandra", cassandraService);
+            sb.service("/cassandra/debug", cassandraServiceDebug);
+            sb.service("/hbase", hbaseService);
+            sb.service("/oneway", onewayHelloService);
 
             sb.serviceUnder(
                     "/docs/",

--- a/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftSerializationFormatsTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftSerializationFormatsTest.java
@@ -41,9 +41,9 @@ public class ThriftSerializationFormatsTest {
     public static final ServerRule server = new ServerRule() {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
-            sb.serviceAt("/hello", THttpService.of(HELLO_SERVICE))
-              .serviceAt("/hellobinaryonly", THttpService.ofFormats(HELLO_SERVICE, BINARY))
-              .serviceAt("/hellotextonly", THttpService.ofFormats(HELLO_SERVICE, TEXT));
+            sb.service("/hello", THttpService.of(HELLO_SERVICE))
+              .service("/hellobinaryonly", THttpService.ofFormats(HELLO_SERVICE, BINARY))
+              .service("/hellotextonly", THttpService.ofFormats(HELLO_SERVICE, TEXT));
         }
     };
 

--- a/zipkin/src/test/java/com/linecorp/armeria/it/tracing/HttpTracingIntegrationTest.java
+++ b/zipkin/src/test/java/com/linecorp/armeria/it/tracing/HttpTracingIntegrationTest.java
@@ -63,11 +63,11 @@ public class HttpTracingIntegrationTest {
     public final ServerRule server = new ServerRule() {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
-            sb.serviceAt("/foo", decorate("service/foo", THttpService.of(
+            sb.service("/foo", decorate("service/foo", THttpService.of(
                     (AsyncIface) (name, resultHandler) ->
                             barClient.hello("Miss. " + name, new DelegatingCallback(resultHandler)))));
 
-            sb.serviceAt("/bar", decorate("service/bar", THttpService.of(
+            sb.service("/bar", decorate("service/bar", THttpService.of(
                     (AsyncIface) (name, resultHandler) -> {
                         if (name.startsWith("Miss. ")) {
                             name = "Ms. " + name.substring(6);
@@ -75,7 +75,7 @@ public class HttpTracingIntegrationTest {
                         quxClient.hello(name, new DelegatingCallback(resultHandler));
                     })));
 
-            sb.serviceAt("/qux", decorate("service/qux", THttpService.of(
+            sb.service("/qux", decorate("service/qux", THttpService.of(
                     (AsyncIface) (name, resultHandler) -> resultHandler.onComplete("Hello, " + name + '!'))));
         }
     };

--- a/zookeeper/src/test/java/com/linecorp/armeria/server/zookeeper/ZooKeeperRegistrationTest.java
+++ b/zookeeper/src/test/java/com/linecorp/armeria/server/zookeeper/ZooKeeperRegistrationTest.java
@@ -66,8 +66,8 @@ public class ZooKeeperRegistrationTest extends TestBase implements ZooKeeperAsse
         try {
             for (Endpoint endpoint : sampleEndpoints) {
                 ServerBuilder sb = new ServerBuilder();
-                Server server = sb.serviceAt("/", new EchoService()).port(endpoint.port(),
-                                                                          HttpSessionProtocols.HTTP).build();
+                Server server = sb.service("/", new EchoService()).port(endpoint.port(),
+                                                                        HttpSessionProtocols.HTTP).build();
                 ZooKeeperUpdatingListener listener;
                 listener = new ZooKeeperUpdatingListener(instance().connectString().get(), zNode,
                                                          sessionTimeout,


### PR DESCRIPTION
Motivation:

It would be more convenient if a user can specify a path pattern in the
following style:

- /login (no path parameters)
- /users/{userId} (curly-brace style)
- /list/:productType/by/:ordering (colon style)
- exact:/foo/bar (exact match)
- prefix:/files (prefix match)
- glob:/~*/downloads/** (glob pattern)
- regex:^/files/(?<filePath>.*)$ (regular expression)

We already support the first three forms for serviceAt() and we want to
support more.

Modifications:

- Improve PathMapping.of() support the 'exact:', 'prefix:', 'glob:' and
  'regex:' prefix
- Rename serviceAt() into service() because it's not an exact match only
  anymore
  - Rename service() for annotated service objects to annotatedService()
    to avoid confusion
  - Add deprecated serviceAt() for smooth migration
  - Update documentation
- Improve AnnotatedServiceMethods.pathMapping() so that the new path
  patterns are supported for annotated services

Result:

- Fixes #583