### PR TITLE
Make the default blockingTaskExecutor utilize more than one thread

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -118,10 +118,18 @@ public final class ServerBuilder {
     }
 
     private static final class DefaultBlockingTaskExecutorHolder {
-        static final Executor INSTANCE = new ThreadPoolExecutor(
-                0, DEFAULT_MAX_BLOCKING_TASK_THREADS,
-                60, TimeUnit.SECONDS, new LinkedTransferQueue<>(),
-                new DefaultThreadFactory("armeria-blocking-tasks", true));
+        static final Executor INSTANCE;
+
+        static {
+            // Threads spawned as needed and reused, with a 60s timeout and unbounded work queue.
+            final ThreadPoolExecutor instance = new ThreadPoolExecutor(
+                    DEFAULT_MAX_BLOCKING_TASK_THREADS, DEFAULT_MAX_BLOCKING_TASK_THREADS,
+                    60, TimeUnit.SECONDS, new LinkedTransferQueue<>(),
+                    new DefaultThreadFactory("armeria-blocking-tasks", true));
+
+            instance.allowCoreThreadTimeOut(true);
+            INSTANCE = instance;
+        }
     }
 
     private final List<ServerPort> ports = new ArrayList<>();


### PR DESCRIPTION
Motivation:

The default blockingTaskExecutor uses 0 core threads and an unbounded
task queue. This will make blockingTaskExecutor single-threaded because
ThreadPoolExecutor will spawn a new thread only when a task queue
rejects a task, which will never happen with an unbounded task queue.

Modifications:

- Set the number of the core threads to the maximum and allow the core
  threads to be timed out instead.

Result:

The default blockingTaskExecutor is not single-threaded anymore.