### PR TITLE
Fix a leak in DefaultStreamMessage / Improve the life cycle contract of reference-counted objects in StreamMessage

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/http/HttpMessageAggregator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/http/HttpMessageAggregator.java
@@ -24,7 +24,7 @@ import java.util.function.BiConsumer;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
-import com.linecorp.armeria.internal.http.ByteBufHttpData;
+import io.netty.util.ReferenceCountUtil;
 
 abstract class HttpMessageAggregator implements Subscriber<HttpObject>, BiConsumer<Void, Throwable> {
 
@@ -89,8 +89,8 @@ abstract class HttpMessageAggregator implements Subscriber<HttpObject>, BiConsum
                 added = true;
             }
         } finally {
-            if (!added && data instanceof ByteBufHttpData) {
-                ((ByteBufHttpData) data).buf().release();
+            if (!added) {
+                ReferenceCountUtil.safeRelease(data);
             }
         }
     }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/PublisherBasedStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/PublisherBasedStreamMessage.java
@@ -80,7 +80,7 @@ public class PublisherBasedStreamMessage<T> implements StreamMessage<T> {
     @Override
     public void subscribe(Subscriber<? super T> subscriber, boolean withPooledObjects) {
         requireNonNull(subscriber, "subscriber");
-        subscribe0(subscriber, null, withPooledObjects);
+        subscribe0(subscriber, null);
     }
 
     @Override
@@ -92,10 +92,10 @@ public class PublisherBasedStreamMessage<T> implements StreamMessage<T> {
     public void subscribe(Subscriber<? super T> subscriber, Executor executor, boolean withPooledObjects) {
         requireNonNull(subscriber, "subscriber");
         requireNonNull(executor, "executor");
-        subscribe0(subscriber, executor, withPooledObjects);
+        subscribe0(subscriber, executor);
     }
 
-    private void subscribe0(Subscriber<? super T> subscriber, Executor executor, boolean withPooledObjects) {
+    private void subscribe0(Subscriber<? super T> subscriber, Executor executor) {
         final SubscriberWrapper s = new SubscriberWrapper(this, subscriber, executor);
         if (!subscriberUpdater.compareAndSet(this, null, s)) {
             if (this.subscriber == ABORTED_SUBSCRIBER) {

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -23,6 +23,10 @@ import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufHolder;
+import io.netty.util.ReferenceCounted;
+
 /**
  * A variant of <a href="http://www.reactive-streams.org/">Reactive Streams</a> {@link Publisher}, which allows
  * only one {@link Subscriber}. Unlike a usual {@link Publisher}, a {@link StreamMessage} can stream itself
@@ -46,7 +50,27 @@ import org.reactivestreams.Subscription;
  *
  * <h3>Getting notified when a {@link StreamMessage} is closed</h3>
  *
- * <p>Use {@link #closeFuture()}
+ * <p>{@link Subscriber#onComplete()} and {@link Subscriber#onError(Throwable)} will not be invoked when its
+ * {@link Subscription} has been {@linkplain Subscription#cancel() cancelled} or {@linkplain #abort() aborted}.
+ * Use {@link #closeFuture()} if you need to get notified when a {@link StreamMessage} is closed regardless of
+ * whether it's been cancelled, aborted or closed.
+ *
+ * <h3>Publication and Consumption of {@link ReferenceCounted} objects</h3>
+ *
+ * <p>{@link StreamMessage} will reject the publication request of a {@link ReferenceCounted} object except
+ * {@link ByteBuf} and {@link ByteBufHolder}.
+ *
+ * <p>{@link StreamMessage} will discard the publication request of a {@link ByteBuf} or a {@link ByteBufHolder}
+ * silently and release it automatically when the publication is attempted after the stream is closed.
+ *
+ * <p>For {@link ByteBuf} and {@link ByteBufHolder}, {@link StreamMessage} will convert them into their
+ * respective unpooled versions that never leak, so that the {@link Subscriber} does not need to worry about
+ * leaks.
+ *
+ * <p>If a {@link Subscriber} does not want a {@link StreamMessage} to make a copy of a {@link ByteBufHolder},
+ * use {@link #subscribe(Subscriber, boolean)} or {@link #subscribe(Subscriber, Executor, boolean)} and
+ * specify {@code true} for {@code withPooledObjects}. Note that the {@link Subscriber} is responsible for
+ * releasing the objects given with {@link Subscriber#onNext(Object)}.
  *
  * @param <T> the type of element signaled
  */
@@ -78,10 +102,11 @@ public interface StreamMessage<T> extends Publisher<T> {
     void subscribe(Subscriber<? super T> s);
 
     /**
-     * Requests to start streaming data to the specified {@link Subscriber}, receiving pooled objects as is.
-     * Ownership of all pooled objects is transferred to the {@link Subscriber}, which must release them when
-     * finished. If you don't know what this means, use {@link StreamMessage#subscribe(Subscriber)}.
+     * Requests to start streaming data to the specified {@link Subscriber}.
      *
+     * @param withPooledObjects if {@code true}, receives the pooled {@link ByteBuf} and {@link ByteBufHolder}
+     *                          as is, without making a copy. If you don't know what this means, use
+     *                          {@link StreamMessage#subscribe(Subscriber)}.
      * @throws IllegalStateException if there is a {@link Subscriber} who subscribed to this stream already
      */
     void subscribe(Subscriber<? super T> s, boolean withPooledObjects);
@@ -96,10 +121,11 @@ public interface StreamMessage<T> extends Publisher<T> {
 
     /**
      * Requests to start streaming data, invoking the specified {@link Subscriber} from the specified
-     * {@link Executor}, receiving pooled objects as is. Ownership of all pooled objects is transferred to the
-     * {@link Subscriber}, which must release them when finished. If you don't know what this means, use
-     * {@link StreamMessage#subscribe(Subscriber, Executor)}.
+     * {@link Executor}.
      *
+     * @param withPooledObjects if {@code true}, receives the pooled {@link ByteBuf} and {@link ByteBufHolder}
+     *                          as is, without making a copy. If you don't know what this means, use
+     *                          {@link StreamMessage#subscribe(Subscriber)}.
      * @throws IllegalStateException if there is a {@link Subscriber} who subscribed to this stream already
      */
     void subscribe(Subscriber<? super T> s, Executor executor, boolean withPooledObjects);

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamWriter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamWriter.java
@@ -36,12 +36,20 @@ public interface StreamWriter<T> {
     /**
      * Writes the specified object to the {@link StreamMessage}. The written object will be transferred to the
      * {@link Subscriber}.
+     *
+     * @return {@code true} if the specified object has been scheduled for publication. {@code false} if the
+     *         stream has been closed already.
+     *
+     * @throws IllegalArgumentException if the publication of the specified object has been rejected
      */
     boolean write(T o);
 
     /**
      * Writes the specified object {@link Supplier} to the {@link StreamMessage}. The object provided by the
      * {@link Supplier} will be transferred to the {@link Subscriber}.
+     *
+     * @return {@code true} if the specified object has been scheduled for publication. {@code false} if the
+     *         stream has been closed already.
      */
     boolean write(Supplier<? extends T> o);
 

--- a/core/src/main/java/com/linecorp/armeria/internal/http/Http2ObjectEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/http/Http2ObjectEncoder.java
@@ -27,6 +27,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http2.Http2ConnectionEncoder;
 import io.netty.handler.codec.http2.Http2Error;
 import io.netty.handler.codec.http2.Http2Stream;
+import io.netty.util.ReferenceCountUtil;
 
 public final class Http2ObjectEncoder extends HttpObjectEncoder {
 
@@ -55,6 +56,7 @@ public final class Http2ObjectEncoder extends HttpObjectEncoder {
 
         final ChannelFuture future = validateStream(ctx, streamId);
         if (future != null) {
+            ReferenceCountUtil.safeRelease(data);
             return future;
         }
 

--- a/core/src/main/java/com/linecorp/armeria/internal/http/HttpObjectEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/http/HttpObjectEncoder.java
@@ -22,10 +22,12 @@ import com.linecorp.armeria.common.http.HttpHeaders;
 import com.linecorp.armeria.common.http.HttpObject;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufHolder;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http2.Http2Error;
+import io.netty.util.ReferenceCountUtil;
 
 /**
  * Converts an {@link HttpObject} into a protocol-specific object and writes it into a {@link Channel}.
@@ -61,6 +63,7 @@ public abstract class HttpObjectEncoder {
         assert ctx.channel().eventLoop().inEventLoop();
 
         if (closed) {
+            ReferenceCountUtil.safeRelease(data);
             return newFailedFuture(ctx);
         }
 
@@ -106,8 +109,8 @@ public abstract class HttpObjectEncoder {
     }
 
     protected static ByteBuf toByteBuf(ChannelHandlerContext ctx, HttpData data) {
-        if (data instanceof ByteBufHttpData) {
-            return ((ByteBufHttpData) data).buf();
+        if (data instanceof ByteBufHolder) {
+            return ((ByteBufHolder) data).content();
         }
         final ByteBuf buf = ctx.alloc().directBuffer(data.length(), data.length());
         buf.writeBytes(data.array(), data.offset(), data.length());

--- a/core/src/test/java/com/linecorp/armeria/client/http/HttpClientIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/http/HttpClientIntegrationTest.java
@@ -74,7 +74,8 @@ import com.linecorp.armeria.server.http.encoding.HttpEncodingService;
 import com.linecorp.armeria.testing.server.ServerRule;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.ByteBufHolder;
+import io.netty.util.ReferenceCountUtil;
 
 public class HttpClientIntegrationTest {
 
@@ -137,12 +138,11 @@ public class HttpClientIntegrationTest {
 
                 @Override
                 public void onNext(HttpObject httpObject) {
-                    if (httpObject instanceof ByteBufHttpData) {
-                        ByteBuf buf = ((ByteBufHttpData) httpObject).buf();
+                    if (httpObject instanceof ByteBufHolder) {
                         try {
-                            decorated.write(HttpData.of(ByteBufUtil.getBytes(buf)));
+                            decorated.write(HttpData.of(((ByteBufHolder) httpObject).content()));
                         } finally {
-                            buf.release();
+                            ReferenceCountUtil.safeRelease(httpObject);
                         }
                     } else {
                         decorated.write(httpObject);

--- a/core/src/test/java/com/linecorp/armeria/common/stream/DefaultStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/DefaultStreamMessageTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import com.linecorp.armeria.common.util.Exceptions;
+import com.linecorp.armeria.internal.http.ByteBufHttpData;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufHolder;
+import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.buffer.UnpooledHeapByteBuf;
+import io.netty.util.AbstractReferenceCounted;
+import io.netty.util.ReferenceCounted;
+
+public class DefaultStreamMessageTest {
+
+    @Test
+    public void releaseOnConsumption_ByteBuf() throws Exception {
+        final DefaultStreamMessage<ByteBuf> m = new DefaultStreamMessage<>();
+        final ByteBuf buf = newPooledBuffer();
+
+        assertThat(m.write(buf)).isTrue();
+        assertThat(buf.refCnt()).isEqualTo(1);
+
+        m.subscribe(new Subscriber<ByteBuf>() {
+            @Override
+            public void onSubscribe(Subscription subscription) {
+                subscription.request(1);
+            }
+
+            @Override
+            public void onNext(ByteBuf o) {
+                assertThat(o).isNotSameAs(buf);
+                assertThat(o).isInstanceOf(UnpooledHeapByteBuf.class);
+                assertThat(o.refCnt()).isEqualTo(1);
+                assertThat(buf.refCnt()).isZero();
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                Exceptions.throwUnsafely(throwable);
+            }
+
+            @Override
+            public void onComplete() {}
+        });
+    }
+
+    @Test
+    public void releaseOnConsumption_HttpData() throws Exception {
+        final DefaultStreamMessage<ByteBufHolder> m = new DefaultStreamMessage<>();
+        final ByteBufHttpData data = new ByteBufHttpData(newPooledBuffer(), false);
+
+        assertThat(m.write(data)).isTrue();
+        assertThat(data.refCnt()).isEqualTo(1);
+
+        m.subscribe(new Subscriber<ByteBufHolder>() {
+            @Override
+            public void onSubscribe(Subscription subscription) {
+                subscription.request(1);
+            }
+
+            @Override
+            public void onNext(ByteBufHolder o) {
+                assertThat(o).isNotSameAs(data);
+                assertThat(o).isInstanceOf(ByteBufHttpData.class);
+                assertThat(o.content()).isInstanceOf(UnpooledHeapByteBuf.class);
+                assertThat(o.refCnt()).isEqualTo(1);
+                assertThat(data.refCnt()).isZero();
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                Exceptions.throwUnsafely(throwable);
+            }
+
+            @Override
+            public void onComplete() {}
+        });
+    }
+
+    @Test
+    public void rejectReferenceCounted() {
+        final DefaultStreamMessage<Object> m = new DefaultStreamMessage<>();
+        assertThatThrownBy(() -> m.write(new AbstractReferenceCounted() {
+            @Override
+            protected void deallocate() {}
+
+            @Override
+            public ReferenceCounted touch(Object hint) {
+                return this;
+            }
+        })).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void releaseWhenWritingToClosedStream_ByteBuf() {
+        final DefaultStreamMessage<Object> m = new DefaultStreamMessage<>();
+        final ByteBuf buf = PooledByteBufAllocator.DEFAULT.buffer();
+        m.close();
+
+        assertThat(m.write(buf)).isFalse();
+        assertThat(buf.refCnt()).isZero();
+    }
+
+    @Test
+    public void releaseWhenWritingToClosedStream_HttpData() {
+        final DefaultStreamMessage<Object> m = new DefaultStreamMessage<>();
+        final ByteBufHttpData data = new ByteBufHttpData(newPooledBuffer(), true);
+        m.close();
+
+        assertThat(m.write(data)).isFalse();
+        assertThat(data.refCnt()).isZero();
+    }
+
+    private static ByteBuf newPooledBuffer() {
+        return PooledByteBufAllocator.DEFAULT.buffer().writeByte(0);
+    }
+}


### PR DESCRIPTION
Motivation:

- There's a buffer leak in DefaultStreamMessage.write() where a
  ByteBufHttpData is not released when it's written after the stream is
  closed.
- It is currently somewhat unclear how withPooledObjects works in the
  documentation.

Modification:

- Clearly state that StreamMessage accepts a ReferenceCounted only when
  it's a ByteBuf or a ByteBufHolder.
- Clearly state that the object will be released when it's attempted for
  publication on a closed stream.
- Fix a leak in DefaultStreamMessage.write()
- Add more validation in DefaultStreamMessage.write()
- Make ByteBufHttpData implement ByteBufHolder and make
  DefaultStreamMessage handle ByteBufHolder and ByteBuf correctly

Result:

- Safety
- Less leaks