### PR TITLE
Print the log messages of failed tests for shaded-test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -729,7 +729,7 @@ configure(javaProjects) {
 
     // Print interesting test results, except when running from IntelliJ IDEA which has its own output listener.
     if (System.getProperty('idea.no.launcher') == null) {
-        test {
+        tasks.withType(Test) {
             def buf = new StringBuilder()
 
             // Record the test output.


### PR DESCRIPTION
Motivation:

We currently do not print the log messages of failed tests, which is
sometimes a problem when a test failed in shaded-test but not in a
non-shaded one.

Modifications:

- Print the log message of failed tests for shaded-test as well

Result:

More build visibility