### PR TITLE
Add path parameter support to glob path patterns

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/server/AnnotatedHttpServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/AnnotatedHttpServiceTest.java
@@ -306,7 +306,11 @@ public class AnnotatedHttpServiceTest {
         @Get
         @Path("glob:glob2") // The pattern that does not start with '/'
         public String glob2(ServiceRequestContext ctx) {
-            return "glob2:" + ctx.path();
+            // When this method is bound with a prefix 'foo', the path mapping of this method will be:
+            // - /foo/**/glob2
+            // Even if the resulting path mapping contains '**', ctx.pathParams().size() must be 0
+            // because a user did not specify it.
+            return "glob2:" + ctx.path() + ':' + ctx.pathParams().size();
         }
 
         @Get
@@ -453,7 +457,7 @@ public class AnnotatedHttpServiceTest {
             }
             try (CloseableHttpResponse res = hc.execute(new HttpGet(rule.httpUri("/4/baz/glob2")))) {
                 assertThat(res.getStatusLine().toString(), is("HTTP/1.1 200 OK"));
-                assertThat(EntityUtils.toString(res.getEntity()), is("String[glob2:/4/baz/glob2]"));
+                assertThat(EntityUtils.toString(res.getEntity()), is("String[glob2:/4/baz/glob2:0]"));
             }
 
             // Regex pattern

--- a/core/src/test/java/com/linecorp/armeria/server/GlobPathMappingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/GlobPathMappingTest.java
@@ -85,8 +85,40 @@ public class GlobPathMappingTest {
     }
 
     @Test
-    public void paramNames() throws Exception {
-        assertThat(ofGlob("/bar/baz/*").paramNames()).isEmpty();
+    public void params() throws Exception {
+        PathMapping m;
+
+        m = ofGlob("baz");
+        assertThat(m.paramNames()).isEmpty();
+        // Should not create a param for 'bar'
+        assertThat(m.apply("/bar/baz", null).pathParams()).isEmpty();
+
+        m = ofGlob("/bar/baz/*");
+        assertThat(m.paramNames()).containsExactly("0");
+        assertThat(m.apply("/bar/baz/qux", null).pathParams())
+                .containsEntry("0", "qux")
+                .hasSize(1);
+
+        m = ofGlob("/foo/**");
+        assertThat(m.paramNames()).containsExactly("0");
+        assertThat(m.apply("/foo/bar/baz", null).pathParams())
+                .containsEntry("0", "bar/baz")
+                .hasSize(1);
+        assertThat(m.apply("/foo/", null).pathParams())
+                .containsEntry("0", "")
+                .hasSize(1);
+
+        m = ofGlob("/**/*.js");
+        assertThat(m.paramNames()).containsExactlyInAnyOrder("0", "1");
+        assertThat(m.apply("/lib/jquery.min.js", null).pathParams())
+                .containsEntry("0", "lib")
+                .containsEntry("1", "jquery.min")
+                .hasSize(2);
+
+        assertThat(m.apply("/lodash.js", null).pathParams())
+                .containsEntry("0", "")
+                .containsEntry("1", "lodash")
+                .hasSize(2);
     }
 
     private static void pass(String glob, String... paths) {

--- a/core/src/test/java/com/linecorp/armeria/server/PathMappingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/PathMappingTest.java
@@ -56,7 +56,7 @@ public class PathMappingTest {
 
         m = PathMapping.of("glob:/home/*/files/**");
         assertThat(m).isInstanceOf(GlobPathMapping.class);
-        assertThat(((GlobPathMapping) m).asRegex().pattern()).isEqualTo("^/home/[^/]+/files/.*$");
+        assertThat(((GlobPathMapping) m).asRegex().pattern()).isEqualTo("^/home/([^/]+)/files/(.*)$");
 
         m = PathMapping.of("glob:foo");
         assertThat(m).isInstanceOf(GlobPathMapping.class);


### PR DESCRIPTION
Motivation:

There's currently no simple way to get the value of '*' or '**' in a
glob path pattern.

Modifications:

- Make GlobPathMapping produce an integer-indexed path parameter map
- Modify AnnotatedHttpServices.pathMapping() so that the path parameters
  of a glob path pattern is handled correctly when an annotated service is
  bound with a prefix

Result:

- Fixes #569