### PR TITLE
Inject a query string parameter as an annotated method argument

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/http/DefaultHttpParameters.java
+++ b/core/src/main/java/com/linecorp/armeria/common/http/DefaultHttpParameters.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.http;
+
+import static io.netty.util.HashingStrategy.JAVA_HASHER;
+
+import io.netty.handler.codec.DefaultHeaders;
+import io.netty.util.HashingStrategy;
+
+/**
+ * Default implementation of {@link HttpParameters} which uses the {@link HashingStrategy#JAVA_HASHER}
+ * to support case-sensitive parameter names.
+ */
+public class DefaultHttpParameters
+        extends DefaultHeaders<String, String, HttpParameters> implements HttpParameters {
+
+    /**
+     * Creates a new instance with a default value converter.
+     */
+    @SuppressWarnings("unchecked")
+    public DefaultHttpParameters() {
+        super(JAVA_HASHER, StringValueConverter.INSTANCE);
+    }
+
+    /**
+     * Create a new instance with a default value converter and the specified hint of array size.
+     *
+     * @param arraySizeHint A hint as to how large the hash data structure should be.
+     *        The next positive power of two will be used. An upper bound may be enforced.
+     */
+    @SuppressWarnings("unchecked")
+    public DefaultHttpParameters(int arraySizeHint) {
+        super(JAVA_HASHER, StringValueConverter.INSTANCE, NameValidator.NOT_NULL, arraySizeHint);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/common/http/HttpParameters.java
+++ b/core/src/main/java/com/linecorp/armeria/common/http/HttpParameters.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.http;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Map;
+
+import io.netty.handler.codec.Headers;
+
+/**
+ * HTTP parameters map.
+ */
+public interface HttpParameters extends Headers<String, String, HttpParameters> {
+
+    /**
+     * An immutable empty HTTP parameters map.
+     */
+    HttpParameters EMPTY_PARAMETERS = of().asImmutable();
+
+    /**
+     * Returns a new empty HTTP parameters map.
+     */
+    static HttpParameters of() {
+        return new DefaultHttpParameters();
+    }
+
+    /**
+     * Returns a new HTTP parameters map with the specified {@code Map<String, ? extends Iterable<String>>}.
+     */
+    static HttpParameters copyOf(Map<String, ? extends Iterable<String>> parameters) {
+        requireNonNull(parameters, "parameters");
+        final HttpParameters httpParameters = new DefaultHttpParameters();
+        parameters.forEach((name, values) ->
+                                   values.forEach(value -> httpParameters.add(name, value)));
+        return httpParameters;
+    }
+
+    /**
+     * Returns a copy of the specified {@code Headers<String, String, ?>}.
+     */
+    static HttpParameters copyOf(Headers<String, String, ?> parameters) {
+        return of().set(requireNonNull(parameters, "parameters"));
+    }
+
+    /**
+     * Returns the immutable view of this parameters map.
+     */
+    default HttpParameters asImmutable() {
+        return new ImmutableHttpParameters(this);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/common/http/ImmutableHttpHeaders.java
+++ b/core/src/main/java/com/linecorp/armeria/common/http/ImmutableHttpHeaders.java
@@ -35,11 +35,6 @@ final class ImmutableHttpHeaders implements HttpHeaders {
     }
 
     @Override
-    public Iterator<Entry<AsciiString, String>> iterator() {
-        return delegate.iterator();
-    }
-
-    @Override
     public HttpMethod method() {
         return delegate.method();
     }
@@ -560,6 +555,11 @@ final class ImmutableHttpHeaders implements HttpHeaders {
     @Override
     public HttpHeaders clear() {
         return unsupported();
+    }
+
+    @Override
+    public Iterator<Entry<AsciiString, String>> iterator() {
+        return delegate.iterator();
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/http/ImmutableHttpParameters.java
+++ b/core/src/main/java/com/linecorp/armeria/common/http/ImmutableHttpParameters.java
@@ -1,0 +1,525 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.http;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import io.netty.handler.codec.Headers;
+
+final class ImmutableHttpParameters implements HttpParameters {
+
+    private final HttpParameters delegate;
+
+    ImmutableHttpParameters(HttpParameters delegate) {
+        this.delegate = requireNonNull(delegate, "delegate");
+    }
+
+    @Override
+    public String get(String name) {
+        return delegate.get(name);
+    }
+
+    @Override
+    public String get(String name, String defaultValue) {
+        return delegate.get(name, defaultValue);
+    }
+
+    @Override
+    public String getAndRemove(String name) {
+        return unsupported();
+    }
+
+    @Override
+    public String getAndRemove(String name, String defaultValue) {
+        return unsupported();
+    }
+
+    @Override
+    public List<String> getAll(String name) {
+        return delegate.getAll(name);
+    }
+
+    @Override
+    public List<String> getAllAndRemove(String name) {
+        return unsupported();
+    }
+
+    @Override
+    public Boolean getBoolean(String name) {
+        return delegate.getBoolean(name);
+    }
+
+    @Override
+    public boolean getBoolean(String name, boolean defaultValue) {
+        return delegate.getBoolean(name, defaultValue);
+    }
+
+    @Override
+    public Byte getByte(String name) {
+        return delegate.getByte(name);
+    }
+
+    @Override
+    public byte getByte(String name, byte defaultValue) {
+        return delegate.getByte(name, defaultValue);
+    }
+
+    @Override
+    public Character getChar(String name) {
+        return delegate.getChar(name);
+    }
+
+    @Override
+    public char getChar(String name, char defaultValue) {
+        return delegate.getChar(name, defaultValue);
+    }
+
+    @Override
+    public Short getShort(String name) {
+        return delegate.getShort(name);
+    }
+
+    @Override
+    public short getShort(String name, short defaultValue) {
+        return delegate.getShort(name, defaultValue);
+    }
+
+    @Override
+    public Integer getInt(String name) {
+        return delegate.getInt(name);
+    }
+
+    @Override
+    public int getInt(String name, int defaultValue) {
+        return delegate.getInt(name, defaultValue);
+    }
+
+    @Override
+    public Long getLong(String name) {
+        return delegate.getLong(name);
+    }
+
+    @Override
+    public long getLong(String name, long defaultValue) {
+        return delegate.getLong(name, defaultValue);
+    }
+
+    @Override
+    public Float getFloat(String name) {
+        return delegate.getFloat(name);
+    }
+
+    @Override
+    public float getFloat(String name, float defaultValue) {
+        return delegate.getFloat(name, defaultValue);
+    }
+
+    @Override
+    public Double getDouble(String name) {
+        return delegate.getDouble(name);
+    }
+
+    @Override
+    public double getDouble(String name, double defaultValue) {
+        return delegate.getDouble(name, defaultValue);
+    }
+
+    @Override
+    public Long getTimeMillis(String name) {
+        return delegate.getTimeMillis(name);
+    }
+
+    @Override
+    public long getTimeMillis(String name, long defaultValue) {
+        return delegate.getTimeMillis(name, defaultValue);
+    }
+
+    @Override
+    public Boolean getBooleanAndRemove(String name) {
+        return unsupported();
+    }
+
+    @Override
+    public boolean getBooleanAndRemove(String name, boolean defaultValue) {
+        return unsupported();
+    }
+
+    @Override
+    public Byte getByteAndRemove(String name) {
+        return unsupported();
+    }
+
+    @Override
+    public byte getByteAndRemove(String name, byte defaultValue) {
+        return unsupported();
+    }
+
+    @Override
+    public Character getCharAndRemove(String name) {
+        return unsupported();
+    }
+
+    @Override
+    public char getCharAndRemove(String name, char defaultValue) {
+        return unsupported();
+    }
+
+    @Override
+    public Short getShortAndRemove(String name) {
+        return unsupported();
+    }
+
+    @Override
+    public short getShortAndRemove(String name, short defaultValue) {
+        return unsupported();
+    }
+
+    @Override
+    public Integer getIntAndRemove(String name) {
+        return unsupported();
+    }
+
+    @Override
+    public int getIntAndRemove(String name, int defaultValue) {
+        return unsupported();
+    }
+
+    @Override
+    public Long getLongAndRemove(String name) {
+        return unsupported();
+    }
+
+    @Override
+    public long getLongAndRemove(String name, long defaultValue) {
+        return unsupported();
+    }
+
+    @Override
+    public Float getFloatAndRemove(String name) {
+        return unsupported();
+    }
+
+    @Override
+    public float getFloatAndRemove(String name, float defaultValue) {
+        return unsupported();
+    }
+
+    @Override
+    public Double getDoubleAndRemove(String name) {
+        return unsupported();
+    }
+
+    @Override
+    public double getDoubleAndRemove(String name, double defaultValue) {
+        return unsupported();
+    }
+
+    @Override
+    public Long getTimeMillisAndRemove(String name) {
+        return unsupported();
+    }
+
+    @Override
+    public long getTimeMillisAndRemove(String name, long defaultValue) {
+        return unsupported();
+    }
+
+    @Override
+    public boolean contains(String name) {
+        return delegate.contains(name);
+    }
+
+    @Override
+    public boolean contains(String name, String value) {
+        return delegate.contains(name, value);
+    }
+
+    @Override
+    public boolean containsObject(String name, Object value) {
+        return delegate.containsObject(name, value);
+    }
+
+    @Override
+    public boolean containsBoolean(String name, boolean value) {
+        return delegate.containsBoolean(name, value);
+    }
+
+    @Override
+    public boolean containsByte(String name, byte value) {
+        return delegate.containsByte(name, value);
+    }
+
+    @Override
+    public boolean containsChar(String name, char value) {
+        return delegate.containsChar(name, value);
+    }
+
+    @Override
+    public boolean containsShort(String name, short value) {
+        return delegate.containsShort(name, value);
+    }
+
+    @Override
+    public boolean containsInt(String name, int value) {
+        return delegate.containsInt(name, value);
+    }
+
+    @Override
+    public boolean containsLong(String name, long value) {
+        return delegate.containsLong(name, value);
+    }
+
+    @Override
+    public boolean containsFloat(String name, float value) {
+        return delegate.containsFloat(name, value);
+    }
+
+    @Override
+    public boolean containsDouble(String name, double value) {
+        return delegate.containsDouble(name, value);
+    }
+
+    @Override
+    public boolean containsTimeMillis(String name, long value) {
+        return delegate.containsTimeMillis(name, value);
+    }
+
+    @Override
+    public int size() {
+        return delegate.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return delegate.isEmpty();
+    }
+
+    @Override
+    public Set<String> names() {
+        return delegate.names();
+    }
+
+    @Override
+    public HttpParameters add(String name, String value) {
+        return unsupported();
+    }
+
+    @Override
+    public HttpParameters add(String name, Iterable<? extends String> values) {
+        return unsupported();
+    }
+
+    @Override
+    public HttpParameters add(String name, String... values) {
+        return unsupported();
+    }
+
+    @Override
+    public HttpParameters add(Headers<? extends String, ? extends String, ?> headers) {
+        return unsupported();
+    }
+
+    @Override
+    public HttpParameters addObject(String name, Object value) {
+        return unsupported();
+    }
+
+    @Override
+    public HttpParameters addObject(String name, Iterable<?> values) {
+        return unsupported();
+    }
+
+    @Override
+    public HttpParameters addObject(String name, Object... values) {
+        return unsupported();
+    }
+
+    @Override
+    public HttpParameters addBoolean(String name, boolean value) {
+        return unsupported();
+    }
+
+    @Override
+    public HttpParameters addByte(String name, byte value) {
+        return unsupported();
+    }
+
+    @Override
+    public HttpParameters addChar(String name, char value) {
+        return unsupported();
+    }
+
+    @Override
+    public HttpParameters addShort(String name, short value) {
+        return unsupported();
+    }
+
+    @Override
+    public HttpParameters addInt(String name, int value) {
+        return unsupported();
+    }
+
+    @Override
+    public HttpParameters addLong(String name, long value) {
+        return unsupported();
+    }
+
+    @Override
+    public HttpParameters addFloat(String name, float value) {
+        return unsupported();
+    }
+
+    @Override
+    public HttpParameters addDouble(String name, double value) {
+        return unsupported();
+    }
+
+    @Override
+    public HttpParameters addTimeMillis(String name, long value) {
+        return unsupported();
+    }
+
+    @Override
+    public HttpParameters set(String name, String value) {
+        return unsupported();
+    }
+
+    @Override
+    public HttpParameters set(String name, Iterable<? extends String> values) {
+        return unsupported();
+    }
+
+    @Override
+    public HttpParameters set(String name, String... values) {
+        return unsupported();
+    }
+
+    @Override
+    public HttpParameters set(Headers<? extends String, ? extends String, ?> headers) {
+        return unsupported();
+    }
+
+    @Override
+    public HttpParameters setObject(String name, Object value) {
+        return unsupported();
+    }
+
+    @Override
+    public HttpParameters setObject(String name, Iterable<?> values) {
+        return unsupported();
+    }
+
+    @Override
+    public HttpParameters setObject(String name, Object... values) {
+        return unsupported();
+    }
+
+    @Override
+    public HttpParameters setBoolean(String name, boolean value) {
+        return unsupported();
+    }
+
+    @Override
+    public HttpParameters setByte(String name, byte value) {
+        return unsupported();
+    }
+
+    @Override
+    public HttpParameters setChar(String name, char value) {
+        return unsupported();
+    }
+
+    @Override
+    public HttpParameters setShort(String name, short value) {
+        return unsupported();
+    }
+
+    @Override
+    public HttpParameters setInt(String name, int value) {
+        return unsupported();
+    }
+
+    @Override
+    public HttpParameters setLong(String name, long value) {
+        return unsupported();
+    }
+
+    @Override
+    public HttpParameters setFloat(String name, float value) {
+        return unsupported();
+    }
+
+    @Override
+    public HttpParameters setDouble(String name, double value) {
+        return unsupported();
+    }
+
+    @Override
+    public HttpParameters setTimeMillis(String name, long value) {
+        return unsupported();
+    }
+
+    @Override
+    public HttpParameters setAll(Headers<? extends String, ? extends String, ?> headers) {
+        return unsupported();
+    }
+
+    @Override
+    public boolean remove(String name) {
+        return unsupported();
+    }
+
+    @Override
+    public HttpParameters clear() {
+        return unsupported();
+    }
+
+    @Override
+    public Iterator<Entry<String, String>> iterator() {
+        return delegate.iterator();
+    }
+
+    @Override
+    public HttpParameters asImmutable() {
+        return this;
+    }
+
+    @Override
+    public int hashCode() {
+        return delegate.hashCode();
+    }
+
+    @Override
+    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
+    public boolean equals(Object obj) {
+        return delegate.equals(obj);
+    }
+
+    @Override
+    public String toString() {
+        return delegate.toString();
+    }
+
+    private static <T> T unsupported() {
+        throw new UnsupportedOperationException("immutable");
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/internal/DefaultValues.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/DefaultValues.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal;
+
+import javax.annotation.Nullable;
+
+import com.linecorp.armeria.server.http.annotation.Optional;
+
+/**
+ * Holds the default values used in annotation attributes.
+ */
+public final class DefaultValues {
+
+    /**
+     * A string constant defining unspecified values from users.
+     *
+     * @see Optional#value()
+     */
+    public static final String UNSPECIFIED = "\n\t\t\n\t\t\n\000\001\002\n\t\t\t\t\n";
+
+    /**
+     * Returns whether the specified value is specified by a user.
+     */
+    public static boolean isSpecified(@Nullable String value) {
+        return !UNSPECIFIED.equals(value);
+    }
+
+    /**
+     * Returns whether the specified value is not specified by a user.
+     */
+    public static boolean isUnspecified(@Nullable String value) {
+        return UNSPECIFIED.equals(value);
+    }
+
+    private DefaultValues() {}
+}

--- a/core/src/main/java/com/linecorp/armeria/server/AbstractVirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AbstractVirtualHostBuilder.java
@@ -42,7 +42,7 @@ import com.linecorp.armeria.common.http.HttpRequest;
 import com.linecorp.armeria.common.http.HttpResponse;
 import com.linecorp.armeria.common.http.HttpSessionProtocols;
 import com.linecorp.armeria.common.util.NativeLibraries;
-import com.linecorp.armeria.server.http.dynamic.ResponseConverter;
+import com.linecorp.armeria.server.http.annotation.ResponseConverter;
 
 import io.netty.handler.codec.http2.Http2SecurityUtil;
 import io.netty.handler.ssl.ApplicationProtocolConfig;

--- a/core/src/main/java/com/linecorp/armeria/server/AnnotatedHttpServiceMethod.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AnnotatedHttpServiceMethod.java
@@ -17,6 +17,7 @@
 package com.linecorp.armeria.server;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static com.linecorp.armeria.common.http.HttpParameters.EMPTY_PARAMETERS;
 import static java.util.Objects.requireNonNull;
 
 import java.lang.reflect.InvocationTargetException;
@@ -30,84 +31,69 @@ import java.util.function.BiFunction;
 
 import javax.annotation.Nullable;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.common.collect.ImmutableList;
 
+import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.http.AggregatedHttpMessage;
+import com.linecorp.armeria.common.http.HttpHeaderNames;
+import com.linecorp.armeria.common.http.HttpParameters;
 import com.linecorp.armeria.common.http.HttpRequest;
 import com.linecorp.armeria.common.http.HttpResponse;
+import com.linecorp.armeria.common.http.HttpStatus;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.common.util.SafeCloseable;
+import com.linecorp.armeria.internal.DefaultValues;
 import com.linecorp.armeria.internal.Types;
-import com.linecorp.armeria.server.http.dynamic.PathParam;
-import com.linecorp.armeria.server.http.dynamic.ResponseConverter;
+import com.linecorp.armeria.server.http.annotation.Optional;
+import com.linecorp.armeria.server.http.annotation.Param;
+import com.linecorp.armeria.server.http.annotation.ResponseConverter;
+
+import io.netty.handler.codec.http.HttpConstants;
+import io.netty.handler.codec.http.HttpUtil;
+import io.netty.handler.codec.http.QueryStringDecoder;
 
 /**
  * Invokes an individual method of an annotated service. An annotated service method whose return type is not
  * {@link CompletionStage} or {@link HttpResponse} will be run in the blocking task executor.
  */
 final class AnnotatedHttpServiceMethod implements BiFunction<ServiceRequestContext, HttpRequest, Object> {
+    private static final Logger logger = LoggerFactory.getLogger(AnnotatedHttpServiceMethod.class);
 
     private final Object object;
     private final Method method;
     private final List<Parameter> parameters;
     private final boolean isAsynchronous;
-    private final boolean aggregationRequired;
+    private final AggregationStrategy aggregationStrategy;
 
-    AnnotatedHttpServiceMethod(Object object, Method method) {
+    AnnotatedHttpServiceMethod(Object object, Method method, PathMapping pathMapping) {
         this.object = requireNonNull(object, "object");
         this.method = requireNonNull(method, "method");
-        parameters = parameters(method);
+        requireNonNull(pathMapping, "pathMapping");
+
+        parameters = parameters(method, pathMapping.paramNames());
         final Class<?> returnType = method.getReturnType();
         isAsynchronous = HttpResponse.class.isAssignableFrom(returnType) ||
                          CompletionStage.class.isAssignableFrom(returnType);
-        aggregationRequired = parameters.stream().anyMatch(
-                entry -> entry.getType().isAssignableFrom(AggregatedHttpMessage.class));
+        aggregationStrategy = AggregationStrategy.resolve(parameters);
     }
 
     /**
-     * Returns the array of {@link Parameter}, which holds the type and {@link PathParam} value.
-     */
-    private static List<Parameter> parameters(Method method) {
-        boolean hasRequestMessage = false;
-        final ImmutableList.Builder<Parameter> entries = ImmutableList.builder();
-        for (java.lang.reflect.Parameter p : method.getParameters()) {
-            final String name;
-
-            PathParam pathParam = p.getAnnotation(PathParam.class);
-            if (pathParam != null) {
-                name = p.getAnnotation(PathParam.class).value();
-            } else if (p.getType().isAssignableFrom(ServiceRequestContext.class)) {
-                name = null;
-            } else if (p.getType().isAssignableFrom(HttpRequest.class) ||
-                       p.getType().isAssignableFrom(AggregatedHttpMessage.class)) {
-                if (hasRequestMessage) {
-                    throw new IllegalArgumentException("Only one request message variable is allowed.");
-                }
-                name = null;
-                hasRequestMessage = true;
-            } else {
-                throw new IllegalArgumentException("Unsupported object type: " + p.getType());
-            }
-
-            entries.add(new Parameter(p.getType(), name));
-        }
-        return entries.build();
-    }
-
-    /**
-     * Returns the set of parameter names which have an annotation of {@link PathParam}.
+     * Returns the set of parameter names which have an annotation of {@link Param}.
      */
     Set<String> pathParamNames() {
         return parameters.stream()
                          .filter(Parameter::isPathParam)
-                         .map(Parameter::getName)
+                         .map(Parameter::name)
                          .collect(toImmutableSet());
     }
 
     @Override
     public Object apply(ServiceRequestContext ctx, HttpRequest req) {
-        if (aggregationRequired) {
+        if (AggregationStrategy.aggregationRequired(aggregationStrategy, req)) {
             final CompletableFuture<AggregatedHttpMessage> aggregationFuture = req.aggregate();
             if (CompletionStage.class.isAssignableFrom(method.getReturnType())) {
                 return aggregationFuture.thenCompose(msg -> (CompletionStage<?>) invoke(ctx, req, msg));
@@ -127,43 +113,6 @@ final class AnnotatedHttpServiceMethod implements BiFunction<ServiceRequestConte
         return CompletableFuture.supplyAsync(() -> invoke(ctx, req, null), ctx.blockingTaskExecutor());
     }
 
-    private Object invoke(ServiceRequestContext ctx, HttpRequest req, @Nullable AggregatedHttpMessage message) {
-        try (SafeCloseable ignored = RequestContext.push(ctx, false)) {
-            return method.invoke(object, parameterValues(ctx, req, message));
-        } catch (Exception e) {
-            if (e instanceof InvocationTargetException) {
-                final Throwable cause = e.getCause();
-                if (cause != null) {
-                    return Exceptions.throwUnsafely(cause);
-                }
-            }
-            return Exceptions.throwUnsafely(e);
-        }
-    }
-
-    /**
-     * Returns array of parameters for method invocation.
-     */
-    private Object[] parameterValues(ServiceRequestContext ctx, HttpRequest req,
-                                     @Nullable AggregatedHttpMessage message) {
-        Object[] parameters = new Object[this.parameters.size()];
-        for (int i = 0; i < this.parameters.size(); ++i) {
-            Parameter entry = this.parameters.get(i);
-            if (entry.isPathParam()) {
-                String value = ctx.pathParam(entry.getName());
-                assert value != null;
-                parameters[i] = convertParameter(value, entry.getType());
-            } else if (entry.getType().isAssignableFrom(ServiceRequestContext.class)) {
-                parameters[i] = ctx;
-            } else if (entry.getType().isAssignableFrom(HttpRequest.class)) {
-                parameters[i] = req;
-            } else if (entry.getType().isAssignableFrom(AggregatedHttpMessage.class)) {
-                parameters[i] = message;
-            }
-        }
-        return parameters;
-    }
-
     BiFunction<ServiceRequestContext, HttpRequest, Object> withConverter(ResponseConverter converter) {
         return (ctx, req) ->
                 executeSyncOrAsync(ctx, req).thenApply(obj -> convertResponse(obj, converter));
@@ -180,6 +129,184 @@ final class AnnotatedHttpServiceMethod implements BiFunction<ServiceRequestConte
         final Object ret = apply(ctx, req);
         return ret instanceof CompletionStage ?
                (CompletionStage<?>) ret : CompletableFuture.completedFuture(ret);
+    }
+
+    private Object invoke(ServiceRequestContext ctx, HttpRequest req, @Nullable AggregatedHttpMessage message) {
+        try (SafeCloseable ignored = RequestContext.push(ctx, false)) {
+            return method.invoke(object, parameterValues(ctx, req, parameters, message));
+        } catch (IllegalArgumentException e) {
+            // Return "400 Bad Request" if the request has not sufficient arguments or has an invalid argument.
+            return HttpResponse.of(HttpStatus.BAD_REQUEST);
+        } catch (Exception e) {
+            if (e instanceof InvocationTargetException) {
+                final Throwable cause = e.getCause();
+                if (cause != null) {
+                    return Exceptions.throwUnsafely(cause);
+                }
+            }
+            return Exceptions.throwUnsafely(e);
+        }
+    }
+
+    /**
+     * Returns the array of {@link Parameter}, which holds the type and {@link Param} value.
+     */
+    private static List<Parameter> parameters(Method method, final Set<String> pathParams) {
+        requireNonNull(pathParams, "pathParams");
+        boolean hasRequestMessage = false;
+        final ImmutableList.Builder<Parameter> entries = ImmutableList.builder();
+        for (java.lang.reflect.Parameter p : method.getParameters()) {
+            final Param param = p.getAnnotation(Param.class);
+            if (param != null) {
+                final Optional optional = p.getAnnotation(Optional.class);
+                if (pathParams.contains(param.value())) {
+                    // Path variable
+                    if (optional != null) {
+                        throw new IllegalArgumentException(
+                                "Path variable '" + param.value() + "' should not have @Optional annotation");
+                    }
+                    entries.add(Parameter.ofPathParam(p.getType(), param.value()));
+                } else {
+                    // Query string parameter or form data parameter
+                    final boolean required = optional == null;
+                    final String defaultValue;
+                    if (required) {
+                        defaultValue = null;
+                    } else {
+                        final String v = optional.value();
+                        // Set the default value to null if it was not specified.
+                        // The default value might also be specified as null value by a user.
+                        defaultValue = DefaultValues.isSpecified(v) ? v : null;
+                    }
+                    entries.add(Parameter.ofParam(required, p.getType(), param.value(), defaultValue));
+                }
+                continue;
+            }
+
+            if (p.getType().isAssignableFrom(ServiceRequestContext.class) ||
+                p.getType().isAssignableFrom(HttpParameters.class)) {
+                entries.add(Parameter.ofPredefinedType(p.getType()));
+                continue;
+            }
+
+            if (p.getType().isAssignableFrom(HttpRequest.class) ||
+                p.getType().isAssignableFrom(AggregatedHttpMessage.class)) {
+                if (hasRequestMessage) {
+                    throw new IllegalArgumentException("Only one request message variable is allowed.");
+                }
+                hasRequestMessage = true;
+                entries.add(Parameter.ofPredefinedType(p.getType()));
+                continue;
+            }
+
+            throw new IllegalArgumentException("Unsupported object type: " + p.getType());
+        }
+        return entries.build();
+    }
+
+    /**
+     * Returns array of parameters for method invocation.
+     */
+    private static Object[] parameterValues(ServiceRequestContext ctx, HttpRequest req,
+                                            List<Parameter> parameters,
+                                            @Nullable AggregatedHttpMessage message) {
+        HttpParameters httpParameters = null;
+        Object[] values = new Object[parameters.size()];
+        for (int i = 0; i < parameters.size(); ++i) {
+            Parameter entry = parameters.get(i);
+            final String value;
+            switch (entry.parameterType()) {
+                case PATH_PARAM:
+                    value = ctx.pathParam(entry.name());
+                    assert value != null;
+                    values[i] = convertParameter(value, entry.type());
+                    break;
+                case PARAM:
+                    if (httpParameters == null) {
+                        httpParameters = httpParametersOf(ctx, req, message);
+                    }
+                    value = httpParameterValue(httpParameters, entry);
+                    values[i] = value != null ? convertParameter(value, entry.type()) : null;
+                    break;
+                case PREDEFINED_TYPE:
+                    if (entry.type().isAssignableFrom(ServiceRequestContext.class)) {
+                        values[i] = ctx;
+                    } else if (entry.type().isAssignableFrom(HttpRequest.class)) {
+                        values[i] = req;
+                    } else if (entry.type().isAssignableFrom(AggregatedHttpMessage.class)) {
+                        values[i] = message;
+                    } else if (entry.type().isAssignableFrom(HttpParameters.class)) {
+                        if (httpParameters == null) {
+                            httpParameters = httpParametersOf(ctx, req, message);
+                        }
+                        values[i] = httpParameters;
+                    }
+                    break;
+            }
+        }
+        return values;
+    }
+
+    /**
+     * Returns a map of parameters decoded from a request.
+     *
+     * <p>Usually one of a query string of a URI or URL-encoded form data is specified in the request.
+     * If both of them exist though, they would be decoded and merged into a parameter map.</p>
+     *
+     * <p>Names and values of the parameters would be decoded as UTF-8 character set.</p>
+     * @see QueryStringDecoder#QueryStringDecoder(String, boolean)
+     * @see HttpConstants#DEFAULT_CHARSET
+     */
+    private static HttpParameters httpParametersOf(ServiceRequestContext ctx, HttpRequest req,
+                                                   @Nullable AggregatedHttpMessage message) {
+        try {
+            Map<String, List<String>> parameters = null;
+            final String query = ctx.query();
+            if (query != null) {
+                parameters = new QueryStringDecoder(query, false).parameters();
+            }
+            if (AggregationStrategy.aggregationAvailable(req)) {
+                assert message != null;
+                final String body = message.content().toStringAscii();
+                if (!body.isEmpty()) {
+                    final Map<String, List<String>> p =
+                            new QueryStringDecoder(body, false).parameters();
+                    if (parameters == null) {
+                        parameters = p;
+                    } else if (p != null) {
+                        parameters.putAll(p);
+                    }
+                }
+            }
+            if (parameters == null || parameters.isEmpty()) {
+                return EMPTY_PARAMETERS;
+            }
+            return HttpParameters.copyOf(parameters);
+
+        } catch (Exception e) {
+            // If we failed to decode the query string, we ignore the exception raised here.
+            // A missing parameter might be checked when invoking the annotated method.
+            logger.debug("Failed to decode query string: {}", e);
+            return EMPTY_PARAMETERS;
+        }
+    }
+
+    /**
+     * Returns the value of the specified parameter name.
+     */
+    @Nullable
+    private static String httpParameterValue(HttpParameters httpParameters, Parameter entry) {
+        String value = httpParameters.get(entry.name());
+        if (value != null) {
+            // The first decoded value.
+            return value;
+        }
+        if (!entry.isRequired()) {
+            // May return null if no default value is specified.
+            return entry.defaultValue();
+        }
+
+        throw new IllegalArgumentException("Required parameter '" + entry.name() + "' is missing.");
     }
 
     /**
@@ -211,11 +338,11 @@ final class AnnotatedHttpServiceMethod implements BiFunction<ServiceRequestConte
             throw e;
         } catch (Exception e) {
             throw new IllegalArgumentException(
-                    "Can't convert " + str + " to type " + clazz.getSimpleName(), e);
+                    "Can't convert '" + str + "' to type '" + clazz.getSimpleName() + "'.", e);
         }
 
         throw new IllegalArgumentException(
-                "Type " + clazz.getSimpleName() + " can't be converted.");
+                "Type '" + clazz.getSimpleName() + "' can't be converted.");
     }
 
     /**
@@ -291,32 +418,116 @@ final class AnnotatedHttpServiceMethod implements BiFunction<ServiceRequestConte
         }
 
         // No appropriate converter found: raise runtime exception.
-        throw new IllegalArgumentException("Converter not available for " + type.getSimpleName());
+        throw new IllegalArgumentException("Converter not available for: " + type.getSimpleName());
     }
 
     /**
      * Parameter entry, which will be used to invoke the {@link AnnotatedHttpService}.
      */
     private static final class Parameter {
-        private final Class<?> type;
-        private final String name;
 
-        Parameter(Class<?> type, @Nullable String name) {
-            this.type = type;
-            this.name = name;
+        static Parameter ofPathParam(Class<?> type, String name) {
+            return new Parameter(ParameterType.PATH_PARAM, true, type, name, null);
         }
 
-        Class<?> getType() {
+        static Parameter ofParam(boolean required, Class<?> type, String name, @Nullable String defaultValue) {
+            return new Parameter(ParameterType.PARAM, required, type, name, defaultValue);
+        }
+
+        static Parameter ofPredefinedType(Class<?> type) {
+            return new Parameter(ParameterType.PREDEFINED_TYPE, true, type, null, null);
+        }
+
+        private final ParameterType parameterType;
+        private final boolean required;
+        private final Class<?> type;
+        private final String name;
+        private final String defaultValue;
+
+        Parameter(ParameterType parameterType,
+                  boolean required, Class<?> type,
+                  @Nullable String name, @Nullable String defaultValue) {
+            this.parameterType = parameterType;
+            this.required = required;
+            this.type = requireNonNull(type, "type");
+            this.name = name;
+            this.defaultValue = defaultValue;
+        }
+
+        ParameterType parameterType() {
+            return parameterType;
+        }
+
+        boolean isRequired() {
+            return required;
+        }
+
+        Class<?> type() {
             return type;
         }
 
         @Nullable
-        String getName() {
+        String name() {
             return name;
         }
 
+        @Nullable
+        String defaultValue() {
+            return defaultValue;
+        }
+
         boolean isPathParam() {
-            return name != null;
+            return parameterType() == ParameterType.PATH_PARAM;
+        }
+    }
+
+    private enum ParameterType {
+        PATH_PARAM, PARAM, PREDEFINED_TYPE
+    }
+
+    private enum AggregationStrategy {
+        NONE, ALWAYS, FOR_FORM_DATA;
+
+        /**
+         * Whether the request should be aggregated.
+         */
+        static boolean aggregationRequired(AggregationStrategy strategy, HttpRequest req) {
+            requireNonNull(strategy, "strategy");
+            switch (strategy) {
+                case ALWAYS:
+                    return true;
+                case FOR_FORM_DATA:
+                    return aggregationAvailable(req);
+            }
+            return false;
+        }
+
+        /**
+         * Whether the request is available to be aggregated.
+         */
+        static boolean aggregationAvailable(HttpRequest req) {
+            final String contentType = req.headers().get(HttpHeaderNames.CONTENT_TYPE);
+            // We aggregate request stream messages for the media type of form data currently.
+            return contentType != null &&
+                   MediaType.FORM_DATA.toString().equals(HttpUtil.getMimeType(contentType));
+        }
+
+        /**
+         * Returns {@link AggregationStrategy} which specifies how to aggregate the request
+         * for injecting its parameters.
+         */
+        static AggregationStrategy resolve(List<Parameter> parameters) {
+            AggregationStrategy strategy = NONE;
+            for (Parameter p : parameters) {
+                if (p.type().isAssignableFrom(AggregatedHttpMessage.class)) {
+                    return ALWAYS;
+                }
+                if (p.parameterType() == ParameterType.PARAM ||
+                    p.type().isAssignableFrom(HttpParameters.class)) {
+                    strategy = FOR_FORM_DATA;
+                }
+            }
+            return strategy;
         }
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -43,7 +43,7 @@ import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.http.HttpRequest;
 import com.linecorp.armeria.common.http.HttpResponse;
-import com.linecorp.armeria.server.http.dynamic.ResponseConverter;
+import com.linecorp.armeria.server.http.annotation.ResponseConverter;
 
 import io.netty.handler.ssl.SslContext;
 import io.netty.util.concurrent.DefaultThreadFactory;

--- a/core/src/main/java/com/linecorp/armeria/server/http/annotation/Converter.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/annotation/Converter.java
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-package com.linecorp.armeria.server.http.dynamic;
+package com.linecorp.armeria.server.http.annotation;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Repeatable;

--- a/core/src/main/java/com/linecorp/armeria/server/http/annotation/Converters.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/annotation/Converters.java
@@ -14,19 +14,21 @@
  * under the License.
  */
 
-package com.linecorp.armeria.server.http.dynamic;
+package com.linecorp.armeria.server.http.annotation;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import com.linecorp.armeria.common.http.HttpMethod;
-
 /**
- * Annotation for mapping {@link HttpMethod#GET} onto specific method.
+ * The containing annotation type for {@link Converter}.
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.METHOD)
-public @interface Get {
+@Target({ ElementType.TYPE, ElementType.METHOD })
+public @interface Converters {
+    /**
+     * An array of {@link Converter}s.
+     */
+    Converter[] value();
 }

--- a/core/src/main/java/com/linecorp/armeria/server/http/annotation/Delete.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/annotation/Delete.java
@@ -14,7 +14,9 @@
  * under the License.
  */
 
-package com.linecorp.armeria.server.http.dynamic;
+package com.linecorp.armeria.server.http.annotation;
+
+import static com.linecorp.armeria.internal.DefaultValues.UNSPECIFIED;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -29,4 +31,9 @@ import com.linecorp.armeria.common.http.HttpMethod;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface Delete {
+
+    /**
+     * A path pattern for the annotated method.
+     */
+    String value() default UNSPECIFIED;
 }

--- a/core/src/main/java/com/linecorp/armeria/server/http/annotation/Get.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/annotation/Get.java
@@ -14,7 +14,9 @@
  * under the License.
  */
 
-package com.linecorp.armeria.server.http.dynamic;
+package com.linecorp.armeria.server.http.annotation;
+
+import static com.linecorp.armeria.internal.DefaultValues.UNSPECIFIED;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -24,9 +26,14 @@ import java.lang.annotation.Target;
 import com.linecorp.armeria.common.http.HttpMethod;
 
 /**
- * Annotation for mapping {@link HttpMethod#PUT} onto specific method.
+ * Annotation for mapping {@link HttpMethod#GET} onto specific method.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
-public @interface Put {
+public @interface Get {
+
+    /**
+     * A path pattern for the annotated method.
+     */
+    String value() default UNSPECIFIED;
 }

--- a/core/src/main/java/com/linecorp/armeria/server/http/annotation/Head.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/annotation/Head.java
@@ -14,7 +14,9 @@
  * under the License.
  */
 
-package com.linecorp.armeria.server.http.dynamic;
+package com.linecorp.armeria.server.http.annotation;
+
+import static com.linecorp.armeria.internal.DefaultValues.UNSPECIFIED;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -24,9 +26,14 @@ import java.lang.annotation.Target;
 import com.linecorp.armeria.common.http.HttpMethod;
 
 /**
- * Annotation for mapping {@link HttpMethod#POST} onto specific method.
+ * Annotation for mapping {@link HttpMethod#HEAD} onto specific method.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
-public @interface Post {
+public @interface Head {
+
+    /**
+     * A path pattern for the annotated method.
+     */
+    String value() default UNSPECIFIED;
 }

--- a/core/src/main/java/com/linecorp/armeria/server/http/annotation/Optional.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/annotation/Optional.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 LINE Corporation
+ * Copyright 2017 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -14,7 +14,9 @@
  * under the License.
  */
 
-package com.linecorp.armeria.server.http.dynamic;
+package com.linecorp.armeria.server.http.annotation;
+
+import static com.linecorp.armeria.internal.DefaultValues.UNSPECIFIED;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -22,13 +24,19 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * The containing annotation type for {@link Converter}.
+ * Specifies a parameter as an optional and provides the default value.
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.TYPE, ElementType.METHOD })
-public @interface Converters {
+@Target(ElementType.PARAMETER)
+public @interface Optional {
+
     /**
-     * An array of {@link Converter}s.
+     * The default value to use as a fallback when the request parameter is not provided or has an empty value.
+     * When {@link Optional} annotation exists but {@link Optional#value()} is not specified, {@code null}
+     * value would be set if the parameter is not present in the request.
+     *
+     * {@link Optional} annotation is not allowed for a path variable. If a user uses {@link Optional}
+     * annotation on a path variable, {@link IllegalArgumentException} would be raised.
      */
-    Converter[] value();
+    String value() default UNSPECIFIED;
 }

--- a/core/src/main/java/com/linecorp/armeria/server/http/annotation/Options.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/annotation/Options.java
@@ -14,7 +14,26 @@
  * under the License.
  */
 
+package com.linecorp.armeria.server.http.annotation;
+
+import static com.linecorp.armeria.internal.DefaultValues.UNSPECIFIED;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.linecorp.armeria.common.http.HttpMethod;
+
 /**
- * Dynamic HTTP service.
+ * Annotation for mapping {@link HttpMethod#OPTIONS} onto specific method.
  */
-package com.linecorp.armeria.server.http.dynamic;
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Options {
+
+    /**
+     * A path pattern for the annotated method.
+     */
+    String value() default UNSPECIFIED;
+}

--- a/core/src/main/java/com/linecorp/armeria/server/http/annotation/Param.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/annotation/Param.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.http.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation for mapping a parameter of a request onto a method parameter.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface Param {
+
+    /**
+     * The name of the request parameter to bind to.
+     * The path variable, the parameter name in a query string or a URL-encoded form data,
+     * or the name of a multipart.
+     */
+    String value();
+}

--- a/core/src/main/java/com/linecorp/armeria/server/http/annotation/Patch.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/annotation/Patch.java
@@ -14,7 +14,9 @@
  * under the License.
  */
 
-package com.linecorp.armeria.server.http.dynamic;
+package com.linecorp.armeria.server.http.annotation;
+
+import static com.linecorp.armeria.internal.DefaultValues.UNSPECIFIED;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -29,4 +31,9 @@ import com.linecorp.armeria.common.http.HttpMethod;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface Patch {
+
+    /**
+     * A path pattern for the annotated method.
+     */
+    String value() default UNSPECIFIED;
 }

--- a/core/src/main/java/com/linecorp/armeria/server/http/annotation/Path.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/annotation/Path.java
@@ -14,19 +14,22 @@
  * under the License.
  */
 
-package com.linecorp.armeria.server.http.dynamic;
+package com.linecorp.armeria.server.http.annotation;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import com.linecorp.armeria.common.http.HttpMethod;
-
 /**
- * Annotation for mapping {@link HttpMethod#OPTIONS} onto specific method.
+ * Annotation for mapping dynamic web requests onto specific method.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
-public @interface Options {
+public @interface Path {
+
+    /**
+     * A path pattern for the annotated method.
+     */
+    String value();
 }

--- a/core/src/main/java/com/linecorp/armeria/server/http/annotation/Post.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/annotation/Post.java
@@ -14,18 +14,26 @@
  * under the License.
  */
 
-package com.linecorp.armeria.server.http.dynamic;
+package com.linecorp.armeria.server.http.annotation;
 
-import com.linecorp.armeria.common.http.HttpResponse;
+import static com.linecorp.armeria.internal.DefaultValues.UNSPECIFIED;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.linecorp.armeria.common.http.HttpMethod;
 
 /**
- * Converts given object into {@link HttpResponse}.
+ * Annotation for mapping {@link HttpMethod#POST} onto specific method.
  */
-@FunctionalInterface
-public interface ResponseConverter {
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Post {
 
     /**
-     * Returns {@link HttpResponse} instance corresponds to the given {@code resObj}.
+     * A path pattern for the annotated method.
      */
-    HttpResponse convert(Object resObj) throws Exception;
+    String value() default UNSPECIFIED;
 }

--- a/core/src/main/java/com/linecorp/armeria/server/http/annotation/Put.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/annotation/Put.java
@@ -14,7 +14,9 @@
  * under the License.
  */
 
-package com.linecorp.armeria.server.http.dynamic;
+package com.linecorp.armeria.server.http.annotation;
+
+import static com.linecorp.armeria.internal.DefaultValues.UNSPECIFIED;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -24,9 +26,14 @@ import java.lang.annotation.Target;
 import com.linecorp.armeria.common.http.HttpMethod;
 
 /**
- * Annotation for mapping {@link HttpMethod#HEAD} onto specific method.
+ * Annotation for mapping {@link HttpMethod#PUT} onto specific method.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
-public @interface Head {
+public @interface Put {
+
+    /**
+     * A path pattern for the annotated method.
+     */
+    String value() default UNSPECIFIED;
 }

--- a/core/src/main/java/com/linecorp/armeria/server/http/annotation/ResponseConverter.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/annotation/ResponseConverter.java
@@ -14,19 +14,18 @@
  * under the License.
  */
 
-package com.linecorp.armeria.server.http.dynamic;
+package com.linecorp.armeria.server.http.annotation;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
-
-import com.linecorp.armeria.common.http.HttpMethod;
+import com.linecorp.armeria.common.http.HttpResponse;
 
 /**
- * Annotation for mapping {@link HttpMethod#TRACE} onto specific method.
+ * Converts given object into {@link HttpResponse}.
  */
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.METHOD)
-public @interface Trace {
+@FunctionalInterface
+public interface ResponseConverter {
+
+    /**
+     * Returns {@link HttpResponse} instance corresponds to the given {@code resObj}.
+     */
+    HttpResponse convert(Object resObj) throws Exception;
 }

--- a/core/src/main/java/com/linecorp/armeria/server/http/annotation/Trace.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/annotation/Trace.java
@@ -14,22 +14,26 @@
  * under the License.
  */
 
-package com.linecorp.armeria.server.http.dynamic;
+package com.linecorp.armeria.server.http.annotation;
+
+import static com.linecorp.armeria.internal.DefaultValues.UNSPECIFIED;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import com.linecorp.armeria.common.http.HttpMethod;
+
 /**
- * Annotation for mapping dynamic web requests onto specific method.
+ * Annotation for mapping {@link HttpMethod#TRACE} onto specific method.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
-public @interface Path {
+public @interface Trace {
 
     /**
-     * Template of dynamic url.
+     * A path pattern for the annotated method.
      */
-    String value();
+    String value() default UNSPECIFIED;
 }

--- a/core/src/main/java/com/linecorp/armeria/server/http/annotation/package-info.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/annotation/package-info.java
@@ -14,22 +14,7 @@
  * under the License.
  */
 
-package com.linecorp.armeria.server.http.dynamic;
-
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
-
 /**
- * Annotation for mapping dynamic web requests onto specific parameter.
+ * Dynamic HTTP service.
  */
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.PARAMETER)
-public @interface PathParam {
-
-    /**
-     * Variable name in {@link Path}.
-     */
-    String value();
-}
+package com.linecorp.armeria.server.http.annotation;

--- a/core/src/test/java/com/linecorp/armeria/common/http/HttpParametersTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/http/HttpParametersTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.Test;
+
+public class HttpParametersTest {
+
+    @Test
+    public void caseSensitive() {
+        HttpParameters p = HttpParameters.of();
+        p.add("abc", "abc1");
+        p.add("abc", "abc2");
+        p.add("ABC", "ABC");
+
+        assertThat(p.size()).isEqualTo(3);
+
+        List<String> values = p.getAll("abc");
+        assertThat(values.size()).isEqualTo(2);
+        assertThat(values.get(0)).isEqualTo("abc1");
+        assertThat(values.get(1)).isEqualTo("abc2");
+
+        assertThat(p.get("abc")).isEqualTo("abc1");
+        assertThat(p.get("ABC")).isEqualTo("ABC");
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/AnnotatedHttpServiceBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/AnnotatedHttpServiceBuilderTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.Test;
+
+import com.linecorp.armeria.server.http.annotation.Get;
+import com.linecorp.armeria.server.http.annotation.Options;
+import com.linecorp.armeria.server.http.annotation.Path;
+import com.linecorp.armeria.server.http.annotation.Post;
+
+public class AnnotatedHttpServiceBuilderTest {
+
+    @Test
+    public void successfulOf() {
+        new ServerBuilder().annotatedService(new Object() {
+            @Get("/")
+            public Object root() {
+                return null;
+            }
+        });
+        new ServerBuilder().annotatedService(new Object() {
+            @Path("/")
+            @Get
+            public Object root() {
+                return null;
+            }
+        });
+        new ServerBuilder().annotatedService(new Object() {
+            @Path("/")
+            @Get
+            @Post
+            public Object root() {
+                return null;
+            }
+        });
+        new ServerBuilder().annotatedService(new Object() {
+            @Options
+            @Get
+            @Post("/")
+            public Object root() {
+                return null;
+            }
+        });
+    }
+
+    @Test
+    public void failedOf() {
+        assertThatThrownBy(() -> new ServerBuilder().annotatedService(new Object() {
+            @Path("/")
+            @Get("/")
+            public Object root() {
+                return null;
+            }
+        })).isInstanceOf(IllegalArgumentException.class);
+
+        assertThatThrownBy(() -> new ServerBuilder().annotatedService(new Object() {
+            @Post("/")
+            @Get("/")
+            public Object root() {
+                return null;
+            }
+        })).isInstanceOf(IllegalArgumentException.class);
+
+        assertThatThrownBy(() -> new ServerBuilder().annotatedService(new Object() {
+            @Get
+            public Object root() {
+                return null;
+            }
+        })).isInstanceOf(IllegalArgumentException.class);
+
+        assertThatThrownBy(() -> new ServerBuilder().annotatedService(new Object() {
+            @Get("")
+            public Object root() {
+                return null;
+            }
+        })).isInstanceOf(IllegalArgumentException.class);
+
+        assertThatThrownBy(() -> new ServerBuilder().annotatedService(new Object() {
+            @Get("  ")
+            public Object root() {
+                return null;
+            }
+        })).isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/TestConverters.java
+++ b/core/src/test/java/com/linecorp/armeria/server/TestConverters.java
@@ -22,7 +22,7 @@ import com.linecorp.armeria.common.http.HttpHeaderNames;
 import com.linecorp.armeria.common.http.HttpHeaders;
 import com.linecorp.armeria.common.http.HttpResponse;
 import com.linecorp.armeria.common.http.HttpStatus;
-import com.linecorp.armeria.server.http.dynamic.ResponseConverter;
+import com.linecorp.armeria.server.http.annotation.ResponseConverter;
 
 final class TestConverters {
 

--- a/site/src/sphinx/server-basics.rst
+++ b/site/src/sphinx/server-basics.rst
@@ -77,9 +77,8 @@ Even if we opened a port, it's of no use if we didn't bind any services to them.
 
     // Using an annotated service object:
     sb.annotatedService(new Object() {
-        @Get
-        @Path("/greet2/{name}")
-        public HttpResponse greet(@PathParam("name") String name) {
+        @Get("/greet2/{name}")
+        public HttpResponse greet(@Param("name") String name) {
             return HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "Hello, %s!", name);
         }
     });
@@ -97,10 +96,28 @@ Even if we opened a port, it's of no use if we didn't bind any services to them.
 
     // Using an annotated service object:
     sb.annotatedService(new Object() {
-        @Get
-        @Path("regex:^/greet4/(?<name>.*)$")
-        public HttpResponse greet(@PathParam("name") String name) {
+        @Get("regex:^/greet4/(?<name>.*)$")
+        public HttpResponse greet(@Param("name") String name) {
             return HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "Hello, %s!", name);
+        }
+    });
+
+    // Using a query parameter (e.g. /greet5?name=alice) on an annotated service object:
+    sb.annotatedService(new Object() {
+        @Get("/greet5")
+        public HttpResponse greet(@Param("name") String name,
+                                  @Param("title") @Optional("Mr.") String title) {
+            // "Mr." is used by default if there is no title parameter in the request.
+            return HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "Hello, %s %s!", title, name);
+        }
+    });
+
+    // Getting a map of query parameters on an annotated service object:
+    sb.annotatedService(new Object() {
+        @Get("/greet6")
+        public HttpResponse greet(HttpParameters parameters) {
+            return HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "Hello, %s!",
+                                   parameters.get("name");
         }
     });
 


### PR DESCRIPTION
Related to #580 

Motivation:

The other framework, such as Spring framework, provides query string parameter injection basically.
So it is better to support the feature on Armeria so that a user writes less codes.
We are going to support parameter injection for a query string of HTTP GET requests and URL-encoded form data of HTTP POST requests.

Modifications:
- Add `@Param` annotation for parameter injection.
- Add `HttpParameters` interface to inject every parameters.
- Replace `@PathParam` with `@Param` annotation. `@PathParam` is removed.
- Respond `400 Bad Request` if the request has not sufficient arguments or has an invalid argument. (was: `500 Internal Server Error`)
- Allow path pattern as a value of HTTP method annotations. e.g, `@Get("/path")`
- Add `@Optional` annotation to specify an optional parameter and its default value. e.g, `@Param("name") @Optional("thomas") String name`

Result:
- A user is able to get parameter easily on his/her annotated service methods.