### PR TITLE
Add idle timeout handler after http2 handler, not before, for proper …

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/http/HttpClientPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/client/http/HttpClientPipelineConfigurator.java
@@ -321,7 +321,7 @@ class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
 
         final long idleTimeoutMillis = options.idleTimeoutMillis();
         if (idleTimeoutMillis > 0) {
-            pipeline.addFirst(new HttpClientIdleTimeoutHandler(idleTimeoutMillis));
+            addBeforeSessionHandler(pipeline, new HttpClientIdleTimeoutHandler(idleTimeoutMillis));
         }
 
         pipeline.channel().eventLoop().execute(() -> pipeline.fireUserEventTriggered(protocol));

--- a/core/src/main/java/com/linecorp/armeria/server/http/HttpServerPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/server/http/HttpServerPipelineConfigurator.java
@@ -112,7 +112,7 @@ public final class HttpServerPipelineConfigurator extends ChannelInitializer<Cha
 
     private void configureRequestCountingHandlers(ChannelPipeline p) {
         if (config.idleTimeoutMillis() > 0) {
-            p.addFirst(new HttpServerIdleTimeoutHandler(config.idleTimeoutMillis()));
+            p.addLast(new HttpServerIdleTimeoutHandler(config.idleTimeoutMillis()));
         }
     }
 


### PR DESCRIPTION
…connection closing.

@trustin Not sure if this is the correct fix but it does seem to be the source of the behavior I'm seeing in #637 the idle timeout handler is at the beginning of the pipeline, so when it calls close it gets handled by the head handler, not connection handler.

Fixes #637