### PR TITLE
Update dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -121,6 +121,7 @@ configure(javaProjects) {
     // Add the 'managedDependencies' DSL which allows us to add dependencies without versions and exclusions.
     project.metaClass.managedDependencies = { Closure action ->
         def addManagedDependency = { String scope, String name ->
+            def dependencyManagement = rootProject.ext.dependencyManagement
             def components = name.split(':')
             if (components.length != 2 && components.length != 3) {
                 throw new IllegalDependencyNotation(name)
@@ -129,21 +130,34 @@ configure(javaProjects) {
             def groupId = components[0]
             def artifactId = components[1]
             def classifier = components.length == 3 ? components[2] : null
-            if (!rootProject.ext.dependencyManagement[groupId] ||
-                !rootProject.ext.dependencyManagement[groupId][artifactId]) {
+            if (!dependencyManagement[groupId] ||
+                !dependencyManagement[groupId][artifactId]) {
                 throw new UnknownDomainObjectException("unknown dependency: ${name}")
             }
 
-            def props = rootProject.ext.dependencyManagement[groupId][artifactId]
-            project.dependencies."$scope"(group: groupId, name: artifactId,
-                    version: props.version, classifier: classifier) {
-                if (props.exclusions) {
-                    props.exclusions.each {
-                        def exclusionComponents = it.split(':')
+            // Add a dependency.
+            def version = dependencyManagement[groupId][artifactId].version
+            Dependency dep;
+            if (classifier == null) {
+                dep = project.dependencies.add(scope, "$groupId:$artifactId:$version")
+            } else {
+                dep = project.dependencies.add(scope, "$groupId:$artifactId:$version:$classifier")
+            }
+
+            project.configurations.detachedConfiguration(dep).resolvedConfiguration.resolvedArtifacts.each {
+                def moduleId = it.moduleVersion.id
+                if (!dependencyManagement[moduleId.group] ||
+                    !dependencyManagement[moduleId.group][moduleId.name]) {
+                    return
+                }
+                def exclusions = dependencyManagement[moduleId.group][moduleId.name].exclusions
+                if (exclusions) {
+                    exclusions.each { String exclusion ->
+                        def exclusionComponents = exclusion.split(':')
                         if (exclusionComponents.length != 2) {
-                            throw new IllegalDependencyNotation(it)
+                            throw new IllegalDependencyNotation(exclusion)
                         }
-                        exclude group: exclusionComponents[0], module: exclusionComponents[1]
+                        dep.exclude group: exclusionComponents[0], module: exclusionComponents[1]
                     }
                 }
             }

--- a/core/src/main/java/com/linecorp/armeria/client/NonDecoratingClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/NonDecoratingClientFactory.java
@@ -33,8 +33,8 @@ import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
 import io.netty.resolver.AddressResolverGroup;
-import io.netty.resolver.dns.DefaultDnsServerAddressStreamProvider;
 import io.netty.resolver.dns.DnsAddressResolverGroup;
+import io.netty.resolver.dns.DnsServerAddressStreamProviders;
 import io.netty.util.concurrent.DefaultThreadFactory;
 
 /**
@@ -109,14 +109,7 @@ public abstract class NonDecoratingClientFactory extends AbstractClientFactory {
         return options.addressResolverGroup().orElseGet(
                 () -> new DnsAddressResolverGroup(
                         TransportType.datagramChannelType(eventLoopGroup),
-                        // TODO(trustin): Use DnsServerAddressStreamProviders.platformDefault()
-                        //                once Netty fixes its bug: https://github.com/netty/netty/issues/6736
-                        DefaultDnsServerAddressStreamProvider.INSTANCE));
-    }
-
-    private static IllegalStateException unsupportedEventLoopType(EventLoopGroup eventLoopGroup) {
-        return new IllegalStateException("unsupported event loop type: " +
-                                         eventLoopGroup.getClass().getName());
+                        DnsServerAddressStreamProviders.platformDefault()));
     }
 
     @Override

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -1,8 +1,8 @@
 ch.qos.logback:
-  logback-classic: { version: '1.2.2' }
+  logback-classic: { version: '1.2.3' }
 
 com.fasterxml.jackson.core:
-  jackson-annotations: { version: &JACKSON_VERSION '2.8.8' }
+  jackson-annotations: { version: &JACKSON_VERSION '2.8.9' }
   jackson-core: { version: *JACKSON_VERSION }
   jackson-databind: { version: *JACKSON_VERSION }
 
@@ -10,15 +10,22 @@ com.google.code.findbugs:
   jsr305: { version: '3.0.2' }
 
 com.google.guava:
-  guava: { version: &GUAVA_VERSION '21.0' }
+  guava:
+    version: &GUAVA_VERSION '22.0'
+    exclusions:
+    - com.google.code.findbugs:jsr305
+    - com.google.errorprone:error_prone_annotations
+    - com.google.j2objc:j2objc-annotations
+    - org.codehaus.mojo:animal-sniffer-annotations
   guava-testlib:
     version: *GUAVA_VERSION
     exclusions:
     - com.google.code.findbugs:jsr305
     - com.google.errorprone:error_prone_annotations
+    - com.google.j2objc:j2objc-annotations
 
 com.puppycrawl.tools:
-  checkstyle: { version: '7.7' }
+  checkstyle: { version: '7.8.1' }
 
 com.ryantenney.metrics:
   metrics-spring: { version: '3.1.3' }
@@ -27,7 +34,7 @@ com.spotify:
   completable-futures: { version: '0.3.0' }
 
 com.squareup.retrofit2:
-  retrofit: { version: &RETROFIT2_VERSION '2.2.0' }
+  retrofit: { version: &RETROFIT2_VERSION '2.3.0' }
   adapter-java8: { version: *RETROFIT2_VERSION }
   converter-jackson: { version: *RETROFIT2_VERSION }
 
@@ -39,36 +46,38 @@ io.dropwizard.metrics:
 
 io.grpc:
   grpc-core:
-    version: &GRPC_VERSION '1.3.0'
+    version: &GRPC_VERSION '1.4.0'
     exclusions:
     - com.google.code.findbugs:jsr305
+    - com.google.errorprone:error_prone_annotations
   grpc-interop-testing:
     version: *GRPC_VERSION
     exclusions:
-    - io.netty:netty-codec-http2
+    - io.grpc:grpc-netty
     - com.google.guava:guava-jdk5
+    - io.netty:netty-tcnative-boringssl-static
   grpc-okhttp: { version: *GRPC_VERSION }
   grpc-protobuf: { version: *GRPC_VERSION }
   grpc-stub: { version: *GRPC_VERSION }
   grpc-testing: { version: *GRPC_VERSION }
 
 io.netty:
-  netty-codec-http2: { version: &NETTY_VERSION '4.1.11.Final' }
+  netty-codec-http2: { version: &NETTY_VERSION '4.1.12.Final' }
   netty-handler: { version: *NETTY_VERSION }
   netty-resolver-dns: { version: *NETTY_VERSION }
   netty-transport: { version: *NETTY_VERSION }
   netty-transport-native-epoll: { version: *NETTY_VERSION }
-  netty-tcnative-boringssl-static: { version: '2.0.1.Final' }
+  netty-tcnative-boringssl-static: { version: '2.0.3.Final' }
 
 io.prometheus:
-  simpleclient_common: { version: 0.0.22 }
+  simpleclient_common: { version: 0.0.23 }
 
 io.zipkin.brave:
   brave-core: { version: &BRAVE_VERSION '4.2.0' }
   brave-http: { version: *BRAVE_VERSION }
 
 it.unimi.dsi:
-  fastutil: { version: '7.2.0' }
+  fastutil: { version: '7.2.1' }
 
 javax.inject:
   javax.inject: { version: '1' }
@@ -80,13 +89,16 @@ junit:
   junit: { version: '4.12' }
 
 net.javacrumbs.json-unit:
-  json-unit: { version: &JSON_UNIT_VERSION '1.22.0' }
+  json-unit: { version: &JSON_UNIT_VERSION '1.23.0' }
   json-unit-fluent: { version: *JSON_UNIT_VERSION }
 
 org.apache.hbase:
   hbase-shaded-client:
-    version: '1.2.5'
+    version: '1.2.6'
     exclusions:
+    - com.github.stephenc.findbugs:findbugs-annotations
+    - commons-logging:commons-logging
+    - log4j:log4j
     - org.slf4j:slf4j-log4j12
 
 org.apache.httpcomponents:
@@ -106,7 +118,7 @@ org.apache.thrift:
     - org.apache.httpcomponents:httpclient
 
 org.apache.tomcat.embed:
-  tomcat-embed-core: { version: &TOMCAT_VERSION '8.5.14' }
+  tomcat-embed-core: { version: &TOMCAT_VERSION '8.5.15' }
   tomcat-embed-jasper: { version: *TOMCAT_VERSION }
   tomcat-embed-el: { version: *TOMCAT_VERSION }
 
@@ -114,19 +126,19 @@ org.apache.zookeeper:
   zookeeper: { version: '3.4.10' }
 
 org.assertj:
-  assertj-core: { version: '3.6.2' }
+  assertj-core: { version: '3.8.0' }
 
 org.awaitility:
   awaitility: { version: '3.0.0' }
 
 org.curioswitch.curiostack:
-  protobuf-jackson: { version: '0.1.0' }
+  protobuf-jackson: { version: '0.1.1' }
 
 org.dmonix.junit:
   zookeeper-junit: { version: '1.2' }
 
 org.eclipse.jetty:
-  apache-jsp: { version: &JETTY_VERSION '9.4.4.v20170414' }
+  apache-jsp: { version: &JETTY_VERSION '9.4.6.v20170531' }
   apache-jstl: { version: *JETTY_VERSION }
   jetty-annotations: { version: *JETTY_VERSION }
   jetty-server: { version: *JETTY_VERSION  }
@@ -148,7 +160,7 @@ org.javassist:
   javassist: { version: '3.21.0-GA' }
 
 org.mockito:
-  mockito-core: { version: '2.7.22' }
+  mockito-core: { version: '2.8.9' }
 
 org.mortbay.jetty.alpn:
   jetty-alpn-agent: { version: '2.0.6' }
@@ -167,7 +179,7 @@ org.slf4j:
   slf4j-api: { version: *SLF4J_VERSION }
 
 org.springframework.boot:
-  spring-boot: { version: &SPRING_BOOT_VERSION '1.5.2.RELEASE' }
+  spring-boot: { version: &SPRING_BOOT_VERSION '1.5.4.RELEASE' }
   spring-boot-autoconfigure: { version: *SPRING_BOOT_VERSION }
   spring-boot-starter-logging: { version: *SPRING_BOOT_VERSION }
   spring-boot-starter-test: { version: *SPRING_BOOT_VERSION }

--- a/tomcat8.0/build.gradle
+++ b/tomcat8.0/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
     // Tomcat
     [ 'tomcat-embed-core', 'tomcat-embed-jasper', 'tomcat-embed-el' ].each {
-        compile "org.apache.tomcat.embed:$it:8.0.43"
+        compile "org.apache.tomcat.embed:$it:8.0.44"
     }
 }
 


### PR DESCRIPTION
- AssertJ: 3.6.2 -> 3.8.0
- Checkstyle: 7.7 -> 7.8.1
- fastutil: 7.2.0 -> 7.2.1
- gRPC: 1.3.0 -> 1.4.0
  - Re-enable the GRPC interop test by using an OkHttp-based client
- Guava: 21.0 -> 22.0
- HBase client: 1.2.5 -> 1.2.6
- Jackson: 2.8.8 -> 2.8.9
- Jetty: 9.4.4 -> 9.4.6
- JSON-unit: 1.22.0 -> 1.23.0
- Logback: 1.2.2 -> 1.2.3
- Mockito: 2.7.22 -> 2.8.9
- Netty: 4.1.11 -> 4.1.12
- Prometheus: 0.22 -> 0.23
- protobuf-jackson: 0.1.0 -> 0.1.1
- Retrofit: 2.2.0 -> 2.3.0
- Spring Boot: 1.5.2 -> 1.5.4
- Tomcat: 8.5.14 -> 8.5.15, 8.0.43 -> 8.0.44
- Note: Did not update Brave to 4.3.3 due to non-trivial API changes
  - https://github.com/openzipkin/brave/releases/tag/4.3.3