### PR TITLE
Fix memory leak which occurs when a client-side response stream is closed unexpectedly

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/http/HttpClientPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/client/http/HttpClientPipelineConfigurator.java
@@ -576,7 +576,7 @@ class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
         Http2ConnectionEncoder encoder = new DefaultHttp2ConnectionEncoder(conn, writer);
         Http2ConnectionDecoder decoder = new DefaultHttp2ConnectionDecoder(conn, encoder, reader);
 
-        final Http2ResponseDecoder listener = new Http2ResponseDecoder(conn, ch);
+        final Http2ResponseDecoder listener = new Http2ResponseDecoder(conn, ch, encoder);
 
         final Http2ClientConnectionHandler handler =
                 new Http2ClientConnectionHandler(decoder, encoder, new Http2Settings(), listener);

--- a/core/src/test/java/com/linecorp/armeria/client/http/HttpClientTimeoutTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/http/HttpClientTimeoutTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketTimeoutException;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.DisableOnDebug;
+import org.junit.rules.TestRule;
+import org.junit.rules.Timeout;
+
+import com.linecorp.armeria.client.ClientBuilder;
+import com.linecorp.armeria.client.ClientFactory;
+import com.linecorp.armeria.client.ResponseTimeoutException;
+import com.linecorp.armeria.client.SessionOption;
+import com.linecorp.armeria.client.SessionOptions;
+import com.linecorp.armeria.common.http.HttpResponse;
+
+public class HttpClientTimeoutTest {
+
+    private static ClientFactory factory;
+
+    @BeforeClass
+    public static void init() {
+        factory = new HttpClientFactory(SessionOptions.of(SessionOption.USE_HTTP2_PREFACE.newValue(true)));
+    }
+
+    @AfterClass
+    public static void destroy() {
+        factory.close();
+    }
+
+    @Rule
+    public TestRule globalTimeout = new DisableOnDebug(new Timeout(10, TimeUnit.SECONDS));
+
+    @Test
+    public void responseTimeoutH1C() throws Exception {
+        try (ServerSocket ss = new ServerSocket(0)) {
+            final HttpClient client = new ClientBuilder("none+h1c://127.0.0.1:" + ss.getLocalPort())
+                    .factory(factory)
+                    .defaultResponseTimeout(Duration.ofSeconds(1))
+                    .build(HttpClient.class);
+
+            final HttpResponse res = client.get("/");
+            try (Socket s = ss.accept()) {
+                s.setSoTimeout(1000);
+
+                // Let the response timeout occur.
+                assertThatThrownBy(() -> res.aggregate().join())
+                        .isInstanceOf(CompletionException.class)
+                        .hasCauseInstanceOf(ResponseTimeoutException.class);
+
+                // Make sure that the connection is closed.
+                final InputStream in = s.getInputStream();
+                while (in.read() >= 0) {
+                    continue;
+                }
+            }
+        }
+    }
+
+    @Test
+    public void responseTimeoutH2C() throws Exception {
+        try (ServerSocket ss = new ServerSocket(0)) {
+            final HttpClient client = new ClientBuilder("none+h2c://127.0.0.1:" + ss.getLocalPort())
+                    .factory(factory)
+                    .defaultResponseTimeout(Duration.ofSeconds(1))
+                    .build(HttpClient.class);
+
+            final HttpResponse res = client.get("/");
+            try (Socket s = ss.accept()) {
+                s.setSoTimeout(1000);
+
+                final InputStream in = s.getInputStream();
+                final OutputStream out = s.getOutputStream();
+
+                // Wait for the client to send an H2C upgrade request.
+                assertThat(in.read()).isGreaterThanOrEqualTo(0);
+
+                // Send an empty SETTINGS frame.
+                out.write(new byte[] { 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00 });
+
+                // Send a SETTINGS_ACK frame.
+                out.write(new byte[] { 0x00, 0x00, 0x00, 0x04, 0x01, 0x00, 0x00, 0x00, 0x00 });
+
+                // Let the response timeout occur.
+                assertThatThrownBy(() -> res.aggregate().join())
+                        .isInstanceOf(CompletionException.class)
+                        .hasCauseInstanceOf(ResponseTimeoutException.class);
+
+                // Make sure that the client sent the RST_STREAM frame.
+                final byte[] buf = new byte[8192];
+                int bufLen = 0;
+                try {
+                    for (;;) {
+                        final int numBytes = in.read(buf, bufLen, buf.length - bufLen);
+                        assertThat(numBytes).isGreaterThanOrEqualTo(0);
+                        bufLen += numBytes;
+                    }
+                } catch (SocketTimeoutException expected) {
+                    // At this point, the 'buf' should contain the RST_STREAM frame at the end.
+                }
+
+                assertThat(Arrays.copyOfRange(buf, bufLen - 13, bufLen)).containsExactly(
+                        0x00, 0x00, 0x04,        // Length = 4
+                        0x03, 0x00,              // Type = 3 (RST_STREAM), Flag = 0
+                        0x00, 0x00, 0x00, 0x03,  // Stream ID = 3
+                        0x00, 0x00, 0x00, 0x08); // Error Code = 8 (CANCEL)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

A client-side response can be closed unexpectedly due to various
reasons, most notably due to a ResponseTimeoutException. When it
happens, an HTTP/1 connection has to be closed and an HTTP/2 stream has
to be reset with CANCEL error code. We don't do anything.

Modifications:

- Close the connection when a response of an HTTP/1 connection is closed
  unexpectedly.
- Reset the stream with CANCEL error code when a response of an HTTP/2
  connection is closed unexpectedly.

Result:

Memory leak is fixed.