### PR TITLE
Fix EventLoop.terminationFuture() listener leak

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/http/HttpClientDelegate.java
+++ b/core/src/main/java/com/linecorp/armeria/client/http/HttpClientDelegate.java
@@ -19,9 +19,6 @@ import static java.util.Objects.requireNonNull;
 
 import java.net.InetSocketAddress;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.function.Function;
 import java.util.regex.Pattern;
 
 import org.slf4j.Logger;
@@ -30,11 +27,7 @@ import org.slf4j.LoggerFactory;
 import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
-import com.linecorp.armeria.client.SessionOptions;
-import com.linecorp.armeria.client.pool.DefaultKeyedChannelPool;
 import com.linecorp.armeria.client.pool.KeyedChannelPool;
-import com.linecorp.armeria.client.pool.KeyedChannelPoolHandler;
-import com.linecorp.armeria.client.pool.KeyedChannelPoolHandlerAdapter;
 import com.linecorp.armeria.client.pool.PoolKey;
 import com.linecorp.armeria.common.ClosedSessionException;
 import com.linecorp.armeria.common.SessionProtocol;
@@ -43,27 +36,16 @@ import com.linecorp.armeria.common.http.HttpHeaders;
 import com.linecorp.armeria.common.http.HttpRequest;
 import com.linecorp.armeria.common.http.HttpResponse;
 
-import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.EventLoop;
-import io.netty.channel.pool.ChannelHealthChecker;
 import io.netty.util.AsciiString;
 import io.netty.util.concurrent.Future;
-import io.netty.util.concurrent.FutureListener;
 
 final class HttpClientDelegate implements Client<HttpRequest, HttpResponse> {
 
     private static final Logger logger = LoggerFactory.getLogger(HttpClientDelegate.class);
 
-    private static final KeyedChannelPoolHandlerAdapter<PoolKey> NOOP_POOL_HANDLER =
-            new KeyedChannelPoolHandlerAdapter<>();
-
-    private static final ChannelHealthChecker POOL_HEALTH_CHECKER =
-            ch -> ch.eventLoop().newSucceededFuture(HttpSession.get(ch).isActive());
-
     private static final Pattern CONSECUTIVE_SLASHES_PATTERN = Pattern.compile("/{2,}");
-
-    final ConcurrentMap<EventLoop, KeyedChannelPool<PoolKey>> map = new ConcurrentHashMap<>();
 
     private final HttpClientFactory factory;
 
@@ -82,7 +64,7 @@ final class HttpClientDelegate implements Client<HttpRequest, HttpResponse> {
                 ctx.sessionProtocol());
 
         final EventLoop eventLoop = ctx.eventLoop();
-        final Future<Channel> channelFuture = pool(eventLoop).acquire(poolKey);
+        final Future<Channel> channelFuture = factory.pool(eventLoop).acquire(poolKey);
         final DecodedHttpResponse res = new DecodedHttpResponse(eventLoop);
 
         if (channelFuture.isDone()) {
@@ -168,36 +150,6 @@ final class HttpClientDelegate implements Client<HttpRequest, HttpResponse> {
         }
     }
 
-    private KeyedChannelPool<PoolKey> pool(EventLoop eventLoop) {
-        KeyedChannelPool<PoolKey> pool = map.get(eventLoop);
-        if (pool != null) {
-            return pool;
-        }
-
-        return map.computeIfAbsent(eventLoop, e -> {
-            final Bootstrap bootstrap = factory.newBootstrap();
-            final SessionOptions options = factory.options();
-
-            bootstrap.group(eventLoop);
-
-            Function<PoolKey, Future<Channel>> channelFactory =
-                    new HttpSessionChannelFactory(bootstrap, options);
-
-            final KeyedChannelPoolHandler<PoolKey> handler =
-                    options.poolHandlerDecorator().apply(NOOP_POOL_HANDLER);
-
-            final KeyedChannelPool<PoolKey> newPool = new DefaultKeyedChannelPool<>(
-                    eventLoop, channelFactory, POOL_HEALTH_CHECKER, handler, true);
-
-            eventLoop.terminationFuture().addListener((FutureListener<Object>) f -> {
-                map.remove(eventLoop);
-                newPool.close();
-            });
-
-            return newPool;
-        });
-    }
-
     void invoke0(Channel channel, ClientRequestContext ctx,
                  HttpRequest req, DecodedHttpResponse res, PoolKey poolKey) {
         final KeyedChannelPool<PoolKey> pool = KeyedChannelPool.findPool(channel);
@@ -243,9 +195,5 @@ final class HttpClientDelegate implements Client<HttpRequest, HttpResponse> {
         } catch (Throwable t) {
             logger.warn("Failed to return a Channel to the pool: {}", channel, t);
         }
-    }
-
-    void close() {
-        map.values().forEach(KeyedChannelPool::close);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/http/HttpServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/http/HttpServerTest.java
@@ -717,9 +717,7 @@ public class HttpServerTest {
         clientMaxResponseLength = 0;
         serverRequestTimeoutMillis = 0;
 
-        final DefaultHttpRequest req = new DefaultHttpRequest(HttpMethod.GET,
-                                                              "/zeroes/" + STREAMING_CONTENT_LENGTH);
-        final HttpResponse res = client().execute(req);
+        final HttpResponse res = client().get("/zeroes/" + STREAMING_CONTENT_LENGTH);
         final AtomicReference<HttpStatus> status = new AtomicReference<>();
 
         final StreamConsumer consumer = new StreamConsumer(GlobalEventExecutor.INSTANCE, slowClient) {


### PR DESCRIPTION
Motivation:

HttpClientDelegate.pool() lazily creates a KeyedChannelPool which pools
TCP/IP connections. When a new pool is created, as a defensive measure,
pool() adds a listener to the terminationFuture() of EventLoop which
closes the all connections in the pool and removes itself from the map
of pools.

However, this can lead to a leak when a lot of HttpClientDelegates are
created because the listeners added to EventLoop.terminationFuture()
will linger until the EventLoop shuts down, which usually never happens
until the application shuts down.

It is also notable that it's not a good idea to close connections in
terminationFuture()'s listeners, because it's impossible to perform I/O
in a terminated EventLoop in Netty.

Modifications:

- Keep the number of HttpClientDelegates per HttpClientFactory to one
- Move the connection pool management from HttpClientDelegate to
  HttpClientFactory
- Use weak-key ConcurrentMap instead of ConcurrentHashMap so that the
  map of pools do not leak even when EventLoops are terminated and
  unreferenced externally
- Do not add a listener to terminationFuture()
- Double-check if the connection going back to a pool is active

Result:

Less leaks