### PR TITLE
Add more rules to Checkstyle configuration

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientBuilderParams.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientBuilderParams.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package com.linecorp.armeria.client;
 
 import static java.util.Objects.requireNonNull;

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientFactory.java
@@ -229,7 +229,6 @@ final class HttpClientFactory extends AbstractClientFactory {
         }
     }
 
-
     KeyedChannelPool<PoolKey> pool(EventLoop eventLoop) {
         KeyedChannelPool<PoolKey> pool = pools.get(eventLoop);
         if (pool != null) {

--- a/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
@@ -251,7 +251,6 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
         }
     }
 
-
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
         Exceptions.logIfUnexpected(logger, ctx.channel(), protocol(), cause);

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerBuilder.java
@@ -242,5 +242,4 @@ public final class CircuitBreakerBuilder {
                                          counterSlidingWindow, counterUpdateInterval,
                                          exceptionFilter, Collections.unmodifiableList(listeners)));
     }
-
 }

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerConfig.java
@@ -110,5 +110,4 @@ class CircuitBreakerConfig {
                 .add("counterUpdateInterval", counterUpdateInterval)
                 .toString();
     }
-
 }

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerListener.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerListener.java
@@ -35,5 +35,4 @@ public interface CircuitBreakerListener {
      * Invoked when the circuit breaker rejects a request.
      */
     void onRequestRejected(CircuitBreaker circuitBreaker) throws Exception;
-
 }

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/ExceptionFilter.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/ExceptionFilter.java
@@ -29,5 +29,4 @@ public interface ExceptionFilter {
      * @return {@code true} if the error should be dealt with circuit breaker
      */
     boolean shouldDealWith(Throwable throwable) throws Exception;
-
 }

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/metrics/DropwizardCircuitBreakerMetrics.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/metrics/DropwizardCircuitBreakerMetrics.java
@@ -104,5 +104,4 @@ final class DropwizardCircuitBreakerMetrics {
     void onRequestRejected() {
         requestRejected.mark();
     }
-
 }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/EndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/EndpointGroup.java
@@ -51,5 +51,4 @@ public interface EndpointGroup extends Listenable<List<Endpoint>>, SafeCloseable
     default EndpointGroup orElse(EndpointGroup nextEndpointGroup) {
         return new OrElseEndpointGroup(this, nextEndpointGroup);
     }
-
 }

--- a/core/src/main/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingHttpClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingHttpClient.java
@@ -56,7 +56,6 @@ public final class ConcurrencyLimitingHttpClient extends ConcurrencyLimitingClie
         return delegate -> new ConcurrencyLimitingHttpClient(delegate, maxConcurrency, timeout, unit);
     }
 
-
     private ConcurrencyLimitingHttpClient(Client<HttpRequest, HttpResponse> delegate, int maxConcurrency) {
         super(delegate, maxConcurrency);
     }

--- a/core/src/main/java/com/linecorp/armeria/client/metric/PrometheusMetricCollectingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/metric/PrometheusMetricCollectingClient.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package com.linecorp.armeria.client.metric;
 
 import java.util.Map;
@@ -97,5 +96,4 @@ public final class PrometheusMetricCollectingClient<T extends MetricLabel<T>,
     public O execute(ClientRequestContext ctx, I req) throws Exception {
         return requestDecorator.execute(delegate(), ctx, req);
     }
-
 }

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryStrategy.java
@@ -83,5 +83,4 @@ public interface RetryStrategy<I extends Request, O extends Response> {
     default boolean shouldRetry(I request, Throwable thrown) {
         return true;
     }
-
 }

--- a/core/src/main/java/com/linecorp/armeria/common/AbstractRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AbstractRequestContext.java
@@ -209,5 +209,4 @@ public abstract class AbstractRequestContext implements RequestContext {
     public final boolean equals(Object obj) {
         return super.equals(obj);
     }
-
 }

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -107,7 +107,6 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
         final DefaultHttpResponse res = new DefaultHttpResponse();
         res.respond(status, mediaType, content, offset, length);
         return res;
