### PR TITLE
Increase the chance of reusing idle client connections

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactory.java
@@ -24,6 +24,7 @@ import java.util.function.Supplier;
 import org.slf4j.LoggerFactory;
 
 import com.linecorp.armeria.common.Scheme;
+import com.linecorp.armeria.common.util.ReleasableHolder;
 
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
@@ -79,6 +80,13 @@ public interface ClientFactory extends AutoCloseable {
      * {@link ClientFactory}.
      */
     Supplier<EventLoop> eventLoopSupplier();
+
+    /**
+     * Acquires an {@link EventLoop} that is expected to handle a connection to the specified {@link Endpoint}.
+     * The caller must release the returned {@link EventLoop} back by calling {@link ReleasableHolder#release()}
+     * so that {@link ClientFactory} utilizes {@link EventLoop}s efficiently.
+     */
+    ReleasableHolder<EventLoop> acquireEventLoop(Endpoint endpoint);
 
     /**
      * Creates a new client that connects to the specified {@code uri}.

--- a/core/src/main/java/com/linecorp/armeria/client/DecoratingClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DecoratingClientFactory.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import java.util.function.Supplier;
 
 import com.linecorp.armeria.common.Scheme;
+import com.linecorp.armeria.common.util.ReleasableHolder;
 
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
@@ -62,6 +63,11 @@ public class DecoratingClientFactory extends AbstractClientFactory {
     @Override
     public Supplier<EventLoop> eventLoopSupplier() {
         return delegate().eventLoopSupplier();
+    }
+
+    @Override
+    public ReleasableHolder<EventLoop> acquireEventLoop(Endpoint endpoint) {
+        return delegate().acquireEventLoop(endpoint);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientFactory.java
@@ -33,6 +33,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Streams;
 
 import com.linecorp.armeria.common.Scheme;
+import com.linecorp.armeria.common.util.ReleasableHolder;
 
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
@@ -93,6 +94,11 @@ final class DefaultClientFactory extends AbstractClientFactory {
     @Override
     public Supplier<EventLoop> eventLoopSupplier() {
         return httpClientFactory.eventLoopSupplier();
+    }
+
+    @Override
+    public ReleasableHolder<EventLoop> acquireEventLoop(Endpoint endpoint) {
+        return httpClientFactory.acquireEventLoop(endpoint);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultHttpClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultHttpClient.java
@@ -19,6 +19,8 @@ package com.linecorp.armeria.client;
 import static com.linecorp.armeria.internal.ArmeriaHttpUtil.concatPaths;
 import static com.linecorp.armeria.internal.ArmeriaHttpUtil.splitPathAndQuery;
 
+import javax.annotation.Nullable;
+
 import com.linecorp.armeria.common.AggregatedHttpMessage;
 import com.linecorp.armeria.common.DefaultHttpResponse;
 import com.linecorp.armeria.common.HttpRequest;
@@ -37,10 +39,10 @@ final class DefaultHttpClient extends UserClient<HttpRequest, HttpResponse> impl
 
     @Override
     public HttpResponse execute(HttpRequest req) {
-        return execute(eventLoop(), req);
+        return execute(null, req);
     }
 
-    private HttpResponse execute(EventLoop eventLoop, HttpRequest req) {
+    private HttpResponse execute(@Nullable EventLoop eventLoop, HttpRequest req) {
         final String concatPaths = concatPaths(uri().getRawPath(), req.path());
         req.path(concatPaths);
 
@@ -59,10 +61,10 @@ final class DefaultHttpClient extends UserClient<HttpRequest, HttpResponse> impl
 
     @Override
     public HttpResponse execute(AggregatedHttpMessage aggregatedReq) {
-        return execute(eventLoop(), aggregatedReq);
+        return execute(null, aggregatedReq);
     }
 
-    HttpResponse execute(EventLoop eventLoop, AggregatedHttpMessage aggregatedReq) {
+    HttpResponse execute(@Nullable EventLoop eventLoop, AggregatedHttpMessage aggregatedReq) {
         return execute(eventLoop, aggregatedReq.toHttpRequest());
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
@@ -275,7 +275,19 @@ public final class Endpoint {
         }
 
         final Endpoint that = (Endpoint) obj;
-        return authority().equals(that.authority()) && weight() == that.weight();
+        if (isGroup()) {
+            if (that.isGroup()) {
+                return authority().equals(that.authority());
+            } else {
+                return false;
+            }
+        } else {
+            if (that.isGroup()) {
+                return false;
+            } else {
+                return authority().equals(that.authority()) && weight() == that.weight();
+            }
+        }
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/EventLoopScheduler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/EventLoopScheduler.java
@@ -1,0 +1,326 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadLocalRandom;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Joiner;
+import com.google.common.collect.Streams;
+
+import com.linecorp.armeria.common.util.ReleasableHolder;
+
+import io.netty.channel.EventLoop;
+import io.netty.channel.EventLoopGroup;
+
+final class EventLoopScheduler {
+
+    private static final long CLEANUP_INTERVAL_NANOS = Duration.ofMinutes(1).toNanos();
+
+    private final List<EventLoop> eventLoops;
+    private final Map<String, State> map = new ConcurrentHashMap<>();
+    private int counter;
+    private volatile long lastCleanupTimeNanos = System.nanoTime();
+
+    EventLoopScheduler(EventLoopGroup eventLoopGroup) {
+        eventLoops = Streams.stream(eventLoopGroup)
+                            .map(EventLoop.class::cast)
+                            .collect(toImmutableList());
+    }
+
+    Entry acquire(Endpoint endpoint) {
+        requireNonNull(endpoint, "endpoint");
+        final State state = state(endpoint);
+        final Entry acquired = state.acquire();
+        cleanup();
+        return acquired;
+    }
+
+    @VisibleForTesting
+    List<Entry> entries(Endpoint endpoint) {
+        return state(endpoint).entries();
+    }
+
+    private State state(Endpoint endpoint) {
+        final String authority = endpoint.authority();
+        return map.computeIfAbsent(authority, e -> new State(eventLoops));
+    }
+
+    /**
+     * Cleans up empty entries with no activity for more than 1 minute. For reduced overhead, we perform this
+     * only when 1) the last clean-up was more than 1 minute ago and 2) the number of acquisitions % 256 is 0.
+     */
+    private void cleanup() {
+        if ((++counter & 0xFF) != 0) { // (++counter % 256) != 0
+            return;
+        }
+
+        final long currentTimeNanos = System.nanoTime();
+        if (currentTimeNanos - lastCleanupTimeNanos < CLEANUP_INTERVAL_NANOS) {
+            return;
+        }
+
+        for (Iterator<State> i = map.values().iterator(); i.hasNext();) {
+            final State state = i.next();
+            final boolean remove;
+
+            synchronized (state) {
+                remove = state.allActiveRequests == 0 &&
+                         currentTimeNanos - state.lastActivityTimeNanos >= CLEANUP_INTERVAL_NANOS;
+            }
+
+            if (remove) {
+                i.remove();
+            }
+        }
+
+        lastCleanupTimeNanos = System.nanoTime();
+    }
+
+    private static final class State {
+        /**
+         * A binary heap of Entry. Ordered by:
+         * <ul>
+         *   <li>{@link Entry#activeRequests()} (lower is better)</li>
+         *   <li>{@link Entry#id()} (lower is better)</li>
+         * </ul>
+         */
+        private final List<Entry> entries;
+        private final List<EventLoop> eventLoops;
+        private int nextUnusedEventLoopIdx;
+        private int allActiveRequests;
+
+        /**
+         * Updated only when {@link #allActiveRequests} is 0 by {@link #release(Entry)}.
+         */
+        private long lastActivityTimeNanos = System.nanoTime();
+
+        State(List<EventLoop> eventLoops) {
+            this.eventLoops = eventLoops;
+            entries = new ArrayList<>();
+            nextUnusedEventLoopIdx = ThreadLocalRandom.current().nextInt(eventLoops.size());
+            addUnusedEventLoop();
+        }
+
+        List<Entry> entries() {
+            return entries;
+        }
+
+        synchronized Entry acquire() {
+            Entry e = entries.get(0);
+            if (e.activeRequests() > 0) {
+                // All event loops are handling connections; try to add an unused event loop.
+                if (addUnusedEventLoop()) {
+                    e = entries.get(0);
+                    assert e.activeRequests() == 0;
+                }
+            }
+
+            assert e.index() == 0;
+            e.activeRequests++;
+            allActiveRequests++;
+            bubbleDown(0);
+            return e;
+        }
+
+        private boolean addUnusedEventLoop() {
+            if (entries.size() < eventLoops.size()) {
+                push(new Entry(this, eventLoops.get(nextUnusedEventLoopIdx), entries.size()));
+                nextUnusedEventLoopIdx = (nextUnusedEventLoopIdx + 1) % eventLoops.size();
+                return true;
+            } else {
+                return false;
+            }
+        }
+
+        synchronized void release(Entry e) {
+            assert e.parent() == this;
+            e.activeRequests--;
+            bubbleUp(e.index());
+            if (--allActiveRequests == 0) {
+                lastActivityTimeNanos = System.nanoTime();
+            }
+        }
+
+        // Heap implementation, modified from the public domain code at https://stackoverflow.com/a/714873
+        private void push(Entry e) {
+            entries.add(e);
+            bubbleUp(entries.size() - 1);
+        }
+
+        private void bubbleDown(int i) {
+            int best = i;
+            for (;;) {
+                final int oldBest = best;
+                final int left = left(best);
+
+                if (left < entries.size()) {
+                    final int right = right(best);
+                    if (isBetter(left, best)) {
+                        if (right < entries.size()) {
+                            if (isBetter(right, left)) {
+                                // Left leaf is better but right leaf is even better.
+                                best = right;
+                            } else {
+                                // Left leaf is better than the current entry and right left.
+                                best = left;
+                            }
+                        } else {
+                            // Left leaf is better and there's no right leaf.
+                            best = left;
+                        }
+                    } else if (right < entries.size()) {
+                        if (isBetter(right, best)) {
+                            // Left leaf is not better but right leaf is better.
+                            best = right;
+                        } else {
+                            // Both left and right leaves are not better.
+                            break;
+                        }
+                    } else {
+                        // Left leaf is not better and there's no right leaf.
+                        break;
+                    }
+                } else {
+                    // There are no leaves, because right leaf can't be present if left leaf isn't.
+                    break;
+                }
+
+                swap(best, oldBest);
+            }
+        }
+
+        private void bubbleUp(int i) {
+            while (i > 0) {
+                final int parent = parent(i);
+                if (isBetter(parent, i)) {
+                    break;
+                }
+
+                swap(parent, i);
+                i = parent;
+            }
+        }
+
+        /**
+         * Returns {@code true} if the entry at {@code a} is a better choice than the entry at {@code b}.
+         */
+        private boolean isBetter(int a, int b) {
+            final Entry entryA = entries.get(a);
+            final Entry entryB = entries.get(b);
+            if (entryA.activeRequests() < entryB.activeRequests()) {
+                return true;
+            }
+            if (entryA.activeRequests() > entryB.activeRequests()) {
+                return false;
+            }
+
+            return entryA.id() < entryB.id();
+        }
+
+        private static int parent(int i) {
+            return (i - 1) / 2;
+        }
+
+        private static int left(int i) {
+            return 2 * i + 1;
+        }
+
+        private static int right(int i) {
+            return 2 * i + 2;
+        }
+
+        private void swap(int i, int j) {
+            final Entry entryI = entries.get(i);
+            final Entry entryJ = entries.get(j);
+            entries.set(i, entryJ);
+            entries.set(j, entryI);
+
+            // Swap the index as well.
+            entryJ.setIndex(i);
+            entryI.setIndex(j);
+        }
+
+        @Override
+        public String toString() {
+            return '[' + Joiner.on(", ").join(entries) + ']';
+        }
+    }
+
+    static final class Entry implements ReleasableHolder<EventLoop> {
+        private final State parent;
+        private final EventLoop eventLoop;
+        private final int id;
+        private int activeRequests;
+
+        /**
+         * Index in the binary heap {@link State#entries}. Updated by {@link State#swap(int, int)} after
+         * {@link #activeRequests} is updated by {@link State#acquire()} and {@link State#release(Entry)}.
+         */
+        private int index;
+
+        Entry(State parent, EventLoop eventLoop, int id) {
+            this.parent = parent;
+            this.eventLoop = eventLoop;
+            this.id = index = id;
+        }
+
+        @Override
+        public EventLoop get() {
+            return eventLoop;
+        }
+
+        State parent() {
+            return parent;
+        }
+
+        int id() {
+            return id;
+        }
+
+        int index() {
+            return index;
+        }
+
+        void setIndex(int index) {
+            this.index = index;
+        }
+
+        int activeRequests() {
+            return activeRequests;
+        }
+
+        @Override
+        public void release() {
+            parent.release(this);
+        }
+
+        @Override
+        public String toString() {
+            return "(" + index + ", " + id + ", " + activeRequests + ')';
+        }
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/client/Http1ResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http1ResponseDecoder.java
@@ -16,9 +16,12 @@
 
 package com.linecorp.armeria.client;
 
+import javax.annotation.Nullable;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.linecorp.armeria.common.ClosedSessionException;
 import com.linecorp.armeria.common.ContentTooLargeException;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpRequest;
@@ -53,6 +56,7 @@ final class Http1ResponseDecoder extends HttpResponseDecoder implements ChannelI
     }
 
     /** The request being decoded currently. */
+    @Nullable
     private HttpResponseWrapper res;
     private int resId = 1;
     private State state = State.NEED_HEADERS;
@@ -105,6 +109,9 @@ final class Http1ResponseDecoder extends HttpResponseDecoder implements ChannelI
 
     @Override
     public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+        if (res != null) {
+            res.close(ClosedSessionException.get());
+        }
         ctx.fireChannelInactive();
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/Http2ResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http2ResponseDecoder.java
@@ -96,7 +96,12 @@ final class Http2ResponseDecoder extends HttpResponseDecoder implements Http2Con
     public void onStreamHalfClosed(Http2Stream stream) {}
 
     @Override
-    public void onStreamClosed(Http2Stream stream) {}
+    public void onStreamClosed(Http2Stream stream) {
+        final HttpResponseWrapper res = getResponse(streamIdToId(stream.id()), true);
+        if (res != null) {
+            res.close(ClosedSessionException.get());
+        }
+    }
 
     @Override
     public void onStreamRemoved(Http2Stream stream) {}

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientDelegate.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientDelegate.java
@@ -18,7 +18,6 @@ package com.linecorp.armeria.client;
 import static com.linecorp.armeria.internal.ArmeriaHttpUtil.splitPathAndQuery;
 import static java.util.Objects.requireNonNull;
 
-import java.net.InetSocketAddress;
 import java.util.concurrent.CompletableFuture;
 
 import org.slf4j.Logger;
@@ -57,11 +56,8 @@ final class HttpClientDelegate implements Client<HttpRequest, HttpResponse> {
             return HttpResponse.ofFailure(new IllegalArgumentException("invalid path: " + req.path()));
         }
 
-        final PoolKey poolKey = new PoolKey(
-                InetSocketAddress.createUnresolved(endpoint.host(), endpoint.port()),
-                ctx.sessionProtocol());
-
         final EventLoop eventLoop = ctx.eventLoop();
+        final PoolKey poolKey = new PoolKey(endpoint.host(), endpoint.port(), ctx.sessionProtocol());
         final Future<Channel> channelFuture = factory.pool(eventLoop).acquire(poolKey);
         final DecodedHttpResponse res = new DecodedHttpResponse(eventLoop);
 

--- a/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
@@ -20,6 +20,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
+import javax.annotation.Nullable;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -77,14 +79,17 @@ abstract class HttpResponseDecoder {
         return newRes;
     }
 
+    @Nullable
     final HttpResponseWrapper getResponse(int id) {
         return responses.get(id);
     }
 
+    @Nullable
     final HttpResponseWrapper getResponse(int id, boolean remove) {
         return remove ? removeResponse(id) : getResponse(id);
     }
 
+    @Nullable
     final HttpResponseWrapper removeResponse(int id) {
         return responses.remove(id);
     }

--- a/core/src/main/java/com/linecorp/armeria/client/HttpSessionChannelFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpSessionChannelFactory.java
@@ -57,7 +57,7 @@ class HttpSessionChannelFactory implements Function<PoolKey, Future<Channel>> {
 
     @Override
     public Future<Channel> apply(PoolKey key) {
-        final InetSocketAddress remoteAddress = key.remoteAddress();
+        final InetSocketAddress remoteAddress = InetSocketAddress.createUnresolved(key.host(), key.port());
         final SessionProtocol protocol = key.sessionProtocol();
 
         if (SessionProtocolNegotiationCache.isUnsupported(remoteAddress, protocol)) {

--- a/core/src/main/java/com/linecorp/armeria/client/pool/PoolKey.java
+++ b/core/src/main/java/com/linecorp/armeria/client/pool/PoolKey.java
@@ -18,38 +18,43 @@ package com.linecorp.armeria.client.pool;
 
 import static java.util.Objects.requireNonNull;
 
-import java.net.InetSocketAddress;
-
 import com.linecorp.armeria.common.SessionProtocol;
 
 /**
  * The default key of {@link KeyedChannelPool}. It consists of:
  * <ul>
- *   <li>the server's {@link InetSocketAddress}</li>
+ *   <li>the server's host name</li>
+ *   <li>the server's port number</li>
  *   <li>the server's {@link SessionProtocol}</li>
  * </ul>
  */
 public final class PoolKey {
 
-    private final InetSocketAddress remoteAddress;
+    private final String host;
+    private final int port;
     private final SessionProtocol sessionProtocol;
-    private final String value;
 
     /**
-     * Creates a new key with the specified {@code remoteAddress} and {@code sessionProtocol}.
+     * Creates a new key with the specified {@code host}, {@code port} and {@code sessionProtocol}.
      */
-    public PoolKey(InetSocketAddress remoteAddress, SessionProtocol sessionProtocol) {
-        this.remoteAddress = requireNonNull(remoteAddress, "remoteAddress");
+    public PoolKey(String host, int port, SessionProtocol sessionProtocol) {
+        this.host = requireNonNull(host, "host");
+        this.port = port;
         this.sessionProtocol = requireNonNull(sessionProtocol, "sessionProtocol");
-        value = sessionProtocol.uriText() + "://" + remoteAddress.getHostString() + ':' +
-                remoteAddress.getPort();
     }
 
     /**
-     * Returns the remote address of the server associated with this key.
+     * Returns the host name of the server associated with this key.
      */
-    public InetSocketAddress remoteAddress() {
-        return remoteAddress;
+    public String host() {
+        return host;
+    }
+
+    /**
+     * Returns the port number of the server associated with this key.
+     */
+    public int port() {
+        return port;
     }
 
     /**
@@ -69,17 +74,17 @@ public final class PoolKey {
             return false;
         }
 
-        PoolKey poolKey = (PoolKey) o;
-        return value.equals(poolKey.value);
+        final PoolKey that = (PoolKey) o;
+        return host.equals(that.host) && port == that.port && sessionProtocol == that.sessionProtocol;
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return (host.hashCode() * 31 + port) * 31 + sessionProtocol.hashCode();
     }
 
     @Override
     public String toString() {
-        return "PoolKey[" + value + ']';
+        return sessionProtocol.uriText() + "://" + host + ':' + port;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/util/ReleasableHolder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/ReleasableHolder.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.util;
+
+/**
+ * A holder of releasable resource {@link T}.
+ */
+public interface ReleasableHolder<T> {
+
+    /**
+     * Returns the resource.
+     */
+    T get();
+
+    /**
+     * Releases the resource.
+     */
+    void release();
+}

--- a/core/src/test/java/com/linecorp/armeria/client/EventLoopSchedulerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/EventLoopSchedulerTest.java
@@ -1,0 +1,268 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.junit.Test;
+
+import com.linecorp.armeria.client.EventLoopScheduler.Entry;
+
+import io.netty.channel.DefaultEventLoopGroup;
+import io.netty.channel.EventLoop;
+import io.netty.channel.EventLoopGroup;
+
+public class EventLoopSchedulerTest {
+
+    private static final int GROUP_SIZE = 3;
+    private static final EventLoopGroup group = new DefaultEventLoopGroup(GROUP_SIZE);
+    private static final Endpoint endpoint = Endpoint.of("example.com");
+
+    /**
+     * A simple case.
+     * (acquire, release) * 3.
+     */
+    @Test
+    public void acquireAndRelease() {
+        final EventLoopScheduler s = new EventLoopScheduler(group);
+        final Entry e0 = s.acquire(endpoint);
+        final EventLoop loop = e0.get();
+        assertThat(e0.id()).isZero();
+        assertThat(e0.activeRequests()).isEqualTo(1);
+        e0.release();
+        assertThat(e0.activeRequests()).isZero();
+
+        for (int i = 0; i < 2; i++) {
+            final Entry e0again = s.acquire(endpoint);
+            assertThat(e0again).isSameAs(e0);
+            assertThat(e0again.id()).isZero();
+            assertThat(e0again.activeRequests()).isEqualTo(1);
+            assertThat(e0again.get()).isSameAs(loop);
+            e0again.release();
+        }
+    }
+
+    /**
+     * Slightly more complicated case.
+     * (acquire(1), acquire(2), acquire(3), release(1), release(2), release(3))
+     */
+    @Test
+    public void orderedRelease() {
+        final EventLoopScheduler s = new EventLoopScheduler(group);
+
+        // acquire() should return the entry 0 because all entries have same activeRequests (0).
+        final Entry e0 = s.acquire(endpoint);
+        final EventLoop loop1 = e0.get();
+        assertThat(e0.id()).isZero();
+        assertThat(e0.activeRequests()).isEqualTo(1);
+
+        // acquire() should return the entry 1 because it's the entry with the lowest ID
+        // among the entries with the least activeRequests.
+        final Entry e1 = s.acquire(endpoint);
+        final EventLoop loop2 = e1.get();
+        assertThat(e1).isNotSameAs(e0);
+        assertThat(loop2).isNotSameAs(loop1);
+        assertThat(e1.id()).isEqualTo(1);
+        assertThat(e1.activeRequests()).isEqualTo(1);
+
+        // acquire() should return the entry 2 because it's the entry with the lowest ID
+        // among the entries with the least activeRequests.
+        final Entry e2 = s.acquire(endpoint);
+        final EventLoop loop3 = e2.get();
+        assertThat(e2).isNotSameAs(e0);
+        assertThat(e2).isNotSameAs(e1);
+        assertThat(loop3).isNotSameAs(loop1);
+        assertThat(loop3).isNotSameAs(loop2);
+        assertThat(e2.id()).isEqualTo(2);
+        assertThat(e2.activeRequests()).isEqualTo(1);
+
+        // Releasing the entry 0 will change its activeRequests back to 0,
+        // and acquire() will return the entry 0 again because it's the entry
+        // with the lowest ID among the entries with the least activeRequests.
+        e0.release();
+        assertThat(e0.activeRequests()).isZero();
+        final Entry e0again = s.acquire(endpoint);
+        assertThat(e0again).isSameAs(e0);
+        assertThat(e0again.activeRequests()).isEqualTo(1);
+
+        // Releasing the entry 1 will change its activeRequests back to 0,
+        // and acquire() will return the entry 1 again because it's the entry
+        // with the lowest ID among the entries with the least activeRequests.
+        e1.release();
+        assertThat(e1.activeRequests()).isZero();
+        final Entry e1again = s.acquire(endpoint);
+        assertThat(e1again).isSameAs(e1);
+        assertThat(e1again.activeRequests()).isEqualTo(1);
+
+        // Releasing the entry 2 will change its activeRequests back to 0,
+        // and acquire() will return the entry 2 again because it's the entry
+        // with the lowest ID among the entries with the least activeRequests.
+        e2.release();
+        assertThat(e2.activeRequests()).isZero();
+        final Entry e2again = s.acquire(endpoint);
+        assertThat(e2again).isSameAs(e2);
+        assertThat(e2again.activeRequests()).isEqualTo(1);
+    }
+
+    /**
+     * Similar to {@link #orderedRelease()}, but entries are released non-sequentially.
+     */
+    @Test
+    public void unorderedRelease() {
+        final EventLoopScheduler s = new EventLoopScheduler(group);
+
+        // acquire() should return the entry 0 because all entries have same activeRequests (0).
+        final Entry e0 = s.acquire(endpoint);
+        final EventLoop loop1 = e0.get();
+        assertThat(e0.id()).isZero();
+        assertThat(e0.activeRequests()).isEqualTo(1);
+
+        // acquire() should return the entry 1 because it's the entry with the lowest ID
+        // among the entries with the least activeRequests.
+        final Entry e1 = s.acquire(endpoint);
+        final EventLoop loop2 = e1.get();
+        assertThat(e1).isNotSameAs(e0);
+        assertThat(loop2).isNotSameAs(loop1);
+        assertThat(e1.id()).isEqualTo(1);
+        assertThat(e1.activeRequests()).isEqualTo(1);
+
+        // acquire() should return the entry 2 because it's the entry with the lowest ID
+        // among the entries with the least activeRequests.
+        final Entry e2 = s.acquire(endpoint);
+        final EventLoop loop3 = e2.get();
+        assertThat(e2).isNotSameAs(e0);
+        assertThat(e2).isNotSameAs(e1);
+        assertThat(loop3).isNotSameAs(loop1);
+        assertThat(loop3).isNotSameAs(loop2);
+        assertThat(e2.id()).isEqualTo(2);
+        assertThat(e2.activeRequests()).isEqualTo(1);
+
+        // Releasing the entry 1 will change its activeRequests back to 0,
+        // and acquire() will return the entry 1 again because it's the entry
+        // with the lowest ID among the entries with the least activeRequests.
+        e1.release();
+        assertThat(e1.activeRequests()).isZero();
+        final Entry e1again = s.acquire(endpoint);
+        assertThat(e1again).isSameAs(e1);
+        assertThat(e1again.activeRequests()).isEqualTo(1);
+
+        // Releasing the entry 2 will change its activeRequests back to 0,
+        // and acquire() will return the entry 2 again because it's the entry
+        // with the lowest ID among the entries with the least activeRequests.
+        e2.release();
+        assertThat(e2.activeRequests()).isZero();
+        final Entry e2again = s.acquire(endpoint);
+        assertThat(e2again).isSameAs(e2);
+        assertThat(e2again.activeRequests()).isEqualTo(1);
+
+        // Releasing the entry 0 will change its activeRequests back to 0,
+        // and acquire() will return the entry 0 again because it's the entry
+        // with the lowest ID among the entries with the least activeRequests.
+        e0.release();
+        assertThat(e0.activeRequests()).isZero();
+        final Entry e0again = s.acquire(endpoint);
+        assertThat(e0again).isSameAs(e0);
+        assertThat(e0again.activeRequests()).isEqualTo(1);
+    }
+
+    /**
+     * Makes sure different endpoints get different entries.
+     */
+    @Test
+    public void multipleEndpoints() {
+        final EventLoopScheduler s = new EventLoopScheduler(group);
+        final Endpoint endpointA = Endpoint.of("a.com");
+        final Endpoint endpointB = Endpoint.of("b.com");
+        final Set<Entry> entriesA = new LinkedHashSet<>();
+        final Set<Entry> entriesB = new LinkedHashSet<>();
+        for (int i = 0; i < GROUP_SIZE; i++) {
+            entriesA.add(s.acquire(endpointA));
+            entriesB.add(s.acquire(endpointB));
+        }
+        assertThat(entriesA).hasSize(GROUP_SIZE);
+        assertThat(entriesB).hasSize(GROUP_SIZE);
+
+        // At this point, all entries should have activeRequests of 1.
+        entriesA.forEach(e -> assertThat(e.activeRequests()).isEqualTo(1));
+        entriesB.forEach(e -> assertThat(e.activeRequests()).isEqualTo(1));
+
+        // Acquire again for endpoint A.
+        for (int i = 0; i < GROUP_SIZE; i++) {
+            entriesA.add(s.acquire(endpointA));
+        }
+        assertThat(entriesA).hasSize(GROUP_SIZE);
+        entriesA.forEach(e -> assertThat(e.activeRequests()).isEqualTo(2));
+
+        // The entries for endpoint B shouldn't be affected.
+        entriesB.forEach(e -> assertThat(e.activeRequests()).isEqualTo(1));
+    }
+
+    @Test
+    public void stressTest() {
+        final EventLoopGroup group = new DefaultEventLoopGroup(1024);
+        final EventLoopScheduler s = new EventLoopScheduler(group);
+
+        final List<Entry> acquiredEntries = new ArrayList<>();
+        stressTest(s, acquiredEntries, 0.8);
+        stressTest(s, acquiredEntries, 0.5);
+        stressTest(s, acquiredEntries, 0.2);
+
+        // Release all acquired entries to make sure activeRequests are all 0.
+        acquiredEntries.forEach(Entry::release);
+        final List<Entry> entries = s.entries(endpoint);
+        for (Entry e : entries) {
+            assertThat(e.activeRequests()).withFailMessage("All entries must have 0 activeRequests.").isZero();
+        }
+        assertThat(entries.get(0).id()).isZero();
+    }
+
+    private static void stressTest(EventLoopScheduler s, List<Entry> acquiredEntries, double acquireRatio) {
+        final List<Entry> entries = s.entries(endpoint);
+        final Random random = ThreadLocalRandom.current();
+        final int acquireRatioAsInt = (int) (Integer.MAX_VALUE * acquireRatio);
+
+        for (int i = 0; i < 16384; i++) {
+            // Strictly speaking, this can yield a negative value (Integer.MIN_VALUE),
+            // but it shouldn't affect the outcome of this test.
+            final int randomValue = Math.abs(random.nextInt());
+            if (randomValue < acquireRatioAsInt) {
+                final Entry e = s.acquire(endpoint);
+                acquiredEntries.add(e);
+
+                // The acquired entry must be the best available.
+                final int activeRequests = e.activeRequests() - 1;
+                for (Entry entry : entries) {
+                    if (activeRequests == entry.activeRequests()) {
+                        assertThat(e.id()).isLessThan(entry.id());
+                    } else {
+                        assertThat(activeRequests).isLessThan(entry.activeRequests());
+                    }
+                }
+            } else if (!acquiredEntries.isEmpty()) {
+                final Entry e = acquiredEntries.remove(random.nextInt(acquiredEntries.size()));
+                e.release();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Motivations:

Armeria currently keeps a client connection pool for each EventLoop. It
means, when a user sends a client request from N different EventLoops,
N new connections will be created. It is not a problem for light usage
but it can consume large amount of resources when the number of
EventLoops and the kinds of Endpoints get bigger.

Modifications:

- Add ClientFactory.acquireEventLoop(Endpoint) which enables a client
  implementation to choose the EventLoop which is more likely to have an
  idle Channel connected to the desired Endpoint.
- Add EventLoopScheduler which provides the implementation of
  acquireEventLoop(Endpoint)
- Use ClientFactory.acquireEventLoop(Endpoint) wherever possible
  - UserClient
  - ArmeriaChannel (gRPC)
- Miscellaneous:
  - Add ReleasableHolder
  - Fix IllegalStateException in Endpoint.equals(Object)
  - Reduce the memory footprint of PoolKey
  - Fix HttpTracingIntegrationTest so that it works even if the
    collected spans are not ordered

Result:

- The number of idle connections do not grow aggressively when the
  number of EventLoops and Endpoints are big.