### PR TITLE
add ServerBuilder.grpcServiceUnder()

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/AbstractVirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AbstractVirtualHostBuilder.java
@@ -207,6 +207,16 @@ abstract class AbstractVirtualHostBuilder<B extends AbstractVirtualHostBuilder> 
     }
 
     /**
+     * Binds the specified grpc {@link Service} under the specified directory.
+     */
+    public B grpcServiceUnder(
+            String pathPrefix,
+            Service<HttpRequest, HttpResponse> service) {
+        service(PathMapping.ofPrefix(pathPrefix, false), service);
+        return self();
+    }
+
+    /**
      * Binds the specified {@link Service} under the specified directory.
      */
     public B serviceUnder(String pathPrefix, Service<HttpRequest, HttpResponse> service) {

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -352,9 +352,26 @@ public final class ServerBuilder {
      * @throws IllegalStateException if the default {@link VirtualHost} has been set via
      *                               {@link #defaultVirtualHost(VirtualHost)} already
      */
-    public ServerBuilder serviceUnder(String pathPrefix, Service<HttpRequest, HttpResponse> service) {
+    public ServerBuilder serviceUnder(
+            String pathPrefix,
+            Service<HttpRequest, HttpResponse> service) {
         defaultVirtualHostBuilderUpdated();
         defaultVirtualHostBuilder.serviceUnder(pathPrefix, service);
+        return this;
+    }
+
+    /**
+     * Binds the specified grpc {@link Service} under the specified directory of the default
+     * {@link VirtualHost}.
+     *
+     * @throws IllegalStateException if the default {@link VirtualHost} has been set via
+     *                               {@link #defaultVirtualHost(VirtualHost)} already
+     */
+    public ServerBuilder grpcServiceUnder(
+            String pathPrefix,
+            Service<HttpRequest, HttpResponse> service) {
+        defaultVirtualHostBuilderUpdated();
+        defaultVirtualHostBuilder.grpcServiceUnder(pathPrefix, service);
         return this;
     }
 


### PR DESCRIPTION
One issue found in GrpcServiceBuilder.
in the comment of build() method, using serviceUnder() to bind grpc services to a prefix is recommended.
```
    /**
     * Constructs a new {@link GrpcService} that can be bound to
     * {@link com.linecorp.armeria.server.ServerBuilder}. As GRPC services themselves are mounted at a path that
     * corresponds to their protobuf package, you will almost always want to bind to a prefix, e.g. by using
     * {@link com.linecorp.armeria.server.ServerBuilder#serviceUnder(String, Service)}.
     */
```

While, when tried to using serviceUnder(), there happened "UNIMPLEMENTED, Method not found" exception.

After checking the related code, following approach seems to be the simplest solution.
```
    /**
     * Binds the specified {@link Service} under the specified directory.
     */
    public B serviceUnder(String pathPrefix, Service<HttpRequest, HttpResponse> service) {
        service(PathMapping.ofPrefix(pathPrefix, !(service instanceof GrpcService)), service);
        return self();
    }
```
But, this approach lead to circular dependency between core and grpc module. So added grpcServiceUnder() instead. Please help to reviw and share your opinions, thank you.