### PR TITLE
Provide a default value that limits the number of request try attempt

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/retry/Backoff.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/Backoff.java
@@ -16,7 +16,9 @@
 package com.linecorp.armeria.client.retry;
 
 import static com.linecorp.armeria.client.retry.FixedBackoff.NO_DELAY;
+import static java.util.Objects.requireNonNull;
 
+import java.util.Optional;
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Supplier;
@@ -66,6 +68,21 @@ public interface Backoff {
      * @throws IllegalArgumentException if {@code numAttemptsSoFar} is equal to or less than {@code 0}
      */
     long nextIntervalMillis(int numAttemptsSoFar);
+
+
+    /**
+     * Undecorates this {@link Backoff} to find the {@link Backoff} which is an instance of the specified
+     * {@code backoffType}.
+     *
+     * @param backoffType the type of the desired {@link Backoff}
+     * @return the {@link Backoff} which is an instance of {@code backoffType} if this {@link Backoff}
+     *         decorated such a {@link Backoff}. {@link Optional#empty()} otherwise.
+     */
+    default <T> Optional<T> as(Class<T> backoffType) {
+        requireNonNull(backoffType, "backoffType");
+        return backoffType.isInstance(this) ? Optional.of(backoffType.cast(this))
+                                            : Optional.empty();
+    }
 
     /**
      * Returns a {@link Backoff} that provides an interval that increases using

--- a/core/src/main/java/com/linecorp/armeria/client/retry/BackoffWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/BackoffWrapper.java
@@ -17,6 +17,8 @@ package com.linecorp.armeria.client.retry;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import java.util.Optional;
+
 import com.google.common.base.MoreObjects;
 
 /**
@@ -36,6 +38,12 @@ public class BackoffWrapper implements Backoff {
 
     protected Backoff delegate() {
         return delegate;
+    }
+
+    @Override
+    public final <T> Optional<T> as(Class<T> backoffType) {
+        final Optional<T> result = Backoff.super.as(backoffType);
+        return result.isPresent() ? result : delegate.as(backoffType);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClient.java
@@ -41,8 +41,7 @@ public class RetryingRpcClient extends RetryingClient<RpcRequest, RpcResponse> {
      */
     public static Function<Client<RpcRequest, RpcResponse>, RetryingRpcClient>
     newDecorator(RetryRequestStrategy<RpcRequest, RpcResponse> retryRequestStrategy) {
-        return delegate -> new RetryingRpcClient(delegate, retryRequestStrategy,
-                                                 Backoff::withoutDelay);
+        return newDecorator(retryRequestStrategy, Backoff::withoutDelay);
     }
 
     /**
@@ -55,12 +54,39 @@ public class RetryingRpcClient extends RetryingClient<RpcRequest, RpcResponse> {
     }
 
     /**
+     * Creates a new {@link Client} decorator that handles failures of an invocation and retries RPC requests.
+     */
+    public static Function<Client<RpcRequest, RpcResponse>, RetryingRpcClient>
+    newDecorator(RetryRequestStrategy<RpcRequest, RpcResponse> retryRequestStrategy, int defaultMaxAttempts) {
+        return newDecorator(retryRequestStrategy, Backoff::withoutDelay, defaultMaxAttempts);
+    }
+
+    /**
+     * Creates a new {@link Client} decorator that handles failures of an invocation and retries RPC requests.
+     */
+    public static Function<Client<RpcRequest, RpcResponse>, RetryingRpcClient>
+    newDecorator(RetryRequestStrategy<RpcRequest, RpcResponse> retryRequestStrategy,
+                 Supplier<? extends Backoff> backoffSupplier, int defaultMaxAttempts) {
+        return delegate ->
+                new RetryingRpcClient(delegate, retryRequestStrategy, backoffSupplier, defaultMaxAttempts);
+    }
+
+    /**
      * Creates a new instance that decorates the specified {@link Client}.
      */
     public RetryingRpcClient(Client<RpcRequest, RpcResponse> delegate,
                              RetryRequestStrategy<RpcRequest, RpcResponse> retryStrategy,
                              Supplier<? extends Backoff> backoffSupplier) {
         super(delegate, retryStrategy, backoffSupplier);
+    }
+
+    /**
+     * Creates a new instance that decorates the specified {@link Client}.
+     */
+    public RetryingRpcClient(Client<RpcRequest, RpcResponse> delegate,
+                             RetryRequestStrategy<RpcRequest, RpcResponse> retryStrategy,
+                             Supplier<? extends Backoff> backoffSupplier, int defaultMaxAttempts) {
+        super(delegate, retryStrategy, backoffSupplier, defaultMaxAttempts);
     }
 
     @Override

--- a/core/src/test/java/com/linecorp/armeria/client/retry/BackoffTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/BackoffTest.java
@@ -16,10 +16,16 @@
 package com.linecorp.armeria.client.retry;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 import java.util.Random;
 
 import org.junit.Test;
+
+import com.linecorp.armeria.client.Client;
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.common.Request;
+import com.linecorp.armeria.common.Response;
 
 public class BackoffTest {
     @Test
@@ -70,5 +76,33 @@ public class BackoffTest {
         assertThat(backoff.nextIntervalMillis(1)).isEqualTo(100);
         assertThat(backoff.nextIntervalMillis(2)).isEqualTo(-1);
         assertThat(backoff.nextIntervalMillis(3)).isEqualTo(-1);
+    }
+
+    @Test
+    public void limitRetryAttempts() {
+        @SuppressWarnings("unchecked")
+        final Client<Request, Response> client = mock(Client.class);
+        @SuppressWarnings("unchecked")
+        final RetryRequestStrategy<Request, Response> strategy = mock(RetryRequestStrategy.class);
+        final Backoff backoff = Backoff.withoutDelay();
+        final int maxAttempts = 5;
+        RetryingClient<Request, Response> retryingClient =
+                new RetryingClient<Request, Response>(client, strategy, () -> backoff, maxAttempts) {
+            @Override
+            public Response execute(ClientRequestContext ctx, Request req) throws Exception {
+                return null; // Not executed.
+            }
+        };
+
+        final Backoff newBackoff = retryingClient.newBackoff();
+        int currentAttemptNo = 1;
+        assertThat(newBackoff.nextIntervalMillis(currentAttemptNo++)).isEqualTo(0);
+        assertThat(newBackoff.nextIntervalMillis(currentAttemptNo++)).isEqualTo(0);
+        assertThat(newBackoff.nextIntervalMillis(currentAttemptNo++)).isEqualTo(0);
+        assertThat(newBackoff.nextIntervalMillis(currentAttemptNo++)).isEqualTo(0);
+
+        // After 5 tries which are the sum of first normal try and 4 consecutive retries,
+        // it's failed returning -1.
+        assertThat(newBackoff.nextIntervalMillis(currentAttemptNo++)).isEqualTo(-1);
     }
 }


### PR DESCRIPTION
Motivation:

If a client does not invoke `withMaxAttempts` on `Backoff` when it use `RetryingClient`, it can retry infinitely in certain circumstance.
That will consume bandwidth of network and overload the server side as well.
We need a safety mechanism that prevents that situation.

Modifications:

- Add `as` method to Backoff and BackoffWrapper
- Add com.linecorp.armeria.defaultBackoffMaxAttempts system property
- Add AttemptLimitingBackoff to the Backoff who doesn’t have it

Result:

- Close # 546