### PR TITLE
Add service(ServiceWithPathMapping,...) to AbstractVirtualHostBuilder

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/AbstractVirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AbstractVirtualHostBuilder.java
@@ -254,6 +254,28 @@ abstract class AbstractVirtualHostBuilder<B extends AbstractVirtualHostBuilder> 
     }
 
     /**
+     * Binds the specified {@link ServiceWithPathMappings} at multiple {@link PathMapping}s.
+     */
+    public <T extends ServiceWithPathMappings<HttpRequest, HttpResponse>>
+    B service(T serviceWithPathMappings) {
+        return service(serviceWithPathMappings, Function.identity());
+    }
+
+    /**
+     * Decorates and binds the specified {@link ServiceWithPathMappings} at multiple {@link PathMapping}s.
+     */
+    public <T extends ServiceWithPathMappings<HttpRequest, HttpResponse>,
+            R extends Service<HttpRequest, HttpResponse>>
+    B service(T serviceWithPathMappings, Function<T, R> decorator) {
+        requireNonNull(serviceWithPathMappings, "serviceWithPathMappings");
+        requireNonNull(serviceWithPathMappings.pathMappings(), "serviceWithPathMappings.pathMappings()");
+        requireNonNull(decorator, "decorator");
+        final Service<HttpRequest, HttpResponse> decorated = decorator.apply(serviceWithPathMappings);
+        serviceWithPathMappings.pathMappings().forEach(pathMapping -> service(pathMapping, decorated));
+        return self();
+    }
+
+    /**
      * Binds the specified annotated service object under the path prefix {@code "/"}.
      */
     public B annotatedService(Object service) {

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -420,19 +420,21 @@ public final class ServerBuilder {
     }
 
     /**
-     * Binds the specified {@link ServiceWithPathMappings} at multiple {@link PathMapping}
+     * Binds the specified {@link ServiceWithPathMappings} at multiple {@link PathMapping}s
      * of the default {@link VirtualHost}.
      *
      * @throws IllegalStateException if the default {@link VirtualHost} has been set via
      *                               {@link #defaultVirtualHost(VirtualHost)} already
      */
     public <T extends ServiceWithPathMappings<HttpRequest, HttpResponse>>
-            ServerBuilder service(T serviceWithPathMapping) {
-        return service(serviceWithPathMapping, Function.identity());
+    ServerBuilder service(T serviceWithPathMappings) {
+        defaultVirtualHostBuilderUpdated();
+        defaultVirtualHostBuilder.service(serviceWithPathMappings);
+        return this;
     }
 
     /**
-     * Decorates and binds the specified {@link ServiceWithPathMappings} at multiple {@link PathMapping}
+     * Decorates and binds the specified {@link ServiceWithPathMappings} at multiple {@link PathMapping}s
      * of the default {@link VirtualHost}.
      *
      * @throws IllegalStateException if the default {@link VirtualHost} has been set via
@@ -440,12 +442,9 @@ public final class ServerBuilder {
      */
     public <T extends ServiceWithPathMappings<HttpRequest, HttpResponse>,
             R extends Service<HttpRequest, HttpResponse>>
-            ServerBuilder service(T serviceWithPathMapping, Function<T, R> decorator) {
-        requireNonNull(serviceWithPathMapping, "serviceWithPathMapping");
-        requireNonNull(serviceWithPathMapping.pathMappings(), "serviceWithPathMapping.pathMappings()");
-        requireNonNull(decorator, "decorator");
-        serviceWithPathMapping.pathMappings()
-                .forEach(pathMapping -> service(pathMapping, decorator.apply(serviceWithPathMapping)));
+    ServerBuilder service(T serviceWithPathMappings, Function<T, R> decorator) {
+        defaultVirtualHostBuilderUpdated();
+        defaultVirtualHostBuilder.service(serviceWithPathMappings, decorator);
         return this;
     }
 


### PR DESCRIPTION
.. because ServerBuilder and AbstractVirtualHostBuilder should have the
same set of service-adding methods

/cc @demongaorui 