### PR TITLE
Add more convenience methods for constructing HTTP requests and responses

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/http/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/http/HttpResponse.java
@@ -35,8 +35,8 @@ import com.linecorp.armeria.common.stream.StreamMessage;
  */
 public interface HttpResponse extends Response, StreamMessage<HttpObject> {
 
-    // Note: Ensure we provide the same set of `of()` methods with the `respond()` methods of
-    //       HttpResponseWriter for consistency.
+    // Note: Ensure we provide the same set of `of()` methods with the `of()` and `respond()` methods of
+    //       HttpResponseWriter and AggregatedHttpMessage for consistency.
 
     /**
      * Creates a new HTTP response of the specified {@code statusCode} and closes the stream if the
@@ -59,8 +59,7 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
     }
 
     /**
-     * Creates a new HTTP response of the specified {@link HttpStatus} and closes the stream if the
-     * {@link HttpStatusClass} is not {@linkplain HttpStatusClass#INFORMATIONAL informational} (1xx).
+     * Creates a new HTTP response of the specified {@link HttpStatus} and closes the stream.
      *
      * @param mediaType the {@link MediaType} of the response content
      * @param content the content of the response
@@ -72,8 +71,7 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
     }
 
     /**
-     * Creates a new HTTP response of the specified {@link HttpStatus} and closes the stream if the
-     * {@link HttpStatusClass} is not {@linkplain HttpStatusClass#INFORMATIONAL informational} (1xx).
+     * Creates a new HTTP response of the specified {@link HttpStatus} and closes the stream.
      * The content of the response is formatted by {@link String#format(Locale, String, Object...)} with
      * {@linkplain Locale#ENGLISH English locale}.
      *
@@ -88,8 +86,7 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
     }
 
     /**
-     * Creates a new HTTP response of the specified {@link HttpStatus} and closes the stream if the
-     * {@link HttpStatusClass} is not {@linkplain HttpStatusClass#INFORMATIONAL informational} (1xx).
+     * Creates a new HTTP response of the specified {@link HttpStatus} and closes the stream.
      *
      * @param mediaType the {@link MediaType} of the response content
      * @param content the content of the response
@@ -98,12 +95,10 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
         final DefaultHttpResponse res = new DefaultHttpResponse();
         res.respond(status, mediaType, content);
         return res;
-
     }
 
     /**
-     * Creates a new HTTP response of the specified {@link HttpStatus} and closes the stream if the
-     * {@link HttpStatusClass} is not {@linkplain HttpStatusClass#INFORMATIONAL informational} (1xx).
+     * Creates a new HTTP response of the specified {@link HttpStatus} and closes the stream.
      *
      * @param mediaType the {@link MediaType} of the response content
      * @param content the content of the response
@@ -118,8 +113,7 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
     }
 
     /**
-     * Creates a new HTTP response of the specified {@link HttpStatus} and closes the stream if the
-     * {@link HttpStatusClass} is not {@linkplain HttpStatusClass#INFORMATIONAL informational} (1xx).
+     * Creates a new HTTP response of the specified {@link HttpStatus} and closes the stream.
      *
      * @param mediaType the {@link MediaType} of the response content
      * @param content the content of the response
@@ -128,7 +122,20 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
         final DefaultHttpResponse res = new DefaultHttpResponse();
         res.respond(status, mediaType, content);
         return res;
+    }
 
+    /**
+     * Creates a new HTTP response of the specified {@link HttpStatus} and closes the stream.
+     *
+     * @param mediaType the {@link MediaType} of the response content
+     * @param content the content of the response
+     * @param trailingHeaders the trailing HTTP headers
+     */
+    static HttpResponse of(HttpStatus status, MediaType mediaType, HttpData content,
+                           HttpHeaders trailingHeaders) {
+        final DefaultHttpResponse res = new DefaultHttpResponse();
+        res.respond(status, mediaType, content, trailingHeaders);
+        return res;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/internal/http/ArmeriaHttpUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/http/ArmeriaHttpUtil.java
@@ -44,6 +44,7 @@ import java.util.Map.Entry;
 import java.util.regex.Pattern;
 
 import com.linecorp.armeria.common.http.DefaultHttpHeaders;
+import com.linecorp.armeria.common.http.HttpData;
 import com.linecorp.armeria.common.http.HttpHeaderNames;
 import com.linecorp.armeria.common.http.HttpHeaders;
 import com.linecorp.armeria.common.http.HttpMethod;
@@ -282,6 +283,31 @@ public final class ArmeriaHttpUtil {
         }
 
         return false;
+    }
+
+    /**
+     * Returns {@code true} if the content of the response with the given {@link HttpStatus} is expected to
+     * be always empty (1xx, 204, 205 and 304 responses.)
+     *
+     * @throws IllegalArgumentException if the specified {@code content} or {@code trailingHeaders} are
+     *                                  non-empty when the content is always empty
+     */
+    public static boolean isContentAlwaysEmptyWithValidation(
+            HttpStatus status, HttpData content, HttpHeaders trailingHeaders) {
+        if (!isContentAlwaysEmpty(status)) {
+            return false;
+        }
+
+        if (!content.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "A " + status + " response must have empty content: " + content.length() + " byte(s)");
+        }
+        if (!trailingHeaders.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "A " + status + " response must not have trailing headers: " + trailingHeaders);
+        }
+
+        return true;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/http/healthcheck/HttpHealthCheckService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/healthcheck/HttpHealthCheckService.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.http.AggregatedHttpMessage;
 import com.linecorp.armeria.common.http.HttpData;
 import com.linecorp.armeria.common.http.HttpRequest;
