### PR TITLE
Improve JMH integration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,16 +8,16 @@ buildscript {
     repositories {
         mavenCentral()
         jcenter()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
     dependencies {
         classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.1'
         classpath 'com.google.gradle:osdetector-gradle-plugin:1.4.0'
+        classpath 'me.champeau.gradle:jmh-gradle-plugin:0.4.4'
         classpath 'org.yaml:snakeyaml:1.18'
     }
-}
-
-plugins {
-    id 'me.champeau.gradle.jmh' version '0.4.4' apply false
 }
 
 apply plugin: 'com.google.osdetector'
@@ -103,6 +103,7 @@ configure(javaProjects) {
     apply plugin: 'java'
     apply plugin: 'jacoco'
     apply plugin: 'checkstyle'
+    apply plugin: 'me.champeau.gradle.jmh'
 
     apply plugin: 'maven-publish'
     apply plugin: 'signing'
@@ -295,6 +296,35 @@ configure(javaProjects) {
             finalizedBy tasks.jacocoTestReport
         }
     }
+
+    // Configure JMH.
+    jmh {
+        forceGC = true
+        includeTests = true
+        duplicateClassesStrategy = DuplicatesStrategy.EXCLUDE
+        jmhVersion = rootProject.ext.dependencyManagement['org.openjdk.jmh']['jmh-core'].version
+
+        if (rootProject.hasProperty('jmh.fork')) {
+            fork = Integer.parseInt(String.valueOf(rootProject.findProperty('jmh.fork')))
+        } else {
+            fork = 1
+        }
+        if (rootProject.hasProperty('jmh.iterations')) {
+            iterations = Integer.parseInt(String.valueOf(rootProject.findProperty('jmh.iterations')))
+        }
+        if (rootProject.hasProperty('jmh.warmupIterations')) {
+            warmupIterations = Integer.parseInt(String.valueOf(rootProject.findProperty('jmh.warmupIterations')))
+        } else {
+            warmupIterations = iterations
+        }
+        if (rootProject.hasProperty('jmh.profilers')) {
+            profilers = String.valueOf(rootProject.findProperty('jmh.profilers')).split(',')
+        }
+        if (rootProject.hasProperty('jmh.verbose')) {
+            verbosity = 'EXTRA'
+        }
+    }
+    configurations.jmh.extendsFrom configurations.testRuntime
 
     // Require Java 8 to build the project.
     tasks.withType(JavaCompile) {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -7,8 +7,6 @@ buildscript {
     }
 }
 
-apply plugin: 'me.champeau.gradle.jmh'
-
 managedDependencies {
     // Caffeine
     compile 'com.github.ben-manes.caffeine:caffeine'
@@ -133,10 +131,3 @@ class ProGuardTask extends proguard.gradle.ProGuardTask {
         keep "class ${className},${className}\$* { *; }"
     }
 }
-
-jmh {
-    fork = 1
-    forceGC = true
-    includeTests = false
-}
-configurations.jmh.extendsFrom configurations.compile

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -190,6 +190,10 @@ org.mockito:
 org.mortbay.jetty.alpn:
   jetty-alpn-agent: { version: '2.0.6' }
 
+org.openjdk.jmh:
+  jmh-core: { version: &JMH_VERSION '1.19' }
+  jmh-generator-annprocess: { version: *JMH_VERSION }
+
 org.reactivestreams:
   reactive-streams: { version: &REACTIVE_STREAMS_VERSION '1.0.1' }
   reactive-streams-tck: { version: *REACTIVE_STREAMS_VERSION }

--- a/grpc/build.gradle
+++ b/grpc/build.gradle
@@ -8,11 +8,10 @@ buildscript {
 }
 
 apply plugin: 'com.google.protobuf'
-apply plugin: 'me.champeau.gradle.jmh'
 
 // Use a flag to control whether we are running downstream or upstream benchmarks, to use to
 // share business logic while managing dependency conflicts.
-def upstreamJmh = rootProject.findProperty('grpcJmh.upstream')
+def upstreamJmh = rootProject.findProperty('jmh.grpcUpstream') == 'true'
 
 managedDependencies {
     // gRPC

--- a/thrift/build.gradle
+++ b/thrift/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'me.champeau.gradle.jmh'
-
 managedDependencies {
     // Thrift
     compile 'org.apache.thrift:libthrift'
@@ -25,5 +23,3 @@ tasks.shadedJar.doLast {
         }
     }
 }
-
-configurations.jmh.extendsFrom configurations.testRuntimeClasspath


### PR DESCRIPTION
- Apply JMH plugin for all Java projects
- Add JMH annotation processor to the dependencies so that a developer
  can launch a benchmark from his or her IDE
- Add 'jmh.*' properties for tuning JMH plugin configuration
  - Rename grpcJmh.upstream to jmh.grpcUpstream