### PR TITLE
Use NoopMeterRegistry by default

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.client;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.netty.handler.codec.http2.Http2CodecUtil.DEFAULT_MAX_FRAME_SIZE;
 import static io.netty.handler.codec.http2.Http2CodecUtil.DEFAULT_WINDOW_SIZE;
@@ -43,10 +44,10 @@ import com.linecorp.armeria.client.pool.PoolKey;
 import com.linecorp.armeria.common.CommonPools;
 import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.Request;
+import com.linecorp.armeria.common.metric.NoopMeterRegistry;
 import com.linecorp.armeria.internal.TransportType;
 
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.epoll.EpollChannelOption;
@@ -292,13 +293,12 @@ public final class ClientFactoryBuilder {
      * Returns a newly-created {@link ClientFactory} based on the properties of this builder.
      */
     public ClientFactory build() {
-        final MeterRegistry meterRegistry = this.meterRegistry != null ? this.meterRegistry
-                                                                       : new SimpleMeterRegistry();
         return new DefaultClientFactory(new HttpClientFactory(
                 workerGroup, shutdownWorkerGroupOnClose, socketOptions, sslContextCustomizer,
                 addressResolverGroupFactory, initialHttp2ConnectionWindowSize, initialHttp2StreamWindowSize,
                 http2MaxFrameSize, idleTimeoutMillis, useHttp2Preface,
-                useHttp1Pipelining, connectionPoolListener, meterRegistry));
+                useHttp1Pipelining, connectionPoolListener,
+                firstNonNull(meterRegistry, NoopMeterRegistry.get())));
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/metric/NoopMeterRegistry.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/NoopMeterRegistry.java
@@ -1,0 +1,89 @@
+/*
+ *  Copyright 2017 LINE Corporation
+ *
+ *  LINE Corporation licenses this file to you under the Apache License,
+ *  version 2.0 (the "License"); you may not use this file except in compliance
+ *  with the License. You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package com.linecorp.armeria.common.metric;
+
+import java.util.function.ToDoubleFunction;
+
+import io.micrometer.core.instrument.AbstractMeterRegistry;
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.LongTaskTimer;
+import io.micrometer.core.instrument.Measurement;
+import io.micrometer.core.instrument.Meter.Type;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.noop.NoopCounter;
+import io.micrometer.core.instrument.noop.NoopDistributionSummary;
+import io.micrometer.core.instrument.noop.NoopGauge;
+import io.micrometer.core.instrument.noop.NoopLongTaskTimer;
+import io.micrometer.core.instrument.noop.NoopTimer;
+import io.micrometer.core.instrument.stats.hist.Histogram;
+import io.micrometer.core.instrument.stats.quantile.Quantiles;
+
+/**
+ * A {@link MeterRegistry} which does not record any values.
+ */
+public final class NoopMeterRegistry extends AbstractMeterRegistry {
+
+    private static final NoopMeterRegistry INSTANCE = new NoopMeterRegistry();
+
+    /**
+     * Returns the singleton instance.
+     */
+    public static NoopMeterRegistry get() {
+        return INSTANCE;
+    }
+
+    private NoopMeterRegistry() {
+        super(Clock.SYSTEM);
+        config().namingConvention(MoreNamingConventions.identity());
+    }
+
+    @Override
+    protected DistributionSummary newDistributionSummary(String name, Iterable<Tag> tags, String description,
+                                                         Quantiles quantiles, Histogram<?> histogram) {
+        return NoopDistributionSummary.INSTANCE;
+    }
+
+    @Override
+    protected <T> Gauge newGauge(String name, Iterable<Tag> tags, String description, ToDoubleFunction<T> f,
+                                 T obj) {
+        return NoopGauge.INSTANCE;
+    }
+
+    @Override
+    protected Counter newCounter(String name, Iterable<Tag> tags, String description) {
+        return NoopCounter.INSTANCE;
+    }
+
+    @Override
+    protected LongTaskTimer newLongTaskTimer(String name, Iterable<Tag> tags, String description) {
+        return NoopLongTaskTimer.INSTANCE;
+    }
+
+    @Override
+    protected Timer newTimer(String name, Iterable<Tag> tags, String description, Histogram<?> histogram,
+                             Quantiles quantiles) {
+        return NoopTimer.INSTANCE;
+    }
+
+    @Override
+    protected void newMeter(String name, Iterable<Tag> tags, Type type, Iterable<Measurement> measurements) {}
+}

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.server;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.linecorp.armeria.common.SessionProtocol.HTTP;
 import static com.linecorp.armeria.server.ServerConfig.validateDefaultMaxRequestLength;
 import static com.linecorp.armeria.server.ServerConfig.validateDefaultRequestTimeoutMillis;
