### PR TITLE
Use NoopMeterRegistry by default (again)

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
@@ -41,10 +41,10 @@ import com.linecorp.armeria.client.pool.PoolKey;
 import com.linecorp.armeria.common.CommonPools;
 import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.Request;
+import com.linecorp.armeria.common.metric.NoopMeterRegistry;
 import com.linecorp.armeria.internal.TransportType;
 
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Metrics;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.epoll.EpollChannelOption;
@@ -106,7 +106,7 @@ public final class ClientFactoryBuilder {
     private boolean useHttp2Preface = Flags.defaultUseHttp2Preface();
     private boolean useHttp1Pipelining = Flags.defaultUseHttp1Pipelining();
     private KeyedChannelPoolHandler<? super PoolKey> connectionPoolListener = DEFAULT_CONNECTION_POOL_LISTENER;
-    private MeterRegistry meterRegistry = Metrics.globalRegistry;
+    private MeterRegistry meterRegistry = NoopMeterRegistry.get();
 
     /**
      * Creates a new instance.

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -42,10 +42,10 @@ import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.metric.NoopMeterRegistry;
 import com.linecorp.armeria.server.annotation.ResponseConverter;
 
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Metrics;
 import io.netty.channel.EventLoopGroup;
 import io.netty.handler.ssl.SslContext;
 
@@ -107,7 +107,7 @@ public final class ServerBuilder {
     private Duration gracefulShutdownQuietPeriod = DEFAULT_GRACEFUL_SHUTDOWN_QUIET_PERIOD;
     private Duration gracefulShutdownTimeout = DEFAULT_GRACEFUL_SHUTDOWN_TIMEOUT;
     private Executor blockingTaskExecutor = CommonPools.blockingTaskExecutor();
-    private MeterRegistry meterRegistry = Metrics.globalRegistry;
+    private MeterRegistry meterRegistry = NoopMeterRegistry.get();
     private String serviceLoggerPrefix = DEFAULT_SERVICE_LOGGER_PREFIX;
 
     private Function<Service<HttpRequest, HttpResponse>, Service<HttpRequest, HttpResponse>> decorator;


### PR DESCRIPTION
Motivation:

Using Metrics.globalRegistry can make Server or ClientFactory attempt to
register meters with duplicate IDs.

Modifications:

- Use NoopMeterRegistry.get() instead of Metrics.globalRegistry

Result:

Server or Client does not fail due to duplicate meter IDs.