### PR TITLE
Add HttpClientBuilder and factory methods to HttpClient

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientBuilder.java
@@ -21,7 +21,9 @@ import java.net.URI;
 
 /**
  * Creates a new client that connects to the specified {@link URI} using the builder pattern. Use the factory
- * methods in {@link Clients} if you do not have many options to override.
+ * methods in {@link Clients} if you do not have many options to override. If you are creating an
+ * {@link HttpClient}, it is recommended to use the {@link HttpClientBuilder} or
+ * factory methods in {@link HttpClient}.
  *
  * <h3>How are decorators and HTTP headers configured?</h3>
  *

--- a/core/src/main/java/com/linecorp/armeria/client/Clients.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Clients.java
@@ -30,6 +30,8 @@ import io.netty.util.AsciiString;
 
 /**
  * Creates a new client that connects to a specified {@link URI}.
+ * If you are creating an {@link HttpClient}, it is recommended to use the factory methods in
+ * {@link HttpClient}.
  */
 public final class Clients {
 
@@ -257,7 +259,7 @@ public final class Clients {
 
     /**
      * Sets the specified HTTP header in a thread-local variable so that the header is sent by the client call
-     * made from the current thread. Use the `try-resources-finally` block with the returned
+     * made from the current thread. Use the `try-with-resources` block with the returned
      * {@link SafeCloseable} to unset the thread-local variable automatically:
      * <pre>{@code
      * import static com.linecorp.armeria.common.HttpHeaderNames.AUTHORIZATION;
@@ -291,7 +293,7 @@ public final class Clients {
 
     /**
      * Sets the specified HTTP header manipulating function in a thread-local variable so that the manipulated
-     * headers are sent by the client call made from the current thread. Use the `try-resources-finally` block
+     * headers are sent by the client call made from the current thread. Use the `try-with-resources` block
      * with the returned {@link SafeCloseable} to unset the thread-local variable automatically:
      * <pre>{@code
      * import static com.linecorp.armeria.common.HttpHeaderNames.AUTHORIZATION;
@@ -326,7 +328,6 @@ public final class Clients {
 
         final Function<HttpHeaders, HttpHeaders> oldManipulator =
                 UserClient.THREAD_LOCAL_HEADER_MANIPULATOR.get();
-
 
         if (oldManipulator != null) {
             UserClient.THREAD_LOCAL_HEADER_MANIPULATOR.set(oldManipulator.andThen(headerManipulator));

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClient.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.client;
 
+import java.net.URI;
 import java.nio.charset.Charset;
 
 import com.linecorp.armeria.common.AggregatedHttpMessage;
@@ -29,6 +30,114 @@ import com.linecorp.armeria.common.HttpResponse;
  * An HTTP client.
  */
 public interface HttpClient extends ClientBuilderParams {
+
+    /**
+     * Creates a new HTTP client that connects to the specified {@code uri} using the default
+     * {@link ClientFactory}.
+     *
+     * @param uri the URI of the server endpoint
+     * @param options the {@link ClientOptionValue}s
+     *
+     * @throws IllegalArgumentException if the scheme of the specified {@code uri} is not an HTTP scheme
+     */
+    static HttpClient of(String uri, ClientOptionValue<?>... options) {
+        return of(ClientFactory.DEFAULT, uri, options);
+    }
+
+    /**
+     * Creates a new HTTP client that connects to the specified {@code uri} using the default
+     * {@link ClientFactory}.
+     *
+     * @param uri the URI of the server endpoint
+     * @param options the {@link ClientOptions}
+     *
+     * @throws IllegalArgumentException if the scheme of the specified {@code uri} is not an HTTP scheme
+     */
+    static HttpClient of(String uri, ClientOptions options) {
+        return of(ClientFactory.DEFAULT, uri, options);
+    }
+
+    /**
+     * Creates a new HTTP client that connects to the specified {@code uri} using an alternative
+     * {@link ClientFactory}.
+     *
+     * @param factory an alternative {@link ClientFactory}
+     * @param uri the URI of the server endpoint
+     * @param options the {@link ClientOptionValue}s
+     *
+     * @throws IllegalArgumentException if the scheme of the specified {@code uri} is not an HTTP scheme
+     */
+    static HttpClient of(ClientFactory factory, String uri, ClientOptionValue<?>... options) {
+        return new HttpClientBuilder(uri).factory(factory).options(options).build();
+    }
+
+    /**
+     * Creates a new HTTP client that connects to the specified {@code uri} using an alternative
+     * {@link ClientFactory}.
+     *
+     * @param factory an alternative {@link ClientFactory}
+     * @param uri the URI of the server endpoint
+     * @param options the {@link ClientOptions}
+     *
+     * @throws IllegalArgumentException if the scheme of the specified {@code uri} is not an HTTP scheme
+     */
+    static HttpClient of(ClientFactory factory, String uri, ClientOptions options) {
+        return new HttpClientBuilder(uri).factory(factory).options(options).build();
+    }
+
+    /**
+     * Creates a new HTTP client that connects to the specified {@link URI} using the default
+     * {@link ClientFactory}.
+     *
+     * @param uri the URI of the server endpoint
+     * @param options the {@link ClientOptionValue}s
+     *
+     * @throws IllegalArgumentException if the scheme of the specified {@code uri} is not an HTTP scheme
+     */
+    static HttpClient of(URI uri, ClientOptionValue<?>... options) {
+        return of(ClientFactory.DEFAULT, uri, options);
+    }
+
+    /**
+     * Creates a new HTTP client that connects to the specified {@link URI} using the default
+     * {@link ClientFactory}.
+     *
+     * @param uri the URI of the server endpoint
+     * @param options the {@link ClientOptions}
+     *
+     * @throws IllegalArgumentException if the scheme of the specified {@code uri} is not an HTTP scheme
+     */
+    static HttpClient of(URI uri, ClientOptions options) {
+        return of(ClientFactory.DEFAULT, uri, options);
+    }
+
+    /**
+     * Creates a new HTTP client that connects to the specified {@link URI} using an alternative
+     * {@link ClientFactory}.
+     *
+     * @param factory an alternative {@link ClientFactory}
+     * @param uri the URI of the server endpoint
+     * @param options the {@link ClientOptionValue}s
+     *
+     * @throws IllegalArgumentException if the scheme of the specified {@code uri} is not an HTTP scheme
+     */
+    static HttpClient of(ClientFactory factory, URI uri, ClientOptionValue<?>... options) {
+        return new HttpClientBuilder(uri).factory(factory).options(options).build();
+    }
+
+    /**
+     * Creates a new HTTP client that connects to the specified {@link URI} using an alternative
+     * {@link ClientFactory}.
+     *
+     * @param factory an alternative {@link ClientFactory}
+     * @param uri the URI of the server endpoint
+     * @param options the {@link ClientOptions}
+     *
+     * @throws IllegalArgumentException if the scheme of the specified {@code uri} is not an HTTP scheme
+     */
+    static HttpClient of(ClientFactory factory, URI uri, ClientOptions options) {
+        return new HttpClientBuilder(uri).factory(factory).options(options).build();
+    }
 
     /**
      * Sends the specified HTTP request.

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientBuilder.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import static java.util.Objects.requireNonNull;
+
+import java.net.URI;
+import java.util.function.Function;
+
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.SerializationFormat;
+import com.linecorp.armeria.common.SessionProtocol;
+
+/**
+ * Creates a new HTTP client that connects to the specified {@link URI} using the builder pattern.
+ * Use the factory methods in {@link HttpClient} if you do not have many options to override.
+ * Please refer to {@link ClientBuilder} for how decorators and HTTP headers are configured
+ */
+public final class HttpClientBuilder extends AbstractClientOptionsBuilder<HttpClientBuilder> {
+
+    private final URI uri;
+    private ClientFactory factory = ClientFactory.DEFAULT;
+
+    /**
+     * Creates a new instance.
+     *
+     * @throws IllegalArgumentException if the scheme of the uri is not one of the fields
+     *                                  in {@link SessionProtocol} or the uri violates RFC 2396
+     */
+    public HttpClientBuilder(String uri) {
+        this(URI.create(requireNonNull(uri, "uri")));
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @throws IllegalArgumentException if the scheme of the uri is not one of the fields
+     *                                  in {@link SessionProtocol}
+     */
+    public HttpClientBuilder(URI uri) {
+        validateScheme(requireNonNull(uri, "uri").getScheme());
+        this.uri = URI.create(SerializationFormat.NONE + "+" + uri.toString());
+    }
+
+    private static void validateScheme(String scheme) {
+        for (SessionProtocol p : SessionProtocol.values()) {
+            if (scheme.equalsIgnoreCase(p.uriText())) {
+                return;
+            }
+        }
+        throw new IllegalArgumentException("scheme : " + scheme + " (expected: one of " +
+                                           ImmutableList.copyOf(SessionProtocol.values()) + ")");
+    }
+
+    /**
+     * Sets the {@link ClientFactory} of the client. The default is {@link ClientFactory#DEFAULT}.
+     */
+    public HttpClientBuilder factory(ClientFactory factory) {
+        this.factory = requireNonNull(factory, "factory");
+        return this;
+    }
+
+    /**
+     * Adds the specified {@code decorator}.
+     *
+     * @param decorator the {@link Function} that transforms a {@link Client} to another
+     */
+    public HttpClientBuilder decorator(
+            Function<? extends Client<HttpRequest, HttpResponse>, ? extends Client<HttpRequest, HttpResponse>>
+                    decorator) {
+        return super.decorator(HttpRequest.class, HttpResponse.class, decorator);
+    }
+
+    /**
+     * Adds the specified {@code decorator}.
+     *
+     * @param decorator the {@link DecoratingClientFunction} that intercepts an invocation
+     */
+    public HttpClientBuilder decorator(DecoratingClientFunction<HttpRequest, HttpResponse> decorator) {
+        return super.decorator(HttpRequest.class, HttpResponse.class, decorator);
+    }
+
+    /**
+     * Returns a newly-created HTTP client based on the properties of this builder.
+     *
+     * @throws IllegalArgumentException if the scheme of the {@code uri} specified in
+     *                                  {@link #HttpClientBuilder(String)} or {@link #HttpClientBuilder(URI)}
+     *                                  is not an HTTP scheme
+     */
+    public HttpClient build() {
+        return factory.newClient(uri, HttpClient.class, buildOptions());
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroup.java
@@ -21,7 +21,6 @@ import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 
 import com.linecorp.armeria.client.ClientFactory;
-import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
@@ -87,9 +86,7 @@ public final class HttpHealthCheckedEndpointGroup extends HealthCheckedEndpointG
         private HttpEndpointHealthChecker(ClientFactory clientFactory,
                                           Endpoint endpoint,
                                           String healthCheckPath) {
-            httpClient = Clients.newClient(clientFactory,
-                                           "none+http://" + endpoint.authority(),
-                                           HttpClient.class);
+            httpClient = HttpClient.of(clientFactory, "http://" + endpoint.authority());
             this.healthCheckPath = healthCheckPath;
         }
 

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientIntegrationTest.java
@@ -57,7 +57,6 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpResponseWriter;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
-import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.util.CompletionActions;
 import com.linecorp.armeria.internal.ByteBufHttpData;
 import com.linecorp.armeria.server.AbstractHttpService;
@@ -294,8 +293,7 @@ public class HttpClientIntegrationTest {
 
     @Test
     public void testRequestNoBody() throws Exception {
-        HttpClient client = Clients.newClient(server.uri(SerializationFormat.NONE, "/"),
-                                              HttpClient.class);
+        HttpClient client = HttpClient.of(server.uri("/"));
 
         AggregatedHttpMessage response = client.execute(
                 HttpHeaders.of(HttpMethod.GET, "/httptestbody")
@@ -309,8 +307,7 @@ public class HttpClientIntegrationTest {
 
     @Test
     public void testRequestWithBody() throws Exception {
-        HttpClient client = Clients.newClient(server.uri(SerializationFormat.NONE, "/"),
-                                              HttpClient.class);
+        HttpClient client = HttpClient.of(server.uri("/"));
 
         AggregatedHttpMessage response = client.execute(
                 HttpHeaders.of(HttpMethod.POST, "/httptestbody")
@@ -325,8 +322,7 @@ public class HttpClientIntegrationTest {
 
     @Test
     public void testNot200() throws Exception {
-        HttpClient client = Clients.newClient(server.uri(SerializationFormat.NONE, "/"),
-                                              HttpClient.class);
+        HttpClient client = HttpClient.of(server.uri("/"));
 
         AggregatedHttpMessage response = client.get("/not200").aggregate().get();
 
@@ -360,9 +356,7 @@ public class HttpClientIntegrationTest {
 
         HttpHeaders headers = HttpHeaders.of(HttpHeaderNames.USER_AGENT, TEST_USER_AGENT_NAME);
         ClientOptions options = ClientOptions.of(ClientOption.HTTP_HEADERS.newValue(headers));
-
-        HttpClient client = Clients.newClient(server.uri(SerializationFormat.NONE, "/"),
-                                              HttpClient.class, options);
+        HttpClient client = HttpClient.of(server.uri("/"), options);
 
         AggregatedHttpMessage response = client.get("/useragent").aggregate().get();
 
@@ -374,9 +368,7 @@ public class HttpClientIntegrationTest {
 
         HttpHeaders headers = HttpHeaders.of(HttpHeaderNames.USER_AGENT, TEST_USER_AGENT_NAME);
         ClientOptions options = ClientOptions.of(ClientOption.HTTP_HEADERS.newValue(headers));
-
-        HttpClient client = Clients.newClient(server.uri(SerializationFormat.NONE, "/"),
-                                              HttpClient.class, options);
+        HttpClient client = HttpClient.of(server.uri("/"), options);
 
         final String OVERIDDEN_USER_AGENT_NAME = "Overridden";
 
@@ -390,11 +382,9 @@ public class HttpClientIntegrationTest {
 
     @Test
     public void httpDecoding() throws Exception {
-        HttpClient client = new ClientBuilder(
-                server.uri(SerializationFormat.NONE, "/"))
-                .factory(clientFactory)
-                .decorator(HttpRequest.class, HttpResponse.class, HttpDecodingClient.newDecorator())
-                .build(HttpClient.class);
+        HttpClient client = new HttpClientBuilder(server.uri("/"))
+                .factory(clientFactory).decorator(HttpDecodingClient.newDecorator()).build();
+
         AggregatedHttpMessage response =
                 client.execute(HttpHeaders.of(HttpMethod.GET, "/encoding")).aggregate().get();
         assertThat(response.headers().get(HttpHeaderNames.CONTENT_ENCODING)).isEqualTo("gzip");
@@ -404,12 +394,10 @@ public class HttpClientIntegrationTest {
 
     @Test
     public void httpDecoding_deflate() throws Exception {
-        HttpClient client = new ClientBuilder(
-                server.uri(SerializationFormat.NONE, "/"))
+        HttpClient client = new HttpClientBuilder(server.uri("/"))
                 .factory(clientFactory)
-                .decorator(HttpRequest.class, HttpResponse.class, HttpDecodingClient.newDecorator(
-                        new DeflateStreamDecoderFactory()))
-                .build(HttpClient.class);
+                .decorator(HttpDecodingClient.newDecorator(new DeflateStreamDecoderFactory())).build();
+
         AggregatedHttpMessage response =
                 client.execute(HttpHeaders.of(HttpMethod.GET, "/encoding")).aggregate().get();
         assertThat(response.headers().get(HttpHeaderNames.CONTENT_ENCODING)).isEqualTo("deflate");
@@ -419,12 +407,10 @@ public class HttpClientIntegrationTest {
 
     @Test
     public void httpDecoding_noEncodingApplied() throws Exception {
-        HttpClient client = new ClientBuilder(
-                server.uri(SerializationFormat.NONE, "/"))
+        HttpClient client = new HttpClientBuilder(server.uri("/"))
                 .factory(clientFactory)
-                .decorator(HttpRequest.class, HttpResponse.class, HttpDecodingClient.newDecorator(
-                        new DeflateStreamDecoderFactory()))
-                .build(HttpClient.class);
+                .decorator(HttpDecodingClient.newDecorator(new DeflateStreamDecoderFactory())).build();
+
         AggregatedHttpMessage response =
                 client.execute(HttpHeaders.of(HttpMethod.GET, "/encoding-toosmall")).aggregate().get();
         assertThat(response.headers().get(HttpHeaderNames.CONTENT_ENCODING)).isNull();
@@ -464,8 +450,7 @@ public class HttpClientIntegrationTest {
 
     @Test
     public void givenHttpClientUriPathAndRequestPath_whenGet_thenRequestToConcatenatedPath() throws Exception {
-        HttpClient client = Clients.newClient(server.uri(SerializationFormat.NONE, "/hello"),
-                                              HttpClient.class);
+        HttpClient client = HttpClient.of(server.uri("/hello"));
 
         AggregatedHttpMessage response = client.get("/world").aggregate().get();
 
@@ -474,8 +459,7 @@ public class HttpClientIntegrationTest {
 
     @Test
     public void givenRequestPath_whenGet_thenRequestToPath() throws Exception {
-        HttpClient client = Clients.newClient(server.uri(SerializationFormat.NONE, "/"),
-                                              HttpClient.class);
+        HttpClient client = HttpClient.of(server.uri("/"));
 
         AggregatedHttpMessage response = client.get("/hello/world").aggregate().get();
 
@@ -484,8 +468,7 @@ public class HttpClientIntegrationTest {
 
     @Test
     public void testPooledResponseDefaultSubscriber() throws Exception {
-        HttpClient client = Clients.newClient(server.uri(SerializationFormat.NONE, "/"),
-                                              HttpClient.class);
+        HttpClient client = HttpClient.of(server.uri("/"));
 
         AggregatedHttpMessage response = client.execute(
                 HttpHeaders.of(HttpMethod.GET, "/pooled")).aggregate().get();
@@ -497,8 +480,7 @@ public class HttpClientIntegrationTest {
 
     @Test
     public void testPooledResponsePooledSubscriber() throws Exception {
-        HttpClient client = Clients.newClient(server.uri(SerializationFormat.NONE, "/"),
-                                              HttpClient.class);
+        HttpClient client = HttpClient.of(server.uri("/"));
 
         AggregatedHttpMessage response = client.execute(
                 HttpHeaders.of(HttpMethod.GET, "/pooled-aware")).aggregate().get();
@@ -510,8 +492,7 @@ public class HttpClientIntegrationTest {
 
     @Test
     public void testUnpooledResponsePooledSubscriber() throws Exception {
-        HttpClient client = Clients.newClient(server.uri(SerializationFormat.NONE, "/"),
-                                              HttpClient.class);
+        HttpClient client = HttpClient.of(server.uri("/"));
 
         AggregatedHttpMessage response = client.execute(
                 HttpHeaders.of(HttpMethod.GET, "/pooled-unaware")).aggregate().get();

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientPipeliningTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientPipeliningTest.java
@@ -126,8 +126,8 @@ public class HttpClientPipeliningTest {
 
     @Test
     public void withoutPipelining() throws Exception {
-        final HttpClient client = Clients.newClient(
-                factoryWithoutPipelining, "none+h1c://127.0.0.1:" + server.httpPort(), HttpClient.class);
+        final HttpClient client = HttpClient.of(
+                factoryWithoutPipelining, "h1c://127.0.0.1:" + server.httpPort());
 
         final HttpResponse res1 = client.get("/");
         final HttpResponse res2 = client.get("/");
@@ -147,8 +147,8 @@ public class HttpClientPipeliningTest {
 
     @Test
     public void withPipelining() throws Exception {
-        final HttpClient client = Clients.newClient(
-                factoryWithPipelining, "none+h1c://127.0.0.1:" + server.httpPort(), HttpClient.class);
+        final HttpClient client = HttpClient.of(
+                factoryWithPipelining, "h1c://127.0.0.1:" + server.httpPort());
 
         final HttpResponse res1;
         lock.lock();

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientSniTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientSniTest.java
@@ -130,9 +130,7 @@ public class HttpClientSniTest {
     }
 
     private static String get(String fqdn) throws Exception {
-        HttpClient client = Clients.newClient(
-                clientFactory, "none+https://" + fqdn + ':' + httpsPort,
-                HttpClient.class);
+        final HttpClient client = HttpClient.of(clientFactory, "https://" + fqdn + ':' + httpsPort);
 
         AggregatedHttpMessage response = client.get("/").aggregate().get();
 

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientTimeoutTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientTimeoutTest.java
@@ -59,10 +59,8 @@ public class HttpClientTimeoutTest {
     @Test
     public void responseTimeoutH1C() throws Exception {
         try (ServerSocket ss = new ServerSocket(0)) {
-            final HttpClient client = new ClientBuilder("none+h1c://127.0.0.1:" + ss.getLocalPort())
-                    .factory(factory)
-                    .defaultResponseTimeout(Duration.ofSeconds(1))
-                    .build(HttpClient.class);
+            final HttpClient client = new HttpClientBuilder("h1c://127.0.0.1:" + ss.getLocalPort())
+                    .factory(factory).defaultResponseTimeout(Duration.ofSeconds(1)).build();
 
             final HttpResponse res = client.get("/");
             try (Socket s = ss.accept()) {
@@ -85,10 +83,8 @@ public class HttpClientTimeoutTest {
     @Test
     public void responseTimeoutH2C() throws Exception {
         try (ServerSocket ss = new ServerSocket(0)) {
-            final HttpClient client = new ClientBuilder("none+h2c://127.0.0.1:" + ss.getLocalPort())
-                    .factory(factory)
-                    .defaultResponseTimeout(Duration.ofSeconds(1))
-                    .build(HttpClient.class);
+            final HttpClient client = new HttpClientBuilder("h2c://127.0.0.1:" + ss.getLocalPort())
+                    .factory(factory).defaultResponseTimeout(Duration.ofSeconds(1)).build();
 
             final HttpResponse res = client.get("/");
             try (Socket s = ss.accept()) {

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerTest.java
@@ -71,10 +71,10 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.ByteStreams;
 
-import com.linecorp.armeria.client.ClientBuilder;
 import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.ClientFactoryBuilder;
 import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.client.HttpClientBuilder;
 import com.linecorp.armeria.common.AggregatedHttpMessage;
 import com.linecorp.armeria.common.ClosedSessionException;
 import com.linecorp.armeria.common.DefaultHttpRequest;
@@ -838,13 +838,12 @@ public class HttpServerTest {
             return client;
         }
 
-        final ClientBuilder builder = new ClientBuilder(
-                "none+" + protocol.uriText() + "://127.0.0.1:" +
+        final HttpClientBuilder builder = new HttpClientBuilder(
+                protocol.uriText() + "://127.0.0.1:" +
                 (protocol.isTls() ? server.httpsPort() : server.httpPort()));
 
         builder.factory(clientFactory);
         builder.decorator(
-                HttpRequest.class, HttpResponse.class,
                 (delegate, ctx, req) -> {
                     ctx.setWriteTimeoutMillis(clientWriteTimeoutMillis);
                     ctx.setResponseTimeoutMillis(clientResponseTimeoutMillis);
@@ -852,7 +851,7 @@ public class HttpServerTest {
                     return delegate.execute(ctx, req);
                 });
 
-        return client = builder.build(HttpClient.class);
+        return client = builder.build();
     }
 
     private static class CountingService extends AbstractHttpService {

--- a/core/src/test/java/com/linecorp/armeria/server/cors/HttpServerCorsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/cors/HttpServerCorsTest.java
@@ -15,7 +15,6 @@
  */
 package com.linecorp.armeria.server.cors;
 
-import static com.linecorp.armeria.common.SerializationFormat.NONE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
@@ -23,7 +22,6 @@ import org.junit.ClassRule;
 import org.junit.Test;
 
 import com.linecorp.armeria.client.ClientFactory;
-import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.common.AggregatedHttpMessage;
 import com.linecorp.armeria.common.HttpHeaderNames;
@@ -76,7 +74,7 @@ public class HttpServerCorsTest {
 
     @Test
     public void testCorsPreflight() throws Exception {
-        HttpClient client = Clients.newClient(clientFactory, server.uri(NONE, "/"), HttpClient.class);
+        HttpClient client = HttpClient.of(clientFactory, server.uri("/"));
         AggregatedHttpMessage response = client.execute(
                 HttpHeaders.of(HttpMethod.OPTIONS, "/cors")
                            .set(HttpHeaderNames.ACCEPT, "utf-8")
@@ -91,7 +89,7 @@ public class HttpServerCorsTest {
 
     @Test
     public void testCorsAllowed() throws Exception {
-        HttpClient client = Clients.newClient(clientFactory, server.uri(NONE, "/"), HttpClient.class);
+        HttpClient client = HttpClient.of(clientFactory, server.uri("/"));
         AggregatedHttpMessage response = client.execute(
                 HttpHeaders.of(HttpMethod.POST, "/cors")
                            .set(HttpHeaderNames.ACCEPT, "utf-8")
@@ -104,7 +102,7 @@ public class HttpServerCorsTest {
 
     @Test
     public void testCorsForbidden() throws Exception {
-        HttpClient client = Clients.newClient(clientFactory, server.uri(NONE, "/"), HttpClient.class);
+        HttpClient client = HttpClient.of(clientFactory, server.uri("/"));
         AggregatedHttpMessage response = client.execute(
                 HttpHeaders.of(HttpMethod.POST, "/cors")
                            .set(HttpHeaderNames.ACCEPT, "utf-8")

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
@@ -43,7 +43,6 @@ import com.google.protobuf.ByteString;
 
 import com.linecorp.armeria.client.ClientBuilder;
 import com.linecorp.armeria.client.ClientRequestContext;
-import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.client.SimpleDecoratingClient;
 import com.linecorp.armeria.common.AggregatedHttpMessage;
@@ -379,7 +378,7 @@ public class GrpcServiceServerTest {
 
     @Test
     public void unframed() throws Exception {
-        HttpClient client = Clients.newClient("none+" + server.httpUri("/"), HttpClient.class);
+        HttpClient client = HttpClient.of(server.httpUri("/"));
         AggregatedHttpMessage response = client.execute(
                 HttpHeaders.of(HttpMethod.POST,
                                UnitTestServiceGrpc.METHOD_STATIC_UNARY_CALL.getFullMethodName())
@@ -393,7 +392,7 @@ public class GrpcServiceServerTest {
 
     @Test
     public void unframed_acceptEncoding() throws Exception {
-        HttpClient client = Clients.newClient("none+" + server.httpUri("/"), HttpClient.class);
+        HttpClient client = HttpClient.of(server.httpUri("/"));
         AggregatedHttpMessage response = client.execute(
                 HttpHeaders.of(HttpMethod.POST,
                                UnitTestServiceGrpc.METHOD_STATIC_UNARY_CALL.getFullMethodName())
@@ -408,7 +407,7 @@ public class GrpcServiceServerTest {
 
     @Test
     public void unframed_streamingApi() throws Exception {
-        HttpClient client = Clients.newClient("none+" + server.httpUri("/"), HttpClient.class);
+        HttpClient client = HttpClient.of(server.httpUri("/"));
         AggregatedHttpMessage response = client.execute(
                 HttpHeaders.of(HttpMethod.POST,
                                UnitTestServiceGrpc.METHOD_STATIC_STREAMED_OUTPUT_CALL.getFullMethodName())
@@ -419,7 +418,7 @@ public class GrpcServiceServerTest {
 
     @Test
     public void unframed_noContentType() throws Exception {
-        HttpClient client = Clients.newClient("none+" + server.httpUri("/"), HttpClient.class);
+        HttpClient client = HttpClient.of(server.httpUri("/"));
         AggregatedHttpMessage response = client.execute(
                 HttpHeaders.of(HttpMethod.POST,
                                UnitTestServiceGrpc.METHOD_STATIC_UNARY_CALL.getFullMethodName()),
@@ -429,7 +428,7 @@ public class GrpcServiceServerTest {
 
     @Test
     public void unframed_grpcEncoding() throws Exception {
-        HttpClient client = Clients.newClient("none+" + server.httpUri("/"), HttpClient.class);
+        HttpClient client = HttpClient.of(server.httpUri("/"));
         AggregatedHttpMessage response = client.execute(
                 HttpHeaders.of(HttpMethod.POST,
                                UnitTestServiceGrpc.METHOD_STATIC_UNARY_CALL.getFullMethodName())
@@ -441,7 +440,7 @@ public class GrpcServiceServerTest {
 
     @Test
     public void unframed_serviceError() throws Exception {
-        HttpClient client = Clients.newClient("none+" + server.httpUri("/"), HttpClient.class);
+        HttpClient client = HttpClient.of(server.httpUri("/"));
         AggregatedHttpMessage response = client.execute(
                 HttpHeaders.of(HttpMethod.POST,
                                UnitTestServiceGrpc.METHOD_STATIC_UNARY_CALL.getFullMethodName())
@@ -456,7 +455,7 @@ public class GrpcServiceServerTest {
 
     @Test
     public void grpcWeb() throws Exception {
-        HttpClient client = Clients.newClient("none+" + server.httpUri("/"), HttpClient.class);
+        HttpClient client = HttpClient.of(server.httpUri("/"));
         AggregatedHttpMessage response = client.execute(
                 HttpHeaders.of(HttpMethod.POST,
                                UnitTestServiceGrpc.METHOD_STATIC_UNARY_CALL.getFullMethodName())

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/ArmeriaCallFactory.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/ArmeriaCallFactory.java
@@ -27,15 +27,11 @@ import java.util.regex.Pattern;
 
 import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.ClientOptionsBuilder;
-import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.common.Scheme;
-import com.linecorp.armeria.common.SerializationFormat;
-import com.linecorp.armeria.common.SessionProtocol;
 
 import okhttp3.Call;
 import okhttp3.Call.Factory;
@@ -86,10 +82,9 @@ final class ArmeriaCallFactory implements Factory {
         return httpClients.computeIfAbsent(authority, key -> {
             final String finalAuthority = isGroup(key) ?
                                           GROUP_PREFIX_MATCHER.matcher(key).replaceFirst("group:") : key;
-            final String uriText = Scheme.of(SerializationFormat.NONE, SessionProtocol.of(sessionProtocol))
-                                         .uriText() + "://" + finalAuthority;
-            return Clients.newClient(clientFactory, uriText, HttpClient.class,
-                                     configurator.apply(uriText, new ClientOptionsBuilder()).build());
+            final String uriText = sessionProtocol + "://" + finalAuthority;
+            return HttpClient.of(
+                    clientFactory, uriText, configurator.apply(uriText, new ClientOptionsBuilder()).build());
         });
     }
 

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/ArmeriaRetrofitBuilder.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/ArmeriaRetrofitBuilder.java
@@ -26,11 +26,9 @@ import java.util.function.BiFunction;
 
 import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.ClientOptionsBuilder;
-import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.common.Scheme;
-import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.SessionProtocol;
 
 import okhttp3.HttpUrl;
@@ -174,11 +172,9 @@ public final class ArmeriaRetrofitBuilder {
     public Retrofit build() {
         checkState(baseUrl != null, "baseUrl not set");
         final URI uri = URI.create(baseUrl);
-        final Scheme scheme = Scheme.of(SerializationFormat.NONE, SessionProtocol.of(uri.getScheme()));
-        final String fullUri = scheme.uriText() + "://" + uri.getAuthority();
-        final HttpClient baseHttpClient =
-                Clients.newClient(clientFactory, fullUri, HttpClient.class,
-                                  configurator.apply(fullUri, new ClientOptionsBuilder()).build());
+        final String fullUri = SessionProtocol.of(uri.getScheme()) + "://" + uri.getAuthority();
+        final HttpClient baseHttpClient = HttpClient.of(
+                clientFactory, fullUri, configurator.apply(fullUri, new ClientOptionsBuilder()).build());
         return retrofitBuilder.baseUrl(convertToOkHttpUrl(baseHttpClient, uri.getPath(), GROUP_PREFIX))
                               .callFactory(new ArmeriaCallFactory(baseHttpClient, clientFactory, configurator))
                               .build();

--- a/site/src/sphinx/client-http.rst
+++ b/site/src/sphinx/client-http.rst
@@ -5,15 +5,13 @@ Calling an HTTP service
 
 .. code-block:: java
 
-    import com.linecorp.armeria.client.Clients;
     import com.linecorp.armeria.client.HttpClient;
     import com.linecorp.armeria.common.AggregatedHttpMessage;
     import com.linecorp.armeria.common.HttpHeaderNames;
     import com.linecorp.armeria.common.HttpHeaders;
     import com.linecorp.armeria.common.HttpMethod;
 
-    HttpClient httpClient = Clients.newClient(
-            "none+http://example.com/", HttpClient.class);
+    HttpClient httpClient = HttpClient.of("http://example.com/");
 
     AggregatedHttpMessage textResponse = httpClient.get("/foo/bar.txt").aggregate().join();
 

--- a/spring-boot/autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaAutoConfigurationTest.java
+++ b/spring-boot/autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaAutoConfigurationTest.java
@@ -127,7 +127,7 @@ public class ArmeriaAutoConfigurationTest {
 
     @Test
     public void testHttpServiceRegistrationBean() throws Exception {
-        HttpClient client = Clients.newClient(newUrl("none+h1c"), HttpClient.class);
+        HttpClient client = HttpClient.of(newUrl("h1c"));
 
         HttpResponse response = client.get("/ok");
 
@@ -138,7 +138,7 @@ public class ArmeriaAutoConfigurationTest {
 
     @Test
     public void testAnnotatedServiceRegistrationBean() throws Exception {
-        HttpClient client = Clients.newClient(newUrl("none+h1c"), HttpClient.class);
+        HttpClient client = HttpClient.of(newUrl("h1c"));
 
         HttpResponse response = client.get("/annotated/get");
 
@@ -154,7 +154,7 @@ public class ArmeriaAutoConfigurationTest {
 
         assertThat(client.hello("world")).isEqualTo("hello world");
 
-        HttpClient httpClient = Clients.newClient(newUrl("none+h1c"), HttpClient.class);
+        HttpClient httpClient = HttpClient.of(newUrl("h1c"));
         HttpResponse response = httpClient.get("/internal/docs/specification.json");
 
         AggregatedHttpMessage msg = response.aggregate().get();

--- a/testing/src/main/java/com/linecorp/armeria/testing/server/webapp/WebAppContainerTest.java
+++ b/testing/src/main/java/com/linecorp/armeria/testing/server/webapp/WebAppContainerTest.java
@@ -16,7 +16,6 @@
 
 package com.linecorp.armeria.testing.server.webapp;
 
-import static com.linecorp.armeria.common.SerializationFormat.NONE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
@@ -148,7 +147,7 @@ public abstract class WebAppContainerTest {
         ClientFactory clientFactory = new ClientFactoryBuilder()
                 .sslContextCustomizer(b -> b.trustManager(InsecureTrustManagerFactory.INSTANCE))
                 .build();
-        HttpClient client = clientFactory.newClient(server().httpsUri(NONE, "/"), HttpClient.class);
+        HttpClient client = HttpClient.of(clientFactory, server().httpsUri("/"));
         AggregatedHttpMessage response = client.get("/jsp/index.jsp").aggregate().get();
         final String actualContent = CR_OR_LF.matcher(response.content().toStringUtf8())
                                              .replaceAll("");

--- a/thrift/src/test/java/com/linecorp/armeria/it/metric/PrometheusMetricsIntegrationTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/metric/PrometheusMetricsIntegrationTest.java
@@ -35,7 +35,6 @@ import org.junit.Test;
 import com.google.common.collect.ImmutableSortedMap;
 
 import com.linecorp.armeria.client.ClientBuilder;
-import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.client.metric.PrometheusMetricCollectingClient;
 import com.linecorp.armeria.common.AggregatedHttpMessage;
@@ -83,7 +82,7 @@ public class PrometheusMetricsIntegrationTest {
                                           log -> defaultMetricName(log, "HelloService2"))));
 
             sb.service("/internal/prometheus/metrics",
-                         new PrometheusExporterHttpService(registry));
+                       new PrometheusExporterHttpService(registry));
         }
     };
 
@@ -241,8 +240,7 @@ public class PrometheusMetricsIntegrationTest {
 
     private static AggregatedHttpMessage makeMetricsRequest() throws ExecutionException,
                                                                      InterruptedException {
-        final HttpClient client = Clients.newClient("none+http://127.0.0.1:" + server.httpPort(),
-                                                    HttpClient.class);
+        final HttpClient client = HttpClient.of("http://127.0.0.1:" + server.httpPort());
         return client.execute(HttpHeaders.of(HttpMethod.GET, "/internal/prometheus/metrics")
                                          .setObject(HttpHeaderNames.ACCEPT, MediaType.PLAIN_TEXT_UTF_8))
                      .aggregate().get();


### PR DESCRIPTION
Motivation:

When a user creates an HttpClient, he/she needs to specify type parameters such as HttpClient.class for construction and HttpRequest.class, HttpResponse.class for the decorator which is painful.
We needed to simplify that.

Modifications:

- Add HttpClientBuilder whilch doesn't need to specify type parameters
- Add of(...) factory methods to HttpClient
- Replace old `HttpClient client = Clients.newClient()` to `HttpClient.of()` in test cases
- Modify RetryingHttpClientTest parameter a little bit and make client use different eventLoop from server's

Result:

- Simplified HttpClient creation
- Less flaky tests