### PR TITLE
Enhance Annotated http service exception handling

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -21,11 +21,12 @@ import static java.util.Objects.requireNonNull;
 import java.util.Formatter;
 import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
 
 import org.reactivestreams.Publisher;
+
+import com.google.common.base.Throwables;
 
 import com.linecorp.armeria.common.stream.StreamMessage;
 
@@ -172,11 +173,7 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
         final DeferredHttpResponse res = new DeferredHttpResponse();
         stage.whenComplete((delegate, thrown) -> {
             if (thrown != null) {
-                if (thrown instanceof CompletionException && thrown.getCause() != null) {
-                    res.close(thrown.getCause());
-                } else {
-                    res.close(thrown);
-                }
+                res.close(Throwables.getRootCause(thrown));
             } else if (delegate == null) {
                 res.close(new NullPointerException("delegate stage produced a null response: " + stage));
             } else {

--- a/core/src/main/java/com/linecorp/armeria/server/AnnotatedHttpService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AnnotatedHttpService.java
@@ -18,11 +18,11 @@ package com.linecorp.armeria.server;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.function.BiFunction;
 
 import com.google.common.base.MoreObjects;
+import com.google.common.base.Throwables;
 
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
@@ -89,11 +89,7 @@ final class AnnotatedHttpService implements HttpService {
         CompletionStage<HttpResponse> castStage = (CompletionStage<HttpResponse>) ret;
         return HttpResponse.from(castStage.handle((httpResponse, throwable) -> {
             if (throwable != null) {
-                if (throwable instanceof CompletionException &&
-                    throwable.getCause() instanceof IllegalArgumentException) {
-                    return HttpResponse.of(HttpStatus.BAD_REQUEST);
-                }
-                if (throwable instanceof IllegalArgumentException) {
+                if (Throwables.getRootCause(throwable) instanceof IllegalArgumentException) {
                     return HttpResponse.of(HttpStatus.BAD_REQUEST);
                 }
                 return Exceptions.throwUnsafely(throwable);

--- a/core/src/main/java/com/linecorp/armeria/server/AnnotatedHttpService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AnnotatedHttpService.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.server;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.function.BiFunction;
 
@@ -25,6 +26,8 @@ import com.google.common.base.MoreObjects;
 
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.util.Exceptions;
 
 /**
  * {@link PathMapping} and their corresponding {@link BiFunction}.
@@ -69,7 +72,14 @@ final class AnnotatedHttpService implements HttpService {
 
     @Override
     public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
-        final Object ret = function.apply(ctx, req);
+
+        final Object ret;
+        try {
+            ret = function.apply(ctx, req);
+        } catch (IllegalArgumentException ignore) {
+            throw new HttpResponseException(HttpStatus.BAD_REQUEST);
+        }
+
         if (!(ret instanceof CompletionStage)) {
             return HttpResponse.ofFailure(new IllegalStateException(
                     "illegal return type: " + ret.getClass().getSimpleName()));
@@ -77,7 +87,19 @@ final class AnnotatedHttpService implements HttpService {
 
         @SuppressWarnings("unchecked")
         CompletionStage<HttpResponse> castStage = (CompletionStage<HttpResponse>) ret;
-        return HttpResponse.from(castStage);
+        return HttpResponse.from(castStage.handle((httpResponse, throwable) -> {
+            if (throwable != null) {
+                if (throwable instanceof CompletionException &&
+                    throwable.getCause() instanceof IllegalArgumentException) {
+                    return HttpResponse.of(HttpStatus.BAD_REQUEST);
+                }
+                if (throwable instanceof IllegalArgumentException) {
+                    return HttpResponse.of(HttpStatus.BAD_REQUEST);
+                }
+                return Exceptions.throwUnsafely(throwable);
+            }
+            return httpResponse;
+        }));
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/AnnotatedHttpServiceMethod.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AnnotatedHttpServiceMethod.java
@@ -41,7 +41,6 @@ import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpParameters;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.util.Exceptions;
@@ -142,9 +141,6 @@ final class AnnotatedHttpServiceMethod implements BiFunction<ServiceRequestConte
     private Object invoke(ServiceRequestContext ctx, HttpRequest req, @Nullable AggregatedHttpMessage message) {
         try (SafeCloseable ignored = RequestContext.push(ctx, false)) {
             return method.invoke(object, parameterValues(ctx, req, parameters, message));
-        } catch (IllegalArgumentException e) {
-            // Return "400 Bad Request" if the request has not sufficient arguments or has an invalid argument.
-            return HttpResponse.of(HttpStatus.BAD_REQUEST);
         } catch (Exception e) {
             if (e instanceof InvocationTargetException) {
                 final Throwable cause = e.getCause();

--- a/core/src/test/java/com/linecorp/armeria/server/AnnotatedHttpServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/AnnotatedHttpServiceTest.java
@@ -115,6 +115,9 @@ public class AnnotatedHttpServiceTest {
 
             sb.annotatedService("/9", new MyAnnotatedService9(),
                                 LoggingService.newDecorator());
+
+            sb.annotatedService("/10", new MyAnnotatedService10(),
+                                LoggingService.newDecorator());
         }
     };
 
@@ -482,6 +485,44 @@ public class AnnotatedHttpServiceTest {
         }
     }
 
+    @Converter(target = String.class, value = UnformattedStringConverter.class)
+    public static class MyAnnotatedService10 {
+
+        @Get("/syncThrow")
+        public String sync() {
+            throw new IllegalArgumentException("foo");
+        }
+
+        @Get("/asyncThrow")
+        public CompletableFuture<String> async() {
+            throw new IllegalArgumentException("bar");
+        }
+
+        @Get("/asyncThrowWrapped")
+        public CompletableFuture<String> asyncThrowWrapped() {
+            return CompletableFuture.supplyAsync(() -> {
+                throw new IllegalArgumentException("hoge");
+            });
+        }
+
+        @Get("/syncThrow401")
+        public String sync401() {
+            throw new HttpResponseException(HttpStatus.UNAUTHORIZED);
+        }
+
+        @Get("/asyncThrow401")
+        public CompletableFuture<String> async401() {
+            throw new HttpResponseException(HttpStatus.UNAUTHORIZED);
+        }
+
+        @Get("/asyncThrowWrapped401")
+        public CompletableFuture<String> asyncThrowWrapped401() {
+            return CompletableFuture.supplyAsync(() -> {
+                throw new HttpResponseException(HttpStatus.UNAUTHORIZED);
+            });
+        }
+    }
+
     @Test
     public void testAnnotatedHttpService() throws Exception {
         try (CloseableHttpClient hc = HttpClients.createMinimal()) {
@@ -608,6 +649,24 @@ public class AnnotatedHttpServiceTest {
             // No match on 'Accept' header list.
             testStatusCode(hc, post(uri, null, "application/json"), 406);
             testStatusCode(hc, get(uri, "application/json;charset=UTF-8;q=0.9, text/html;q=0.7"), 406);
+        }
+    }
+
+    @Test
+    public void testServiceThrowIllegalArgumentException() throws Exception {
+        try (CloseableHttpClient hc = HttpClients.createMinimal()) {
+            testStatusCode(hc, get("/10/syncThrow"), 400);
+            testStatusCode(hc, get("/10/asyncThrow"), 400);
+            testStatusCode(hc, get("/10/asyncThrowWrapped"), 400);
+        }
+    }
+
+    @Test
+    public void testServiceThrowHttpResponseException() throws Exception {
+        try (CloseableHttpClient hc = HttpClients.createMinimal()) {
+            testStatusCode(hc, get("/10/syncThrow401"), 401);
+            testStatusCode(hc, get("/10/asyncThrow401"), 401);
+            testStatusCode(hc, get("/10/asyncThrowWrapped401"), 401);
         }
     }
 


### PR DESCRIPTION
* Return status code 400 when annotated http service throwing IllegalArgumentException.
Currently only param check by armeria will be treat as 400 error. But user may want to do some param check with throwing IllegalArgumentException.

* Return correct status code when user code throws HttpResponseException.