### PR TITLE
Client side Thrift callback not notified correctly for a void method with RetryingRpcClient (#780)

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClient.java
@@ -114,9 +114,14 @@ public final class RetryingRpcClient extends RetryingClient<RpcRequest, RpcRespo
                 }
             } else {
                 response.handle(voidFunction((result, thrown) -> {
-                    if (result != null) {
+                    // !!! DO NOT use "result != null" as the success/fail check condition !!!
+                    // !!! because the return value of the RPC target method may be void !!!
+                    // See: https://github.com/line/armeria/issues/780
+                    if (thrown == null) {
+                        // normal response
                         responseFuture.complete(result);
                     } else {
+                        // failed
                         responseFuture.completeExceptionally(thrown);
                     }
                 }));

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClient.java
@@ -114,9 +114,6 @@ public final class RetryingRpcClient extends RetryingClient<RpcRequest, RpcRespo
                 }
             } else {
                 response.handle(voidFunction((result, thrown) -> {
-                    // !!! DO NOT use "result != null" as the success/fail check condition !!!
-                    // !!! because the return value of the RPC target method may be void !!!
-                    // See: https://github.com/line/armeria/issues/780
                     if (thrown == null) {
                         // normal response
                         responseFuture.complete(result);

--- a/thrift/src/test/java/com/linecorp/armeria/it/client/retry/RetryingRpcClientTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/client/retry/RetryingRpcClientTest.java
@@ -149,7 +149,7 @@ public class RetryingRpcClientTest {
 
         private int retriedCount;
 
-        public MaxTimeRetryStrategy(final int maxRetryTime) {
+        MaxTimeRetryStrategy(final int maxRetryTime) {
             this.maxRetryTime = maxRetryTime;
         }
 
@@ -158,14 +158,10 @@ public class RetryingRpcClientTest {
             if (retriedCount < maxRetryTime) {
                 retriedCount++;
 
-                System.out.println("retriedCount: " + retriedCount);
-
                 Backoff backoff = Backoff.exponential(100, 500, 2);
 
                 return CompletableFuture.completedFuture(Optional.of(backoff));
             } else {
-                System.out.println("No retry");
-
                 return CompletableFuture.completedFuture(Optional.empty());
             }
         }


### PR DESCRIPTION
See: https://github.com/line/armeria/issues/780