### PR TITLE
Increase the heap size for Gradle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ env:
   global:
     - JAVA_HOME=$HOME/.jdk/default
     - PATH=$JAVA_HOME/bin:$PATH
-    - GRADLE_OPTS=-Xmx768m
+    - GRADLE_OPTS=-Xmx1024m
 
 before_install:
   - .travis/install-jdk.sh

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ build:
   verbosity: detailed
 
 build_script:
-  - gradlew.bat --no-daemon --stacktrace checkstyle build test
+  - gradlew.bat --no-daemon --stacktrace checkstyle test build
 
 cache:
   - "%USERPROFILE%\\.gradle\\wrapper\\dists"
@@ -16,7 +16,7 @@ cache:
 
 environment:
   JAVA_HOME: C:\Program Files\Java\jdk1.8.0
-  GRADLE_OPTS: -Xmx768m
+  GRADLE_OPTS: -Xmx1024m
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
.. from 768m to 1024m to fix the problem where ProGuard takes too much time or fails due to GC overhead

Will merge once the build passes. /cc @hyangtack @minwoox