### PR TITLE
Move the JVM system property flags to Flags

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ResponseTimeoutException.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ResponseTimeoutException.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.client;
 
+import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.TimeoutException;
 import com.linecorp.armeria.common.util.Exceptions;
 
@@ -31,10 +32,10 @@ public final class ResponseTimeoutException extends TimeoutException {
 
     /**
      * Returns a {@link ResponseTimeoutException} which may be a singleton or a new instance, depending on
-     * whether {@link Exceptions#isVerbose() the verbose mode} is enabled.
+     * whether {@link Flags#verboseExceptions() the verbose exception mode} is enabled.
      */
     public static ResponseTimeoutException get() {
-        return Exceptions.isVerbose() ? new ResponseTimeoutException() : INSTANCE;
+        return Flags.verboseExceptions() ? new ResponseTimeoutException() : INSTANCE;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/SessionOptions.java
+++ b/core/src/main/java/com/linecorp/armeria/client/SessionOptions.java
@@ -33,11 +33,9 @@ import java.util.function.Function;
 
 import javax.net.ssl.TrustManagerFactory;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.linecorp.armeria.client.pool.KeyedChannelPoolHandler;
 import com.linecorp.armeria.client.pool.PoolKey;
+import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.util.AbstractOptions;
 
 import io.netty.channel.EventLoopGroup;
@@ -48,23 +46,13 @@ import io.netty.resolver.AddressResolverGroup;
  */
 public final class SessionOptions extends AbstractOptions {
 
-    private static final Logger logger = LoggerFactory.getLogger(SessionOptions.class);
-
     private static final Duration DEFAULT_CONNECTION_TIMEOUT = Duration.ofMillis(3200);
     private static final Duration DEFAULT_IDLE_TIMEOUT = Duration.ofSeconds(10);
-    private static final Boolean DEFAULT_USE_HTTP2_PREFACE =
-            "true".equals(System.getProperty("com.linecorp.armeria.defaultUseHttp2Preface", "false"));
-    private static final Boolean DEFAULT_USE_HTTP1_PIPELINING =
-            "true".equals(System.getProperty("com.linecorp.armeria.defaultUseHttp1Pipelining", "true"));
-
-    static {
-        logger.info("defaultUseHttp2Preface: {}", DEFAULT_USE_HTTP2_PREFACE);
-    }
 
     private static final SessionOptionValue<?>[] DEFAULT_OPTION_VALUES = {
             CONNECT_TIMEOUT.newValue(DEFAULT_CONNECTION_TIMEOUT),
             IDLE_TIMEOUT.newValue(DEFAULT_IDLE_TIMEOUT),
-            USE_HTTP2_PREFACE.newValue(DEFAULT_USE_HTTP2_PREFACE)
+            USE_HTTP2_PREFACE.newValue(Flags.defaultUseHttp2Preface())
     };
 
     /**
@@ -269,13 +257,13 @@ public final class SessionOptions extends AbstractOptions {
      * Returns whether {@link SessionOption#USE_HTTP2_PREFACE} is enabled or not.
      */
     public boolean useHttp2Preface() {
-        return getOrElse(USE_HTTP2_PREFACE, DEFAULT_USE_HTTP2_PREFACE);
+        return getOrElse(USE_HTTP2_PREFACE, Flags.defaultUseHttp2Preface());
     }
 
     /**
      * Returns whether {@link SessionOption#USE_HTTP1_PIPELINING} is enabled or not.
      */
     public boolean useHttp1Pipelining() {
-        return getOrElse(USE_HTTP1_PIPELINING, DEFAULT_USE_HTTP1_PIPELINING);
+        return getOrElse(USE_HTTP1_PIPELINING, Flags.defaultUseHttp1Pipelining());
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/WriteTimeoutException.java
+++ b/core/src/main/java/com/linecorp/armeria/client/WriteTimeoutException.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.client;
 
+import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.TimeoutException;
 import com.linecorp.armeria.common.util.Exceptions;
 
@@ -30,10 +31,10 @@ public final class WriteTimeoutException extends TimeoutException {
 
     /**
      * Returns a {@link WriteTimeoutException} which may be a singleton or a new instance, depending on
-     * whether {@link Exceptions#isVerbose() the verbose mode} is enabled.
+     * whether {@link Flags#verboseExceptions() the verbose exception mode} is enabled.
      */
     public static WriteTimeoutException get() {
-        return Exceptions.isVerbose() ? new WriteTimeoutException() : INSTANCE;
+        return Flags.verboseExceptions() ? new WriteTimeoutException() : INSTANCE;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/http/HttpClientPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/client/http/HttpClientPipelineConfigurator.java
@@ -41,11 +41,11 @@ import com.google.common.base.Ascii;
 import com.linecorp.armeria.client.SessionOptions;
 import com.linecorp.armeria.client.SessionProtocolNegotiationCache;
 import com.linecorp.armeria.client.SessionProtocolNegotiationException;
+import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.http.HttpObject;
 import com.linecorp.armeria.common.logging.RequestLogBuilder;
 import com.linecorp.armeria.common.util.Exceptions;
-import com.linecorp.armeria.common.util.NativeLibraries;
 import com.linecorp.armeria.internal.FlushConsolidationHandler;
 import com.linecorp.armeria.internal.ReadSuppressingHandler;
 import com.linecorp.armeria.internal.TrafficLoggingHandler;
@@ -137,7 +137,7 @@ class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
                 final SslContextBuilder builder = SslContextBuilder.forClient();
 
                 builder.sslProvider(
-                        NativeLibraries.isOpenSslAvailable() ? SslProvider.OPENSSL : SslProvider.JDK);
+                        Flags.useOpenSsl() ? SslProvider.OPENSSL : SslProvider.JDK);
                 options.trustManagerFactory().ifPresent(builder::trustManager);
 
                 if (httpPreference == HttpPreference.HTTP2_REQUIRED ||

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory;
 
 import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.client.SimpleDecoratingClient;
+import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
 
@@ -38,30 +39,6 @@ public abstract class RetryingClient<I extends Request, O extends Response>
 
     private static final Logger logger = LoggerFactory.getLogger(RetryingClient.class);
 
-    private static final int FALLBACK_DEFAULT_DEFAULT_MAX_ATTEMPTS = 5;
-    private static final int DEFAULT_DEFAULT_MAX_ATTEMPTS;
-
-    static {
-        String value = System.getProperty("com.linecorp.armeria.defaultBackoffMaxAttempts",
-                                          String.valueOf(FALLBACK_DEFAULT_DEFAULT_MAX_ATTEMPTS));
-        int defaultDefaultMaxAttempts;
-        try {
-            defaultDefaultMaxAttempts = Integer.parseInt(value);
-            if (defaultDefaultMaxAttempts <= 0) {
-                logger.warn("The input: {}, for defaultBackoffMaxAttempts should be greater than 0." +
-                            " Therefore, it's set to the default value.",
-                            defaultDefaultMaxAttempts);
-                defaultDefaultMaxAttempts = FALLBACK_DEFAULT_DEFAULT_MAX_ATTEMPTS;
-            }
-        } catch (Exception ignored) {
-            logger.warn("The input: {}, for defaultBackoffMaxAttempts should be an integer value." +
-                        " Therefore, it's set to the default value.", value);
-            defaultDefaultMaxAttempts = FALLBACK_DEFAULT_DEFAULT_MAX_ATTEMPTS;
-        }
-        logger.info("defaultBackoffMaxAttempts: {}", defaultDefaultMaxAttempts);
-        DEFAULT_DEFAULT_MAX_ATTEMPTS = defaultDefaultMaxAttempts;
-    }
-
     private final Supplier<? extends Backoff> backoffSupplier;
     private final RetryRequestStrategy<I, O> retryStrategy;
     private final int defaultMaxAttempts;
@@ -72,7 +49,7 @@ public abstract class RetryingClient<I extends Request, O extends Response>
     protected RetryingClient(Client<? super I, ? extends O> delegate,
                              RetryRequestStrategy<I, O> retryStrategy,
                              Supplier<? extends Backoff> backoffSupplier) {
-        this(delegate, retryStrategy, backoffSupplier, DEFAULT_DEFAULT_MAX_ATTEMPTS);
+        this(delegate, retryStrategy, backoffSupplier, Flags.defaultBackoffMaxAttempts());
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/ClosedSessionException.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ClosedSessionException.java
@@ -28,10 +28,10 @@ public final class ClosedSessionException extends RuntimeException {
 
     /**
      * Returns a {@link ClosedSessionException} which may be a singleton or a new instance, depending on
-     * whether {@link Exceptions#isVerbose() the verbose mode} is enabled.
+     * whether {@link Flags#verboseExceptions() the verbose exception mode} is enabled.
      */
     public static ClosedSessionException get() {
-        return Exceptions.isVerbose() ? new ClosedSessionException() : INSTANCE;
+        return Flags.verboseExceptions() ? new ClosedSessionException() : INSTANCE;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/ContentTooLargeException.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ContentTooLargeException.java
@@ -30,10 +30,10 @@ public final class ContentTooLargeException extends RuntimeException {
 
     /**
      * Returns a {@link ContentTooLargeException} which may be a singleton or a new instance, depending on
-     * whether {@link Exceptions#isVerbose() the verbose mode} is enabled.
+     * whether {@link Flags#verboseExceptions() the verbose exception mode} is enabled.
      */
     public static ContentTooLargeException get() {
-        return Exceptions.isVerbose() ? new ContentTooLargeException() : INSTANCE;
+        return Flags.verboseExceptions() ? new ContentTooLargeException() : INSTANCE;
     }
 
     private ContentTooLargeException() {}

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -1,0 +1,210 @@
+/*
+ *  Copyright 2017 LINE Corporation
+ *
+ *  LINE Corporation licenses this file to you under the Apache License,
+ *  version 2.0 (the "License"); you may not use this file except in compliance
+ *  with the License. You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package com.linecorp.armeria.common;
+
+import java.util.function.IntPredicate;
+import java.util.function.Predicate;
+
+import javax.net.ssl.SSLEngine;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Ascii;
+
+import com.linecorp.armeria.client.SessionOption;
+import com.linecorp.armeria.client.retry.RetryingClient;
+
+import io.netty.channel.epoll.Epoll;
+import io.netty.handler.ssl.OpenSsl;
+
+/**
+ * The system properties that affect Armeria's runtime behavior.
+ */
+public final class Flags {
+
+    private static final Logger logger = LoggerFactory.getLogger(Flags.class);
+
+    private static final String PREFIX = "com.linecorp.armeria.";
+
+    private static final boolean VERBOSE_EXCEPTION = getBoolean("verboseExceptions", false);
+
+    private static final boolean USE_EPOLL = getBoolean("useEpoll", Epoll.isAvailable(),
+                                                        value -> Epoll.isAvailable() || !value);
+    private static final boolean USE_OPENSSL = getBoolean("useOpenSsl", OpenSsl.isAvailable(),
+                                                          value -> OpenSsl.isAvailable() || !value);
+
+    private static final boolean DEFAULT_USE_HTTP2_PREFACE = getBoolean("defaultUseHttp2Preface", false);
+    private static final boolean DEFAULT_USE_HTTP1_PIPELINING = getBoolean("defaultUseHttp1Pipelining", true);
+
+    private static final int DEFAULT_DEFAULT_BACKOFF_MAX_ATTEMPTS = 5;
+    private static final int DEFAULT_BACKOFF_MAX_ATTEMPTS = getInt("defaultBackoffMaxAttempts",
+                                                                   DEFAULT_DEFAULT_BACKOFF_MAX_ATTEMPTS,
+                                                                   value -> value > 0);
+
+    static {
+        if (!Epoll.isAvailable()) {
+            final Throwable cause = filterCause(Epoll.unavailabilityCause());
+            logger.info("/dev/epoll not available: {}", cause.toString());
+        } else if (USE_EPOLL) {
+            logger.info("Using /dev/epoll");
+        }
+
+        if (!OpenSsl.isAvailable()) {
+            final Throwable cause = filterCause(OpenSsl.unavailabilityCause());
+            logger.info("OpenSSL not available: {}", cause.toString());
+        } else if (USE_OPENSSL) {
+            logger.info("Using OpenSSL: {}, 0x{}",
+                        OpenSsl.versionString(),
+                        Long.toHexString(OpenSsl.version() & 0xFFFFFFFFL));
+        }
+    }
+
+    /**
+     * Returns whether the verbose exception mode is enabled. When enabled, the exceptions frequently thrown by
+     * Armeria will have full stack trace. When disabled, such exceptions will have empty stack trace to
+     * eliminate the cost of capturing the stack trace.
+     *
+     * <p>This flag is disabled by default. Specify the {@code -Dcom.linecorp.armeria.verboseExceptions=true}
+     * JVM option to enable it.
+     */
+    public static boolean verboseExceptions() {
+        return VERBOSE_EXCEPTION;
+    }
+
+    /**
+     * Returns whether the JNI-based {@code /dev/epoll} socket I/O is enabled. When enabled on Linux, Armeria
+     * uses {@code /dev/epoll} directly for socket I/O. When disabled, {@code java.nio} socket API is used
+     * instead.
+     *
+     * <p>This flag is enabled by default for supported platforms. Specify the
+     * {@code -Dcom.linecorp.armeria.useEpoll=false} JVM option to disable it.
+     */
+    public static boolean useEpoll() {
+        return USE_EPOLL;
+    }
+
+    /**
+     * Returns whether the JNI-based TLS support with OpenSSL is enabled. When enabled, Armeria uses OpenSSL
+     * for processing TLS connections. When disabled, the current JVM's default {@link SSLEngine} is used
+     * instead.
+     *
+     * <p>This flag is enabled by default for supported platforms. Specify the
+     * {@code -Dcom.linecorp.armeria.useOpenSsl=false} JVM option to disable it.
+     */
+    public static boolean useOpenSsl() {
+        return USE_OPENSSL;
+    }
+
+    /**
+     * Returns the default value of the {@link SessionOption#USE_HTTP2_PREFACE} option. Note that this value
+     * has effect only if a user did not specify the {@link SessionOption#USE_HTTP2_PREFACE} option.
+     *
+     * <p>This flag is disabled by default. Specify the
+     * {@code -Dcom.linecorp.armeria.defaultUseHttp2Preface=true} to enable it.
+     */
+    public static boolean defaultUseHttp2Preface() {
+        return DEFAULT_USE_HTTP2_PREFACE;
+    }
+
+    /**
+     * Returns the default value of the {@link SessionOption#USE_HTTP1_PIPELINING} option. Note that this value
+     * has effect only if a user did not specify the {@link SessionOption#USE_HTTP1_PIPELINING} option.
+     *
+     * <p>This flag is enabled by default. Specify the
+     * {@code -Dcom.linecorp.armeria.defaultUseHttp1Pipelining=false} to disable it.
+     */
+    public static boolean defaultUseHttp1Pipelining() {
+        return DEFAULT_USE_HTTP1_PIPELINING;
+    }
+
+    /**
+     * Returns the default value of the {@code defaultBackoffMaxAttempts} parameter when instantiating a
+     * {@link RetryingClient} and its subtypes. Note that this value has effect only if a user did not specify
+     * the {@code defaultBackoffMaxAttempts} in the constructor call.
+     *
+     * <p>The default value of this flag is {@value DEFAULT_DEFAULT_BACKOFF_MAX_ATTEMPTS}. Specify the
+     * {@code -Dcom.linecorp.armeria.defaultBackoffMaxAttempts=<integer>} to override the default value.
+     */
+    public static int defaultBackoffMaxAttempts() {
+        return DEFAULT_BACKOFF_MAX_ATTEMPTS;
+    }
+
+    private static boolean getBoolean(String name, boolean defaultValue) {
+        return getBoolean(name, defaultValue, value -> true);
+    }
+
+    private static boolean getBoolean(String name, boolean defaultValue, Predicate<Boolean> validator) {
+        return "true".equals(getNormalized(name, String.valueOf(defaultValue), value -> {
+            if ("true".equals(value)) {
+                return validator.test(true);
+            }
+
+            if ("false".equals(value)) {
+                return validator.test(false);
+            }
+
+            return false;
+        }));
+    }
+
+    private static int getInt(String name, int defaultValue, IntPredicate validator) {
+        return Integer.parseInt(getNormalized(name, String.valueOf(defaultValue), value -> {
+            try {
+                return validator.test(Integer.parseInt(value));
+            } catch (Exception e) {
+                // null or non-integer
+                return false;
+            }
+        }));
+    }
+
+    private static String getNormalized(String name, String defaultValue, Predicate<String> validator) {
+        final String fullName = PREFIX + name;
+        final String value = getLowerCased(fullName);
+        if (value == null) {
+            logger.info("{}: {} (default)", fullName, defaultValue);
+            return defaultValue;
+        }
+
+        if (validator.test(value)) {
+            logger.info("{}: {}", fullName, value);
+            return value;
+        }
+
+        logger.info("{}: {} (default instead of: {})", fullName, defaultValue, value);
+        return defaultValue;
+    }
+
+    private static String getLowerCased(String fullName) {
+        String value = System.getProperty(fullName);
+        if (value != null) {
+            value = Ascii.toLowerCase(value);
+        }
+        return value;
+    }
+
+    private static Throwable filterCause(Throwable cause) {
+        if (cause instanceof ExceptionInInitializerError) {
+            return cause.getCause();
+        }
+
+        return cause;
+    }
+
+    private Flags() {}
+}

--- a/core/src/main/java/com/linecorp/armeria/common/ProtocolViolationException.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ProtocolViolationException.java
@@ -16,8 +16,6 @@
 
 package com.linecorp.armeria.common;
 
-import com.linecorp.armeria.common.util.Exceptions;
-
 /**
  * A {@link RuntimeException} raised when a remote peer violated the current {@link SessionProtocol}.
  */
@@ -61,7 +59,7 @@ public class ProtocolViolationException extends RuntimeException {
 
     @Override
     public Throwable fillInStackTrace() {
-        if (Exceptions.isVerbose()) {
+        if (Flags.verboseExceptions()) {
             super.fillInStackTrace();
         }
         return this;

--- a/core/src/main/java/com/linecorp/armeria/common/stream/CancelledSubscriptionException.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/CancelledSubscriptionException.java
@@ -19,6 +19,7 @@ package com.linecorp.armeria.common.stream;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
+import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.util.Exceptions;
 
 /**
@@ -34,10 +35,10 @@ public final class CancelledSubscriptionException extends RuntimeException {
 
     /**
      * Returns a {@link CancelledSubscriptionException} which may be a singleton or a new instance, depending
-     * on whether {@link Exceptions#isVerbose() the verbose mode} is enabled.
+     * on whether {@link Flags#verboseExceptions() the verbose exception mode} is enabled.
      */
     public static CancelledSubscriptionException get() {
-        return Exceptions.isVerbose() ? new CancelledSubscriptionException() : INSTANCE;
+        return Flags.verboseExceptions() ? new CancelledSubscriptionException() : INSTANCE;
     }
 
     private CancelledSubscriptionException() {}

--- a/core/src/main/java/com/linecorp/armeria/common/stream/ClosedPublisherException.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/ClosedPublisherException.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.common.stream;
 
+import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.util.Exceptions;
 
 /**
@@ -31,10 +32,10 @@ public final class ClosedPublisherException extends RuntimeException {
 
     /**
      * Returns a {@link ClosedPublisherException} which may be a singleton or a new instance, depending on
-     * whether {@link Exceptions#isVerbose() the verbose mode} is enabled.
+     * whether {@link Flags#verboseExceptions() the verbose exception mode} is enabled.
      */
     public static ClosedPublisherException get() {
-        return Exceptions.isVerbose() ? new ClosedPublisherException() : INSTANCE;
+        return Flags.verboseExceptions() ? new ClosedPublisherException() : INSTANCE;
     }
 
     private ClosedPublisherException() {}

--- a/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
@@ -31,6 +31,7 @@ import org.reactivestreams.Subscription;
 
 import com.google.common.base.MoreObjects;
 
+import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.util.Exceptions;
 
 import io.netty.buffer.ByteBuf;
@@ -517,8 +518,8 @@ public class DefaultStreamMessage<T> implements StreamMessage<T>, StreamWriter<T
         public void cancel() {
             if (publisher.setState(State.OPEN, State.CLEANUP)) {
                 final CloseEvent closeEvent =
-                        Exceptions.isVerbose() ? new CloseEvent(CancelledSubscriptionException.get())
-                                               : CANCELLED_CLOSE;
+                        Flags.verboseExceptions() ? new CloseEvent(CancelledSubscriptionException.get())
+                                                  : CANCELLED_CLOSE;
 
                 publisher.pushObject(closeEvent);
                 return;

--- a/core/src/main/java/com/linecorp/armeria/common/util/Exceptions.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/Exceptions.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 import com.google.common.base.Throwables;
 
 import com.linecorp.armeria.common.ClosedSessionException;
+import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.SessionProtocol;
 
 import io.netty.channel.Channel;
@@ -52,23 +53,12 @@ public final class Exceptions {
 
     private static final StackTraceElement[] EMPTY_STACK_TRACE = new StackTraceElement[0];
 
-    private static final boolean VERBOSE =
-            "true".equals(System.getProperty("com.linecorp.armeria.verboseExceptions", "false"));
-
-    static {
-        logger.info("com.linecorp.armeria.verboseExceptions: {}", VERBOSE);
-    }
-
     /**
-     * Returns whether the verbose mode is enabled. When enabled, the exceptions frequently thrown by Armeria
-     * will have full stack trace. When disabled, such exceptions will have empty stack trace to eliminate the
-     * cost of capturing the stack trace.
-     *
-     * <p>The verbose mode is disabled by default. Specify the
-     * {@code -Dcom.linecorp.armeria.verboseExceptions=true} JVM option to enable it.
+     * @deprecated Use {@link Flags#verboseExceptions()} instead.
      */
+    @Deprecated
     public static boolean isVerbose() {
-        return VERBOSE;
+        return Flags.verboseExceptions();
     }
 
     /**
@@ -135,7 +125,7 @@ public final class Exceptions {
      * </ul>
      */
     public static boolean isExpected(Throwable cause) {
-        if (VERBOSE) {
+        if (Flags.verboseExceptions()) {
             return true;
         }
 

--- a/core/src/main/java/com/linecorp/armeria/common/util/NativeLibraries.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/NativeLibraries.java
@@ -16,77 +16,37 @@
 
 package com.linecorp.armeria.common.util;
 
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import io.netty.channel.epoll.Epoll;
-import io.netty.handler.ssl.OpenSsl;
+import com.linecorp.armeria.common.Flags;
 
 /**
  * Reports the availability of the native libraries used by Armeria.
+ *
+ * @deprecated Use {@link Flags} instead.
  */
+@Deprecated
 public final class NativeLibraries {
 
-    private static final Logger logger = LoggerFactory.getLogger(NativeLibraries.class);
-    private static final AtomicBoolean reported = new AtomicBoolean();
-
-    private static final boolean USE_EPOLL =
-            !"false".equals(System.getProperty("com.linecorp.armeria.useEpoll", "true"));
-
-    private static final boolean USE_OPENSSL =
-            !"false".equals(System.getProperty("com.linecorp.armeria.useOpenSsl", "true"));
+    /**
+     * @deprecated This method will be removed without a replacement, because the information about
+     *             the availability of the native libraries are now logged automatically by {@link Flags}.
+     */
+    @Deprecated
+    public static void report() {}
 
     /**
-     * Logs the availability of the native libraries used by Armeria. This method does nothing if it was
-     * called once before.
+     * @deprecated Use {@link Flags#useEpoll()} instead.
      */
-    public static void report() {
-        if (!reported.compareAndSet(false, true)) {
-            return;
-        }
-
-        if (USE_EPOLL) {
-            logger.info("/dev/epoll: " +
-                        (Epoll.isAvailable() ? "yes"
-                                             : "no (" + filterCause(Epoll.unavailabilityCause()) + ')'));
-        } else {
-            logger.info("/dev/epoll: disabled");
-        }
-
-        if (USE_OPENSSL) {
-            logger.info("OpenSSL: " +
-                        (OpenSsl.isAvailable() ? "yes (" + OpenSsl.versionString() + ", " +
-                                                           OpenSsl.version() + ')'
-                                               : "no (" + filterCause(OpenSsl.unavailabilityCause()) + ')'));
-        } else {
-            logger.info("OpenSSL: disabled");
-        }
-    }
-
-    private static Throwable filterCause(Throwable cause) {
-        if (cause instanceof ExceptionInInitializerError) {
-            return cause.getCause();
-        }
-
-        return cause;
-    }
-
-    /**
-     * Returns {@code true} if JNI-based {@code /dev/epoll} transport is available.
-     */
+    @Deprecated
     public static boolean isEpollAvailable() {
-        report();
-        return USE_EPOLL && Epoll.isAvailable();
+        return Flags.useEpoll();
     }
 
     /**
-     * Returns {@code true} if JNI-based OpenSSL/BoringSSL/LibreSSL transport is available.
+     * @deprecated Use {@link Flags#useOpenSsl()} instead.
      */
+    @Deprecated
     public static boolean isOpenSslAvailable() {
-        report();
-        return USE_OPENSSL && OpenSsl.isAvailable();
+        return Flags.useOpenSsl();
     }
 
     private NativeLibraries() {}

--- a/core/src/main/java/com/linecorp/armeria/internal/TransportType.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/TransportType.java
@@ -1,12 +1,12 @@
 package com.linecorp.armeria.internal;
 
-import static com.linecorp.armeria.common.util.NativeLibraries.isEpollAvailable;
-
 import java.util.concurrent.ThreadFactory;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import com.google.common.base.Ascii;
+
+import com.linecorp.armeria.common.Flags;
 
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.ServerChannel;
@@ -50,7 +50,7 @@ public enum TransportType {
     }
 
     /**
-     * Returns the {@link ServerChannel} class that is avaiable for this transport type.
+     * Returns the {@link ServerChannel} class that is available for this transport type.
      */
     public Class<? extends ServerChannel> serverChannelClass() {
         return serverChannelClass;
@@ -69,7 +69,7 @@ public enum TransportType {
      * Returns the available {@link TransportType}.
      */
     public static TransportType detectTransportType() {
-        if (isEpollAvailable()) {
+        if (Flags.useEpoll()) {
             return EPOLL;
         } else {
             return NIO;

--- a/core/src/main/java/com/linecorp/armeria/server/AbstractVirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AbstractVirtualHostBuilder.java
@@ -37,11 +37,11 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableMap;
 
+import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.http.HttpRequest;
 import com.linecorp.armeria.common.http.HttpResponse;
 import com.linecorp.armeria.common.http.HttpSessionProtocols;
-import com.linecorp.armeria.common.util.NativeLibraries;
 import com.linecorp.armeria.server.http.annotation.ResponseConverter;
 
 import io.netty.handler.codec.http2.Http2SecurityUtil;
@@ -191,7 +191,7 @@ abstract class AbstractVirtualHostBuilder<B extends AbstractVirtualHostBuilder> 
 
         final SslContextBuilder builder = SslContextBuilder.forServer(keyCertChainFile, keyFile, keyPassword);
 
-        builder.sslProvider(NativeLibraries.isOpenSslAvailable() ? SslProvider.OPENSSL : SslProvider.JDK);
+        builder.sslProvider(Flags.useOpenSsl() ? SslProvider.OPENSSL : SslProvider.JDK);
         builder.ciphers(Http2SecurityUtil.CIPHERS, SupportedCipherSuiteFilter.INSTANCE);
         builder.applicationProtocolConfig(HTTPS_ALPN_CFG);
 

--- a/core/src/main/java/com/linecorp/armeria/server/RequestTimeoutException.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RequestTimeoutException.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.server;
 
+import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.TimeoutException;
 import com.linecorp.armeria.common.util.Exceptions;
 
@@ -31,10 +32,10 @@ public final class RequestTimeoutException extends TimeoutException {
 
     /**
      * Returns a {@link RequestTimeoutException} which may be a singleton or a new instance, depending on
-     * whether {@link Exceptions#isVerbose() the verbose mode} is enabled.
+     * whether {@link Flags#verboseExceptions() the verbose exception mode} is enabled.
      */
     public static RequestTimeoutException get() {
-        return Exceptions.isVerbose() ? new RequestTimeoutException() : INSTANCE;
+        return Flags.verboseExceptions() ? new RequestTimeoutException() : INSTANCE;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/ResourceNotFoundException.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ResourceNotFoundException.java
@@ -15,6 +15,7 @@
  */
 package com.linecorp.armeria.server;
 
+import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.util.Exceptions;
 
 /**
@@ -29,10 +30,10 @@ public final class ResourceNotFoundException extends RuntimeException {
 
     /**
      * Returns a {@link ResourceNotFoundException} which may be a singleton or a new instance, depending on
-     * whether {@link Exceptions#isVerbose() the verbose mode} is enabled.
+     * whether {@link Flags#verboseExceptions() the verbose exception mode} is enabled.
      */
     public static ResourceNotFoundException get() {
-        return Exceptions.isVerbose() ? new ResourceNotFoundException() : INSTANCE;
+        return Flags.verboseExceptions() ? new ResourceNotFoundException() : INSTANCE;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceUnavailableException.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceUnavailableException.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.server;
 
+import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.util.Exceptions;
 
 /**
@@ -31,10 +32,10 @@ public final class ServiceUnavailableException extends RuntimeException {
 
     /**
      * Returns a {@link ServiceUnavailableException} which may be a singleton or a new instance, depending on
-     * whether {@link Exceptions#isVerbose() the verbose mode} is enabled.
+     * whether {@link Flags#verboseExceptions() the verbose exception mode} is enabled.
      */
     public static ServiceUnavailableException get() {
-        return Exceptions.isVerbose() ? new ServiceUnavailableException() : INSTANCE;
+        return Flags.verboseExceptions() ? new ServiceUnavailableException() : INSTANCE;
     }
 
     /**


### PR DESCRIPTION
Motivation:

It would be good to have a single central place to get the values of all
available JVM system properties that affect the runtime behavior of
Armeria.

Modifications:

- Add Flags and move System.getProperty() there
- Deprecate the methods that accesses the System properties in favor or
  Flags

Result:

A user can find out what JVM system property options he or she can
specify to change the behavior of Armeria.