### PR TITLE
Fix PathMapping implementations to produce their loggerName and metricName correctly

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/AbstractPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AbstractPathMapping.java
@@ -78,7 +78,10 @@ public abstract class AbstractPathMapping implements PathMapping {
         if ("/".equals(normalized)) {
             return "__ROOT__";
         }
-        normalized = normalized.substring(1); // Strip the first slash.
+
+        if (normalized.startsWith("/")) {
+            normalized = normalized.substring(1); // Strip the first slash.
+        }
 
         final int end;
         if (normalized.endsWith("/")) {

--- a/core/src/main/java/com/linecorp/armeria/server/AnnotatedHttpServices.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AnnotatedHttpServices.java
@@ -36,6 +36,7 @@ import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 
@@ -326,10 +327,13 @@ final class AnnotatedHttpServices {
     /**
      * A {@link PathMapping} implementation that combines path prefix and another {@link PathMapping}.
      */
-    private static final class PrefixAddingPathMapping extends AbstractPathMapping {
+    @VisibleForTesting
+    static final class PrefixAddingPathMapping extends AbstractPathMapping {
 
         private final String pathPrefix;
         private final PathMapping mapping;
+        private final String loggerName;
+        private final String metricName;
 
         PrefixAddingPathMapping(String pathPrefix, PathMapping mapping) {
             assert mapping instanceof GlobPathMapping || mapping instanceof RegexPathMapping
@@ -337,6 +341,8 @@ final class AnnotatedHttpServices {
 
             this.pathPrefix = pathPrefix;
             this.mapping = mapping;
+            loggerName = loggerName(pathPrefix) + '.' + mapping.loggerName();
+            metricName = pathPrefix + mapping.metricName();
         }
 
         @Override
@@ -356,6 +362,16 @@ final class AnnotatedHttpServices {
         @Override
         public Set<String> paramNames() {
             return mapping.paramNames();
+        }
+
+        @Override
+        public String loggerName() {
+            return loggerName;
+        }
+
+        @Override
+        public String metricName() {
+            return metricName;
         }
 
         @Override

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultPathMapping.java
@@ -73,6 +73,9 @@ final class DefaultPathMapping extends AbstractPathMapping {
      */
     private final Set<String> paramNames;
 
+    private final String loggerName;
+    private final String metricName;
+
     /**
      * Create a {@link DefaultPathMapping} instance from given {@code pathPattern}.
      *
@@ -123,6 +126,9 @@ final class DefaultPathMapping extends AbstractPathMapping {
         skeleton = skeletonJoiner.toString();
         paramNameArray = paramNames.toArray(new String[paramNames.size()]);
         this.paramNames = ImmutableSet.copyOf(paramNames);
+
+        loggerName = loggerName(pathPattern);
+        metricName = pathPattern;
     }
 
     /**
@@ -156,6 +162,16 @@ final class DefaultPathMapping extends AbstractPathMapping {
     @Override
     public Set<String> paramNames() {
         return paramNames;
+    }
+
+    @Override
+    public String loggerName() {
+        return loggerName;
+    }
+
+    @Override
+    public String metricName() {
+        return metricName;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/GlobPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/GlobPathMapping.java
@@ -55,6 +55,7 @@ final class GlobPathMapping extends AbstractPathMapping {
     private final int numParams;
     private final Set<String> paramNames;
     private final String loggerName;
+    private final String metricName;
     private final String strVal;
 
     GlobPathMapping(String glob) {
@@ -70,8 +71,13 @@ final class GlobPathMapping extends AbstractPathMapping {
         }
         this.paramNames = paramNames.build();
 
-        loggerName = loggerName(glob);
         strVal = PREFIX + glob;
+
+        // Make the glob pattern as an absolute form to distinguish 'glob:foo' from 'exact:/foo'
+        // when generating logger and metric names.
+        final String aGlob = glob.startsWith("/") ? glob : "/**/" + glob;
+        loggerName = loggerName(aGlob);
+        metricName = aGlob;
     }
 
     @Override
@@ -106,7 +112,7 @@ final class GlobPathMapping extends AbstractPathMapping {
 
     @Override
     public String metricName() {
-        return glob;
+        return metricName;
     }
 
     @VisibleForTesting

--- a/core/src/main/java/com/linecorp/armeria/server/RegexPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RegexPathMapping.java
@@ -38,12 +38,14 @@ final class RegexPathMapping extends AbstractPathMapping {
     private final Pattern regex;
     private final Set<String> paramNames;
     private final String loggerName;
+    private final String metricName;
     private final String strVal;
 
     RegexPathMapping(Pattern regex) {
         this.regex = requireNonNull(regex, "regex");
         paramNames = findParamNames(regex);
         loggerName = toLoggerName(regex);
+        metricName = '/' + PREFIX + regex.pattern();
         strVal = PREFIX + regex.pattern();
     }
 
@@ -109,7 +111,7 @@ final class RegexPathMapping extends AbstractPathMapping {
 
     @Override
     public String metricName() {
-        return strVal;
+        return metricName;
     }
 
     @VisibleForTesting

--- a/core/src/test/java/com/linecorp/armeria/server/CatchAllPathMappingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/CatchAllPathMappingTest.java
@@ -26,4 +26,9 @@ public class CatchAllPathMappingTest {
     public void testLoggerName() throws Exception {
         assertThat(ofCatchAll().loggerName()).isEqualTo("__ROOT__");
     }
+
+    @Test
+    public void testMetricName() throws Exception {
+        assertThat(ofCatchAll().metricName()).isEqualTo("/**");
+    }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/DefaultPathMappingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/DefaultPathMappingTest.java
@@ -15,6 +15,7 @@
  */
 package com.linecorp.armeria.server;
 
+import static com.linecorp.armeria.server.PathMapping.of;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -126,5 +127,15 @@ public class DefaultPathMappingTest {
         assertThat(ppe.hashCode()).isEqualTo(ppe2.hashCode());
         assertThat(ppe.hashCode()).isNotEqualTo(ppe3.hashCode());
         assertThat(ppe2.hashCode()).isNotEqualTo(ppe3.hashCode());
+    }
+
+    @Test
+    public void testLoggerName() {
+        assertThat(of("/service/{value}").loggerName()).isEqualTo("service._value_");
+    }
+
+    @Test
+    public void testMetricName() {
+        assertThat(of("/service/{value}").metricName()).isEqualTo("/service/{value}");
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/ExactPathMappingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ExactPathMappingTest.java
@@ -49,4 +49,9 @@ public class ExactPathMappingTest {
     public void testLoggerName() throws Exception {
         assertThat(ofExact("/foo/bar").loggerName()).isEqualTo("foo.bar");
     }
+
+    @Test
+    public void testMetricName() throws Exception {
+        assertThat(ofExact("/foo/bar").metricName()).isEqualTo("/foo/bar");
+    }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/GlobPathMappingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/GlobPathMappingTest.java
@@ -82,6 +82,13 @@ public class GlobPathMappingTest {
     @Test
     public void testLoggerName() throws Exception {
         assertThat(ofGlob("/foo/bar/**").loggerName()).isEqualTo("foo.bar.__");
+        assertThat(ofGlob("foo").loggerName()).isEqualTo("__.foo");
+    }
+
+    @Test
+    public void testMetricName() throws Exception {
+        assertThat(ofGlob("/foo/bar/**").metricName()).isEqualTo("/foo/bar/**");
+        assertThat(ofGlob("foo").metricName()).isEqualTo("/**/foo");
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/server/PrefixAddingPathMappingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/PrefixAddingPathMappingTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+import com.linecorp.armeria.server.AnnotatedHttpServices.PrefixAddingPathMapping;
+
+public class PrefixAddingPathMappingTest {
+
+    @Test
+    public void testLoggerName() {
+        assertThat(new PrefixAddingPathMapping("/foo", PathMapping.ofGlob("/bar/**")).loggerName())
+                .isEqualTo("foo.bar.__");
+        assertThat(new PrefixAddingPathMapping("/foo", PathMapping.ofGlob("bar")).loggerName())
+                .isEqualTo("foo.__.bar");
+        assertThat(new PrefixAddingPathMapping("/foo", PathMapping.ofRegex("/(foo|bar)")).loggerName())
+                .isEqualTo("foo.regex.__foo_bar_");
+    }
+
+    @Test
+    public void testMetricName() {
+        assertThat(new PrefixAddingPathMapping("/foo", PathMapping.ofGlob("/bar/**")).metricName())
+                .isEqualTo("/foo/bar/**");
+        assertThat(new PrefixAddingPathMapping("/foo", PathMapping.ofGlob("bar")).metricName())
+                .isEqualTo("/foo/**/bar");
+        assertThat(new PrefixAddingPathMapping("/foo", PathMapping.ofRegex("/(foo|bar)")).metricName())
+                .isEqualTo("/foo/regex:/(foo|bar)");
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/PrefixPathMappingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/PrefixPathMappingTest.java
@@ -30,6 +30,11 @@ public class PrefixPathMappingTest {
     }
 
     @Test
+    public void testMetricName() throws Exception {
+        assertThat(ofPrefix("/foo/bar").metricName()).isEqualTo("/foo/bar/**");
+    }
+
+    @Test
     public void mappingResult() {
         final PathMapping a = ofPrefix("/foo");
         PathMappingResult result = a.apply("/foo/bar/cat", "");

--- a/core/src/test/java/com/linecorp/armeria/server/RegexPathMappingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/RegexPathMappingTest.java
@@ -28,6 +28,11 @@ public class RegexPathMappingTest {
     }
 
     @Test
+    public void testMetricName() throws Exception {
+        assertThat(ofRegex("foo/bar").metricName()).isEqualTo("/regex:foo/bar");
+    }
+
+    @Test
     public void basic() {
         final PathMapping mapping = ofRegex("foo");
         final PathMappingResult result = mapping.apply("/barfoobar", null);


### PR DESCRIPTION
Motivation:

- For some cases, a user may get `__UNKNOWN__` as `loggerName` and/or `__UNKNOWN_PATH__` as `metricName`.

Modifications:

- Set `loggerName` and `metricName` when instantiating `PrefixAddingPathMapping` and `DefaultPathMapping` class.
- A glob pattern not starting with '/' will be treated as `/**/..pattern..` for `loggerName` and `metricName`.
- Make `metricName` of `RegexPathMapping` as `/regex:...` instead of `regex:...`.

Result:

- Fixes #651