### PR TITLE
Guarantee that RequestContext is accessible during converting a respo…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/AnnotatedHttpServiceMethod.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AnnotatedHttpServiceMethod.java
@@ -115,14 +115,22 @@ final class AnnotatedHttpServiceMethod implements BiFunction<ServiceRequestConte
 
     BiFunction<ServiceRequestContext, HttpRequest, Object> withConverter(ResponseConverter converter) {
         return (ctx, req) ->
-                executeSyncOrAsync(ctx, req).thenApply(obj -> convertResponse(obj, converter));
+                executeSyncOrAsync(ctx, req).thenApply(obj -> {
+                    try (SafeCloseable ignored = RequestContext.push(ctx, false)) {
+                        return convertResponse(obj, converter);
+                    }
+                });
     }
 
     BiFunction<ServiceRequestContext, HttpRequest, Object> withConverters(
             Map<Class<?>, ResponseConverter> converters) {
 
         return (ctx, req) ->
-                executeSyncOrAsync(ctx, req).thenApply(obj -> convertResponse(obj, converters));
+                executeSyncOrAsync(ctx, req).thenApply(obj -> {
+                    try (SafeCloseable ignored = RequestContext.push(ctx, false)) {
+                        return convertResponse(obj, converters);
+                    }
+                });
     }
 
     private CompletionStage<?> executeSyncOrAsync(ServiceRequestContext ctx, HttpRequest req) {

--- a/core/src/test/java/com/linecorp/armeria/server/TestConverters.java
+++ b/core/src/test/java/com/linecorp/armeria/server/TestConverters.java
@@ -22,6 +22,7 @@ import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.server.annotation.ResponseConverter;
 
 final class TestConverters {
@@ -29,6 +30,7 @@ final class TestConverters {
     public static class NaiveIntConverter implements ResponseConverter {
         @Override
         public HttpResponse convert(Object resObj) throws Exception {
+            assert RequestContext.current() != null;
             final DefaultHttpResponse res = new DefaultHttpResponse();
             final HttpData data = HttpData.ofUtf8(String.format("Integer: %d", resObj));
             final long current = System.currentTimeMillis();
@@ -46,6 +48,7 @@ final class TestConverters {
     public static class NaiveNumberConverter implements ResponseConverter {
         @Override
         public HttpResponse convert(Object resObj) throws Exception {
+            assert RequestContext.current() != null;
             final DefaultHttpResponse res = new DefaultHttpResponse();
             final HttpData data = HttpData.ofUtf8(String.format("Number: %d", resObj));
             final long current = System.currentTimeMillis();
@@ -63,6 +66,7 @@ final class TestConverters {
     public static class NaiveStringConverter implements ResponseConverter {
         @Override
         public HttpResponse convert(Object resObj) throws Exception {
+            assert RequestContext.current() != null;
             final DefaultHttpResponse res = new DefaultHttpResponse();
             final HttpData data = HttpData.ofUtf8(String.format("String: %s", resObj));
             final long current = System.currentTimeMillis();
@@ -80,6 +84,7 @@ final class TestConverters {
     public static class TypedNumberConverter implements ResponseConverter {
         @Override
         public HttpResponse convert(Object resObj) throws Exception {
+            assert RequestContext.current() != null;
             final DefaultHttpResponse res = new DefaultHttpResponse();
             final HttpData data = HttpData.ofUtf8(String.format("Number[%d]", resObj));
             final long current = System.currentTimeMillis();
@@ -97,6 +102,7 @@ final class TestConverters {
     public static class TypedStringConverter implements ResponseConverter {
         @Override
         public HttpResponse convert(Object resObj) throws Exception {
+            assert RequestContext.current() != null;
             final DefaultHttpResponse res = new DefaultHttpResponse();
             final HttpData data = HttpData.ofUtf8(String.format("String[%s]", resObj));
             final long current = System.currentTimeMillis();
@@ -114,6 +120,7 @@ final class TestConverters {
     public static class UnformattedStringConverter implements ResponseConverter {
         @Override
         public HttpResponse convert(Object resObj) throws Exception {
+            assert RequestContext.current() != null;
             final DefaultHttpResponse res = new DefaultHttpResponse();
             final HttpData data = HttpData.ofUtf8(resObj.toString());
             final long current = System.currentTimeMillis();


### PR DESCRIPTION
…nse by ResponseConverter.

Motivation:

An annotated method may return a future instance which runs over common ForkJoinPool, so we may get an error like ‘java.lang.IllegalStateException: RequestContext unavailable’  when accessing the context of a request in a RequestConverter. So we should guarantee that RequestContext is accessible during converting a response by ResponseConverter.

Modifications:

Call ‘RequestContext.push’ before converting a response by a ResponseConverter.

Result:

We are able to guarantee that RequestContext is accessible during converting a response by ResponseConverter.