### PR TITLE
Do shaded tests on all Java modules

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -61,7 +61,7 @@ task trimShadedJar(type: ProGuardTask,
                    group: 'Build',
                    description: 'Shrinks the shaded JAR by removing unused classes.') {
 
-    publishedJavaProjects.each {
+    javaProjects.each {
         dependsOn it.tasks.shadedJar
         dependsOn it.tasks.shadedTestJar
     }
@@ -78,7 +78,7 @@ task trimShadedJar(type: ProGuardTask,
     // Include the shaded JARs from other modules as well
     // so that ProGuard does not trim the classes and methods that are used actually.
     injars tasks.shadedTestJar.archivePath
-    publishedJavaProjects.each {
+    javaProjects.each {
         if (it != project) {
             injars it.tasks.shadedJar.archivePath
             injars it.tasks.shadedTestJar.archivePath,
@@ -89,7 +89,7 @@ task trimShadedJar(type: ProGuardTask,
     }
 
     def dependencyJars = []
-    publishedJavaProjects.each {
+    javaProjects.each {
         // NB: ProGuardTask picks the dependencies added *after* evaluation correctly
         //     because libraryjar() intentionally keeps the specified dependencies as-is.
         //     See ProGuardTask.libraryjar() for more information.

--- a/shaded-test/build.gradle
+++ b/shaded-test/build.gradle
@@ -1,7 +1,7 @@
 import com.google.common.base.CaseFormat
 
 ext {
-    requiredProjects = rootProject.ext.publishedJavaProjects + project(':testing-internal')
+    requiredProjects = rootProject.ext.javaProjects - project
 }
 
 // Evaluate other projects first so that their dependencies are fully populated.
@@ -35,7 +35,7 @@ task shadedTest(group: 'Verification',
                 description: 'Runs the unit tests with the shaded JARs.')
 tasks.test.dependsOn tasks.shadedTest
 
-rootProject.ext.publishedJavaProjects.each { testProject ->
+requiredProjects.each { testProject ->
     def shadedTestJarExtractTask = tasks.create(shadedName(testProject, 'TestJarExtract'), Copy) {
         def shadedTestJarTask = testProject.tasks.shadedTestJar
         dependsOn shadedTestJarTask


### PR DESCRIPTION
We did not include non-published Java projects from shaded tests, but
there's no reason that keeps us from doing so. With this change, ':it'
is also shade-tested.