### PR TITLE
Only log an unexpected exception during authorization when there actu…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/auth/HttpAuthService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/auth/HttpAuthService.java
@@ -96,7 +96,9 @@ public abstract class HttpAuthService extends SimpleDecoratingService<HttpReques
      */
     protected HttpResponse onFailure(ServiceRequestContext ctx, HttpRequest req, @Nullable Throwable cause)
             throws Exception {
-        logger.warn("Unexpected exception during authorization:", cause);
+        if (cause != null) {
+            logger.warn("Unexpected exception during authorization.", cause);
+        }
         final DefaultHttpResponse res = new DefaultHttpResponse();
         res.respond(HttpStatus.UNAUTHORIZED);
         return res;


### PR DESCRIPTION
…ally was an exception.

Normal authentication failure should not be logged at WARN level by default.