### PR TITLE
Add keep-alive term next to idle timeout to improve grepability.

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -236,7 +236,7 @@ public final class ServerBuilder {
     }
 
     /**
-     * Sets the idle timeout of a connection in milliseconds.
+     * Sets the idle timeout of a connection in milliseconds for keep-alive.
      *
      * @param idleTimeoutMillis the timeout in milliseconds. {@code 0} disables the timeout.
      */
@@ -245,7 +245,7 @@ public final class ServerBuilder {
     }
 
     /**
-     * Sets the idle timeout of a connection.
+     * Sets the idle timeout of a connection for keep-alive.
      *
      * @param idleTimeout the timeout. {@code 0} disables the timeout.
      */

--- a/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
@@ -339,7 +339,7 @@ public final class ServerConfig {
     }
 
     /**
-     * Returns the idle timeout of a connection in milliseconds.
+     * Returns the idle timeout of a connection in milliseconds for keep-alive.
      */
     public long idleTimeoutMillis() {
         return idleTimeoutMillis;


### PR DESCRIPTION
Keep-alive is a very common term when referring to idle timeout, and having the term next to the setting makes it easier for users to find the appropriate setting when searching.