### PR TITLE
Simplify type parameters of Clients and Services

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/AbstractClientOptionsBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/AbstractClientOptionsBuilder.java
@@ -172,8 +172,7 @@ class AbstractClientOptionsBuilder<B extends AbstractClientOptionsBuilder<?>> {
      * @param <I> the {@link Request} type of the {@link Client} being decorated
      * @param <O> the {@link Response} type of the {@link Client} being decorated
      */
-    public <T extends Client<? super I, ? extends O>, R extends Client<I, O>,
-            I extends Request, O extends Response>
+    public <T extends Client<I, O>, R extends Client<I, O>, I extends Request, O extends Response>
     B decorator(Class<I> requestType, Class<O> responseType, Function<T, R> decorator) {
         decoration.add(requestType, responseType, decorator);
         return self();

--- a/core/src/main/java/com/linecorp/armeria/client/Client.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Client.java
@@ -18,6 +18,10 @@ package com.linecorp.armeria.client;
 
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
+import com.linecorp.armeria.common.RpcRequest;
+import com.linecorp.armeria.common.RpcResponse;
+import com.linecorp.armeria.common.http.HttpRequest;
+import com.linecorp.armeria.common.http.HttpResponse;
 
 /**
  * Sends a {@link Request} to a remote {@link Endpoint}.
@@ -27,8 +31,8 @@ import com.linecorp.armeria.common.Response;
  * a {@link Request}. A user is supposed to make his or her {@link Request} via the object returned by
  * a {@link ClientBuilder} or {@link Clients}, which usually does not implement this interface.
  *
- * @param <I> the type of the outgoing {@link Request}
- * @param <O> the type of the incoming {@link Response}
+ * @param <I> the type of outgoing {@link Response}. Must be {@link HttpResponse} or {@link RpcResponse}.
+ * @param <O> the type of incoming {@link Request}. Must be {@link HttpRequest} or {@link RpcRequest}.
  *
  * @see UserClient
  */

--- a/core/src/main/java/com/linecorp/armeria/client/ClientDecoration.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientDecoration.java
@@ -42,8 +42,7 @@ public final class ClientDecoration {
      * @param <T> the type of the {@link Client} being decorated
      * @param <R> the type of the {@link Client} produced by the {@code decorator}
      */
-    public static <T extends Client<? super I, ? extends O>, R extends Client<I, O>,
-                   I extends Request, O extends Response>
+    public static <T extends Client<I, O>, R extends Client<I, O>, I extends Request, O extends Response>
     ClientDecoration of(Class<I> requestType, Class<O> responseType, Function<T, R> decorator) {
         return new ClientDecorationBuilder().add(requestType, responseType, decorator).build();
     }

--- a/core/src/main/java/com/linecorp/armeria/client/ClientDecorationBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientDecorationBuilder.java
@@ -25,6 +25,10 @@ import java.util.function.Function;
 import com.linecorp.armeria.client.ClientDecoration.Entry;
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
+import com.linecorp.armeria.common.RpcRequest;
+import com.linecorp.armeria.common.RpcResponse;
+import com.linecorp.armeria.common.http.HttpRequest;
+import com.linecorp.armeria.common.http.HttpResponse;
 
 /**
  * Creates a new {@link ClientDecoration} using the builder pattern.
@@ -44,13 +48,19 @@ public final class ClientDecorationBuilder {
      * @param <I> the {@link Request} type of the {@link Client} being decorated
      * @param <O> the {@link Response} type of the {@link Client} being decorated
      */
-    public <T extends Client<? super I, ? extends O>, R extends Client<I, O>,
-            I extends Request, O extends Response>
+    public <T extends Client<I, O>, R extends Client<I, O>, I extends Request, O extends Response>
     ClientDecorationBuilder add(Class<I> requestType, Class<O> responseType, Function<T, R> decorator) {
 
         requireNonNull(requestType, "requestType");
         requireNonNull(responseType, "responseType");
         requireNonNull(decorator, "decorator");
+
+        if (!(requestType == HttpRequest.class && responseType == HttpResponse.class ||
+              requestType == RpcRequest.class && responseType == RpcResponse.class)) {
+            throw new IllegalArgumentException(
+                    "requestType and responseType must be HttpRequest and HttpResponse or " +
+                    "RpcRequest and RpcResponse: " + requestType.getName() + " and " + responseType.getName());
+        }
 
         entries.add(new Entry<>(requestType, responseType, decorator));
         return this;

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClient.java
@@ -52,7 +52,7 @@ public final class CircuitBreakerClient<I extends Request, O extends Response>
      * @param circuitBreaker The {@link CircuitBreaker} instance to be used
      */
     public static <I extends Request, O extends Response>
-    Function<Client<? super I, ? extends O>, CircuitBreakerClient<I, O>>
+    Function<Client<I, O>, CircuitBreakerClient<I, O>>
     newDecorator(CircuitBreaker circuitBreaker) {
         return newDecorator((ctx, req) -> circuitBreaker);
     }
@@ -61,7 +61,7 @@ public final class CircuitBreakerClient<I extends Request, O extends Response>
      * Creates a new decorator with the specified {@link CircuitBreakerMapping}.
      */
     public static <I extends Request, O extends Response>
-    Function<Client<? super I, ? extends O>, CircuitBreakerClient<I, O>>
+    Function<Client<I, O>, CircuitBreakerClient<I, O>>
     newDecorator(CircuitBreakerMapping mapping) {
         return delegate -> new CircuitBreakerClient<>(delegate, mapping);
     }
@@ -72,7 +72,7 @@ public final class CircuitBreakerClient<I extends Request, O extends Response>
      * @param factory A function that takes a method name and creates a new {@link CircuitBreaker}.
      */
     public static <I extends Request, O extends Response>
-    Function<Client<? super I, ? extends O>, CircuitBreakerClient<I, O>>
+    Function<Client<I, O>, CircuitBreakerClient<I, O>>
     newPerMethodDecorator(Function<String, CircuitBreaker> factory) {
         return newDecorator(new KeyedCircuitBreakerMapping<>(KeySelector.METHOD, factory));
     }
@@ -83,7 +83,7 @@ public final class CircuitBreakerClient<I extends Request, O extends Response>
      * @param factory A function that takes a host name and creates a new {@link CircuitBreaker}.
      */
     public static <I extends Request, O extends Response>
-    Function<Client<? super I, ? extends O>, CircuitBreakerClient<I, O>>
+    Function<Client<I, O>, CircuitBreakerClient<I, O>>
     newPerHostDecorator(Function<String, CircuitBreaker> factory) {
         return newDecorator(new KeyedCircuitBreakerMapping<>(KeySelector.HOST, factory));
     }
@@ -94,7 +94,7 @@ public final class CircuitBreakerClient<I extends Request, O extends Response>
      * @param factory A function that takes a host+method name and creates a new {@link CircuitBreaker}.
      */
     public static <I extends Request, O extends Response>
-    Function<Client<? super I, ? extends O>, CircuitBreakerClient<I, O>>
+    Function<Client<I, O>, CircuitBreakerClient<I, O>>
     newPerHostAndMethodDecorator(Function<String, CircuitBreaker> factory) {
         return newDecorator(new KeyedCircuitBreakerMapping<>(KeySelector.HOST_AND_METHOD, factory));
     }

--- a/core/src/main/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingHttpClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingHttpClient.java
@@ -36,13 +36,12 @@ import com.linecorp.armeria.common.http.HttpResponse;
  * }</pre>
  *
  */
-public final class ConcurrencyLimitingHttpClient
-        extends ConcurrencyLimitingClient<HttpRequest, HttpResponse> {
+public final class ConcurrencyLimitingHttpClient extends ConcurrencyLimitingClient<HttpRequest, HttpResponse> {
 
     /**
      * Creates a new {@link Client} decorator that limits the concurrent number of active HTTP requests.
      */
-    public static Function<Client<? super HttpRequest, ? extends HttpResponse>, ConcurrencyLimitingHttpClient>
+    public static Function<Client<HttpRequest, HttpResponse>, ConcurrencyLimitingHttpClient>
     newDecorator(int maxConcurrency) {
         validateMaxConcurrency(maxConcurrency);
         return delegate -> new ConcurrencyLimitingHttpClient(delegate, maxConcurrency);
@@ -51,19 +50,18 @@ public final class ConcurrencyLimitingHttpClient
     /**
      * Creates a new {@link Client} decorator that limits the concurrent number of active HTTP requests.
      */
-    public static Function<Client<? super HttpRequest, ? extends HttpResponse>, ConcurrencyLimitingHttpClient>
-    newDecorator(int maxConcurrency, long timeout, TimeUnit unit) {
+    public static Function<Client<HttpRequest, HttpResponse>, ConcurrencyLimitingHttpClient> newDecorator(
+            int maxConcurrency, long timeout, TimeUnit unit) {
         validateAll(maxConcurrency, timeout, unit);
         return delegate -> new ConcurrencyLimitingHttpClient(delegate, maxConcurrency, timeout, unit);
     }
 
 
-    private ConcurrencyLimitingHttpClient(Client<? super HttpRequest, ? extends HttpResponse> delegate,
-                                          int maxConcurrency) {
+    private ConcurrencyLimitingHttpClient(Client<HttpRequest, HttpResponse> delegate, int maxConcurrency) {
         super(delegate, maxConcurrency);
     }
 
-    private ConcurrencyLimitingHttpClient(Client<? super HttpRequest, ? extends HttpResponse> delegate,
+    private ConcurrencyLimitingHttpClient(Client<HttpRequest, HttpResponse> delegate,
                                           int maxConcurrency, long timeout, TimeUnit unit) {
         super(delegate, maxConcurrency, timeout, unit);
     }

--- a/core/src/main/java/com/linecorp/armeria/client/metric/DropwizardMetricCollectingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/metric/DropwizardMetricCollectingClient.java
@@ -64,7 +64,7 @@ public final class DropwizardMetricCollectingClient<I extends Request, O extends
      * @param metricNameFunc the function that transforms a {@link RequestLog} into a metric name
      */
     public static <I extends Request, O extends Response>
-    Function<Client<? super I, ? extends O>, DropwizardMetricCollectingClient<I, O>> newDecorator(
+    Function<Client<I, O>, DropwizardMetricCollectingClient<I, O>> newDecorator(
             MetricRegistry metricRegistry,
             Function<? super RequestLog, String> metricNameFunc) {
 
@@ -81,7 +81,7 @@ public final class DropwizardMetricCollectingClient<I extends Request, O extends
      * @param metricNamePrefix the prefix of the names of the metrics created by the returned decorator.
      */
     public static <I extends Request, O extends Response>
-    Function<Client<? super I, ? extends O>, DropwizardMetricCollectingClient<I, O>> newDecorator(
+    Function<Client<I, O>, DropwizardMetricCollectingClient<I, O>> newDecorator(
             MetricRegistry metricRegistry, String metricNamePrefix) {
 
         requireNonNull(metricNamePrefix, "metricNamePrefix");

--- a/core/src/main/java/com/linecorp/armeria/client/metric/PrometheusMetricCollectingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/metric/PrometheusMetricCollectingClient.java
@@ -51,7 +51,7 @@ public final class PrometheusMetricCollectingClient<T extends MetricLabel<T>,
      * @return A client decorator function
      */
     public static <T extends MetricLabel<T>, I extends Request, O extends Response>
-    Function<Client<? super I, ? extends O>, PrometheusMetricCollectingClient<T, I, O>>
+    Function<Client<I, O>, PrometheusMetricCollectingClient<T, I, O>>
     newDecorator(CollectorRegistry collectorRegistry,
                  T[] metricLabels,
                  Function<RequestLog, Map<T, String>> labelingFunction) {
@@ -73,7 +73,7 @@ public final class PrometheusMetricCollectingClient<T extends MetricLabel<T>,
      * @return A client decorator function
      */
     public static <T extends MetricLabel<T>, I extends Request, O extends Response>
-    Function<Client<? super I, ? extends O>, PrometheusMetricCollectingClient<T, I, O>>
+    Function<Client<I, O>, PrometheusMetricCollectingClient<T, I, O>>
     newDecorator(CollectorRegistry collectorRegistry,
                  Iterable<T> metricLabels,
                  Function<RequestLog, Map<T, String>> labelingFunction) {

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClient.java
@@ -39,7 +39,7 @@ public class RetryingRpcClient extends RetryingClient<RpcRequest, RpcResponse> {
     /**
      * Creates a new {@link Client} decorator that handles failures of an invocation and retries RPC requests.
      */
-    public static Function<Client<? super RpcRequest, ? extends RpcResponse>, RetryingRpcClient>
+    public static Function<Client<RpcRequest, RpcResponse>, RetryingRpcClient>
     newDecorator(RetryRequestStrategy<RpcRequest, RpcResponse> retryRequestStrategy) {
         return delegate -> new RetryingRpcClient(delegate, retryRequestStrategy,
                                                  Backoff::withoutDelay);
@@ -48,7 +48,7 @@ public class RetryingRpcClient extends RetryingClient<RpcRequest, RpcResponse> {
     /**
      * Creates a new {@link Client} decorator that handles failures of an invocation and retries RPC requests.
      */
-    public static Function<Client<? super RpcRequest, ? extends RpcResponse>, RetryingRpcClient>
+    public static Function<Client<RpcRequest, RpcResponse>, RetryingRpcClient>
     newDecorator(RetryRequestStrategy<RpcRequest, RpcResponse> retryRequestStrategy,
                  Supplier<? extends Backoff> backoffSupplier) {
         return delegate -> new RetryingRpcClient(delegate, retryRequestStrategy, backoffSupplier);
@@ -57,7 +57,7 @@ public class RetryingRpcClient extends RetryingClient<RpcRequest, RpcResponse> {
     /**
      * Creates a new instance that decorates the specified {@link Client}.
      */
-    public RetryingRpcClient(Client<? super RpcRequest, ? extends RpcResponse> delegate,
+    public RetryingRpcClient(Client<RpcRequest, RpcResponse> delegate,
                              RetryRequestStrategy<RpcRequest, RpcResponse> retryStrategy,
                              Supplier<? extends Backoff> backoffSupplier) {
         super(delegate, retryStrategy, backoffSupplier);

--- a/core/src/main/java/com/linecorp/armeria/common/Request.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Request.java
@@ -17,17 +17,8 @@
 package com.linecorp.armeria.common;
 
 import com.linecorp.armeria.common.http.HttpRequest;
-import com.linecorp.armeria.common.stream.StreamMessage;
 
 /**
- * A request. It is usually one of the following:
- * <ul>
- *   <li>A {@link StreamMessage} with some initial information (if necessary)
- *     <ul>
- *       <li>e.g. {@link HttpRequest} whose initial information is its initial HTTP headers</li>
- *     </ul>
- *   </li>
- *   <li>A simple object whose content is readily available. e.g. {@link RpcRequest}</li>
- * </ul>
+ * A request. It has to be a {@link HttpRequest} or a {@link RpcRequest}.
  */
 public interface Request {}

--- a/core/src/main/java/com/linecorp/armeria/common/Response.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Response.java
@@ -19,11 +19,12 @@ package com.linecorp.armeria.common;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
+import com.linecorp.armeria.common.http.HttpResponse;
 import com.linecorp.armeria.common.stream.StreamMessage;
 
 /**
  * A response stream or a holder of the future result value.
- * It must implement {@link StreamMessage} or {@link CompletionStage}, but not both.
+ * It has to be a {@link HttpResponse} or a {@link RpcResponse}.
  */
 public interface Response {
 

--- a/core/src/main/java/com/linecorp/armeria/server/Service.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Service.java
@@ -24,12 +24,16 @@ import java.util.function.Function;
 
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
+import com.linecorp.armeria.common.RpcRequest;
+import com.linecorp.armeria.common.RpcResponse;
+import com.linecorp.armeria.common.http.HttpRequest;
+import com.linecorp.armeria.common.http.HttpResponse;
 
 /**
  * Handles a {@link Request} received by a {@link Server}.
  *
- * @param <I> the type of incoming {@link Request}
- * @param <O> the type of outgoing {@link Response}
+ * @param <I> the type of incoming {@link Request}. Must be {@link HttpRequest} or {@link RpcRequest}.
+ * @param <O> the type of outgoing {@link Response}. Must be {@link HttpResponse} or {@link RpcResponse}.
  */
 @FunctionalInterface
 public interface Service<I extends Request, O extends Response> {
@@ -106,7 +110,7 @@ public interface Service<I extends Request, O extends Response> {
     /**
      * Creates a new {@link Service} that decorates this {@link Service} with the specified {@code decorator}.
      */
-    default <T extends Service<? super I, ? extends O>,
+    default <T extends Service<I, O>,
              R extends Service<R_I, R_O>, R_I extends Request, R_O extends Response>
     R decorate(Function<T, R> decorator) {
         @SuppressWarnings("unchecked")

--- a/core/src/main/java/com/linecorp/armeria/server/http/auth/HttpAuthService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/auth/HttpAuthService.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.server.http.auth;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 
@@ -49,8 +51,8 @@ public abstract class HttpAuthService extends SimpleDecoratingService<HttpReques
      *
      * @param authorizers a list of {@link Authorizer}s.
      */
-    public static Function<Service<? super HttpRequest, ? extends HttpResponse>,
-            HttpAuthService> newDecorator(Iterable<? extends Authorizer<HttpRequest>> authorizers) {
+    public static Function<Service<HttpRequest, HttpResponse>, HttpAuthService> newDecorator(
+            Iterable<? extends Authorizer<HttpRequest>> authorizers) {
         return service -> new HttpAuthServiceImpl(service, authorizers);
     }
 
@@ -60,15 +62,16 @@ public abstract class HttpAuthService extends SimpleDecoratingService<HttpReques
      *
      * @param authorizers the array of {@link Authorizer}s.
      */
-    public static Function<Service<? super HttpRequest, ? extends HttpResponse>,
-            HttpAuthService> newDecorator(Authorizer<HttpRequest>... authorizers) {
-        return newDecorator(ImmutableList.copyOf(authorizers));
+    @SafeVarargs
+    public static Function<Service<HttpRequest, HttpResponse>, HttpAuthService>
+    newDecorator(Authorizer<HttpRequest>... authorizers) {
+        return newDecorator(ImmutableList.copyOf(requireNonNull(authorizers, "authorizers")));
     }
 
     /**
      * Creates a new instance that provides HTTP authorization functionality to {@code delegate}.
      */
-    protected HttpAuthService(Service<? super HttpRequest, ? extends HttpResponse> delegate) {
+    protected HttpAuthService(Service<HttpRequest, HttpResponse> delegate) {
         super(delegate);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/http/auth/HttpAuthServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/auth/HttpAuthServiceBuilder.java
@@ -57,7 +57,7 @@ public final class HttpAuthServiceBuilder {
      * Adds an HTTP basic {@link Authorizer}.
      */
     public HttpAuthServiceBuilder addBasicAuth(Authorizer<? super BasicToken> authorizer) {
-        this.authorizers.add(
+        authorizers.add(
                 tokenAuthorizer(AuthTokenExtractors.BASIC, requireNonNull(authorizer, "authorizer")));
         return this;
     }
@@ -66,7 +66,7 @@ public final class HttpAuthServiceBuilder {
      * Adds an OAuth1a {@link Authorizer}.
      */
     public HttpAuthServiceBuilder addOAuth1a(Authorizer<? super OAuth1aToken> authorizer) {
-        this.authorizers.add(
+        authorizers.add(
                 tokenAuthorizer(AuthTokenExtractors.OAUTH1A, requireNonNull(authorizer, "authorizer")));
         return this;
     }
@@ -75,7 +75,7 @@ public final class HttpAuthServiceBuilder {
      * Adds an OAuth2 {@link Authorizer}.
      */
     public HttpAuthServiceBuilder addOAuth2(Authorizer<? super OAuth2Token> authorizer) {
-        this.authorizers.add(
+        authorizers.add(
                 tokenAuthorizer(AuthTokenExtractors.OAUTH2, requireNonNull(authorizer, "authorizer")));
         return this;
     }
@@ -84,7 +84,7 @@ public final class HttpAuthServiceBuilder {
      * Creates a new {@link HttpAuthService} instance with the given {@code delegate} and all of the
      * authorization {@link Authorizer}s.
      */
-    public HttpAuthService build(Service<? super HttpRequest, ? extends HttpResponse> delegate) {
+    public HttpAuthService build(Service<HttpRequest, HttpResponse> delegate) {
         return new HttpAuthServiceImpl(requireNonNull(delegate, "delegate"), authorizers);
     }
 
@@ -92,11 +92,11 @@ public final class HttpAuthServiceBuilder {
      * Creates a new {@link HttpAuthService} {@link Service} decorator that supports all of the given
      * authorization {@link Authorizer}s.
      */
-    public Function<Service<? super HttpRequest, ? extends HttpResponse>, HttpAuthService> newDecorator() {
+    public Function<Service<HttpRequest, HttpResponse>, HttpAuthService> newDecorator() {
         return HttpAuthService.newDecorator(authorizers);
     }
 
-    private <T> Authorizer<HttpRequest> tokenAuthorizer(
+    private static <T> Authorizer<HttpRequest> tokenAuthorizer(
             Function<HttpHeaders, T> tokenExtractor, Authorizer<? super T> authorizer) {
         return (ctx, req) -> {
             T token = tokenExtractor.apply(req.headers());

--- a/core/src/main/java/com/linecorp/armeria/server/http/auth/HttpAuthServiceImpl.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/auth/HttpAuthServiceImpl.java
@@ -40,14 +40,14 @@ final class HttpAuthServiceImpl extends HttpAuthService {
 
     private final List<? extends Authorizer<HttpRequest>> authorizers;
 
-    HttpAuthServiceImpl(Service<? super HttpRequest, ? extends HttpResponse> delegate,
+    HttpAuthServiceImpl(Service<HttpRequest, HttpResponse> delegate,
                         Iterable<? extends Authorizer<HttpRequest>> authorizers) {
         super(delegate);
         this.authorizers = ImmutableList.copyOf(authorizers);
     }
 
     @Override
-    public CompletionStage<Boolean> authorize(HttpRequest req, ServiceRequestContext ctx) {
+    protected CompletionStage<Boolean> authorize(HttpRequest req, ServiceRequestContext ctx) {
         CompletableFuture<Boolean> result = CompletableFuture.completedFuture(false);
         for (Authorizer<HttpRequest> authorizer : authorizers) {
             result = result.exceptionally(t -> {

--- a/core/src/main/java/com/linecorp/armeria/server/http/cors/CorsService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/cors/CorsService.java
@@ -28,8 +28,6 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Ascii;
 
-import com.linecorp.armeria.common.Request;
-import com.linecorp.armeria.common.Response;
 import com.linecorp.armeria.common.http.DefaultHttpResponse;
 import com.linecorp.armeria.common.http.FilteredHttpResponse;
 import com.linecorp.armeria.common.http.HttpHeaderNames;
@@ -40,9 +38,9 @@ import com.linecorp.armeria.common.http.HttpRequest;
 import com.linecorp.armeria.common.http.HttpResponse;
 import com.linecorp.armeria.common.http.HttpStatus;
 import com.linecorp.armeria.common.http.HttpStatusClass;
-import com.linecorp.armeria.server.DecoratingService;
 import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.SimpleDecoratingService;
 
 import io.netty.util.AsciiString;
 
@@ -51,13 +49,9 @@ import io.netty.util.AsciiString;
  * <a href="https://en.wikipedia.org/wiki/Cross-origin_resource_sharing">Cross-Origin Resource Sharing
  * (CORS)</a> support.
  *
- * @param <I> the {@link Request} type of the {@link Service} being decorated
- * @param <O> the {@link Response} type of the {@link Service} being decorated
- *
  * @see CorsServiceBuilder
  */
-public final class CorsService<I extends HttpRequest, O extends HttpResponse>
-        extends DecoratingService<I, O, I, HttpResponse> {
+public final class CorsService extends SimpleDecoratingService<HttpRequest, HttpResponse> {
 
     private static final Logger logger = LoggerFactory.getLogger(CorsService.class);
 
@@ -69,7 +63,7 @@ public final class CorsService<I extends HttpRequest, O extends HttpResponse>
     /**
      * Creates a new {@link CorsService} that decorates the specified {@code delegate} to add CORS support.
      */
-    public CorsService(Service<? super I, ? extends O> delegate, CorsConfig config) {
+    public CorsService(Service<HttpRequest, HttpResponse> delegate, CorsConfig config) {
         super(delegate);
         this.config = requireNonNull(config, "config");
     }
@@ -82,7 +76,7 @@ public final class CorsService<I extends HttpRequest, O extends HttpResponse>
     }
 
     @Override
-    public HttpResponse serve(ServiceRequestContext ctx, I req) throws Exception {
+    public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
         // check if CORS preflight must be returned, or if
         // we need to forbid access because origin could not be validated
         if (config.isEnabled()) {

--- a/core/src/main/java/com/linecorp/armeria/server/http/cors/CorsServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/cors/CorsServiceBuilder.java
@@ -421,18 +421,17 @@ public final class CorsServiceBuilder {
      *
      * @return {@link CorsConfig} the configured CorsConfig instance.
      */
-    public <I extends HttpRequest, O extends HttpResponse>
-    CorsService<I, O> build(Service<? super I, ? extends O> delegate) {
-        return new CorsService<>(delegate, new CorsConfig(this));
+    public CorsService build(Service<HttpRequest, HttpResponse> delegate) {
+        return new CorsService(delegate, new CorsConfig(this));
     }
 
     /**
      * Creates a new decorator that decorates a {@link Service} with a new {@link CorsService}.
      */
     public <I extends HttpRequest, O extends HttpResponse>
-    Function<Service<? super I, ? extends O>, CorsService<I, O>> newDecorator() {
+    Function<Service<HttpRequest, HttpResponse>, CorsService> newDecorator() {
         final CorsConfig config = new CorsConfig(this);
-        return s -> new CorsService<>(s, config);
+        return s -> new CorsService(s, config);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/metric/DropwizardMetricCollectingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/metric/DropwizardMetricCollectingService.java
@@ -65,7 +65,7 @@ public final class DropwizardMetricCollectingService<I extends Request, O extend
      * @param metricNameFunc the function that transforms a {@link RequestLog} into a metric name
      */
     public static <I extends Request, O extends Response>
-    Function<Service<? super I, ? extends O>, DropwizardMetricCollectingService<I, O>> newDecorator(
+    Function<Service<I, O>, DropwizardMetricCollectingService<I, O>> newDecorator(
             MetricRegistry metricRegistry,
             Function<? super RequestLog, String> metricNameFunc) {
 
@@ -84,7 +84,7 @@ public final class DropwizardMetricCollectingService<I extends Request, O extend
      * @param metricNamePrefix the prefix of the names of the metrics created by the returned decorator.
      */
     public static <I extends Request, O extends Response>
-    Function<Service<? super I, ? extends O>, DropwizardMetricCollectingService<I, O>> newDecorator(
+    Function<Service<I, O>, DropwizardMetricCollectingService<I, O>> newDecorator(
             MetricRegistry metricRegistry, String metricNamePrefix) {
 
         requireNonNull(metricNamePrefix, "metricNamePrefix");

--- a/core/src/main/java/com/linecorp/armeria/server/metric/PrometheusMetricCollectingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/metric/PrometheusMetricCollectingService.java
@@ -51,7 +51,7 @@ public final class PrometheusMetricCollectingService
      * @return A service decorator function
      */
     public static <T extends MetricLabel<T>, I extends Request, O extends Response>
-    Function<Service<? super I, ? extends O>, PrometheusMetricCollectingService<T, I, O>>
+    Function<Service<I, O>, PrometheusMetricCollectingService<T, I, O>>
     newDecorator(CollectorRegistry collectorRegistry,
                  T[] metricLabels,
                  Function<RequestLog, Map<T, String>> labelingFunction) {
@@ -72,7 +72,7 @@ public final class PrometheusMetricCollectingService
      * @return A service decorator function
      */
     public static <T extends MetricLabel<T>, I extends Request, O extends Response>
-    Function<Service<? super I, ? extends O>, PrometheusMetricCollectingService<T, I, O>>
+    Function<Service<I, O>, PrometheusMetricCollectingService<T, I, O>>
     newDecorator(CollectorRegistry collectorRegistry,
                  Iterable<T> metricLabels,
                  Function<RequestLog, Map<T, String>> labelingFunction) {

--- a/core/src/test/java/com/linecorp/armeria/client/ClientDecorationBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientDecorationBuilderTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import static java.util.function.Function.identity;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.Test;
+
+import com.linecorp.armeria.common.DefaultRpcRequest;
+import com.linecorp.armeria.common.DefaultRpcResponse;
+import com.linecorp.armeria.common.Request;
+import com.linecorp.armeria.common.Response;
+import com.linecorp.armeria.common.RpcRequest;
+import com.linecorp.armeria.common.RpcResponse;
+import com.linecorp.armeria.common.http.DefaultHttpRequest;
+import com.linecorp.armeria.common.http.DefaultHttpResponse;
+import com.linecorp.armeria.common.http.HttpRequest;
+import com.linecorp.armeria.common.http.HttpResponse;
+
+public class ClientDecorationBuilderTest {
+
+    /**
+     * Make sure only {@link HttpRequest} and {@link HttpResponse} or {@link RpcRequest} and {@link RpcRequest}
+     * are allowed.
+     */
+    @Test
+    public void typeConstraints() {
+        final ClientDecorationBuilder cdb = new ClientDecorationBuilder();
+        assertThatThrownBy(() -> cdb.add(Request.class, Response.class, identity()))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> cdb.add(HttpRequest.class, RpcResponse.class, identity()))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> cdb.add(RpcRequest.class, HttpResponse.class, identity()))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> cdb.add(DefaultHttpRequest.class, DefaultHttpResponse.class, identity()))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> cdb.add(DefaultRpcRequest.class, DefaultRpcResponse.class, identity()))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClientTest.java
@@ -365,7 +365,7 @@ public class CircuitBreakerClientTest {
         assertThat(future1.cause(), is(not(instanceOf(FailFastException.class))));
     }
 
-    private static void invoke(Function<Client<? super RpcRequest, ? extends RpcResponse>,
+    private static void invoke(Function<Client<RpcRequest, RpcResponse>,
                                         ? extends Client<RpcRequest, RpcResponse>> decorator) throws Exception {
 
         @SuppressWarnings("unchecked")
@@ -377,7 +377,7 @@ public class CircuitBreakerClientTest {
 
     private static void failFastInvocation(
             CircuitBreaker circuitBreaker,
-            Function<Client<? super RpcRequest, ? extends RpcResponse>,
+            Function<Client<RpcRequest, RpcResponse>,
                      ? extends Client<RpcRequest, RpcResponse>> decorator, int count) throws Exception {
 
         for (int i = 0; i < count; i++) {

--- a/kafka/src/main/java/com/linecorp/armeria/server/logging/structured/kafka/KafkaStructuredLoggingService.java
+++ b/kafka/src/main/java/com/linecorp/armeria/server/logging/structured/kafka/KafkaStructuredLoggingService.java
@@ -85,7 +85,7 @@ public class KafkaStructuredLoggingService<I extends Request, O extends Response
      * @return a service decorator which adds structured logging support integrated to Kafka
      */
     public static <I extends Request, O extends Response, L>
-    Function<Service<? super I, ? extends O>, StructuredLoggingService<I, O, L>> newDecorator(
+    Function<Service<I, O>, StructuredLoggingService<I, O, L>> newDecorator(
             Producer<byte[], L> producer, String topic,
             StructuredLogBuilder<L> logBuilder, KeySelector<L> keySelector) {
         return service -> new KafkaStructuredLoggingService<>(
@@ -105,7 +105,7 @@ public class KafkaStructuredLoggingService<I extends Request, O extends Response
      * @return a service decorator which adds structured logging support integrated to Kafka
      */
     public static <I extends Request, O extends Response, L>
-    Function<Service<? super I, ? extends O>, StructuredLoggingService<I, O, L>> newDecorator(
+    Function<Service<I, O>, StructuredLoggingService<I, O, L>> newDecorator(
             Producer<byte[], L> producer, String topic,
             StructuredLogBuilder<L> logBuilder) {
         return newDecorator(producer, topic, logBuilder, null);
@@ -125,7 +125,7 @@ public class KafkaStructuredLoggingService<I extends Request, O extends Response
      * @return a service decorator which adds structured logging support integrated to Kafka
      */
     public static <I extends Request, O extends Response, L>
-    Function<Service<? super I, ? extends O>, StructuredLoggingService<I, O, L>> newDecorator(
+    Function<Service<I, O>, StructuredLoggingService<I, O, L>> newDecorator(
             String bootstrapServers, String topic,
             StructuredLogBuilder<L> logBuilder, KeySelector<L> keySelector) {
         Producer<byte[], L> producer = new KafkaProducer<>(newDefaultConfig(bootstrapServers));
@@ -147,7 +147,7 @@ public class KafkaStructuredLoggingService<I extends Request, O extends Response
      * @return a service decorator which adds structured logging support integrated to Kafka
      */
     public static <I extends Request, O extends Response, L>
-    Function<Service<? super I, ? extends O>, StructuredLoggingService<I, O, L>>
+    Function<Service<I, O>, StructuredLoggingService<I, O, L>>
     newDecorator(String bootstrapServers, String topic, StructuredLogBuilder<L> logBuilder) {
         return newDecorator(bootstrapServers, topic, logBuilder, null);
     }

--- a/zipkin/src/main/java/com/linecorp/armeria/client/tracing/HttpTracingClient.java
+++ b/zipkin/src/main/java/com/linecorp/armeria/client/tracing/HttpTracingClient.java
@@ -48,12 +48,11 @@ public class HttpTracingClient extends AbstractTracingClient<HttpRequest, HttpRe
     /**
      * Creates a new tracing {@link Client} decorator using the specified {@link Brave} instance.
      */
-    public static Function<Client<? super HttpRequest, ? extends HttpResponse>, HttpTracingClient>
-    newDecorator(Brave brave) {
+    public static Function<Client<HttpRequest, HttpResponse>, HttpTracingClient> newDecorator(Brave brave) {
         return delegate -> new HttpTracingClient(delegate, brave);
     }
 
-    HttpTracingClient(Client<? super HttpRequest, ? extends HttpResponse> delegate, Brave brave) {
+    HttpTracingClient(Client<HttpRequest, HttpResponse> delegate, Brave brave) {
         super(delegate, brave);
     }
 

--- a/zipkin/src/main/java/com/linecorp/armeria/server/tracing/HttpTracingService.java
+++ b/zipkin/src/main/java/com/linecorp/armeria/server/tracing/HttpTracingService.java
@@ -46,12 +46,11 @@ public class HttpTracingService extends AbstractTracingService<HttpRequest, Http
     /**
      * Creates a new tracing {@link Service} decorator using the specified {@link Brave} instance.
      */
-    public static Function<Service<? super HttpRequest, ? extends HttpResponse>,
-                           HttpTracingService> newDecorator(Brave brave) {
+    public static Function<Service<HttpRequest, HttpResponse>, HttpTracingService> newDecorator(Brave brave) {
         return service -> new HttpTracingService(service, brave);
     }
 
-    HttpTracingService(Service<? super HttpRequest, ? extends HttpResponse> delegate, Brave brave) {
+    HttpTracingService(Service<HttpRequest, HttpResponse> delegate, Brave brave) {
         super(delegate, brave);
     }
 


### PR DESCRIPTION
.. by assuming the type parameters of a Client or a Service are only one
of the following:

- HttpRequest and HttpResponse
- RpcRequest and RpcResponse

We give up the ability to use a subtype of these types as a type
parameter and take the simplicity of the decorator declarations.

For example:

    public class MyService<I extends HttpRequest, O extneds HttpResponse> { ... }

    myService = new MyService<HttpRequest, HttpResponse>();
    // This works.
    myService.decorate(HttpAuthService.newDecorator(...));

    mySpecialService = new MyService<SpecialHttpRequest, SpecialHttpResponse>();
    // This fails.
    mySpecialService.decorate(HttpAuthService.newDecorator(...));