### PR TITLE
Remove unnecessary dependencies from micrometer-spring-legacy

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -70,7 +70,12 @@ io.grpc:
 
 io.micrometer:
   micrometer-core: { version: &MICROMETER_VERSION '0.10.0.RELEASE' }
-  micrometer-spring-legacy: { version: *MICROMETER_VERSION }
+  micrometer-spring-legacy:
+    version: *MICROMETER_VERSION
+    exclusions:
+    - org.springframework.boot:spring-boot-actuator
+    - org.springframework:spring-web
+    - org.springframework:spring-webmvc
 
 io.netty:
   netty-codec-http2: { version: &NETTY_VERSION '4.1.15.Final' }

--- a/spring-boot/autoconfigure/build.gradle
+++ b/spring-boot/autoconfigure/build.gradle
@@ -12,7 +12,6 @@ managedDependencies {
     compile 'org.springframework.boot:spring-boot-autoconfigure'
     compile 'org.springframework.boot:spring-boot-starter-logging'
 
-    testCompile 'org.springframework.boot:spring-boot-starter-web'
     testCompile 'org.springframework.boot:spring-boot-starter-test'
     testCompile 'org.hibernate:hibernate-validator'
 }


### PR DESCRIPTION
Apply this change will remove spring-boot-actuator, spring-web and spring-webmvc.

e.g. Below code will be failed when we don't exclude dependencies.  
```
Caused by:

org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'mappingJackson2HttpMessageConverter' defined in class path resource [org/springframework/boot/autoconfigure/web/JacksonHttpMessageConvertersConfiguration$MappingJackson2HttpMessageConverterConfiguration.class]: Unsatisfied dependency expressed through method 'mappingJackson2HttpMessageConverter' parameter 0; nested exception is org.springframework.beans.factory.NoUniqueBeanDefinitionException: No qualifying bean of type 'com.fasterxml.jackson.databind.ObjectMapper' available: expected single matching bean but found 2: objectMapper1,objectMapper2
```

```
package com.linecorp.armeria.spring;

import static org.assertj.core.api.Assertions.assertThat;

import javax.inject.Inject;

import org.junit.Test;
import org.junit.runner.RunWith;
import org.springframework.boot.autoconfigure.SpringBootApplication;
import org.springframework.boot.test.context.SpringBootTest;
import org.springframework.context.annotation.Bean;
import org.springframework.test.annotation.DirtiesContext;
import org.springframework.test.context.ActiveProfiles;
import org.springframework.test.context.junit4.SpringRunner;

import com.fasterxml.jackson.databind.ObjectMapper;

import com.linecorp.armeria.common.HttpRequest;
import com.linecorp.armeria.common.HttpResponseWriter;
import com.linecorp.armeria.common.HttpStatus;
import com.linecorp.armeria.common.MediaType;
import com.linecorp.armeria.common.metric.MoreMeters;
import com.linecorp.armeria.server.AbstractHttpService;
import com.linecorp.armeria.server.PathMapping;
import com.linecorp.armeria.server.ServiceRequestContext;
import com.linecorp.armeria.server.logging.LoggingService;
import com.linecorp.armeria.spring.ArmeriaAutoConfigurationTest.TestConfiguration;

import io.micrometer.core.instrument.MeterRegistry;
import io.micrometer.spring.export.prometheus.EnablePrometheusMetrics;

@RunWith(SpringRunner.class)
@SpringBootTest(classes = TestConfiguration.class)
@ActiveProfiles({ "local", "autoConfTest" })
@DirtiesContext
@EnablePrometheusMetrics
public class ArmeriaMeterBindersTest {

    @SpringBootApplication
    public static class TestConfiguration {

        @Bean
        ObjectMapper objectMapper1() {
            return new ObjectMapper();
        }

        @Bean
        ObjectMapper objectMapper2() {
            return new ObjectMapper();
        }

        @Bean
        public HttpServiceRegistrationBean okService() {
            return new HttpServiceRegistrationBean()
                    .setServiceName("okService")
                    .setService(new AbstractHttpService() {
                        @Override
                        protected void doGet(ServiceRequestContext ctx, HttpRequest req,
                                             HttpResponseWriter res) throws Exception {
                            res.respond(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "ok");
                        }
                    })
                    .setPathMapping(PathMapping.ofExact("/ok"))
                    .setDecorator(LoggingService.newDecorator());
        }
    }

    @Inject
    private MeterRegistry registry;

    @Test
    public void testDefaultMetrics() throws Exception {
        assertThat(MoreMeters.measureAll(registry)).containsKeys(
                "classes.loaded#value",
                "cpu.total#value",
                "jvm.buffer.count#value{id=direct}",
                "jvm.memory.max#value{id=Code Cache}",
                "logback.events#count{level=debug}",
                "threads.daemon#value");
    }
}
```