### PR TITLE
Customize http status for error response

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/ArmeriaHttpException.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ArmeriaHttpException.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server;
+
+import com.linecorp.armeria.common.HttpStatus;
+
+import io.netty.handler.codec.http2.Http2Error;
+
+/**
+ * A {@link RuntimeException} that is raised when an armeria internal http exception has occurred.
+ * This class is the general class of exceptions produced by a failed request or a reset stream.
+ */
+public abstract class ArmeriaHttpException extends RuntimeException {
+    private static final long serialVersionUID = 3487991462085151316L;
+
+    private final HttpStatus httpStatus;
+    private final Http2Error http2error;
+
+    /**
+     * Creates a new instance.
+     */
+    protected ArmeriaHttpException(HttpStatus httpStatus, Http2Error http2error) {
+        this.httpStatus = httpStatus;
+        this.http2error = http2error;
+    }
+
+    /**
+     * Returns the {@link HttpStatus} that will be sent to a client.
+     */
+    HttpStatus httpStatus() {
+        return httpStatus;
+    }
+
+    /**
+     * Returns the {@link Http2Error} that will be sent to a stream.
+     */
+    Http2Error http2error() {
+        return http2error;
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseException.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseException.java
@@ -23,7 +23,7 @@ import io.netty.handler.codec.http2.Http2Error;
  * A {@link RuntimeException} that is raised when an armeria internal http exception has occurred.
  * This class is the general class of exceptions produced by a failed request or a reset stream.
  */
-public abstract class ArmeriaHttpException extends RuntimeException {
+public abstract class HttpResponseException extends RuntimeException {
     private static final long serialVersionUID = 3487991462085151316L;
 
     private final HttpStatus httpStatus;
@@ -32,7 +32,7 @@ public abstract class ArmeriaHttpException extends RuntimeException {
     /**
      * Creates a new instance.
      */
-    protected ArmeriaHttpException(HttpStatus httpStatus, Http2Error http2error) {
+    protected HttpResponseException(HttpStatus httpStatus, Http2Error http2error) {
         this.httpStatus = httpStatus;
         this.http2error = http2error;
     }

--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseException.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 LINE Corporation
+ * Copyright 2017 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -15,9 +15,8 @@
  */
 package com.linecorp.armeria.server;
 
+import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.HttpStatus;
-
-import io.netty.handler.codec.http2.Http2Error;
 
 /**
  * A {@link RuntimeException} that is raised when an armeria internal http exception has occurred.
@@ -27,14 +26,12 @@ public abstract class HttpResponseException extends RuntimeException {
     private static final long serialVersionUID = 3487991462085151316L;
 
     private final HttpStatus httpStatus;
-    private final Http2Error http2error;
 
     /**
      * Creates a new instance.
      */
-    protected HttpResponseException(HttpStatus httpStatus, Http2Error http2error) {
+    protected HttpResponseException(HttpStatus httpStatus) {
         this.httpStatus = httpStatus;
-        this.http2error = http2error;
     }
 
     /**
@@ -44,10 +41,11 @@ public abstract class HttpResponseException extends RuntimeException {
         return httpStatus;
     }
 
-    /**
-     * Returns the {@link Http2Error} that will be sent to a stream.
-     */
-    Http2Error http2error() {
-        return http2error;
+    @Override
+    public synchronized Throwable fillInStackTrace() {
+        if (Flags.verboseExceptions()) {
+            return super.fillInStackTrace();
+        }
+        return this;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseException.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseException.java
@@ -15,6 +15,8 @@
  */
 package com.linecorp.armeria.server;
 
+import static java.util.Objects.requireNonNull;
+
 import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.HttpStatus;
 
@@ -31,13 +33,18 @@ public abstract class HttpResponseException extends RuntimeException {
      * Creates a new instance.
      */
     protected HttpResponseException(HttpStatus httpStatus) {
+        requireNonNull(httpStatus, "httpStatus");
+        if (100 <= httpStatus.code() && httpStatus.code() < 399) {
+            throw new IllegalArgumentException("httpStatus: " + httpStatus +
+                                               " (expected: code < 100 || 400 <= code");
+        }
         this.httpStatus = httpStatus;
     }
 
     /**
      * Returns the {@link HttpStatus} that will be sent to a client.
      */
-    HttpStatus httpStatus() {
+    public HttpStatus httpStatus() {
         return httpStatus;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseException.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseException.java
@@ -35,8 +35,9 @@ public abstract class HttpResponseException extends RuntimeException {
     protected HttpResponseException(HttpStatus httpStatus) {
         requireNonNull(httpStatus, "httpStatus");
         if (100 <= httpStatus.code() && httpStatus.code() < 400) {
-            throw new IllegalArgumentException("httpStatus: " + httpStatus +
-                                               " (expected: code < 100 || code >= 400)");
+            throw new IllegalArgumentException(
+                    "httpStatus: " + httpStatus +
+                    " (expected: a status that's neither informational, success nor redirection)");
         }
         this.httpStatus = httpStatus;
     }

--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseException.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseException.java
@@ -33,7 +33,7 @@ public abstract class HttpResponseException extends RuntimeException {
      * Creates a new instance.
      */
     protected HttpResponseException(HttpStatus httpStatus) {
-        requireNonNull(httpStatus, "httpStatus");
+        super(requireNonNull(httpStatus, "httpStatus").toString());
         if (100 <= httpStatus.code() && httpStatus.code() < 400) {
             throw new IllegalArgumentException(
                     "httpStatus: " + httpStatus +

--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseException.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseException.java
@@ -34,9 +34,9 @@ public abstract class HttpResponseException extends RuntimeException {
      */
     protected HttpResponseException(HttpStatus httpStatus) {
         requireNonNull(httpStatus, "httpStatus");
-        if (100 <= httpStatus.code() && httpStatus.code() < 399) {
+        if (100 <= httpStatus.code() && httpStatus.code() < 400) {
             throw new IllegalArgumentException("httpStatus: " + httpStatus +
-                                               " (expected: code < 100 || 400 <= code");
+                                               " (expected: code < 100 || code >= 400)");
         }
         this.httpStatus = httpStatus;
     }

--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
@@ -216,10 +216,9 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject>, RequestTim
 
     @Override
     public void onError(Throwable cause) {
-        if (cause instanceof ServiceUnavailableException) {
-            failAndRespond(cause, HttpStatus.SERVICE_UNAVAILABLE, Http2Error.CANCEL);
-        } else if (cause instanceof ResourceNotFoundException) {
-            failAndRespond(cause, HttpStatus.NOT_FOUND, Http2Error.CANCEL);
+        if (cause instanceof ArmeriaHttpException) {
+            ArmeriaHttpException exception = (ArmeriaHttpException) cause;
+            failAndRespond(cause, exception.httpStatus(), exception.http2error());
         } else {
             logger.warn("{} Unexpected exception from a service or a response publisher: {}",
                         ctx.channel(), service(), cause);

--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
@@ -217,8 +217,7 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject>, RequestTim
     @Override
     public void onError(Throwable cause) {
         if (cause instanceof HttpResponseException) {
-            HttpResponseException exception = (HttpResponseException) cause;
-            failAndRespond(cause, exception.httpStatus(), exception.http2error());
+            failAndRespond(cause, ((HttpResponseException) cause).httpStatus(), Http2Error.CANCEL);
         } else {
             logger.warn("{} Unexpected exception from a service or a response publisher: {}",
                         ctx.channel(), service(), cause);

--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
@@ -216,8 +216,8 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject>, RequestTim
 
     @Override
     public void onError(Throwable cause) {
-        if (cause instanceof ArmeriaHttpException) {
-            ArmeriaHttpException exception = (ArmeriaHttpException) cause;
+        if (cause instanceof HttpResponseException) {
+            HttpResponseException exception = (HttpResponseException) cause;
             failAndRespond(cause, exception.httpStatus(), exception.http2error());
         } else {
             logger.warn("{} Unexpected exception from a service or a response publisher: {}",

--- a/core/src/main/java/com/linecorp/armeria/server/ResourceNotFoundException.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ResourceNotFoundException.java
@@ -19,8 +19,6 @@ import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.util.Exceptions;
 
-import io.netty.handler.codec.http2.Http2Error;
-
 /**
  * A {@link RuntimeException} raised when a {@link Service} failed to find a resource.
  */
@@ -43,6 +41,6 @@ public final class ResourceNotFoundException extends HttpResponseException {
      * Creates a new instance.
      */
     private ResourceNotFoundException() {
-        super(HttpStatus.NOT_FOUND, Http2Error.CANCEL);
+        super(HttpStatus.NOT_FOUND);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/ResourceNotFoundException.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ResourceNotFoundException.java
@@ -16,12 +16,15 @@
 package com.linecorp.armeria.server;
 
 import com.linecorp.armeria.common.Flags;
+import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.util.Exceptions;
+
+import io.netty.handler.codec.http2.Http2Error;
 
 /**
  * A {@link RuntimeException} raised when a {@link Service} failed to find a resource.
  */
-public final class ResourceNotFoundException extends RuntimeException {
+public final class ResourceNotFoundException extends ArmeriaHttpException {
 
     private static final long serialVersionUID = 1268757990666737813L;
 
@@ -39,5 +42,7 @@ public final class ResourceNotFoundException extends RuntimeException {
     /**
      * Creates a new instance.
      */
-    private ResourceNotFoundException() {}
+    private ResourceNotFoundException() {
+        super(HttpStatus.NOT_FOUND, Http2Error.CANCEL);
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/ResourceNotFoundException.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ResourceNotFoundException.java
@@ -24,7 +24,7 @@ import io.netty.handler.codec.http2.Http2Error;
 /**
  * A {@link RuntimeException} raised when a {@link Service} failed to find a resource.
  */
-public final class ResourceNotFoundException extends ArmeriaHttpException {
+public final class ResourceNotFoundException extends HttpResponseException {
 
     private static final long serialVersionUID = 1268757990666737813L;
 

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceUnavailableException.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceUnavailableException.java
@@ -20,8 +20,6 @@ import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.util.Exceptions;
 
-import io.netty.handler.codec.http2.Http2Error;
-
 /**
  * A {@link RuntimeException} that is raised when a requested invocation cannot be served.
  */
@@ -44,6 +42,6 @@ public final class ServiceUnavailableException extends HttpResponseException {
      * Creates a new instance.
      */
     private ServiceUnavailableException() {
-        super(HttpStatus.SERVICE_UNAVAILABLE, Http2Error.CANCEL);
+        super(HttpStatus.SERVICE_UNAVAILABLE);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceUnavailableException.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceUnavailableException.java
@@ -17,12 +17,15 @@
 package com.linecorp.armeria.server;
 
 import com.linecorp.armeria.common.Flags;
+import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.util.Exceptions;
+
+import io.netty.handler.codec.http2.Http2Error;
 
 /**
  * A {@link RuntimeException} that is raised when a requested invocation cannot be served.
  */
-public final class ServiceUnavailableException extends RuntimeException {
+public final class ServiceUnavailableException extends ArmeriaHttpException {
 
     private static final long serialVersionUID = -9092895165959388396L;
 
@@ -40,5 +43,7 @@ public final class ServiceUnavailableException extends RuntimeException {
     /**
      * Creates a new instance.
      */
-    private ServiceUnavailableException() {}
+    private ServiceUnavailableException() {
+        super(HttpStatus.SERVICE_UNAVAILABLE, Http2Error.CANCEL);
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceUnavailableException.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceUnavailableException.java
@@ -25,7 +25,7 @@ import io.netty.handler.codec.http2.Http2Error;
 /**
  * A {@link RuntimeException} that is raised when a requested invocation cannot be served.
  */
-public final class ServiceUnavailableException extends ArmeriaHttpException {
+public final class ServiceUnavailableException extends HttpResponseException {
 
     private static final long serialVersionUID = -9092895165959388396L;
 

--- a/core/src/test/java/com/linecorp/armeria/server/HttpResponseExceptionTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpResponseExceptionTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+import com.linecorp.armeria.common.HttpStatus;
+
+public class HttpResponseExceptionTest {
+    static {
+        System.setProperty("com.linecorp.armeria.verboseExceptions", "false");
+    }
+
+    @Test
+    public void fillInStackTrace() throws Exception {
+        MyHttpResponseException exception = new MyHttpResponseException();
+        assertThat(exception.getStackTrace()).isEmpty();
+    }
+
+    private static class MyHttpResponseException extends HttpResponseException {
+        private static final long serialVersionUID = 3634745947516435390L;
+
+        MyHttpResponseException() {
+            super(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/HttpResponseExceptionTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpResponseExceptionTest.java
@@ -16,27 +16,26 @@
 package com.linecorp.armeria.server;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.Test;
 
 import com.linecorp.armeria.common.HttpStatus;
 
 public class HttpResponseExceptionTest {
-    static {
-        System.setProperty("com.linecorp.armeria.verboseExceptions", "false");
+    @Test
+    public void httpStatus() throws Exception {
+        HttpResponseException exception = new HttpResponseException(HttpStatus.INTERNAL_SERVER_ERROR) {
+            private static final long serialVersionUID = -1132103140930994783L;
+        };
+        assertThat(exception.httpStatus()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
     @Test
-    public void fillInStackTrace() throws Exception {
-        MyHttpResponseException exception = new MyHttpResponseException();
-        assertThat(exception.getStackTrace()).isEmpty();
-    }
-
-    private static class MyHttpResponseException extends HttpResponseException {
-        private static final long serialVersionUID = 3634745947516435390L;
-
-        MyHttpResponseException() {
-            super(HttpStatus.INTERNAL_SERVER_ERROR);
-        }
+    public void onlyAcceptErrorHttpStatus() throws Exception {
+        assertThatThrownBy(() -> new HttpResponseException(HttpStatus.ACCEPTED) {
+            private static final long serialVersionUID = -1132103140930994783L;
+        }).isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("expected: code < 100 || 400 <= code");
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/HttpResponseExceptionTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpResponseExceptionTest.java
@@ -36,6 +36,6 @@ public class HttpResponseExceptionTest {
         assertThatThrownBy(() -> new HttpResponseException(HttpStatus.ACCEPTED) {
             private static final long serialVersionUID = -1132103140930994783L;
         }).isInstanceOf(IllegalArgumentException.class)
-          .hasMessageContaining("expected: code < 100 || 400 <= code");
+          .hasMessageContaining("expected: code < 100 || code >= 400)");
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/HttpResponseExceptionTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpResponseExceptionTest.java
@@ -36,6 +36,6 @@ public class HttpResponseExceptionTest {
         assertThatThrownBy(() -> new HttpResponseException(HttpStatus.ACCEPTED) {
             private static final long serialVersionUID = -1132103140930994783L;
         }).isInstanceOf(IllegalArgumentException.class)
-          .hasMessageContaining("expected: code < 100 || code >= 400)");
+          .hasMessageContaining("(expected: a status that's neither informational, success nor redirection)");
     }
 }


### PR DESCRIPTION
Motivations:
- The error behavior of HttpResponseSubscriber#onError is hard-coded and cannot customize error code.

Modifications:
- Add ArmeriaHttpException which makes more customizable error handling

Results:
- A user can customize error code through ArmeriaHttpException
- Fixes #543