### PR TITLE
Make CaffineMetricSupport more tolerant to double registration

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/metric/CaffeineMetricSupport.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/metric/CaffeineMetricSupport.java
@@ -16,12 +16,24 @@
 
 package com.linecorp.armeria.internal.metric;
 
-import static com.google.common.base.Preconditions.checkState;
+import static com.linecorp.armeria.internal.metric.CaffeineMetricSupport.Type.EVICTION_COUNT;
+import static com.linecorp.armeria.internal.metric.CaffeineMetricSupport.Type.EVICTION_WEIGHT;
+import static com.linecorp.armeria.internal.metric.CaffeineMetricSupport.Type.HIT_COUNT;
+import static com.linecorp.armeria.internal.metric.CaffeineMetricSupport.Type.LOAD_FAILURE_COUNT;
+import static com.linecorp.armeria.internal.metric.CaffeineMetricSupport.Type.LOAD_SUCCESS_COUNT;
+import static com.linecorp.armeria.internal.metric.CaffeineMetricSupport.Type.MISS_COUNT;
+import static com.linecorp.armeria.internal.metric.CaffeineMetricSupport.Type.TOTAL_LOAD_TIME;
 import static java.util.Objects.requireNonNull;
 
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
-import java.util.function.DoubleSupplier;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.ToDoubleFunction;
+
+import javax.annotation.Nullable;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.LoadingCache;
@@ -47,63 +59,145 @@ public final class CaffeineMetricSupport {
 
     public static void setup(MeterRegistry registry, MeterId id, Cache<?, ?> cache, Ticker ticker) {
         final CaffeineMetrics metrics = MicrometerUtil.register(
-                registry, id, CaffeineMetrics.class, (r, i) -> new CaffeineMetrics(r, i, cache, ticker));
-        checkState(metrics.cache == cache, "Meters for a different Cache have been registered for id: %s", id);
+                registry, id, CaffeineMetrics.class, CaffeineMetrics::new);
+        metrics.add(cache, ticker);
     }
 
     private CaffeineMetricSupport() {}
 
+    enum Type {
+        HIT_COUNT,
+        MISS_COUNT,
+        EVICTION_COUNT,
+        EVICTION_WEIGHT,
+        LOAD_SUCCESS_COUNT,
+        LOAD_FAILURE_COUNT,
+        TOTAL_LOAD_TIME;
+
+        static final int count = Type.values().length;
+    }
+
     private static final class CaffeineMetrics {
-        private final Cache<?, ?> cache;
-        private final Ticker ticker;
 
-        private volatile long lastStatsUpdateTime;
-        private CacheStats cacheStats;
-        private long estimatedSize;
+        private final MeterRegistry parent;
+        private final MeterId id;
+        private final List<CacheReference> cacheRefs = new ArrayList<>(2);
+        private final AtomicBoolean hasLoadingCache = new AtomicBoolean();
 
-        CaffeineMetrics(MeterRegistry parent, MeterId id, Cache<?, ?> cache, Ticker ticker) {
-            requireNonNull(parent, "parent");
-            this.cache = requireNonNull(cache, "cache");
-            this.ticker = requireNonNull(ticker, "ticker");
+        /**
+         * An array whose each element is the sum of the garbage-collected {@link Cache} stats.
+         * {@link Type#ordinal()} signifies the index of this array.
+         */
+        private final double[] statsForGarbageCollected = new double[Type.count];
 
-            updateCacheStats(true);
+        CaffeineMetrics(MeterRegistry parent, MeterId id) {
+            this.parent = requireNonNull(parent, "parent");
+            this.id = requireNonNull(id, "id");
 
             final String requests = id.name("requests");
             parent.more().counter(requests, id.tags("result", "hit"), this,
-                                  new CacheStatFunction(() -> cacheStats.hitCount()));
+                                  func(HIT_COUNT, ref -> ref.cacheStats.hitCount()));
             parent.more().counter(requests, id.tags("result", "miss"), this,
-                                  new CacheStatFunction(() -> cacheStats.missCount()));
+                                  func(MISS_COUNT, ref -> ref.cacheStats.missCount()));
+            parent.more().counter(id.name("evictions"), id.tags(), this,
+                                  func(EVICTION_COUNT, ref -> ref.cacheStats.evictionCount()));
+            parent.more().counter(id.name("evictionWeight"), id.tags(), this,
+                                  func(EVICTION_WEIGHT, ref -> ref.cacheStats.evictionWeight()));
+            parent.gauge(id.name("estimatedSize"), id.tags(), this,
+                         func(null, ref -> ref.estimatedSize));
+        }
 