@@ -69,8 +70,8 @@ import com.linecorp.armeria.server.http.HttpService;
  */
 public class HttpHealthCheckService extends AbstractHttpService {
 
-    private static final HttpData RES_OK = HttpData.ofAscii("ok");
-    private static final HttpData RES_NOT_OK = HttpData.ofAscii("not ok");
+    private static final HttpData RES_OK = HttpData.ofUtf8("ok");
+    private static final HttpData RES_NOT_OK = HttpData.ofUtf8("not ok");
 
     private final List<HealthChecker> healthCheckers;
     private final ServerListener serverHealthUpdater;
@@ -96,7 +97,7 @@ public class HttpHealthCheckService extends AbstractHttpService {
     protected AggregatedHttpMessage newHealthyResponse(
             @SuppressWarnings("UnusedParameters") ServiceRequestContext ctx) {
 
-        return AggregatedHttpMessage.of(HttpStatus.OK, RES_OK);
+        return AggregatedHttpMessage.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, RES_OK);
     }
 
     /**
@@ -105,7 +106,7 @@ public class HttpHealthCheckService extends AbstractHttpService {
     protected AggregatedHttpMessage newUnhealthyResponse(
             @SuppressWarnings("UnusedParameters") ServiceRequestContext ctx) {
 
-        return AggregatedHttpMessage.of(HttpStatus.SERVICE_UNAVAILABLE, RES_NOT_OK);
+        return AggregatedHttpMessage.of(HttpStatus.SERVICE_UNAVAILABLE, MediaType.PLAIN_TEXT_UTF_8, RES_NOT_OK);
     }
 
     @Override

--- a/core/src/test/java/com/linecorp/armeria/common/http/DefaultAggregatedHttpMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/http/DefaultAggregatedHttpMessageTest.java
@@ -16,6 +16,10 @@
 
 package com.linecorp.armeria.common.http;
 
+import static com.linecorp.armeria.common.MediaType.PLAIN_TEXT_UTF_8;
+import static com.linecorp.armeria.common.http.HttpHeaderNames.CONTENT_LENGTH;
+import static com.linecorp.armeria.common.http.HttpHeaderNames.CONTENT_MD5;
+import static com.linecorp.armeria.common.http.HttpHeaderNames.CONTENT_TYPE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -37,13 +41,14 @@ public class DefaultAggregatedHttpMessageTest {
     @Test
     public void toHttpRequest() throws Exception {
         final AggregatedHttpMessage aReq = AggregatedHttpMessage.of(
-                HttpMethod.POST, "/foo", HttpData.of(StandardCharsets.US_ASCII, "bar"));
+                HttpMethod.POST, "/foo", PLAIN_TEXT_UTF_8, "bar");
         final HttpRequest req = aReq.toHttpRequest();
         final List<HttpObject> unaggregated = unaggregate(req);
 
         assertThat(req.headers()).isEqualTo(HttpHeaders.of(HttpMethod.POST, "/foo")
-                                                       .setInt(HttpHeaderNames.CONTENT_LENGTH, 3));
-        assertThat(unaggregated).containsExactly(HttpData.of(StandardCharsets.US_ASCII, "bar"));
+                                                       .setObject(CONTENT_TYPE, PLAIN_TEXT_UTF_8)
+                                                       .setInt(CONTENT_LENGTH, 3));
+        assertThat(unaggregated).containsExactly(HttpData.of(StandardCharsets.UTF_8, "bar"));
     }
 
     @Test
@@ -59,16 +64,17 @@ public class DefaultAggregatedHttpMessageTest {
     @Test
     public void toHttpRequestWithTrailingHeaders() throws Exception {
         final AggregatedHttpMessage aReq = AggregatedHttpMessage.of(
-                HttpMethod.PUT, "/baz", HttpData.of(StandardCharsets.US_ASCII, "bar"),
-                HttpHeaders.of(HttpHeaderNames.CONTENT_MD5, "37b51d194a7513e45b56f6524f2d51f2"));
+                HttpMethod.PUT, "/baz", PLAIN_TEXT_UTF_8, HttpData.ofUtf8("bar"),
+                HttpHeaders.of(CONTENT_MD5, "37b51d194a7513e45b56f6524f2d51f2"));
         final HttpRequest req = aReq.toHttpRequest();
         final List<HttpObject> unaggregated = unaggregate(req);
 
         assertThat(req.headers()).isEqualTo(HttpHeaders.of(HttpMethod.PUT, "/baz")
-                                                       .setInt(HttpHeaderNames.CONTENT_LENGTH, 3));
+                                                       .setObject(CONTENT_TYPE, PLAIN_TEXT_UTF_8)
+                                                       .setInt(CONTENT_LENGTH, 3));
         assertThat(unaggregated).containsExactly(
-                HttpData.of(StandardCharsets.US_ASCII, "bar"),
-                HttpHeaders.of(HttpHeaderNames.CONTENT_MD5, "37b51d194a7513e45b56f6524f2d51f2"));
+                HttpData.of(StandardCharsets.UTF_8, "bar"),
+                HttpHeaders.of(CONTENT_MD5, "37b51d194a7513e45b56f6524f2d51f2"));
     }
 
     @Test
@@ -93,40 +99,44 @@ public class DefaultAggregatedHttpMessageTest {
     @Test
     public void toHttpResponse() throws Exception {
         final AggregatedHttpMessage aRes = AggregatedHttpMessage.of(
-                HttpStatus.OK, HttpData.of(StandardCharsets.US_ASCII, "alice"));
+                HttpStatus.OK, PLAIN_TEXT_UTF_8, "alice");
         final HttpResponse res = aRes.toHttpResponse();
         final List<HttpObject> unaggregated = unaggregate(res);
 
         assertThat(unaggregated).containsExactly(
                 HttpHeaders.of(HttpStatus.OK)
-                           .setInt(HttpHeaderNames.CONTENT_LENGTH, 5),
-                HttpData.of(StandardCharsets.US_ASCII, "alice"));
+                           .setObject(CONTENT_TYPE, PLAIN_TEXT_UTF_8)
+                           .setInt(CONTENT_LENGTH, 5),
+                HttpData.of(StandardCharsets.UTF_8, "alice"));
     }
 
     @Test
     public void toHttpResponseWithoutContent() throws Exception {
-        final AggregatedHttpMessage aRes = AggregatedHttpMessage.of(HttpStatus.OK);
+        final AggregatedHttpMessage aRes = AggregatedHttpMessage.of(HttpStatus.OK, PLAIN_TEXT_UTF_8,
+                                                                    HttpData.EMPTY_DATA);
         final HttpResponse res = aRes.toHttpResponse();
         final List<HttpObject> unaggregated = unaggregate(res);
 
         assertThat(unaggregated).containsExactly(
                 HttpHeaders.of(HttpStatus.OK)
-                           .setInt(HttpHeaderNames.CONTENT_LENGTH, 0));
+                           .setObject(CONTENT_TYPE, PLAIN_TEXT_UTF_8)
+                           .setInt(CONTENT_LENGTH, 0));
     }
 
     @Test
     public void toHttpResponseWithTrailingHeaders() throws Exception {
         final AggregatedHttpMessage aRes = AggregatedHttpMessage.of(
-                HttpStatus.OK, HttpData.of(StandardCharsets.US_ASCII, "bob"),
-                HttpHeaders.of(HttpHeaderNames.CONTENT_MD5, "9f9d51bc70ef21ca5c14f307980a29d8"));
+                HttpStatus.OK, PLAIN_TEXT_UTF_8, HttpData.ofUtf8("bob"),
+                HttpHeaders.of(CONTENT_MD5, "9f9d51bc70ef21ca5c14f307980a29d8"));
         final HttpResponse res = aRes.toHttpResponse();
         final List<HttpObject> unaggregated = unaggregate(res);
 
         assertThat(unaggregated).containsExactly(
                 HttpHeaders.of(HttpStatus.OK)
-                           .setInt(HttpHeaderNames.CONTENT_LENGTH, 3),
-                HttpData.of(StandardCharsets.US_ASCII, "bob"),
-                HttpHeaders.of(HttpHeaderNames.CONTENT_MD5, "9f9d51bc70ef21ca5c14f307980a29d8"));
+                           .setObject(CONTENT_TYPE, PLAIN_TEXT_UTF_8)
+                           .setInt(CONTENT_LENGTH, 3),
+                HttpData.of(StandardCharsets.UTF_8, "bob"),
+                HttpHeaders.of(CONTENT_MD5, "9f9d51bc70ef21ca5c14f307980a29d8"));
     }
 
     @Test
@@ -141,7 +151,7 @@ public class DefaultAggregatedHttpMessageTest {
         assertThat(unaggregated).containsExactly(
                 HttpHeaders.of(HttpStatus.CONTINUE),
                 HttpHeaders.of(HttpStatus.OK)
-                           .setInt(HttpHeaderNames.CONTENT_LENGTH, 0));
+                           .setInt(CONTENT_LENGTH, 0));
     }
 
     @Test

--- a/zipkin/src/test/java/com/linecorp/armeria/client/tracing/HttpTracingClientTest.java
+++ b/zipkin/src/test/java/com/linecorp/armeria/client/tracing/HttpTracingClientTest.java
@@ -30,7 +30,6 @@ import com.linecorp.armeria.client.ClientOptions;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.DefaultClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
-import com.linecorp.armeria.common.http.DefaultHttpRequest;
 import com.linecorp.armeria.common.http.HttpHeaders;
 import com.linecorp.armeria.common.http.HttpMethod;
 import com.linecorp.armeria.common.http.HttpRequest;
@@ -69,9 +68,7 @@ public class HttpTracingClientTest extends HttpTracingTestBase {
     }
 
     private static HttpRequest newRequest() {
-        final DefaultHttpRequest req = new DefaultHttpRequest(HttpMethod.POST, "/hello");
-        req.close();
-        return req;
+        return HttpRequest.of(HttpMethod.POST, "/hello");
     }
 
     private static ClientRequestContext newClientContext(HttpRequest req) {

--- a/zipkin/src/test/java/com/linecorp/armeria/server/tracing/HttpTracingServiceTest.java
+++ b/zipkin/src/test/java/com/linecorp/armeria/server/tracing/HttpTracingServiceTest.java
@@ -27,9 +27,9 @@ import org.junit.Test;
 import com.github.kristofa.brave.Brave;
 import com.github.kristofa.brave.TraceData;
 
-import com.linecorp.armeria.common.http.DefaultHttpRequest;
 import com.linecorp.armeria.common.http.HttpHeaders;
 import com.linecorp.armeria.common.http.HttpMethod;
+import com.linecorp.armeria.common.http.HttpRequest;
 import com.linecorp.armeria.common.tracing.HttpTracingTestBase;
 import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceRequestContext;
@@ -41,9 +41,8 @@ public class HttpTracingServiceTest extends HttpTracingTestBase {
 
     @Test
     public void testGetTraceData() {
-        final DefaultHttpRequest httpRequest =
-                new DefaultHttpRequest(HttpHeaders.of(HttpMethod.GET, "/").add(traceHeaders()));
-        httpRequest.close();
+        final HttpRequest httpRequest = HttpRequest.of(HttpHeaders.of(HttpMethod.GET, "/")
+                                                                  .add(traceHeaders()));
 
         ServiceRequestContext ctx = mock(ServiceRequestContext.class);
         when(ctx.request()).thenReturn(httpRequest);
@@ -55,10 +54,7 @@ public class HttpTracingServiceTest extends HttpTracingTestBase {
 
     @Test
     public void testGetTraceDataIfRequestDoesNotContainTraceData() {
-        final DefaultHttpRequest httpRequest =
-                new DefaultHttpRequest(HttpHeaders.of(HttpMethod.GET, "/").add(
-                        emptyHttpHeaders()));
-        httpRequest.close();
+        final HttpRequest httpRequest = HttpRequest.of(HttpMethod.GET, "/");
 
         ServiceRequestContext ctx = mock(ServiceRequestContext.class);
         when(ctx.request()).thenReturn(httpRequest);
@@ -76,9 +72,8 @@ public class HttpTracingServiceTest extends HttpTracingTestBase {
     }
 
     private static void testGetTraceDataIfRequestIsNotSampled(HttpHeaders headers) {
-        final DefaultHttpRequest httpRequest =
-                new DefaultHttpRequest(HttpHeaders.of(HttpMethod.GET, "/").add(headers));
-        httpRequest.close();
+        final HttpRequest httpRequest = HttpRequest.of(HttpHeaders.of(HttpMethod.GET, "/")
+                                                                  .add(headers));
 
         ServiceRequestContext ctx = mock(ServiceRequestContext.class);
         when(ctx.request()).thenReturn(httpRequest);


### PR DESCRIPTION
- Add HTTP request and response construction methods to
  AggregatedHttpMessage
- Add HTTP request construction methods to HttpRequest
- Ensure HttpResponse, HttpResponseWriter and AggregatedHttpMessage have
  the same set of convenience methods
- The AggregatedHttpMessage created by AggregatedHttpMessage.of(status)
  now has content
- Add missing 'mediaType' parameter to the construction methods who
  require content