### PR TITLE
Enable response timeout is enforced across the retries by RetryingClient

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/Http1ResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http1ResponseDecoder.java
@@ -70,6 +70,8 @@ final class Http1ResponseDecoder extends HttpResponseDecoder implements ChannelI
                 super.addResponse(id, req, res, logBuilder, responseTimeoutMillis, maxContentLength);
 
         resWrapper.closeFuture().whenComplete((unused, cause) -> {
+            // Ensure that the scheduled timeout is not executed.
+            resWrapper.cancelTimeout();
             if (cause != null) {
                 // Disconnect when the response has been closed with an exception because there's no way
                 // to recover from it in HTTP/1.

--- a/core/src/main/java/com/linecorp/armeria/client/Http2ResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http2ResponseDecoder.java
@@ -67,6 +67,8 @@ final class Http2ResponseDecoder extends HttpResponseDecoder implements Http2Con
                 super.addResponse(id, req, res, logBuilder, responseTimeoutMillis, maxContentLength);
 
         resWrapper.closeFuture().whenCompleteAsync((unused, cause) -> {
+            // Ensure that the scheduled timeout is not executed.
+            resWrapper.cancelTimeout();
             if (cause != null) {
                 // We are not closing the connection but just send a RST_STREAM,
                 // so we have to remove the response manually.

--- a/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
@@ -145,6 +145,16 @@ abstract class HttpResponseDecoder {
                     this, responseTimeoutMillis, TimeUnit.MILLISECONDS);
         }
 
+        boolean cancelTimeout() {
+            final ScheduledFuture<?> responseTimeoutFuture = this.responseTimeoutFuture;
+            if (responseTimeoutFuture == null) {
+                return true;
+            }
+
+            this.responseTimeoutFuture = null;
+            return responseTimeoutFuture.cancel(false);
+        }
+
         long maxContentLength() {
             return maxContentLength;
         }
@@ -222,16 +232,6 @@ abstract class HttpResponseDecoder {
                     logger.warn("Unexpected exception:", cause);
                 }
             }
-        }
-
-        private boolean cancelTimeout() {
-            final ScheduledFuture<?> responseTimeoutFuture = this.responseTimeoutFuture;
-            if (responseTimeoutFuture == null) {
-                return true;
-            }
-
-            this.responseTimeoutFuture = null;
-            return responseTimeoutFuture.cancel(false);
         }
 
         @Override

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
@@ -17,12 +17,20 @@ package com.linecorp.armeria.client.retry;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import com.linecorp.armeria.client.Client;
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.ResponseTimeoutException;
 import com.linecorp.armeria.client.SimpleDecoratingClient;
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
+
+import io.netty.util.Attribute;
+import io.netty.util.AttributeKey;
 
 /**
  * A {@link Client} decorator that handles failures of remote invocation and retries requests.
@@ -32,6 +40,9 @@ import com.linecorp.armeria.common.Response;
  */
 public abstract class RetryingClient<I extends Request, O extends Response>
         extends SimpleDecoratingClient<I, O> {
+
+    private static final AttributeKey<Long> RESPONSE_TIMEOUT_DEADLINE_NANOS =
+            AttributeKey.valueOf("RESPONSE_TIMEOUT_DEADLINE_NANOS");
 
     private final Supplier<? extends Backoff> backoffSupplier;
     private final RetryStrategy<I, O> retryStrategy;
@@ -48,13 +59,24 @@ public abstract class RetryingClient<I extends Request, O extends Response>
         this.defaultMaxAttempts = defaultMaxAttempts;
     }
 
-    /**
-     * Creates a new {@link Backoff} instance.
-     * If the created instance does not have {@link AttemptLimitingBackoff}, it will be wrapped with
-     * the instance of {@link AttemptLimitingBackoff}.
-     * @return the {@link Backoff} which is wrapped by {@link AttemptLimitingBackoff} if it doesn't have
-     */
-    protected Backoff newBackoff() {
+    @Override
+    public O execute(ClientRequestContext ctx, I req) throws Exception {
+        setDeadlineOfThisRequest(ctx);
+        return doExecute(ctx, req, newBackoff());
+    }
+
+    private static void setDeadlineOfThisRequest(ClientRequestContext ctx) {
+        final Attribute<Long> deadlineNanosAttr = ctx.attr(RESPONSE_TIMEOUT_DEADLINE_NANOS);
+        if (ctx.responseTimeoutMillis() <= 0) {
+            deadlineNanosAttr.set(-1L);
+        } else {
+            deadlineNanosAttr.set(
+                    System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(ctx.responseTimeoutMillis()));
+        }
+    }
+
+    @VisibleForTesting
+    Backoff newBackoff() {
         Backoff backoff = backoffSupplier.get();
         if (!backoff.as(AttemptLimitingBackoff.class).isPresent()) {
             backoff = backoff.withMaxAttempts(defaultMaxAttempts);
@@ -62,7 +84,51 @@ public abstract class RetryingClient<I extends Request, O extends Response>
         return backoff;
     }
 
+    /**
+     * Invoked by {@link #execute(ClientRequestContext, Request)}
+     * after the deadline for response timeout is set.
+     */
+    protected abstract O doExecute(ClientRequestContext ctx, I req, Backoff backoff) throws Exception;
+
     protected RetryStrategy<I, O> retryStrategy() {
         return retryStrategy;
+    }
+
+    /**
+     * Resets the {@link ClientRequestContext#responseTimeoutMillis()}.
+     * @throws ResponseTimeoutException if the remaining response timeout is equal to or less than 0
+     */
+    protected final void resetResponseTimeout(ClientRequestContext ctx) {
+        final long responseTimeoutMillis = responseTimeoutMillis(ctx);
+        if (responseTimeoutMillis < 0) { // response timeout is disabled.
+            return;
+        }
+
+        ctx.setResponseTimeoutMillis(responseTimeoutMillis);
+    }
+
+    /**
+     * Returns the next delay which retry will be made after. The delay is the smaller value of
+     * {@code nextDelay} and {@code responseTimeoutMillis}. If response timeout is disabled,
+     * just returns {@code nextDelay}.
+     * @throws ResponseTimeoutException if the remaining response timeout is equal to or less than 0
+     */
+    protected final long getNextDelay(long nextDelay, ClientRequestContext ctx) {
+        long responseTimeoutMillis = responseTimeoutMillis(ctx);
+        return responseTimeoutMillis < 0 ? nextDelay : Math.min(nextDelay, responseTimeoutMillis);
+    }
+
+    private static long responseTimeoutMillis(ClientRequestContext ctx) {
+        final Long deadlineNanos = ctx.attr(RESPONSE_TIMEOUT_DEADLINE_NANOS).get();
+        if (deadlineNanos < 0) { // response timeout is disabled.
+            return -1;
+        }
+
+        final long responseTimeoutMillis = TimeUnit.NANOSECONDS.toMillis(deadlineNanos - System.nanoTime());
+        if (responseTimeoutMillis > 0) { // 0 is not from the first, but subtracted to that, so it's timeout.
+            return responseTimeoutMillis;
+        }
+
+        throw ResponseTimeoutException.get(); // timeout!!
     }
 }


### PR DESCRIPTION
Motivation:

Currently, response timeout is applied to an individual retry made by RetryingClient.
However, the timeout needs to happen when the time passed timout milliseconds from the first attempt.

Modification:

- Add timestamp and reset the responseTimeoutMillis whenever retries is made

Result:

Close #627