-            if (cache instanceof LoadingCache) {
-                final String loads = id.name("loads");
-                parent.more().counter(loads, id.tags("result", "success"), this,
-                                      new CacheStatFunction(() -> cacheStats.loadSuccessCount()));
-                parent.more().counter(loads, id.tags("result", "failure"), this,
-                                      new CacheStatFunction(() -> cacheStats.loadFailureCount()));
+        void add(Cache<?, ?> cache, Ticker ticker) {
+            synchronized (cacheRefs) {
+                for (CacheReference ref : cacheRefs) {
+                    if (ref.get() == cache) {
+                        // Do not aggregate more than once for the same instance.
+                        return;
+                    }
+                }
 
-                final DoubleSupplier totalLoadTimeSupplier;
-                totalLoadTimeSupplier = () -> cacheStats.totalLoadTime();
-                parent.more().counter(id.name("loadDuration"), id.tags(), this,
-                                      new CacheStatFunction(totalLoadTimeSupplier));
+                cacheRefs.add(new CacheReference(cache, ticker));
             }
 
-            parent.more().counter(id.name("evictions"), id.tags(), this,
-                                  new CacheStatFunction(() -> cacheStats.evictionCount()));
-            parent.more().counter(id.name("evictionWeight"), id.tags(), this,
-                                  new CacheStatFunction(() -> cacheStats.evictionWeight()));
-            parent.gauge(id.name("estimatedSize"), id.tags(), this,
-                         new CacheStatFunction(() -> estimatedSize));
+            if (cache instanceof LoadingCache && hasLoadingCache.compareAndSet(false, true)) {
+                // Add the following meters only for LoadingCache and only once.
+                final String loads = id.name("loads");
+
+                parent.more().counter(loads, id.tags("result", "success"), this,
+                                      func(LOAD_SUCCESS_COUNT, ref -> ref.cacheStats.loadSuccessCount()));
+                parent.more().counter(loads, id.tags("result", "failure"), this,
+                                      func(LOAD_FAILURE_COUNT, ref -> ref.cacheStats.loadFailureCount()));
+                parent.more().counter(id.name("loadDuration"), id.tags(), this,
+                                      func(TOTAL_LOAD_TIME, ref -> ref.cacheStats.totalLoadTime()));
+            }
         }
 
-        private void updateCacheStats() {
-            updateCacheStats(false);
+        private ToDoubleFunction<CaffeineMetrics> func(@Nullable Type type,
+                                                       ToDoubleFunction<CacheReference> valueFunction) {
+            return value -> {
+                double sum = 0;
+                synchronized (cacheRefs) {
+                    for (Iterator<CacheReference> i = cacheRefs.iterator(); i.hasNext();) {
+                        final CacheReference ref = i.next();
+                        final boolean garbageCollected = ref.updateCacheStats();
+                        if (!garbageCollected) {
+                            sum += valueFunction.applyAsDouble(ref);
+                        } else {
+                            // Remove the garbage-collected reference from the list to prevent it from
+                            // growing infinitely.
+                            i.remove();
+
+                            // Accumulate the stats of the removed reference so the counters do not decrease.
+                            // NB: We do not accumulate 'estimatedSize' because it's not a counter but a gauge.
+                            final CacheStats stats = ref.cacheStats;
+                            statsForGarbageCollected[HIT_COUNT.ordinal()] += stats.hitCount();
+                            statsForGarbageCollected[MISS_COUNT.ordinal()] += stats.missCount();
+                            statsForGarbageCollected[EVICTION_COUNT.ordinal()] += stats.evictionCount();
+                            statsForGarbageCollected[EVICTION_WEIGHT.ordinal()] += stats.evictionWeight();
+                            statsForGarbageCollected[LOAD_SUCCESS_COUNT.ordinal()] += stats.loadSuccessCount();
+                            statsForGarbageCollected[LOAD_FAILURE_COUNT.ordinal()] += stats.loadFailureCount();
+                            statsForGarbageCollected[TOTAL_LOAD_TIME.ordinal()] += stats.totalLoadTime();
+                        }
+                    }
+
+                    if (type != null) {
+                        // Add the value of the garbage-collected caches.
+                        sum += statsForGarbageCollected[type.ordinal()];
+                    }
+                }
+
+                return sum;
+            };
+        }
+    }
+
+    private static final class CacheReference extends WeakReference<Cache<?, ?>> {
+
+        private final Ticker ticker;
+        private volatile long lastStatsUpdateTime;
+        private CacheStats cacheStats = CacheStats.empty();
+        private long estimatedSize;
+
+        CacheReference(Cache<?, ?> cache, Ticker ticker) {
+            super(requireNonNull(cache, "cache"));
+            this.ticker = requireNonNull(ticker, "ticker");
+            updateCacheStats(true);
         }
 
-        private void updateCacheStats(boolean force) {
+        boolean updateCacheStats() {
+            return updateCacheStats(false);
+        }
+
+        private boolean updateCacheStats(boolean force) {
+            final Cache<?, ?> cache = get();
+            if (cache == null) {
+                return true; // GC'd
+            }
+
             final long currentTimeNanos = ticker.read();
             if (!force) {
                 if (currentTimeNanos - lastStatsUpdateTime < UPDATE_INTERVAL_NANOS) {
-                    return;
+                    return false; // Not GC'd
                 }
             }
 
@@ -113,21 +207,7 @@ public final class CaffeineMetricSupport {
             // Write the volatile field last so that cacheStats and estimatedSize are visible
             // after reading the volatile field.
             lastStatsUpdateTime = currentTimeNanos;
-        }
-    }
-
-    private static final class CacheStatFunction implements ToDoubleFunction<CaffeineMetrics> {
-
-        private final DoubleSupplier valueSupplier;
-
-        CacheStatFunction(DoubleSupplier valueSupplier) {
-            this.valueSupplier = valueSupplier;
-        }
-
-        @Override
-        public double applyAsDouble(CaffeineMetrics value) {
-            value.updateCacheStats();
-            return valueSupplier.getAsDouble();
+            return false; // Not GC'd
         }
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/internal/metric/CaffeineMetricSupportTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/metric/CaffeineMetricSupportTest.java
@@ -18,19 +18,22 @@ package com.linecorp.armeria.internal.metric;
 
 import static com.linecorp.armeria.internal.metric.CaffeineMetricSupport.UPDATE_INTERVAL_NANOS;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
+import java.lang.ref.WeakReference;
+import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 
 import org.junit.Test;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.Policy;
 import com.github.benmanes.caffeine.cache.stats.CacheStats;
-import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.common.metric.MeterId;
 import com.linecorp.armeria.common.metric.MoreMeters;
@@ -42,16 +45,13 @@ public class CaffeineMetricSupportTest {
 
     @Test
     public void test() {
-        final LoadingCache<?, ?> cache = mock(LoadingCache.class);
-        when(cache.stats()).thenReturn(new CacheStats(1, 2, 3, 4, 5, 6, 7));
-        when(cache.estimatedSize()).thenReturn(8L);
-
+        final MockLoadingCache cache = new MockLoadingCache(1, 2, 3, 4, 5, 6, 7, 8);
         final AtomicLong ticker = new AtomicLong();
         final MeterRegistry registry = PrometheusMeterRegistries.newRegistry();
         CaffeineMetricSupport.setup(registry, new MeterId("foo"), cache, ticker::get);
 
-        verify(cache, times(1)).stats();
-        verify(cache, times(1)).estimatedSize();
+        assertThat(cache.statsCalls()).isOne();
+        assertThat(cache.estimatedSizeCalls()).isOne();
 
         assertThat(MoreMeters.measureAll(registry))
                 .containsEntry("foo.requests#count{result=hit}", 1.0)
@@ -64,13 +64,12 @@ public class CaffeineMetricSupportTest {
                 .containsEntry("foo.estimatedSize#value", 8.0);
 
         // Make sure Cache.stats() and estimatedSize() are not called since the initial update.
-        verify(cache, times(1)).stats();
-        verify(cache, times(1)).estimatedSize();
+        assertThat(cache.statsCalls()).isOne();
+        assertThat(cache.estimatedSizeCalls()).isOne();
 
         // Advance the ticker so that the next collection triggers stats() and estimatedSize().
         ticker.addAndGet(UPDATE_INTERVAL_NANOS);
-        when(cache.stats()).thenReturn(new CacheStats(9, 10, 11, 12, 13, 14, 15));
-        when(cache.estimatedSize()).thenReturn(16L);
+        cache.update(9, 10, 11, 12, 13, 14, 15, 16);
 
         assertThat(MoreMeters.measureAll(registry))
                 .containsEntry("foo.requests#count{result=hit}", 9.0)
@@ -83,22 +82,19 @@ public class CaffeineMetricSupportTest {
                 .containsEntry("foo.estimatedSize#value", 16.0);
 
         // Make sure Cache.stats() and estimatedSize() were called once more since the initial update.
-        verify(cache, times(2)).stats();
-        verify(cache, times(2)).estimatedSize();
+        assertThat(cache.statsCalls()).isEqualTo(2);
+        assertThat(cache.estimatedSizeCalls()).isEqualTo(2);
     }
 
     @Test
     public void testNonLoadingCache() {
-        final Cache<?, ?> cache = mock(Cache.class);
-        when(cache.stats()).thenReturn(new CacheStats(1, 2, 0, 0, 0, 3, 4));
-        when(cache.estimatedSize()).thenReturn(5L);
-
+        final MockCache cache = new MockCache(1, 2, 3, 4, 5);
         final AtomicLong ticker = new AtomicLong();
         final MeterRegistry registry = PrometheusMeterRegistries.newRegistry();
-        CaffeineMetricSupport.setup(registry, new MeterId("bar", ImmutableList.of()), cache, ticker::get);
+        CaffeineMetricSupport.setup(registry, new MeterId("bar"), cache, ticker::get);
 
-        verify(cache, times(1)).stats();
-        verify(cache, times(1)).estimatedSize();
+        assertThat(cache.statsCalls()).isOne();
+        assertThat(cache.estimatedSizeCalls()).isOne();
 
         assertThat(MoreMeters.measureAll(registry))
                 .containsEntry("bar.requests#count{result=hit}", 1.0)
@@ -112,5 +108,231 @@ public class CaffeineMetricSupportTest {
                 "bar.loads#count{result=success}",
                 "bar.loads#count{result=failure}",
                 "bar.loadDuration#count");
+    }
+
+    @Test
+    public void aggregation() {
+        final MockLoadingCache cache1 = new MockLoadingCache(1, 2, 3, 4, 5, 6, 7, 8);
+        final MockLoadingCache cache2 = new MockLoadingCache(9, 10, 11, 12, 13, 14, 15, 16);
+        final MeterRegistry registry = PrometheusMeterRegistries.newRegistry();
+        final MeterId id = new MeterId("baz");
+
+        // Register two caches at the same meter ID.
+        CaffeineMetricSupport.setup(registry, id, cache1);
+        CaffeineMetricSupport.setup(registry, id, cache2);
+
+        // .. and their stats are aggregated.
+        assertThat(MoreMeters.measureAll(registry))
+                .containsEntry("baz.requests#count{result=hit}", 10.0)
+                .containsEntry("baz.requests#count{result=miss}", 12.0)
+                .containsEntry("baz.loads#count{result=success}", 14.0)
+                .containsEntry("baz.loads#count{result=failure}", 16.0)
+                .containsEntry("baz.loadDuration#count", 18.0)
+                .containsEntry("baz.evictions#count", 20.0)
+                .containsEntry("baz.evictionWeight#count", 22.0)
+                .containsEntry("baz.estimatedSize#value", 24.0);
+    }
+
+    @Test
+    public void aggregationAfterGC() throws Exception {
+        final MockCache cache1 = new MockCache(1, 2, 3, 4, 5);
+        final WeakReference<MockLoadingCache> cache2 =
+                new WeakReference<>(new MockLoadingCache(6, 7, 8, 9, 10, 11, 12, 13));
+        final MeterRegistry registry = PrometheusMeterRegistries.newRegistry();
+        final AtomicLong ticker = new AtomicLong();
+        final MeterId id = new MeterId("baz");
+
+        // Register two caches at the same meter ID.
+        CaffeineMetricSupport.setup(registry, id, cache1, ticker::get);
+        CaffeineMetricSupport.setup(registry, id, cache2.get(), ticker::get);
+
+        assertThat(MoreMeters.measureAll(registry))
+                .containsEntry("baz.requests#count{result=hit}", 7.0)
+                .containsEntry("baz.requests#count{result=miss}", 9.0)
+                .containsEntry("baz.loads#count{result=success}", 8.0)
+                .containsEntry("baz.loads#count{result=failure}", 9.0)
+                .containsEntry("baz.loadDuration#count", 10.0)
+                .containsEntry("baz.evictions#count", 14.0)
+                .containsEntry("baz.evictionWeight#count", 16.0)
+                .containsEntry("baz.estimatedSize#value", 18.0);
+
+        ticker.addAndGet(UPDATE_INTERVAL_NANOS);
+
+        // Ensure the weak reference which held the cache is cleaned up.
+        System.gc();
+        Thread.sleep(1000);
+        assertThat(cache2.get()).isNull();
+
+        // Check if the counters are not decreased after the second cache is GC'd.
+        assertThat(MoreMeters.measureAll(registry))
+                .containsEntry("baz.requests#count{result=hit}", 7.0)
+                .containsEntry("baz.requests#count{result=miss}", 9.0)
+                .containsEntry("baz.loads#count{result=success}", 8.0)
+                .containsEntry("baz.loads#count{result=failure}", 9.0)
+                .containsEntry("baz.loadDuration#count", 10.0)
+                .containsEntry("baz.evictions#count", 14.0)
+                .containsEntry("baz.evictionWeight#count", 16.0)
+                .containsEntry("baz.estimatedSize#value", 5.0); // .. except 'estimatedSize' which is a gauge
+    }
+
+    @Test
+    public void sameCacheTwice() {
+        final MockCache cache = new MockCache(1, 2, 3, 4, 5);
+        final MeterRegistry registry = PrometheusMeterRegistries.newRegistry();
+        final MeterId id = new MeterId("baz");
+
+        // Register the same cache twice at the same meter ID.
+        CaffeineMetricSupport.setup(registry, id, cache);
+        CaffeineMetricSupport.setup(registry, id, cache);
+
+        // .. and check if the stats are *not* doubled.
+        assertThat(MoreMeters.measureAll(registry))
+                .containsEntry("baz.requests#count{result=hit}", 1.0)
+                .containsEntry("baz.requests#count{result=miss}", 2.0)
+                .containsEntry("baz.evictions#count", 3.0)
+                .containsEntry("baz.evictionWeight#count", 4.0)
+                .containsEntry("baz.estimatedSize#value", 5.0);
+    }
+
+    // Not using mocking framework because we need tight control over the life cycle of the mock object.
+    private static class MockCache implements Cache<Object, Object> {
+
+        private CacheStats stats;
+        private long estimatedSize;
+        private int statsCalls;
+        private int estimatedSizeCalls;
+
+        MockCache(long hitCount, long missCount, long evictionCount, long evictionWeight, long estimatedSize) {
+            update(hitCount, missCount, evictionCount, evictionWeight, estimatedSize);
+        }
+
+        MockCache(long hitCount, long missCount, long loadSuccessCount, long loadFailureCount,
+                  long totalLoadTime, long evictionCount, long evictionWeight, long estimatedSize) {
+
+            update(hitCount, missCount, loadSuccessCount, loadFailureCount,
+                   totalLoadTime, evictionCount, evictionWeight, estimatedSize);
+        }
+
+        void update(long hitCount, long missCount,
+                    long evictionCount, long evictionWeight, long estimatedSize) {
+
+            update(hitCount, missCount, 0, 0, 0, evictionCount, evictionWeight, estimatedSize);
+        }
+
+        void update(long hitCount, long missCount, long loadSuccessCount, long loadFailureCount,
+                    long totalLoadTime, long evictionCount, long evictionWeight, long estimatedSize) {
+            stats = new CacheStats(hitCount, missCount, loadSuccessCount, loadFailureCount,
+                                   totalLoadTime, evictionCount, evictionWeight);
+            this.estimatedSize = estimatedSize;
+        }
+
+        int statsCalls() {
+            return statsCalls;
+        }
+
+        int estimatedSizeCalls() {
+            return estimatedSizeCalls;
+        }
+
+        @Nonnull
+        @Override
+        public CacheStats stats() {
+            statsCalls++;
+            return stats;
+        }
+
+        @Override
+        public long estimatedSize() {
+            estimatedSizeCalls++;
+            return estimatedSize;
+        }
+
+        @Override
+        public Object getIfPresent(@Nonnull Object key) {
+            return reject();
+        }
+
+        @Override
+        public Object get(@Nonnull Object key, @Nonnull Function<? super Object, ?> mappingFunction) {
+            return reject();
+        }
+
+        @Nonnull
+        @Override
+        public Map<Object, Object> getAllPresent(@Nonnull Iterable<?> keys) {
+            return reject();
+        }
+
+        @Override
+        public void put(@Nonnull Object key, @Nonnull Object value) {
+            reject();
+        }
+
+        @Override
+        public void putAll(@Nonnull Map<?, ?> map) {
+            reject();
+        }
+
+        @Override
+        public void invalidate(@Nonnull Object key) {
+            reject();
+        }
+
+        @Override
+        public void invalidateAll(@Nonnull Iterable<?> keys) {
+            reject();
+        }
+
+        @Override
+        public void invalidateAll() {
+            reject();
+        }
+
+        @Nonnull
+        @Override
+        public ConcurrentMap<Object, Object> asMap() {
+            return reject();
+        }
+
+        @Override
+        public void cleanUp() {
+            reject();
+        }
+
+        @Nonnull
+        @Override
+        public Policy<Object, Object> policy() {
+            return reject();
+        }
+
+        protected static <T> T reject() {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private static final class MockLoadingCache extends MockCache implements LoadingCache<Object, Object> {
+
+        MockLoadingCache(long hitCount, long missCount, long loadSuccessCount, long loadFailureCount,
+                         long totalLoadTime, long evictionCount, long evictionWeight, long estimatedSize) {
+            super(hitCount, missCount, loadSuccessCount, loadFailureCount,
+                  totalLoadTime, evictionCount, evictionWeight, estimatedSize);
+        }
+
+        @CheckForNull
+        @Override
+        public Object get(@Nonnull Object key) {
+            return reject();
+        }
+
+        @Nonnull
+        @Override
+        public Map<Object, Object> getAll(@Nonnull Iterable<?> keys) {
+            return reject();
+        }
+
+        @Override
+        public void refresh(@Nonnull Object key) {
+            reject();
+        }
     }
 }


### PR DESCRIPTION
Motivation:

Currently, CaffeineMetricsSupport raises an IllegalStateException when a
user tries to call setup() with different Cache instances at the same
metric ID. This can result in the failure of Server startup when a user
reuses a registry or uses a Metrics.globalRegistry.

Modifications:

- Improve CaffeineMetricsSupport so that it aggregates the stats of all
  Cache instances instead of rejection

Result:

Less surprise to users