### PR TITLE
Do not cache PathMappingResult when query string exists

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/PathMappings.java
+++ b/core/src/main/java/com/linecorp/armeria/server/PathMappings.java
@@ -101,9 +101,9 @@ public class PathMappings<T> implements BiFunction<String, String, PathMapped<T>
     public PathMapped<T> apply(String path, @Nullable String query) {
         freeze();
 
-        // Look up the cache if the cache is available.
+        // Look up the cache if the cache is available and query string does not exist.
         final Map<String, PathMapped<T>> cache =
-                threadLocalCache != null ? threadLocalCache.get() : null;
+                query == null && threadLocalCache != null ? threadLocalCache.get() : null;
 
         if (cache != null) {
             final PathMapped<T> value = cache.get(path);

--- a/testing/src/main/java/com/linecorp/armeria/testing/server/webapp/WebAppContainerTest.java
+++ b/testing/src/main/java/com/linecorp/armeria/testing/server/webapp/WebAppContainerTest.java
@@ -181,6 +181,19 @@ public abstract class WebAppContainerTest {
                         "<p>bar is 2</p>" +
                         "</body></html>");
             }
+
+            // Send a query again with different values to make sure the query strings are not cached.
+            try (CloseableHttpResponse res = hc.execute(
+                    new HttpGet(server().uri("/jsp/query_string.jsp?foo=%33&bar=%34")))) {
+
+                final String actualContent = CR_OR_LF.matcher(EntityUtils.toString(res.getEntity()))
+                                                     .replaceAll("");
+                assertThat(actualContent).isEqualTo(
+                        "<html><body>" +
+                        "<p>foo is 3</p>" +
+                        "<p>bar is 4</p>" +
+                        "</body></html>");
+            }
         }
     }
 
@@ -201,6 +214,21 @@ public abstract class WebAppContainerTest {
                         "<html><body>" +
                         "<p>foo is 3</p>" +
                         "<p>bar is 4</p>" +
+                        "</body></html>");
+            }
+
+            // Send a query again with different values to make sure the query strings are not cached.
+            final HttpPost post2 = new HttpPost(server().uri("/jsp/query_string.jsp?foo=5"));
+            post2.setEntity(new UrlEncodedFormEntity(
+                    Collections.singletonList(new BasicNameValuePair("bar", "6")), StandardCharsets.UTF_8));
+
+            try (CloseableHttpResponse res = hc.execute(post2)) {
+                final String actualContent = CR_OR_LF.matcher(EntityUtils.toString(res.getEntity()))
+                                                     .replaceAll("");
+                assertThat(actualContent).isEqualTo(
+                        "<html><body>" +
+                        "<p>foo is 5</p>" +
+                        "<p>bar is 6</p>" +
                         "</body></html>");
             }
         }


### PR DESCRIPTION
Motivation:

There's a bug in PathMappings.apply() where it reuses the cached
PathMappingResult even when query strings are different from the current
request.

Modifications:

- Do not cache PathMappingResult when a request contains a query string

Result:

A query string is not polluted by the PathMappingResult cache.