### PR TITLE
Allow setting a custom request timeout handler using ServiceRequestCo…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
@@ -58,6 +58,8 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
     private ExecutorService blockingTaskExecutor;
 
     private long requestTimeoutMillis;
+    @Nullable
+    private Runnable requestTimeoutHandler;
     private long maxRequestLength;
     private volatile RequestTimeoutChangeListener requestTimeoutChangeListener;
 
@@ -192,6 +194,16 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
     @Override
     public void setRequestTimeout(Duration requestTimeout) {
         setRequestTimeoutMillis(requireNonNull(requestTimeout, "requestTimeout").toMillis());
+    }
+
+    @Nullable
+    public Runnable requestTimeoutHandler() {
+        return requestTimeoutHandler;
+    }
+
+    @Override
+    public void setRequestTimeoutHandler(Runnable requestTimeoutHandler) {
+        this.requestTimeoutHandler = requireNonNull(requestTimeoutHandler, "requestTimeoutHandler");
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
@@ -119,8 +119,13 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject>, RequestTim
     private void onTimeout() {
         if (state != State.DONE) {
             reqCtx.setTimedOut();
-            failAndRespond(RequestTimeoutException.get(),
-                           HttpStatus.SERVICE_UNAVAILABLE, Http2Error.INTERNAL_ERROR);
+            Runnable requestTimeoutHandler = reqCtx.requestTimeoutHandler();
+            if (requestTimeoutHandler != null) {
+                requestTimeoutHandler.run();
+            } else {
+                failAndRespond(RequestTimeoutException.get(),
+                               HttpStatus.SERVICE_UNAVAILABLE, Http2Error.INTERNAL_ERROR);
+            }
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
@@ -230,7 +230,8 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject>, RequestTim
 
     @Override
     public void onComplete() {
-        if (!cancelTimeout()) {
+        if (!cancelTimeout() && reqCtx.requestTimeoutHandler() == null) {
+            // We have already returned a failed response due to a timeout.
             return;
         }
 

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
@@ -25,6 +25,8 @@ import org.slf4j.Logger;
 import com.linecorp.armeria.common.ContentTooLargeException;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpResponseWriter;
+import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.RequestContext;
 
@@ -108,6 +110,22 @@ public interface ServiceRequestContext extends RequestContext {
      * This value is initially set from {@link ServerConfig#defaultRequestTimeoutMillis()}.
      */
     void setRequestTimeout(Duration requestTimeout);
+
+    /**
+     * Sets a handler to run when the request times out. {@code requestTimeoutHandler} must close the response,
+     * e.g., by calling {@link HttpResponseWriter#respond(int)}. If not set, the response will be closed with
+     * {@link HttpStatus#SERVICE_UNAVAILABLE}.
+     *
+     * <p>For example,
+     * <pre>{@code
+     *   DefaultHttpResponse res = new DefaultHttpResponse();
+     *   ctx.setRequestTimeoutHandler(() -> {
+     *      res.respond(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "Request timed out.");
+     *   });
+     *   ...
+     * }</pre>
+     */
+    void setRequestTimeoutHandler(Runnable requestTimeoutHandler);
 
     /**
      * Returns the maximum length of the current {@link Request}.

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
@@ -95,6 +95,11 @@ public class ServiceRequestContextWrapper
     }
 
     @Override
+    public void setRequestTimeoutHandler(Runnable requestTimeoutHandler) {
+        delegate().setRequestTimeoutHandler(requestTimeoutHandler);
+    }
+
+    @Override
     public long maxRequestLength() {
         return delegate().maxRequestLength();
     }

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerTest.java
@@ -166,6 +166,17 @@ public class HttpServerTest {
                 }
             });
 
+            sb.service("/delay-custom/{delay}", new AbstractHttpService() {
+                @Override
+                protected void doGet(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) {
+                    ctx.setRequestTimeoutHandler(
+                            () -> res.respond(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "timed out"));
+                    final long delayMillis = Long.parseLong(ctx.pathParam("delay"));
+                    ctx.eventLoop().schedule(() -> res.respond(HttpStatus.OK),
+                                             delayMillis, TimeUnit.MILLISECONDS);
+                }
+            });
+
             sb.service("/informed_delay/{delay}", new AbstractHttpService() {
                 @Override
                 protected void doGet(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) {
@@ -449,6 +460,16 @@ public class HttpServerTest {
         assertThat(res.headers().get(HttpHeaderNames.CONTENT_TYPE), is(MediaType.PLAIN_TEXT_UTF_8.toString()));
         assertThat(res.content().toStringUtf8(), is("503 Service Unavailable"));
         assertThat(requestLogs.take().statusCode(), is(503));
+    }
+
+    @Test(timeout = 10000)
+    public void testTimeout_customHandler() throws Exception {
+        serverRequestTimeoutMillis = 100L;
+        final AggregatedHttpMessage res = client().get("/delay-custom/2000").aggregate().get();
+        assertThat(res.headers().status(), is(HttpStatus.OK));
+        assertThat(res.headers().get(HttpHeaderNames.CONTENT_TYPE), is(MediaType.PLAIN_TEXT_UTF_8.toString()));
+        assertThat(res.content().toStringUtf8(), is("timed out"));
+        assertThat(requestLogs.take().statusCode(), is(200));
     }
 
     @Test(timeout = 10000)

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
@@ -151,6 +151,9 @@ public final class GrpcService extends AbstractHttpService {
         ArmeriaServerCall<?, ?> call = startCall(
                 methodName, method, ctx, req.headers(), res, serializationFormat);
         if (call != null) {
+            ctx.setRequestTimeoutHandler(() -> {
+                call.close(Status.DEADLINE_EXCEEDED, EMPTY_METADATA);
+            });
             req.subscribe(call.messageReader());
         }
     }

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientTest.java
@@ -656,12 +656,8 @@ public class GrpcClientTest {
                                           .build();
         Throwable t = catchThrowable(() -> stub.streamingOutputCall(request).next());
         assertThat(t).isInstanceOf(StatusRuntimeException.class);
-        // (anuraag): As GRPC supports handling timeouts in the server or client due to the grpc-timeout
-        // header, it's not guaranteed which is the source of this error.
-        // Until https://github.com/line/armeria/issues/521 a servTODOer side timeout will not have the correct
-        // status so we don't verify it for now.
-        //assertThat(((StatusRuntimeException) t).getStatus().getCode())
-        //.isEqualTo(Status.DEADLINE_EXCEEDED.getCode());
+        assertThat(((StatusRuntimeException) t).getStatus().getCode())
+                .isEqualTo(Status.DEADLINE_EXCEEDED.getCode());
     }
 
     @Test(timeout = 10000)
@@ -686,13 +682,10 @@ public class GrpcClientTest {
                         ClientOption.DEFAULT_RESPONSE_TIMEOUT_MILLIS.newValue(30L));
         stub.streamingOutputCall(request, recorder);
         recorder.awaitCompletion();
-        // TODO(anuraag): As GRPC supports handling timeouts in the server or client due to the grpc-timeout
-        // header, it's not guaranteed which is the source of this error.
-        // Until https://github.com/line/armeria/issues/521 a server side timeout will not have the correct
-        // status so we don't verify it for now.
+
         assertThat(recorder.getError()).isNotNull();
-        //assertThat(Status.fromThrowable(recorder.getError()).getCode())
-        //.isEqualTo(Status.DEADLINE_EXCEEDED.getCode());
+        assertThat(Status.fromThrowable(recorder.getError()).getCode())
+                .isEqualTo(Status.DEADLINE_EXCEEDED.getCode());
     }
 
     // NB: It's unclear when anyone would set a negative timeout, and trying to set the negative timeout


### PR DESCRIPTION
…ntext.

I just went with the approach of setting a custom handler on the context since it seems like the simplest approach and flexible enough for all use cases. Let me know if this can be improved.

Also adds custom timeout handler to `GrpcService` - deadline tests work as expected now and no more memory leak when running gRPC tests.

Fixes #521 