### PR TITLE
Add the registration bean for an annotated service object

### DIFF
--- a/spring-boot/autoconfigure/src/main/java/com/linecorp/armeria/spring/AnnotatedServiceRegistrationBean.java
+++ b/spring-boot/autoconfigure/src/main/java/com/linecorp/armeria/spring/AnnotatedServiceRegistrationBean.java
@@ -1,0 +1,133 @@
+/*
+ *  Copyright 2017 LINE Corporation
+ *
+ *  LINE Corporation licenses this file to you under the Apache License,
+ *  version 2.0 (the "License"); you may not use this file except in compliance
+ *  with the License. You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations
+ *  under the License.
+ */
+package com.linecorp.armeria.spring;
+
+import java.util.function.Function;
+
+import javax.validation.constraints.NotNull;
+
+import com.linecorp.armeria.common.http.HttpRequest;
+import com.linecorp.armeria.common.http.HttpResponse;
+import com.linecorp.armeria.server.Service;
+
+/**
+ * A bean with information for registering an annotated service object. It enables dropwizard
+ * monitoring of the service automatically.
+ * <pre>{@code
+ * > @Bean
+ * > public AnnotatedServiceRegistrationBean okService() {
+ * >     return new AnnotatedServiceRegistrationBean()
+ * >             .setServiceName("myAnnotatedService")
+ * >             .setPathPrefix("/my_service")
+ * >             .setService(new MyAnnotatedService())
+ * >             .setDecorator(LoggingService.newDecorator());
+ * > }
+ * }</pre>
+ */
+public class AnnotatedServiceRegistrationBean {
+
+    /**
+     * The annotated service object to register.
+     */
+    @NotNull
+    private Object service;
+
+    /**
+     * The path prefix of the annotated service object.
+     */
+    @NotNull
+    private String pathPrefix = "/";
+
+    /**
+     * A service name to use in monitoring.
+     */
+    @NotNull
+    private String serviceName;
+
+    /**
+     * The decorator of the annotated service object.
+     */
+    @NotNull
+    private Function<Service<HttpRequest, HttpResponse>,
+                     ? extends Service<HttpRequest, HttpResponse>> decorator = Function.identity();
+
+    /**
+     * Returns the annotated service object registered to this bean.
+     */
+    @NotNull
+    public Object getService() {
+        return service;
+    }
+
+    /**
+     * Registers an annotated service object.
+     */
+    public AnnotatedServiceRegistrationBean setService(@NotNull Object service) {
+        this.service = service;
+        return this;
+    }
+
+    /**
+     * Returns the path prefix.
+     */
+    @NotNull
+    public String getPathPrefix() {
+        return pathPrefix;
+    }
+
+    /**
+     * Sets the path prefix.
+     */
+    public AnnotatedServiceRegistrationBean setPathPrefix(@NotNull String pathPrefix) {
+        this.pathPrefix = pathPrefix;
+        return this;
+    }
+
+    /**
+     * Returns this service name to use in monitoring.
+     */
+    @NotNull
+    public String getServiceName() {
+        return serviceName;
+    }
+
+    /**
+     * Sets service name to use in monitoring.
+     */
+    public AnnotatedServiceRegistrationBean setServiceName(@NotNull String serviceName) {
+        this.serviceName = serviceName;
+        return this;
+    }
+
+    /**
+     * Returns the decorator of the annotated service object.
+     */
+    @NotNull
+    public Function<Service<HttpRequest, HttpResponse>,
+                    ? extends Service<HttpRequest, HttpResponse>> getDecorator() {
+        return decorator;
+    }
+
+    /**
+     * Sets the decorator of the annotated service object.
+     */
+    public AnnotatedServiceRegistrationBean setDecorator(
+            @NotNull Function<Service<HttpRequest, HttpResponse>,
+                              ? extends Service<HttpRequest, HttpResponse>> decorator) {
+        this.decorator = decorator;
+        return this;
+    }
+}

--- a/spring-boot/autoconfigure/src/main/java/com/linecorp/armeria/spring/HttpServiceRegistrationBean.java
+++ b/spring-boot/autoconfigure/src/main/java/com/linecorp/armeria/spring/HttpServiceRegistrationBean.java
@@ -15,8 +15,12 @@
  */
 package com.linecorp.armeria.spring;
 
-import javax.annotation.Nonnull;
+import java.util.function.Function;
 
+import javax.validation.constraints.NotNull;
+
+import com.linecorp.armeria.common.http.HttpRequest;
+import com.linecorp.armeria.common.http.HttpResponse;
 import com.linecorp.armeria.server.PathMapping;
 import com.linecorp.armeria.server.Service;
 
@@ -29,7 +33,8 @@ import com.linecorp.armeria.server.Service;
  * >     return new HttpServiceRegistrationBean()
  * >             .setServiceName("okService")
  * >             .setService(new OkService())
