### PR TITLE
Restore prefix mapping stripping to allow it to work together with arbitrarily mapped PathMappingResult

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/PathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/PathMapping.java
@@ -106,16 +106,39 @@ public interface PathMapping {
 
     /**
      * Creates a new {@link PathMapping} that matches a {@linkplain ServiceRequestContext#path() path}
-     * under the specified directory prefix.
+     * under the specified directory prefix. It also removes the specified directory prefix from the matched
+     * path so that {@link ServiceRequestContext#path()} does not have the specified directory prefix.
+     * For example, when {@code pathPrefix} is {@code "/foo/"}:
+     * <ul>
+     *   <li>{@code "/foo/"} translates to {@code "/"}</li>
+     *   <li>{@code "/foo/bar"} translates to  {@code "/bar"}</li>
+     *   <li>{@code "/foo/bar/baz"} translates to {@code "/bar/baz"}</li>
+     * </ul>
+     * This method is a shortcut to {@link #ofPrefix(String, boolean) ofPrefix(pathPrefix, true)}.
      */
     static PathMapping ofPrefix(String pathPrefix) {
+        return ofPrefix(pathPrefix, true);
+    }
+
+    /**
+     * Creates a new {@link PathMapping} that matches a {@linkplain ServiceRequestContext#path() path}
+     * under the specified directory prefix. When {@code stripPrefix} is {@code true}, it also removes the
+     * specified directory prefix from the matched path so that {@link ServiceRequestContext#path()}
+     * does not have the specified directory prefix. For example, when {@code pathPrefix} is {@code "/foo/"}:
+     * <ul>
+     *   <li>{@code "/foo/"} translates to {@code "/"}</li>
+     *   <li>{@code "/foo/bar"} translates to  {@code "/bar"}</li>
+     *   <li>{@code "/foo/bar/baz"} translates to {@code "/bar/baz"}</li>
+     * </ul>
+     */
+    static PathMapping ofPrefix(String pathPrefix, boolean stripPrefix) {
         requireNonNull(pathPrefix, "pathPrefix");
         if ("/".equals(pathPrefix)) {
             // Every path starts with '/'.
             return ofCatchAll();
         }
 
-        return new PrefixPathMapping(pathPrefix);
+        return new PrefixPathMapping(pathPrefix, stripPrefix);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/PrefixPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/PrefixPathMapping.java
@@ -29,20 +29,22 @@ final class PrefixPathMapping extends AbstractPathMapping {
     static final int PREFIX_LEN = PREFIX.length();
 
     private final String prefix;
+    private final boolean stripPrefix;
     private final String loggerName;
     private final String metricName;
     private final String strVal;
 
-    PrefixPathMapping(String prefix) {
+    PrefixPathMapping(String prefix, boolean stripPrefix) {
         prefix = ensureAbsolutePath(prefix, "prefix");
         if (!prefix.endsWith("/")) {
             prefix += '/';
         }
 
         this.prefix = prefix;
+        this.stripPrefix = stripPrefix;
         loggerName = loggerName(prefix);
         metricName = prefix + "**";
-        strVal = PREFIX + prefix;
+        strVal = PREFIX + prefix + " (stripPrefix: " + stripPrefix + ')';
     }
 
     @Override
@@ -51,7 +53,7 @@ final class PrefixPathMapping extends AbstractPathMapping {
             return PathMappingResult.empty();
         }
 
-        return PathMappingResult.of(path, query);
+        return PathMappingResult.of(stripPrefix ? path.substring(prefix.length() - 1) : path, query);
     }
 
     @Override
@@ -71,7 +73,7 @@ final class PrefixPathMapping extends AbstractPathMapping {
 
     @Override
     public int hashCode() {
-        return prefix.hashCode();
+        return stripPrefix ? prefix.hashCode() : -prefix.hashCode();
     }
 
     @Override
@@ -85,7 +87,7 @@ final class PrefixPathMapping extends AbstractPathMapping {
         }
 
         final PrefixPathMapping that = (PrefixPathMapping) obj;
-        return prefix.equals(that.prefix);
+        return stripPrefix == that.stripPrefix && prefix.equals(that.prefix);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
@@ -64,17 +64,6 @@ public interface ServiceRequestContext extends RequestContext {
     }
 
     /**
-     * Returns the path with its prefix removed. This method can be useful for a reusable service bound
-     * at various path prefixes.
-     *
-     * @return the path with its prefix removed, starting with '/'. If the {@link #pathMapping()} is not a
-     *         prefix-mapping, the same value with {@link #path()} will be returned.
-     */
-    default String pathWithoutPrefix() {
-        return pathMapping().prefix().map(s -> path().substring(s.length() - 1)).orElseGet(this::path);
-    }
-
-    /**
      * Returns the {@link Service} that is handling the current {@link Request}.
      */
     <T extends Service<? super HttpRequest, ? extends HttpResponse>> T service();
@@ -90,12 +79,10 @@ public interface ServiceRequestContext extends RequestContext {
     ExecutorService blockingTaskExecutor();
 
     /**
-     * @deprecated Use {@link #pathWithoutPrefix()} instead.
+     * Returns the path with its context path removed. This method can be useful for a reusable service bound
+     * at various path prefixes.
      */
-    @Deprecated
-    default String mappedPath() {
-        return pathWithoutPrefix();
-    }
+    String mappedPath();
 
     /**
      * @deprecated Use a logging framework integration such as {@code RequestContextExportingAppender} in

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
@@ -32,8 +32,6 @@ import com.linecorp.armeria.common.http.HttpResponse;
 public class ServiceRequestContextWrapper
         extends RequestContextWrapper<ServiceRequestContext> implements ServiceRequestContext {
 
-    private String pathWithoutPrefix;
-
     /**
      * Creates a new instance.
      */
@@ -57,15 +55,6 @@ public class ServiceRequestContextWrapper
     }
 
     @Override
-    public String pathWithoutPrefix() {
-        if (pathWithoutPrefix == null) {
-            return pathWithoutPrefix = ServiceRequestContext.super.pathWithoutPrefix();
-        } else {
-            return pathWithoutPrefix;
-        }
-    }
-
-    @Override
     public Map<String, String> pathParams() {
         return delegate().pathParams();
     }
@@ -78,6 +67,11 @@ public class ServiceRequestContextWrapper
     @Override
     public ExecutorService blockingTaskExecutor() {
         return delegate().blockingTaskExecutor();
+    }
+
+    @Override
+    public String mappedPath() {
+        return delegate().mappedPath();
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/http/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/HttpServerHandler.java
@@ -281,7 +281,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
         final Channel channel = ctx.channel();
         final DefaultServiceRequestContext reqCtx = new DefaultServiceRequestContext(
                 serviceCfg, channel, protocol, req.method(),
-                mappingResult, req, getSSLSession(channel));
+                path, mappingResult, req, getSSLSession(channel));
 
         try (SafeCloseable ignored = RequestContext.push(reqCtx)) {
             final RequestLogBuilder logBuilder = reqCtx.logBuilder();

--- a/core/src/main/java/com/linecorp/armeria/server/http/file/HttpFileService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/file/HttpFileService.java
@@ -186,7 +186,7 @@ public final class HttpFileService extends AbstractHttpService {
     }
 
     private Entry getEntry(ServiceRequestContext ctx, HttpRequest req) {
-        final String pathWithoutPrefix = ctx.pathWithoutPrefix();
+        final String mappedPath = ctx.mappedPath();
 
         EnumSet<FileServiceContentEncoding> supportedEncodings =
                 EnumSet.noneOf(FileServiceContentEncoding.class);
@@ -206,13 +206,13 @@ public final class HttpFileService extends AbstractHttpService {
             }
         }
 
-        final Entry entry = getEntryWithSupportedEncodings(pathWithoutPrefix, supportedEncodings);
+        final Entry entry = getEntryWithSupportedEncodings(mappedPath, supportedEncodings);
 
         if (entry.lastModifiedMillis() == 0) {
-            if (pathWithoutPrefix.charAt(pathWithoutPrefix.length() - 1) == '/') {
+            if (mappedPath.charAt(mappedPath.length() - 1) == '/') {
                 // Try index.html if it was a directory access.
                 final Entry indexEntry = getEntryWithSupportedEncodings(
-                        pathWithoutPrefix + "index.html", supportedEncodings);
+                        mappedPath + "index.html", supportedEncodings);
                 if (indexEntry.lastModifiedMillis() != 0) {
                     return indexEntry;
                 }

--- a/core/src/test/java/com/linecorp/armeria/server/AnnotatedHttpServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/AnnotatedHttpServiceTest.java
@@ -294,7 +294,7 @@ public class AnnotatedHttpServiceTest {
         @Get
         @Path("prefix:/prefix")
         public String prefix(ServiceRequestContext ctx) {
-            return "prefix:" + ctx.path() + ':' + ctx.pathWithoutPrefix();
+            return "prefix:" + ctx.path() + ':' + ctx.mappedPath();
         }
 
         @Get

--- a/core/src/test/java/com/linecorp/armeria/server/PrefixPathMappingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/PrefixPathMappingTest.java
@@ -30,6 +30,13 @@ public class PrefixPathMappingTest {
     }
 
     @Test
+    public void mappingResult() {
+        final PathMapping a = ofPrefix("/foo");
+        PathMappingResult result = a.apply("/foo/bar/cat", "");
+        assertThat(result.path()).isEqualTo("/bar/cat");
+    }
+
+    @Test
     public void equality() {
         final PathMapping a = ofPrefix("/foo");
         final PathMapping b = ofPrefix("/bar");

--- a/core/src/test/java/com/linecorp/armeria/server/composition/CompositeServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/composition/CompositeServiceTest.java
@@ -132,7 +132,7 @@ public class CompositeServiceTest {
         @Override
         protected void doGet(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) {
             res.respond(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8,
-                        "%s:%s:%s", name, ctx.path(), ctx.pathWithoutPrefix());
+                        "%s:%s:%s", name, ctx.path(), ctx.mappedPath());
         }
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/http/HttpServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/http/HttpServerTest.java
@@ -213,7 +213,7 @@ public class HttpServerTest {
                 protected void doHead(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) {
                     res.write(HttpHeaders.of(HttpStatus.OK)
                                          .setInt(HttpHeaderNames.CONTENT_LENGTH,
-                                                 ctx.pathWithoutPrefix().length()));
+                                                 ctx.mappedPath().length()));
                     res.close();
                 }
 
@@ -221,8 +221,8 @@ public class HttpServerTest {
                 protected void doGet(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) {
                     res.write(HttpHeaders.of(HttpStatus.OK)
                                          .setInt(HttpHeaderNames.CONTENT_LENGTH,
-                                                 ctx.pathWithoutPrefix().length()));
-                    res.write(HttpData.ofAscii(ctx.pathWithoutPrefix()));
+                                                 ctx.mappedPath().length()));
+                    res.write(HttpData.ofAscii(ctx.mappedPath()));
                     res.close();
                 }
             });
@@ -267,7 +267,7 @@ public class HttpServerTest {
             sb.serviceUnder("/zeroes", new AbstractHttpService() {
                 @Override
                 protected void doGet(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) {
-                    final long length = Long.parseLong(ctx.pathWithoutPrefix().substring(1));
+                    final long length = Long.parseLong(ctx.mappedPath().substring(1));
                     res.write(HttpHeaders.of(HttpStatus.OK)
                                          .setLong(HttpHeaderNames.CONTENT_LENGTH, length));
 

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcRequestUtil.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcRequestUtil.java
@@ -28,7 +28,7 @@ final class GrpcRequestUtil {
     @Nullable
     static String determineMethod(ServiceRequestContext ctx) {
         // Remove the leading slash of the path and get the fully qualified method name
-        String path = ctx.pathWithoutPrefix();
+        String path = ctx.mappedPath();
         if (path.charAt(0) != '/') {
             return null;
         }

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceTest.java
@@ -90,7 +90,7 @@ public class GrpcServiceTest {
 
     @Test
     public void pathMissingSlash() throws Exception {
-        when(ctx.pathWithoutPrefix()).thenReturn("grpc.testing.TestService.UnaryCall");
+        when(ctx.mappedPath()).thenReturn("grpc.testing.TestService.UnaryCall");
         grpcService.doPost(
                 ctx,
                 HttpRequest.of(HttpHeaders.of(HttpMethod.POST, "grpc.testing.TestService.UnaryCall")
@@ -104,7 +104,7 @@ public class GrpcServiceTest {
 
     @Test
     public void missingMethod() throws Exception {
-        when(ctx.pathWithoutPrefix()).thenReturn("/grpc.testing.TestService/FooCall");
+        when(ctx.mappedPath()).thenReturn("/grpc.testing.TestService/FooCall");
         grpcService.doPost(
                 ctx,
                 HttpRequest.of(HttpHeaders.of(HttpMethod.POST, "/grpc.testing.TestService/FooCall")

--- a/jetty/src/main/java/com/linecorp/armeria/server/http/jetty/JettyService.java
+++ b/jetty/src/main/java/com/linecorp/armeria/server/http/jetty/JettyService.java
@@ -322,7 +322,7 @@ public final class JettyService implements HttpService {
         uriBuf.append(aHeaders.path());
 
         final HttpURI uri = new HttpURI(uriBuf.toString());
-        uri.setPath(ctx.pathWithoutPrefix());
+        uri.setPath(ctx.mappedPath());
 
         // Convert HttpHeaders to HttpFields
         final HttpFields jHeaders = new HttpFields(aHeaders.size());

--- a/logback/src/test/java/com/linecorp/armeria/common/logback/RequestContextExportingAppenderTest.java
+++ b/logback/src/test/java/com/linecorp/armeria/common/logback/RequestContextExportingAppenderTest.java
@@ -416,6 +416,7 @@ public class RequestContextExportingAppenderTest {
         final ServiceRequestContext ctx = new DefaultServiceRequestContext(
                 serviceConfig,
                 ch, HttpSessionProtocols.H2, req.method(),
+                path,
                 PathMappingResult.of(path, query, ImmutableMap.of()),
                 req, newSslSession());
 

--- a/tomcat/src/main/java/com/linecorp/armeria/server/http/tomcat/TomcatService.java
+++ b/tomcat/src/main/java/com/linecorp/armeria/server/http/tomcat/TomcatService.java
@@ -411,7 +411,7 @@ public final class TomcatService implements HttpService {
 
     @Nullable
     private Request convertRequest(ServiceRequestContext ctx, AggregatedHttpMessage req) {
-        final String mappedPath = ctx.pathWithoutPrefix();
+        final String mappedPath = ctx.mappedPath();
         final Request coyoteReq = new Request();
 
         coyoteReq.scheme().setString(req.scheme());


### PR DESCRIPTION
Currently, the way to get a stripped prefix path is `pathWithoutPrefix`, but we support internal redirects / arbitrary mapping with `PathMappingResult.path`, which is returned by `path`. This makes it mostly impossible to have a service respect both types of mapping.

This PR restores the behavior of prefix mapping stripping the input and allowing services to use the `mappedPath` which has been undeprecated.

We're basically back to before the HTTP-only PR, with `mappedPath` returning `PathMappingResult.path`.

Also removes `pathWithoutPrefix` since it's not needed with this change, and is very short lived so probably not worth deprecating.