### PR TITLE
Support path parameter names that start with a digit

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/server/DefaultPathMappingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/DefaultPathMappingTest.java
@@ -61,6 +61,17 @@ public class DefaultPathMappingTest {
     }
 
     @Test
+    public void testNumericPathParamNames() {
+        final DefaultPathMapping m = new DefaultPathMapping("/{0}/{1}/{2}");
+        assertThat(m.paramNames()).containsExactlyInAnyOrder("0", "1", "2");
+        assertThat(m.apply("/alice/bob/charlie", null).pathParams())
+                .containsEntry("0", "alice")
+                .containsEntry("1", "bob")
+                .containsEntry("2", "charlie")
+                .hasSize(3);
+    }
+
+    @Test
     public void testVariables() throws Exception {
         final DefaultPathMapping ppe =
                 new DefaultPathMapping("/service/{value}/test/:value2/something/{value3}");


### PR DESCRIPTION
Motivation:

For example, the following will fail:

    PathMapping.of("/{0}");

.. because we use the path parameter name a user specified in verbatim
when building a regular expression. We don't really need to use named
capturing groups in the generated regular expression. We can simply keep
an array which contains the path parameter names in the order of
appearance and then map the capturing group number into a path parameter
name at O(1) time.

Modifications:

- Use numbered capturing groups for the regular expression generated by
  DefaultPathMapping

Result:

- Fixes #586