- * >             .setPathMapping(PathMapping.ofExact("/ok"));
+ * >             .setPathMapping(PathMapping.ofExact("/ok"))
+ * >             .setDecorator(LoggingService.newDecorator());
  * > }
  * }</pre>
  */
@@ -38,33 +43,40 @@ public class HttpServiceRegistrationBean {
     /**
      * The http service to register.
      */
-    @Nonnull
-    private Service<?, ?> service;
+    @NotNull
+    private Service<HttpRequest, HttpResponse> service;
 
     /**
      * The pathMapping for the http service. For example, {@code PathMapping.ofPrefix("/foobar")}.
      */
-    @Nonnull
+    @NotNull
     private PathMapping pathMapping;
 
     /**
      * A service name to use in monitoring.
      */
-    @Nonnull
+    @NotNull
     private String serviceName;
+
+    /**
+     * The decorator of the HTTP service.
+     */
+    @NotNull
+    private Function<Service<HttpRequest, HttpResponse>,
+                     ? extends Service<HttpRequest, HttpResponse>> decorator = Function.identity();
 
     /**
      * Returns the http {@link Service} registered to this bean.
      */
-    @Nonnull
-    public Service<?, ?> getService() {
+    @NotNull
+    public Service<HttpRequest, HttpResponse> getService() {
         return service;
     }
 
     /**
      * Register a http {@link Service}.
      */
-    public HttpServiceRegistrationBean setService(@Nonnull Service<?, ?> service) {
+    public HttpServiceRegistrationBean setService(@NotNull Service<HttpRequest, HttpResponse> service) {
         this.service = service;
         return this;
     }
@@ -72,6 +84,7 @@ public class HttpServiceRegistrationBean {
     /**
      * Returns the {@link PathMapping} that this service map to.
      */
+    @NotNull
     public PathMapping getPathMapping() {
         return pathMapping;
     }
@@ -79,15 +92,22 @@ public class HttpServiceRegistrationBean {
     /**
      * Sets a {@link PathMapping} that this service map to.
      */
-    public HttpServiceRegistrationBean setPathMapping(PathMapping pathMapping) {
+    public HttpServiceRegistrationBean setPathMapping(@NotNull PathMapping pathMapping) {
         this.pathMapping = pathMapping;
         return this;
     }
 
     /**
+     * Sets the path pattern of the service.
+     */
+    public HttpServiceRegistrationBean setPathPattern(@NotNull String pathPattern) {
+        return setPathMapping(PathMapping.of(pathPattern));
+    }
+
+    /**
      * Returns this service name to use in monitoring.
      */
-    @Nonnull
+    @NotNull
     public String getServiceName() {
         return serviceName;
     }
@@ -95,8 +115,27 @@ public class HttpServiceRegistrationBean {
     /**
      * Sets service name to use in monitoring.
      */
-    public HttpServiceRegistrationBean setServiceName(@Nonnull String serviceName) {
+    public HttpServiceRegistrationBean setServiceName(@NotNull String serviceName) {
         this.serviceName = serviceName;
+        return this;
+    }
+
+    /**
+     * Returns the decorator of the HTTP service.
+     */
+    @NotNull
+    public Function<Service<HttpRequest, HttpResponse>,
+                    ? extends Service<HttpRequest, HttpResponse>> getDecorator() {
+        return decorator;
+    }
+
+    /**
+     * Sets the decorator of the HTTP service.
+     */
+    public HttpServiceRegistrationBean setDecorator(
+            @NotNull Function<Service<HttpRequest, HttpResponse>,
+                              ? extends Service<HttpRequest, HttpResponse>> decorator) {
+        this.decorator = decorator;
         return this;
     }
 }

--- a/spring-boot/autoconfigure/src/main/java/com/linecorp/armeria/spring/ThriftServiceRegistrationBean.java
+++ b/spring-boot/autoconfigure/src/main/java/com/linecorp/armeria/spring/ThriftServiceRegistrationBean.java
@@ -17,12 +17,15 @@ package com.linecorp.armeria.spring;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.function.Function;
 
 import javax.validation.constraints.NotNull;
 
 import org.apache.thrift.TBase;
 
 import com.linecorp.armeria.common.http.HttpHeaders;
+import com.linecorp.armeria.common.http.HttpRequest;
+import com.linecorp.armeria.common.http.HttpResponse;
 import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.docs.DocService;
 
@@ -37,11 +40,12 @@ public class ThriftServiceRegistrationBean {
      * The thrift service to register.
      */
     @NotNull
-    private Service<?, ?> service;
+    private Service<HttpRequest, HttpResponse> service;
 
     /**
      * The url path to register the service at. If not specified, defaults to {@code /api}.
      */
+    @NotNull
     private String path = "/api";
 
     /**
@@ -52,28 +56,38 @@ public class ThriftServiceRegistrationBean {
     private String serviceName;
 
     /**
+     * The decorator of the service.
+     */
+    @NotNull
+    private Function<Service<HttpRequest, HttpResponse>,
+                     ? extends Service<HttpRequest, HttpResponse>> decorator = Function.identity();
+
+    /**
      * Sample requests to populate debug forms in {@link DocService}.
      * This should be a list of request objects (e.g., methodName_args) which correspond to methods
      * in this thrift service.
      */
+    @NotNull
     private Collection<? extends TBase<?, ?>> exampleRequests = new ArrayList<>();
 
     /**
      * Example {@link HttpHeaders} being used in debug forms.
      */
+    @NotNull
     private Collection<HttpHeaders> exampleHeaders = new ArrayList<>();
 
     /**
      * Returns the thrift {@link Service} that is registered to this bean.
      */
-    public Service<?, ?> getService() {
+    @NotNull
+    public Service<HttpRequest, HttpResponse> getService() {
         return service;
     }
 
     /**
      * Register the thrift {@link Service} to this bean.
      */
-    public ThriftServiceRegistrationBean setService(Service<?, ?> service) {
+    public ThriftServiceRegistrationBean setService(@NotNull Service<HttpRequest, HttpResponse> service) {
         this.service = service;
         return this;
     }
@@ -81,6 +95,7 @@ public class ThriftServiceRegistrationBean {
     /**
      * Returns the url path this service map to.
      */
+    @NotNull
     public String getPath() {
         return path;
     }
@@ -88,7 +103,7 @@ public class ThriftServiceRegistrationBean {
     /**
      * Register the url path this service map to.
      */
-    public ThriftServiceRegistrationBean setPath(String path) {
+    public ThriftServiceRegistrationBean setPath(@NotNull String path) {
         this.path = path;
         return this;
     }
@@ -96,6 +111,7 @@ public class ThriftServiceRegistrationBean {
     /**
      * Returns the service name to use in monitoring.
      */
+    @NotNull
     public String getServiceName() {
         return serviceName;
     }
@@ -103,14 +119,34 @@ public class ThriftServiceRegistrationBean {
     /**
      * Register the service name to use in monitoring.
      */
-    public ThriftServiceRegistrationBean setServiceName(String serviceName) {
+    public ThriftServiceRegistrationBean setServiceName(@NotNull String serviceName) {
         this.serviceName = serviceName;
+        return this;
+    }
+
+    /**
+     * Returns the decorator of the service.
+     */
+    @NotNull
+    public Function<Service<HttpRequest, HttpResponse>,
+                    ? extends Service<HttpRequest, HttpResponse>> getDecorator() {
+        return decorator;
+    }
+
+    /**
+     * Sets the decorator of the service.
+     */
+    public ThriftServiceRegistrationBean setDecorator(
+            @NotNull Function<Service<HttpRequest, HttpResponse>,
+                              ? extends Service<HttpRequest, HttpResponse>> decorator) {
+        this.decorator = decorator;
         return this;
     }
 
     /**
      * Returns sample requests of {@link #getService()}.
      */
+    @NotNull
     public Collection<? extends TBase<?, ?>> getExampleRequests() {
         return exampleRequests;
     }
@@ -118,7 +154,8 @@ public class ThriftServiceRegistrationBean {
     /**
      * Sets sample requests for {@link #getService()}.
      */
-    public ThriftServiceRegistrationBean setExampleRequests(Collection<? extends TBase<?, ?>> exampleRequests) {
+    public ThriftServiceRegistrationBean setExampleRequests(
+            @NotNull Collection<? extends TBase<?, ?>> exampleRequests) {
         this.exampleRequests = exampleRequests;
         return this;
     }
@@ -126,6 +163,7 @@ public class ThriftServiceRegistrationBean {
     /**
      * Returns example {@link HttpHeaders}.
      */
+    @NotNull
     public Collection<HttpHeaders> getExampleHeaders() {
         return exampleHeaders;
     }
@@ -133,7 +171,7 @@ public class ThriftServiceRegistrationBean {
     /**
      * Sets example {@link HttpHeaders}.
      */
-    public ThriftServiceRegistrationBean setExampleHeaders(Collection<HttpHeaders> exampleHeaders) {
+    public ThriftServiceRegistrationBean setExampleHeaders(@NotNull Collection<HttpHeaders> exampleHeaders) {
         this.exampleHeaders = exampleHeaders;
         return this;
     }


### PR DESCRIPTION
Motivation:

We forgot to add a registration bean for an annotated service object.

Modifications:

- Add AnnotatedServiceRegistrationBean

Result:

A user can add an annotated service object to a Server without using the
configurator.