### PR TITLE
Provide a way to specify a Backoff using a string expression

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/retry/BackoffSpec.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/BackoffSpec.java
@@ -1,0 +1,301 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.retry;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Ascii;
+import com.google.common.base.MoreObjects;
+import com.google.common.base.MoreObjects.ToStringHelper;
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
+
+/**
+ * A specification of a {@link Backoff} configuration represented by a string. The string syntax is
+ * a series of comma-separated options(key-values pair) and each values is colon-separated.
+ * The options are divided into two groups which are base options and decorators. Base options include
+ * {@link ExponentialBackoff}, {@link FixedBackoff} and {@link RandomBackoff}. Only one of them can be
+ * specified in the {@code specification}, otherwise {@link IllegalArgumentException} will occur.
+ * When you create a {@link Backoff} using {@link #build()}, decorators, {@link JitterAddingBackoff} and
+ * {@link AttemptLimitingBackoff}, are chaining with the base option in order even if you didn't specify
+ * them in the {@code specification}.
+ *
+ * @see Backoff#of(String) for the format of the specification, please refer to Backoff#of(String)
+ */
+final class BackoffSpec {
+    private static final Splitter OPTION_SPLITTER = Splitter.on(',').trimResults();
+    private static final Splitter KEY_VALUE_SPLITTER = Splitter.on('=').trimResults();
+    private static final Splitter VALUE_SPLITTER = Splitter.on(':').trimResults();
+
+    private static final List<String> ORDINALS = ImmutableList.of("first", "second", "third");
+
+    private static final long DEFAULT_INITIAL_DELAY_MILLIS = 200;
+    private static final long DEFAULT_MAX_DELAY_MILLIS = 10000;
+    private static final double DEFAULT_MULTIPLIER = 2.0;
+    private static final double DEFAULT_MAX_JITTER_RATE = 0.2;
+    private static final int DEFAULT_MAX_ATTEMPTS = 10;
+
+    private final String specification;
+
+    private enum BaseOption {
+        exponential, // exponential backoff will be used to build when none of the base options are set
+        fixed,
+        random
+    }
+
+    private BaseOption baseOption;
+
+    private boolean jitterConfigured;
+    private boolean maxAttemptsConfigured;
+
+    @VisibleForTesting
+    long initialDelayMillis = DEFAULT_INITIAL_DELAY_MILLIS;
+    @VisibleForTesting
+    long maxDelayMillis = DEFAULT_MAX_DELAY_MILLIS;
+    @VisibleForTesting
+    double multiplier = DEFAULT_MULTIPLIER;
+    @VisibleForTesting
+    double minJitterRate = -DEFAULT_MAX_JITTER_RATE;
+    @VisibleForTesting
+    double maxJitterRate = DEFAULT_MAX_JITTER_RATE;
+    @VisibleForTesting
+    int maxAttempts = DEFAULT_MAX_ATTEMPTS;
+    @VisibleForTesting
+    long fixedDelayMillis;
+    @VisibleForTesting
+    long randomMinDelayMillis;
+    @VisibleForTesting
+    long randomMaxDelayMillis;
+
+    /**
+     * Creates a {@link BackoffSpec} from a string.
+     */
+    static BackoffSpec parse(String specification) {
+        requireNonNull(specification, "specification");
+        final BackoffSpec spec = new BackoffSpec(specification);
+        for (String option : OPTION_SPLITTER.split(specification)) {
+            spec.parseOption(option);
+        }
+        return spec;
+    }
+
+    private BackoffSpec(String specification) {
+        this.specification = specification;
+    }
+
+    private void parseOption(String option) {
+        if (option.isEmpty()) {
+            return;
+        }
+
+        final List<String> keyAndValues = KEY_VALUE_SPLITTER.splitToList(option);
+        checkArgument(keyAndValues.size() == 2,
+                      "option '%s' (expected 'key=value1:value2...')", option);
+
+        configure(keyAndValues.get(0), keyAndValues.get(1));
+    }
+
+    private void configure(String key, String values) {
+        switch (Ascii.toLowerCase(key)) {
+            case "exponential":
+                exponential(key, values);
+                return;
+            case "fixed":
+                fixed(key, values);
+                return;
+            case "random":
+                randomBackoff(key, values);
+                return;
+            case "jitter":
+                jitter(key, values);
+                return;
+            case "maxattempts":
+                maxAttempts(key, values);
+                return;
+            default:
+                throw new IllegalArgumentException("Unknown key " + key);
+        }
+    }
+
+    private void exponential(String key, String exponentialValues) {
+        checkBaseBackoffConfigured();
+        baseOption = BaseOption.exponential;
+
+        final List<String> values = VALUE_SPLITTER.splitToList(exponentialValues);
+        checkArgument(values.size() == 2 || values.size() == 3,
+                      "the number of values for '%s' should be 2 or 3. input '%s'", key, exponentialValues);
+
+        initialDelayMillis = parseLong(key, values.get(0), ORDINALS.get(0));
+        checkNegative(key, initialDelayMillis, ORDINALS.get(0));
+
+        maxDelayMillis = parseLong(key, values.get(1), ORDINALS.get(1));
+        checkNegative(key, maxDelayMillis, ORDINALS.get(1));
+
+        if (initialDelayMillis > maxDelayMillis) {
+            long temp = initialDelayMillis;
+            this.initialDelayMillis = maxDelayMillis;
+            this.maxDelayMillis = temp;
+        }
+
+        if (values.size() == 3) {
+            multiplier = parseDouble(key, values.get(2), ORDINALS.get(2));
+        }
+    }
+
+    private void checkBaseBackoffConfigured() {
+        checkArgument(baseOption == null, "%s backoff is already set.", baseOption);
+    }
+
+    private static void checkNegative(String key, long value, String ordinal) {
+        checkArgument(value >= 0, "%s parameter for %s must be a positive value. input: %s",
+                      ordinal, key, value);
+    }
+
+    private void fixed(String key, String value) {
+        checkBaseBackoffConfigured();
+        baseOption = BaseOption.fixed;
+        fixedDelayMillis = parseLong(key, value, ORDINALS.get(0));
+        checkNegative(key, fixedDelayMillis, ORDINALS.get(0));
+    }
+
+    private void randomBackoff(String key, String randomValues) {
+        checkBaseBackoffConfigured();
+        baseOption = BaseOption.random;
+
+        final List<String> values = VALUE_SPLITTER.splitToList(randomValues);
+        checkArgument(values.size() == 2,
+                      "the number of values for '%s' should be 2. input '%s'", key, randomValues);
+
+        randomMinDelayMillis = parseLong(key, values.get(0), ORDINALS.get(0));
+        checkNegative(key, randomMinDelayMillis, ORDINALS.get(0));
+        randomMaxDelayMillis = parseLong(key, values.get(1), ORDINALS.get(1));
+        checkNegative(key, randomMaxDelayMillis, ORDINALS.get(1));
+
+        if (randomMinDelayMillis > randomMaxDelayMillis) {
+            long temp = randomMinDelayMillis;
+            this.randomMinDelayMillis = randomMaxDelayMillis;
+            this.randomMaxDelayMillis = temp;
+        }
+    }
+
+    private void jitter(String key, String jitterValues) {
+        checkArgument(!jitterConfigured,
+                      "jitter parameters are already set. minJitterRate: %s, maxJitterRate: %s",
+                      minJitterRate, maxJitterRate);
+        jitterConfigured = true;
+
+        final List<String> values = VALUE_SPLITTER.splitToList(jitterValues);
+        checkArgument(values.size() == 1 || values.size() == 2,
+                      "the number of values for '%s' should be 1 or 2. input '%s'", key, jitterValues);
+
+        if (values.size() == 1) {
+            double jitterRate = parseDouble(key, values.get(0), ORDINALS.get(0));
+            checkDoubleBetween(key, jitterRate, 0.0, 1.0, ORDINALS.get(0));
+            minJitterRate = jitterRate * -1;
+            maxJitterRate = jitterRate;
+        } else {
+            minJitterRate = parseDouble(key, values.get(0), ORDINALS.get(0));
+            checkDoubleBetween(key, minJitterRate, -1.0, 1.0, ORDINALS.get(0));
+            maxJitterRate = parseDouble(key, values.get(1), ORDINALS.get(1));
+            checkDoubleBetween(key, maxJitterRate, -1.0, 1.0, ORDINALS.get(1));
+            if (minJitterRate > maxJitterRate) {
+                double temp = minJitterRate;
+                minJitterRate = maxJitterRate;
+                maxJitterRate = temp;
+            }
+        }
+    }
+
+    private void checkDoubleBetween(String key, double value, double min, double max, String ordinal) {
+        checkArgument(min <= value && value <= max,
+                      "%s parameter for %s must be >= %s and <= %s. input: %s",
+                      ordinal, key, min, max, value);
+    }
+
+    private void maxAttempts(String key, String value) {
+        checkArgument(!maxAttemptsConfigured, "maxAttempts parameters is already set. maxAttempts: %s",
+                      maxAttempts);
+        maxAttemptsConfigured = true;
+        maxAttempts = parseInt(key, value);
+        checkNegative(key, maxAttempts, ORDINALS.get(0));
+    }
+
+    private static long parseLong(String key, String value, String ordinal) {
+        try {
+            return Long.parseLong(value);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(String.format(
+                    "%s parameter for %s was set to %s, must be a long", ordinal, key, value), e);
+        }
+    }
+
+    private static double parseDouble(String key, String value, String ordinal) {
+        try {
+            return Double.parseDouble(value);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(String.format(
+                    "%s parameter for %s was set to %s, must be a double", ordinal, key, value), e);
+        }
+    }
+
+    private static int parseInt(String key, String value) {
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(
+                    String.format("%s was set to %s, must be an integer", key, value), e);
+        }
+    }
+
+    /**
+     * Returns a newly-created {@link Backoff} based on the properties of this spec.
+     */
+    Backoff build() {
+        Backoff backoff;
+        if (baseOption == BaseOption.fixed) {
+            backoff = Backoff.fixed(fixedDelayMillis);
+        } else if (baseOption == BaseOption.random) {
+            backoff = Backoff.random(randomMinDelayMillis, randomMaxDelayMillis);
+        } else {
+            backoff = Backoff.exponential(initialDelayMillis, maxDelayMillis, multiplier);
+        }
+
+        return backoff.withJitter(minJitterRate, maxJitterRate).withMaxAttempts(maxAttempts);
+    }
+
+    @Override
+    public String toString() {
+        final ToStringHelper stringHelper = MoreObjects.toStringHelper(this)
+                                                       .add("specification", specification);
+        if (baseOption == BaseOption.fixed) {
+            stringHelper.add("fixedDelayMillis", fixedDelayMillis);
+        } else if (baseOption == BaseOption.random) {
+            stringHelper.add("randomMinDelayMillis", randomMinDelayMillis)
+                        .add("randomMaxDelayMillis", randomMaxDelayMillis);
+        } else {
+            stringHelper.add("initialDelayMillis", initialDelayMillis).add("maxDelayMillis", maxDelayMillis)
+                        .add("multiplier", multiplier);
+        }
+
+        return stringHelper.add("minJitterRate", minJitterRate).add("maxJitterRate", maxJitterRate)
+                           .add("maxAttempts", maxAttempts).toString();
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClientBuilder.java
@@ -26,7 +26,6 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.MoreObjects.ToStringHelper;
 
 import com.linecorp.armeria.client.Client;
-import com.linecorp.armeria.client.ClientOptions;
 import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
@@ -43,14 +42,11 @@ public abstract class RetryingClientBuilder<
         T extends RetryingClientBuilder<T, U, I, O>, U extends RetryingClient<I, O>,
         I extends Request, O extends Response> {
 
+    private static final BackoffSpec DEFAULT_BACKOFF_SPEC = BackoffSpec.parse(Flags.defaultBackoffSpec());
+
     final RetryStrategy<I, O> retryStrategy;
-    // TODO(minwoox) remove hardcoded paramters and add them to Flags with a new parser
-    Supplier<? extends Backoff> backoffSupplier = () -> Backoff
-            .exponential(Flags.defaultExponentialBackoffInitialDelayMillis(),
-                         ClientOptions.DEFAULT.defaultResponseTimeoutMillis())
-            .withJitter(0.3)
-            .withMaxAttempts(Flags.defaultBackoffMaxAttempts());
-    int defaultMaxAttempts = Flags.defaultBackoffMaxAttempts();
+    Supplier<? extends Backoff> backoffSupplier = () -> DEFAULT_BACKOFF_SPEC.build();
+    int defaultMaxAttempts = DEFAULT_BACKOFF_SPEC.maxAttempts;
 
     /**
      * Creates a new builder with the specified retry strategy.
@@ -79,8 +75,8 @@ public abstract class RetryingClientBuilder<
     /**
      * Sets the {@code defaultMaxAttempts}. When a client sets the {@link Backoff} and does not invoke the
      * {@link Backoff#withMaxAttempts(int)}, the client could retry infinitely in certain circumstance.
-     * This would prevent that situation. The value will be set by the
-     * {@link Flags#DEFAULT_BACKOFF_MAX_ATTEMPTS}, if the client dose not specify.
+     * This would prevent that situation. The value will be set by the default value in
+     * {@link Flags#DEFAULT_BACKOFF_SPEC}, if the client dose not specify.
      *
      * @return {@link T} to support method chaining.
      */

--- a/core/src/test/java/com/linecorp/armeria/client/retry/BackoffSpecTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/BackoffSpecTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.retry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.Test;
+
+import com.linecorp.armeria.common.Flags;
+
+public class BackoffSpecTest {
+
+    @Test
+    public void defaultBackoffSpec() {
+        final BackoffSpec backoffSpec = BackoffSpec.parse(Flags.defaultBackoffSpec());
+        assertThat(backoffSpec.initialDelayMillis).isEqualTo(200);
+        assertThat(backoffSpec.maxDelayMillis).isEqualTo(10000);
+        assertThat(backoffSpec.multiplier).isEqualTo(2.0);
+        assertThat(backoffSpec.minJitterRate).isEqualTo(-0.2);
+        assertThat(backoffSpec.maxJitterRate).isEqualTo(0.2);
+        assertThat(backoffSpec.maxAttempts).isEqualTo(10);
+    }
+
+    @Test
+    public void backoffSpecWithString() {
+        final String spec = "exponential=1000:60000:1.2,jitter=-0.4:0.3,maxAttempts=100";
+        final BackoffSpec backoffSpec = BackoffSpec.parse(spec);
+        assertThat(backoffSpec.initialDelayMillis).isEqualTo(1000);
+        assertThat(backoffSpec.maxDelayMillis).isEqualTo(60000);
+        assertThat(backoffSpec.multiplier).isEqualTo(1.2);
+        assertThat(backoffSpec.minJitterRate).isEqualTo(-0.4);
+        assertThat(backoffSpec.maxJitterRate).isEqualTo(0.3);
+        assertThat(backoffSpec.maxAttempts).isEqualTo(100);
+    }
+
+    @Test
+    public void backoffSpecWithoutBaseOption() {
+        String spec = "jitter=-0.4:0.2,maxAttempts=100";
+        final BackoffSpec backoffSpec = BackoffSpec.parse(spec);
+        // Set by default values
+        assertThat(backoffSpec.initialDelayMillis).isEqualTo(200);
+        assertThat(backoffSpec.maxDelayMillis).isEqualTo(10000);
+        assertThat(backoffSpec.multiplier).isEqualTo(2.0);
+
+        // Set by the spec
+        assertThat(backoffSpec.minJitterRate).isEqualTo(-0.4);
+        assertThat(backoffSpec.maxJitterRate).isEqualTo(0.2);
+        assertThat(backoffSpec.maxAttempts).isEqualTo(100);
+
+        final Backoff backoff = backoffSpec.build();
+        // default base backoff is ExponentialBackoff
+        assertThat(backoff.as(ExponentialBackoff.class).isPresent()).isTrue();
+    }
+
+    @Test
+    public void backoffSpecWithOnlyBaseOption() {
+        String spec1 = "random=0:1000";
+        final BackoffSpec backoffSpec1 = BackoffSpec.parse(spec1);
+        // Set by the spec
+        assertThat(backoffSpec1.randomMinDelayMillis).isEqualTo(0);
+        assertThat(backoffSpec1.randomMaxDelayMillis).isEqualTo(1000);
+
+        // Set by default values
+        assertThat(backoffSpec1.multiplier).isEqualTo(2.0);
+        assertThat(backoffSpec1.minJitterRate).isEqualTo(-0.2);
+        assertThat(backoffSpec1.maxJitterRate).isEqualTo(0.2);
+        assertThat(backoffSpec1.maxAttempts).isEqualTo(10);
+
+        assertThat(Backoff.of(spec1).as(RandomBackoff.class).isPresent()).isTrue();
+
+        String spec2 = "fixed=1000";
+        final BackoffSpec backoffSpec2 = BackoffSpec.parse(spec2);
+        // Set by the spec
+        assertThat(backoffSpec2.fixedDelayMillis).isEqualTo(1000);
+
+        // Set by default values
+        assertThat(backoffSpec2.multiplier).isEqualTo(2.0);
+        assertThat(backoffSpec2.minJitterRate).isEqualTo(-0.2);
+        assertThat(backoffSpec2.maxJitterRate).isEqualTo(0.2);
+        assertThat(backoffSpec2.maxAttempts).isEqualTo(10);
+
+        assertThat(Backoff.of(spec2).as(FixedBackoff.class).isPresent()).isTrue();
+    }
+
+    @Test
+    public void backoffWithWrongArguments() {
+        // wrong negative value
+        String spec1 = "exponential=-1000:60000:2.0";
+        assertThatThrownBy(() -> BackoffSpec.parse(spec1)).isInstanceOf(IllegalArgumentException.class);
+
+        // exceed bound
+        String spec2 = "jitter=-0.4:1.000000001";
+        assertThatThrownBy(() -> BackoffSpec.parse(spec2)).isInstanceOf(IllegalArgumentException.class);
+
+        // same backoff twice
+        String spec3 = "jitter=-0.4:0.2,maxAttempts=100,jitter=-0.4:0.2";
+        assertThatThrownBy(() -> BackoffSpec.parse(spec3)).isInstanceOf(IllegalArgumentException.class);
+
+        // two base backoffs
+        String spec4 = "exponential=1000:60000,fixed=1000";
+        assertThatThrownBy(() -> BackoffSpec.parse(spec4)).isInstanceOf(IllegalArgumentException.class);
+
+        // typo key
+        String spec5 = "texponential=1000:60000:2.0";
+        assertThatThrownBy(() -> BackoffSpec.parse(spec5)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void backOffSpecWithOneValue() {
+        final String spec = "exponential=100:1000,jitter=-0.4:0.3,maxAttempts=100";
+        final BackoffSpec backoffSpec = BackoffSpec.parse(spec);
+        //set by the spec
+        assertThat(backoffSpec.initialDelayMillis).isEqualTo(100);
+        assertThat(backoffSpec.maxDelayMillis).isEqualTo(1000);
+        //set by default values
+        assertThat(backoffSpec.multiplier).isEqualTo(2.0);
+        //set by the spec
+        assertThat(backoffSpec.minJitterRate).isEqualTo(-0.4);
+        assertThat(backoffSpec.maxJitterRate).isEqualTo(0.3);
+        assertThat(backoffSpec.maxAttempts).isEqualTo(100);
+    }
+}


### PR DESCRIPTION
Motivation:

It would be very userful to define a string expression for a Backoff.

Modification:

- Add BackoffSpec that takes a backoff string expression as an argument and builds Backoff using it
- Add defaultBackoffSpec to Flags so that a user can specify it using system property

Result:

- A user can create default backoff using either Backoff.of() or defaultBackOffSpec system.property
- Close #628