### PR TITLE
Use only the necessary Scanners when scanning with Reflections

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/docs/DocStringExtractor.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/DocStringExtractor.java
@@ -51,7 +51,7 @@ public abstract class DocStringExtractor {
     private final String path;
 
     protected DocStringExtractor(String defaultPath, String pathPropertyName) {
-        this.path = computePath(defaultPath, pathPropertyName);
+        path = computePath(defaultPath, pathPropertyName);
     }
 
     /**
@@ -67,7 +67,7 @@ public abstract class DocStringExtractor {
                 .filterInputsBy(new FilterBuilder().includePackage(path))
                 .setUrls(ClasspathHelper.forPackage(path))
                 .addClassLoader(classLoader)
-                .addScanners(new ResourcesScanner());
+                .setScanners(new ResourcesScanner());
         if (configuration.getUrls() == null || configuration.getUrls().isEmpty()) {
             return Collections.emptyMap();
         }


### PR DESCRIPTION
Motivations:

When DocStringExtractor scans the docstring directory using Reflections,
the following messages can be logged:

    06:16:52.582 [Test worker] DEBUG c.l.a.i.s.reflections.Reflections - could not scan file META-INF/armeria/grpc/armeria-test.dsc in url file:/C:/projects/armeria/shaded-test/build/classes/test-grpc/ with scanner SubTypesScanner
    com.linecorp.armeria.internal.shaded.reflections.ReflectionsException: could not create class object from file META-INF/armeria/grpc/armeria-test.dsc

Although harmless, it can pollute the log file.

Modifications:

- Use only the necessary Scanners (ResourcesScanner only) when scanning
  with Reflections in DocStringExtractor

Result:

- Less noise in a log file