### PR TITLE
Migrate to Brave 4.9.0

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -90,7 +90,7 @@ io.prometheus:
   simpleclient_common: { version: '0.1.0' }
 
 io.zipkin.brave:
-  brave: { version: &BRAVE_VERSION '4.6.0' }
+  brave: { version: &BRAVE_VERSION '4.9.0' }
 
 it.unimi.dsi:
   fastutil: { version: '8.1.0' }

--- a/zipkin/src/test/java/com/linecorp/armeria/common/tracing/SpanCollectingReporter.java
+++ b/zipkin/src/test/java/com/linecorp/armeria/common/tracing/SpanCollectingReporter.java
@@ -19,8 +19,8 @@ package com.linecorp.armeria.common.tracing;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedTransferQueue;
 
-import zipkin.Span;
-import zipkin.reporter.Reporter;
+import zipkin2.Span;
+import zipkin2.reporter.Reporter;
 
 public final class SpanCollectingReporter implements Reporter<Span> {
 


### PR DESCRIPTION
Fixes #791

This is a breaking change, users of the old `Span` API will either have to
- Update the official zipkin collector to a version that supports v2 API
- https://github.com/openzipkin/brave/tree/master/brave#zipkin-v1-setup
- Reimplement the reporter if using some non-official API (like a custom Thrift API)