### PR TITLE
Remove exception throwing when a context is timed out.

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/RequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestContext.java
@@ -350,6 +350,12 @@ public interface RequestContext extends AttributeMap {
     }
 
     /**
+     * Returns whether this {@link RequestContext} has been timed-out (e.g., when the corresponding request
+     * passes a deadline).
+     */
+    boolean isTimedOut();
+
+    /**
      * Registers {@code callback} to be run when re-entering this {@link RequestContext}, usually when using
      * the {@link #makeContextAware} family of methods. Any thread-local state associated with this context
      * should be restored by this callback.

--- a/core/src/test/java/com/linecorp/armeria/common/RequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/RequestContextTest.java
@@ -17,7 +17,6 @@
 package com.linecorp.armeria.common;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
@@ -25,7 +24,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Callable;
-import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
@@ -158,19 +156,6 @@ public class RequestContextTest {
     }
 
     @Test
-    public void makeContextAwareCallable_timedOut() throws Exception {
-        NonWrappingRequestContext context = createContext();
-        AtomicBoolean called = new AtomicBoolean();
-        Callable<?> callable = context.makeContextAware(() -> {
-            called.set(true);
-            return "success";
-        });
-        context.setTimedOut();
-        assertThatThrownBy(callable::call).isInstanceOf(CancellationException.class);
-        assertThat(called.get()).isFalse();
-    }
-
-    @Test
     public void makeContextAwareRunnable() {
         RequestContext context = createContext();
         context.makeContextAware(() -> {
@@ -178,16 +163,6 @@ public class RequestContextTest {
             assertDepth(1);
         }).run();
         assertDepth(0);
-    }
-
-    @Test
-    public void makeContextAwareRunnable_timedOut() {
-        NonWrappingRequestContext context = createContext();
-        AtomicBoolean called = new AtomicBoolean();
-        Runnable runnable = context.makeContextAware(() -> called.set(true));
-        context.setTimedOut();
-        assertThatThrownBy(runnable::run).isInstanceOf(CancellationException.class);
-        assertThat(called.get()).isFalse();
     }
 
     @Test
@@ -203,24 +178,6 @@ public class RequestContextTest {
         promise.setSuccess("success");
     }
 
-    @Test(timeout = 10000)
-    @SuppressWarnings("deprecation")
-    public void makeContextAwareFutureListener_timedOut() throws Exception {
-        when(channel.eventLoop()).thenReturn(eventLoop);
-        NonWrappingRequestContext context = createContext();
-        Promise<String> promise = new DefaultPromise<>(ImmediateEventExecutor.INSTANCE);
-        CountDownLatch latch = new CountDownLatch(1);
-        promise.addListener(context.makeContextAware((FutureListener<String>) f -> {
-            assertThatThrownBy(f::get).isInstanceOf(CancellationException.class);
-            latch.countDown();
-        }));
-        context.setTimedOut();
-        promise.setSuccess("success");
-
-        // The latch will not complete if the assertion in the FutureListener fails.
-        latch.await();
-    }
-
     @Test
     @SuppressWarnings("deprecation")
     public void makeContextAwareChannelFutureListener() {
@@ -232,24 +189,6 @@ public class RequestContextTest {
             assertThat(f.getNow()).isNull();
         }));
         promise.setSuccess(null);
-    }
-
-    @Test(timeout = 10000)
-    @SuppressWarnings("deprecation")
-    public void makeContextAwareChannelFutureListener_timedOut() throws Exception {
-        when(channel.eventLoop()).thenReturn(eventLoop);
-        NonWrappingRequestContext context = createContext();
-        ChannelPromise promise = new DefaultChannelPromise(channel, ImmediateEventExecutor.INSTANCE);
-        CountDownLatch latch = new CountDownLatch(1);
-        promise.addListener(context.makeContextAware((ChannelFutureListener) f -> {
-            assertThatThrownBy(f::get).isInstanceOf(CancellationException.class);
-            latch.countDown();
-        }));
-        context.setTimedOut();
-        promise.setSuccess(null);
-
-        // The latch will not complete if the assertion in the ChannelFutureListener fails.
-        latch.await();
     }
 
     @Test
@@ -266,20 +205,6 @@ public class RequestContextTest {
         originalFuture.complete("success");
         assertDepth(0);
         resultFuture.get(); // this will propagate assertions.
-    }
-
-    @Test
-    public void makeContextAwareCompletableFutureInSameThread_timedOut() throws Exception {
-        NonWrappingRequestContext context = createContext();
-        CompletableFuture<String> originalFuture = new CompletableFuture<>();
-        CompletableFuture<String> contextAwareFuture = context.makeContextAware(originalFuture);
-        AtomicBoolean called = new AtomicBoolean();
-        CompletableFuture<String> resultFuture =
-                contextAwareFuture.whenComplete((result, cause) -> called.set(true));
-        context.setTimedOut();
-        originalFuture.complete("success");
-        assertThat(called.get()).isFalse();
-        assertThatThrownBy(resultFuture::get).isInstanceOf(CancellationException.class);
     }
 
     @Test
@@ -424,6 +349,14 @@ public class RequestContextTest {
             assertThat(nested.get()).isFalse();
         }
         assertDepth(0);
+    }
+
+    @Test
+    public void timedOut() {
+        RequestContext ctx = createContext();
+        assertThat(ctx.isTimedOut()).isFalse();
+        ((AbstractRequestContext) ctx).setTimedOut();
+        assertThat(ctx.isTimedOut()).isTrue();
     }
 
     private void assertDepth(int expectedDepth) {


### PR DESCRIPTION
Failing all callbacks when a context is timed out can prevent cleanup logic, etc from being run. It is better to leave it up to the user which callbacks are safe to cancel or not.