### PR TITLE
Fix a race condition in DeferredStreamMessage.subscribeToDelegate()

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
@@ -180,8 +180,13 @@ public class DefaultStreamMessage<T> implements StreamMessage<T>, StreamWriter<T
 
     private void subscribe0(SubscriptionImpl subscription) {
         if (!subscriptionUpdater.compareAndSet(this, null, subscription)) {
-            throw new IllegalStateException(
-                    "subscribed by other subscriber already: " + this.subscription.subscriber());
+            final Subscriber<?> oldSubscriber = this.subscription.subscriber();
+            if (oldSubscriber == AbortingSubscriber.INSTANCE) {
+                throw new IllegalStateException("cannot subscribe to an aborted publisher");
+            } else {
+                throw new IllegalStateException(
+                        "subscribed by other subscriber already: " + oldSubscriber);
+            }
         }
 
         final Executor executor = subscription.executor();


### PR DESCRIPTION
Motivation:

DeferredStreamMessage.subscribeToDelegate() can subscribe to the
delegate twice when one thread calls subscribe() and the other one calls
delegate().

Modifications:

- Make sure subscribeToDelegate() call StreamMessage.subscribe() only
  once by using CAS

Result:

- Fixes #623