### PR TITLE
Update dependencies

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
@@ -26,7 +26,6 @@ import org.reactivestreams.Subscription;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.linecorp.armeria.common.ClosedSessionException;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
@@ -251,11 +250,6 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject>, RequestTim
         }
 
         final Channel ch = ctx.channel();
-        if (!ch.isActive()) {
-            fail(ClosedSessionException.get());
-            return;
-        }
-
         if (endOfStream) {
             setDone();
         }

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -7,19 +7,19 @@ ch.qos.logback:
   logback-classic: { version: '1.2.3' }
 
 com.fasterxml.jackson.core:
-  jackson-annotations: { version: &JACKSON_VERSION '2.8.9' }
+  jackson-annotations: { version: &JACKSON_VERSION '2.9.2' }
   jackson-core: { version: *JACKSON_VERSION }
   jackson-databind: { version: *JACKSON_VERSION }
 
 com.github.ben-manes.caffeine:
-  caffeine: { version: '2.5.5' }
+  caffeine: { version: '2.5.6' }
 
 com.google.code.findbugs:
   jsr305: { version: '3.0.2' }
 
 com.google.guava:
   guava:
-    version: &GUAVA_VERSION '23.0'
+    version: &GUAVA_VERSION '23.2-jre'
     exclusions:
     - com.google.code.findbugs:jsr305
     - com.google.errorprone:error_prone_annotations
@@ -33,10 +33,10 @@ com.google.guava:
     - com.google.j2objc:j2objc-annotations
 
 com.puppycrawl.tools:
-  checkstyle: { version: '8.2' }
+  checkstyle: { version: '8.3' }
 
 com.spotify:
-  completable-futures: { version: '0.3.1' }
+  completable-futures: { version: '0.3.2' }
 
 com.squareup.retrofit2:
   retrofit: { version: &RETROFIT2_VERSION '2.3.0' }
@@ -44,12 +44,12 @@ com.squareup.retrofit2:
   converter-jackson: { version: *RETROFIT2_VERSION }
 
 io.dropwizard.metrics:
-  metrics-core: { version: &DROPWIZARD_VERSION '3.2.4' }
+  metrics-core: { version: &DROPWIZARD_VERSION '3.2.5' }
   metrics-json: { version: *DROPWIZARD_VERSION }
 
 io.grpc:
   grpc-core:
-    version: &GRPC_VERSION '1.6.1'
+    version: &GRPC_VERSION '1.7.0'
     exclusions:
     - com.google.code.findbugs:jsr305
     - com.google.errorprone:error_prone_annotations
@@ -78,7 +78,7 @@ io.micrometer:
     - org.springframework:spring-webmvc
 
 io.netty:
-  netty-codec-http2: { version: &NETTY_VERSION '4.1.15.Final' }
+  netty-codec-http2: { version: &NETTY_VERSION '4.1.16.Final' }
   netty-handler: { version: *NETTY_VERSION }
   netty-resolver-dns: { version: *NETTY_VERSION }
   netty-transport: { version: *NETTY_VERSION }
@@ -87,7 +87,7 @@ io.netty:
   netty-tcnative-boringssl-static: { version: '2.0.6.Final' }
 
 io.prometheus:
-  simpleclient_common: { version: '0.0.26' }
+  simpleclient_common: { version: '0.1.0' }
 
 io.zipkin.brave:
   brave: { version: &BRAVE_VERSION '4.6.0' }
@@ -99,7 +99,7 @@ javax.inject:
   javax.inject: { version: '1' }
 
 javax.validation:
-  validation-api: { version: '1.1.0.Final' }
+  validation-api: { version: '2.0.0.Final' }
 
 junit:
   junit: { version: '4.12' }
@@ -124,7 +124,7 @@ org.apache.httpcomponents:
     - commons-logging:commons-logging
 
 org.apache.kafka:
-  kafka-clients: { version: '0.11.0.0' }
+  kafka-clients: { version: '0.11.0.1' }
 
 org.apache.thrift:
   libthrift:
@@ -134,7 +134,7 @@ org.apache.thrift:
     - org.apache.httpcomponents:httpclient
 
 org.apache.tomcat.embed:
