### PR TITLE
Add the response timeout corresponding to each request that is made …

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingHttpClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingHttpClientBuilder.java
@@ -77,7 +77,7 @@ public class RetryingHttpClientBuilder extends RetryingClientBuilder<
     @Override
     public RetryingHttpClient build(Client<HttpRequest, HttpResponse> delegate) {
         return new RetryingHttpClient(delegate, retryStrategy, defaultMaxAttempts,
-                                      useRetryAfter, contentPreviewLength);
+                                      responseTimeoutMillisForEachAttempt, useRetryAfter, contentPreviewLength);
     }
 
     /**
@@ -86,8 +86,9 @@ public class RetryingHttpClientBuilder extends RetryingClientBuilder<
      */
     @Override
     public Function<Client<HttpRequest, HttpResponse>, RetryingHttpClient> newDecorator() {
-        return delegate -> new RetryingHttpClient(delegate, retryStrategy, defaultMaxAttempts,
-                                                  useRetryAfter, contentPreviewLength);
+        return delegate -> new RetryingHttpClient(
+                delegate, retryStrategy, defaultMaxAttempts, responseTimeoutMillisForEachAttempt,
+                useRetryAfter, contentPreviewLength);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClientBuilder.java
@@ -41,7 +41,8 @@ public class RetryingRpcClientBuilder
      */
     @Override
     public RetryingRpcClient build(Client<RpcRequest, RpcResponse> delegate) {
-        return new RetryingRpcClient(delegate, retryStrategy, defaultMaxAttempts);
+        return new RetryingRpcClient(
+                delegate, retryStrategy, defaultMaxAttempts, responseTimeoutMillisForEachAttempt);
     }
 
     /**
@@ -51,6 +52,7 @@ public class RetryingRpcClientBuilder
     @Override
     public Function<Client<RpcRequest, RpcResponse>, RetryingRpcClient> newDecorator() {
         return delegate ->
-                new RetryingRpcClient(delegate, retryStrategy, defaultMaxAttempts);
+                new RetryingRpcClient(
+                        delegate, retryStrategy, defaultMaxAttempts, responseTimeoutMillisForEachAttempt);
     }
 }

--- a/thrift/src/test/java/com/linecorp/armeria/it/client/retry/RetryingRpcClientTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/client/retry/RetryingRpcClientTest.java
@@ -58,8 +58,12 @@ public class RetryingRpcClientTest {
     private static final RetryStrategy<RpcRequest, RpcResponse> ONLY_HANDLES_EXCEPTION =
         (request, response) -> {
             final CompletableFuture<Optional<Backoff>> future = new CompletableFuture<>();
-            response.handle(voidFunction((unused1, unused2) -> {
-                future.complete(Optional.empty());
+            response.handle(voidFunction((unused1, cause) -> {
+                if (cause != null) {
+                    future.complete(Optional.of(Backoff.withoutDelay()));
+                } else {
+                    future.complete(Optional.empty());
+                }
             }));
             return future;
         };


### PR DESCRIPTION
…in `RetryingClient`

Motivation:

`ResponseTimeout` was applied to the whole requests in `RetryingClient`. A client could not
handle the responses with the timeout individually.

Modification:

- Add `responseTimeoutMillisForEachAttempt` when `RetryingClient` is made
- Remove `shouldRetry(request, exception)` in `RetryStrategy`

Result:

- A client can handle each response with the timeout