### PR TITLE
Fix flaky tests in zookeeper module

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -764,6 +764,11 @@ configure(javaProjects) {
                         case 'com.linecorp.armeria.client.zookeeper.EndpointGroupTest':
                             lines.removeIf { it.contains('ServerCnxn$EndOfStreamException') }
                             break
+                        case 'com.linecorp.armeria.server.zookeeper.ZooKeeperRegistrationTest':
+                            lines.removeIf { it.contains('ServerCnxn$EndOfStreamException') }
+                            lines.removeIf { it.contains('KeeperException$ConnectionLossException') }
+                            lines.removeIf { it.contains('ZooKeeperException: Failed to notify ZooKeeper listener') }
+                            break
                     }
 
                     printBuffer = !lines.isEmpty()

--- a/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
@@ -201,7 +201,7 @@ public class ServerTest {
             }
             long elapsedTimeMillis = TimeUnit.MILLISECONDS.convert(
                     System.nanoTime() - connectedNanos, TimeUnit.NANOSECONDS);
-            assertThat(elapsedTimeMillis).isGreaterThanOrEqualTo(idleTimeoutMillis);
+            assertThat(elapsedTimeMillis).isGreaterThan((long) (idleTimeoutMillis * 0.9));
         }
     }
 

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -123,7 +123,12 @@ org.apache.tomcat.embed:
   tomcat-embed-el: { version: *TOMCAT_VERSION }
 
 org.apache.zookeeper:
-  zookeeper: { version: '3.4.10' }
+  zookeeper:
+    version: '3.4.10'
+    exclusions:
+    - jline:jline
+    - log4j:log4j
+    - org.slf4j:slf4j-log4j12
 
 org.assertj:
   assertj-core: { version: '3.8.0' }

--- a/zookeeper/src/test/java/com/linecorp/armeria/client/zookeeper/TestBase.java
+++ b/zookeeper/src/test/java/com/linecorp/armeria/client/zookeeper/TestBase.java
@@ -15,9 +15,19 @@
  */
 package com.linecorp.armeria.client.zookeeper;
 
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
 
+import org.apache.zookeeper.Watcher.Event.KeeperState;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -36,31 +46,61 @@ public class TestBase {
     protected static final Logger logger = LoggerFactory.getLogger(EndpointGroupTest.class);
     protected static final String zNode = "/testEndPoints";
     protected static final int sessionTimeout = 20000;
-    protected static final Set<Endpoint> sampleEndpoints = ImmutableSet.of(Endpoint.of("127.0.0.1", 1234, 2),
-                                                                           Endpoint.of("127.0.0.1", 2345, 4),
-                                                                           Endpoint.of("127.0.0.1", 3456, 2));
+    protected static final Set<Endpoint> sampleEndpoints;
+
+    static {
+        final int[] ports = unusedPorts(3);
+        sampleEndpoints = ImmutableSet.of(Endpoint.of("127.0.0.1", ports[0], 2),
+                                          Endpoint.of("127.0.0.1", ports[1], 4),
+                                          Endpoint.of("127.0.0.1", ports[2], 2));
+    }
+
     private static final Duration duration = Duration.ofSeconds(10);
     @ClassRule
     public static final TemporaryFolder ROOT_FOLDER = new TemporaryFolder();
     private static ZKInstance zkInstance;
 
     @BeforeClass
-    public static void start() {
-        try {
-            zkInstance = ZKFactory.apply().withRootDir(ROOT_FOLDER.newFolder("zookeeper")).create();
-            zkInstance.start().result(duration);
-        } catch (Throwable throwable) {
-            throw new IllegalStateException(throwable);
-        }
+    public static void start() throws Throwable {
+        zkInstance = ZKFactory.apply().withRootDir(ROOT_FOLDER.newFolder("zookeeper")).create();
+        zkInstance.start().result(duration);
     }
 
     @AfterClass
-    public static void stop() {
-        try {
-            zkInstance.stop().ready(duration);
-        } catch (Exception e) {
-            logger.warn("Failed to stop the ZooKeeper zkInstance", e);
+    public static void stop() throws Throwable {
+        zkInstance.stop().ready(duration);
+    }
+
+    protected static List<KeeperState> takeAllStates(BlockingQueue<KeeperState> queue) throws Exception {
+        final List<KeeperState> actualStates = new ArrayList<>();
+        for (;;) {
+            final KeeperState state = queue.poll(3, TimeUnit.SECONDS);
+            if (state == null) {
+                break;
+            }
+            actualStates.add(state);
         }
+        return actualStates;
+    }
+
+    private static int[] unusedPorts(int numPorts) {
+        final int[] ports = new int[numPorts];
+        final Random random = ThreadLocalRandom.current();
+        for (int i = 0; i < numPorts; i++) {
+            for (;;) {
+                final int candidatePort = random.nextInt(64512) + 1024;
+                try (ServerSocket ss = new ServerSocket()) {
+                    ss.bind(new InetSocketAddress("127.0.0.1", candidatePort));
+                    ports[i] = candidatePort;
+                    break;
+                } catch (IOException e) {
+                    // Port in use or unable to bind.
+                    continue;
+                }
+            }
+        }
+
+        return ports;
     }
 
     public ZKInstance instance() {


### PR DESCRIPTION
- Fixes #639
- Fixes #477
- Do not use fixed port numbers
- Use Awaitility where necessary
- Give more tolerance to state transition tests
- Exclude unnecessary transitive dependencies pulled in by ZooKeeper
- Miscellaneous:
  - Fix flaky ServerTest.testIdleTimeoutByNoContentSent() as well