### PR TITLE
Ensure DefaultStreamMessage cleans up the objects even when demand is 0

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/http/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/HttpResponseSubscriber.java
@@ -49,6 +49,7 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http2.Http2Error;
+import io.netty.util.ReferenceCountUtil;
 
 final class HttpResponseSubscriber implements Subscriber<HttpObject>, RequestTimeoutChangeListener,
                                               ChannelFutureListener {
@@ -208,6 +209,7 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject>, RequestTim
                 break;
             }
             case DONE:
+                ReferenceCountUtil.safeRelease(o);
                 return;
         }
 


### PR DESCRIPTION
Motivation:

DefaultStreamMessage does not release all pending objects when:

- the stream is closed by the publisher and
- the subscriber cancels its subscription when its demand is 0.

Modifications:

- Make sure cleanup() is invoked when the subscriber cancels its
  subscription when the stream is closed so that all the pending objects
  are released even if the subscriber's demand is 0.
- Make HttpResponseSubscriber.onNext() release HttpObjects received
  after its state became DONE.

Result:

- Less leaks