### PR TITLE
Rename PrometheusExporterHttpService to PrometheusExpositionService

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/metric/PrometheusExpositionService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/metric/PrometheusExpositionService.java
@@ -32,18 +32,21 @@ import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.exporter.common.TextFormat;
 
 /**
- * Exports Prometheus metrics.
+ * Exposes Prometheus metrics in <a href="https://prometheus.io/docs/instrumenting/exposition_formats/">text
+ * format 0.0.4</a>.
  */
-public class PrometheusExporterHttpService extends AbstractHttpService {
+public class PrometheusExpositionService extends AbstractHttpService {
+
     private static final MediaType CONTENT_TYPE_004 = MediaType.parse(TextFormat.CONTENT_TYPE_004);
 
     private final CollectorRegistry collectorRegistry;
 
     /**
-     * Create a {@link PrometheusExporterHttpService} instance.
+     * Creates a new instance.
+     *
      * @param collectorRegistry Prometheus registry
      */
-    public PrometheusExporterHttpService(CollectorRegistry collectorRegistry) {
+    public PrometheusExpositionService(CollectorRegistry collectorRegistry) {
         requireNonNull(collectorRegistry, "collectorRegistry");
         this.collectorRegistry = collectorRegistry;
     }

--- a/spring-boot/autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaAutoConfiguration.java
+++ b/spring-boot/autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaAutoConfiguration.java
@@ -63,7 +63,7 @@ import com.linecorp.armeria.server.docs.DocServiceBuilder;
 import com.linecorp.armeria.server.healthcheck.HealthChecker;
 import com.linecorp.armeria.server.healthcheck.HttpHealthCheckService;
 import com.linecorp.armeria.server.metric.MetricCollectingService;
-import com.linecorp.armeria.server.metric.PrometheusExporterHttpService;
+import com.linecorp.armeria.server.metric.PrometheusExpositionService;
 import com.linecorp.armeria.server.thrift.THttpService;
 import com.linecorp.armeria.spring.ArmeriaSettings.Port;
 
@@ -186,7 +186,7 @@ public class ArmeriaAutoConfiguration {
                 final CollectorRegistry prometheusRegistry =
                         ((PrometheusMeterRegistry) registry).getPrometheusRegistry();
                 server.service(armeriaSettings.getMetricsPath(),
-                               new PrometheusExporterHttpService(prometheusRegistry));
+                               new PrometheusExpositionService(prometheusRegistry));
             } else if (registry instanceof DropwizardMeterRegistry) {
                 final MetricRegistry dropwizardRegistry =
                         ((DropwizardMeterRegistry) registry).getDropwizardRegistry();

--- a/thrift/src/test/java/com/linecorp/armeria/it/metric/PrometheusMetricsIntegrationTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/metric/PrometheusMetricsIntegrationTest.java
@@ -48,7 +48,7 @@ import com.linecorp.armeria.common.metric.MeterIdFunction;
 import com.linecorp.armeria.common.metric.PrometheusMeterRegistries;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.metric.MetricCollectingService;
-import com.linecorp.armeria.server.metric.PrometheusExporterHttpService;
+import com.linecorp.armeria.server.metric.PrometheusExpositionService;
 import com.linecorp.armeria.server.thrift.THttpService;
 import com.linecorp.armeria.service.test.thrift.main.HelloService.Iface;
 import com.linecorp.armeria.testing.server.ServerRule;
@@ -84,7 +84,7 @@ public class PrometheusMetricsIntegrationTest {
                             (registry, log) -> meterId(registry, log, "server", "Bar"))));
 
             sb.service("/internal/prometheus/metrics",
-                       new PrometheusExporterHttpService(prometheusRegistry));
+                       new PrometheusExpositionService(prometheusRegistry));
         }
     };
 


### PR DESCRIPTION
.. because exporter and exposition are different things, as documented
in:

- https://prometheus.io/docs/instrumenting/writing_exporters/
- https://prometheus.io/docs/instrumenting/exposition_formats/