### PR TITLE
Fix EventLoop.terminationFuture() listener leak

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerTest.java
@@ -733,9 +733,7 @@ public class HttpServerTest {
         clientMaxResponseLength = 0;
         serverRequestTimeoutMillis = 0;
 
-        final DefaultHttpRequest req = new DefaultHttpRequest(HttpMethod.GET,
-                                                              "/zeroes/" + STREAMING_CONTENT_LENGTH);
-        final HttpResponse res = client().execute(req);
+        final HttpResponse res = client().get("/zeroes/" + STREAMING_CONTENT_LENGTH);
         final AtomicReference<HttpStatus> status = new AtomicReference<>();
 
         final StreamConsumer consumer = new StreamConsumer(GlobalEventExecutor.INSTANCE, slowClient) {


### PR DESCRIPTION
Motivation:

HttpClientDelegate.pool() lazily creates a KeyedChannelPool which pools
TCP/IP connections. When a new pool is created, as a defensive measure,
pool() adds a listener to the terminationFuture() of EventLoop which
closes the all connections in the pool and removes itself from the map
of pools.

However, this can lead to a leak when a lot of HttpClientDelegates are
created because the listeners added to EventLoop.terminationFuture()
will linger until the EventLoop shuts down, which usually never happens
until the application shuts down.

It is also notable that it's not a good idea to close connections in
terminationFuture()'s listeners, because it's impossible to perform I/O
in a terminated EventLoop in Netty.

Modifications:

- Keep the number of HttpClientDelegates per HttpClientFactory to one
- Move the connection pool management from HttpClientDelegate to
  HttpClientFactory
- Use weak-key ConcurrentMap instead of ConcurrentHashMap so that the
  map of pools do not leak even when EventLoops are terminated and
  unreferenced externally
- Do not add a listener to terminationFuture()
- Double-check if the connection going back to a pool is active

Result:

Less leaks