### PR TITLE
Clean up the closed channels from DefaultKeyedChannelPool

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/http/HttpClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/http/HttpClientFactory.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 import com.google.common.collect.MapMaker;
 
@@ -49,7 +50,6 @@ import com.linecorp.armeria.common.http.HttpSessionProtocols;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.EventLoop;
-import io.netty.channel.pool.ChannelHealthChecker;
 import io.netty.util.concurrent.Future;
 
 /**
@@ -65,8 +65,8 @@ public class HttpClientFactory extends NonDecoratingClientFactory {
     private static final KeyedChannelPoolHandlerAdapter<PoolKey> NOOP_POOL_HANDLER =
             new KeyedChannelPoolHandlerAdapter<>();
 
-    private static final ChannelHealthChecker POOL_HEALTH_CHECKER =
-            ch -> ch.eventLoop().newSucceededFuture(ch.isActive() && HttpSession.get(ch).isActive());
+    private static final Predicate<Channel> POOL_HEALTH_CHECKER =
+            ch -> ch.isActive() && HttpSession.get(ch).isActive();
 
     private final ConcurrentMap<EventLoop, KeyedChannelPool<PoolKey>> pools = new MapMaker().weakKeys()
                                                                                             .makeMap();


### PR DESCRIPTION
Motivation:

DefaultKeyedChannelPool uses Deque in FIFO manner to manage available
channels. This has the following issues:

- An older channel gets higher chance of acquisition. This increases
  overall lifespan of an idle channel unnecessarily.
- We do not clean up the connections which were closed while they are in
  the Deque. They will eventually be cleaned up, but it may take longer
  time than expected, combined with the first issue.

Modifications:

- Use LIFO so that a recently used channel get higher chance of
  acquisition.
- Clean up the both ends of the Deque so that the closed channels are
  cleaned up more aggressively, combined with the first modification.
- Use synchronous health checks instead of the asynchronous one because
  we do not need it for HTTP.

Result:

- Reduced memory footprint
- Slightly lower number of client-side connections