-
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponseWriter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponseWriter.java
@@ -134,7 +134,6 @@ public interface HttpResponseWriter extends StreamWriter<HttpObject> {
         respond(status, mediaType, content, HttpHeaders.EMPTY_HEADERS);
     }
 
-
     /**
      * Writes the HTTP response of the specified {@link HttpStatus} and closes the stream.
      *

--- a/core/src/main/java/com/linecorp/armeria/common/HttpStatusClass.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpStatusClass.java
@@ -1,4 +1,19 @@
 /*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+/*
  * Copyright 2014 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
@@ -13,7 +28,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package com.linecorp.armeria.common;
 
 import io.netty.util.AsciiString;

--- a/core/src/main/java/com/linecorp/armeria/common/MediaType.java
+++ b/core/src/main/java/com/linecorp/armeria/common/MediaType.java
@@ -1,4 +1,19 @@
 /*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+/*
  * Copyright (C) 2011 The Guava Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/core/src/main/java/com/linecorp/armeria/common/RequestContextAwareCompletableFuture.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestContextAwareCompletableFuture.java
@@ -243,5 +243,4 @@ final class RequestContextAwareCompletableFuture<T> extends CompletableFuture<T>
     public CompletableFuture<T> exceptionally(Function<Throwable, ? extends T> fn) {
         return ctx.makeContextAware(super.exceptionally(ctx.makeContextAware(fn)));
     }
-
 }

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogAvailabilitySet.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogAvailabilitySet.java
@@ -80,7 +80,6 @@ final class RequestLogAvailabilitySet extends AbstractSet<RequestLogAvailability
         this.values = values.toArray(new RequestLogAvailability[values.size()]);
     }
 
-
     @Override
     public Iterator<RequestLogAvailability> iterator() {
         return Iterators.forArray(values);

--- a/core/src/main/java/com/linecorp/armeria/common/util/Listenable.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/Listenable.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package com.linecorp.armeria.common.util;
 
 import java.util.function.Consumer;

--- a/core/src/main/java/com/linecorp/armeria/common/util/TextFormatter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/TextFormatter.java
@@ -142,5 +142,4 @@ public final class TextFormatter {
         appendEpoch(buf, timeMillis);
         return buf;
     }
-
 }

--- a/core/src/main/java/com/linecorp/armeria/common/util/Ticker.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/Ticker.java
@@ -1,4 +1,19 @@
 /*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+/*
  * Copyright (C) 2011 The Guava Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/core/src/main/java/com/linecorp/armeria/internal/FlushConsolidationHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/FlushConsolidationHandler.java
@@ -1,4 +1,19 @@
 /*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+/*
  * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,

--- a/core/src/main/java/com/linecorp/armeria/internal/Http1ClientCodec.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/Http1ClientCodec.java
@@ -1,4 +1,19 @@
 /*
+ * Copyright 2015 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+/*
  * Copyright 2012 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,

--- a/core/src/main/java/com/linecorp/armeria/internal/TransportType.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/TransportType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package com.linecorp.armeria.internal;
 
 import java.util.concurrent.ThreadFactory;

--- a/core/src/main/java/com/linecorp/armeria/server/AbstractVirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AbstractVirtualHostBuilder.java
@@ -56,7 +56,7 @@ import io.netty.handler.ssl.SupportedCipherSuiteFilter;
 
 /**
  * Contains information for the build of the virtual host.
- * 
+ *
  * @see ChainedVirtualHostBuilder
  * @see VirtualHostBuilder
  */
@@ -64,7 +64,7 @@ import io.netty.handler.ssl.SupportedCipherSuiteFilter;
 abstract class AbstractVirtualHostBuilder<B extends AbstractVirtualHostBuilder> {
 
     private static final Logger logger = LoggerFactory.getLogger(AbstractVirtualHostBuilder.class);
-    
+
     private static final ApplicationProtocolConfig HTTPS_ALPN_CFG = new ApplicationProtocolConfig(
             Protocol.ALPN,
             // NO_ADVERTISE is currently the only mode supported by both OpenSsl and JDK providers.

--- a/core/src/main/java/com/linecorp/armeria/server/AnnotatedHttpServiceMethod.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AnnotatedHttpServiceMethod.java
@@ -278,11 +278,12 @@ final class AnnotatedHttpServiceMethod implements BiFunction<ServiceRequestConte
                     }
                 }
             }
