### PR TITLE
Log stacktrace for error responses in LoggingService.

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/logging/LoggingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/LoggingService.java
@@ -165,8 +165,14 @@ public final class LoggingService<I extends Request, O extends Response> extends
         final LogLevel level =
                 log.responseCause() == null ? successfulResponseLogLevel : failedResponseLogLevel;
         if (level.isEnabled(logger)) {
-            level.log(logger, RESPONSE_FORMAT,
-                      log.toStringResponseOnly(responseHeadersSanitizer, responseContentSanitizer));
+            if (log.responseCause() == null) {
+                level.log(logger, RESPONSE_FORMAT,
+                          log.toStringResponseOnly(responseHeadersSanitizer, responseContentSanitizer));
+            } else {
+                level.log(logger, RESPONSE_FORMAT,
+                          log.toStringResponseOnly(responseHeadersSanitizer, responseContentSanitizer),
+                          log.responseCause());
+            }
         }
     }
 }


### PR DESCRIPTION
Currently, error responses have the exception's toString included but not the stacktrace, which makes it harder to pinpoint errors. This allows the stacktrace to be dumped together with the response log for easier debugging.