### PR TITLE
Use HdrHistogram as the default Quantiles implementation

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -93,6 +93,11 @@ This product contains a modified part of Micrometer, distributed by Pivotal Soft
   * License: licenses/LICENSE.micrometer.al20.txt (Apache License v2.0)
   * Homepage: https://micrometer.io/
 
+This product contains a modified part of Rolling Metrics, distributed by Vladimir Bukhtoyarov:
+
+  * License: licenses/LICENSE.rolling-metrics.al20.txt (Apache License v2.0)
+  * Homepage: https://github.com/vladimir-bukhtoyarov/rolling-metrics
+
 This product contains a modified part of Twitter Commons, distributed by Twitter, Inc:
 
   * License: license/LICENSE.twitter.al20.txt (Apache License v2.0)
@@ -156,6 +161,11 @@ This product depends on Hamcrest, distributed by hamcrest.org:
 
   * License: licenses/LICENSE.hamcrest.bsd.txt (BSD License)
   * Homepage: http://hamcrest.org/
+
+This product depends on HdrHistogram, distributed by Gil Tene and others:
+
+  * License: licenses/LICENSE.hdrhistogram.cc0.txt (Pubic domain)
+  * Homepage: http://hdrhistogram.github.io/HdrHistogram/
 
 This product depends on Hibernate Validator, distributed by Red Hat, Inc:
 

--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,7 @@ ext {
             ['com.google.guava:guava', 'com.google.thirdparty.publicsuffix', "${shadedPackage}.publicsuffix"],
             ['com.spotify:completable-futures', 'com.spotify.futures', "${shadedPackage}.futures"],
             ['it.unimi.dsi:fastutil', 'it.unimi.dsi.fastutil', "${shadedPackage}.fastutil"],
+            ['org.hdrhistogram:HdrHistogram', 'org.HdrHistogram', "${shadedPackage}.hdrhistogram"],
             ['org.reflections:reflections', 'org.reflections', "${shadedPackage}.reflections"]
     ]
 
@@ -87,7 +88,6 @@ allprojects {
 
     // Define common repositories.
     repositories {
-        mavenLocal()
         mavenCentral()
     }
 }