+
             if (parameters == null || parameters.isEmpty()) {
                 return EMPTY_PARAMETERS;
             }
-            return HttpParameters.copyOf(parameters);
 
+            return HttpParameters.copyOf(parameters);
         } catch (Exception e) {
             // If we failed to decode the query string, we ignore the exception raised here.
             // A missing parameter might be checked when invoking the annotated method.

--- a/core/src/main/java/com/linecorp/armeria/server/ChainedVirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ChainedVirtualHostBuilder.java
@@ -20,12 +20,12 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * Builds a new {@link VirtualHost}.
- * 
+ *
  * <p>This class can only be created through the {@link ServerBuilder#withDefaultVirtualHost()} or
  * {@link ServerBuilder#withVirtualHost(String)} method of the {@link ServerBuilder}.
- * 
+ *
  * <p>Call {@link #and()} method can also return to {@link ServerBuilder}.
- * 
+ *
  * @see ServerBuilder
  * @see PathMapping
  * @see VirtualHostBuilder
@@ -36,7 +36,7 @@ public final class ChainedVirtualHostBuilder extends AbstractVirtualHostBuilder<
 
     /**
      * Creates a new {@link ChainedVirtualHostBuilder} whose hostname pattern is {@code "*"} (match-all).
-     * 
+     *
      * @param serverBuilder the parent {@link ServerBuilder} to be returned by {@link #and()}.
      */
     ChainedVirtualHostBuilder(ServerBuilder serverBuilder) {
@@ -46,7 +46,7 @@ public final class ChainedVirtualHostBuilder extends AbstractVirtualHostBuilder<
 
     /**
      * Creates a new {@link ChainedVirtualHostBuilder} with the specified hostname pattern.
-     * 
+     *
      * @param hostnamePattern the hostname pattern of this virtual host.
      * @param serverBuilder the parent {@link ServerBuilder} to be returned by {@link #and()}.
      */
@@ -60,7 +60,7 @@ public final class ChainedVirtualHostBuilder extends AbstractVirtualHostBuilder<
     /**
      * Creates a new {@link ChainedVirtualHostBuilder} with
      * the default host name and the specified hostname pattern.
-     * 
+     *
      * @param defaultHostname the default hostname of this virtual host.
      * @param hostnamePattern the hostname pattern of this virtual host.
      * @param serverBuilder the parent {@link ServerBuilder} to be returned by {@link #and()}.

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -380,7 +380,6 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
                                    .set(HttpHeaderNames.LOCATION, location)));
     }
 
-
     private void respond(ChannelHandlerContext ctx, DecodedHttpRequest req, HttpStatus status) {
 
         if (status.code() < 400) {

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
@@ -163,7 +163,6 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
             throw new IllegalStateException("unknown protocol: " + protocol);
         }
 
-
         private void addHttp2Handlers(ChannelHandlerContext ctx) {
             final ChannelPipeline p = ctx.pipeline();
             p.addLast(newHttp2ConnectionHandler(p));

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceUnavailableException.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceUnavailableException.java
@@ -26,7 +26,6 @@ public final class ServiceUnavailableException extends RuntimeException {
 
     private static final long serialVersionUID = -9092895165959388396L;
 
-
     private static final ServiceUnavailableException INSTANCE =
             Exceptions.clearTrace(new ServiceUnavailableException());
 

--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsService.java
@@ -153,7 +153,6 @@ public final class CorsService extends SimpleDecoratingService<HttpRequest, Http
         }
     }
 
-
     /**
      * Emit CORS headers if origin was found.
      *

--- a/core/src/main/java/com/linecorp/armeria/server/docs/DocService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/DocService.java
@@ -232,7 +232,6 @@ public class DocService extends AbstractCompositeService<HttpRequest, HttpRespon
                                   .map(field -> addFieldDocString(e, field, docStrings))
                                   .collect(toImmutableList()),
                                  docString(e.name(), e.docString(), docStrings));
-
     }
 
     private static FieldInfo addFieldDocString(NamedTypeInfo parent, FieldInfo field,

--- a/core/src/main/java/com/linecorp/armeria/server/docs/DocServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/DocServiceBuilder.java
@@ -102,7 +102,6 @@ public final class DocServiceBuilder {
         return exampleHttpHeaders0(serviceName, "", exampleHttpHeaders);
     }
 
-
     /**
      * Adds the example {@link HttpHeaders} for the method with the specified type and method name.
      * This method is a shortcut to:

--- a/core/src/main/java/com/linecorp/armeria/server/docs/MethodInfo.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/MethodInfo.java
@@ -138,7 +138,6 @@ public final class MethodInfo {
         return exceptionTypeSignatures;
     }
 
-
     /**
      * Returns the example HTTP headers of the method.
      */

--- a/core/src/main/java/com/linecorp/armeria/server/file/HttpFileService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/HttpFileService.java
@@ -310,7 +310,6 @@ public final class HttpFileService extends AbstractHttpService {
         }
     }
 
-
     /**
      * Creates a new {@link HttpService} that tries this {@link HttpFileService} first and then the specified
      * {@link HttpService} when this {@link HttpFileService} does not have a requested resource.

--- a/core/src/test/java/com/linecorp/armeria/client/ClientOptionsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientOptionsTest.java
@@ -38,7 +38,6 @@ public class ClientOptionsTest {
 
         ClientOptions options2 = ClientOptions.DEFAULT;
         assertThat(options2.get(ClientOption.HTTP_HEADERS), is(Optional.of(HttpHeaders.EMPTY_HEADERS)));
-
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerBuilderTest.java
@@ -191,5 +191,4 @@ public class CircuitBreakerBuilderTest {
     public void testExceptionFilterWithInvalidArgument() {
         throwsException(() -> builder().exceptionFilter(null));
     }
-
 }

--- a/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/NonBlockingCircuitBreakerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/NonBlockingCircuitBreakerTest.java
@@ -252,5 +252,4 @@ public class NonBlockingCircuitBreakerTest {
         verify(listener, times(1)).onEventCountUpdated(cb, EventCount.ZERO);
         verify(listener, times(1)).onStateChanged(cb, CircuitState.CLOSED);
     }
-
 }

--- a/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/SlidingWindowCounterTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/SlidingWindowCounterTest.java
@@ -145,5 +145,4 @@ public class SlidingWindowCounterTest {
         assertThat(counter.onSuccess()).isEmpty();
         assertThat(counter.count()).isEqualTo(new EventCount(0, 0));
     }
-
 }

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/EndpointGroupUtilTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/EndpointGroupUtilTest.java
@@ -35,7 +35,6 @@ public class EndpointGroupUtilTest {
         assertEquals("myGroupName", EndpointGroupUtil.getEndpointGroupName("http://" + endpointGroupMark + "myGroupName:8080/"));
         assertEquals("myGroupName", EndpointGroupUtil.getEndpointGroupName("http://" + endpointGroupMark + "myGroupName:8080/"));
         assertEquals("myGroupName", EndpointGroupUtil.getEndpointGroupName("http://username:password@" + endpointGroupMark + "myGroupName:8080/"));
-
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/OrElseEndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/OrElseEndpointGroupTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package com.linecorp.armeria.client.endpoint;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/RoundRobinStrategyTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/RoundRobinStrategyTest.java
@@ -52,5 +52,4 @@ public class RoundRobinStrategyTest {
         assertThat(catchThrowable(() -> EndpointGroupRegistry.selectNode("empty")))
                 .isInstanceOf(EndpointGroupException.class);
     }
-
 }

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroupTest.java
@@ -55,7 +55,6 @@ public class HttpHealthCheckedEndpointGroupTest {
     @Rule
     public final ServerRule serverTwo = new HealthCheckServerRule();
 
-
     @Test
     public void endpoints() throws Exception {
         serverOne.start();

--- a/core/src/test/java/com/linecorp/armeria/common/MediaTypeTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/MediaTypeTest.java
@@ -1,4 +1,19 @@
 /*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+/*
  * Copyright (C) 2011 The Guava Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +28,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.linecorp.armeria.common;
 
 import static com.google.common.base.Charsets.UTF_16;

--- a/core/src/test/java/com/linecorp/armeria/common/SerializationFormatTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/SerializationFormatTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package com.linecorp.armeria.common;
 
 import static com.linecorp.armeria.common.MediaType.parse;

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerIdleTimeoutHandlerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerIdleTimeoutHandlerTest.java
@@ -81,7 +81,6 @@ public class HttpServerIdleTimeoutHandlerTest {
         //pending request count turns to 0
         waitUntilTimeout();
         assertFalse(ch.isOpen());
-
     }
 
     private void waitUntilTimeout() throws InterruptedException {

--- a/core/src/test/java/com/linecorp/armeria/server/encoding/HttpEncodersTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/encoding/HttpEncodersTest.java
@@ -64,5 +64,4 @@ public class HttpEncodersTest {
         when(request.headers()).thenReturn(HttpHeaders.of(HttpHeaderNames.ACCEPT_ENCODING, "piedpiper"));
         assertThat(HttpEncoders.getWrapperForRequest(request)).isNull();
     }
-
 }

--- a/core/src/test/java/com/linecorp/armeria/server/file/HttpFileServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/file/HttpFileServiceTest.java
@@ -118,7 +118,6 @@ public class HttpFileServiceTest {
                 Files.delete(dir);
                 return FileVisitResult.CONTINUE;
             }
-
         });
     }
 
@@ -148,7 +147,6 @@ public class HttpFileServiceTest {
             assert200Ok(res, "text/plain", "bar");
         }
     }
-
 
     @Test
     public void testIndexHtml() throws Exception {

--- a/core/src/test/java/com/linecorp/armeria/server/healthcheck/SettableHealthCheckerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/healthcheck/SettableHealthCheckerTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package com.linecorp.armeria.server.healthcheck;
 
 import static org.junit.Assert.assertFalse;
@@ -42,5 +41,4 @@ public class SettableHealthCheckerTest {
         checker.setHealthy(false);
         assertFalse(checker.isHealthy());
     }
-
 }

--- a/core/src/test/java/com/linecorp/armeria/server/logging/LoggingServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/logging/LoggingServiceTest.java
@@ -181,5 +181,4 @@ public class LoggingServiceTest {
         service.serve(ctx, REQUEST);
         verifyZeroInteractions(logger);
     }
-
 }

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientFactory.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientFactory.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package com.linecorp.armeria.client.grpc;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -77,11 +76,9 @@ final class GrpcClientFactory extends DecoratingClientFactory {
 
     @Override
     public <T> T newClient(URI uri, Class<T> clientType, ClientOptions options) {
-        Scheme scheme = validateScheme(uri);
-        SerializationFormat serializationFormat = scheme.serializationFormat();
-
-
-        Class<?> stubClass = clientType.getEnclosingClass();
+        final Scheme scheme = validateScheme(uri);
+        final SerializationFormat serializationFormat = scheme.serializationFormat();
+        final Class<?> stubClass = clientType.getEnclosingClass();
         if (stubClass == null) {
             throw new IllegalArgumentException("Client type not a GRPC client stub class, " +
                                                "should be something like ServiceNameGrpc.ServiceNameXXStub: " +

--- a/grpc/src/test/java/com/linecorp/armeria/internal/grpc/TestServiceImpl.java
+++ b/grpc/src/test/java/com/linecorp/armeria/internal/grpc/TestServiceImpl.java
@@ -13,9 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
-
-
 package com.linecorp.armeria.internal.grpc;
 
 import java.io.IOException;

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcDocStringExtractorTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcDocStringExtractorTest.java
@@ -98,5 +98,4 @@ public class GrpcDocStringExtractorTest {
                 "armeria.grpc.testing.SimpleRequest.NestedEnum/OK",
                 " We're ok.\n");
     }
-
 }

--- a/it/src/test/java/com/linecorp/armeria/server/grpc/interop/NoopStatsContextFactory.java
+++ b/it/src/test/java/com/linecorp/armeria/server/grpc/interop/NoopStatsContextFactory.java
@@ -1,4 +1,19 @@
 /*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+/*
  * Copyright 2016, Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/jetty/src/main/java/com/linecorp/armeria/server/jetty/JettyService.java
+++ b/jetty/src/main/java/com/linecorp/armeria/server/jetty/JettyService.java
@@ -169,7 +169,6 @@ public final class JettyService implements HttpService {
         configurator = new Configurator();
     }
 
-
     @Override
     public void serviceAdded(ServiceConfig cfg) throws Exception {
         if (armeriaServer != null) {

--- a/logback/src/main/java/com/linecorp/armeria/common/logback/RequestContextExporterBuilder.java
+++ b/logback/src/main/java/com/linecorp/armeria/common/logback/RequestContextExporterBuilder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package com.linecorp.armeria.common.logback;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;

--- a/logback/src/test/java/com/linecorp/armeria/common/logback/CustomValue.java
+++ b/logback/src/test/java/com/linecorp/armeria/common/logback/CustomValue.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package com.linecorp.armeria.common.logback;
 
 public class CustomValue {

--- a/logback/src/test/java/com/linecorp/armeria/common/logback/CustomValueStringifier.java
+++ b/logback/src/test/java/com/linecorp/armeria/common/logback/CustomValueStringifier.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package com.linecorp.armeria.common.logback;
 
 import java.util.function.Function;

--- a/settings/checkstyle/checkstyle.xml
+++ b/settings/checkstyle/checkstyle.xml
@@ -23,6 +23,45 @@
     <property name="eachLine" value="true"/>
   </module>
 
+  <!-- Copyright headers -->
+  <module name="RegexpSingleline">
+    <property name="format" value="^(?:\s|\*)*Copyright\s+[0-9]+\s+LINE Corporation\s*$"/>
+    <property name="minimum" value="1"/>
+    <property name="maximum" value="1"/>
+    <property name="message" value="missing copyright header"/>
+  </module>
+  <!-- Unmaintainable Javadoc tags -->
+  <module name="RegexpSingleline">
+    <property name="format" value="(?:@version|\(non-Javadoc\))"/>
+    <property name="ignoreCase" value="true"/>
+    <property name="message" value="unmaintainable Javadoc tags: @version or (non-Javadoc)"/>
+  </module>
+  <!-- IDE-generated comment -->
+  <module name="RegexpSingleline">
+    <property name="format" value="File \| Settings \| File Templates"/>
+    <property name="message" value="IDE-generated comment"/>
+  </module>
+  <!-- Trailing spaces -->
+  <module name="RegexpSingleline">
+    <property name="format" value="\s+$"/>
+    <property name="message" value="trailing spaces"/>
+  </module>
+  <!-- Consecutive empty lines -->
+  <module name="RegexpMultiline">
+    <property name="format" value="[^\r\n](?:\r?\n){3,}"/>
+    <property name="message" value="consecutive empty lines"/>
+  </module>
+  <!-- Empty lines between two opening braces -->
+  <module name="RegexpMultiline">
+    <property name="format" value="\{(?:\s*\r?\n){2,}\s*\{"/>
+    <property name="message" value="empty lines between two opening braces ('{')"/>
+  </module>
+  <!-- Empty lines before a closing brace -->
+  <module name="RegexpMultiline">
+    <property name="format" value="(?:\s*\r?\n){2,}\s*\}"/>
+    <property name="message" value="empty lines before a closing brace ('}')"/>
+  </module>
+
   <module name="JavadocPackage"/>
 
   <module name="TreeWalker">

--- a/spring-boot/autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaSettings.java
+++ b/spring-boot/autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaSettings.java
@@ -240,5 +240,4 @@ public class ArmeriaSettings {
     public void setEnableDropwizardMetrics(boolean enableDropwizardMetrics) {
         this.enableDropwizardMetrics = enableDropwizardMetrics;
     }
-
 }

--- a/thrift/src/main/java/com/linecorp/armeria/common/thrift/ThriftSerializationFormats.java
+++ b/thrift/src/main/java/com/linecorp/armeria/common/thrift/ThriftSerializationFormats.java
@@ -13,7 +13,6 @@
  *  License for the specific language governing permissions and limitations
  *  under the License.
  */
-
 package com.linecorp.armeria.common.thrift;
 
 import static java.util.Objects.requireNonNull;
@@ -49,7 +48,6 @@ public final class ThriftSerializationFormats {
      * compatibility and should only be used in non-production use cases like debugging.
      */
     public static final SerializationFormat TEXT = SerializationFormat.of("ttext");
-
 
     private static final Set<SerializationFormat> THRIFT_FORMATS =
             ImmutableSet.of(BINARY, COMPACT, JSON, TEXT);

--- a/thrift/src/main/java/com/linecorp/armeria/common/thrift/text/BaseContext.java
+++ b/thrift/src/main/java/com/linecorp/armeria/common/thrift/text/BaseContext.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 // =================================================================================================
 // Copyright 2011 Twitter, Inc.
 // -------------------------------------------------------------------------------------------------

--- a/thrift/src/main/java/com/linecorp/armeria/common/thrift/text/MapContext.java
+++ b/thrift/src/main/java/com/linecorp/armeria/common/thrift/text/MapContext.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 // =================================================================================================
 // Copyright 2011 Twitter, Inc.
 // -------------------------------------------------------------------------------------------------
@@ -13,7 +28,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // =================================================================================================
-
 package com.linecorp.armeria.common.thrift.text;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/thrift/src/main/java/com/linecorp/armeria/common/thrift/text/PairContext.java
+++ b/thrift/src/main/java/com/linecorp/armeria/common/thrift/text/PairContext.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 // =================================================================================================
 // Copyright 2011 Twitter, Inc.
 // -------------------------------------------------------------------------------------------------
@@ -13,7 +28,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // =================================================================================================
-
 package com.linecorp.armeria.common.thrift.text;
 
 import java.util.Iterator;

--- a/thrift/src/main/java/com/linecorp/armeria/common/thrift/text/SequenceContext.java
+++ b/thrift/src/main/java/com/linecorp/armeria/common/thrift/text/SequenceContext.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 // =================================================================================================
 // Copyright 2011 Twitter, Inc.
 // -------------------------------------------------------------------------------------------------
@@ -13,7 +28,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // =================================================================================================
-
 package com.linecorp.armeria.common.thrift.text;
 
 import java.util.Iterator;

--- a/thrift/src/main/java/com/linecorp/armeria/common/thrift/text/StructContext.java
+++ b/thrift/src/main/java/com/linecorp/armeria/common/thrift/text/StructContext.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 // =================================================================================================
 // Copyright 2011 Twitter, Inc.
 // -------------------------------------------------------------------------------------------------
@@ -13,7 +28,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // =================================================================================================
-
 package com.linecorp.armeria.common.thrift.text;
 
 import java.lang.reflect.Constructor;

--- a/thrift/src/main/java/com/linecorp/armeria/common/thrift/text/TTextProtocol.java
+++ b/thrift/src/main/java/com/linecorp/armeria/common/thrift/text/TTextProtocol.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 // =================================================================================================
 // Copyright 2011 Twitter, Inc.
 // -------------------------------------------------------------------------------------------------
@@ -13,7 +28,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // =================================================================================================
-
 package com.linecorp.armeria.common.thrift.text;
 
 import java.io.ByteArrayOutputStream;
@@ -770,7 +784,6 @@ public class TTextProtocol extends TProtocol {
                 byte[] bytes = toByteArray();
                 trans_.write(bytes);
                 trans_.flush();
-
             } catch (TTransportException ex) {
                 throw new IOException(ex);
             }

--- a/thrift/src/main/java/com/linecorp/armeria/common/thrift/text/TypedParser.java
+++ b/thrift/src/main/java/com/linecorp/armeria/common/thrift/text/TypedParser.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 // =================================================================================================
 // Copyright 2011 Twitter, Inc.
 // -------------------------------------------------------------------------------------------------
@@ -13,7 +28,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // =================================================================================================
-
 package com.linecorp.armeria.common.thrift.text;
 
 import java.io.IOException;

--- a/thrift/src/main/java/com/linecorp/armeria/common/thrift/text/package-info.java
+++ b/thrift/src/main/java/com/linecorp/armeria/common/thrift/text/package-info.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 // =================================================================================================
 // Copyright 2011 Twitter, Inc.
 // -------------------------------------------------------------------------------------------------

--- a/thrift/src/main/java/com/linecorp/armeria/server/thrift/ThriftDocServicePlugin.java
+++ b/thrift/src/main/java/com/linecorp/armeria/server/thrift/ThriftDocServicePlugin.java
@@ -191,7 +191,6 @@ public class ThriftDocServicePlugin implements DocServicePlugin {
         return methodInfo;
     }
 
-
     private static MethodInfo newMethodInfo(String name,
                                             Class<? extends TBase<?, ?>> argsClass,
                                             @Nullable Class<? extends TBase<?, ?>> resultClass,

--- a/thrift/src/test/java/com/linecorp/armeria/common/thrift/text/TTextProtocolTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/common/thrift/text/TTextProtocolTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 // =================================================================================================
 // Copyright 2011 Twitter, Inc.
 // -------------------------------------------------------------------------------------------------
@@ -13,7 +28,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // =================================================================================================
-
 package com.linecorp.armeria.common.thrift.text;
 
 import static net.javacrumbs.jsonunit.JsonAssert.assertJsonEquals;
@@ -143,7 +157,6 @@ public class TTextProtocolTest {
                 .setW(TestUnion.f2(4))
                 .setX(ImmutableList.of(TestUnion.f2(5), TestUnion.f1(base64Encoder.decode("SGVsbG8gV29ybGQ="))))
                 .setY(Letter.ALPHA);
-
     }
 
     private static Sub sub(int s, int x) {

--- a/thrift/src/test/java/com/linecorp/armeria/it/thrift/ThriftDynamicTimeoutTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/thrift/ThriftDynamicTimeoutTest.java
@@ -134,7 +134,6 @@ public class ThriftDynamicTimeoutTest {
         }
     }
 
-
     private static final class TimeoutDisablingService
             extends SimpleDecoratingService<RpcRequest, RpcResponse> {
 

--- a/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftSerializationFormatsTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftSerializationFormatsTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package com.linecorp.armeria.server.thrift;
 
 import static com.linecorp.armeria.common.MediaType.parse;

--- a/tomcat/src/main/java/com/linecorp/armeria/server/tomcat/Tomcat85InputBuffer.java
+++ b/tomcat/src/main/java/com/linecorp/armeria/server/tomcat/Tomcat85InputBuffer.java
@@ -63,5 +63,4 @@ class Tomcat85InputBuffer implements InputBuffer {
     private boolean isNeedToRead() {
         return !(read || content.isEmpty());
     }
-
 }

--- a/tomcat/src/main/java/com/linecorp/armeria/server/tomcat/TomcatService.java
+++ b/tomcat/src/main/java/com/linecorp/armeria/server/tomcat/TomcatService.java
@@ -560,5 +560,4 @@ public final class TomcatService implements HttpService {
             stop();
         }
     }
-
 }

--- a/tomcat/src/main/java/com/linecorp/armeria/server/tomcat/TomcatUtil.java
+++ b/tomcat/src/main/java/com/linecorp/armeria/server/tomcat/TomcatUtil.java
@@ -79,7 +79,6 @@ final class TomcatUtil {
         try {
             Method m = Service.class.getDeclaredMethod("getContainer");
             return (Engine) m.invoke(service);
-
         } catch (Exception e) {
             throw new Error("failed to invoke Service.getContainer()", e);
         }

--- a/zookeeper/src/main/java/com/linecorp/armeria/common/zookeeper/ZooKeeperListener.java
+++ b/zookeeper/src/main/java/com/linecorp/armeria/common/zookeeper/ZooKeeperListener.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package com.linecorp.armeria.common.zookeeper;
 
 import java.util.Map;


### PR DESCRIPTION
Add rules that make sure:

- The license header is present.
- There are no trailing spaces.
- There are no consecutive empty lines.
- There are no empty lines between two opening braces (`{`).
- There are no empty lines before a closing brace (`}`).

Please let me know if you find any of the rules added in this PR seems too restrictive. We can discuss and relax.