### PR TITLE
Handle as success even if one way thrift function throw exception

### DIFF
--- a/thrift/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
+++ b/thrift/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
@@ -591,13 +591,13 @@ public final class THttpService extends AbstractHttpService {
         }
 
         reply.handle(voidFunction((result, cause) -> {
-            if (cause != null) {
-                handleException(ctx, reply, res, serializationFormat, seqId, func, cause);
+            if (func.isOneWay()) {
+                handleOneWaySuccess(ctx, reply, res, serializationFormat);
                 return;
             }
 
-            if (func.isOneWay()) {
-                handleOneWaySuccess(ctx, reply, res, serializationFormat);
+            if (cause != null) {
+                handleException(ctx, reply, res, serializationFormat, seqId, func, cause);
                 return;
             }
 

--- a/thrift/src/test/java/com/linecorp/armeria/client/thrift/ThriftOverHttpClientTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/client/thrift/ThriftOverHttpClientTest.java
@@ -110,11 +110,16 @@ public class ThriftOverHttpClientTest {
     private static final HelloService.AsyncIface exceptionThrowingHandler = (name, resultHandler)
             -> resultHandler.onError(new Exception(name));
 
+    private static final OnewayHelloService.AsyncIface exceptionThrowingOnewayHandler =
+            (name, resultHandler) -> {
+                assertThat(serverReceivedNames.add(name)).isTrue();
+                resultHandler.onError(new Exception(name));
+            };
+
     private static final OnewayHelloService.AsyncIface onewayHelloHandler = (name, resultHandler) -> {
         resultHandler.onComplete(null);
         assertThat(serverReceivedNames.add(name)).isTrue();
     };
-
     private static final DevNullService.AsyncIface devNullHandler = (value, resultHandler) -> {
         resultHandler.onComplete(null);
         assertThat(serverReceivedNames.add(value)).isTrue();
@@ -144,6 +149,8 @@ public class ThriftOverHttpClientTest {
         HELLO(helloHandler, HelloService.Iface.class, HelloService.AsyncIface.class),
         EXCEPTION(exceptionThrowingHandler, HelloService.Iface.class, HelloService.AsyncIface.class),
         ONEWAYHELLO(onewayHelloHandler, OnewayHelloService.Iface.class, OnewayHelloService.AsyncIface.class),
+        EXCEPTION_ONEWAY(exceptionThrowingOnewayHandler, OnewayHelloService.Iface.class,
+                         OnewayHelloService.AsyncIface.class),
         DEVNULL(devNullHandler, DevNullService.Iface.class, DevNullService.AsyncIface.class),
         BINARY(binaryHandler, BinaryService.Iface.class, BinaryService.AsyncIface.class),
         TIME(timeServiceHandler, TimeService.Iface.class, TimeService.AsyncIface.class),
@@ -362,6 +369,38 @@ public class ThriftOverHttpClientTest {
         OnewayHelloService.AsyncIface client =
                 Clients.newClient(clientFactory(), getURI(Handlers.ONEWAYHELLO),
                                   Handlers.ONEWAYHELLO.asyncIface(), clientOptions);
+        BlockingQueue<Object> resQueue = new LinkedBlockingQueue<>();
+
+        String[] names = { "kukuman", "kukuman2" };
+        for (String name : names) {
+            client.hello(name, new RequestQueuingCallback(resQueue));
+        }
+
+        for (String ignored : names) {
+            assertThat(resQueue.take()).isEqualTo("null");
+        }
+
+        for (String ignored : names) {
+            assertThat(serverReceivedNames.take()).isIn(names);
+        }
+    }
+
+    @Test(timeout = 10000)
+    public void testExceptionThrowingOnewayServiceSync() throws Exception {
+        OnewayHelloService.Iface client =
+                Clients.newClient(clientFactory(), getURI(Handlers.EXCEPTION_ONEWAY),
+                                  Handlers.EXCEPTION_ONEWAY.iface(), clientOptions);
+        client.hello("kukuman");
+        client.hello("kukuman2");
+        assertThat(serverReceivedNames.take()).isEqualTo("kukuman");
+        assertThat(serverReceivedNames.take()).isEqualTo("kukuman2");
+    }
+
+    @Test(timeout = 10000)
+    public void testExceptionThrowingOnewayServiceAsync() throws Exception {
+        OnewayHelloService.AsyncIface client =
+                Clients.newClient(clientFactory(), getURI(Handlers.EXCEPTION_ONEWAY),
+                                  Handlers.EXCEPTION_ONEWAY.asyncIface(), clientOptions);
         BlockingQueue<Object> resQueue = new LinkedBlockingQueue<>();
 
         String[] names = { "kukuman", "kukuman2" };


### PR DESCRIPTION
Because there is no way to notify server-side exception to client on
one-way thrift API, thrift service does not need to return exception
response.

Results
- Thrift service handles exception throwned one-way method correctly
- Fixes #782