-  tomcat-embed-core: { version: &TOMCAT_VERSION '8.5.20' }
+  tomcat-embed-core: { version: &TOMCAT_VERSION '8.5.23' }
   tomcat-embed-jasper: { version: *TOMCAT_VERSION }
   tomcat-embed-el: { version: *TOMCAT_VERSION }
 
@@ -159,7 +159,7 @@ org.dmonix.junit:
   zookeeper-junit: { version: '1.2' }
 
 org.eclipse.jetty:
-  apache-jsp: { version: &JETTY_VERSION '9.4.6.v20170531' }
+  apache-jsp: { version: &JETTY_VERSION '9.4.7.v20170914' }
   apache-jstl: { version: *JETTY_VERSION }
   jetty-annotations: { version: *JETTY_VERSION }
   jetty-server: { version: *JETTY_VERSION  }
@@ -174,14 +174,14 @@ org.eclipse.jetty.http2:
 org.hamcrest:
   hamcrest-library: { version: '1.3' }
 
-org.hibernate:
-  hibernate-validator: { version: '5.4.1.Final' }
+org.hibernate.validator:
+  hibernate-validator: { version: '6.0.3.Final' }
 
 org.javassist:
-  javassist: { version: '3.21.0-GA' }
+  javassist: { version: '3.22.0-GA' }
 
 org.mockito:
-  mockito-core: { version: '2.8.47' }
+  mockito-core: { version: '2.11.0' }
 
 org.mortbay.jetty.alpn:
   jetty-alpn-agent: { version: '2.0.6' }
@@ -201,7 +201,7 @@ org.slf4j:
   slf4j-api: { version: *SLF4J_VERSION }
 
 org.springframework.boot:
-  spring-boot: { version: &SPRING_BOOT_VERSION '1.5.6.RELEASE' }
+  spring-boot: { version: &SPRING_BOOT_VERSION '1.5.8.RELEASE' }
   spring-boot-autoconfigure: { version: *SPRING_BOOT_VERSION }
   spring-boot-starter-logging: { version: *SPRING_BOOT_VERSION }
   spring-boot-starter-test: { version: *SPRING_BOOT_VERSION }

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
@@ -18,7 +18,6 @@ package com.linecorp.armeria.server.grpc;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
-
 import static java.util.Objects.requireNonNull;
 
 import java.util.Set;

--- a/spring-boot/autoconfigure/build.gradle
+++ b/spring-boot/autoconfigure/build.gradle
@@ -13,5 +13,5 @@ managedDependencies {
     compile 'org.springframework.boot:spring-boot-starter-logging'
 
     testCompile 'org.springframework.boot:spring-boot-starter-test'
-    testCompile 'org.hibernate:hibernate-validator'
+    testCompile 'org.hibernate.validator:hibernate-validator'
 }

--- a/tomcat8.0/build.gradle
+++ b/tomcat8.0/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
     // Tomcat
     [ 'tomcat-embed-core', 'tomcat-embed-jasper', 'tomcat-embed-el' ].each {
-        compile "org.apache.tomcat.embed:$it:8.0.46"
+        compile "org.apache.tomcat.embed:$it:8.0.47"
     }
 }
 


### PR DESCRIPTION
- Caffeine 2.5.5 -> 2.5.6
- Checkstyle 8.2 -> 8.3
- completable-futures -> 0.3.1 -> 0.3.2
- Dropwizard Metrics 3.2.4 -> 3.2.5
- gRPC 1.6.1 -> 1.7.0
- Guave 23.0 -> 23.2
- Hibernate Validator 5.4.1 -> 6.0.3
- Jackson 2.8.9 -> 2.9.2
- java.validation 1.0.0 -> 2.0.0
- Javassist 3.21.0 -> 3.22.0
- Jetty 9.4.6 -> 9.4.7
- Kafka clients 0.11.0.0 -> 0.11.0.1
- Mockito 2.8.47 -> 2.11.0
- Netty 4.1.15 -> 4.1.16
- Prometheus 0.0.26 -> 0.1.0
- Spring Boot 1.5.6 -> 1.5.8
- Tomcat 8.5.20 -> 8.5.23, 8.0.46 -> 8.0.47