### PR TITLE
Allow duplicate docstring keys in grpc docstring extractor.

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcDocStringExtractor.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcDocStringExtractor.java
@@ -92,7 +92,7 @@ final class GrpcDocStringExtractor extends DocStringExtractor {
                         }
                     })
                     .flatMap(f -> parseFile(f).entrySet().stream())
-                    .collect(toImmutableMap(Entry::getKey, Entry::getValue));
+                    .collect(toImmutableMap(Entry::getKey, Entry::getValue, (entry, unused) -> entry));
     }
 
     private static Map<String, String> parseFile(FileDescriptorProto descriptor) {


### PR DESCRIPTION
It's quite normal for the same key to be present in multiple files when both APIs import the same dependency (common with google standard dependencies like Timestamp).