### PR TITLE
Make StreamMessage implementations pass Reactive Streams TCK

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ import org.apache.tools.zip.ZipOutputStream
 import org.yaml.snakeyaml.Yaml
 
 import java.time.LocalDateTime
+import java.util.stream.Streams
 
 buildscript {
     repositories {
@@ -123,6 +124,8 @@ configure(javaProjects) {
                 }
             }
         }
+
+        jacocoEnabled = project.hasProperty('coverage')
     }
 
     // Add the 'managedDependencies' DSL which allows us to add dependencies without versions and exclusions.
@@ -254,18 +257,18 @@ configure(javaProjects) {
     }
 
     // Enable JaCoCo test coverage when '-Pcoverage' option is specified.
-    def jacocoEnabled = project.hasProperty('coverage')
-
-    test {
+    tasks.withType(Test) {
         jacoco {
-            enabled = jacocoEnabled
+            enabled = project.ext.jacocoEnabled
             append = false
         }
     }
 
     jacocoTestReport {
         reports {
-            xml.enabled jacocoEnabled
+            csv.enabled false
+            xml.enabled true
+            html.enabled true
         }
 
         afterEvaluate {
@@ -277,8 +280,10 @@ configure(javaProjects) {
         }
     }
 
-    if (jacocoEnabled) {
-        tasks.test.finalizedBy(jacocoTestReport)
+    if (project.ext.jacocoEnabled) {
+        tasks.withType(Test) {
+            finalizedBy tasks.jacocoTestReport
+        }
     }
 
     // Require Java 8 to build the project.
@@ -758,11 +763,18 @@ configure(javaProjects) {
                     // Ignore known false positives.
                     lines.removeIf { it.contains('Only supported on Linux') }
                     switch (td.className) {
-                        case 'com.linecorp.armeria.server.AnnotatedServiceTest':
-                            lines.removeIf { it.contains('For input string: "fourty-two"') }
-                            break
                         case 'com.linecorp.armeria.client.zookeeper.EndpointGroupTest':
                             lines.removeIf { it.contains('ServerCnxn$EndOfStreamException') }
+                            break
+                        case 'com.linecorp.armeria.common.stream.StreamMessageDuplicatorTest':
+                            if (td.name.contains('abort')) {
+                                lines.removeIf {
+                                    it.contains('com.linecorp.armeria.common.stream.AbortedStreamException')
+                                }
+                            }
+                            break
+                        case 'com.linecorp.armeria.server.AnnotatedServiceTest':
+                            lines.removeIf { it.contains('For input string: "fourty-two"') }
                             break
                         case 'com.linecorp.armeria.server.zookeeper.ZooKeeperRegistrationTest':
                             lines.removeIf { it.contains('ServerCnxn$EndOfStreamException') }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -29,8 +29,28 @@ managedDependencies {
 
     // Reactive Streams
     compile 'org.reactivestreams:reactive-streams'
+    testCompile 'org.reactivestreams:reactive-streams-tck'
 }
 
+// Run the test cases based on reactive-streams-tck
+task testNg(type: Test,
+            group: 'Verification',
+            description: 'Runs the TestNG unit tests.') {
+    useTestNG()
+    testClassesDir = tasks.test.testClassesDir
+    classpath = tasks.test.classpath
+    scanForTestClasses = false
+}
+tasks.test.finalizedBy tasks.testNg
+tasks.check.dependsOn tasks.testNg
+
+jacocoTestReport {
+    // Include the coverage data from the TestNG test cases.
+    executionData file("${project.buildDir}/jacoco/testNg.exec")
+}
+
+// Task 'shadedJar' produces a very large JAR. Rename it to '*-untrimmed-*.jar' and
+// let the task 'trimShadedJar' produce the trimmed JAR from it.
 tasks.shadedJar.baseName = "${tasks.jar.baseName}-untrimmed"
 
 task trimShadedJar(type: ProGuardTask,

--- a/core/src/main/java/com/linecorp/armeria/client/HttpRequestSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpRequestSubscriber.java
@@ -33,6 +33,7 @@ import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpObject;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.logging.RequestLogBuilder;
+import com.linecorp.armeria.common.stream.AbortedStreamException;
 import com.linecorp.armeria.common.stream.ClosedPublisherException;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.internal.HttpObjectEncoder;
@@ -271,7 +272,7 @@ final class HttpRequestSubscriber implements Subscriber<HttpObject>, ChannelFutu
         if (response.isOpen()) {
             response.close(cause);
             error = Http2Error.INTERNAL_ERROR;
-        } else if (cause instanceof WriteTimeoutException) {
+        } else if (cause instanceof WriteTimeoutException || cause instanceof AbortedStreamException) {
             error = Http2Error.CANCEL;
         } else {
             Exceptions.logIfUnexpected(logger, ch,

--- a/core/src/main/java/com/linecorp/armeria/common/stream/AbortedStreamException.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AbortedStreamException.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.stream;
+
+import org.reactivestreams.Subscriber;
+
+import com.linecorp.armeria.common.Flags;
+import com.linecorp.armeria.common.util.Exceptions;
+
+/**
+ * A {@link RuntimeException} that is raised to signal a {@link Subscriber} that the {@link StreamMessage}
+ * it subscribed to has been aborted by {@link StreamMessage#abort()}.
+ */
+public final class AbortedStreamException extends RuntimeException {
+
+    private static final long serialVersionUID = -7665826869012452735L;
+
+    private static final AbortedStreamException INSTANCE =
+            Exceptions.clearTrace(new AbortedStreamException());
+
+    /**
+     * Returns a {@link AbortedStreamException} which may be a singleton or a new instance, depending on
+     * whether {@link Flags#verboseExceptions() the verbose exception mode} is enabled.
+     */
+    public static AbortedStreamException get() {
+        return Flags.verboseExceptions() ? new AbortedStreamException() : INSTANCE;
+    }
+
+    private AbortedStreamException() {}
+}

--- a/core/src/main/java/com/linecorp/armeria/common/stream/NeverInvokedSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/NeverInvokedSubscriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 LINE Corporation
+ * Copyright 2017 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -19,28 +19,32 @@ package com.linecorp.armeria.common.stream;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
-final class AbortingSubscriber<T> implements Subscriber<T> {
+final class NeverInvokedSubscriber<T> implements Subscriber<T> {
 
-    private static final AbortingSubscriber<Object> INSTANCE = new AbortingSubscriber<>();
+    private static final NeverInvokedSubscriber<Object> INSTANCE = new NeverInvokedSubscriber<>();
 
     @SuppressWarnings("unchecked")
-    static <T> AbortingSubscriber<T> get() {
-        return (AbortingSubscriber<T>) INSTANCE;
+    static <T> NeverInvokedSubscriber<T> get() {
+        return (NeverInvokedSubscriber<T>) INSTANCE;
     }
-
-    private AbortingSubscriber() {}
 
     @Override
     public void onSubscribe(Subscription s) {
-        s.cancel();
+        throw new IllegalStateException("onSubscribe(" + s + ')');
     }
 
     @Override
-    public void onNext(T o) {}
+    public void onNext(T t) {
+        throw new IllegalStateException("onNext(" + t + ')');
+    }
 
     @Override
-    public void onError(Throwable cause) {}
+    public void onError(Throwable t) {
+        throw new IllegalStateException("onError(" + t + ')', t);
+    }
 
     @Override
-    public void onComplete() {}
+    public void onComplete() {
+        throw new IllegalStateException("onComplete()");
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/NoopSubscription.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/NoopSubscription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 LINE Corporation
+ * Copyright 2017 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -16,31 +16,17 @@
 
 package com.linecorp.armeria.common.stream;
 
-import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
-final class AbortingSubscriber<T> implements Subscriber<T> {
+final class NoopSubscription implements Subscription {
 
-    private static final AbortingSubscriber<Object> INSTANCE = new AbortingSubscriber<>();
+    static final NoopSubscription INSTANCE = new NoopSubscription();
 
-    @SuppressWarnings("unchecked")
-    static <T> AbortingSubscriber<T> get() {
-        return (AbortingSubscriber<T>) INSTANCE;
-    }
-
-    private AbortingSubscriber() {}
+    private NoopSubscription() {}
 
     @Override
-    public void onSubscribe(Subscription s) {
-        s.cancel();
-    }
+    public void request(long n) {}
 
     @Override
-    public void onNext(T o) {}
-
-    @Override
-    public void onError(Throwable cause) {}
-
-    @Override
-    public void onComplete() {}
+    public void cancel() {}
 }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -89,20 +89,28 @@ public interface StreamMessage<T> extends Publisher<T> {
 
     /**
      * Returns a {@link CompletableFuture} that completes when this publisher is complete,
-     * either successfully or exceptionally.
+     * either successfully or exceptionally, including cancellation and abortion.
      */
     CompletableFuture<Void> closeFuture();
 
     /**
-     * Requests to start streaming data to the specified {@link Subscriber}.
-     *
-     * @throws IllegalStateException if there is a {@link Subscriber} who subscribed to this stream already
+     * Requests to start streaming data to the specified {@link Subscriber}. If there is a problem subscribing,
+     * {@link Subscriber#onError(Throwable)} will be invoked with one of the following exceptions:
+     * <ul>
+     *   <li>{@link IllegalStateException} if other {@link Subscriber} subscribed to this stream already</li>
+     *   <li>{@link AbortedStreamException} if this stream has been {@linkplain #abort() aborted}.</li>
+     * </ul>
      */
     @Override
     void subscribe(Subscriber<? super T> s);
 
     /**
-     * Requests to start streaming data to the specified {@link Subscriber}.
+     * Requests to start streaming data to the specified {@link Subscriber}. If there is a problem subscribing,
+     * {@link Subscriber#onError(Throwable)} will be invoked with one of the following exceptions:
+     * <ul>
+     *   <li>{@link IllegalStateException} if other {@link Subscriber} subscribed to this stream already</li>
+     *   <li>{@link AbortedStreamException} if this stream has been {@linkplain #abort() aborted}.</li>
+     * </ul>
      *
      * @param withPooledObjects if {@code true}, receives the pooled {@link ByteBuf} and {@link ByteBufHolder}
      *                          as is, without making a copy. If you don't know what this means, use
@@ -113,25 +121,35 @@ public interface StreamMessage<T> extends Publisher<T> {
 
     /**
      * Requests to start streaming data, invoking the specified {@link Subscriber} from the specified
-     * {@link Executor}.
-     *
-     * @throws IllegalStateException if there is a {@link Subscriber} who subscribed to this stream already
+     * {@link Executor}. If there is a problem subscribing, {@link Subscriber#onError(Throwable)} will be
+     * invoked with one of the following exceptions:
+     * <ul>
+     *   <li>{@link IllegalStateException} if other {@link Subscriber} subscribed to this stream already</li>
+     *   <li>{@link AbortedStreamException} if this stream has been {@linkplain #abort() aborted}.</li>
+     * </ul>
      */
     void subscribe(Subscriber<? super T> s, Executor executor);
 
     /**
      * Requests to start streaming data, invoking the specified {@link Subscriber} from the specified
-     * {@link Executor}.
+     * {@link Executor}. If there is a problem subscribing, {@link Subscriber#onError(Throwable)} will be
+     * invoked with one of the following exceptions:
+     * <ul>
+     *   <li>{@link IllegalStateException} if other {@link Subscriber} subscribed to this stream already</li>
+     *   <li>{@link AbortedStreamException} if this stream has been {@linkplain #abort() aborted}.</li>
+     * </ul>
      *
      * @param withPooledObjects if {@code true}, receives the pooled {@link ByteBuf} and {@link ByteBufHolder}
      *                          as is, without making a copy. If you don't know what this means, use
      *                          {@link StreamMessage#subscribe(Subscriber)}.
-     * @throws IllegalStateException if there is a {@link Subscriber} who subscribed to this stream already
      */
     void subscribe(Subscriber<? super T> s, Executor executor, boolean withPooledObjects);
 
     /**
-     * Cancels the {@link Subscription} if any and closes this publisher.
+     * Closes this publisher with {@link AbortedStreamException} and prevents further subscription.
+     * A {@link Subscriber} that attempts to subscribe to an aborted stream will be notified with
+     * an {@link AbortedStreamException} via {@link Subscriber#onError(Throwable)}. Calling this method
+     * on a closed or aborted stream has no effect.
      */
     void abort();
 }

--- a/core/src/test/java/com/linecorp/armeria/common/DefaultHttpRequestTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/DefaultHttpRequestTest.java
@@ -32,7 +32,7 @@ import org.junit.rules.DisableOnDebug;
 import org.junit.rules.TestRule;
 import org.junit.rules.Timeout;
 
-import com.linecorp.armeria.common.stream.CancelledSubscriptionException;
+import com.linecorp.armeria.common.stream.AbortedStreamException;
 
 public class DefaultHttpRequestTest {
 
@@ -51,7 +51,7 @@ public class DefaultHttpRequestTest {
 
         future.whenComplete((unused, cause) -> {
             callbackThread.set(Thread.currentThread());
-            assertThat(cause).isInstanceOf(CancelledSubscriptionException.class);
+            assertThat(cause).isInstanceOf(AbortedStreamException.class);
         });
 
         req.abort();
@@ -81,7 +81,7 @@ public class DefaultHttpRequestTest {
             await().until(() -> callbackThread.get() != null);
 
             assertThat(callbackThread.get()).isNotSameAs(mainThread);
-            assertThat(callbackCause.get()).isInstanceOf(CancelledSubscriptionException.class);
+            assertThat(callbackCause.get()).isInstanceOf(AbortedStreamException.class);
             assertThat(future).isCompletedExceptionally();
         } finally {
             executor.shutdownNow();

--- a/core/src/test/java/com/linecorp/armeria/common/DefaultHttpResponseTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/DefaultHttpResponseTest.java
@@ -32,7 +32,7 @@ import org.junit.rules.DisableOnDebug;
 import org.junit.rules.TestRule;
 import org.junit.rules.Timeout;
 
-import com.linecorp.armeria.common.stream.CancelledSubscriptionException;
+import com.linecorp.armeria.common.stream.AbortedStreamException;
 
 public class DefaultHttpResponseTest {
 
@@ -51,7 +51,7 @@ public class DefaultHttpResponseTest {
 
         future.whenComplete((unused, cause) -> {
             callbackThread.set(Thread.currentThread());
-            assertThat(cause).isInstanceOf(CancelledSubscriptionException.class);
+            assertThat(cause).isInstanceOf(AbortedStreamException.class);
         });
 
         res.abort();
@@ -81,7 +81,7 @@ public class DefaultHttpResponseTest {
             await().until(() -> callbackThread.get() != null);
 
             assertThat(callbackThread.get()).isNotSameAs(mainThread);
-            assertThat(callbackCause.get()).isInstanceOf(CancelledSubscriptionException.class);
+            assertThat(callbackCause.get()).isInstanceOf(AbortedStreamException.class);
             assertThat(future).isCompletedExceptionally();
         } finally {
             executor.shutdownNow();

--- a/core/src/test/java/com/linecorp/armeria/common/stream/DefaultStreamMessageVerification.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/DefaultStreamMessageVerification.java
@@ -1,0 +1,78 @@
+/*
+ *  Copyright 2017 LINE Corporation
+ *
+ *  LINE Corporation licenses this file to you under the Apache License,
+ *  version 2.0 (the "License"); you may not use this file except in compliance
+ *  with the License. You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package com.linecorp.armeria.common.stream;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+public class DefaultStreamMessageVerification extends StreamMessageVerification<Long> {
+
+    @Override
+    public StreamMessage<Long> createPublisher(long elements) {
+        return createStreamMessage(elements, false);
+    }
+
+    static StreamMessage<Long> createStreamMessage(long elements, boolean abort) {
+        final DefaultStreamMessage<Long> stream = new DefaultStreamMessage<>();
+        if (elements == 0) {
+            if (abort) {
+                stream.abort();
+            } else {
+                stream.close();
+            }
+            return stream;
+        }
+
+        final AtomicLong remaining = new AtomicLong(elements);
+        stream(elements, abort, remaining, stream);
+        return stream;
+    }
+
+    private static void stream(long elements, boolean abort,
+                               AtomicLong remaining, DefaultStreamMessage<Long> stream) {
+        stream.onDemand(() -> {
+            for (;;) {
+                final long r = remaining.decrementAndGet();
+                final boolean written = stream.write(elements - r);
+                if (r == 0) {
+                    if (abort) {
+                        stream.abort();
+                    } else {
+                        stream.close();
+                    }
+                    break;
+                }
+
+                if (!written) {
+                    stream(elements, abort, remaining, stream);
+                    break;
+                }
+            }
+        });
+    }
+
+    @Override
+    public StreamMessage<Long> createFailedPublisher() {
+        DefaultStreamMessage<Long> stream = new DefaultStreamMessage<>();
+        stream.subscribe(new NoopSubscriber<>());
+        return stream;
+    }
+
+    @Override
+    public StreamMessage<Long> createAbortedPublisher(long elements) {
+        return createStreamMessage(elements, true);
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/common/stream/DeferredStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/DeferredStreamMessageTest.java
@@ -19,8 +19,9 @@ package com.linecorp.armeria.common.stream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.util.ArrayList;
@@ -57,7 +58,7 @@ public class DeferredStreamMessageTest {
         final DeferredStreamMessage<Object> m = new DeferredStreamMessage<>();
         m.abort();
         assertAborted(m);
-        assertThatThrownBy(() -> m.subscribe(mock(Subscriber.class))).isInstanceOf(IllegalStateException.class);
+        assertFailedSubscription(m, AbortedStreamException.class);
     }
 
     @Test
@@ -96,7 +97,7 @@ public class DeferredStreamMessageTest {
         verify(subscriber).onSubscribe(any());
 
         m.abort();
-        verify(subscriber, never()).onError(any());
+        verify(subscriber, times(1)).onError(isA(AbortedStreamException.class));
 
         assertAborted(m);
         assertAborted(d);
@@ -110,7 +111,7 @@ public class DeferredStreamMessageTest {
         final Subscriber<Object> subscriber = mock(Subscriber.class);
 
         m.subscribe(subscriber);
-        assertThatThrownBy(() -> m.subscribe(mock(Subscriber.class))).isInstanceOf(IllegalStateException.class);
+        assertFailedSubscription(m, IllegalStateException.class);
 
         m.delegate(d);
         verify(subscriber).onSubscribe(any());
@@ -129,7 +130,7 @@ public class DeferredStreamMessageTest {
         m.subscribe(subscriber);
         verify(subscriber).onSubscribe(any());
 
-        assertThatThrownBy(() -> m.subscribe(mock(Subscriber.class))).isInstanceOf(IllegalStateException.class);
+        assertFailedSubscription(m, IllegalStateException.class);
     }
 
     private static void assertAborted(StreamMessage<?> m) {
@@ -137,7 +138,14 @@ public class DeferredStreamMessageTest {
         assertThat(m.isEmpty()).isTrue();
         assertThat(m.closeFuture()).isCompletedExceptionally();
         assertThatThrownBy(() -> m.closeFuture().get())
-                .hasCauseInstanceOf(CancelledSubscriptionException.class);
+                .hasCauseInstanceOf(AbortedStreamException.class);
+    }
+
+    private static void assertFailedSubscription(StreamMessage<?> m, Class<? extends Throwable> causeType) {
+        @SuppressWarnings("unchecked")
+        final Subscriber<Object> subscriber = mock(Subscriber.class);
+        m.subscribe(subscriber);
+        verify(subscriber, times(1)).onError(isA(causeType));
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/common/stream/DeferredStreamMessageVerification.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/DeferredStreamMessageVerification.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.stream;
+
+import static com.linecorp.armeria.common.stream.DefaultStreamMessageVerification.createStreamMessage;
+
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+public class DeferredStreamMessageVerification extends StreamMessageVerification<Long> {
+
+    @Override
+    public StreamMessage<Long> createPublisher(long elements) {
+        final DeferredStreamMessage<Long> stream = new DeferredStreamMessage<>();
+        stream.delegate(createStreamMessage(elements, false));
+        return stream;
+    }
+
+    @Override
+    public StreamMessage<Long> createFailedPublisher() {
+        final DeferredStreamMessage<Long> stream = new DeferredStreamMessage<>();
+        DefaultStreamMessage<Long> delegate = new DefaultStreamMessage<>();
+        delegate.subscribe(new NoopSubscriber<>());
+        stream.delegate(delegate);
+        return stream;
+    }
+
+    @Override
+    public StreamMessage<Long> createAbortedPublisher(long elements) {
+        final DeferredStreamMessage<Long> stream = new DeferredStreamMessage<>();
+        if (elements == 0) {
+            stream.abort();
+        }
+
+        stream.delegate(new StreamMessageWrapper<Long>(createStreamMessage(elements + 1, false)) {
+            @Override
+            public void subscribe(Subscriber<? super Long> subscriber, boolean withPooledObjects) {
+                super.subscribe(new Subscriber<Long>() {
+                    @Override
+                    public void onSubscribe(Subscription s) {
+                        subscriber.onSubscribe(s);
+                    }
+
+                    @Override
+                    public void onNext(Long value) {
+                        subscriber.onNext(value);
+                        if (elements == value) {
+                            stream.abort();
+                        }
+                    }
+
+                    @Override
+                    public void onError(Throwable cause) {
+                        subscriber.onError(cause);
+                    }
+
+                    @Override
+                    public void onComplete() {
+                        subscriber.onComplete();
+                    }
+                }, withPooledObjects);
+            }
+        });
+
+        return stream;
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/common/stream/PublisherBasedStreamMessageVerification.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/PublisherBasedStreamMessageVerification.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.stream;
+
+import static com.linecorp.armeria.common.stream.DefaultStreamMessageVerification.createStreamMessage;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+public class PublisherBasedStreamMessageVerification extends StreamMessageVerification<Long> {
+
+    @Override
+    public StreamMessage<Long> createPublisher(long elements) {
+        return new PublisherBasedStreamMessage<>(createStreamMessage(elements, false));
+    }
+
+    @Override
+    public StreamMessage<Long> createFailedPublisher() {
+        final Publisher<Long> publisher = s -> { /* noop */ };
+        final StreamMessage<Long> stream = new PublisherBasedStreamMessage<>(publisher);
+        stream.subscribe(NoopSubscriber.get());
+        return stream;
+    }
+
+    @Override
+    public StreamMessage<Long> createAbortedPublisher(long elements) {
+        if (elements == 0) {
+            final PublisherBasedStreamMessage<Long> stream
+                    = new PublisherBasedStreamMessage<>(s -> { /* noop */ });
+            stream.abort();
+            return stream;
+        }
+
+        final AtomicReference<StreamMessage<Long>> stream = new AtomicReference<>();
+        final Publisher<Long> publisher =
+                new StreamMessageWrapper<Long>(createStreamMessage(elements + 1, false)) {
+
+            @Override
+            public void subscribe(Subscriber<? super Long> subscriber) {
+                super.subscribe(new Subscriber<Long>() {
+                    @Override
+                    public void onSubscribe(Subscription s) {
+                        subscriber.onSubscribe(s);
+                        if (elements == 0) {
+                            stream.get().abort();
+                        }
+                    }
+
+                    @Override
+                    public void onNext(Long value) {
+                        subscriber.onNext(value);
+                        if (value == elements) {
+                            stream.get().abort();
+                        }
+                    }
+
+                    @Override
+                    public void onError(Throwable t) {
+                        subscriber.onError(t);
+                    }
+
+                    @Override
+                    public void onComplete() {
+                        subscriber.onComplete();
+                    }
+                });
+            }
+        };
+
+        stream.set(new PublisherBasedStreamMessage<>(publisher));
+        return stream.get();
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageDuplicatorVerification.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageDuplicatorVerification.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.stream;
+
+import static com.linecorp.armeria.common.stream.DefaultStreamMessageVerification.createStreamMessage;
+
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import org.testng.SkipException;
+
+public class StreamMessageDuplicatorVerification extends StreamMessageVerification<Long> {
+
+    @Override
+    public StreamMessage<Long> createPublisher(long elements) {
+        final StreamMessage<Long> source = createStreamMessage(elements, false);
+        final StreamMessageDuplicator duplicator = new StreamMessageDuplicator(source);
+        return duplicator.duplicateStream();
+    }
+
+    @Override
+    public StreamMessage<Long> createFailedPublisher() {
+        final StreamMessage<Long> source = new DefaultStreamMessage<>();
+        final StreamMessageDuplicator duplicator = new StreamMessageDuplicator(source);
+        final StreamMessage<Long> duplicate = duplicator.duplicateStream();
+        duplicate.subscribe(new NoopSubscriber<>());
+        return duplicate;
+    }
+
+    @Override
+    public StreamMessage<Long> createAbortedPublisher(long elements) {
+        final StreamMessage<Long> source = createStreamMessage(elements + 1, false);
+        final StreamMessageDuplicator duplicator = new StreamMessageDuplicator(source);
+        final StreamMessage<Long> duplicate = duplicator.duplicateStream();
+        if (elements == 0) {
+            duplicate.abort();
+            return duplicate;
+        }
+
+        return new StreamMessageWrapper<Long>(duplicate) {
+            @Override
+            public void subscribe(Subscriber<? super Long> subscriber) {
+                super.subscribe(new Subscriber<Long>() {
+                    @Override
+                    public void onSubscribe(Subscription s) {
+                        subscriber.onSubscribe(s);
+                    }
+
+                    @Override
+                    public void onNext(Long value) {
+                        subscriber.onNext(value);
+                        if (value == elements) {
+                            duplicate.abort();
+                        }
+                    }
+
+                    @Override
+                    public void onError(Throwable cause) {
+                        subscriber.onError(cause);
+                    }
+
+                    @Override
+                    public void onComplete() {
+                        subscriber.onComplete();
+                    }
+                });
+            }
+        };
+    }
+
+    @Override
+    public void required_spec317_mustNotSignalOnErrorWhenPendingAboveLongMaxValue() {
+        throw new SkipException(
+                "Can't test because duplicator cannot cancel the upstream subscription " +
+                "even if a downstream subscription has been cancelled. Duplicator will " +
+                "end up raising OOME because it has to keep all published signals.");
+    }
+
+    private static class StreamMessageDuplicator
+            extends AbstractStreamMessageDuplicator<Long, StreamMessage<Long>> {
+        StreamMessageDuplicator(StreamMessage<Long> publisher) {
+            super(publisher);
+        }
+
+        @Override
+        public StreamMessage<Long> doDuplicateStream(StreamMessage<Long> delegate) {
+            return new MulticastStream(delegate);
+        }
+
+        private static class MulticastStream extends StreamMessageWrapper<Long> {
+            MulticastStream(StreamMessage<Long> delegate) {
+                super(delegate);
+            }
+        }
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageVerification.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageVerification.java
@@ -1,0 +1,180 @@
+/*
+ *  Copyright 2017 LINE Corporation
+ *
+ *  LINE Corporation licenses this file to you under the Apache License,
+ *  version 2.0 (the "License"); you may not use this file except in compliance
+ *  with the License. You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package com.linecorp.armeria.common.stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.annotation.Nullable;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscription;
+import org.reactivestreams.tck.PublisherVerification;
+import org.reactivestreams.tck.TestEnvironment;
+import org.reactivestreams.tck.TestEnvironment.Latch;
+import org.reactivestreams.tck.TestEnvironment.ManualSubscriber;
+import org.reactivestreams.tck.TestEnvironment.TestSubscriber;
+import org.testng.SkipException;
+import org.testng.annotations.Test;
+
+public abstract class StreamMessageVerification<T> extends PublisherVerification<T> {
+
+    private final TestEnvironment env;
+
+    protected StreamMessageVerification() {
+        this(new TestEnvironment());
+    }
+
+    protected StreamMessageVerification(TestEnvironment env) {
+        super(env);
+        this.env = env;
+    }
+
+    @Override
+    public abstract StreamMessage<T> createPublisher(long elements);
+
+    @Override
+    public abstract StreamMessage<T> createFailedPublisher();
+
+    @Nullable
+    public abstract StreamMessage<T> createAbortedPublisher(long elements);
+
+    @Test
+    public void required_closeFutureMustCompleteOnTermination0() throws Throwable {
+        activePublisherTest(0, true, pub -> {
+            final ManualSubscriber<T> sub = env.newManualSubscriber(pub);
+            final StreamMessage<?> stream = (StreamMessage<?>) pub;
+
+            if (!(stream instanceof PublisherBasedStreamMessage)) {
+                // It's impossible for PublisherBasedStreamMessage to tell if the stream is
+                // closed or empty yet because Publisher doesn't have enough information.
+                assertThat(stream.isOpen()).isFalse();
+                assertThat(stream.isEmpty()).isTrue();
+            }
+
+            assertThat(stream.closeFuture()).isNotDone();
+            sub.requestEndOfStream();
+
+            assertThat(stream.isOpen()).isFalse();
+            assertThat(stream.isEmpty()).isTrue();
+            assertThat(stream.closeFuture()).isCompleted();
+            sub.expectNone();
+        });
+    }
+
+    @Test
+    public void required_closeFutureMustCompleteOnTermination1() throws Throwable {
+        activePublisherTest(1, true, pub -> {
+            final ManualSubscriber<T> sub = env.newManualSubscriber(pub);
+            final StreamMessage<?> stream = (StreamMessage<?>) pub;
+            assertThat(stream.isOpen()).isTrue();
+            assertThat(stream.isEmpty()).isFalse();
+
+            assertThat(stream.closeFuture()).isNotDone();
+            sub.requestNextElement();
+            sub.requestEndOfStream();
+            assertThat(stream.closeFuture()).isCompleted();
+            sub.expectNone();
+        });
+    }
+
+    @Test
+    public void required_closeFutureMustCompleteOnCancellation() throws Throwable {
+        activePublisherTest(10, true, pub -> {
+            final ManualSubscriber<T> sub = env.newManualSubscriber(pub);
+            final StreamMessage<?> stream = (StreamMessage<?>) pub;
+
+            assertThat(stream.closeFuture()).isNotDone();
+            sub.requestNextElement();
+            assertThat(stream.closeFuture()).isNotDone();
+            sub.cancel();
+            sub.expectNone();
+
+            assertThat(stream.closeFuture()).isCompletedExceptionally();
+            assertThatThrownBy(() -> stream.closeFuture().join())
+                    .isInstanceOf(CompletionException.class)
+                    .hasCauseInstanceOf(CancelledSubscriptionException.class);
+        });
+    }
+
+    /**
+     * Modified from {@link #optional_spec104_mustSignalOnErrorWhenFails()}.
+     */
+    @Test
+    public void required_subscribeOnAbortedStreamMustFail() throws Throwable {
+        final StreamMessage<T> pub = createAbortedPublisher(0);
+        assumeAbortedPublisherAvailable(pub);
+        assertThat(pub.isOpen()).isFalse();
+        assertThatThrownBy(() -> pub.closeFuture().join())
+                .isInstanceOf(CompletionException.class)
+                .hasCauseInstanceOf(AbortedStreamException.class);
+
+        final AtomicReference<Throwable> capturedCause = new AtomicReference<>();
+        final Latch onErrorLatch = new Latch(env);
+        final Latch onSubscribeLatch = new Latch(env);
+        pub.subscribe(new TestSubscriber<T>(env) {
+            @Override
+            public void onSubscribe(Subscription subs) {
+                onSubscribeLatch.assertOpen("Only one onSubscribe call expected");
+                onSubscribeLatch.close();
+            }
+
+            @Override
+            public void onError(Throwable cause) {
+                onSubscribeLatch.assertClosed("onSubscribe should be called prior to onError always");
+                onErrorLatch.assertOpen(String.format(
+                        "Error-state Publisher %s called `onError` twice on new Subscriber", pub));
+                capturedCause.set(cause);
+                onErrorLatch.close();
+            }
+        });
+
+        onSubscribeLatch.expectClose("Should have received onSubscribe");
+        onErrorLatch.expectClose(String.format(
+                "Error-state Publisher %s did not call `onError` on new Subscriber", pub));
+
+        env.verifyNoAsyncErrors();
+        assertThat(capturedCause.get()).isInstanceOf(AbortedStreamException.class);
+    }
+
+    @Test
+    public void required_abortMustNotifySubscriber() throws Throwable {
+        final StreamMessage<T> pub = createAbortedPublisher(1);
+        assumeAbortedPublisherAvailable(pub);
+        assertThat(pub.isOpen()).isTrue();
+
+        final ManualSubscriber<T> sub = env.newManualSubscriber(pub);
+        sub.request(1); // First element
+        assertThat(sub.nextElement()).isNotNull();
+        sub.request(1); // Abortion
+        sub.expectError(AbortedStreamException.class);
+
+        env.verifyNoAsyncErrorsNoDelay();
+        assertThatThrownBy(() -> pub.closeFuture().join())
+                .isInstanceOf(CompletionException.class)
+                .hasCauseInstanceOf(AbortedStreamException.class);
+    }
+
+    private void assumeAbortedPublisherAvailable(@Nullable Publisher<T> pub) {
+        if (pub == null) {
+            throw new SkipException("Skipping because no aborted StreamMessage provided.");
+        }
+    }
+}

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -171,7 +171,8 @@ org.mortbay.jetty.alpn:
   jetty-alpn-agent: { version: '2.0.6' }
 
 org.reactivestreams:
-  reactive-streams: { version: '1.0.0' }
+  reactive-streams: { version: &REACTIVE_STREAMS_VERSION '1.0.1-RC1' }
+  reactive-streams-tck: { version: *REACTIVE_STREAMS_VERSION }
 
 org.reflections:
   reflections:

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,7 +9,6 @@ include 'logback'
 include 'retrofit2'
 include 'spring-boot:autoconfigure'
 include 'spring-boot:starter'
-include 'testing'
 include 'thrift'
 include 'thrift0.9'
 include 'tomcat'
@@ -20,6 +19,7 @@ include 'zookeeper'
 // Unpublished Java projects
 include 'it'
 include 'shaded-test'
+include 'testing'
 
 // Site generation project
 include 'site'


### PR DESCRIPTION
Motivations:

- Our StreamMessage implementations do not pass Reactive Streams TCK.
- The contract of StreamMessage.abort() is not clear enough. It is
  undistinguishable for a Subscriber from a cancellation.

Modifications:

- Update Reactive Streams to 1.0.1-RC1
- Add Reactive Streams TCK 1.0.1-RC1 to the dependencies
  - Add core:testNg task because TCK uses TestNG rather than JUnit
  - Make sure core:testNg is included into test coverage
- Redefine the behavior of StreamMessage.abort()
  - Add AbortStreamException
  - Subscriber is notified with onError(AbortedStreamException)
- Add StreamMessageVerification which adds the tests on top of the TCK
- Make DefaultStreamMessage pass the TCK
- Make DeferrtedStreamMessage pass the TCK
- Make PublisherBasedStreamMessage pass the TCK
- Make AbstractStreamMessageDuplicator pass the TCK and clean it up
  - Do not keep the upstream closeFuture result in a separate field but
    keep it as an element of the signal list.
  - Moved some logic in the processor to DownstreamSubscription because
    I felt it reads better and they refer to the fields of
    DownstreamSubscrption more often than those of the processor.
  - Removed some compare-and-swap operations and volatile keywords for
    the fields that are only accessed from the same thread.

Result:

- We now know major StreamMessage implementations are really Reactive
  Streams.
- StreamMessage.abort() has better behavior.