### PR TITLE
Use explicit last-modified set instead of Thread.sleep to make less f…

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/server/file/HttpFileServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/file/HttpFileServiceTest.java
@@ -31,6 +31,7 @@ import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Date;
+import java.util.concurrent.TimeUnit;
 import java.util.zip.GZIPInputStream;
 
 import org.apache.http.HttpHeaders;
@@ -263,17 +264,18 @@ public class HttpFileServiceTest {
 
             // Test if the 'If-Modified-Since' header works as expected after the file is modified.
             req = new HttpGet(newUri("/fs/bar.html"));
-            req.setHeader(HttpHeaders.IF_MODIFIED_SINCE, currentHttpDate());
+            Date now = new Date();
+            req.setHeader(HttpHeaders.IF_MODIFIED_SINCE, httpDate(now));
 
-            // HTTP-date has no sub-second precision; wait until the current second changes.
-            Thread.sleep(1000);
-
+            // HTTP-date has no sub-second precision; just add a few seconds to the time.
             Files.write(barFile.toPath(), expectedContentB.getBytes(StandardCharsets.UTF_8));
+            assertThat(barFile.setLastModified(now.getTime() + TimeUnit.SECONDS.toMillis(5)),
+                       is(true));
 
             try (CloseableHttpResponse res = hc.execute(req)) {
                 final String newLastModified = assert200Ok(res, "text/html", expectedContentB);
 
-                // Ensure that the 'Last-Modified' header did not change.
+                // Ensure that the 'Last-Modified' changed.
                 assertThat(newLastModified, is(not(lastModified)));
             }
 
@@ -339,6 +341,10 @@ public class HttpFileServiceTest {
     }
 
     private static String currentHttpDate() {
+        return httpDate(new Date());
+    }
+
+    private static String httpDate(Date date) {
         return DateFormatter.format(new Date());
     }
 

--- a/core/src/test/java/com/linecorp/armeria/server/file/HttpFileServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/file/HttpFileServiceTest.java
@@ -345,7 +345,7 @@ public class HttpFileServiceTest {
     }
 
     private static String httpDate(Date date) {
-        return DateFormatter.format(new Date());
+        return DateFormatter.format(date);
     }
 
     private static String newUri(String path) {


### PR DESCRIPTION
…laky.

I noticed this flaky test and think this should fix it

https://travis-ci.org/line/armeria/builds/272749216#L750
```
com.linecorp.armeria.server.file.HttpFileServiceTest > testFileSystemGet FAILED
    java.lang.AssertionError: 
    Expected: is "HTTP/1.1 200 OK"
         but: was "HTTP/1.1 304 Not Modified"
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
        at org.junit.Assert.assertThat(Assert.java:956)
        at org.junit.Assert.assertThat(Assert.java:923)
        at com.linecorp.armeria.server.file.HttpFileServiceTest.assertStatusLine(HttpFileServiceTest.java:338)
        at com.linecorp.armeria.server.file.HttpFileServiceTest.assert200Ok(HttpFileServiceTest.java:297)
        at com.linecorp.armeria.server.file.HttpFileServiceTest.testFileSystemGet(HttpFileServiceTest.java:274)
04:11:10.804 [Thread-5] DEBUG c.l.armeria.client.ClientFactory - Closing the default ClientFactory
```