### PR TITLE
Restore idle timeout handler to beginning of pipeline and use channel…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
@@ -318,7 +318,7 @@ final class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
 
         final long idleTimeoutMillis = options.idleTimeoutMillis();
         if (idleTimeoutMillis > 0) {
-            addBeforeSessionHandler(pipeline, new HttpClientIdleTimeoutHandler(idleTimeoutMillis));
+            pipeline.addFirst(new HttpClientIdleTimeoutHandler(idleTimeoutMillis));
         }
 
         pipeline.channel().eventLoop().execute(() -> pipeline.fireUserEventTriggered(protocol));

--- a/core/src/main/java/com/linecorp/armeria/internal/IdleTimeoutHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/IdleTimeoutHandler.java
@@ -46,7 +46,7 @@ public abstract class IdleTimeoutHandler extends IdleStateHandler {
 
         if (!hasRequestsInProgress(ctx)) {
             logger.debug("{} Closing an idle {} connection", ctx.channel(), name);
-            ctx.close();
+            ctx.channel().close();
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
@@ -109,7 +109,7 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
 
     private void configureRequestCountingHandlers(ChannelPipeline p) {
         if (config.idleTimeoutMillis() > 0) {
-            p.addLast(new HttpServerIdleTimeoutHandler(config.idleTimeoutMillis()));
+            p.addFirst(new HttpServerIdleTimeoutHandler(config.idleTimeoutMillis()));
         }
     }
 


### PR DESCRIPTION
….close instead of ctx.close to make sure all handlers are run on idle timeout connection close.

With the current implementation, for HTTP/2 connections, IdleTimeoutHandler will not see any more channel reads after the initial handshake and will treat streaming requests as idle. Instead, we restore idle timeout handler to the beginning of the pipeline so it sees all channel reads, and have it close the channel, instead of the handler context, to ensure all outbound handlers are called, which will ensure logic like HTTP/2 goaway runs as described in #637 

The regression test is quite slow and I'm worried about flakiness, it might not be worth it.