### PR TITLE
Prevent premature shutdown of JVM when running a Server

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/CommonPools.java
+++ b/core/src/main/java/com/linecorp/armeria/common/CommonPools.java
@@ -34,22 +34,18 @@ import io.netty.util.concurrent.DefaultThreadFactory;
 public final class CommonPools {
 
     private static final Executor BLOCKING_TASK_EXECUTOR;
-    private static final EventLoopGroup BOSS_GROUP;
     private static final EventLoopGroup WORKER_GROUP;
 
     static {
         // Threads spawned as needed and reused, with a 60s timeout and unbounded work queue.
-        final int DEFAULT_MAX_BLOCKING_TASK_THREADS = 200; // from Tomcat's default maxThreads.
         final ThreadPoolExecutor blockingTaskExecutor = new ThreadPoolExecutor(
-                DEFAULT_MAX_BLOCKING_TASK_THREADS, DEFAULT_MAX_BLOCKING_TASK_THREADS,
+                Flags.numCommonBlockingTaskThreads(), Flags.numCommonBlockingTaskThreads(),
                 60, TimeUnit.SECONDS, new LinkedTransferQueue<>(),
                 new DefaultThreadFactory("armeria-common-blocking-tasks", true));
 
         blockingTaskExecutor.allowCoreThreadTimeOut(true);
         BLOCKING_TASK_EXECUTOR = blockingTaskExecutor;
 
-        BOSS_GROUP = EventLoopGroups.newEventLoopGroup(Flags.numCommonBosses(),
-                                                       "armeria-common-boss", true);
         WORKER_GROUP = EventLoopGroups.newEventLoopGroup(Flags.numCommonWorkers(),
                                                          "armeria-common-worker", true);
     }
@@ -60,14 +56,6 @@ public final class CommonPools {
      */
     public static Executor blockingTaskExecutor() {
         return BLOCKING_TASK_EXECUTOR;
-    }
-
-    /**
-     * Returns the common boss {@link EventLoopGroup} which is used when
-     * {@link ServerBuilder#bossGroup(EventLoopGroup, boolean)} is not specified.
-     */
-    public static EventLoopGroup bossGroup() {
-        return BOSS_GROUP;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -51,13 +51,15 @@ public final class Flags {
     private static final boolean USE_OPENSSL = getBoolean("useOpenSsl", OpenSsl.isAvailable(),
                                                           value -> OpenSsl.isAvailable() || !value);
 
-    private static final int DEFAULT_NUM_COMMON_BOSSES = 1;
-    private static final int NUM_COMMON_BOSSES =
-            getInt("numCommonBosses", DEFAULT_NUM_COMMON_BOSSES, value -> value > 0);
-
     private static final int DEFAULT_NUM_COMMON_WORKERS = NUM_CPU_CORES * 2;
     private static final int NUM_COMMON_WORKERS =
             getInt("numCommonWorkers", DEFAULT_NUM_COMMON_WORKERS, value -> value > 0);
+
+    private static final int DEFAULT_NUM_COMMON_BLOCKING_TASK_THREADS = 200; // from Tomcat default maxThreads
+    private static final int NUM_COMMON_BLOCKING_TASK_THREADS =
+            getInt("numCommonBlockingTaskThreads",
+                   DEFAULT_NUM_COMMON_BLOCKING_TASK_THREADS,
+                   value -> value > 0);
 
     private static final long DEFAULT_DEFAULT_CONNECT_TIMEOUT_MILLIS = 3200; // 3.2 seconds
     private static final long DEFAULT_CONNECT_TIMEOUT_MILLIS =
@@ -89,6 +91,7 @@ public final class Flags {
                     Backoff.of(value);
                     return true;
                 } catch (Exception e) {
+                    // Invalid backoff specification
                     return false;
                 }
             });
@@ -148,24 +151,25 @@ public final class Flags {
     }
 
     /**
-     * Returns the default number of {@linkplain CommonPools#bossGroup() common boss group} threads.
-     *
-     * <p>The default value of this flag is {@value #DEFAULT_NUM_COMMON_BOSSES}. Specify the
-     * {@code -Dcom.linecorp.armeria.numCommonBosses=<integer>} to override the default value.
-     */
-    public static int numCommonBosses() {
-        return NUM_COMMON_BOSSES;
-    }
-
-    /**
      * Returns the default number of {@linkplain CommonPools#workerGroup() common worker group} threads.
-     * Note that this value has effect only if a user did not specify it.
+     * Note that this value has effect only if a user did not specify a worker group.
      *
      * <p>The default value of this flag is {@code 2 * <numCpuCores>}. Specify the
      * {@code -Dcom.linecorp.armeria.numCommonWorkers=<integer>} to override the default value.
      */
     public static int numCommonWorkers() {
         return NUM_COMMON_WORKERS;
+    }
+
+    /**
+     * Returns the default number of {@linkplain CommonPools#blockingTaskExecutor() blocking task executor}
+     * threads. Note that this value has effect only if a user did not specify a blocking task executor.
+     *
+     * <p>The default value of this flag is {@value #DEFAULT_NUM_COMMON_BLOCKING_TASK_THREADS}. Specify the
+     * {@code -Dcom.linecorp.armeria.numCommonBlockingTaskThreads=<integer>} to override the default value.
+     */
+    public static int numCommonBlockingTaskThreads() {
+        return NUM_COMMON_BLOCKING_TASK_THREADS;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/util/EventLoopGroups.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/EventLoopGroups.java
@@ -19,6 +19,8 @@ package com.linecorp.armeria.common.util;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
+import java.util.concurrent.ThreadFactory;
+
 import com.linecorp.armeria.internal.TransportType;
 
 import io.netty.channel.EventLoopGroup;
@@ -73,9 +75,22 @@ public final class EventLoopGroups {
 
         final TransportType type = TransportType.detectTransportType();
         final String prefix = threadNamePrefix + '-' + type.lowerCasedName();
+        return newEventLoopGroup(numThreads, new DefaultThreadFactory(prefix, useDaemonThreads));
+    }
 
-        return type.newEventLoopGroup(numThreads,
-                                      unused -> new DefaultThreadFactory(prefix, useDaemonThreads));
+    /**
+     * Returns a newly-created {@link EventLoopGroup}.
+     *
+     * @param numThreads the number of event loop threads
+     * @param threadFactory the factory of event loop threads
+     */
+    public static EventLoopGroup newEventLoopGroup(int numThreads, ThreadFactory threadFactory) {
+
+        checkArgument(numThreads > 0, "numThreads: %s (expected: > 0)", numThreads);
+        requireNonNull(threadFactory, "threadFactory");
+
+        final TransportType type = TransportType.detectTransportType();
+        return type.newEventLoopGroup(numThreads, unused -> threadFactory);
     }
 
     private EventLoopGroups() {}

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -98,8 +98,6 @@ public final class ServerBuilder {
     private boolean updatedDefaultVirtualHostBuilder;
 
     private VirtualHost defaultVirtualHost;
-    private EventLoopGroup bossGroup = CommonPools.bossGroup();
-    private boolean shutdownBossGroupOnStop;
     private EventLoopGroup workerGroup = CommonPools.workerGroup();
     private boolean shutdownWorkerGroupOnStop;
     private int maxNumConnections = DEFAULT_MAX_NUM_CONNECTIONS;
@@ -166,19 +164,6 @@ public final class ServerBuilder {
      */
     public ServerBuilder virtualHost(VirtualHost virtualHost) {
         virtualHosts.add(requireNonNull(virtualHost, "virtualHost"));
-        return this;
-    }
-
-    /**
-     * Sets the boss {@link EventLoopGroup} which is responsible for accepting incoming connections.
-     * If not set, {@linkplain CommonPools#bossGroup() the common boss group} is used.
-     *
-     * @param shutdownOnStop whether to shut down the boss {@link EventLoopGroup}
-     *                       when the {@link Server} stops
-     */
-    public ServerBuilder bossGroup(EventLoopGroup bossGroup, boolean shutdownOnStop) {
-        this.bossGroup = requireNonNull(bossGroup, "bossGroup");
-        shutdownBossGroupOnStop = shutdownOnStop;
         return this;
     }
 
@@ -626,9 +611,8 @@ public final class ServerBuilder {
             virtualHosts = this.virtualHosts;
         }
 
-        Server server = new Server(new ServerConfig(
-                ports, defaultVirtualHost, virtualHosts,
-                bossGroup, shutdownBossGroupOnStop, workerGroup, shutdownWorkerGroupOnStop,
+        final Server server = new Server(new ServerConfig(
+                ports, defaultVirtualHost, virtualHosts, workerGroup, shutdownWorkerGroupOnStop,
                 maxNumConnections, idleTimeoutMillis, defaultRequestTimeoutMillis, defaultMaxRequestLength,
                 gracefulShutdownQuietPeriod, gracefulShutdownTimeout,
                 blockingTaskExecutor, serviceLoggerPrefix));
@@ -639,10 +623,8 @@ public final class ServerBuilder {
     @Override
     public String toString() {
         return ServerConfig.toString(
-                getClass(), ports, defaultVirtualHost, virtualHosts,
-                bossGroup, shutdownBossGroupOnStop, workerGroup, shutdownWorkerGroupOnStop,
-                maxNumConnections, idleTimeoutMillis,
-                defaultRequestTimeoutMillis, defaultMaxRequestLength,
+                getClass(), ports, defaultVirtualHost, virtualHosts, workerGroup, shutdownWorkerGroupOnStop,
+                maxNumConnections, idleTimeoutMillis, defaultRequestTimeoutMillis, defaultMaxRequestLength,
                 gracefulShutdownQuietPeriod, gracefulShutdownTimeout,
                 blockingTaskExecutor, serviceLoggerPrefix);
     }

--- a/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
@@ -52,8 +52,6 @@ public final class ServerConfig {
     private final DomainNameMapping<VirtualHost> virtualHostMapping;
     private final List<ServiceConfig> services;
 
-    private final EventLoopGroup bossGroup;
-    private final boolean shutdownBossGroupOnStop;
     private final EventLoopGroup workerGroup;
     private final boolean shutdownWorkerGroupOnStop;
     private final int maxNumConnections;
@@ -73,7 +71,6 @@ public final class ServerConfig {
     ServerConfig(
             Iterable<ServerPort> ports,
             VirtualHost defaultVirtualHost, Iterable<VirtualHost> virtualHosts,
-            EventLoopGroup bossGroup, boolean shutdownBossGroupOnStop,
             EventLoopGroup workerGroup, boolean shutdownWorkerGroupOnStop,
             int maxNumConnections, long idleTimeoutMillis,
             long defaultRequestTimeoutMillis, long defaultMaxRequestLength,
@@ -85,8 +82,6 @@ public final class ServerConfig {
         requireNonNull(defaultVirtualHost, "defaultVirtualHost");
 
         // Set the primitive properties.
-        this.bossGroup = requireNonNull(bossGroup, "bossGroup");
-        this.shutdownBossGroupOnStop = shutdownBossGroupOnStop;
         this.workerGroup = requireNonNull(workerGroup, "workerGroup");
         this.shutdownWorkerGroupOnStop = shutdownWorkerGroupOnStop;
         this.maxNumConnections = validateMaxNumConnections(maxNumConnections);
@@ -309,20 +304,6 @@ public final class ServerConfig {
     }
 
     /**
-     * Returns the boss {@link EventLoopGroup} which is responsible for accepting incoming connections.
-     */
-    public EventLoopGroup bossGroup() {
-        return bossGroup;
-    }
-
-    /**
-     * Returns whether the boss {@link EventLoopGroup} is shut down when the {@link Server} stops.
-     */
-    public boolean shutdownBossGroupOnStop() {
-        return shutdownBossGroupOnStop;
-    }
-
-    /**
      * Returns the worker {@link EventLoopGroup} which is responsible for performing socket I/O and running
      * {@link Service#serve(ServiceRequestContext, Request)}.
      */
@@ -405,7 +386,6 @@ public final class ServerConfig {
         if (strVal == null) {
             this.strVal = strVal = toString(
                     getClass(), ports(), null, virtualHosts(),
-                    bossGroup(), shutdownBossGroupOnStop(),
                     workerGroup(), shutdownWorkerGroupOnStop(),
                     maxNumConnections(), idleTimeoutMillis(),
                     defaultRequestTimeoutMillis(), defaultMaxRequestLength(),
@@ -419,7 +399,6 @@ public final class ServerConfig {
     static String toString(
             Class<?> type,
             Iterable<ServerPort> ports, VirtualHost defaultVirtualHost, List<VirtualHost> virtualHosts,
-            EventLoopGroup bossGroup, boolean shutdownBossGroupOnStop,
             EventLoopGroup workerGroup, boolean shutdownWorkerGroupOnStop,
             int maxNumConnections, long idleTimeoutMillis,
             long defaultRequestTimeoutMillis, long defaultMaxRequestLength,
@@ -468,11 +447,7 @@ public final class ServerConfig {
                                             defaultVirtualHost.serviceConfigs()));
         }
 
-        buf.append("], bossGroup: ");
-        buf.append(bossGroup);
-        buf.append(" (shutdownOnStop=");
-        buf.append(shutdownBossGroupOnStop);
-        buf.append("), workerGroup: ");
+        buf.append("], workerGroup: ");
         buf.append(workerGroup);
         buf.append(" (shutdownOnStop=");
         buf.append(shutdownWorkerGroupOnStop);


### PR DESCRIPTION
Motivation:

Unless a user specified, Armeria uses the common boss and worker group
when building a Server. This can be a problem because all threads in the
common groups are daemon. If the user's main thread exits and there are
only the common group threads in the JVM, the JVM will choose to
terminate itself because all the remaining threads are daemon.

Modifications:

- Server now creates a dedicated single-thread boss EventLoopGroup for
  each ServerPort, and the thread is non-daemon.
  - Remove CommonPools.bossGroup
  - Remove ServerConfig.bossGroup and shutdownBossGroupOnStop
  - Server sets the thread name of boss groups dynamically to show which
    thread is handling which server port.
  - Server terminates the boss groups lastly so that the JVM does not
    terminate itself until the graceful shutdown is complete.
- Add Flags.numCommonBlockingTaskThreads() which replaces hard-coded 200.
- Add EventLoopGroups.newEventLoopGroup(numThreads, threadFactory)

Result:

- No more surprising JVM termination immediately after starting a Server up
- Ability to configure the number of common blocking task executor threads