### PR TITLE
Add StreamMessageDuplicator

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/http/HttpRequestDuplicator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/http/HttpRequestDuplicator.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.http;
+
+import static java.util.Objects.requireNonNull;
+
+import com.google.common.base.MoreObjects;
+
+import com.linecorp.armeria.common.stream.AbstractStreamMessageDuplicator;
+import com.linecorp.armeria.common.stream.StreamMessage;
+import com.linecorp.armeria.common.stream.StreamMessageWrapper;
+
+/**
+ * Allows subscribing to a {@link HttpRequest} multiple times by duplicating the stream.
+ *
+ * <pre>{@code
+ * final HttpRequest originalReq = ...
+ * final HttpRequestDuplicator reqDuplicator = new HttpRequestDuplicator(originalReq);
+ *
+ * final HttpRequest dupReq1 = reqDuplicator.duplicateStream();
+ * final HttpRequest dupReq2 = reqDuplicator.duplicateStream();
+ *
+ * dupReq1.subscribe(new FooSubscriber() {
+ *     ...
+ *     // Do something according to the first few elements of the request.
+ * });
+ *
+ * final CompletableFuture<AggregatedHttpMessage> future2 = dupReq2.aggregate();
+ * future2.handle((message, cause) -> {
+ *     // Do something with message.
+ * }
+ * }</pre>
+ */
+public class HttpRequestDuplicator extends AbstractStreamMessageDuplicator<HttpObject, HttpRequest> {
+
+    private final HttpHeaders headers;
+
+    private final boolean keepAlive;
+
+    /**
+     * Creates a new instance wrapping a {@link HttpRequest} and publishing to multiple subscribers.
+     * @param req the request that will publish data to subscribers
+     */
+    public HttpRequestDuplicator(HttpRequest req) {
+        super(requireNonNull(req, "req"));
+        headers = req.headers();
+        keepAlive = req.isKeepAlive();
+    }
+
+    @Override
+    protected HttpRequest doDuplicateStream(StreamMessage<HttpObject> delegate) {
+        return new DuplicateHttpRequest(delegate);
+    }
+
+    private class DuplicateHttpRequest
+            extends StreamMessageWrapper<HttpObject> implements HttpRequest {
+
+        DuplicateHttpRequest(StreamMessage<? extends HttpObject> delegate) {
+            super(delegate);
+        }
+
+        @Override
+        public HttpHeaders headers() {
+            return headers;
+        }
+
+        @Override
+        public boolean isKeepAlive() {
+            return keepAlive;
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(this)
+                              .add("keepAlive", isKeepAlive())
+                              .add("headers", headers()).toString();
+        }
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/common/http/HttpResponseDuplicator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/http/HttpResponseDuplicator.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.http;
+
+import static java.util.Objects.requireNonNull;
+
+import com.google.common.base.MoreObjects;
+
+import com.linecorp.armeria.common.stream.AbstractStreamMessageDuplicator;
+import com.linecorp.armeria.common.stream.StreamMessage;
+import com.linecorp.armeria.common.stream.StreamMessageWrapper;
+
+/**
+ * Allows subscribing to a {@link HttpResponse} multiple times by duplicating the stream.
+ *
+ * <pre><code>
+ * final HttpResponse originalRes = ...
+ * final HttpResponseDuplicator resDuplicator = new HttpResponseDuplicator(originalRes);
+ *
+ * final HttpResponse dupRes1 = resDuplicator.duplicateStream();
+ * final HttpResponse dupRes2 = resDuplicator.duplicateStream();
+ *
+ * dupRes1.subscribe(new FooHeaderSubscriber() {
+ *    {@literal @}Override
+ *     public void onNext(Object o) {
+ *     ...
+ *     // Do something according to the header's status.
+ *     }
+ * });
+ *
+ * dupRes2.aggregate().handle((aRes, cause){@literal ->} {
+ *     // Do something with the message.
+ * });
+ *
+ * }</code></pre>
+ */
+public class HttpResponseDuplicator
+        extends AbstractStreamMessageDuplicator<HttpObject, HttpResponse> {
+
+    /**
+     * Creates a new instance wrapping a {@link HttpResponse} and publishing to multiple subscribers.
+     * @param res the response that will publish data to subscribers
+     */
+    public HttpResponseDuplicator(HttpResponse res) {
+        super(requireNonNull(res, "res"));
+    }
+
+    @Override
+    protected HttpResponse doDuplicateStream(StreamMessage<HttpObject> delegate) {
+        return new DuplicateHttpResponse(delegate);
+    }
+
+    private static class DuplicateHttpResponse
+            extends StreamMessageWrapper<HttpObject> implements HttpResponse {
+
+        DuplicateHttpResponse(StreamMessage<? extends HttpObject> delegate) {
+            super(delegate);
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(this).toString();
+        }
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessageDuplicator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessageDuplicator.java
@@ -1,0 +1,601 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.stream;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import com.linecorp.armeria.common.util.SafeCloseable;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufHolder;
+import io.netty.buffer.Unpooled;
+import io.netty.util.ReferenceCountUtil;
+import io.netty.util.internal.ConcurrentSet;
+
+/**
+ * Allows subscribing to a {@link StreamMessage} multiple times by duplicating the stream.
+ * <p>
+ * Only one subscriber can subscribe other stream messages such as {@link DefaultStreamMessage},
+ * {@link DeferredStreamMessage}, etc.
+ * This factory is wrapping one of those {@link StreamMessage}s and spawns duplicated stream messages
+ * which are created using {@link AbstractStreamMessageDuplicator#duplicateStream()} and subscribed
+ * by subscribers one by one.
+ * </p><p>
+ * The published elements can be shared across {@link Subscriber}s, so do not manipulate the
+ * data unless you copy them. Only one case does not share the elements which is when you
+ * {@link StreamMessage#subscribe(Subscriber, boolean)} with the {@code withPooledObjects}
+ * as {@code false} while the elements is one of two pooled object classes which are {@link ByteBufHolder}
+ * and {@link ByteBuf}.
+ * </p><p>
+ * This factory has to be closed by {@link AbstractStreamMessageDuplicator#close()} when
+ * you do not need the contents anymore, otherwise memory leak might happen.
+ * </p>
+ * @param <T> the type of elements
+ * @param <U> the type of the publisher and duplicated stream messages
+ */
+public abstract class AbstractStreamMessageDuplicator<T, U extends StreamMessage<? extends T>>
+        implements SafeCloseable {
+
+    private final StreamMessageProcessor<T> processor;
+
+    /**
+     * Creates a new instance wrapping a {@code publisher} and publishing to multiple subscribers.
+     * @param publisher the publisher who will publish data to subscribers
+     */
+    protected AbstractStreamMessageDuplicator(U publisher) {
+        requireNonNull(publisher, "publisher");
+        processor = new StreamMessageProcessor<>(publisher);
+    }
+
+    /**
+     * Creates a new {@link U} instance that publishes data from the {@code publisher} you create
+     * this factory with.
+     */
+    public U duplicateStream() {
+        if (!processor.isOpen()) {
+            throw new IllegalStateException("This factory has been closed already.");
+        }
+        return doDuplicateStream(new ChildStreamMessage<>(processor));
+    }
+
+    /**
+     * Creates a new {@link U} instance that wraps {@link ChildStreamMessage} and forwards its method
+     * invocations to it.
+     * @param delegate {@link ChildStreamMessage}
+     */
+    protected abstract U doDuplicateStream(StreamMessage<T> delegate);
+
+    /**
+     * Closes this factory and stream messages who are invoked by
+     * {@link AbstractStreamMessageDuplicator#duplicateStream()}.
+     * Also, clean up the data published from {@code publisher}.
+     */
+    @Override
+    public void close() {
+        processor.close();
+    }
+
+    @VisibleForTesting
+    static class StreamMessageProcessor<T> implements Subscriber<T> {
+
+        private enum State {
+            /**
+             * The initial state. Will enter {@link #CLOSED}.
+             */
+            OPEN,
+            /**
+              * {@link AbstractStreamMessageDuplicator#close()} has been called.
+             */
+            CLOSED
+        }
+
+        @SuppressWarnings("rawtypes")
+        private static final AtomicReferenceFieldUpdater<StreamMessageProcessor, State> stateUpdater =
+                AtomicReferenceFieldUpdater.newUpdater(StreamMessageProcessor.class, State.class, "state");
+
+        @SuppressWarnings("rawtypes")
+        private static final AtomicLongFieldUpdater<StreamMessageProcessor> requestedDemandUpdater =
+                AtomicLongFieldUpdater.newUpdater(StreamMessageProcessor.class, "requestedDemand");
+
+        private final Set<DownstreamSubscription> downstreamSubscriptions = new ConcurrentSet<>();
+
+        private final List<T> contentList = new ArrayList<>();
+
+        @SuppressWarnings("unused")
+        private volatile long requestedDemand;
+        private volatile Subscription upstreamSubscription;
+        private volatile boolean upstreamCompleted;
+        private volatile int upstreamOffset;
+        private volatile State state = State.OPEN;
+
+        private Throwable upstreamCause;
+
+        StreamMessageProcessor(StreamMessage<? extends T> upstream) {
+            upstream.subscribe(this, true);
+            notifyDownstreamWhenUpstreamCompleted(upstream);
+        }
+
+        private void notifyDownstreamWhenUpstreamCompleted(StreamMessage<? extends T> upstream) {
+            upstream.closeFuture().whenComplete((unused, cause) -> {
+                upstreamCompleted = true;
+                if (cause != null) {
+                    upstreamCause = cause;
+                }
+                notifyDownstreams();
+            });
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            upstreamSubscription = s;
+            downstreamSubscriptions.forEach(downstream -> {
+                if (downstream.setSubscribed()) {
+                    if (downstream.executor() != null) {
+                        downstream.executor().execute(() -> downstream.subscriber().onSubscribe(downstream));
+                    } else {
+                        downstream.subscriber().onSubscribe(downstream);
+                    }
+                }
+            });
+            if (state == State.CLOSED) {
+                s.cancel();
+            }
+        }
+
+        @Override
+        public void onNext(T t) {
+            if (upstreamOffset >= Integer.MAX_VALUE) {
+                //TODO(minwoox) limit by the size of data not by the size of contentList.
+                upstreamSubscription.cancel();
+                throw new IllegalStateException("Published numbers of data is greater than Integer.MAX_VALUE");
+            }
+            contentList.add(t);
+            upstreamOffset++;
+            notifyDownstreams();
+        }
+
+        /**
+         * Handled by {@link #notifyDownstreamWhenUpstreamCompleted(StreamMessage)} instead.
+         */
+        @Override
+        public void onError(Throwable t) {}
+
+        /**
+         * Handled by {@link #notifyDownstreamWhenUpstreamCompleted(StreamMessage)} instead.
+         */
+        @Override
+        public void onComplete() {}
+
+        void subscribe(DownstreamSubscription subscription) {
+            if (state == State.OPEN) {
+                downstreamSubscriptions.add(subscription);
+                if (state == State.CLOSED) {
+                    downstreamSubscriptions.remove(subscription);
+                    throw new IllegalStateException("This factory has been closed already.");
+                }
+            } else {
+                throw new IllegalStateException("This factory has been closed already.");
+            }
+
+            final Subscriber<Object> subscriber = subscription.subscriber();
+            if (upstreamSubscription != null && subscription.setSubscribed()) {
+                final Executor executor = subscription.executor();
+                if (executor != null) {
+                    executor.execute(() -> subscriber.onSubscribe(subscription));
+                } else {
+                    subscriber.onSubscribe(subscription);
+                }
+            }
+        }
+
+        void requestDemand(long cumulativeDemand) {
+            for (;;) {
+                if (cumulativeDemand <= requestedDemand) {
+                    return;
+                }
+                long currentRequested = requestedDemand;
+                if (requestedDemandUpdater.compareAndSet(this, currentRequested, cumulativeDemand)) {
+                    upstreamSubscription.request(cumulativeDemand - currentRequested);
+                    return;
+                }
+            }
+        }
+
+        void notifyDownstreams() {
+            if (downstreamSubscriptions.isEmpty()) {
+                return;
+            }
+            downstreamSubscriptions.forEach(downstream -> {
+                final Executor executor = downstream.executor();
+                if (executor != null) {
+                    executor.execute(() -> notifyDownstream(downstream));
+                } else {
+                    notifyDownstream(downstream);
+                }
+            });
+        }
+
+        void notifyDownstream(DownstreamSubscription downstream) {
+            for (;;) {
+                int offsetOfSubscriber = downstream.offset;
+                int upstreamOffset = this.upstreamOffset;
+                if (upstreamCompleted && offsetOfSubscriber == upstreamOffset) {
+                    if (DownstreamSubscription.notifyingUpdater.compareAndSet(downstream, 0, 1)) {
+                        completeDownstream(downstream, upstreamCause);
+                        // Don't have to bring notifying back to 0 because it's completed.
+                    }
+                    return;
+                }
+
+                if (downstream.cancelled) {
+                    if (DownstreamSubscription.notifyingUpdater.compareAndSet(downstream, 0, 1)) {
+                        completeDownstream(downstream, CancelledSubscriptionException.get());
+                        // Don't have to bring notifying back to 0 because it's completed.
+                    }
+                    return;
+                }
+
+                if (offsetOfSubscriber == upstreamOffset) {
+                    break;
+                }
+
+                if (!publishData(downstream)) {
+                    break;
+                }
+            }
+        }
+
+        private void completeDownstream(DownstreamSubscription downstream, Throwable cause) {
+            downstreamSubscriptions.remove(downstream);
+            if (cause == null) {
+                try {
+                    downstream.subscriber().onComplete();
+                } finally {
+                    @SuppressWarnings("unchecked")
+                    final CompletableFuture<Void> f =
+                            (CompletableFuture<Void>) downstream.streamMessage().closeFuture();
+                    f.complete(null);
+                }
+            } else {
+                try {
+                    if (!(cause instanceof CancelledSubscriptionException)) {
+                        downstream.subscriber().onError(cause);
+                    }
+                } finally {
+                    downstream.streamMessage().closeFuture().completeExceptionally(cause);
+                }
+            }
+        }
+
+        private boolean publishData(DownstreamSubscription downstream) {
+            for (;;) {
+                final long demand = downstream.demand;
+                if (demand == 0) {
+                    break;
+                }
+
+                if (demand == Long.MAX_VALUE ||
+                    DownstreamSubscription.demandUpdater.compareAndSet(downstream, demand, demand - 1)) {
+                    final Subscriber<Object> subscriber = downstream.subscriber();
+                    if (DownstreamSubscription.notifyingUpdater.compareAndSet(downstream, 0, 1)) {
+                        T o = contentList.get(downstream.offset++);
+                        ReferenceCountUtil.touch(o);
+                        if (downstream.withPooledObjects()) {
+                            if (o instanceof ByteBufHolder) {
+                                o = retainedDuplicate((ByteBufHolder) o);
+                            } else if (o instanceof ByteBuf) {
+                                o = retainedDuplicate((ByteBuf) o);
+                            }
+                        } else {
+                            if (o instanceof ByteBufHolder) {
+                                o = copy((ByteBufHolder) o);
+                            } else if (o instanceof ByteBuf) {
+                                o = copy((ByteBuf) o);
+                            }
+                        }
+
+                        subscriber.onNext(o);
+                        downstream.notifying = 0;
+                        return true;
+                    } else {
+                        if (demand != Long.MAX_VALUE) {
+                            incrementDemand(downstream);
+                        }
+                        return false;
+                    }
+                }
+            }
+            return false;
+        }
+
+        @SuppressWarnings("unchecked")
+        private T retainedDuplicate(ByteBufHolder o) {
+            return (T) o.replace(o.content().retainedDuplicate());
+        }
+
+        @SuppressWarnings("unchecked")
+        private T retainedDuplicate(ByteBuf o) {
+            return (T) o.retainedDuplicate();
+        }
+
+        @SuppressWarnings("unchecked")
+        private T copy(ByteBufHolder o) {
+           return (T) o.replace(Unpooled.copiedBuffer(o.content()));
+        }
+
+        @SuppressWarnings("unchecked")
+        private T copy(ByteBuf o) {
+            return (T) Unpooled.copiedBuffer(o);
+        }
+
+        private void incrementDemand(DownstreamSubscription downstream) {
+            for (;;) {
+                final long oldDemand = downstream.demand;
+                if (DownstreamSubscription.demandUpdater.compareAndSet(
+                        downstream, oldDemand, oldDemand + 1)) {
+                    break;
+                }
+            }
+        }
+
+        boolean isOpen() {
+            return state == State.OPEN;
+        }
+
+        void close() {
+            if (stateUpdater.compareAndSet(this, State.OPEN, State.CLOSED)) {
+                state = State.CLOSED;
+                final Subscription upstream = this.upstreamSubscription;
+                if (upstream != null) {
+                    upstream.cancel();
+                }
+                cleanup();
+            }
+        }
+
+        private void cleanup() {
+            final List<CompletableFuture<Void>> closeFutures = new ArrayList<>();
+            downstreamSubscriptions.forEach(s -> {
+                @SuppressWarnings("unchecked")
+                final CompletableFuture<Void> future = s.streamMessage().closeFuture();
+                closeFutures.add(future);
+            });
+            final CompletableFuture<Void> allDoneFuture =
+                    CompletableFuture.allOf(closeFutures.toArray(new CompletableFuture[closeFutures.size()]));
+            allDoneFuture.whenComplete((unused, cause) -> {
+                contentList.forEach(ReferenceCountUtil::safeRelease);
+                contentList.clear();
+            });
+        }
+    }
+
+    private static class ChildStreamMessage<T> implements StreamMessage<T> {
+
+        @SuppressWarnings("rawtypes")
+        private static final AtomicReferenceFieldUpdater<ChildStreamMessage, DownstreamSubscription>
+                subscriptionUpdater = AtomicReferenceFieldUpdater.newUpdater(
+                ChildStreamMessage.class, DownstreamSubscription.class, "subscription");
+
+        private StreamMessageProcessor processor;
+        @SuppressWarnings("unused")
+        private volatile DownstreamSubscription subscription;
+
+        private CompletableFuture<Void> closeFuture = new CompletableFuture<>();
+
+        ChildStreamMessage(StreamMessageProcessor<? extends T> processor) {
+            this.processor = processor;
+        }
+
+        @Override
+        public boolean isOpen() {
+            return !closeFuture.isDone();
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return !isOpen() && processor.upstreamOffset == 0;
+        }
+
+        @Override
+        public CompletableFuture<Void> closeFuture() {
+            return closeFuture;
+        }
+
+        @Override
+        public void subscribe(Subscriber<? super T> subscriber) {
+            requireNonNull(subscriber, "subscriber");
+            subscribe(subscriber, false);
+        }
+
+        @Override
+        public void subscribe(Subscriber<? super T> subscriber, boolean withPooledObjects) {
+            requireNonNull(subscriber, "subscriber");
+            subscribe0(subscriber, null, withPooledObjects);
+        }
+
+        @Override
+        public void subscribe(Subscriber<? super T> subscriber, Executor executor) {
+            requireNonNull(subscriber, "subscriber");
+            requireNonNull(executor, "executor");
+            subscribe(subscriber, executor, false);
+        }
+
+        @Override
+        public void subscribe(Subscriber<? super T> subscriber, Executor executor,
+                              boolean withPooledObjects) {
+            requireNonNull(subscriber, "subscriber");
+            requireNonNull(executor, "executor");
+            subscribe0(subscriber, executor, withPooledObjects);
+        }
+
+        private void subscribe0(Subscriber<? super T> subscriber, Executor executor,
+                                boolean withPooledObjects) {
+            final DownstreamSubscription subscription = new DownstreamSubscription(
+                    this, subscriber, processor, executor, withPooledObjects);
+            if (!subscriptionUpdater.compareAndSet(this, null, subscription)) {
+                throw new IllegalStateException(
+                        "Subscribed by other subscriber already: " + this.subscription.subscriber());
+            }
+            processor.subscribe(subscription);
+        }
+
+        @Override
+        public void abort() {
+            final DownstreamSubscription currentSubscription = subscription;
+            if (currentSubscription != null) {
+                currentSubscription.cancel();
+                return;
+            }
+
+            final DownstreamSubscription newSubscription = new DownstreamSubscription(
+                    this, AbortingSubscriber.INSTANCE, processor, null, false);
+            if (subscriptionUpdater.compareAndSet(this, null, newSubscription)) {
+                processor.subscribe(newSubscription);
+            } else {
+                subscription.cancel();
+            }
+        }
+    }
+
+    @VisibleForTesting
+    static class DownstreamSubscription implements Subscription {
+
+        @SuppressWarnings("rawtypes")
+        private static final AtomicIntegerFieldUpdater<DownstreamSubscription> subscribedUpdater =
+                AtomicIntegerFieldUpdater.newUpdater(DownstreamSubscription.class, "subscribed");
+
+        @SuppressWarnings("rawtypes")
+        static final AtomicLongFieldUpdater<DownstreamSubscription> demandUpdater =
+                AtomicLongFieldUpdater.newUpdater(DownstreamSubscription.class, "demand");
+
+        @SuppressWarnings("rawtypes")
+        static final AtomicIntegerFieldUpdater<DownstreamSubscription> notifyingUpdater =
+                AtomicIntegerFieldUpdater.newUpdater(DownstreamSubscription.class, "notifying");
+
+        private final ChildStreamMessage streamMessage;
+        private final Subscriber<Object> subscriber;
+        private final StreamMessageProcessor processor;
+        private final Executor executor;
+        private final boolean withPooledObjects;
+
+        @SuppressWarnings("unused")
+        private volatile long demand;
+
+        private volatile boolean cancelled;
+
+        @SuppressWarnings("unused")
+        private volatile int subscribed; // 0: not on subscribe, 1: on subscribe
+
+        private volatile int offset;
+
+        volatile int notifying;
+
+        private long cumulativeDemand;
+
+        @SuppressWarnings("unchecked")
+        DownstreamSubscription(ChildStreamMessage streamMessage,
+                               Subscriber<?> subscriber, StreamMessageProcessor processor,
+                               Executor executor, boolean withPooledObjects) {
+            this.streamMessage = streamMessage;
+            this.subscriber = (Subscriber<Object>) subscriber;
+            this.processor = processor;
+            this.executor = executor;
+            this.withPooledObjects = withPooledObjects;
+        }
+
+        StreamMessage streamMessage() {
+            return streamMessage;
+        }
+
+        Subscriber<Object> subscriber() {
+            return subscriber;
+        }
+
+        Executor executor() {
+            return executor;
+        }
+
+        boolean withPooledObjects() {
+            return withPooledObjects;
+        }
+
+        @Override
+        public void request(long n) {
+            if (n <= 0) {
+                throw new IllegalArgumentException("n: " + n + " (expected: > 0)");
+            }
+
+            accumulateDemand(n);
+            processor.requestDemand(cumulativeDemand);
+
+            for (;;) {
+                final long oldDemand = demand;
+                final long newDemand;
+                if (oldDemand >= Long.MAX_VALUE - n) {
+                    newDemand = Long.MAX_VALUE;
+                } else {
+                    newDemand = oldDemand + n;
+                }
+
+                if (demandUpdater.compareAndSet(this, oldDemand, newDemand)) {
+                    if (oldDemand == 0) {
+                        processor.notifyDownstream(this);
+                    }
+                    break;
+                }
+            }
+        }
+
+        private void accumulateDemand(long n) {
+            if (n == Long.MAX_VALUE || Long.MAX_VALUE - n >= cumulativeDemand) {
+                cumulativeDemand = Long.MAX_VALUE;
+            } else {
+                cumulativeDemand += n;
+            }
+        }
+
+        @Override
+        public void cancel() {
+            if (!cancelled) {
+                cancelled = true;
+            }
+            if (executor != null) {
+                executor.execute(() -> processor.notifyDownstream(this));
+            } else {
+                processor.notifyDownstream(this);
+            }
+        }
+
+        boolean setSubscribed() {
+            return subscribedUpdater.compareAndSet(this, 0, 1);
+        }
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageWrapper.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.stream;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+import org.reactivestreams.Subscriber;
+
+import com.google.common.base.MoreObjects;
+
+/**
+ * Wraps a {@link StreamMessage} and forwards its method invocations to {@code delegate}.
+ * @param <T> the type of elements
+ */
+public class StreamMessageWrapper<T> implements StreamMessage<T> {
+
+    private final StreamMessage<? extends T> delegate;
+
+    /**
+     * Creates a new instance that wraps a {@code delegate}.
+     */
+    public StreamMessageWrapper(StreamMessage<? extends T> delegate) {
+        requireNonNull(delegate, "delegate");
+        this.delegate = delegate;
+    }
+
+    /**
+     * Returns the {@link StreamMessage} being decorated.
+     */
+    protected final StreamMessage<? extends T> delegate() {
+        return delegate;
+    }
+
+    @Override
+    public boolean isOpen() {
+        return delegate().isOpen();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return delegate().isEmpty();
+    }
+
+    @Override
+    public CompletableFuture<Void> closeFuture() {
+        return delegate().closeFuture();
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super T> s) {
+        delegate().subscribe(s);
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super T> s, boolean withPooledObjects) {
+        delegate().subscribe(s, withPooledObjects);
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super T> s, Executor executor) {
+        delegate().subscribe(s, executor);
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super T> s, Executor executor, boolean withPooledObjects) {
+        delegate().subscribe(s, executor, withPooledObjects);
+    }
+
+    @Override
+    public void abort() {
+        delegate().abort();
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("delegate", delegate()).toString();
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/common/http/HttpRequestDuplicatorTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/http/HttpRequestDuplicatorTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.http;
+
+import static com.linecorp.armeria.common.MediaType.PLAIN_TEXT_UTF_8;
+import static com.linecorp.armeria.common.http.HttpHeaderNames.CONTENT_LENGTH;
+import static com.linecorp.armeria.common.http.HttpHeaderNames.CONTENT_MD5;
+import static com.linecorp.armeria.common.http.HttpHeaderNames.CONTENT_TYPE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.Test;
+
+public class HttpRequestDuplicatorTest {
+
+    @Test
+    public void aggregateTwice() {
+        final AggregatedHttpMessage aReq = AggregatedHttpMessage.of(
+                HttpMethod.PUT, "/foo", PLAIN_TEXT_UTF_8, HttpData.ofUtf8("bar"),
+                HttpHeaders.of(CONTENT_MD5, "37b51d194a7513e45b56f6524f2d51f2"));
+
+        final HttpRequest publisher = aReq.toHttpRequest();
+        final HttpRequestDuplicator reqDuplicator = new HttpRequestDuplicator(publisher);
+
+        final AggregatedHttpMessage req1 = reqDuplicator.duplicateStream().aggregate().join();
+        final AggregatedHttpMessage req2 = reqDuplicator.duplicateStream().aggregate().join();
+
+        assertThat(req1.headers()).isEqualTo(
+                HttpHeaders.of(HttpMethod.PUT, "/foo")
+                           .setObject(CONTENT_TYPE, PLAIN_TEXT_UTF_8)
+                           .setInt(CONTENT_LENGTH, 3));
+        assertThat(req1.content()).isEqualTo(HttpData.of(StandardCharsets.UTF_8, "bar"));
+        assertThat(req1.trailingHeaders()).isEqualTo(
+                HttpHeaders.of(CONTENT_MD5, "37b51d194a7513e45b56f6524f2d51f2"));
+
+        assertThat(req2.headers()).isEqualTo(
+                HttpHeaders.of(HttpMethod.PUT, "/foo")
+                           .setObject(CONTENT_TYPE, PLAIN_TEXT_UTF_8)
+                           .setInt(CONTENT_LENGTH, 3));
+        assertThat(req2.content()).isEqualTo(HttpData.of(StandardCharsets.UTF_8, "bar"));
+        assertThat(req2.trailingHeaders()).isEqualTo(
+                HttpHeaders.of(CONTENT_MD5, "37b51d194a7513e45b56f6524f2d51f2"));
+        reqDuplicator.close();
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/common/http/HttpResponseDuplicatorTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/http/HttpResponseDuplicatorTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.http;
+
+import static com.linecorp.armeria.common.http.HttpHeaderNames.CONTENT_TYPE;
+import static com.linecorp.armeria.common.http.HttpHeaderNames.VARY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class HttpResponseDuplicatorTest {
+
+    @Test
+    public void aggregateTwice() {
+        final DefaultHttpResponse publisher = new DefaultHttpResponse();
+        final HttpResponseDuplicator resDuplicator = new HttpResponseDuplicator(publisher);
+
+        publisher.write(HttpHeaders.of(HttpStatus.OK).set(CONTENT_TYPE, "text/plain"));
+        publisher.write(HttpData.ofUtf8("Armeria "));
+        publisher.write(HttpData.ofUtf8("is "));
+        publisher.write(HttpData.ofUtf8("awesome!"));
+        publisher.close();
+
+        final AggregatedHttpMessage res1 = resDuplicator.duplicateStream().aggregate().join();
+        final AggregatedHttpMessage res2 = resDuplicator.duplicateStream().aggregate().join();
+
+        assertThat(res1.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res1.headers().get(CONTENT_TYPE)).isEqualTo("text/plain");
+        assertThat(res1.headers().get(VARY)).isNull();
+        assertThat(res1.content().toStringUtf8()).isEqualTo("Armeria is awesome!");
+
+        assertThat(res2.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res2.headers().get(CONTENT_TYPE)).isEqualTo("text/plain");
+        assertThat(res2.headers().get(VARY)).isNull();
+        assertThat(res2.content().toStringUtf8()).isEqualTo("Armeria is awesome!");
+        resDuplicator.close();
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageDuplicatorTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageDuplicatorTest.java
@@ -1,0 +1,301 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.function.BiConsumer;
+
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import com.linecorp.armeria.common.stream.AbstractStreamMessageDuplicator.DownstreamSubscription;
+import com.linecorp.armeria.common.stream.AbstractStreamMessageDuplicator.StreamMessageProcessor;
+
+public class StreamMessageDuplicatorTest {
+
+    @Test
+    public void subscribeTwice() {
+        @SuppressWarnings("unchecked")
+        final StreamMessage<String> publisher = mock(StreamMessage.class);
+        when(publisher.closeFuture()).thenReturn(new CompletableFuture<>());
+
+        final AbstractStreamMessageDuplicator<String, StreamMessage<String>> duplicator =
+                new StreamMessageDuplicator(publisher);
+
+        @SuppressWarnings("unchecked")
+        final ArgumentCaptor<StreamMessageProcessor<String>> processorCaptor =
+                ArgumentCaptor.forClass(StreamMessageProcessor.class);
+
+        verify(publisher).subscribe(processorCaptor.capture(), eq(true));
+
+        verify(publisher).subscribe(any(), eq(true));
+        final Subscriber<String> subscriber1 = subscribeWithMock(duplicator.duplicateStream());
+        final Subscriber<String> subscriber2 = subscribeWithMock(duplicator.duplicateStream());
+        // Publisher's subscribe() is not invoked when a new subscriber subscribes.
+        verify(publisher).subscribe(any(), eq(true));
+
+        final StreamMessageProcessor<String> processor = processorCaptor.getValue();
+
+        // Verify that the propagated triggers onSubscribe().
+        verify(subscriber1, never()).onSubscribe(any());
+        verify(subscriber2, never()).onSubscribe(any());
+        processor.onSubscribe(mock(Subscription.class));
+        verify(subscriber1).onSubscribe(any(DownstreamSubscription.class));
+        verify(subscriber2).onSubscribe(any(DownstreamSubscription.class));
+        duplicator.close();
+    }
+
+    private Subscriber<String> subscribeWithMock(StreamMessage<String> streamMessage) {
+        @SuppressWarnings("unchecked")
+        final Subscriber<String> subscriber = mock(Subscriber.class);
+        streamMessage.subscribe(subscriber);
+        return subscriber;
+    }
+
+    @Test
+    public void closePublisherNormally() throws Exception {
+        final DefaultStreamMessage<String> publisher = new DefaultStreamMessage<>();
+        final AbstractStreamMessageDuplicator<String, StreamMessage<String>> duplicator =
+                new StreamMessageDuplicator(publisher);
+
+        final CompletableFuture<String> future1 = subscribe(duplicator.duplicateStream());
+        final CompletableFuture<String> future2 = subscribe(duplicator.duplicateStream());
+
+        writeData(publisher);
+        publisher.close();
+
+        assertThat(future1.get()).isEqualTo("Armeria is awesome.");
+        assertThat(future2.get()).isEqualTo("Armeria is awesome.");
+        duplicator.close();
+    }
+
+    private void writeData(DefaultStreamMessage<String> publisher) {
+        publisher.write("Armeria ");
+        publisher.write("is ");
+        publisher.write("awesome.");
+    }
+
+    private CompletableFuture<String> subscribe(StreamMessage<String> streamMessage) {
+        return subscribe(streamMessage, Long.MAX_VALUE);
+    }
+
+    private CompletableFuture<String> subscribe(StreamMessage<String> streamMessage, long demand) {
+        final CompletableFuture<String> future = new CompletableFuture<>();
+        final StringSubscriber subscriber = new StringSubscriber(future, demand);
+        streamMessage.closeFuture().whenComplete(subscriber);
+        streamMessage.subscribe(subscriber);
+        return future;
+    }
+
+    @Test
+    public void closePublisherExceptionally() throws ExecutionException, InterruptedException {
+        final DefaultStreamMessage<String> publisher = new DefaultStreamMessage<>();
+        final AbstractStreamMessageDuplicator<String, StreamMessage<String>> duplicator =
+                new StreamMessageDuplicator(publisher);
+
+        final CompletableFuture<String> future1 = subscribe(duplicator.duplicateStream());
+        final CompletableFuture<String> future2 = subscribe(duplicator.duplicateStream());
+
+        writeData(publisher);
+        publisher.close(new IllegalArgumentException());
+
+        assertThat(future1).isCompletedExceptionally();
+        assertThat(future2).isCompletedExceptionally();
+        assertThatThrownBy(future1::get).hasCauseExactlyInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(future2::get).hasCauseExactlyInstanceOf(IllegalArgumentException.class);
+        duplicator.close();
+    }
+
+    @Test
+    public void subscribeAfterPublisherClosed() throws Exception {
+        final DefaultStreamMessage<String> publisher = new DefaultStreamMessage<>();
+        final AbstractStreamMessageDuplicator<String, StreamMessage<String>> duplicator =
+                new StreamMessageDuplicator(publisher);
+
+        final CompletableFuture<String> future1 = subscribe(duplicator.duplicateStream());
+        writeData(publisher);
+        publisher.close();
+
+        assertThat(future1.get()).isEqualTo("Armeria is awesome.");
+
+        // Still subscribable.
+        final CompletableFuture<String> future2 = subscribe(duplicator.duplicateStream());
+        assertThat(future2.get()).isEqualTo("Armeria is awesome.");
+        duplicator.close();
+    }
+
+    @Test
+    public void childStreamIsNotClosedWhenDemandIsNotEnough()
+            throws ExecutionException, InterruptedException {
+        final DefaultStreamMessage<String> publisher = new DefaultStreamMessage<>();
+        final AbstractStreamMessageDuplicator<String, StreamMessage<String>> duplicator =
+                new StreamMessageDuplicator(publisher);
+
+        final CompletableFuture<String> future1 = new CompletableFuture<>();
+        final StringSubscriber subscriber = new StringSubscriber(future1, 2);
+        final StreamMessage<String> sm = duplicator.duplicateStream();
+        sm.closeFuture().whenComplete(subscriber);
+        sm.subscribe(subscriber);
+
+        final CompletableFuture<String> future2 = subscribe(duplicator.duplicateStream(), 3);
+
+        writeData(publisher);
+        publisher.close();
+
+        assertThat(future2.get()).isEqualTo("Armeria is awesome.");
+        assertThat(future1.isDone()).isEqualTo(false);
+
+        subscriber.requestAnother();
+        assertThat(future1.get()).isEqualTo("Armeria is awesome.");
+        duplicator.close();
+    }
+
+    @Test
+    public void abortPublisherWithSubscribers() {
+        final DefaultStreamMessage<String> publisher = new DefaultStreamMessage<>();
+        final AbstractStreamMessageDuplicator<String, StreamMessage<String>> duplicator =
+                new StreamMessageDuplicator(publisher);
+
+        final CompletableFuture<String> future = subscribe(duplicator.duplicateStream());
+        publisher.abort();
+
+        assertThat(future).isCompletedExceptionally();
+        assertThatThrownBy(future::get).hasCauseExactlyInstanceOf(CancelledSubscriptionException.class);
+        duplicator.close();
+    }
+
+    @Test
+    public void abortPublisherWithoutSubscriber() {
+        final DefaultStreamMessage<String> publisher = new DefaultStreamMessage<>();
+        final AbstractStreamMessageDuplicator<String, StreamMessage<String>> duplicator =
+                new StreamMessageDuplicator(publisher);
+        publisher.abort();
+
+        // Completed exceptionally as soon as a subscriber subscribes.
+        final CompletableFuture<String> future = subscribe(duplicator.duplicateStream());
+        assertThat(future).isCompletedExceptionally();
+        assertThatThrownBy(future::get).hasCauseExactlyInstanceOf(CancelledSubscriptionException.class);
+        duplicator.close();
+    }
+
+    @Test
+    public void abortChildStream() {
+        final DefaultStreamMessage<String> publisher = new DefaultStreamMessage<>();
+        final AbstractStreamMessageDuplicator<String, StreamMessage<String>> duplicator =
+                new StreamMessageDuplicator(publisher);
+
+        final StreamMessage<String> sm1 = duplicator.duplicateStream();
+        final CompletableFuture<String> future1 = subscribe(sm1);
+
+        final StreamMessage<String> sm2 = duplicator.duplicateStream();
+        final CompletableFuture<String> future2 = subscribe(sm2);
+
+        sm1.abort();
+        assertThat(future1).isCompletedExceptionally();
+        assertThatThrownBy(future1::get).hasCauseExactlyInstanceOf(CancelledSubscriptionException.class);
+
+        // Aborting from another subscriber does not affect to other subscribers.
+        assertThat(sm2.isOpen()).isEqualTo(true);
+        sm2.abort();
+        assertThat(future2).isCompletedExceptionally();
+        assertThatThrownBy(future2::get).hasCauseExactlyInstanceOf(CancelledSubscriptionException.class);
+        duplicator.close();
+    }
+
+    @Test
+    public void closeMulticastStreamFactory() {
+        final DefaultStreamMessage<String> publisher = new DefaultStreamMessage<>();
+        final AbstractStreamMessageDuplicator<String, StreamMessage<String>> duplicator =
+                new StreamMessageDuplicator(publisher);
+
+        duplicator.close();
+        assertThatThrownBy(duplicator::duplicateStream).isInstanceOf(IllegalStateException.class);
+    }
+
+    private static class StreamMessageDuplicator
+            extends AbstractStreamMessageDuplicator<String, StreamMessage<String>> {
+        StreamMessageDuplicator(StreamMessage<String> publisher) {
+            super(publisher);
+        }
+
+        @Override
+        public StreamMessage<String> doDuplicateStream(StreamMessage<String> delegate) {
+            return new MulticastStream(delegate);
+        }
+
+        private static class MulticastStream extends StreamMessageWrapper<String> {
+            MulticastStream(StreamMessage<? extends String> delegate) {
+                super(delegate);
+            }
+        }
+    }
+
+    private static class StringSubscriber implements Subscriber<String>, BiConsumer<Void, Throwable> {
+
+        private CompletableFuture<String> future;
+        private StringBuffer sb = new StringBuffer();
+        private long demand;
+        private Subscription subscription;
+
+        StringSubscriber(CompletableFuture<String> future, long demand) {
+            this.future = future;
+            this.demand = demand;
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            subscription = s;
+            s.request(demand);
+        }
+
+        @Override
+        public void onNext(String s) {
+            sb.append(s);
+        }
+
+        @Override
+        public void onError(Throwable t) {}
+
+        @Override
+        public void onComplete() {}
+
+        @Override
+        public void accept(Void aVoid, Throwable cause) {
+            if (cause != null) {
+                future.completeExceptionally(cause);
+            } else {
+                future.complete(sb.toString());
+            }
+        }
+
+        void requestAnother() {
+            subscription.request(1);
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

If a stream message is, once published to a subscriber, next subscriber cannot subscribe
the data again. A user may want to see just the head of data and decide to request other
subscriber to do more action according to the data of the head.
In that case, another subscriber cannot see the data consumed already.
We needed to provide the way that a publisher can be subscribed by multiple
subscribers, so a user can use the elements in different places.

Modifications:

- Add StreamMessageDuplicator that wraps a StreamMessage and spawns
  Children stream messages can be subscribed one by one
- Add HttpResponseDuplicator and HttpRequestDuplicator

Result:

- A user can subscribe a publisher with multiple subscribers.

To-do:

- Limit the size of the buffered data in the factory