@@ -209,6 +209,9 @@ configure(javaProjects) {
 
         // Guava
         compile 'com.google.guava:guava'
+
+        // HdrHistogram
+        compile 'org.hdrhistogram:HdrHistogram'
 
         // JSR305 (Can't use compileOnly due to Javadoc errors)
         compile 'com.google.code.findbugs:jsr305'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -107,6 +107,7 @@ task trimShadedJar(type: ProGuardTask,
     keepattributes 'Signature, InnerClasses, Annotation'
     keep "class !${shadedPackage}.**,com.linecorp.armeria.** { *; }"
     keep "class ${shadedPackage}.caffeine.** { *; }" // To make the unsafe field access work.
+    keep "class ${shadedPackage}.hdrhistogram.** { *; }" // To make the reflective access work.
 }
 
 tasks.assemble.dependsOn tasks.trimShadedJar

--- a/core/src/main/java/com/linecorp/armeria/common/metric/RollingHdrQuantiles.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/RollingHdrQuantiles.java
@@ -1,0 +1,338 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ *
+ *  Copyright 2016 Vladimir Bukhtoyarov
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.linecorp.armeria.common.metric;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.LongSupplier;
+import java.util.function.Supplier;
+
+import org.HdrHistogram.DoubleHistogram;
+import org.HdrHistogram.DoubleRecorder;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import io.micrometer.core.instrument.stats.quantile.Quantiles;
+
+final class RollingHdrQuantiles implements Quantiles {
+
+    private static final double[] PREDEFINED_QUANTILES = { 0, 0.5, 0.75, 0.9, 0.95, 0.98, 0.99, 0.999, 1.0 };
+    private static final Collection<Double> MONITORED = Arrays.stream(PREDEFINED_QUANTILES).boxed()
+                                                              .collect(toImmutableList());
+
+    private final long intervalBetweenResettingMillis;
+    private final long creationTimestamp;
+    private final ArchivedHistogram[] archive;
+    private final boolean historySupported;
+    private final LongSupplier clock;
+    private final DoubleHistogram temporarySnapshotHistogram;
+
+    private final Phase left;
+    private final Phase right;
+    private final Phase[] phases;
+    private final AtomicReference<Phase> currentPhaseRef;
+
+    private double[] snapshot;
+    private long lastSnapshotTimeMillis;
+
+    RollingHdrQuantiles() {
+        this(() -> new DoubleRecorder(2), 5, Duration.ofMinutes(2).toMillis(), System::currentTimeMillis);
+    }
+
+    RollingHdrQuantiles(Supplier<DoubleRecorder> recorderSupplier,
+                        int numberHistoryChunks, long intervalBetweenResettingMillis,
+                        LongSupplier clock) {
+
+        this.intervalBetweenResettingMillis = intervalBetweenResettingMillis;
+        this.clock = clock;
+        creationTimestamp = clock.getAsLong();
+
+        left = new Phase(recorderSupplier, creationTimestamp + intervalBetweenResettingMillis);
+        right = new Phase(recorderSupplier, Long.MAX_VALUE);
+        phases = new Phase[] { left, right };
+        currentPhaseRef = new AtomicReference<>(left);
+
+        historySupported = numberHistoryChunks > 0;
+        if (historySupported) {
+            archive = new ArchivedHistogram[numberHistoryChunks];
+            for (int i = 0; i < numberHistoryChunks; i++) {
+                final DoubleHistogram archivedHistogram = createNonConcurrentCopy(left.intervalHistogram);
+                archive[i] = new ArchivedHistogram(archivedHistogram, Long.MIN_VALUE);
+            }
+        } else {
+            archive = null;
+        }
+
+        temporarySnapshotHistogram = createNonConcurrentCopy(left.intervalHistogram);
+    }
+
+    @Override
+    public void observe(double value) {
+        observe(value, 0);
+    }
+
+    public void observe(double value, double expectedIntervalBetweenValueSamples) {
+        final long currentTimeMillis = clock.getAsLong();
+        final Phase currentPhase = currentPhaseRef.get();
+        if (currentTimeMillis < currentPhase.proposedInvalidationTimestamp) {
+            currentPhase.recorder.recordValueWithExpectedInterval(value, expectedIntervalBetweenValueSamples);
+            return;
+        }
+
+        final Phase nextPhase = currentPhase == left ? right : left;
+        nextPhase.recorder.recordValueWithExpectedInterval(value, expectedIntervalBetweenValueSamples);
+
+        if (!currentPhaseRef.compareAndSet(currentPhase, nextPhase)) {
+            // another writer achieved progress and must submit rotation task to backgroundExecutor
+            return;
+        }
+
+        // Current thread is responsible to rotate phases.
+        rotate(currentTimeMillis, currentPhase, nextPhase);
+    }
+
+    private synchronized void rotate(long currentTimeMillis, Phase currentPhase, Phase nextPhase) {
+        try {
+            currentPhase.intervalHistogram =
+                    currentPhase.recorder.getIntervalHistogram(currentPhase.intervalHistogram);
+            addSecondToFirst(currentPhase.totalsHistogram, currentPhase.intervalHistogram);
+            if (historySupported) {
+                // move values from recorder to correspondent archived histogram
+                final long currentPhaseNumber =
+                        (currentPhase.proposedInvalidationTimestamp - creationTimestamp) /
+                        intervalBetweenResettingMillis;
+                final int correspondentArchiveIndex = (int) (currentPhaseNumber - 1) % archive.length;
+                final ArchivedHistogram correspondentArchivedHistogram = archive[correspondentArchiveIndex];
+                reset(correspondentArchivedHistogram.histogram);
+                addSecondToFirst(correspondentArchivedHistogram.histogram, currentPhase.totalsHistogram);
+                correspondentArchivedHistogram.proposedInvalidationTimestamp =
+                        currentPhase.proposedInvalidationTimestamp +
+                        archive.length * intervalBetweenResettingMillis;
+            }
+            reset(currentPhase.totalsHistogram);
+        } finally {
+            final long millisSinceCreation = currentTimeMillis - creationTimestamp;
+            final long intervalsSinceCreation = millisSinceCreation / intervalBetweenResettingMillis;
+            currentPhase.proposedInvalidationTimestamp = Long.MAX_VALUE;
+            nextPhase.proposedInvalidationTimestamp =
+                    creationTimestamp + (intervalsSinceCreation + 1) * intervalBetweenResettingMillis;
+        }
+    }
+
+    @Override
+    public Double get(double percentile) {
+        final double[] snapshot = getSnapshot();
+        for (int i = 0; i < PREDEFINED_QUANTILES.length; i++) {
+            if (percentile <= PREDEFINED_QUANTILES[i]) {
+                return snapshot[i];
+            }
+        }
+        return snapshot[PREDEFINED_QUANTILES.length - 1];
+    }
+
+    @Override
+    public Collection<Double> monitored() {
+        return MONITORED;
+    }
+
+    private synchronized double[] getSnapshot() {
+        final long currentTimeMillis = clock.getAsLong();
+        final double[] oldSnapshot = snapshot;
+        if (oldSnapshot != null && currentTimeMillis - lastSnapshotTimeMillis < 1000) {
+            return oldSnapshot;
+        }
+
+        reset(temporarySnapshotHistogram);
+
+        for (Phase phase : phases) {
+            if (phase.isNeedToBeReportedToSnapshot(currentTimeMillis)) {
+                phase.intervalHistogram = phase.recorder.getIntervalHistogram(phase.intervalHistogram);
+                addSecondToFirst(phase.totalsHistogram, phase.intervalHistogram);
+                addSecondToFirst(temporarySnapshotHistogram, phase.totalsHistogram);
+            }
+        }
+        if (historySupported) {
+            for (ArchivedHistogram archivedHistogram : archive) {
+                if (archivedHistogram.proposedInvalidationTimestamp > currentTimeMillis) {
+                    addSecondToFirst(temporarySnapshotHistogram, archivedHistogram.histogram);
+                }
+            }
+        }
+
+        final double[] snapshot = new double[PREDEFINED_QUANTILES.length];
+        for (int i = 0; i < PREDEFINED_QUANTILES.length; i++) {
+            final double percentile = PREDEFINED_QUANTILES[i] * 100.0;
+            snapshot[i] = temporarySnapshotHistogram.getValueAtPercentile(percentile);
+        }
+        this.snapshot = snapshot;
+        lastSnapshotTimeMillis = currentTimeMillis;
+        return snapshot;
+    }
+
+    @VisibleForTesting
+    synchronized void discardCachedSnapshot() {
+        snapshot = null;
+    }
+
+    @VisibleForTesting
+    int estimatedFootprintInBytes() {
+        // each histogram has equivalent pessimistic estimation
+        int oneHistogramPessimisticFootprint = temporarySnapshotHistogram.getEstimatedFootprintInBytes();
+
+        // 4 - two recorders with two histogram
+        // 2 - two histogram for storing accumulated values from current phase
+        // 1 - temporary histogram used for snapshot extracting
+        return oneHistogramPessimisticFootprint * ((archive != null ? archive.length : 0) + 4 + 2 + 1);
+    }
+
+    private static void reset(DoubleHistogram histogram) {
+        if (histogram.getTotalCount() > 0) {
+            histogram.reset();
+        }
+    }
+
+    private static void addSecondToFirst(DoubleHistogram first, DoubleHistogram second) {
+        if (second.getTotalCount() > 0) {
+            first.add(second);
+        }
+    }
+
+    private static DoubleHistogram createNonConcurrentCopy(DoubleHistogram source) {
+        final DoubleHistogram copy = new DoubleHistogram(
+                source.getHighestToLowestValueRatio(),
+                source.getNumberOfSignificantValueDigits());
+        copy.setAutoResize(source.isAutoResize());
+        return copy;
+    }
+
+    private static String histogramToString(DoubleHistogram histogram) {
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            final PrintStream writer = new PrintStream(baos);
+            histogram.outputPercentileDistribution(writer, 1.0);
+            return new String(baos.toByteArray());
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static String printArray(Object[] array, String elementName) {
+        final StringBuilder buf = new StringBuilder();
+        buf.append('{');
+        for (int i = 0; i < array.length; i++) {
+            buf.append('\n')
+               .append(elementName)
+               .append('[').append(i).append("]=")
+               .append(array[i]);
+        }
+        buf.append("\n}");
+        return buf.toString();
+    }
+
+    private static final class ArchivedHistogram {
+
+        final DoubleHistogram histogram;
+        volatile long proposedInvalidationTimestamp;
+
+        ArchivedHistogram(DoubleHistogram histogram, long proposedInvalidationTimestamp) {
+            this.histogram = histogram;
+            this.proposedInvalidationTimestamp = proposedInvalidationTimestamp;
+        }
+
+        @Override
+        public String toString() {
+            return "ArchivedHistogram{" +
+                    "\n, proposedInvalidationTimestamp=" + proposedInvalidationTimestamp +
+                    "\n, histogram=" + histogramToString(histogram) +
+                    "\n}";
+        }
+    }
+
+    private final class Phase {
+
+        final DoubleRecorder recorder;
+        final DoubleHistogram totalsHistogram;
+        DoubleHistogram intervalHistogram;
+        volatile long proposedInvalidationTimestamp;
+
+        Phase(Supplier<DoubleRecorder> recorderSupplier, long proposedInvalidationTimestamp) {
+            recorder = recorderSupplier.get();
+            intervalHistogram = recorder.getIntervalHistogram();
+            intervalHistogram.setAutoResize(true);
+            totalsHistogram = intervalHistogram.copy();
+            totalsHistogram.setAutoResize(true);
+            this.proposedInvalidationTimestamp = proposedInvalidationTimestamp;
+        }
+
+        @Override
+        public String toString() {
+            return "Phase{" +
+                    "\n, proposedInvalidationTimestamp=" + proposedInvalidationTimestamp +
+                    "\n, totalsHistogram=" + (totalsHistogram != null ? histogramToString(totalsHistogram)
+                                                                      : "null") +
+                    "\n, intervalHistogram=" + histogramToString(intervalHistogram) +
+                    "\n}";
+        }
+
+        boolean isNeedToBeReportedToSnapshot(long currentTimeMillis) {
+            final long proposedInvalidationTimestampLocal = proposedInvalidationTimestamp;
+            if (proposedInvalidationTimestampLocal > currentTimeMillis) {
+                return true;
+            }
+            if (!historySupported) {
+                return false;
+            }
+            final long correspondentChunkProposedInvalidationTimestamp =
+                    proposedInvalidationTimestampLocal + archive.length * intervalBetweenResettingMillis;
+            return correspondentChunkProposedInvalidationTimestamp > currentTimeMillis;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "RollingHdrQuantiles{" +
+                "\nintervalBetweenResettingMillis=" + intervalBetweenResettingMillis +
+                ",\n creationTimestamp=" + creationTimestamp +
+                (!historySupported ? "" : ",\n archive=" + printArray(archive, "chunk")) +
+                ",\n left=" + left +
+                ",\n right=" + right +
+                ",\n currentPhase=" + (currentPhaseRef.get() == left ? "left" : "right") +
+                ",\n temporarySnapshotHistogram=" + histogramToString(temporarySnapshotHistogram)  +
+                '}';
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/common/metric/MoreMetersTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/metric/MoreMetersTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common.metric;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.junit.Test;
+
+import io.micrometer.core.instrument.MeterRegistry;
+
+public class MoreMetersTest {
+    private static final String ESTIMATED_FOOTPRINT = "armeria.hdrHistogram.estimatedFootprint#value";
+    private static final String COUNT = "armeria.hdrHistogram.count#value";
+
+    @Test
+    public void hdrHistogramMeters() {
+        final MeterRegistry registry = PrometheusMeterRegistries.newRegistry();
+
+        // Register a distribution summary.
+        MoreMeters.summaryWithDefaultQuantiles(registry, new MeterId("foo.bar"));
+
+        // Check if estimated footprint is recorded.
+        final Map<String, Double> measurement1 = MoreMeters.measureAll(registry);
+        assertThat(measurement1).containsEntry(COUNT, 1.0).containsKey(ESTIMATED_FOOTPRINT);
+        final double footprint1 = measurement1.get(ESTIMATED_FOOTPRINT);
+        assertThat(footprint1).isPositive();
+
+        // Register a timer.
+        MoreMeters.timerWithDefaultQuantiles(registry, new MeterId("alice.bob"));
+
+        // Check if estimated footprint has increased, because we created two Quantiles.
+        final Map<String, Double> measurement2 = MoreMeters.measureAll(registry);
+        assertThat(measurement2).containsEntry(COUNT, 2.0).containsKey(ESTIMATED_FOOTPRINT);
+        assertThat(measurement2.get(ESTIMATED_FOOTPRINT)).isGreaterThan(footprint1);
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/common/metric/RollingHdrQuantilesTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/metric/RollingHdrQuantilesTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ *
+ *  Copyright 2016 Vladimir Bukhtoyarov
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.linecorp.armeria.common.metric;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.HdrHistogram.DoubleRecorder;
+import org.junit.Test;
+
+import com.linecorp.armeria.common.util.Exceptions;
+
+public class RollingHdrQuantilesTest {
+
+    @Test
+    public void test() {
+        final AtomicLong time = new AtomicLong(0);
+        final RollingHdrQuantiles q =
+                new RollingHdrQuantiles(() -> new DoubleRecorder(2), 3, 1000, time::get);
+
+        q.observe(10);
+        q.observe(20);
+        q.discardCachedSnapshot();
+        assertThat(q.get(0.0)).isBetween(9.0, 11.0);
+        assertThat(q.get(1.0)).isBetween(19.0, 21.0);
+
+        time.getAndAdd(900); // 900
+        q.observe(30);
+        q.observe(40);
+        q.discardCachedSnapshot();
+        assertThat(q.get(0.0)).isBetween(9.0, 11.0);
+        assertThat(q.get(1.0)).isBetween(39.0, 41.0);
+
+        time.getAndAdd(99); // 999
+        q.observe(9);
+        q.observe(60);
+        q.discardCachedSnapshot();
+        assertThat(q.get(0.0)).isBetween(8.0, 10.0);
+        assertThat(q.get(1.0)).isBetween(59.0, 61.0);
+
+        time.getAndAdd(1); // 1000
+        q.observe(12);
+        q.observe(70);
+        q.discardCachedSnapshot();
+        assertThat(q.get(0.0)).isBetween(8.0, 10.0);
+        assertThat(q.get(1.0)).isBetween(69.0, 71.0);
+
+        time.getAndAdd(1001); // 2001
+        q.observe(13);
+        q.observe(80);
+        q.discardCachedSnapshot();
+        assertThat(q.get(0.0)).isBetween(8.0, 10.0);
+        assertThat(q.get(1.0)).isBetween(79.0, 81.0);
+
+        time.getAndAdd(1000); // 3001
+        q.discardCachedSnapshot();
+        assertThat(q.get(0.0)).isBetween(8.0, 10.0);
+        assertThat(q.get(1.0)).isBetween(79.0, 81.0);
+
+        time.getAndAdd(999); // 4000
+        q.discardCachedSnapshot();
+        assertThat(q.get(0.0)).isBetween(11.0, 13.0);
+        assertThat(q.get(1.0)).isBetween(79.0, 81.0);
+        q.observe(1);
+        q.observe(200);
+        q.discardCachedSnapshot();
+        assertThat(q.get(0.0)).isBetween(0.0, 2.0);
+        assertThat(q.get(1.0)).isBetween(199.0, 201.0);
+
+        time.getAndAdd(10000); // 14000
+        q.discardCachedSnapshot();
+        assertThat(q.get(0.0)).isZero();
+        assertThat(q.get(1.0)).isZero();
+        q.observe(3);
+
+        time.addAndGet(3999); // 17999
+        q.discardCachedSnapshot();
+        assertThat(q.get(0.0)).isBetween(2.0, 4.0);
+        assertThat(q.get(1.0)).isBetween(2.0, 4.0);
+
+        time.addAndGet(1); // 18000
+        q.discardCachedSnapshot();
+        assertThat(q.get(0.0)).isZero();
+        assertThat(q.get(1.0)).isZero();
+
+        // Memory footprint should be between 94 and 98 KiB.
+        assertThat(q.estimatedFootprintInBytes()).isBetween(94 * 1024, 98 * 1024);
+    }
+
+    @Test
+    public void testToString() {
+        assertThat(new RollingHdrQuantiles().toString()).isNotEmpty();
+    }
+
+    @Test(timeout = 10000)
+    public void testThatConcurrentThreadsNotHungWithThreeChunks() throws Exception {
+        final RollingHdrQuantiles q = new RollingHdrQuantiles(
+                () -> new DoubleRecorder(2), 3, 1000, System::currentTimeMillis);
+
+        runInParallel(q, Duration.ofSeconds(3).toMillis());
+    }
+
+    private static void runInParallel(RollingHdrQuantiles reservoir, long durationMillis) throws Exception {
+        final AtomicReference<Throwable> errorRef = new AtomicReference<>();
+        final Thread[] threads = new Thread[Runtime.getRuntime().availableProcessors() * 2];
+        final long start = System.currentTimeMillis();
+        final CountDownLatch latch = new CountDownLatch(threads.length);
+        for (int i = 0; i < threads.length; i++) {
+            threads[i] = new Thread(() -> {
+                try {
+                    // update reservoir 100 times and take snapshot on each cycle
+                    while (errorRef.get() == null && System.currentTimeMillis() - start < durationMillis) {
+                        for (int j = 1; j <= 10; j++) {
+                            reservoir.observe(ThreadLocalRandom.current().nextDouble(j));
+                        }
+                        reservoir.discardCachedSnapshot();
+                        reservoir.get(0);
+                    }
+                } catch (Exception e) {
+                    errorRef.set(e);
+                } finally {
+                    latch.countDown();
+                }
+            });
+            threads[i].start();
+        }
+        latch.await();
+        if (errorRef.get() != null) {
+            Exceptions.throwUnsafely(errorRef.get());
+        }
+    }
+}

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -174,6 +174,9 @@ org.eclipse.jetty.http2:
 org.hamcrest:
   hamcrest-library: { version: '1.3' }
 
+org.hdrhistogram:
+  HdrHistogram: { version: '2.1.10' }
+
 org.hibernate.validator:
   hibernate-validator: { version: '6.0.3.Final' }
 

--- a/licenses/LICENSE.hdrhistogram.cc0.txt
+++ b/licenses/LICENSE.hdrhistogram.cc0.txt
@@ -1,0 +1,121 @@
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.

--- a/licenses/LICENSE.rolling-metrics.al20.txt
+++ b/licenses/LICENSE.rolling-metrics.al20.txt
@@ -1,0 +1,202 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2016 Vladimir Bukhtoyarov
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/thrift/src/test/java/com/linecorp/armeria/it/metric/PrometheusMetricsIntegrationTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/metric/PrometheusMetricsIntegrationTest.java
@@ -29,6 +29,8 @@ import org.apache.thrift.TException;
 import org.junit.AfterClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.linecorp.armeria.client.ClientBuilder;
 import com.linecorp.armeria.client.ClientFactory;
@@ -59,6 +61,7 @@ import io.prometheus.client.CollectorRegistry;
 
 public class PrometheusMetricsIntegrationTest {
 
+    private static final Logger logger = LoggerFactory.getLogger(PrometheusMetricsIntegrationTest.class);
     private static final PrometheusMeterRegistry registry = PrometheusMeterRegistries.newRegistry();
     private static final CollectorRegistry prometheusRegistry = registry.getPrometheusRegistry();
 
@@ -140,6 +143,7 @@ public class PrometheusMetricsIntegrationTest {
                           "client_total_duration_seconds_sum{handler=\"Foo\","));
 
         final String content = makeMetricsRequest().content().toStringUtf8();
+        logger.debug("Metrics reported by the exposition service:\n{}", content);
 
         // Server entry count check
         assertThat(content).containsPattern(


### PR DESCRIPTION
Motivation:

The Quantiles implementations provided by Micrometer are not
thread-safe, causing various races.

Modifications:

- Replace CKMSQuantiles with RollingHdrQuantiles, which is a forked
  version of Rolling Metrics ResetByChunksAccumulator
  - https://github.com/vladimir-bukhtoyarov/rolling-metrics/blob/2.0.3/src/main/java/com/github/rollingmetrics/histogram/accumulator/ResetByChunksAccumulator.java
  - Rolling Metrics supports only long integer values so I had to fork
    it to support double values.
- Add the metrics for HdrHistograms used by RollingHdrQuantiles
- Add MicrometerUtil.registerLater()

Result:

- Fixes #793