### PR TITLE
Update dependencies and fix checkstyle violations

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -23,6 +23,7 @@ managedDependencies {
     [ 'netty-transport', 'netty-codec-http2', 'netty-resolver-dns' ].each {
         compile "io.netty:$it"
     }
+    compile 'io.netty:netty-transport-native-unix-common:linux-x86_64'
     compile 'io.netty:netty-transport-native-epoll:linux-x86_64'
     compile 'io.netty:netty-tcnative-boringssl-static'
     runtime 'org.javassist:javassist'

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
@@ -196,7 +196,7 @@ final class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
     }
 
     /**
-     * @see <a href="https://http2.github.io/http2-spec/#discover-https">HTTP/2 specification</a>
+     * See <a href="https://http2.github.io/http2-spec/#discover-https">HTTP/2 specification</a>.
      */
     private void configureAsHttps(Channel ch, InetSocketAddress remoteAddr) {
         final ChannelPipeline p = ch.pipeline();
@@ -375,7 +375,7 @@ final class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
         }
 
         /**
-         * Sends the initial upgrade request, which is {@code "HEAD / HTTP/1.1"}
+         * Sends the initial upgrade request, which is {@code "HEAD / HTTP/1.1"}.
          */
         @Override
         public void channelActive(ChannelHandlerContext ctx) throws Exception {

--- a/core/src/main/java/com/linecorp/armeria/common/HttpHeaderNames.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpHeaderNames.java
@@ -250,7 +250,7 @@ public final class HttpHeaderNames {
      */
     public static final AsciiString IF_UNMODIFIED_SINCE = new AsciiString("if-unmodified-since");
     /**
-     * {@code "keep-alive"}
+     * {@code "keep-alive"}.
      *
      * @deprecated Use {@link #CONNECTION} instead.
      */
@@ -285,7 +285,7 @@ public final class HttpHeaderNames {
      */
     public static final AsciiString PROXY_AUTHORIZATION = new AsciiString("proxy-authorization");
     /**
-     * {@code "proxy-connection"}
+     * {@code "proxy-connection"}.
      *
      * @deprecated Use {@link #CONNECTION} instead.
      */

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -152,6 +152,8 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
     }
 
     /**
+     * Creates a new failed HTTP response.
+     *
      * @deprecated Use {@link #ofFailure(Throwable)} instead.
      */
     @Deprecated

--- a/core/src/main/java/com/linecorp/armeria/common/MediaType.java
+++ b/core/src/main/java/com/linecorp/armeria/common/MediaType.java
@@ -422,7 +422,7 @@ public final class MediaType {
     public static final MediaType PDF = createConstant(APPLICATION_TYPE, "pdf");
     public static final MediaType POSTSCRIPT = createConstant(APPLICATION_TYPE, "postscript");
     /**
-     * <a href="http://tools.ietf.org/html/draft-rfernando-protocol-buffers-00">Protocol buffers</a>
+     * <a href="http://tools.ietf.org/html/draft-rfernando-protocol-buffers-00">Protocol buffers</a>.
      */
     public static final MediaType PROTOBUF = createConstant(APPLICATION_TYPE, "protobuf");
 

--- a/core/src/main/java/com/linecorp/armeria/common/RequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestContext.java
@@ -371,6 +371,10 @@ public interface RequestContext extends AttributeMap {
     void onEnter(Consumer<? super RequestContext> callback);
 
     /**
+     * Registers {@code callback} to be run when re-entering this {@link RequestContext}, usually when using
+     * the {@link #makeContextAware} family of methods. Any thread-local state associated with this context
+     * should be restored by this callback.
+     *
      * @deprecated Use {@link #onEnter(Consumer)} instead.
      */
     @Deprecated
@@ -388,6 +392,10 @@ public interface RequestContext extends AttributeMap {
     void onExit(Consumer<? super RequestContext> callback);
 
     /**
+     * Registers {@code callback} to be run when re-exiting this {@link RequestContext}, usually when using
+     * the {@link #makeContextAware} family of methods. Any thread-local state associated with this context
+     * should be reset by this callback.
+     *
      * @deprecated Use {@link #onExit(Consumer)} instead.
      */
     @Deprecated

--- a/core/src/main/java/com/linecorp/armeria/common/SerializationFormat.java
+++ b/core/src/main/java/com/linecorp/armeria/common/SerializationFormat.java
@@ -55,6 +55,8 @@ public final class SerializationFormat implements Comparable<SerializationFormat
     public static final SerializationFormat UNKNOWN;
 
     /**
+     * Thrift TBinary serialization format.
+     *
      * @deprecated Use {@code ThriftSerializationFormats.BINARY}. Note that the value of this field will be
      *             {@code null} if {@code armeria-thrift} module is not loaded.
      */
@@ -62,6 +64,8 @@ public final class SerializationFormat implements Comparable<SerializationFormat
     public static final SerializationFormat THRIFT_BINARY;
 
     /**
+     * Thrift TCompact serialization format.
+     *
      * @deprecated Use {@code ThriftSerializationFormats.COMPACT}. Note that the value of this field will be
      *             {@code null} if {@code armeria-thrift} module is not loaded.
      */
@@ -69,6 +73,8 @@ public final class SerializationFormat implements Comparable<SerializationFormat
     public static final SerializationFormat THRIFT_COMPACT;
 
     /**
+     * Thrift TJSON serialization format.
+     *
      * @deprecated Use {@code ThriftSerializationFormats.JSON}. Note that the value of this field will be
      *             {@code null} if {@code armeria-thrift} module is not loaded.
      */
@@ -76,6 +82,8 @@ public final class SerializationFormat implements Comparable<SerializationFormat
     public static final SerializationFormat THRIFT_JSON;
 
     /**
+     * Thrift TText serialization format.
+     *
      * @deprecated Use {@code ThriftSerializationFormats.TEXT}. Note that the value of this field will be
      *             {@code null} if {@code armeria-thrift} module is not loaded.
      */
@@ -150,6 +158,8 @@ public final class SerializationFormat implements Comparable<SerializationFormat
     }
 
     /**
+     * Returns the set of all known Thrift serialization formats.
+     *
      * @deprecated Use {@code ThriftSerializationFormats.values()}.
      *
      * @throws IllegalStateException if {@code armeria-thrift} module is not loaded
@@ -223,6 +233,8 @@ public final class SerializationFormat implements Comparable<SerializationFormat
     }
 
     /**
+     * Finds the {@link SerializationFormat} which is accepted by the specified media range.
+     *
      * @deprecated Use {@link #find(MediaType...)}.
      */
     @Deprecated

--- a/core/src/main/java/com/linecorp/armeria/common/util/Exceptions.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/Exceptions.java
@@ -54,6 +54,10 @@ public final class Exceptions {
     private static final StackTraceElement[] EMPTY_STACK_TRACE = new StackTraceElement[0];
 
     /**
+     * Returns whether the verbose exception mode is enabled. When enabled, the exceptions frequently thrown by
+     * Armeria will have full stack trace. When disabled, such exceptions will have empty stack trace to
+     * eliminate the cost of capturing the stack trace.
+     *
      * @deprecated Use {@link Flags#verboseExceptions()} instead.
      */
     @Deprecated

--- a/core/src/main/java/com/linecorp/armeria/common/util/NativeLibraries.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/NativeLibraries.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.common.util;
 
+import javax.net.ssl.SSLEngine;
+
 import com.linecorp.armeria.common.Flags;
 
 /**
@@ -27,6 +29,8 @@ import com.linecorp.armeria.common.Flags;
 public final class NativeLibraries {
 
     /**
+     * This method does nothing.
+     *
      * @deprecated This method will be removed without a replacement, because the information about
      *             the availability of the native libraries are now logged automatically by {@link Flags}.
      */
@@ -34,6 +38,10 @@ public final class NativeLibraries {
     public static void report() {}
 
     /**
+     * Returns whether the JNI-based {@code /dev/epoll} socket I/O is enabled. When enabled on Linux, Armeria
+     * uses {@code /dev/epoll} directly for socket I/O. When disabled, {@code java.nio} socket API is used
+     * instead.
+     *
      * @deprecated Use {@link Flags#useEpoll()} instead.
      */
     @Deprecated
@@ -42,6 +50,10 @@ public final class NativeLibraries {
     }
 
     /**
+     * Returns whether the JNI-based TLS support with OpenSSL is enabled. When enabled, Armeria uses OpenSSL
+     * for processing TLS connections. When disabled, the current JVM's default {@link SSLEngine} is used
+     * instead.
+     *
      * @deprecated Use {@link Flags#useOpenSsl()} instead.
      */
     @Deprecated

--- a/core/src/main/java/com/linecorp/armeria/server/AbstractVirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AbstractVirtualHostBuilder.java
@@ -201,6 +201,8 @@ abstract class AbstractVirtualHostBuilder<B extends AbstractVirtualHostBuilder> 
     }
 
     /**
+     * Binds the specified {@link Service} at the specified path pattern.
+     *
      * @deprecated Use {@link #service(String, Service)} instead.
      */
     @Deprecated
@@ -217,7 +219,7 @@ abstract class AbstractVirtualHostBuilder<B extends AbstractVirtualHostBuilder> 
     }
 
     /**
-     * Binds the specified {@link Service} at the the specified path pattern. e.g.
+     * Binds the specified {@link Service} at the specified path pattern. e.g.
      * <ul>
      *   <li>{@code /login} (no path parameters)</li>
      *   <li>{@code /users/{userId}} (curly-brace style)</li>
@@ -244,6 +246,8 @@ abstract class AbstractVirtualHostBuilder<B extends AbstractVirtualHostBuilder> 
     }
 
     /**
+     * Binds the specified {@link Service} at the specified {@link PathMapping}.
+     *
      * @deprecated Use a logging framework integration such as {@code RequestContextExportingAppender} in
      *             {@code armeria-logback}.
      */

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -352,6 +352,8 @@ public final class ServerBuilder {
     }
 
     /**
+     * Binds the specified {@link Service} at the specified path pattern of the default {@link VirtualHost}.
+     *
      * @deprecated Use {@link #service(String, Service)} instead.
      */
     @Deprecated
@@ -408,6 +410,9 @@ public final class ServerBuilder {
     }
 
     /**
+     * Binds the specified {@link Service} at the specified {@link PathMapping} of the default
+     * {@link VirtualHost}.
+     *
      * @deprecated Use a logging framework integration such as {@code RequestContextExportingAppender} in
      *             {@code armeria-logback}.
      */

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceConfig.java
@@ -121,6 +121,8 @@ public final class ServiceConfig {
     }
 
     /**
+     * Returns the logger name for the {@link Service}.
+     *
      * @deprecated Use a logging framework integration such as {@code RequestContextExportingAppender} in
      *             {@code armeria-logback}.
      */

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
@@ -102,6 +102,8 @@ public interface ServiceRequestContext extends RequestContext {
     MediaType negotiatedProduceType();
 
     /**
+     * Returns the {@link Logger} of the {@link Service}.
+     *
      * @deprecated Use a logging framework integration such as {@code RequestContextExportingAppender} in
      *             {@code armeria-logback}.
      */

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHost.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHost.java
@@ -202,7 +202,7 @@ public final class VirtualHost {
 
     /**
      * Returns the hostname pattern of this virtual host, as defined in
-     * <a href="http://tools.ietf.org/html/rfc2818#section-3.1">the section 3.1 of RFC2818</a>
+     * <a href="http://tools.ietf.org/html/rfc2818#section-3.1">the section 3.1 of RFC2818</a>.
      */
     public String hostnamePattern() {
         return hostnamePattern;

--- a/core/src/main/java/com/linecorp/armeria/server/composition/AbstractCompositeServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/composition/AbstractCompositeServiceBuilder.java
@@ -100,6 +100,8 @@ public abstract class AbstractCompositeServiceBuilder<T extends AbstractComposit
     }
 
     /**
+     * Binds the specified {@link Service} at the specified path pattern.
+     *
      * @deprecated Use {@link #service(String, Service)} instead.
      */
     @Deprecated

--- a/core/src/main/java/com/linecorp/armeria/server/logging/LoggingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/LoggingService.java
@@ -63,6 +63,9 @@ public final class LoggingService<I extends Request, O extends Response> extends
     }
 
     /**
+     * Returns a new {@link Service} decorator that logs {@link Request}s and {@link Response}s at the given
+     * {@link LogLevel}.
+     *
      * @deprecated Use {@link LoggingServiceBuilder}.
      */
     @Deprecated
@@ -81,6 +84,8 @@ public final class LoggingService<I extends Request, O extends Response> extends
     private final Sampler sampler;
 
     /**
+     * Creates a new instance.
+     *
      * @deprecated Use {@link LoggingService#newDecorator()}.
      */
     @Deprecated
@@ -89,6 +94,8 @@ public final class LoggingService<I extends Request, O extends Response> extends
     }
 
     /**
+     * Creates a new instance.
+     *
      * @deprecated Use {@link LoggingServiceBuilder}.
      */
     @Deprecated

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -12,14 +12,14 @@ com.fasterxml.jackson.core:
   jackson-databind: { version: *JACKSON_VERSION }
 
 com.github.ben-manes.caffeine:
-  caffeine: { version: '2.5.3' }
+  caffeine: { version: '2.5.5' }
 
 com.google.code.findbugs:
   jsr305: { version: '3.0.2' }
 
 com.google.guava:
   guava:
-    version: &GUAVA_VERSION '22.0'
+    version: &GUAVA_VERSION '23.0'
     exclusions:
     - com.google.code.findbugs:jsr305
     - com.google.errorprone:error_prone_annotations
@@ -33,7 +33,7 @@ com.google.guava:
     - com.google.j2objc:j2objc-annotations
 
 com.puppycrawl.tools:
-  checkstyle: { version: '8.0' }
+  checkstyle: { version: '8.1' }
 
 com.spotify:
   completable-futures: { version: '0.3.1' }
@@ -44,12 +44,12 @@ com.squareup.retrofit2:
   converter-jackson: { version: *RETROFIT2_VERSION }
 
 io.dropwizard.metrics:
-  metrics-core: { version: &DROPWIZARD_VERSION '3.2.3' }
+  metrics-core: { version: &DROPWIZARD_VERSION '3.2.4' }
   metrics-json: { version: *DROPWIZARD_VERSION }
 
 io.grpc:
   grpc-core:
-    version: &GRPC_VERSION '1.4.0'
+    version: &GRPC_VERSION '1.5.0'
     exclusions:
     - com.google.code.findbugs:jsr305
     - com.google.errorprone:error_prone_annotations
@@ -69,18 +69,19 @@ io.micrometer:
   micrometer-spring-legacy: { version: *MICROMETER_VERSION }
 
 io.netty:
-  netty-codec-http2: { version: &NETTY_VERSION '4.1.13.Final' }
+  netty-codec-http2: { version: &NETTY_VERSION '4.1.14.Final' }
   netty-handler: { version: *NETTY_VERSION }
   netty-resolver-dns: { version: *NETTY_VERSION }
   netty-transport: { version: *NETTY_VERSION }
   netty-transport-native-epoll: { version: *NETTY_VERSION }
+  netty-transport-native-unix-common: { version: *NETTY_VERSION }
   netty-tcnative-boringssl-static: { version: '2.0.5.Final' }
 
 io.prometheus:
   simpleclient_common: { version: '0.0.26' }
 
 io.zipkin.brave:
-  brave: { version: &BRAVE_VERSION '4.5.1' }
+  brave: { version: &BRAVE_VERSION '4.5.2' }
 
 it.unimi.dsi:
   fastutil: { version: '8.1.0' }
@@ -95,7 +96,7 @@ junit:
   junit: { version: '4.12' }
 
 net.javacrumbs.json-unit:
-  json-unit: { version: &JSON_UNIT_VERSION '1.24.0' }
+  json-unit: { version: &JSON_UNIT_VERSION '1.25.0' }
   json-unit-fluent: { version: *JSON_UNIT_VERSION }
 
 org.apache.hbase:
@@ -114,7 +115,7 @@ org.apache.httpcomponents:
     - commons-logging:commons-logging
 
 org.apache.kafka:
-  kafka-clients: { version: '0.10.2.1' }
+  kafka-clients: { version: '0.11.0.0' }
 
 org.apache.thrift:
   libthrift:
@@ -124,7 +125,7 @@ org.apache.thrift:
     - org.apache.httpcomponents:httpclient
 
 org.apache.tomcat.embed:
-  tomcat-embed-core: { version: &TOMCAT_VERSION '8.5.16' }
+  tomcat-embed-core: { version: &TOMCAT_VERSION '8.5.20' }
   tomcat-embed-jasper: { version: *TOMCAT_VERSION }
   tomcat-embed-el: { version: *TOMCAT_VERSION }
 
@@ -177,7 +178,7 @@ org.mortbay.jetty.alpn:
   jetty-alpn-agent: { version: '2.0.6' }
 
 org.reactivestreams:
-  reactive-streams: { version: &REACTIVE_STREAMS_VERSION '1.0.1-RC1' }
+  reactive-streams: { version: &REACTIVE_STREAMS_VERSION '1.0.1' }
   reactive-streams-tck: { version: *REACTIVE_STREAMS_VERSION }
 
 org.reflections:
@@ -191,7 +192,7 @@ org.slf4j:
   slf4j-api: { version: *SLF4J_VERSION }
 
 org.springframework.boot:
-  spring-boot: { version: &SPRING_BOOT_VERSION '1.5.4.RELEASE' }
+  spring-boot: { version: &SPRING_BOOT_VERSION '1.5.6.RELEASE' }
   spring-boot-autoconfigure: { version: *SPRING_BOOT_VERSION }
   spring-boot-starter-logging: { version: *SPRING_BOOT_VERSION }
   spring-boot-starter-test: { version: *SPRING_BOOT_VERSION }

--- a/grpc/build.gradle
+++ b/grpc/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.1'
+        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.3'
     }
 }
 

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaChannel.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaChannel.java
@@ -48,6 +48,7 @@ import io.grpc.Channel;
 import io.grpc.ClientCall;
 import io.grpc.CompressorRegistry;
 import io.grpc.DecompressorRegistry;
+import io.grpc.ManagedChannelBuilder;
 import io.grpc.MethodDescriptor;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.netty.channel.EventLoop;
@@ -59,7 +60,7 @@ import io.netty.channel.EventLoop;
 class ArmeriaChannel extends Channel implements ClientBuilderParams {
 
     /**
-     * @see io.grpc.ManagedChannelBuilder for default setting
+     * See {@link ManagedChannelBuilder} for default setting.
      */
     private static final int DEFAULT_MAX_INBOUND_MESSAGE_SIZE = 4 * 1024 * 1024;
 

--- a/grpc/src/main/java/com/linecorp/armeria/internal/grpc/StatusMessageEscaper.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/grpc/StatusMessageEscaper.java
@@ -78,6 +78,8 @@ public final class StatusMessageEscaper {
     }
 
     /**
+     * Escapes the given byte array.
+     *
      * @param valueBytes the UTF-8 bytes
      * @param ri The reader index, pointed at the first byte that needs escaping.
      */

--- a/grpc/src/main/java/com/linecorp/armeria/internal/grpc/TimeoutHeaderUtil.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/grpc/TimeoutHeaderUtil.java
@@ -53,13 +53,15 @@ import java.util.concurrent.TimeUnit;
 /**
  * Marshals a nanoseconds representation of the timeout to and from a string representation,
  * consisting of an ASCII decimal representation of a number with at most 8 digits, followed by a
- * unit:
- * n = nanoseconds
- * u = microseconds
- * m = milliseconds
- * S = seconds
- * M = minutes
- * H = hours
+ * unit.
+ * <ul>
+ *   <li>n = nanoseconds</li>
+ *   <li>u = microseconds</li>
+ *   <li>m = milliseconds</li>
+ *   <li>S = seconds</li>
+ *   <li>M = minutes</li>
+ *   <li>H = hours</li>
+ * </ul>
  *
  * <p>The representation is greedy with respect to precision. That is, 2 seconds will be
  * represented as `2000000u`.</p>

--- a/tomcat8.0/build.gradle
+++ b/tomcat8.0/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
     // Tomcat
     [ 'tomcat-embed-core', 'tomcat-embed-jasper', 'tomcat-embed-el' ].each {
-        compile "org.apache.tomcat.embed:$it:8.0.45"
+        compile "org.apache.tomcat.embed:$it:8.0.46"
     }
 }
 


### PR DESCRIPTION
- Update dependencies
  - Brave 4.5.1 -> 4.5.2
  - Caffeine 2.5.3 -> 2.5.5
  - Checkstyle 8.0 -> 8.1
  - Dropwizard Metrics 3.2.3 -> 3.2.4
  - gRPC 1.4.0 -> 1.5.0
  - Guava 22.0 -> 23.0
  - JSON-unit 1.24.0 -> 1.25.0
  - Kafka 0.10.2.1 -> 0.11.0.0
  - Netty 4.1.13 -> 4.1.14
  - Reactive Streams 1.0.1-RC1 -> 1.0.1
  - Spring Boot 1.5.4 -> 1.5.6
  - Tomcat 8.5.16 -> 8.5.20 / 8.0.45 -> 8.0.46
- Fix new checkstyle violations reported by 8.1
