### PR TITLE
(WIP) Enhance annotated service path mapping: HTTP method and media t…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/MediaType.java
+++ b/core/src/main/java/com/linecorp/armeria/common/MediaType.java
@@ -1,4 +1,19 @@
 /*
+ *  Copyright 2017 LINE Corporation
+ *
+ *  LINE Corporation licenses this file to you under the Apache License,
+ *  version 2.0 (the "License"); you may not use this file except in compliance
+ *  with the License. You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations
+ *  under the License.
+ */
+/*
  * Copyright (C) 2011 The Guava Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
@@ -100,6 +115,7 @@ public final class MediaType {
     private static final String VIDEO_TYPE = "video";
 
     private static final String WILDCARD = "*";
+    private static final String Q = "q";
 
     private static final Map<MediaType, MediaType> KNOWN_TYPES = Maps.newHashMap();
 
@@ -579,9 +595,25 @@ public final class MediaType {
         return withParameter(CHARSET_ATTRIBUTE, charset.name());
     }
 
-    /** Returns true if either the type or subtype is the wildcard. */
+    /**
+     * Returns true if either the type or subtype is the wildcard.
+     */
     public boolean hasWildcard() {
         return WILDCARD.equals(type) || WILDCARD.equals(subtype);
+    }
+
+    /**
+     * Returns the number of wildcards of this {@link MediaType}.
+     */
+    public int numWildcards() {
+        int numWildcards = 0;
+        if (WILDCARD.equals(type())) {
+            numWildcards++;
+        }
+        if (WILDCARD.equals(subtype())) {
+            numWildcards++;
+        }
+        return numWildcards;
     }
 
     /**
@@ -614,6 +646,53 @@ public final class MediaType {
         return (mediaTypeRange.type.equals(WILDCARD) || mediaTypeRange.type.equals(type)) &&
                (mediaTypeRange.subtype.equals(WILDCARD) || mediaTypeRange.subtype.equals(subtype)) &&
                parameters.entries().containsAll(mediaTypeRange.parameters.entries());
+    }
+
+    /**
+     * Returns {@code true} if this {@link MediaType} belongs to the given {@link MediaType}.
+     * Similar to what {@link MediaType#is(MediaType)} does except that this one compares the parameters
+     * case-insensitively and excludes 'q' parameter.
+     */
+    public boolean belongsTo(MediaType mediaTypeRange) {
+        return (mediaTypeRange.type.equals(WILDCARD) || mediaTypeRange.type.equals(type)) &&
+               (mediaTypeRange.subtype.equals(WILDCARD) || mediaTypeRange.subtype.equals(subtype)) &&
+               containsAllParameters(mediaTypeRange.parameters(), parameters());
+    }
+
+    /**
+     * Returns the quality factor of this {@link MediaType}. If it is not specified,
+     * {@code defaultValueIfNotSpecified} will be returned.
+     */
+    public float qualityFactor(float defaultValueIfNotSpecified) {
+        // Find 'q' or 'Q'.
+        final List<String> qValues = parameters().get(Q);
+        if (qValues == null || qValues.isEmpty()) {
+            // qvalue does not exist.
+            return defaultValueIfNotSpecified;
+        }
+
+        try {
+            // Parse the qvalue. Make sure it's within the range of [0, 1].
+            return Math.max(Math.min(Float.parseFloat(qValues.get(0)), 1.0f), 0.0f);
+        } catch (NumberFormatException e) {
+            // The range with a malformed qvalue gets the lowest possible preference.
+            return 0.0f;
+        }
+    }
+
+    /**
+     * Returns the quality factor of this {@link MediaType}. If it is not specified,
+     * {@code 1.0f} will be returned.
+     */
+    public float qualityFactor() {
+        return qualityFactor(1.0f);
+    }
+
+    /**
+     * Returns a name of this {@link MediaType} only consisting of the type and the sub type.
+     */
+    public String nameWithoutParameters() {
+        return type() + '/' + subtype();
     }
 
     /**
@@ -855,5 +934,60 @@ public final class MediaType {
             escaped.append(ch);
         }
         return escaped.append('"').toString();
+    }
+
+    /**
+     * Returns {@code true} if {@code actualParameters} contains all entries of {@code expectedParameters}.
+     * Note that this method does <b>not</b> require {@code actualParameters} to contain <b>only</b> the
+     * entries of {@code expectedParameters}. i.e. {@code actualParameters} can contain an entry that's
+     * non-existent in {@code expectedParameters}.
+     */
+    private static boolean containsAllParameters(Map<String, List<String>> expectedParameters,
+                                                 Map<String, List<String>> actualParameters) {
+        if (expectedParameters.isEmpty()) {
+            return true;
+        }
+
+        for (Entry<String, List<String>> requiredEntry : expectedParameters.entrySet()) {
+            final String expectedName = requiredEntry.getKey();
+            final List<String> expectedValues = requiredEntry.getValue();
+            if (Q.equals(expectedName)) {
+                continue;
+            }
+
+            final List<String> actualValues = actualParameters.get(expectedName);
+
+            assert !expectedValues.isEmpty();
+            if (actualValues == null || actualValues.isEmpty()) {
+                // Does not contain any required values.
+                return false;
+            }
+
+            if (!containsAllValues(expectedValues, actualValues)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static boolean containsAllValues(List<String> expectedValues, List<String> actualValues) {
+        final int numRequiredValues = expectedValues.size();
+        for (int i = 0; i < numRequiredValues; i++) {
+            if (!containsValue(expectedValues.get(i), actualValues)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean containsValue(String expectedValue, List<String> actualValues) {
+        final int numActualValues = actualValues.size();
+        for (int i = 0; i < numActualValues; i++) {
+            if (Ascii.equalsIgnoreCase(expectedValue, actualValues.get(i))) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/AbstractPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AbstractPathMapping.java
@@ -20,20 +20,19 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Optional;
 
-import javax.annotation.Nullable;
-
 /**
- * A skeletal {@link PathMapping} implementation. Implement {@link #doApply(String, String)}.
+ * A skeletal {@link PathMapping} implementation. Implement {@link #doApply(PathMappingContext)}.
  */
 public abstract class AbstractPathMapping implements PathMapping {
 
     /**
      * {@inheritDoc} This method performs sanity checks on the specified {@code path} and calls
-     * {@link #doApply(String, String)}.
+     * {@link #doApply(PathMappingContext)}.
      */
     @Override
-    public final PathMappingResult apply(String path, @Nullable String query) {
-        return doApply(ensureAbsolutePath(path, "path"), query);
+    public final PathMappingResult apply(PathMappingContext mappingCtx) {
+        ensureAbsolutePath(mappingCtx.path(), "path");
+        return doApply(mappingCtx);
     }
 
     /**
@@ -53,16 +52,15 @@ public abstract class AbstractPathMapping implements PathMapping {
     }
 
     /**
-     * Invoked by {@link #apply(String, String)} to perform the actual path matching and path parameter
+     * Invoked by {@link #apply(PathMappingContext)} to perform the actual path matching and path parameter
      * extraction.
      *
-     * @param path an absolute path, as defined in <a href="https://tools.ietf.org/html/rfc3986">RFC3986</a>
-     * @param query a query, as defined in <a href="https://tools.ietf.org/html/rfc3986">RFC3986</a>.
-     *              {@code null} if query does not exist.
+     * @param mappingCtx a context to find the {@link Service}
+     *
      * @return a non-empty {@link PathMappingResult} if the specified {@code path} matches this mapping.
      *         {@link PathMappingResult#empty()} if not matches.
      */
-    protected abstract PathMappingResult doApply(String path, @Nullable String query);
+    protected abstract PathMappingResult doApply(PathMappingContext mappingCtx);
 
     @Override
     public String loggerName() {

--- a/core/src/main/java/com/linecorp/armeria/server/CatchAllPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/CatchAllPathMapping.java
@@ -19,8 +19,6 @@ package com.linecorp.armeria.server;
 import java.util.Optional;
 import java.util.Set;
 
-import javax.annotation.Nullable;
-
 import com.google.common.collect.ImmutableSet;
 
 final class CatchAllPathMapping extends AbstractPathMapping {
@@ -33,8 +31,8 @@ final class CatchAllPathMapping extends AbstractPathMapping {
     private CatchAllPathMapping() {}
 
     @Override
-    protected PathMappingResult doApply(String path, @Nullable String query) {
-        return PathMappingResult.of(path, query);
+    protected PathMappingResult doApply(PathMappingContext mappingCtx) {
+        return PathMappingResult.of(mappingCtx.path(), mappingCtx.query());
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultPathMapping.java
@@ -26,8 +26,6 @@ import java.util.StringJoiner;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.annotation.Nullable;
-
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
@@ -175,21 +173,21 @@ final class DefaultPathMapping extends AbstractPathMapping {
     }
 
     @Override
-    protected PathMappingResult doApply(String path, @Nullable String query) {
-        final Matcher matcher = pattern.matcher(path);
+    protected PathMappingResult doApply(PathMappingContext mappingCtx) {
+        final Matcher matcher = pattern.matcher(mappingCtx.path());
         if (!matcher.matches()) {
             return PathMappingResult.empty();
         }
 
         if (paramNameArray.length == 0) {
-            return PathMappingResult.of(path, query);
+            return PathMappingResult.of(mappingCtx.path(), mappingCtx.query());
         }
 
         final ImmutableMap.Builder<String, String> pathParams = ImmutableMap.builder();
         for (int i = 0; i < paramNameArray.length; i++) {
             pathParams.put(paramNameArray[i], matcher.group(i + 1));
         }
-        return PathMappingResult.of(path, query, pathParams.build());
+        return PathMappingResult.of(mappingCtx.path(), mappingCtx.query(), pathParams.build());
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultPathMappingContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultPathMappingContext.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringJoiner;
+
+import javax.annotation.Nullable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.MediaTypeSet;
+
+/**
+ * Holds the parameters which are required to find a service available to handle the request.
+ */
+final class DefaultPathMappingContext implements PathMappingContext {
+    private static final Logger logger = LoggerFactory.getLogger(DefaultPathMappingContext.class);
+
+    private static final Splitter ACCEPT_SPLITTER = Splitter.on(',').trimResults();
+
+    private final String hostname;
+    private final HttpMethod method;
+    private final String path;
+    private final String query;
+    private final MediaType consumeType;
+    private final List<MediaType> produceTypes;
+    private final String summary;
+
+    DefaultPathMappingContext(String hostname, HttpMethod method, String path, @Nullable String query,
+                              @Nullable MediaType consumeType, @Nullable List<MediaType> produceTypes) {
+        this.hostname = requireNonNull(hostname, "hostname");
+        this.method = requireNonNull(method, "method");
+        this.path = requireNonNull(path, "path");
+        this.query = query;
+        this.consumeType = consumeType;
+        this.produceTypes = produceTypes == null ? ImmutableList.of() : produceTypes;
+        summary = generateSummary(this);
+    }
+
+    @Override
+    public String hostname() {
+        return hostname;
+    }
+
+    @Override
+    public HttpMethod method() {
+        return method;
+    }
+
+    @Override
+    public String path() {
+        return path;
+    }
+
+    @Nullable
+    @Override
+    public String query() {
+        return query;
+    }
+
+    @Nullable
+    @Override
+    public MediaType consumeType() {
+        return consumeType;
+    }
+
+    @Override
+    public List<MediaType> produceTypes() {
+        return produceTypes;
+    }
+
+    @Override
+    public String summary() {
+        return summary;
+    }
+
+    @Override
+    public int hashCode() {
+        return summary().hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof DefaultPathMappingContext &&
+               (this == obj || summary().equals(((DefaultPathMappingContext) obj).summary()));
+    }
+
+    @Override
+    public String toString() {
+        return summary();
+    }
+
+    /**
+     * Returns a new {@link PathMappingContext} instance.
+     */
+    @VisibleForTesting
+    static PathMappingContext of(String hostname, String path, @Nullable String query,
+                                 HttpHeaders headers, @Nullable MediaTypeSet producibleMediaTypes) {
+        final MediaType consumeType = resolveConsumeType(headers);
+        final List<MediaType> produceTypes = resolveProduceTypes(headers, producibleMediaTypes);
+        return new DefaultPathMappingContext(hostname, headers.method(), path, query,
+                                             consumeType, produceTypes);
+    }
+
+    @VisibleForTesting
+    static MediaType resolveConsumeType(HttpHeaders headers) {
+        final String contentType = headers.get(HttpHeaderNames.CONTENT_TYPE);
+        if (contentType != null) {
+            try {
+                return MediaType.parse(contentType);
+            } catch (IllegalArgumentException e) {
+                logger.debug("Failed to parse the 'content-type' header: {}", contentType, e);
+            }
+        }
+        return null;
+    }
+
+    @VisibleForTesting
+    static List<MediaType> resolveProduceTypes(HttpHeaders headers, MediaTypeSet producibleMediaTypes) {
+        if (producibleMediaTypes == null || producibleMediaTypes.isEmpty()) {
+            return ImmutableList.of();
+        }
+
+        final List<MediaType> selectedTypes = new ArrayList<>(4);
+
+        final List<String> acceptHeaders = headers.getAll(HttpHeaderNames.ACCEPT);
+        for (String acceptHeader : acceptHeaders) {
+            for (String value : ACCEPT_SPLITTER.split(acceptHeader)) {
+                try {
+                    final MediaType type = MediaType.parse(value);
+                    for (MediaType producibleMediaType : producibleMediaTypes) {
+                        if (producibleMediaType.belongsTo(type)) {
+                            selectedTypes.add(type);
+                            break;
+                        }
+                    }
+                } catch (IllegalArgumentException e) {
+                    logger.debug("Failed to parse the media type in 'accept' header: {}", value, e);
+                }
+            }
+        }
+
+        if (selectedTypes.size() > 1) {
+            selectedTypes.sort(DefaultPathMappingContext::compareMediaType);
+        }
+        return selectedTypes;
+    }
+
+    @VisibleForTesting
+    static int compareMediaType(MediaType m1, MediaType m2) {
+        // The order should be "q=1.0, q=0.5".
+        // To ensure descending order, we pass the q values of m2 and m1 respectively.
+        final int qCompare = Float.compare(m2.qualityFactor(), m1.qualityFactor());
+        if (qCompare != 0) {
+            return qCompare;
+        }
+        // The order should be "application/*, */*".
+        final int wildcardCompare = Integer.compare(m1.numWildcards(), m2.numWildcards());
+        if (wildcardCompare != 0) {
+            return wildcardCompare;
+        }
+        // Finally, sort by lexicographic order. ex, application/*, image/*
+        return m1.type().compareTo(m2.type());
+    }
+
+    /**
+     * Returns a summary string of the given {@link PathMappingContext}.
+     */
+    static String generateSummary(PathMappingContext mappingCtx) {
+        requireNonNull(mappingCtx, "mappingCtx");
+
+        StringJoiner summary = new StringJoiner(":");
+
+        summary.add(mappingCtx.hostname())
+               .add(mappingCtx.method().name())
+               .add(mappingCtx.path());
+
+        // Here, the parameters belonging to the media type are not necessary.
+        MediaType consumeType = mappingCtx.consumeType();
+        if (consumeType != null) {
+            summary.add(consumeType.nameWithoutParameters());
+        }
+
+        List<MediaType> produceTypes = mappingCtx.produceTypes();
+        if (produceTypes != null) {
+            produceTypes.forEach(type -> summary.add(type.nameWithoutParameters()));
+        }
+        return summary.toString();
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
@@ -29,7 +29,6 @@ import javax.net.ssl.SSLSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.NonWrappingRequestContext;
@@ -49,6 +48,7 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
 
     private final Channel ch;
     private final ServiceConfig cfg;
+    private final PathMappingContext pathMappingContext;
     private final PathMappingResult pathMappingResult;
     private final SSLSession sslSession;
 
@@ -75,16 +75,15 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
      */
     public DefaultServiceRequestContext(
             ServiceConfig cfg, Channel ch, SessionProtocol sessionProtocol,
-            HttpMethod method, String path, PathMappingResult pathMappingResult, Object request,
+            PathMappingContext pathMappingContext, PathMappingResult pathMappingResult, Object request,
             @Nullable SSLSession sslSession) {
 
-        super(sessionProtocol, method,
-              path,
-              pathMappingResult.query(),
-              request);
+        super(sessionProtocol, pathMappingContext.method(), pathMappingContext.path(),
+              pathMappingResult.query(), request);
 
         this.ch = ch;
         this.cfg = cfg;
+        this.pathMappingContext = pathMappingContext;
         this.pathMappingResult = pathMappingResult;
         this.sslSession = sslSession;
 
@@ -125,6 +124,11 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
     @Override
     public PathMapping pathMapping() {
         return cfg.pathMapping();
+    }
+
+    @Override
+    public PathMappingContext pathMappingContext() {
+        return pathMappingContext;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/ExactPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ExactPathMapping.java
@@ -19,8 +19,6 @@ package com.linecorp.armeria.server;
 import java.util.Optional;
 import java.util.Set;
 
-import javax.annotation.Nullable;
-
 import com.google.common.collect.ImmutableSet;
 
 final class ExactPathMapping extends AbstractPathMapping {
@@ -41,9 +39,9 @@ final class ExactPathMapping extends AbstractPathMapping {
     }
 
     @Override
-    protected PathMappingResult doApply(String path, @Nullable String query) {
-        return exactPath.equals(path) ? PathMappingResult.of(path, query)
-                                      : PathMappingResult.empty();
+    protected PathMappingResult doApply(PathMappingContext mappingCtx) {
+        return exactPath.equals(mappingCtx.path()) ? PathMappingResult.of(mappingCtx.path(), mappingCtx.query())
+                                                   : PathMappingResult.empty();
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/GlobPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/GlobPathMapping.java
@@ -22,8 +22,6 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.annotation.Nullable;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -81,14 +79,14 @@ final class GlobPathMapping extends AbstractPathMapping {
     }
 
     @Override
-    protected PathMappingResult doApply(String path, @Nullable String query) {
-        final Matcher m = pattern.matcher(path);
+    protected PathMappingResult doApply(PathMappingContext mappingCtx) {
+        final Matcher m = pattern.matcher(mappingCtx.path());
         if (!m.matches()) {
             return PathMappingResult.empty();
         }
 
         if (numParams == 0) {
-            return PathMappingResult.of(path, query);
+            return PathMappingResult.of(mappingCtx.path(), mappingCtx.query());
         }
 
         final ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
@@ -97,7 +95,7 @@ final class GlobPathMapping extends AbstractPathMapping {
             params.put(int2str(i - 1), value);
         }
 
-        return PathMappingResult.of(path, query, params.build());
+        return PathMappingResult.of(mappingCtx.path(), mappingCtx.query(), params.build());
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/HttpHeaderPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpHeaderPathMapping.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.StringJoiner;
+
+import javax.annotation.Nullable;
+
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.MediaType;
+
+/**
+ * A {@link PathMapping} based on {@link HttpMethod} and {@link MediaType}.
+ */
+final class HttpHeaderPathMapping implements PathMapping {
+
+    private final PathMapping pathStringMapping;
+    private final Set<HttpMethod> supportedMethods;
+    @Nullable
+    private final MediaType consumeType;
+    @Nullable
+    private final MediaType produceType;
+
+    private final String loggerName;
+    private final String metricName;
+
+    HttpHeaderPathMapping(PathMapping pathStringMapping, Set<HttpMethod> supportedMethods,
+                          @Nullable MediaType consumeType, @Nullable MediaType produceType) {
+        this.pathStringMapping = requireNonNull(pathStringMapping, "pathStringMapping");
+        this.supportedMethods = requireNonNull(supportedMethods, "supportedMethods");
+        this.consumeType = consumeType;
+        this.produceType = produceType;
+
+        loggerName = generateName(".", pathStringMapping.loggerName(),
+                                  supportedMethods, consumeType, produceType);
+        metricName = generateName("/", pathStringMapping.metricName(),
+                                  supportedMethods, consumeType, produceType);
+    }
+
+    @Override
+    public PathMappingResult apply(PathMappingContext mappingCtx) {
+        if (!supportedMethods.contains(mappingCtx.method())) {
+            return PathMappingResult.empty();
+        }
+
+        final PathMappingResult result = pathStringMapping.apply(mappingCtx);
+        if (result.isPresent()) {
+            if (consumeType != null) {
+                final MediaType type = mappingCtx.consumeType();
+                if (type == null || !type.belongsTo(consumeType)) {
+                    return PathMappingResult.empty();
+                }
+            }
+            if (produceType != null) {
+                final List<MediaType> types = mappingCtx.produceTypes();
+                for (int i = 0; i < types.size(); i++) {
+                    if (produceType.belongsTo(types.get(i))) {
+                        // To early stop path mapping traversal,
+                        // we set the score as the best score when the index is 0.
+                        result.setScore(i == 0 ? PathMappingResult.HIGHEST_SCORE : -1 * i);
+                        return result;
+                    }
+                }
+                return PathMappingResult.empty();
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public Set<String> paramNames() {
+        return pathStringMapping.paramNames();
+    }
+
+    @Override
+    public String loggerName() {
+        return loggerName;
+    }
+
+    @Override
+    public String metricName() {
+        return metricName;
+    }
+
+    @Override
+    public Optional<String> exactPath() {
+        return pathStringMapping.exactPath();
+    }
+
+    @Override
+    public Optional<String> prefix() {
+        return pathStringMapping.prefix();
+    }
+
+    public PathMapping pathStringMapping() {
+        return pathStringMapping;
+    }
+
+    public Set<HttpMethod> supportedMethods() {
+        return supportedMethods;
+    }
+
+    @Nullable
+    public MediaType consumeType() {
+        return consumeType;
+    }
+
+    @Nullable
+    public MediaType produceType() {
+        return produceType;
+    }
+
+    private static String generateName(String delim, String prefix, Set<HttpMethod> supportedMethods,
+                                       MediaType consumeType, MediaType produceType) {
+        final StringJoiner methodNames = new StringJoiner("_");
+        supportedMethods.forEach(e -> methodNames.add(e.name()));
+        StringJoiner name = new StringJoiner(delim).add(prefix)
+                                                   .add(methodNames.toString());
+        if (consumeType != null) {
+            name.add(consumeType.type() + '_' + consumeType.subtype());
+        } else {
+            name.add("_");
+        }
+        if (produceType != null) {
+            name.add(produceType.type() + '_' + produceType.subtype());
+        } else {
+            name.add("_");
+        }
+        return name.toString();
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/PathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/PathMapping.java
@@ -21,8 +21,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
 
-import javax.annotation.Nullable;
-
 import com.linecorp.armeria.server.docs.DocService;
 
 /**
@@ -158,13 +156,12 @@ public interface PathMapping {
     /**
      * Matches the specified {@code path} and extracts the path parameters from it.
      *
-     * @param path an absolute path, as defined in <a href="https://tools.ietf.org/html/rfc3986">RFC3986</a>
-     * @param query a query, as defined in <a href="https://tools.ietf.org/html/rfc3986">RFC3986</a>.
-     *              {@code null} if query does not exist.
+     * @param mappingCtx a context to find the {@link Service}.
+     *
      * @return a non-empty {@link PathMappingResult} if the specified {@code path} matches this mapping.
      *         {@link PathMappingResult#empty()} if not matches.
      */
-    PathMappingResult apply(String path, @Nullable String query);
+    PathMappingResult apply(PathMappingContext mappingCtx);
 
     /**
      * Returns the names of the path parameters extracted by this mapping.

--- a/core/src/main/java/com/linecorp/armeria/server/PathMappingContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/PathMappingContext.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.MediaType;
+
+/**
+ * Holds the parameters which are required to find a service available to handle the request.
+ */
+public interface PathMappingContext {
+
+    /**
+     * Returns the virtual host name of the request.
+     */
+    String hostname();
+
+    /**
+     * Returns {@link HttpMethod} of the request.
+     */
+    HttpMethod method();
+
+    /**
+     * Returns the absolute path retrieved from the request,
+     * as defined in <a href="https://tools.ietf.org/html/rfc3986">RFC3986</a>.
+     */
+    String path();
+
+    /**
+     * Returns the query retrieved from the request,
+     * as defined in <a href="https://tools.ietf.org/html/rfc3986">RFC3986</a>.
+     */
+    @Nullable
+    String query();
+
+    /**
+     * Returns {@link MediaType} specified by 'Content-Type' header of the request.
+     */
+    @Nullable
+    MediaType consumeType();
+
+    /**
+     * Returns a list of {@link MediaType} that is ordered by client-side preferences.
+     * It only includes the media types supported by the virtual host.
+     */
+    List<MediaType> produceTypes();
+
+    /**
+     * Returns an identifier of this {@link PathMappingContext} instance.
+     * It would be used as a cache key to reduce pattern list traversal.
+     */
+    String summary();
+
+    /**
+     * Returns a wrapped {@link PathMappingContext} which holds the specified {@code path}.
+     * It is usually used to find a {@link Service} with a prefix-stripped path.
+     */
+    default PathMappingContext overridePath(String path) {
+        requireNonNull(path, "path");
+        return new PathMappingContextWrapper(this) {
+            @Override
+            public String path() {
+                return path;
+            }
+        };
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/PathMappingContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/server/PathMappingContextWrapper.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static com.linecorp.armeria.server.DefaultPathMappingContext.generateSummary;
+
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.MediaType;
+
+/**
+ * A wrapper class of {@link PathMappingContext}. This would be used to override a parameter of the
+ * existing {@link PathMappingContext} instance.
+ */
+class PathMappingContextWrapper implements PathMappingContext {
+
+    private final PathMappingContext delegate;
+    private String summary;
+
+    PathMappingContextWrapper(PathMappingContext delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public String hostname() {
+        return delegate().hostname();
+    }
+
+    @Override
+    public HttpMethod method() {
+        return delegate().method();
+    }
+
+    @Override
+    public String path() {
+        return delegate().path();
+    }
+
+    @Nullable
+    @Override
+    public String query() {
+        return delegate().query();
+    }
+
+    @Nullable
+    @Override
+    public MediaType consumeType() {
+        return delegate().consumeType();
+    }
+
+    @Override
+    public List<MediaType> produceTypes() {
+        return delegate().produceTypes();
+    }
+
+    @Override
+    public String summary() {
+        if (summary == null) {
+            summary = generateSummary(this);
+        }
+        return summary;
+    }
+
+    @Override
+    public int hashCode() {
+        return summary().hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof PathMappingContext && summary().equals(obj);
+    }
+
+    @Override
+    public String toString() {
+        return summary();
+    }
+
+    protected final PathMappingContext delegate() {
+        return delegate;
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/PathMappingResult.java
+++ b/core/src/main/java/com/linecorp/armeria/server/PathMappingResult.java
@@ -25,15 +25,18 @@ import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableMap;
 
 /**
- * The result returned by {@link PathMapping#apply(String, String)}.
+ * The result returned by {@link PathMapping#apply(PathMappingContext)}.
  */
 public final class PathMappingResult {
 
-    private static final PathMappingResult EMPTY = new PathMappingResult(null, null, null);
+    static final int LOWEST_SCORE = Integer.MIN_VALUE;
+    static final int HIGHEST_SCORE = Integer.MAX_VALUE;
+
+    private static final PathMappingResult EMPTY = new PathMappingResult(null, null, null, LOWEST_SCORE);
 
     /**
      * The {@link PathMappingResult} whose {@link #isPresent()} returns {@code false}. It is returned by
-     * {@link PathMapping#apply(String, String)} when the specified path did not match.
+     * {@link PathMapping#apply(PathMappingContext)} when the specified path did not match.
      */
     public static PathMappingResult empty() {
         return EMPTY;
@@ -50,23 +53,35 @@ public final class PathMappingResult {
      * Creates a new instance with the specified {@code path}, {@code query} and the extracted path parameters.
      */
     public static PathMappingResult of(String path, @Nullable String query, Map<String, String> pathParams) {
+        return of(path, query, pathParams, LOWEST_SCORE);
+    }
+
+    /**
+     * Creates a new instance with the specified {@code path}, {@code query}, the extracted path parameters
+     * and the score.
+     */
+    public static PathMappingResult of(String path, @Nullable String query,
+                                       Map<String, String> pathParams, int score) {
         requireNonNull(path, "path");
         requireNonNull(pathParams, "pathParams");
-        return new PathMappingResult(path, query, pathParams);
+        return new PathMappingResult(path, query, pathParams, score);
     }
 
     private final String path;
     private final String query;
     private final Map<String, String> pathParams;
 
+    private int score;
+
     private PathMappingResult(@Nullable String path, @Nullable String query,
-                              @Nullable Map<String, String> pathParams) {
+                              @Nullable Map<String, String> pathParams, int score) {
         assert path == null && query == null && pathParams == null ||
                path != null && pathParams != null;
 
         this.path = path;
         this.query = query;
         this.pathParams = pathParams != null ? ImmutableMap.copyOf(pathParams) : null;
+        this.score = score;
     }
 
     /**
@@ -108,6 +123,38 @@ public final class PathMappingResult {
         return pathParams;
     }
 
+    /**
+     * Returns the score of this result.
+     * {@link Integer#MAX_VALUE} is the highest score of the result, and {@link Integer#MIN_VALUE} is the
+     * lowest score of the result.
+     */
+    public int score() {
+        ensurePresence();
+        return score;
+    }
+
+    /**
+     * Returns that whether the score of this result is the highest or not.
+     */
+    public boolean isHighestScore() {
+        return HIGHEST_SCORE == score();
+    }
+
+    /**
+     * Returns that whether the score of this result is the lowest or not.
+     */
+    public boolean isLowestScore() {
+        return LOWEST_SCORE == score();
+    }
+
+    /**
+     * Sets the new score of this result.
+     */
+    public void setScore(int score) {
+        ensurePresence();
+        this.score = score;
+    }
+
     private void ensurePresence() {
         if (!isPresent()) {
             throw new IllegalStateException("mapping unavailable");
@@ -121,6 +168,7 @@ public final class PathMappingResult {
                               .add("path", path)
                               .add("query", query)
                               .add("pathParams", pathParams)
+                              .add("score", score)
                               .toString();
         } else {
             return getClass().getSimpleName() + "{<empty>}";

--- a/core/src/main/java/com/linecorp/armeria/server/PrefixPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/PrefixPathMapping.java
@@ -19,8 +19,6 @@ package com.linecorp.armeria.server;
 import java.util.Optional;
 import java.util.Set;
 
-import javax.annotation.Nullable;
-
 import com.google.common.collect.ImmutableSet;
 
 final class PrefixPathMapping extends AbstractPathMapping {
@@ -48,12 +46,14 @@ final class PrefixPathMapping extends AbstractPathMapping {
     }
 
     @Override
-    protected PathMappingResult doApply(String path, @Nullable String query) {
+    protected PathMappingResult doApply(PathMappingContext mappingCtx) {
+        final String path = mappingCtx.path();
         if (!path.startsWith(prefix)) {
             return PathMappingResult.empty();
         }
 
-        return PathMappingResult.of(stripPrefix ? path.substring(prefix.length() - 1) : path, query);
+        return PathMappingResult.of(stripPrefix ? path.substring(prefix.length() - 1) : path,
+                                    mappingCtx.query());
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/RegexPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RegexPathMapping.java
@@ -22,8 +22,6 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.annotation.Nullable;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -61,8 +59,8 @@ final class RegexPathMapping extends AbstractPathMapping {
     }
 
     @Override
-    protected PathMappingResult doApply(String path, @Nullable String query) {
-        final Matcher matcher = regex.matcher(path);
+    protected PathMappingResult doApply(PathMappingContext mappingCtx) {
+        final Matcher matcher = regex.matcher(mappingCtx.path());
         if (!matcher.find()) {
             return PathMappingResult.empty();
         }
@@ -80,7 +78,8 @@ final class RegexPathMapping extends AbstractPathMapping {
             builder.put(name, value);
         }
 
-        return PathMappingResult.of(path, query, builder != null ? builder.build() : ImmutableMap.of());
+        return PathMappingResult.of(mappingCtx.path(), mappingCtx.query(),
+                                    builder != null ? builder.build() : ImmutableMap.of());
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
@@ -212,7 +212,7 @@ public final class ServerConfig {
                 h.defaultHostname(), "*", sslCtx,
                 h.serviceConfigs().stream().map(
                         e -> new ServiceConfig(e.pathMapping(), e.service(), e.loggerName().orElse(null)))
-                 .collect(Collectors.toList()));
+                 .collect(Collectors.toList()), h.producibleMediaTypes());
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
@@ -53,6 +53,11 @@ public interface ServiceRequestContext extends RequestContext {
     PathMapping pathMapping();
 
     /**
+     * Returns the {@link PathMappingContext} used to find the {@link Service}.
+     */
+    PathMappingContext pathMappingContext();
+
+    /**
      * Returns the path parameters mapped by the {@link PathMapping} associated with the {@link Service}
      * that is handling the current {@link Request}.
      */

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
@@ -55,6 +55,11 @@ public class ServiceRequestContextWrapper
     }
 
     @Override
+    public PathMappingContext pathMappingContext() {
+        return delegate().pathMappingContext();
+    }
+
+    @Override
     public Map<String, String> pathParams() {
         return delegate().pathParams();
     }

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/ConsumeType.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/ConsumeType.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Specifies a media type which would be consumed by the service method.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface ConsumeType {
+
+    /**
+     * A media type string.
+     */
+    String value();
+}

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/ProduceType.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/ProduceType.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Specifies a media type which would be produced by the service method.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface ProduceType {
+
+    /**
+     * A media type string.
+     */
+    String value();
+}

--- a/core/src/main/java/com/linecorp/armeria/server/composition/SimpleCompositeService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/composition/SimpleCompositeService.java
@@ -18,11 +18,10 @@ package com.linecorp.armeria.server.composition;
 
 import java.util.List;
 
-import javax.annotation.Nullable;
-
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
 import com.linecorp.armeria.server.PathMapped;
+import com.linecorp.armeria.server.PathMappingContext;
 import com.linecorp.armeria.server.Service;
 
 /**
@@ -61,7 +60,7 @@ public class SimpleCompositeService<I extends Request, O extends Response>
     }
 
     @Override
-    public PathMapped<Service<I, O>> findService(String path, @Nullable String query) {
-        return super.findService(path, query);
+    public PathMapped<Service<I, O>> findService(PathMappingContext mappingCtx) {
+        return super.findService(mappingCtx);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/common/MediaTypeTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/MediaTypeTest.java
@@ -275,6 +275,17 @@ public class MediaTypeTest {
     }
 
     @Test
+    public void testBelongsTo() {
+        // For quality factor, "belongsTo" has a different behavior to "is".
+        assertThat(PLAIN_TEXT_UTF_8.is(ANY_TYPE.withParameter("q", "0.9"))).isFalse();
+        assertThat(PLAIN_TEXT_UTF_8.belongsTo(ANY_TYPE.withParameter("q", "0.9"))).isTrue();
+
+        // For the other parameters, "belongsTo" has the same behavior as "is".
+        assertThat(PLAIN_TEXT_UTF_8.is(ANY_TYPE.withParameter("charset", "UTF-16"))).isFalse();
+        assertThat(PLAIN_TEXT_UTF_8.belongsTo(ANY_TYPE.withParameter("charset", "UTF-16"))).isFalse();
+    }
+
+    @Test
     public void testParse_empty() {
         assertThatThrownBy(() -> MediaType.parse("")).isInstanceOf(IllegalArgumentException.class);
     }

--- a/core/src/test/java/com/linecorp/armeria/server/DefaultPathMappingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/DefaultPathMappingTest.java
@@ -16,6 +16,7 @@
 package com.linecorp.armeria.server;
 
 import static com.linecorp.armeria.server.PathMapping.of;
+import static com.linecorp.armeria.server.PathMappingContextTest.create;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -27,7 +28,7 @@ public class DefaultPathMappingTest {
     @Test
     public void givenMatchingPathParam_whenApply_thenReturns() throws Exception {
         final DefaultPathMapping ppe = new DefaultPathMapping("/service/{value}");
-        final PathMappingResult result = ppe.apply("/service/hello", "foo=bar");
+        final PathMappingResult result = ppe.apply(create("/service/hello", "foo=bar"));
 
         assertThat(result.isPresent()).isTrue();
         assertThat(result.path()).isEqualTo("/service/hello");
@@ -41,7 +42,7 @@ public class DefaultPathMappingTest {
     @Test
     public void givenNoMatchingPathParam_whenApply_thenReturnsNull() throws Exception {
         final DefaultPathMapping ppe = new DefaultPathMapping("/service/{value}");
-        final PathMappingResult result = ppe.apply("/service2/hello", "bar=baz");
+        final PathMappingResult result = ppe.apply(create("/service2/hello", "bar=baz"));
 
         assertThat(result.isPresent()).isFalse();
     }
@@ -49,7 +50,7 @@ public class DefaultPathMappingTest {
     @Test
     public void testMultipleMatches() throws Exception {
         final DefaultPathMapping ppe = new DefaultPathMapping("/service/{value}/test/:value2/something");
-        final PathMappingResult result = ppe.apply("/service/hello/test/world/something", "q=1");
+        final PathMappingResult result = ppe.apply(create("/service/hello/test/world/something", "q=1"));
 
         assertThat(result.isPresent()).isTrue();
         assertThat(result.path()).isEqualTo("/service/hello/test/world/something");
@@ -65,7 +66,7 @@ public class DefaultPathMappingTest {
     public void testNumericPathParamNames() {
         final DefaultPathMapping m = new DefaultPathMapping("/{0}/{1}/{2}");
         assertThat(m.paramNames()).containsExactlyInAnyOrder("0", "1", "2");
-        assertThat(m.apply("/alice/bob/charlie", null).pathParams())
+        assertThat(m.apply(create("/alice/bob/charlie")).pathParams())
                 .containsEntry("0", "alice")
                 .containsEntry("1", "bob")
                 .containsEntry("2", "charlie")
@@ -100,7 +101,7 @@ public class DefaultPathMappingTest {
     @Test
     public void testEmptyPattern() throws Exception {
         final DefaultPathMapping ppe = new DefaultPathMapping("/service/value/test/value2");
-        final PathMappingResult result = ppe.apply("/service/value/test/value2", null);
+        final PathMappingResult result = ppe.apply(create("/service/value/test/value2"));
 
         assertThat(result.isPresent()).isTrue();
         assertThat(result.path()).isEqualTo("/service/value/test/value2");

--- a/core/src/test/java/com/linecorp/armeria/server/ExactPathMappingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ExactPathMappingTest.java
@@ -17,6 +17,7 @@
 package com.linecorp.armeria.server;
 
 import static com.linecorp.armeria.server.PathMapping.ofExact;
+import static com.linecorp.armeria.server.PathMappingContextTest.create;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
@@ -25,13 +26,13 @@ public class ExactPathMappingTest {
 
     @Test
     public void shouldReturnEmptyOnMismatch() {
-        final PathMappingResult result = new ExactPathMapping("/find/me").apply("/find/me/not", null);
+        final PathMappingResult result = new ExactPathMapping("/find/me").apply(create("/find/me/not"));
         assertThat(result.isPresent()).isFalse();
     }
 
     @Test
     public void shouldReturnNonEmptyOnMatch() {
-        final PathMappingResult result = new ExactPathMapping("/find/me").apply("/find/me", null);
+        final PathMappingResult result = new ExactPathMapping("/find/me").apply(create("/find/me"));
         assertThat(result.isPresent()).isTrue();
         assertThat(result.path()).isEqualTo("/find/me");
         assertThat(result.query()).isNull();

--- a/core/src/test/java/com/linecorp/armeria/server/GlobPathMappingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/GlobPathMappingTest.java
@@ -17,6 +17,7 @@
 package com.linecorp.armeria.server;
 
 import static com.linecorp.armeria.server.PathMapping.ofGlob;
+import static com.linecorp.armeria.server.PathMappingContextTest.create;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Assert;
@@ -76,7 +77,7 @@ public class GlobPathMappingTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testPathValidation() {
-        compile("**").apply("not/an/absolute/path", null);
+        compile("**").apply(create("not/an/absolute/path"));
     }
 
     @Test
@@ -98,31 +99,31 @@ public class GlobPathMappingTest {
         m = ofGlob("baz");
         assertThat(m.paramNames()).isEmpty();
         // Should not create a param for 'bar'
-        assertThat(m.apply("/bar/baz", null).pathParams()).isEmpty();
+        assertThat(m.apply(create("/bar/baz")).pathParams()).isEmpty();
 
         m = ofGlob("/bar/baz/*");
         assertThat(m.paramNames()).containsExactly("0");
-        assertThat(m.apply("/bar/baz/qux", null).pathParams())
+        assertThat(m.apply(create("/bar/baz/qux")).pathParams())
                 .containsEntry("0", "qux")
                 .hasSize(1);
 
         m = ofGlob("/foo/**");
         assertThat(m.paramNames()).containsExactly("0");
-        assertThat(m.apply("/foo/bar/baz", null).pathParams())
+        assertThat(m.apply(create("/foo/bar/baz")).pathParams())
                 .containsEntry("0", "bar/baz")
                 .hasSize(1);
-        assertThat(m.apply("/foo/", null).pathParams())
+        assertThat(m.apply(create("/foo/")).pathParams())
                 .containsEntry("0", "")
                 .hasSize(1);
 
         m = ofGlob("/**/*.js");
         assertThat(m.paramNames()).containsExactlyInAnyOrder("0", "1");
-        assertThat(m.apply("/lib/jquery.min.js", null).pathParams())
+        assertThat(m.apply(create("/lib/jquery.min.js")).pathParams())
                 .containsEntry("0", "lib")
                 .containsEntry("1", "jquery.min")
                 .hasSize(2);
 
-        assertThat(m.apply("/lodash.js", null).pathParams())
+        assertThat(m.apply(create("/lodash.js")).pathParams())
                 .containsEntry("0", "")
                 .containsEntry("1", "lodash")
                 .hasSize(2);
@@ -131,7 +132,7 @@ public class GlobPathMappingTest {
     private static void pass(String glob, String... paths) {
         final GlobPathMapping pattern = compile(glob);
         for (String p: paths) {
-            if (!pattern.apply(p, null).isPresent()) {
+            if (!pattern.apply(create(p)).isPresent()) {
                 Assert.fail('\'' + p + "' does not match '" + glob + "' or '" + pattern.asRegex() + "'.");
             }
         }
@@ -140,7 +141,7 @@ public class GlobPathMappingTest {
     private static void fail(String glob, String... paths) {
         final GlobPathMapping pattern = compile(glob);
         for (String p: paths) {
-            if (pattern.apply(p, null).isPresent()) {
+            if (pattern.apply(create(p)).isPresent()) {
                 Assert.fail('\'' + p + "' matches '" + glob + "' or '" + pattern.asRegex() + "'.");
             }
         }

--- a/core/src/test/java/com/linecorp/armeria/server/HttpHeaderPathMappingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpHeaderPathMappingTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableSet;
+
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.MediaTypeSet;
+
+public class HttpHeaderPathMappingTest {
+
+    private static final String PATH = "/test";
+    private static final MediaTypeSet PRODUCIBLE_MEDIA_TYPES = new MediaTypeSet(MediaType.JSON_UTF_8,
+                                                                                MediaType.FORM_DATA,
+                                                                                MediaType.PLAIN_TEXT_UTF_8);
+
+    @Test
+    public void testLoggerName() {
+        HttpHeaderPathMapping mapping;
+        mapping = new HttpHeaderPathMapping(PathMapping.of(PATH), ImmutableSet.of(HttpMethod.GET),
+                                            MediaType.PLAIN_TEXT_UTF_8, MediaType.JSON_UTF_8);
+        assertThat(mapping.loggerName()).isEqualTo("test.GET.text_plain.application_json");
+
+        mapping = new HttpHeaderPathMapping(PathMapping.of(PATH), ImmutableSet.of(HttpMethod.GET),
+                                            null, MediaType.JSON_UTF_8);
+        assertThat(mapping.loggerName()).isEqualTo("test.GET._.application_json");
+
+        mapping = new HttpHeaderPathMapping(PathMapping.of(PATH),
+                                            ImmutableSet.of(HttpMethod.GET, HttpMethod.POST),
+                                            MediaType.JSON_UTF_8, null);
+        assertThat(mapping.loggerName()).isEqualTo("test.GET_POST.application_json._");
+    }
+
+    @Test
+    public void testMetricName() {
+        HttpHeaderPathMapping mapping;
+        mapping = new HttpHeaderPathMapping(PathMapping.of(PATH), ImmutableSet.of(HttpMethod.GET),
+                                            MediaType.PLAIN_TEXT_UTF_8, MediaType.JSON_UTF_8);
+        assertThat(mapping.metricName()).isEqualTo("/test/GET/text_plain/application_json");
+
+        mapping = new HttpHeaderPathMapping(PathMapping.of(PATH), ImmutableSet.of(HttpMethod.GET),
+                                            null, MediaType.JSON_UTF_8);
+        assertThat(mapping.metricName()).isEqualTo("/test/GET/_/application_json");
+
+        mapping = new HttpHeaderPathMapping(PathMapping.of(PATH),
+                                            ImmutableSet.of(HttpMethod.GET, HttpMethod.POST),
+                                            MediaType.JSON_UTF_8, null);
+        assertThat(mapping.metricName()).isEqualTo("/test/GET_POST/application_json/_");
+    }
+
+    @Test
+    public void testHttpHeader() {
+        HttpHeaderPathMapping mapping =
+                new HttpHeaderPathMapping(PathMapping.of(PATH),
+                                          ImmutableSet.of(HttpMethod.GET, HttpMethod.POST),
+                                          null, null);
+
+        assertThat(mapping.apply(method(HttpMethod.GET)).isPresent()).isTrue();
+        assertThat(mapping.apply(method(HttpMethod.POST)).isPresent()).isTrue();
+
+        assertThat(mapping.apply(method(HttpMethod.GET)).isLowestScore()).isTrue();
+        assertThat(mapping.apply(method(HttpMethod.POST)).isLowestScore()).isTrue();
+
+        assertThat(mapping.apply(method(HttpMethod.PUT)).isPresent()).isFalse();
+        assertThat(mapping.apply(method(HttpMethod.DELETE)).isPresent()).isFalse();
+    }
+
+    @Test
+    public void testConsumeType() {
+        HttpHeaderPathMapping mapping =
+                new HttpHeaderPathMapping(PathMapping.of(PATH),
+                                          ImmutableSet.of(HttpMethod.POST),
+                                          MediaType.JSON_UTF_8, null);
+
+        assertThat(mapping.apply(consumeType(HttpMethod.POST, MediaType.JSON_UTF_8)).isPresent()).isTrue();
+        assertThat(mapping.apply(consumeType(HttpMethod.POST, MediaType.create("application", "json")))
+                          .isPresent()).isFalse();
+    }
+
+    @Test
+    public void testProduceType() {
+        HttpHeaderPathMapping mapping =
+                new HttpHeaderPathMapping(PathMapping.of(PATH),
+                                          ImmutableSet.of(HttpMethod.GET),
+                                          null, MediaType.JSON_UTF_8);
+
+        assertThat(mapping.apply(produceType(HttpMethod.GET, "*/*")).isPresent()).isTrue();
+        assertThat(mapping.apply(produceType(HttpMethod.GET, "application/json;charset=UTF-8"))
+                          .isPresent()).isTrue();
+
+        PathMappingResult result;
+
+        result = mapping.apply(
+                produceType(HttpMethod.GET, "application/json;charset=UTF-8;q=0.8,text/plain;q=0.9"));
+        assertThat(result.isPresent()).isTrue();
+        assertThat(result.score()).isEqualTo(-1);
+
+        result = mapping.apply(
+                produceType(HttpMethod.GET, "application/json;charset=UTF-8,text/plain;q=0.9"));
+        assertThat(result.isPresent()).isTrue();
+        assertThat(result.isHighestScore()).isTrue();
+
+        assertThat(mapping.apply(produceType(HttpMethod.GET, "application/x-www-form-urlencoded"))
+                          .isPresent()).isFalse();
+    }
+
+    private static PathMappingContext method(HttpMethod method) {
+        return DefaultPathMappingContext.of("example.com", PATH, null,
+                                            HttpHeaders.of(method, PATH), null);
+    }
+
+    private static PathMappingContext consumeType(HttpMethod method, MediaType contentType) {
+        HttpHeaders headers = HttpHeaders.of(method, PATH);
+        headers.add(HttpHeaderNames.CONTENT_TYPE, contentType.toString());
+        return DefaultPathMappingContext.of("example.com", PATH, null,
+                                            headers, null);
+    }
+
+    private static PathMappingContext produceType(HttpMethod method, String acceptHeader) {
+        HttpHeaders headers = HttpHeaders.of(method, PATH);
+        headers.add(HttpHeaderNames.ACCEPT, acceptHeader);
+        return DefaultPathMappingContext.of("example.com", PATH, null,
+                                            headers, PRODUCIBLE_MEDIA_TYPES);
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/PathMappingContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/PathMappingContextTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static com.linecorp.armeria.server.DefaultPathMappingContext.compareMediaType;
+import static com.linecorp.armeria.server.DefaultPathMappingContext.resolveProduceTypes;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+import org.junit.Test;
+
+import com.linecorp.armeria.common.DefaultHttpHeaders;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.MediaTypeSet;
+
+public class PathMappingContextTest {
+
+    @Test
+    public void testProduceTypes() {
+        DefaultHttpHeaders headers = new DefaultHttpHeaders();
+        headers.add(HttpHeaderNames.ACCEPT,
+                    "text/html, application/xhtml+xml, application/xml;q=0.9, */*;q=0.8");
+        MediaTypeSet producibleTypes =
+                new MediaTypeSet(MediaType.create("application", "xml"),
+                                 MediaType.create("text", "html"));
+        List<MediaType> selectedTypes = resolveProduceTypes(headers, producibleTypes);
+
+        assertThat(selectedTypes.size()).isEqualTo(3);
+        assertThat(selectedTypes.get(0).type()).isEqualTo("text");
+        assertThat(selectedTypes.get(1).type()).isEqualTo("application");
+        assertThat(selectedTypes.get(2).type()).isEqualTo("*");
+    }
+
+    @Test
+    public void testProduceTypes2() {
+        DefaultHttpHeaders headers = new DefaultHttpHeaders();
+        headers.add(HttpHeaderNames.ACCEPT,
+                    "text/html ;charset=UTF-8, application/xhtml+xml, application/xml;q=0.9, */*;q=0.8");
+        MediaTypeSet producibleTypes =
+                new MediaTypeSet(MediaType.create("application", "xml"),
+                                 MediaType.create("text", "html"));
+        List<MediaType> selectedTypes = resolveProduceTypes(headers, producibleTypes);
+
+        assertThat(selectedTypes.size()).isEqualTo(2);
+        assertThat(selectedTypes.get(0).type()).isEqualTo("application");
+        assertThat(selectedTypes.get(1).type()).isEqualTo("*");
+    }
+
+    @Test
+    public void testCompareMediaTypes() {
+        // Sort by their quality factor.
+        assertThat(compareMediaType(MediaType.parse("application/octet-stream;q=0.8"),
+                                    MediaType.parse("text/plain;q=0.9")))
+                .isGreaterThan(0);
+        // Sort by their coverage. (the number of wildcards)
+        assertThat(compareMediaType(MediaType.parse("text/*;q=0.9"),
+                                    MediaType.parse("text/plain;q=0.9")))
+                .isGreaterThan(0);
+        // Sort by lexicographic order.
+        assertThat(compareMediaType(MediaType.parse("text/plain;q=0.9"),
+                                    MediaType.parse("application/octet-stream;q=0.9")))
+                .isGreaterThan(0);
+    }
+
+    static PathMappingContext create(String path) {
+        return create(path, null);
+    }
+
+    static PathMappingContext create(String path, @Nullable String query) {
+        DefaultHttpHeaders headers = new DefaultHttpHeaders();
+        headers.method(HttpMethod.GET);
+        return DefaultPathMappingContext.of("server.com", path, query, headers, null);
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/PrefixPathMappingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/PrefixPathMappingTest.java
@@ -17,6 +17,7 @@
 package com.linecorp.armeria.server;
 
 import static com.linecorp.armeria.server.PathMapping.ofPrefix;
+import static com.linecorp.armeria.server.PathMappingContextTest.create;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assume.assumeTrue;
 
@@ -37,7 +38,7 @@ public class PrefixPathMappingTest {
     @Test
     public void mappingResult() {
         final PathMapping a = ofPrefix("/foo");
-        PathMappingResult result = a.apply("/foo/bar/cat", "");
+        PathMappingResult result = a.apply(create("/foo/bar/cat"));
         assertThat(result.path()).isEqualTo("/bar/cat");
     }
 

--- a/core/src/test/java/com/linecorp/armeria/server/RegexPathMappingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/RegexPathMappingTest.java
@@ -17,6 +17,7 @@
 package com.linecorp.armeria.server;
 
 import static com.linecorp.armeria.server.PathMapping.ofRegex;
+import static com.linecorp.armeria.server.PathMappingContextTest.create;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
@@ -35,7 +36,7 @@ public class RegexPathMappingTest {
     @Test
     public void basic() {
         final PathMapping mapping = ofRegex("foo");
-        final PathMappingResult result = mapping.apply("/barfoobar", null);
+        final PathMappingResult result = mapping.apply(create("/barfoobar"));
         assertThat(result.isPresent()).isTrue();
         assertThat(result.path()).isEqualTo("/barfoobar");
         assertThat(result.query()).isNull();
@@ -47,7 +48,7 @@ public class RegexPathMappingTest {
         final PathMapping mapping = ofRegex("^/files/(?<fileName>.*)$");
         assertThat(mapping.paramNames()).containsExactly("fileName");
 
-        final PathMappingResult result = mapping.apply("/files/images/avatar.jpg", "size=512");
+        final PathMappingResult result = mapping.apply(create("/files/images/avatar.jpg", "size=512"));
         assertThat(result.isPresent()).isTrue();
         assertThat(result.path()).isEqualTo("/files/images/avatar.jpg");
         assertThat(result.query()).isEqualTo("size=512");

--- a/logback/src/test/java/com/linecorp/armeria/common/logback/RequestContextExportingAppenderTest.java
+++ b/logback/src/test/java/com/linecorp/armeria/common/logback/RequestContextExportingAppenderTest.java
@@ -15,6 +15,7 @@
  */
 package com.linecorp.armeria.common.logback;
 
+import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
@@ -26,6 +27,7 @@ import java.net.InetSocketAddress;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.List;
 import java.util.Map;
+import java.util.StringJoiner;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Consumer;
 
@@ -42,6 +44,7 @@ import org.junit.rules.TestName;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 import com.linecorp.armeria.client.ClientOptions;
@@ -54,6 +57,7 @@ import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.RpcResponse;
@@ -67,6 +71,7 @@ import com.linecorp.armeria.common.thrift.ThriftSerializationFormats;
 import com.linecorp.armeria.common.util.SafeCloseable;
 import com.linecorp.armeria.server.DefaultServiceRequestContext;
 import com.linecorp.armeria.server.HttpService;
+import com.linecorp.armeria.server.PathMappingContext;
 import com.linecorp.armeria.server.PathMappingResult;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
@@ -411,11 +416,11 @@ public class RequestContextExportingAppenderTest {
                                                   .serviceConfigs().get(0);
         final HttpRequest req = HttpRequest.of(HttpHeaders.of(HttpMethod.GET, path + '?' + query)
                                                           .authority("server.com:8080"));
+        final PathMappingContext mappingCtx =
+                new DummyPathMappingContext("server.com", path, query, req.headers());
 
         final ServiceRequestContext ctx = new DefaultServiceRequestContext(
-                serviceConfig,
-                ch, SessionProtocol.H2, req.method(),
-                path,
+                serviceConfig, ch, SessionProtocol.H2, mappingCtx,
                 PathMappingResult.of(path, query, ImmutableMap.of()),
                 req, newSslSession());
 
@@ -565,5 +570,61 @@ public class RequestContextExportingAppenderTest {
         la.start();
         testLogger.addAppender(a);
         return la.list;
+    }
+
+    private static class DummyPathMappingContext implements PathMappingContext {
+
+        private final String hostname;
+        private final String path;
+        private final String query;
+        private final HttpHeaders headers;
+        private final String summary;
+
+        DummyPathMappingContext(String hostname, String path, String query,
+                                HttpHeaders headers) {
+            this.hostname = requireNonNull(hostname, "hostname");
+            this.path = requireNonNull(path, "path");
+            this.query = query;
+            this.headers = requireNonNull(headers, "headers");
+            summary = new StringJoiner(":")
+                    .add(hostname).add(path).add(headers.method().name()).toString();
+        }
+
+        @Override
+        public String hostname() {
+            return hostname;
+        }
+
+        @Override
+        public HttpMethod method() {
+            return headers.method();
+        }
+
+        @Override
+        public String path() {
+            return path;
+        }
+
+        @Nullable
+        @Override
+        public String query() {
+            return query;
+        }
+
+        @Nullable
+        @Override
+        public MediaType consumeType() {
+            return null;
+        }
+
+        @Override
+        public List<MediaType> produceTypes() {
+            return ImmutableList.of();
+        }
+
+        @Override
+        public String summary() {
+            return summary;
+        }
     }
 }

--- a/site/src/sphinx/server-basics.rst
+++ b/site/src/sphinx/server-basics.rst
@@ -118,6 +118,20 @@ Even if we opened a port, it's of no use if we didn't bind any services to them.
         public HttpResponse greet(HttpParameters parameters) {
             return HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "Hello, %s!",
                                    parameters.get("name");
+    });
+
+    // Using media type negotiation:
+    sb.annotatedService(new Object() {
+        @Get("/greet7")
+        @ProduceType("application/json;charset=UTF-8")
+        public HttpResponse greetGet(@Param("name") String name) {
+            return HttpResponse.of(HttpStatus.OK, MediaType.JSON_UTF_8, "{\"name\":\"%s\"}", name);
+        }
+
+        @Post("/greet7")
+        @ConsumeType("application/x-www-form-urlencoded")
+        public HttpResponse greetPost(@Param("name") String name) {
+            return HttpResponse.of(HttpStatus.OK);
         }
     });
 


### PR DESCRIPTION
…ype based mapping

Motivation:

Currently we cannot bind two or more service methods with the same path even if they have different HTTP methods. Also, we need to bind them depending on 'content-type' or 'accept' header of the request for some cases.
These modifications will affect only to annotated service for now, and then apply this feature to the other services later.

Modifications:

- Fix a bug that might get a wrong service instance from the cache when finding a service.
- Add PathMappingContext and use it PathMapping's argument instead of '(path, query)'.
- Introduce a simple content negotiation mechanism to find a service method by 'content-type' or 'accept' header.
- Add 'score' to PathMappingResult to find the best suitable service method.

Result:

- Fixes #579

To-Do:

- Apply caffeine cache to improve the efficiency of the service cache.
- Introduce some new service routing mechanism to find a service method more faster.