### PR TITLE
Do not throw exception on unsupported HTTP method

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/HttpMethod.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpMethod.java
@@ -30,6 +30,8 @@
  */
 package com.linecorp.armeria.common;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * HTTP request method.
  */
@@ -92,4 +94,27 @@ public enum HttpMethod {
      * The CONNECT method is used for a proxy that can dynamically switch to being a tunnel.
      */
     CONNECT;
+
+    /**
+     * Returns whether the specified {@link String} is one of the supported method names.
+     *
+     * @return {@code true} if supported. {@code false} otherwise.
+     */
+    public static boolean isSupported(String value) {
+        requireNonNull(value, "value");
+        switch (value) {
+            case "OPTIONS":
+            case "GET":
+            case "HEAD":
+            case "POST":
+            case "PUT":
+            case "PATCH":
+            case "DELETE":
+            case "TRACE":
+            case "CONNECT":
+                return true;
+        }
+
+        return false;
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/Http1RequestDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http1RequestDecoder.java
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory;
 
 import com.linecorp.armeria.common.ContentTooLargeException;
 import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.ProtocolViolationException;
 import com.linecorp.armeria.internal.ArmeriaHttpUtil;
@@ -106,6 +107,12 @@ final class Http1RequestDecoder extends ChannelDuplexHandler {
 
                     final HttpHeaders nettyHeaders = nettyReq.headers();
                     final int id = ++receivedRequests;
+
+                    // Validate the method.
+                    if (!HttpMethod.isSupported(nettyReq.method().name())) {
+                        fail(ctx, HttpResponseStatus.METHOD_NOT_ALLOWED);
+                        return;
+                    }
 
                     // Validate the 'content-length' header.
                     final String contentLengthStr = nettyHeaders.get(HttpHeaderNames.CONTENT_LENGTH);

--- a/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
@@ -291,6 +291,11 @@ public class ServerTest {
         testSimple("GET * HTTP/1.1", "HTTP/1.1 400 Bad Request");
     }
 
+    @Test
+    public void testUnsupportedMethod() throws Exception {
+        testSimple("WHOA / HTTP/1.1", "HTTP/1.1 405 Method Not Allowed");
+    }
+
     private static void testSimple(
             String reqLine, String expectedStatusLine, String... expectedHeaders) throws Exception {
 


### PR DESCRIPTION
Motivation:

Armeria's HttpMethod is an enum, and thus HttpMethod.valueOf() will
raise an exception when the given method name does not match any enum
values.

In contrast, Netty's HttpMethod is not an enum and thus supports
arbitrary method names.

As a result, when a user sends a request whose method is not supported
by Armeria's HttpMethod, the server will fail the request with an
unexpected IllegalArgumentException rather than sending '405 Method
Not Allowed' response.

Modifications:

- Add HttpMethod.isSupported(String)
- Add the validation of request method for HTTP/1 and 2

Result:

- Fixes #754
- Armeria responds with '405 Method Not Allowed' when a client sends a
  request with unsupported method.