@@ -43,10 +44,10 @@ import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.metric.NoopMeterRegistry;
 import com.linecorp.armeria.server.annotation.ResponseConverter;
 
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.netty.channel.EventLoopGroup;
 import io.netty.handler.ssl.SslContext;
 
@@ -651,14 +652,11 @@ public final class ServerBuilder {
             virtualHosts = this.virtualHosts;
         }
 
-        final MeterRegistry meterRegistry = this.meterRegistry != null ? this.meterRegistry
-                                                                       : new SimpleMeterRegistry();
-
         final Server server = new Server(new ServerConfig(
                 ports, defaultVirtualHost, virtualHosts, workerGroup, shutdownWorkerGroupOnStop,
                 maxNumConnections, idleTimeoutMillis, defaultRequestTimeoutMillis, defaultMaxRequestLength,
-                gracefulShutdownQuietPeriod, gracefulShutdownTimeout,
-                blockingTaskExecutor, meterRegistry, serviceLoggerPrefix));
+                gracefulShutdownQuietPeriod, gracefulShutdownTimeout, blockingTaskExecutor,
+                firstNonNull(meterRegistry, NoopMeterRegistry.get()), serviceLoggerPrefix));
         serverListeners.forEach(server::addListener);
         return server;
     }

--- a/core/src/test/java/com/linecorp/armeria/client/DefaultHttpClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/DefaultHttpClientTest.java
@@ -30,8 +30,7 @@ import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.SessionProtocol;
-
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import com.linecorp.armeria.common.metric.NoopMeterRegistry;
 
 public class DefaultHttpClientTest {
 
@@ -48,7 +47,7 @@ public class DefaultHttpClientTest {
                                                                                  ClientOptions.DEFAULT);
         DefaultHttpClient defaultHttpClient = new DefaultHttpClient(clientBuilderParams,
                                                                     mockClientDelegate,
-                                                                    new SimpleMeterRegistry(),
+                                                                    NoopMeterRegistry.get(),
                                                                     SessionProtocol.of("http"),
                                                                     Endpoint.of("127.0.0.1"));
 

--- a/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClientTest.java
@@ -48,10 +48,10 @@ import com.linecorp.armeria.client.circuitbreaker.KeyedCircuitBreakerMapping.Key
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.RpcResponse;
+import com.linecorp.armeria.common.metric.NoopMeterRegistry;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.testing.internal.AnticipatedException;
 
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.netty.channel.DefaultEventLoop;
 
 public class CircuitBreakerClientTest {
@@ -60,13 +60,13 @@ public class CircuitBreakerClientTest {
 
     // Remote invocation parameters
     private static final ClientRequestContext ctx = new DefaultClientRequestContext(
-            new DefaultEventLoop(), new SimpleMeterRegistry(), H2C,
+            new DefaultEventLoop(), NoopMeterRegistry.get(), H2C,
             Endpoint.of("dummyhost", 8080),
             HttpMethod.POST, "/", null, null, ClientOptions.DEFAULT,
             RpcRequest.of(Object.class, "methodA", "a", "b"));
 
     private static final ClientRequestContext ctxB = new DefaultClientRequestContext(
-            new DefaultEventLoop(), new SimpleMeterRegistry(), H2C,
+            new DefaultEventLoop(), NoopMeterRegistry.get(), H2C,
             Endpoint.of("dummyhost", 8080),
             HttpMethod.POST, "/", null, null, ClientOptions.DEFAULT,
             RpcRequest.of(Object.class, "methodB", "c", "d"));

--- a/core/src/test/java/com/linecorp/armeria/common/RequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/RequestContextTest.java
@@ -50,9 +50,9 @@ import com.google.common.util.concurrent.MoreExecutors;
 
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.logging.RequestLogBuilder;
+import com.linecorp.armeria.common.metric.NoopMeterRegistry;
 import com.linecorp.armeria.common.util.SafeCloseable;
 
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelPromise;
@@ -407,7 +407,7 @@ public class RequestContextTest {
 
     private class DummyRequestContext extends NonWrappingRequestContext {
         DummyRequestContext() {
-            super(new SimpleMeterRegistry(), SessionProtocol.HTTP,
+            super(NoopMeterRegistry.get(), SessionProtocol.HTTP,
                   HttpMethod.GET, "/", null, new DefaultHttpRequest());
         }
 

--- a/logback/src/test/java/com/linecorp/armeria/common/logback/RequestContextExportingAppenderTest.java
+++ b/logback/src/test/java/com/linecorp/armeria/common/logback/RequestContextExportingAppenderTest.java
@@ -66,6 +66,7 @@ import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.logback.HelloService.hello_args;
 import com.linecorp.armeria.common.logback.HelloService.hello_result;
 import com.linecorp.armeria.common.logging.RequestLogBuilder;
+import com.linecorp.armeria.common.metric.NoopMeterRegistry;
 import com.linecorp.armeria.common.thrift.ThriftCall;
 import com.linecorp.armeria.common.thrift.ThriftReply;
 import com.linecorp.armeria.common.thrift.ThriftSerializationFormats;
@@ -88,7 +89,6 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
 import ch.qos.logback.core.status.Status;
 import ch.qos.logback.core.status.StatusManager;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.netty.channel.Channel;
 import io.netty.channel.EventLoop;
 import io.netty.util.AttributeKey;
@@ -423,7 +423,7 @@ public class RequestContextExportingAppenderTest {
                 new DummyPathMappingContext(virtualHost, "server.com", path, query, req.headers());
 
         final ServiceRequestContext ctx = new DefaultServiceRequestContext(
-                serviceConfig, ch, new SimpleMeterRegistry(), SessionProtocol.H2, mappingCtx,
+                serviceConfig, ch, NoopMeterRegistry.get(), SessionProtocol.H2, mappingCtx,
                 PathMappingResult.of(path, query, ImmutableMap.of()), req, newSslSession());
 
         ctx.attr(MY_ATTR).set(new CustomValue("some-attr"));
@@ -533,7 +533,7 @@ public class RequestContextExportingAppenderTest {
                                                           .authority("server.com:8080"));
 
         final DefaultClientRequestContext ctx = new DefaultClientRequestContext(
-                mock(EventLoop.class), new SimpleMeterRegistry(), SessionProtocol.H2,
+                mock(EventLoop.class), NoopMeterRegistry.get(), SessionProtocol.H2,
                 Endpoint.of("server.com", 8080), req.method(), path, query, null,
                 ClientOptions.DEFAULT, req) {
 

--- a/zipkin/src/test/java/com/linecorp/armeria/client/tracing/HttpTracingClientTest.java
+++ b/zipkin/src/test/java/com/linecorp/armeria/client/tracing/HttpTracingClientTest.java
@@ -41,12 +41,12 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.RpcResponse;
+import com.linecorp.armeria.common.metric.NoopMeterRegistry;
 import com.linecorp.armeria.common.tracing.HelloService;
 import com.linecorp.armeria.common.tracing.SpanCollectingReporter;
 
 import brave.Tracing;
 import brave.sampler.Sampler;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.netty.channel.Channel;
 import io.netty.channel.DefaultEventLoop;
 import zipkin.Annotation;
@@ -108,7 +108,7 @@ public class HttpTracingClientTest {
         final HttpResponse res = HttpResponse.of(HttpStatus.OK);
         final RpcResponse rpcRes = RpcResponse.of("Hello, Armeria!");
         final ClientRequestContext ctx = new DefaultClientRequestContext(
-                new DefaultEventLoop(), new SimpleMeterRegistry(), H2C, Endpoint.of("localhost", 8080),
+                new DefaultEventLoop(), NoopMeterRegistry.get(), H2C, Endpoint.of("localhost", 8080),
                 HttpMethod.POST, "/", null, null, ClientOptions.DEFAULT, req);
 
         ctx.logBuilder().startRequest(mock(Channel.class), H2C, "localhost");


### PR DESCRIPTION
Motivation:

Using SimpleMeterRegistry by default doesn't make much sense because a
user will always want to switch to a better MeterRegistry implementation
such as DropwizardMeterRegistry or PrometheusMeterRegistry.

Modifications:

- Add NoopMeterRegistry and use it by default

Result:

- Less overhead unless a user explicitly requested metric recording