### PR TITLE
Modify RetryStrategy to return backoff according to the response

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/retry/ExponentialBackoff.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/ExponentialBackoff.java
@@ -20,7 +20,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import com.google.common.base.MoreObjects;
 
 final class ExponentialBackoff extends AbstractBackoff {
-    private long currentDelayMillis;
+    private final long initialDelayMillis;
     private final long maxDelayMillis;
     private final double multiplier;
 
@@ -30,19 +30,19 @@ final class ExponentialBackoff extends AbstractBackoff {
                       "initialDelayMillis: %s (expected: >= 0)", initialDelayMillis);
         checkArgument(initialDelayMillis <= maxDelayMillis, "maxDelayMillis: %s (expected: >= %s)",
                       maxDelayMillis, initialDelayMillis);
-        currentDelayMillis = initialDelayMillis;
+        this.initialDelayMillis = initialDelayMillis;
         this.maxDelayMillis = maxDelayMillis;
         this.multiplier = multiplier;
     }
 
     @Override
     protected long doNextDelayMillis(int numAttemptsSoFar) {
-        if (currentDelayMillis >= maxDelayMillis) {
-            return maxDelayMillis;
+        if (numAttemptsSoFar == 1) {
+            return initialDelayMillis;
         }
-        long nextDelay = currentDelayMillis;
-        currentDelayMillis = saturatedMultiply(currentDelayMillis, multiplier);
-        return nextDelay;
+        final long nextDelay =
+                saturatedMultiply(initialDelayMillis, Math.pow(multiplier, numAttemptsSoFar - 1));
+        return Math.min(nextDelay, maxDelayMillis);
     }
 
     private static long saturatedMultiply(long left, double right) {
@@ -53,7 +53,7 @@ final class ExponentialBackoff extends AbstractBackoff {
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
-                          .add("currentDelayMillis", currentDelayMillis)
+                          .add("initialDelayMillis", initialDelayMillis)
                           .add("maxDelayMillis", maxDelayMillis)
                           .add("multiplier", multiplier)
                           .toString();

--- a/core/src/main/java/com/linecorp/armeria/client/retry/HttpStatusBasedRetryStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/HttpStatusBasedRetryStrategy.java
@@ -16,19 +16,16 @@
 
 package com.linecorp.armeria.client.retry;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
-import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-
-import com.google.common.collect.ImmutableList;
+import java.util.function.Function;
 
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
-import com.linecorp.armeria.common.HttpStatusClass;
 import com.linecorp.armeria.internal.HttpHeaderSubscriber;
 
 /**
@@ -37,28 +34,18 @@ import com.linecorp.armeria.internal.HttpHeaderSubscriber;
  */
 final class HttpStatusBasedRetryStrategy implements RetryStrategy<HttpRequest, HttpResponse> {
 
-    private final List<HttpStatus> retryStatuses;
+    private final Function<HttpStatus, Optional<Backoff>> statusBasedBackoffFunction;
 
     /**
      * Creates a new instance.
      */
-    HttpStatusBasedRetryStrategy(Iterable<HttpStatus> retryStatuses) {
-        this.retryStatuses = validateStatus(ImmutableList.copyOf(retryStatuses));
-    }
-
-    private List<HttpStatus> validateStatus(List<HttpStatus> retryStatuses) {
-        requireNonNull(retryStatuses, "retryStatuses");
-        checkArgument(!retryStatuses.isEmpty(), "Need at least a status to retry");
-
-        for (HttpStatus retryStatus : retryStatuses) {
-            checkArgument(retryStatus.codeClass() != HttpStatusClass.INFORMATIONAL,
-                          "retryStatuses contains an informational status: %s", retryStatus);
-        }
-        return retryStatuses;
+    HttpStatusBasedRetryStrategy(Function<HttpStatus, Optional<Backoff>> statusBasedBackoffFunction) {
+        this.statusBasedBackoffFunction = requireNonNull(
+                statusBasedBackoffFunction, "statusBasedBackoffFunction");
     }
 
     @Override
-    public CompletableFuture<Boolean> shouldRetry(HttpRequest request, HttpResponse response) {
+    public CompletableFuture<Optional<Backoff>> shouldRetry(HttpRequest request, HttpResponse response) {
         final CompletableFuture<HttpHeaders> future = new CompletableFuture<>();
         final HttpHeaderSubscriber subscriber = new HttpHeaderSubscriber(future);
         response.closeFuture().whenComplete(subscriber);
@@ -68,11 +55,10 @@ final class HttpStatusBasedRetryStrategy implements RetryStrategy<HttpRequest, H
             if (headers != null) {
                 final HttpStatus resStatus = headers.status();
                 if (resStatus != null) {
-                    return retryStatuses.stream().anyMatch(
-                            retryStatus -> resStatus.code() == retryStatus.code());
+                    return statusBasedBackoffFunction.apply(resStatus);
                 }
             }
-            return false;
+            return Optional.empty();
         });
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClientBuilder.java
@@ -20,7 +20,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.MoreObjects.ToStringHelper;
@@ -45,7 +44,6 @@ public abstract class RetryingClientBuilder<
     private static final BackoffSpec DEFAULT_BACKOFF_SPEC = BackoffSpec.parse(Flags.defaultBackoffSpec());
 
     final RetryStrategy<I, O> retryStrategy;
-    Supplier<? extends Backoff> backoffSupplier = () -> DEFAULT_BACKOFF_SPEC.build();
     int defaultMaxAttempts = DEFAULT_BACKOFF_SPEC.maxAttempts;
 
     /**
@@ -61,21 +59,7 @@ public abstract class RetryingClientBuilder<
     }
 
     /**
-     * Sets the {@link Supplier} that provides a {@link Backoff}. The {@link Backoff} will be used to
-     * calculate next delay to retry when the {@link RetryStrategy#shouldRetry(Request, Response)}
-     * returns {@code true}.
-     *
-     * @return {@link T} to support method chaining.
-     */
-    public T backoffSupplier(Supplier<? extends Backoff> backoffSupplier) {
-        this.backoffSupplier = requireNonNull(backoffSupplier, "backoffSupplier");
-        return self();
-    }
-
-    /**
-     * Sets the {@code defaultMaxAttempts}. When a client sets the {@link Backoff} and does not invoke the
-     * {@link Backoff#withMaxAttempts(int)}, the client could retry infinitely in certain circumstance.
-     * This would prevent that situation. The value will be set by the default value in
+     * Sets the {@code defaultMaxAttempts}. The value will be set by the default value in
      * {@link Flags#DEFAULT_BACKOFF_SPEC}, if the client dose not specify.
      *
      * @return {@link T} to support method chaining.
@@ -106,7 +90,6 @@ public abstract class RetryingClientBuilder<
     ToStringHelper toStringHelper() {
         return MoreObjects.toStringHelper(this)
                           .add("retryStrategy", retryStrategy)
-                          .add("backoff", backoffSupplier.get())
                           .add("defaultMaxAttempts", defaultMaxAttempts);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingHttpClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingHttpClientBuilder.java
@@ -76,8 +76,8 @@ public class RetryingHttpClientBuilder extends RetryingClientBuilder<
      */
     @Override
     public RetryingHttpClient build(Client<HttpRequest, HttpResponse> delegate) {
-        return new RetryingHttpClient(delegate, retryStrategy, backoffSupplier,
-                                      defaultMaxAttempts, useRetryAfter, contentPreviewLength);
+        return new RetryingHttpClient(delegate, retryStrategy, defaultMaxAttempts,
+                                      useRetryAfter, contentPreviewLength);
     }
 
     /**
@@ -86,8 +86,8 @@ public class RetryingHttpClientBuilder extends RetryingClientBuilder<
      */
     @Override
     public Function<Client<HttpRequest, HttpResponse>, RetryingHttpClient> newDecorator() {
-        return delegate -> new RetryingHttpClient(delegate, retryStrategy, backoffSupplier,
-                                                  defaultMaxAttempts, useRetryAfter, contentPreviewLength);
+        return delegate -> new RetryingHttpClient(delegate, retryStrategy, defaultMaxAttempts,
+                                                  useRetryAfter, contentPreviewLength);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClientBuilder.java
@@ -41,7 +41,7 @@ public class RetryingRpcClientBuilder
      */
     @Override
     public RetryingRpcClient build(Client<RpcRequest, RpcResponse> delegate) {
-        return new RetryingRpcClient(delegate, retryStrategy, backoffSupplier, defaultMaxAttempts);
+        return new RetryingRpcClient(delegate, retryStrategy, defaultMaxAttempts);
     }
 
     /**
@@ -51,6 +51,6 @@ public class RetryingRpcClientBuilder
     @Override
     public Function<Client<RpcRequest, RpcResponse>, RetryingRpcClient> newDecorator() {
         return delegate ->
-                new RetryingRpcClient(delegate, retryStrategy, backoffSupplier, defaultMaxAttempts);
+                new RetryingRpcClient(delegate, retryStrategy, defaultMaxAttempts);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/retry/BackoffTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/BackoffTest.java
@@ -16,15 +16,10 @@
 package com.linecorp.armeria.client.retry;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
 
 import java.util.Random;
 
 import org.junit.Test;
-
-import com.linecorp.armeria.client.Client;
-import com.linecorp.armeria.common.HttpRequest;
-import com.linecorp.armeria.common.HttpResponse;
 
 public class BackoffTest {
     @Test
@@ -75,27 +70,5 @@ public class BackoffTest {
         assertThat(backoff.nextDelayMillis(1)).isEqualTo(100);
         assertThat(backoff.nextDelayMillis(2)).isEqualTo(-1);
         assertThat(backoff.nextDelayMillis(3)).isEqualTo(-1);
-    }
-
-    @Test
-    public void limitRetryAttempts() {
-        @SuppressWarnings("unchecked")
-        final Client<HttpRequest, HttpResponse> client = mock(Client.class);
-        @SuppressWarnings("unchecked")
-        final RetryStrategy<HttpRequest, HttpResponse> strategy = mock(RetryStrategy.class);
-        final RetryingClient<HttpRequest, HttpResponse> retryingClient =
-                new RetryingHttpClientBuilder(strategy)
-                        .backoffSupplier(Backoff::withoutDelay).defaultMaxAttempts(5).build(client);
-
-        final Backoff newBackoff = retryingClient.newBackoff();
-        int currentAttemptNo = 1;
-        assertThat(newBackoff.nextDelayMillis(currentAttemptNo++)).isEqualTo(0);
-        assertThat(newBackoff.nextDelayMillis(currentAttemptNo++)).isEqualTo(0);
-        assertThat(newBackoff.nextDelayMillis(currentAttemptNo++)).isEqualTo(0);
-        assertThat(newBackoff.nextDelayMillis(currentAttemptNo++)).isEqualTo(0);
-
-        // After 5 tries which are the sum of first normal try and 4 consecutive retries,
-        // it's failed returning -1.
-        assertThat(newBackoff.nextDelayMillis(currentAttemptNo++)).isEqualTo(-1);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryingHttpClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryingHttpClientTest.java
@@ -20,9 +20,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.Duration;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -93,13 +95,27 @@ public class RetryingHttpClientTest {
                 }
             });
 
+            sb.service("/500-then-success", new AbstractHttpService() {
+                final AtomicInteger reqCount = new AtomicInteger();
+
+                @Override
+                protected void doGet(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res)
+                        throws Exception {
+                    if (reqCount.getAndIncrement() < 1) {
+                        res.respond(HttpStatus.INTERNAL_SERVER_ERROR);
+                    } else {
+                        res.respond(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "Succeeded after retry");
+                    }
+                }
+            });
+
             sb.service("/503-then-success", new AbstractHttpService() {
                 final AtomicInteger reqCount = new AtomicInteger();
 
                 @Override
                 protected void doGet(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res)
                         throws Exception {
-                    if (reqCount.getAndIncrement() < 2) {
+                    if (reqCount.getAndIncrement() < 1) {
                         res.respond(HttpStatus.SERVICE_UNAVAILABLE);
                     } else {
                         res.respond(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "Succeeded after retry");
@@ -210,7 +226,7 @@ public class RetryingHttpClientTest {
     public void retryWhenContentMatched() {
         final RetryStrategy<HttpRequest, HttpResponse> strategy = new RetryOnContent("Need to retry");
         final HttpClient client = new HttpClientBuilder(server.uri("/")).factory(clientFactory)
-                .decorator(RetryingHttpClient.newDecorator(strategy, () -> Backoff.fixed(100))).build();
+                .decorator(RetryingHttpClient.newDecorator(strategy)).build();
 
         final AggregatedHttpMessage res = client.get("/retry-content").aggregate().join();
         assertThat(res.content().toStringUtf8()).isEqualTo("Succeeded after retry");
@@ -218,27 +234,32 @@ public class RetryingHttpClientTest {
 
     private static class RetryOnContent implements RetryStrategy<HttpRequest, HttpResponse> {
         private final String retryContent;
+        private final Backoff backoffOnContent = Backoff.fixed(100);
 
         RetryOnContent(String retryContent) {
             this.retryContent = retryContent;
         }
 
         @Override
-        public CompletableFuture<Boolean> shouldRetry(HttpRequest request, HttpResponse response) {
+        public CompletableFuture<Optional<Backoff>> shouldRetry(HttpRequest request, HttpResponse response) {
             final CompletableFuture<AggregatedHttpMessage> future = response.aggregate();
-            return future.handle((message, thrown) ->
-                                         message != null &&
-                                         message.content().toStringUtf8().equalsIgnoreCase(retryContent)
+            return future.handle((message, unused) -> {
+                                     if (message != null &&
+                                         message.content().toStringUtf8().equalsIgnoreCase(retryContent)) {
+                                         return Optional.of(backoffOnContent);
+                                     } else {
+                                         return Optional.empty();
+                                     }
+                                 }
             );
         }
     }
 
     @Test
     public void retryWhenStatusMatched() {
-        final RetryStrategy<HttpRequest, HttpResponse> strategy =
-                RetryStrategy.onStatus(HttpStatus.SERVICE_UNAVAILABLE);
+        final RetryStrategy<HttpRequest, HttpResponse> strategy = RetryStrategy.onServerErrorStatus();
         final HttpClient client = new HttpClientBuilder(server.uri("/")).factory(clientFactory)
-                .decorator(RetryingHttpClient.newDecorator(strategy, () -> Backoff.fixed(100))).build();
+                .decorator(RetryingHttpClient.newDecorator(strategy)).build();
 
         final AggregatedHttpMessage res = client.get("/503-then-success").aggregate().join();
         assertThat(res.content().toStringUtf8()).isEqualTo("Succeeded after retry");
@@ -246,8 +267,7 @@ public class RetryingHttpClientTest {
 
     @Test
     public void respectRetryAfter() {
-        final RetryStrategy<HttpRequest, HttpResponse> strategy =
-                RetryStrategy.onStatus(HttpStatus.SERVICE_UNAVAILABLE);
+        final RetryStrategy<HttpRequest, HttpResponse> strategy = RetryStrategy.onServerErrorStatus();
         final HttpClient client = retryingHttpClientOf(10000, strategy);
 
         final Stopwatch sw = Stopwatch.createStarted();
@@ -262,16 +282,14 @@ public class RetryingHttpClientTest {
                                             RetryStrategy<HttpRequest, HttpResponse> strategy) {
         return new HttpClientBuilder(server.uri("/")).factory(clientFactory)
                 .defaultResponseTimeoutMillis(responseTimeoutMillis)
-                .decorator(new RetryingHttpClientBuilder(strategy)
-                                   .backoffSupplier(() -> Backoff.fixed(100).withMaxAttempts(1000))
-                                   .useRetryAfter(true).newDecorator())
+                .decorator(new RetryingHttpClientBuilder(strategy).useRetryAfter(true)
+                                                                  .defaultMaxAttempts(100).newDecorator())
                 .build();
     }
 
     @Test
     public void respectRetryAfterWithHttpDate() {
-        final RetryStrategy<HttpRequest, HttpResponse> strategy =
-                RetryStrategy.onStatus(HttpStatus.SERVICE_UNAVAILABLE);
+        final RetryStrategy<HttpRequest, HttpResponse> strategy = RetryStrategy.onServerErrorStatus();
         final HttpClient client = retryingHttpClientOf(10000, strategy);
 
         final Stopwatch sw = Stopwatch.createStarted();
@@ -286,8 +304,7 @@ public class RetryingHttpClientTest {
     @Test
     public void retryAfterOneYear() {
         long responseTimeoutMillis = 1000;
-        final RetryStrategyWrapper strategy = new RetryStrategyWrapper(
-                RetryStrategy.onStatus(HttpStatus.SERVICE_UNAVAILABLE));
+        final RetryStrategyWrapper strategy = new RetryStrategyWrapper(RetryStrategy.onServerErrorStatus());
         final HttpClient client = retryingHttpClientOf(responseTimeoutMillis, strategy);
 
         final Stopwatch sw = Stopwatch.createStarted();
@@ -303,7 +320,7 @@ public class RetryingHttpClientTest {
     public void timeoutWhenServerDoseNotResponse() {
         long responseTimeoutMillis = 1000;
         final RetryStrategyWrapper strategy = new RetryStrategyWrapper(
-                RetryStrategy.onStatus(HttpStatus.SERVICE_UNAVAILABLE));
+                RetryStrategy.onServerErrorStatus());
         final HttpClient client = retryingHttpClientOf(responseTimeoutMillis, strategy);
 
         final Stopwatch sw = Stopwatch.createStarted();
@@ -317,7 +334,7 @@ public class RetryingHttpClientTest {
     public void timeoutWhenServerSendServiceUnavailable() {
         long responseTimeoutMillis = 1000;
         final RetryStrategyWrapper strategy = new RetryStrategyWrapper(
-                RetryStrategy.onStatus(HttpStatus.SERVICE_UNAVAILABLE));
+                RetryStrategy.onServerErrorStatus(Backoff.fixed(100)));
         final HttpClient client = retryingHttpClientOf(responseTimeoutMillis, strategy);
 
         final Stopwatch sw = Stopwatch.createStarted();
@@ -330,8 +347,7 @@ public class RetryingHttpClientTest {
     @Test
     public void consecutiveRequests() {
         long responseTimeoutMillis = 500;
-        final RetryStrategyWrapper strategy = new RetryStrategyWrapper(
-                RetryStrategy.onStatus(HttpStatus.SERVICE_UNAVAILABLE));
+        final RetryStrategyWrapper strategy = new RetryStrategyWrapper(RetryStrategy.onServerErrorStatus());
         final HttpClient client = retryingHttpClientOf(responseTimeoutMillis, strategy);
 
         final Stopwatch sw = Stopwatch.createStarted();
@@ -355,7 +371,7 @@ public class RetryingHttpClientTest {
 
         final HttpClient client = new HttpClientBuilder(server.uri("/")).factory(clientFactory)
                 .defaultResponseTimeoutMillis(0) // disable response timeout
-                .decorator(RetryingHttpClient.newDecorator(strategy, () -> Backoff.fixed(100))).build();
+                .decorator(RetryingHttpClient.newDecorator(strategy)).build();
 
         final AggregatedHttpMessage res = client.get("/retry-content").aggregate().join();
         assertThat(res.content().toStringUtf8()).isEqualTo("Succeeded after retry");
@@ -364,11 +380,11 @@ public class RetryingHttpClientTest {
 
     @Test
     public void differentResponseTimeout() {
+        final Backoff backoffOnServerError = Backoff.fixed(10);
         final RetryStrategyWrapper strategy = new RetryStrategyWrapper(
-                RetryStrategy.onStatus(HttpStatus.SERVICE_UNAVAILABLE));
+                RetryStrategy.onServerErrorStatus(backoffOnServerError));
         final HttpClient client = new HttpClientBuilder(server.uri("/")).factory(clientFactory)
-                .decorator(RetryingHttpClient
-                                   .newDecorator(strategy, () -> Backoff.fixed(100).withMaxAttempts(500)))
+                .decorator(RetryingHttpClient.newDecorator(strategy))
                 .decorator((delegate, ctx, req) -> {
                     if (req.method() == HttpMethod.GET) {
                         ctx.setResponseTimeoutMillis(50);
@@ -384,27 +400,64 @@ public class RetryingHttpClientTest {
         assertThat(res.content().toStringUtf8()).isEqualTo("Succeeded after retry");
     }
 
+    @Test
+    public void differentBackoffBasedOnStatus() {
+        final RetryStrategy<HttpRequest, HttpResponse> strategy = RetryStrategy.onStatus(statusBasedBackoff());
+        final HttpClient client = new HttpClientBuilder(server.uri("/"))
+                .factory(clientFactory).decorator(RetryingHttpClient.newDecorator(strategy)).build();
+
+        final Stopwatch sw = Stopwatch.createStarted();
+        AggregatedHttpMessage res = client.get("/503-then-success").aggregate().join();
+        assertThat(res.content().toStringUtf8()).isEqualTo("Succeeded after retry");
+        assertThat(sw.elapsed(TimeUnit.MILLISECONDS)).isBetween((long) (10 * 0.9), (long) (10000 * 0.9));
+        // second request
+        sw.reset();
+        sw.start();
+        res = client.get("/500-then-success").aggregate().join();
+        assertThat(res.content().toStringUtf8()).isEqualTo("Succeeded after retry");
+        assertThat(sw.elapsed(TimeUnit.MILLISECONDS)).isGreaterThanOrEqualTo((long) (1000 * 0.9));
+    }
+
+    private Function<HttpStatus, Optional<Backoff>> statusBasedBackoff() {
+        return new Function<HttpStatus, Optional<Backoff>>() {
+            private final Backoff backoffOn503 = Backoff.fixed(10).withMaxAttempts(2);
+            private final Backoff backoffOn500 = Backoff.fixed(1000).withMaxAttempts(2);
+
+            @Override
+            public Optional<Backoff> apply(HttpStatus httpStatus) {
+                if (httpStatus == HttpStatus.SERVICE_UNAVAILABLE) {
+                    return Optional.of(backoffOn503);
+                } else if (httpStatus == HttpStatus.INTERNAL_SERVER_ERROR) {
+                    return Optional.of(backoffOn500);
+                } else {
+                    return Optional.empty();
+                }
+            }
+        };
+    }
+
     private static class RetryStrategyWrapper implements RetryStrategy<HttpRequest, HttpResponse> {
 
         private final RetryStrategy<HttpRequest, HttpResponse> delegate;
+        private final Backoff backoffOnException = Backoff.fixed(100).withMaxAttempts(500);
 
         RetryStrategyWrapper(RetryStrategy<HttpRequest, HttpResponse> delegate) {
             this.delegate = delegate;
         }
 
         @Override
-        public CompletableFuture<Boolean> shouldRetry(HttpRequest request, HttpResponse response) {
+        public CompletableFuture<Optional<Backoff>> shouldRetry(HttpRequest request, HttpResponse response) {
             return delegate.shouldRetry(request, response);
         }
 
         @Override
-        public boolean shouldRetry(HttpRequest request, Throwable cause) {
+        public Optional<Backoff> shouldRetry(HttpRequest request, Throwable cause) {
             if (cause != null) {
                 if (cause instanceof ResponseTimeoutException) {
-                    return false;
+                    return Optional.empty();
                 }
             }
-            return true;
+            return Optional.of(backoffOnException);
         }
     }
 }


### PR DESCRIPTION
Motivation:

A `RetryingClient` may want to have different `Backoff` by the responses.
For example, the client wants to retry using exponential backoff when it gets `SERVICE_UNAVAILABLE`.
On the other hand, it wants to keep retrying without delay when it gets revision conflicts.

Modifications:

- Make all of the implementations of `Backoff` stateless
- Change the `shouldRetry` method returng `Optional<Backoff>`

Result:

- Close #655
- Users can choose `Backoff` accroding to the response