### PR TITLE
Add common EventLoopGroups and blocking task Executor

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactory.java
@@ -51,7 +51,7 @@ public interface ClientFactory extends AutoCloseable {
     /**
      * The default {@link ClientFactory} implementation.
      */
-    ClientFactory DEFAULT = new ClientFactoryBuilder().useDaemonThreads(true).build();
+    ClientFactory DEFAULT = new ClientFactoryBuilder().build();
 
     /**
      * Closes the default {@link ClientFactory}.

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingHttpClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingHttpClient.java
@@ -84,7 +84,7 @@ public final class RetryingHttpClient extends RetryingClient<HttpRequest, HttpRe
         final DefaultHttpResponse res = new DefaultHttpResponse();
         final Backoff backoff = newBackoff();
         final HttpRequestDuplicator reqDuplicator = new HttpRequestDuplicator(req);
-        retry(1, backoff, ctx, reqDuplicator, (newReq) -> {
+        retry(1, backoff, ctx, reqDuplicator, newReq -> {
             try {
                 return delegate().execute(ctx, newReq);
             } catch (Exception e) {
@@ -132,7 +132,7 @@ public final class RetryingHttpClient extends RetryingClient<HttpRequest, HttpRe
                        }));
     }
 
-    private long getRetryAfterMillis(HttpResponse res) {
+    private static long getRetryAfterMillis(HttpResponse res) {
         final HttpHeaders headers = getHttpHeaders(res);
         long millisAfter = -1;
         String value = headers.get(HttpHeaderNames.RETRY_AFTER);
@@ -153,7 +153,7 @@ public final class RetryingHttpClient extends RetryingClient<HttpRequest, HttpRe
         return millisAfter;
     }
 
-    private HttpHeaders getHttpHeaders(HttpResponse res) {
+    private static HttpHeaders getHttpHeaders(HttpResponse res) {
         final CompletableFuture<AggregatedHttpMessage> future = new CompletableFuture<>();
         final HttpHeaderSubscriber subscriber = new HttpHeaderSubscriber(future);
         res.closeFuture().whenComplete(subscriber);

--- a/core/src/main/java/com/linecorp/armeria/common/CommonPools.java
+++ b/core/src/main/java/com/linecorp/armeria/common/CommonPools.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.LinkedTransferQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import com.linecorp.armeria.client.ClientFactoryBuilder;
+import com.linecorp.armeria.common.util.EventLoopGroups;
+import com.linecorp.armeria.server.ServerBuilder;
+
+import io.netty.channel.EventLoopGroup;
+import io.netty.util.concurrent.DefaultThreadFactory;
+
+/**
+ * Provides the common shared thread pools and {@link EventLoopGroup}s which is used when not overridden.
+ */
+public final class CommonPools {
+
+    private static final Executor BLOCKING_TASK_EXECUTOR;
+    private static final EventLoopGroup BOSS_GROUP;
+    private static final EventLoopGroup WORKER_GROUP;
+
+    static {
+        // Threads spawned as needed and reused, with a 60s timeout and unbounded work queue.
+        final int DEFAULT_MAX_BLOCKING_TASK_THREADS = 200; // from Tomcat's default maxThreads.
+        final ThreadPoolExecutor blockingTaskExecutor = new ThreadPoolExecutor(
+                DEFAULT_MAX_BLOCKING_TASK_THREADS, DEFAULT_MAX_BLOCKING_TASK_THREADS,
+                60, TimeUnit.SECONDS, new LinkedTransferQueue<>(),
+                new DefaultThreadFactory("armeria-common-blocking-tasks", true));
+
+        blockingTaskExecutor.allowCoreThreadTimeOut(true);
+        BLOCKING_TASK_EXECUTOR = blockingTaskExecutor;
+
+        BOSS_GROUP = EventLoopGroups.newEventLoopGroup(Flags.numCommonBosses(),
+                                                       "armeria-common-boss", true);
+        WORKER_GROUP = EventLoopGroups.newEventLoopGroup(Flags.numCommonWorkers(),
+                                                         "armeria-common-worker", true);
+    }
+
+    /**
+     * Returns the common blocking task {@link Executor} which is used when
+     * {@link ServerBuilder#blockingTaskExecutor(Executor)} is not specified.
+     */
+    public static Executor blockingTaskExecutor() {
+        return BLOCKING_TASK_EXECUTOR;
+    }
+
+    /**
+     * Returns the common boss {@link EventLoopGroup} which is used when
+     * {@link ServerBuilder#bossGroup(EventLoopGroup, boolean)} is not specified.
+     */
+    public static EventLoopGroup bossGroup() {
+        return BOSS_GROUP;
+    }
+
+    /**
+     * Returns the common worker {@link EventLoopGroup} which is used when
+     * {@link ServerBuilder#workerGroup(EventLoopGroup, boolean)} or
+     * {@link ClientFactoryBuilder#workerGroup(EventLoopGroup, boolean)} is not specified.
+     */
+    public static EventLoopGroup workerGroup() {
+        return WORKER_GROUP;
+    }
+
+    private CommonPools() {}
+}

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -52,17 +52,13 @@ public final class Flags {
     private static final boolean USE_OPENSSL = getBoolean("useOpenSsl", OpenSsl.isAvailable(),
                                                           value -> OpenSsl.isAvailable() || !value);
 
-    private static final int DEFAULT_DEFAULT_NUM_SERVER_BOSSES = 1;
-    private static final int DEFAULT_NUM_SERVER_BOSSES =
-            getInt("numServerBosses", DEFAULT_DEFAULT_NUM_SERVER_BOSSES, value -> value > 0);
+    private static final int DEFAULT_NUM_COMMON_BOSSES = 1;
+    private static final int NUM_COMMON_BOSSES =
+            getInt("numCommonBosses", DEFAULT_NUM_COMMON_BOSSES, value -> value > 0);
 
-    private static final int DEFAULT_DEFAULT_NUM_SERVER_WORKERS = NUM_CPU_CORES * 2;
-    private static final int DEFAULT_NUM_SERVER_WORKERS =
-            getInt("numServerWorkers", DEFAULT_DEFAULT_NUM_SERVER_WORKERS, value -> value > 0);
-
-    private static final int DEFAULT_DEFAULT_NUM_CLIENT_WORKERS = NUM_CPU_CORES * 2;
-    private static final int DEFAULT_NUM_CLIENT_WORKERS =
-            getInt("numClientWorkers", DEFAULT_DEFAULT_NUM_CLIENT_WORKERS, value -> value > 0);
+    private static final int DEFAULT_NUM_COMMON_WORKERS = NUM_CPU_CORES * 2;
+    private static final int NUM_COMMON_WORKERS =
+            getInt("numCommonWorkers", DEFAULT_NUM_COMMON_WORKERS, value -> value > 0);
 
     private static final long DEFAULT_DEFAULT_CONNECT_TIMEOUT_MILLIS = 3200; // 3.2 seconds
     private static final long DEFAULT_CONNECT_TIMEOUT_MILLIS =
@@ -150,36 +146,24 @@ public final class Flags {
     }
 
     /**
-     * Returns the default number of server-side boss I/O threads.
-     * Note that this value has effect only if a user did not specify it.
+     * Returns the default number of {@linkplain CommonPools#bossGroup() common boss group} threads.
      *
-     * <p>The default value of this flag is {@value #DEFAULT_DEFAULT_NUM_SERVER_BOSSES}. Specify the
-     * {@code -Dcom.linecorp.armeria.defaultNumServerBosses=<integer>} to override the default value.
+     * <p>The default value of this flag is {@value #DEFAULT_NUM_COMMON_BOSSES}. Specify the
+     * {@code -Dcom.linecorp.armeria.numCommonBosses=<integer>} to override the default value.
      */
-    public static int defaultNumServerBosses() {
-        return DEFAULT_NUM_SERVER_BOSSES;
+    public static int numCommonBosses() {
+        return NUM_COMMON_BOSSES;
     }
 
     /**
-     * Returns the default number of server-side boss I/O threads.
+     * Returns the default number of {@linkplain CommonPools#workerGroup() common worker group} threads.
      * Note that this value has effect only if a user did not specify it.
      *
      * <p>The default value of this flag is {@code 2 * <numCpuCores>}. Specify the
-     * {@code -Dcom.linecorp.armeria.defaultNumServerWorkers=<integer>} to override the default value.
+     * {@code -Dcom.linecorp.armeria.numCommonWorkers=<integer>} to override the default value.
      */
-    public static int defaultNumServerWorkers() {
-        return DEFAULT_NUM_SERVER_WORKERS;
-    }
-
-    /**
-     * Returns the default number of server-side boss I/O threads.
-     * Note that this value has effect only if a user did not specify it.
-     *
-     * <p>The default value of this flag is {@code 2 * <numCpuCores>}. Specify the
-     * {@code -Dcom.linecorp.armeria.defaultNumClientWorkers=<integer>} to override the default value.
-     */
-    public static int defaultNumClientWorkers() {
-        return DEFAULT_NUM_CLIENT_WORKERS;
+    public static int numCommonWorkers() {
+        return NUM_COMMON_WORKERS;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/util/EventLoopGroups.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/EventLoopGroups.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.util;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+import com.linecorp.armeria.internal.TransportType;
+
+import io.netty.channel.EventLoopGroup;
+import io.netty.util.concurrent.DefaultThreadFactory;
+
+/**
+ * Provides methods that are useful for creating an {@link EventLoopGroup}.
+ */
+public final class EventLoopGroups {
+
+    /**
+     * Returns a newly-created {@link EventLoopGroup}.
+     *
+     * @param numThreads the number of event loop threads
+     */
+    public static EventLoopGroup newEventLoopGroup(int numThreads) {
+        return newEventLoopGroup(numThreads, false);
+    }
+
+    /**
+     * Returns a newly-created {@link EventLoopGroup}.
+     *
+     * @param numThreads the number of event loop threads
+     * @param useDaemonThreads whether to create daemon threads or not
+     */
+    public static EventLoopGroup newEventLoopGroup(int numThreads, boolean useDaemonThreads) {
+        return newEventLoopGroup(numThreads, "armeria-eventloop", useDaemonThreads);
+    }
+
+    /**
+     * Returns a newly-created {@link EventLoopGroup}.
+     *
+     * @param numThreads the number of event loop threads
+     * @param threadNamePrefix the prefix of thread names
+     */
+    public static EventLoopGroup newEventLoopGroup(int numThreads, String threadNamePrefix) {
+        return newEventLoopGroup(numThreads, threadNamePrefix, false);
+    }
+
+    /**
+     * Returns a newly-created {@link EventLoopGroup}.
+     *
+     * @param numThreads the number of event loop threads
+     * @param threadNamePrefix the prefix of thread names
+     * @param useDaemonThreads whether to create daemon threads or not
+     */
+    public static EventLoopGroup newEventLoopGroup(int numThreads, String threadNamePrefix,
+                                                   boolean useDaemonThreads) {
+
+        checkArgument(numThreads > 0, "numThreads: %s (expected: > 0)", numThreads);
+        requireNonNull(threadNamePrefix, "threadNamePrefix");
+
+        final TransportType type = TransportType.detectTransportType();
+        final String prefix = threadNamePrefix + '-' + type.lowerCasedName();
+
+        return type.newEventLoopGroup(numThreads,
+                                      unused -> new DefaultThreadFactory(prefix, useDaemonThreads));
+    }
+
+    private EventLoopGroups() {}
+}

--- a/core/src/main/java/com/linecorp/armeria/common/util/Exceptions.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/Exceptions.java
@@ -39,7 +39,7 @@ import io.netty.channel.ChannelException;
 import io.netty.handler.codec.http2.Http2Exception;
 
 /**
- * Provides the methods that are useful for handling exceptions.
+ * Provides methods that are useful for handling exceptions.
  */
 public final class Exceptions {
 

--- a/core/src/main/java/com/linecorp/armeria/internal/ChannelUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/ChannelUtil.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.google.common.collect.ImmutableList;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFutureListener;
+
+public final class ChannelUtil {
+
+    public static CompletableFuture<Void> close(Iterable<? extends Channel> channels) {
+        final List<Channel> channelsCopy = ImmutableList.copyOf(channels);
+        if (channelsCopy.isEmpty()) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        final AtomicInteger numChannelsToClose = new AtomicInteger(channelsCopy.size());
+        final CompletableFuture<Void> future = new CompletableFuture<>();
+        final ChannelFutureListener listener = unused -> {
+            if (numChannelsToClose.decrementAndGet() == 0) {
+                future.complete(null);
+            }
+        };
+
+        for (Channel ch : channelsCopy) {
+            ch.close().addListener(listener);
+        }
+
+        return future;
+    }
+
+    private ChannelUtil() {}
+}

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientPipeliningTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientPipeliningTest.java
@@ -99,12 +99,12 @@ public class HttpClientPipeliningTest {
         // Note: Each event loop has its own connection pool.
         eventLoopGroup = new NioEventLoopGroup(1);
         factoryWithPipelining = new ClientFactoryBuilder()
-                .eventLoopGroup(eventLoopGroup)
+                .workerGroup(eventLoopGroup, false)
                 .useHttp1Pipelining(true)
                 .build();
 
         factoryWithoutPipelining = new ClientFactoryBuilder()
-                .eventLoopGroup(eventLoopGroup)
+                .workerGroup(eventLoopGroup, false)
                 .useHttp1Pipelining(false)
                 .build();
     }

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryingHttpClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryingHttpClientTest.java
@@ -226,8 +226,7 @@ public class RetryingHttpClientTest {
                 RetryStrategy.onStatus(HttpStatus.SERVICE_UNAVAILABLE);
 
         final HttpClient client = new ClientBuilder(server.uri(SerializationFormat.NONE, "/"))
-                .factory(new ClientFactoryBuilder().useDaemonThreads(true)
-                                                   .idleTimeout(Duration.ofSeconds(5))
+                .factory(new ClientFactoryBuilder().idleTimeout(Duration.ofSeconds(5))
                                                    .build())
                 .defaultResponseTimeout(Duration.ofSeconds(5))
                 .decorator(HttpRequest.class, HttpResponse.class,

--- a/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
@@ -15,10 +15,7 @@
  */
 package com.linecorp.armeria.server;
 
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
 import java.io.BufferedReader;
@@ -82,7 +79,7 @@ public class ServerTest {
                         Thread.sleep(processDelayMillis);
                         super.echo(aReq, res);
                     } catch (InterruptedException e) {
-                        e.printStackTrace();
+                        res.close(e);
                     }
                 }
             }.decorate(LoggingService.newDecorator());
@@ -139,9 +136,9 @@ public class ServerTest {
     @Test
     public void testStartStop() throws Exception {
         final Server server = ServerTest.server.server();
-        assertThat(server.activePorts().size(), is(1));
+        assertThat(server.activePorts()).hasSize(1);
         server.stop().get();
-        assertThat(server.activePorts().size(), is(0));
+        assertThat(server.activePorts()).isEmpty();
     }
 
     @Test
@@ -160,8 +157,8 @@ public class ServerTest {
             req.setEntity(new StringEntity("Hello, world!", StandardCharsets.UTF_8));
 
             try (CloseableHttpResponse res = hc.execute(req)) {
-                assertThat(res.getStatusLine().toString(), is("HTTP/1.1 200 OK"));
-                assertThat(EntityUtils.toString(res.getEntity()), is("Hello, world!"));
+                assertThat(res.getStatusLine().toString()).isEqualTo("HTTP/1.1 200 OK");
+                assertThat(EntityUtils.toString(res.getEntity())).isEqualTo("Hello, world!");
             }
         }
     }
@@ -173,8 +170,8 @@ public class ServerTest {
             req.setEntity(new StringEntity("Hello, world!", StandardCharsets.UTF_8));
 
             try (CloseableHttpResponse res = hc.execute(req)) {
-                assertThat(HttpStatusClass.valueOf(res.getStatusLine().getStatusCode()),
-                           is(not(HttpStatusClass.SUCCESS)));
+                assertThat(HttpStatusClass.valueOf(res.getStatusLine().getStatusCode()))
+                        .isNotEqualTo(HttpStatusClass.SUCCESS);
             }
         }
     }
@@ -186,8 +183,8 @@ public class ServerTest {
             req.setEntity(new StringEntity("Hello, world!", StandardCharsets.UTF_8));
 
             try (CloseableHttpResponse res = hc.execute(req)) {
-                assertThat(HttpStatusClass.valueOf(res.getStatusLine().getStatusCode()),
-                           is(HttpStatusClass.SUCCESS));
+                assertThat(HttpStatusClass.valueOf(res.getStatusLine().getStatusCode()))
+                        .isEqualTo(HttpStatusClass.SUCCESS);
             }
         }
     }
@@ -204,7 +201,7 @@ public class ServerTest {
             }
             long elapsedTimeMillis = TimeUnit.MILLISECONDS.convert(
                     System.nanoTime() - connectedNanos, TimeUnit.NANOSECONDS);
-            assertThat(elapsedTimeMillis, is(greaterThanOrEqualTo(idleTimeoutMillis)));
+            assertThat(elapsedTimeMillis).isGreaterThanOrEqualTo(idleTimeoutMillis);
         }
     }
 
@@ -227,7 +224,7 @@ public class ServerTest {
 
             long elapsedTimeMillis = TimeUnit.MILLISECONDS.convert(
                     System.nanoTime() - lastWriteNanos, TimeUnit.NANOSECONDS);
-            assertThat(elapsedTimeMillis, is(greaterThanOrEqualTo(idleTimeoutMillis)));
+            assertThat(elapsedTimeMillis).isGreaterThan((long) (idleTimeoutMillis * 0.9));
         }
     }
 
@@ -263,7 +260,7 @@ public class ServerTest {
 
             long elapsedTimeMillis = TimeUnit.MILLISECONDS.convert(
                     System.nanoTime() - lastWriteNanos, TimeUnit.NANOSECONDS);
-            assertThat(elapsedTimeMillis, is(greaterThanOrEqualTo(idleTimeoutMillis)));
+            assertThat(elapsedTimeMillis).isGreaterThan((long) (idleTimeoutMillis * 0.9));
         }
     }
 
@@ -296,7 +293,7 @@ public class ServerTest {
             BufferedReader in = new BufferedReader(new InputStreamReader(
                     socket.getInputStream(), StandardCharsets.US_ASCII));
 
-            assertThat(in.readLine(), is(expectedStatusLine));
+            assertThat(in.readLine()).isEqualTo(expectedStatusLine);
             // Read till the end of the connection.
             List<String> headers = new ArrayList<>();
             for (;;) {

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
@@ -55,6 +55,7 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
+import com.linecorp.armeria.common.util.EventLoopGroups;
 import com.linecorp.armeria.grpc.testing.Messages.EchoStatus;
 import com.linecorp.armeria.grpc.testing.Messages.Payload;
 import com.linecorp.armeria.grpc.testing.Messages.SimpleRequest;
@@ -207,7 +208,7 @@ public class GrpcServiceServerTest {
     public static ServerRule server = new ServerRule() {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
-            sb.numWorkers(1);
+            sb.workerGroup(EventLoopGroups.newEventLoopGroup(1), true);
             sb.port(0, HTTP);
             sb.defaultMaxRequestLength(0);
 

--- a/thrift/src/main/java/com/linecorp/armeria/internal/thrift/ThriftFieldAccess.java
+++ b/thrift/src/main/java/com/linecorp/armeria/internal/thrift/ThriftFieldAccess.java
@@ -22,7 +22,7 @@ import org.apache.thrift.TBase;
 import org.apache.thrift.TFieldIdEnum;
 
 /**
- * Provides the access to a Thrift field.
+ * Provides access to a Thrift field.
  */
 public final class ThriftFieldAccess {
 

--- a/thrift/src/test/java/com/linecorp/armeria/it/thrift/ThriftStructuredLoggingTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/thrift/ThriftStructuredLoggingTest.java
@@ -23,7 +23,6 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedTransferQueue;
 
 import org.apache.thrift.protocol.TMessageType;
-import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.junit.MockitoJUnit;
@@ -72,10 +71,10 @@ public class ThriftStructuredLoggingTest {
         }
     }
 
-    private static MockedStructuredLoggingService<HttpRequest, HttpResponse> loggingService;
+    private MockedStructuredLoggingService<HttpRequest, HttpResponse> loggingService;
 
-    @ClassRule
-    public static final ServerRule server = new ServerRule() {
+    @Rule
+    public final ServerRule server = new ServerRule() {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
             loggingService = new MockedStructuredLoggingService<>(
@@ -84,8 +83,7 @@ public class ThriftStructuredLoggingTest {
         }
     };
 
-    private static HelloService.Iface newClient() throws Exception {
-        server.start();
+    private HelloService.Iface newClient() throws Exception {
         String uri = server.uri(BINARY, "/hello");
         return Clients.newClient(uri, HelloService.Iface.class);
     }
@@ -122,6 +120,6 @@ public class ThriftStructuredLoggingTest {
     @Test(timeout = 10000)
     public void testWriterClosed() throws Exception {
         server.stop().join();
-        assertThat(loggingService.closed).isEqualTo(1);
+        assertThat(loggingService.closed).isOne();
     }
 }


### PR DESCRIPTION
Motivation:

A simple application would use the default settings usually, and it will
make each ClientFactory and Server has its own EventLoopGroups, which
may create too many event loop threads.

Modifications:

- Add CommonPools that provides the common EventLoopGroups and blocking
  task Executor which are used when a user did not override the default
- Make a user specify whether to shutdown the EventLoopGroups when
  specifying them
- ClientFactory and Server do not create a new EventLoopGroup by
  themselves anymore
  - Add EventLoopGroups.newEventLoopGroup() utility method so that a
    user can create a compatible EventLoopGroup easily instead
- Miscellaneous:
  - Fix flakiness of ServerTest
  - Fix flakiness of ThriftStructuredLoggingTest
  - Clean up GrpcClientTest

Result:

- Saner default behavior
- Fixes #646
- Fixes #636