### PR TITLE
Add a function that removes inside caches when the last subscriber st…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClientOptions.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientOptions.java
@@ -32,6 +32,7 @@ import java.util.Optional;
 import java.util.function.Function;
 
 import com.linecorp.armeria.common.DefaultHttpHeaders;
+import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.SessionProtocol;
@@ -46,8 +47,6 @@ import io.netty.util.AsciiString;
 public final class ClientOptions extends AbstractOptions {
 
     private static final Long DEFAULT_DEFAULT_WRITE_TIMEOUT_MILLIS = Duration.ofSeconds(1).toMillis();
-    private static final Long DEFAULT_DEFAULT_RESPONSE_TIMEOUT_MILLIS = Duration.ofSeconds(10).toMillis();
-    private static final Long DEFAULT_DEFAULT_MAX_RESPONSE_LENGTH = 10L * 1024 * 1024; // 10 MB
 
     @SuppressWarnings("deprecation")
     private static final Collection<AsciiString> BLACKLISTED_HEADER_NAMES =
@@ -71,8 +70,8 @@ public final class ClientOptions extends AbstractOptions {
 
     private static final ClientOptionValue<?>[] DEFAULT_OPTIONS = {
             DEFAULT_WRITE_TIMEOUT_MILLIS.newValue(DEFAULT_DEFAULT_WRITE_TIMEOUT_MILLIS),
-            DEFAULT_RESPONSE_TIMEOUT_MILLIS.newValue(DEFAULT_DEFAULT_RESPONSE_TIMEOUT_MILLIS),
-            DEFAULT_MAX_RESPONSE_LENGTH.newValue(DEFAULT_DEFAULT_MAX_RESPONSE_LENGTH),
+            DEFAULT_RESPONSE_TIMEOUT_MILLIS.newValue(Flags.defaultResponseTimeoutMillis()),
+            DEFAULT_MAX_RESPONSE_LENGTH.newValue(Flags.defaultMaxResponseLength()),
             DECORATION.newValue(ClientDecoration.NONE),
             HTTP_HEADERS.newValue(HttpHeaders.EMPTY_HEADERS)
     };
@@ -215,7 +214,7 @@ public final class ClientOptions extends AbstractOptions {
      * Returns the default timeout of a server reply to a client call.
      */
     public long defaultResponseTimeoutMillis() {
-        return getOrElse(DEFAULT_RESPONSE_TIMEOUT_MILLIS, DEFAULT_DEFAULT_RESPONSE_TIMEOUT_MILLIS);
+        return getOrElse(DEFAULT_RESPONSE_TIMEOUT_MILLIS, Flags.defaultResponseTimeoutMillis());
     }
 
     /**
@@ -230,7 +229,7 @@ public final class ClientOptions extends AbstractOptions {
      */
     @SuppressWarnings("unchecked")
     public long defaultMaxResponseLength() {
-        return getOrElse(DEFAULT_MAX_RESPONSE_LENGTH, DEFAULT_DEFAULT_MAX_RESPONSE_LENGTH);
+        return getOrElse(DEFAULT_MAX_RESPONSE_LENGTH, Flags.defaultMaxResponseLength());
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -61,6 +61,32 @@ public final class Flags {
                    DEFAULT_NUM_COMMON_BLOCKING_TASK_THREADS,
                    value -> value > 0);
 
+    private static final long DEFAULT_DEFAULT_MAX_REQUEST_LENGTH = 10 * 1024 * 1024; // 10 MiB
+    private static final long DEFAULT_MAX_REQUEST_LENGTH =
+            getLong("defaultMaxRequestLength",
+                    DEFAULT_DEFAULT_MAX_REQUEST_LENGTH,
+                    value -> value >= 0);
+
+    private static final long DEFAULT_DEFAULT_MAX_RESPONSE_LENGTH = 10 * 1024 * 1024; // 10 MiB
+    private static final long DEFAULT_MAX_RESPONSE_LENGTH =
+            getLong("defaultMaxResponseLength",
+                    DEFAULT_DEFAULT_MAX_RESPONSE_LENGTH,
+                    value -> value >= 0);
+
+    private static final long DEFAULT_DEFAULT_REQUEST_TIMEOUT_MILLIS = 10 * 1000; // 10 seconds
+    private static final long DEFAULT_REQUEST_TIMEOUT_MILLIS =
+            getLong("defaultRequestTimeoutMillis",
+                    DEFAULT_DEFAULT_REQUEST_TIMEOUT_MILLIS,
+                    value -> value >= 0);
+
+    // Use slightly greater value than the default request timeout so that clients have a higher chance of
+    // getting proper 503 Service Unavailable response when server-side timeout occurs.
+    private static final long DEFAULT_DEFAULT_RESPONSE_TIMEOUT_MILLIS = 15 * 1000; // 15 seconds
+    private static final long DEFAULT_RESPONSE_TIMEOUT_MILLIS =
+            getLong("defaultResponseTimeoutMillis",
+                    DEFAULT_DEFAULT_RESPONSE_TIMEOUT_MILLIS,
+                    value -> value >= 0);
+
     private static final long DEFAULT_DEFAULT_CONNECT_TIMEOUT_MILLIS = 3200; // 3.2 seconds
     private static final long DEFAULT_CONNECT_TIMEOUT_MILLIS =
             getLong("defaultConnectTimeoutMillis",
@@ -173,7 +199,55 @@ public final class Flags {
     }
 
     /**
-     * Returns the default timeout of a socket connection attempt in milliseconds.
+     * Returns the default server-side maximum length of a request. Note that this value has effect
+     * only if a user did not specify it.
+     *
+     * <p>The default value of this flag is {@value #DEFAULT_DEFAULT_MAX_REQUEST_LENGTH}. Specify the
+     * {@code -Dcom.linecorp.armeria.defaultMaxRequestLength=<long>} to override the default value.
+     * {@code 0} disables the length limit.
+     */
+    public static long defaultMaxRequestLength() {
+        return DEFAULT_MAX_REQUEST_LENGTH;
+    }
+
+    /**
+     * Returns the default client-side maximum length of a response. Note that this value has effect
+     * only if a user did not specify it.
+     *
+     * <p>The default value of this flag is {@value #DEFAULT_DEFAULT_MAX_RESPONSE_LENGTH}. Specify the
+     * {@code -Dcom.linecorp.armeria.defaultMaxResponseLength=<long>} to override the default value.
+     * {@code 0} disables the length limit.
+     */
+    public static long defaultMaxResponseLength() {
+        return DEFAULT_MAX_RESPONSE_LENGTH;
+    }
+
+    /**
+     * Returns the default server-side timeout of a request in milliseconds. Note that this value has effect
+     * only if a user did not specify it.
+     *
+     * <p>The default value of this flag is {@value #DEFAULT_DEFAULT_REQUEST_TIMEOUT_MILLIS}.
+     * Specify the {@code -Dcom.linecorp.armeria.defaultRequestTimeoutMillis=<long>} to override
+     * the default value. {@code 0} disables the timeout.
+     */
+    public static long defaultRequestTimeoutMillis() {
+        return DEFAULT_REQUEST_TIMEOUT_MILLIS;
+    }
+
+    /**
+     * Returns the default client-side timeout of a response in milliseconds. Note that this value has effect
+     * only if a user did not specify it.
+     *
+     * <p>The default value of this flag is {@value #DEFAULT_DEFAULT_RESPONSE_TIMEOUT_MILLIS}.
+     * Specify the {@code -Dcom.linecorp.armeria.defaultResponseTimeoutMillis=<long>} to override
+     * the default value. {@code 0} disables the timeout.
+     */
+    public static long defaultResponseTimeoutMillis() {
+        return DEFAULT_RESPONSE_TIMEOUT_MILLIS;
+    }
+
+    /**
+     * Returns the default client-side timeout of a socket connection attempt in milliseconds.
      * Note that this value has effect only if a user did not specify it.
      *
      * <p>The default value of this flag is {@value #DEFAULT_DEFAULT_CONNECT_TIMEOUT_MILLIS}. Specify the

--- a/core/src/main/java/com/linecorp/armeria/common/stream/AbortedStreamException.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AbortedStreamException.java
@@ -27,7 +27,7 @@ import com.linecorp.armeria.common.util.Exceptions;
  */
 public final class AbortedStreamException extends RuntimeException {
 
-    private static final long serialVersionUID = -7665826869012452735L;
+    private static final long serialVersionUID = -5271590540551141199L;
 
     private static final AbortedStreamException INSTANCE =
             Exceptions.clearTrace(new AbortedStreamException());

--- a/core/src/main/java/com/linecorp/armeria/common/stream/SignalLengthGetter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/SignalLengthGetter.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.stream;
+
+/**
+ * A function that accepts one signal and produces the length of the signal.
+ * @param <T> the type of the signal
+ */
+@FunctionalInterface
+public interface SignalLengthGetter<T> {
+
+    /**
+     * Returns the length of {@code obj}.
+     */
+    int length(T obj);
+}

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -83,8 +83,6 @@ public final class ServerBuilder {
     // Use Integer.MAX_VALUE not to limit open connections by default.
     private static final int DEFAULT_MAX_NUM_CONNECTIONS = Integer.MAX_VALUE;
 
-    private static final long DEFAULT_DEFAULT_REQUEST_TIMEOUT_MILLIS = Duration.ofSeconds(10).toMillis();
-    private static final long DEFAULT_DEFAULT_MAX_REQUEST_LENGTH = 10 * 1024 * 1024; // 10 MB
     // Defaults to no graceful shutdown.
     private static final Duration DEFAULT_GRACEFUL_SHUTDOWN_QUIET_PERIOD = Duration.ZERO;
     private static final Duration DEFAULT_GRACEFUL_SHUTDOWN_TIMEOUT = Duration.ZERO;
@@ -102,8 +100,8 @@ public final class ServerBuilder {
     private boolean shutdownWorkerGroupOnStop;
     private int maxNumConnections = DEFAULT_MAX_NUM_CONNECTIONS;
     private long idleTimeoutMillis = Flags.defaultServerIdleTimeoutMillis();
-    private long defaultRequestTimeoutMillis = DEFAULT_DEFAULT_REQUEST_TIMEOUT_MILLIS;
-    private long defaultMaxRequestLength = DEFAULT_DEFAULT_MAX_REQUEST_LENGTH;
+    private long defaultRequestTimeoutMillis = Flags.defaultRequestTimeoutMillis();
+    private long defaultMaxRequestLength = Flags.defaultMaxRequestLength();
     private Duration gracefulShutdownQuietPeriod = DEFAULT_GRACEFUL_SHUTDOWN_QUIET_PERIOD;
     private Duration gracefulShutdownTimeout = DEFAULT_GRACEFUL_SHUTDOWN_TIMEOUT;
     private Executor blockingTaskExecutor = CommonPools.blockingTaskExecutor();

--- a/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageDuplicatorVerification.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageDuplicatorVerification.java
@@ -92,7 +92,7 @@ public class StreamMessageDuplicatorVerification extends StreamMessageVerificati
     private static class StreamMessageDuplicator
             extends AbstractStreamMessageDuplicator<Long, StreamMessage<Long>> {
         StreamMessageDuplicator(StreamMessage<Long> publisher) {
-            super(publisher);
+            super(publisher, l -> 8, 0);
         }
 
         @Override


### PR DESCRIPTION
…arts to subscribe to StreamMessageDuplicator

Motivation:

StreamMessageDuplicator were keeping the signals before the `close()` is invoked due to it's own characteristic. It doesn't, however, have to keep all the signals when it knows that there's no more subscription. Therefore, it's needed to remove already published caches so that it prevents the internal cache growing largely.

Modifications:

- Add `duplicateStream(bool)` to set the last stream
- Replace internal list containing caches to a CircularQueue
- RetryingClient blocks the stream only configured amount of bytes to decide to retry

Result:

- Internal caches doesn't grow largely after the last subscriber starts to subscribes
- Close #622