### PR TITLE
Add okhttp client and non-blocking gRPC benchmarks.

### DIFF
--- a/grpc/build.gradle
+++ b/grpc/build.gradle
@@ -24,6 +24,7 @@ managedDependencies {
     testCompile 'io.grpc:grpc-okhttp'
     testCompile 'io.grpc:grpc-testing'
 
+    jmh 'io.grpc:grpc-okhttp'
     if (upstreamJmh) {
         jmh 'io.grpc:grpc-netty'
     }

--- a/grpc/src/jmh/java/com/linecorp/armeria/grpc/downstream/DownstreamSimpleBenchmark.java
+++ b/grpc/src/jmh/java/com/linecorp/armeria/grpc/downstream/DownstreamSimpleBenchmark.java
@@ -66,7 +66,6 @@ public class DownstreamSimpleBenchmark extends SimpleBenchmarkBase {
         final String url = "gproto+http://127.0.0.1:" + port() + "/";
         githubApiClient = Clients.newClient(url, GithubServiceBlockingStub.class);
         githubApiFutureClient = Clients.newClient(url, GithubServiceFutureStub.class);
-
     }
 
     @Override
@@ -74,11 +73,11 @@ public class DownstreamSimpleBenchmark extends SimpleBenchmarkBase {
         server.stop().join();
     }
 
-    public static void main(String[] args) throws Exception {
+    /*public static void main(String[] args) throws Exception {
         DownstreamSimpleBenchmark benchmark = new DownstreamSimpleBenchmark();
         benchmark.start();
         System.out.println(benchmark.simple());
         System.out.println(benchmark.empty());
         benchmark.stop();
-    }
+    }*/
 }

--- a/grpc/src/jmh/java/com/linecorp/armeria/grpc/downstream/DownstreamSimpleBenchmark.java
+++ b/grpc/src/jmh/java/com/linecorp/armeria/grpc/downstream/DownstreamSimpleBenchmark.java
@@ -73,11 +73,11 @@ public class DownstreamSimpleBenchmark extends SimpleBenchmarkBase {
         server.stop().join();
     }
 
-    /*public static void main(String[] args) throws Exception {
-        DownstreamSimpleBenchmark benchmark = new DownstreamSimpleBenchmark();
-        benchmark.start();
-        System.out.println(benchmark.simple());
-        System.out.println(benchmark.empty());
-        benchmark.stop();
-    }*/
+    // public static void main(String[] args) throws Exception {
+    //     DownstreamSimpleBenchmark benchmark = new DownstreamSimpleBenchmark();
+    //     benchmark.start();
+    //     System.out.println(benchmark.simple());
+    //     System.out.println(benchmark.empty());
+    //     benchmark.stop();
+    // }
 }

--- a/grpc/src/jmh/java/com/linecorp/armeria/grpc/shared/ClientType.java
+++ b/grpc/src/jmh/java/com/linecorp/armeria/grpc/shared/ClientType.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.grpc.shared;
+
+public enum ClientType {
+    // The official client for the benchmark (armeria for downstream, grpc-netty for upstream).
+    NORMAL,
+    // The grpc-okhttp client.
+    OKHTTP;
+}

--- a/grpc/src/jmh/java/com/linecorp/armeria/grpc/shared/SimpleBenchmarkBase.java
+++ b/grpc/src/jmh/java/com/linecorp/armeria/grpc/shared/SimpleBenchmarkBase.java
@@ -117,7 +117,7 @@ public abstract class SimpleBenchmarkBase {
     private GithubServiceFutureStub githubApiOkhttpFutureClient;
 
     @Param
-    public ClientType clientType = ClientType.NORMAL;
+    private ClientType clientType;
 
     @Setup
     public void start() throws Exception {

--- a/grpc/src/jmh/java/com/linecorp/armeria/grpc/shared/SimpleBenchmarkBase.java
+++ b/grpc/src/jmh/java/com/linecorp/armeria/grpc/shared/SimpleBenchmarkBase.java
@@ -81,7 +81,7 @@ public abstract class SimpleBenchmarkBase {
         @TearDown(Level.Iteration)
         public void waitForCurrentRequests() {
             waiting = true;
-            await().until(() -> currentRequests.get() == 0);
+            await().forever().until(() -> currentRequests.get() == 0);
         }
     }
 

--- a/grpc/src/jmh/java/com/linecorp/armeria/grpc/shared/SimpleBenchmarkBase.java
+++ b/grpc/src/jmh/java/com/linecorp/armeria/grpc/shared/SimpleBenchmarkBase.java
@@ -88,29 +88,29 @@ public abstract class SimpleBenchmarkBase {
     /**
      * The port the benchmark's server is listening on.
      */
-    abstract protected int port();
+    protected abstract int port();
 
     /**
      * The normal {@link GithubServiceBlockingStub} for the benchmark. The okhttp version will be set up in this
      * class as it's the same for both upstream and downstream.
      */
-    abstract protected GithubServiceBlockingStub normalClient();
+    protected abstract GithubServiceBlockingStub normalClient();
 
     /**
      * The normal {@link GithubServiceFutureStub} for the benchmark. The okhttp version will be set up in this
      * class as it's the same for both upstream and downstream.
      */
-    abstract protected GithubServiceFutureStub normalFutureClient();
+    protected abstract GithubServiceFutureStub normalFutureClient();
 
     /**
      * Benchmark initialization logic.
      */
-    abstract protected void setUp() throws Exception;
+    protected abstract void setUp() throws Exception;
 
     /**
      * Benchmark teardown logic.
      */
-    abstract protected void tearDown() throws Exception;
+    protected abstract void tearDown() throws Exception;
 
     private ManagedChannel okhttpChannel;
     private GithubServiceBlockingStub githubApiOkhttpClient;

--- a/grpc/src/jmh/java/com/linecorp/armeria/grpc/shared/SimpleBenchmarkBase.java
+++ b/grpc/src/jmh/java/com/linecorp/armeria/grpc/shared/SimpleBenchmarkBase.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.grpc.shared;
+
+import static com.linecorp.armeria.grpc.shared.GithubApiService.SEARCH_RESPONSE;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import javax.annotation.Nullable;
+
+import org.openjdk.jmh.annotations.AuxCounters;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.protobuf.Empty;
+
+import com.linecorp.armeria.benchmarks.GithubApi.SearchResponse;
+import com.linecorp.armeria.benchmarks.GithubServiceGrpc;
+import com.linecorp.armeria.benchmarks.GithubServiceGrpc.GithubServiceBlockingStub;
+import com.linecorp.armeria.benchmarks.GithubServiceGrpc.GithubServiceFutureStub;
+
+import io.grpc.ManagedChannel;
+import io.grpc.okhttp.OkHttpChannelBuilder;
+
+@State(Scope.Benchmark)
+public abstract class SimpleBenchmarkBase {
+
+    @AuxCounters
+    @State(Scope.Thread)
+    public static class Counters {
+        AtomicLong numRequests = new AtomicLong();
+        AtomicLong numFailures = new AtomicLong();
+
+        public long numRequests() {
+            return numRequests.get();
+        }
+
+        public long numFailures() {
+            return this.numFailures.get();
+        }
+
+        @Setup(Level.Iteration)
+        public void reset() {
+            numRequests.set(0);
+            numFailures.set(0);
+        }
+    }
+
+    /**
+     * The port the benchmark's server is listening on.
+     */
+    abstract protected int port();
+
+    /**
+     * The normal {@link GithubServiceBlockingStub} for the benchmark. The okhttp version will be set up in this
+     * class as it's the same for both upstream and downstream.
+     */
+    abstract protected GithubServiceBlockingStub normalClient();
+
+    /**
+     * The normal {@link GithubServiceFutureStub} for the benchmark. The okhttp version will be set up in this
+     * class as it's the same for both upstream and downstream.
+     */
+    abstract protected GithubServiceFutureStub normalFutureClient();
+
+    /**
+     * Benchmark initialization logic.
+     */
+    abstract protected void setUp() throws Exception;
+
+    /**
+     * Benchmark teardown logic.
+     */
+    abstract protected void tearDown() throws Exception;
+
+    private ManagedChannel okhttpChannel;
+    private GithubServiceBlockingStub githubApiOkhttpClient;
+    private GithubServiceFutureStub githubApiOkhttpFutureClient;
+
+    @Param
+    public ClientType clientType = ClientType.NORMAL;
+
+    @Setup
+    public void start() throws Exception {
+        setUp();
+        okhttpChannel = OkHttpChannelBuilder.forAddress("127.0.0.1", port())
+                                            .usePlaintext(true)
+                                            .directExecutor()
+                                            .build();
+        githubApiOkhttpClient = GithubServiceGrpc.newBlockingStub(okhttpChannel);
+        githubApiOkhttpFutureClient = GithubServiceGrpc.newFutureStub(okhttpChannel);
+    }
+
+    @TearDown
+    public void stop() throws Exception {
+        okhttpChannel.shutdownNow().awaitTermination(10, TimeUnit.SECONDS);
+        tearDown();
+    }
+
+    @Benchmark
+    public SearchResponse simple() throws Exception {
+        return stub().simple(SEARCH_RESPONSE);
+    }
+
+    @Benchmark
+    public void simpleNonBlocking(Counters counters) throws Exception {
+        Futures.addCallback(
+                futureStub().simple(SEARCH_RESPONSE),
+                counterIncrementingFutureCallback(counters),
+                MoreExecutors.directExecutor());
+    }
+
+    @Benchmark
+    public Empty empty() throws Exception {
+        return stub().empty(Empty.getDefaultInstance());
+    }
+
+    @Benchmark
+    public void emptyNonBlocking(Counters counters) throws Exception {
+        Futures.addCallback(
+                futureStub().empty(Empty.getDefaultInstance()),
+                counterIncrementingFutureCallback(counters),
+                MoreExecutors.directExecutor());
+    }
+
+    private GithubServiceBlockingStub stub() {
+        return clientType == ClientType.NORMAL ? normalClient() : githubApiOkhttpClient;
+    }
+
+    private GithubServiceFutureStub futureStub() {
+        return clientType == ClientType.NORMAL ? normalFutureClient() : githubApiOkhttpFutureClient;
+    }
+
+    private static <T> FutureCallback<T> counterIncrementingFutureCallback(Counters counters) {
+        return new FutureCallback<T>() {
+            @Override
+            public void onSuccess(@Nullable T result) {
+                counters.numRequests.incrementAndGet();
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                counters.numRequests.incrementAndGet();
+                counters.numFailures.incrementAndGet();
+            }
+        };
+    }
+}

--- a/grpc/src/jmh/java/com/linecorp/armeria/grpc/upstream/UpstreamSimpleBenchmark.java
+++ b/grpc/src/jmh/java/com/linecorp/armeria/grpc/upstream/UpstreamSimpleBenchmark.java
@@ -19,9 +19,7 @@ package com.linecorp.armeria.grpc.upstream;
 import java.util.concurrent.TimeUnit;
 
 import org.openjdk.jmh.annotations.Scope;
-import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.TearDown;
 
 import com.linecorp.armeria.benchmarks.GithubServiceGrpc;
 import com.linecorp.armeria.benchmarks.GithubServiceGrpc.GithubServiceBlockingStub;
@@ -57,7 +55,7 @@ public class UpstreamSimpleBenchmark extends SimpleBenchmarkBase {
         return githubApiFutureClient;
     }
 
-    @Setup
+    @Override
     public void setUp() throws Exception {
         server = ServerBuilder.forPort(0)
                               .addService(new GithubApiService())
@@ -72,7 +70,7 @@ public class UpstreamSimpleBenchmark extends SimpleBenchmarkBase {
         githubApiFutureClient = GithubServiceGrpc.newFutureStub(channel);
     }
 
-    @TearDown
+    @Override
     public void tearDown() throws Exception {
         channel.shutdownNow().awaitTermination(10, TimeUnit.SECONDS);
         server.shutdown().awaitTermination();

--- a/grpc/src/jmh/java/com/linecorp/armeria/grpc/upstream/UpstreamSimpleBenchmark.java
+++ b/grpc/src/jmh/java/com/linecorp/armeria/grpc/upstream/UpstreamSimpleBenchmark.java
@@ -16,22 +16,18 @@
 
 package com.linecorp.armeria.grpc.upstream;
 
-import static com.linecorp.armeria.grpc.shared.GithubApiService.SEARCH_RESPONSE;
-
 import java.util.concurrent.TimeUnit;
 
-import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
-import org.openjdk.jmh.infra.Blackhole;
-
-import com.google.protobuf.Empty;
 
 import com.linecorp.armeria.benchmarks.GithubServiceGrpc;
 import com.linecorp.armeria.benchmarks.GithubServiceGrpc.GithubServiceBlockingStub;
+import com.linecorp.armeria.benchmarks.GithubServiceGrpc.GithubServiceFutureStub;
 import com.linecorp.armeria.grpc.shared.GithubApiService;
+import com.linecorp.armeria.grpc.shared.SimpleBenchmarkBase;
 
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
@@ -39,39 +35,46 @@ import io.grpc.Server;
 import io.grpc.ServerBuilder;
 
 @State(Scope.Benchmark)
-public class UpstreamSimpleBenchmark {
+public class UpstreamSimpleBenchmark extends SimpleBenchmarkBase {
 
     private Server server;
     private ManagedChannel channel;
     private GithubServiceBlockingStub githubApiClient;
+    private GithubServiceFutureStub githubApiFutureClient;
+
+    @Override
+    protected int port() {
+        return server.getPort();
+    }
+
+    @Override
+    protected GithubServiceBlockingStub normalClient() {
+        return githubApiClient;
+    }
+
+    @Override
+    protected GithubServiceFutureStub normalFutureClient() {
+        return githubApiFutureClient;
+    }
 
     @Setup
-    public void startServer() throws Exception {
+    public void setUp() throws Exception {
         server = ServerBuilder.forPort(0)
                               .addService(new GithubApiService())
                               .directExecutor()
                               .build();
         server.start();
-        channel = ManagedChannelBuilder.forAddress("127.0.0.1", server.getPort())
+        channel = ManagedChannelBuilder.forAddress("127.0.0.1", port())
                                        .directExecutor()
                                        .usePlaintext(true)
                                        .build();
         githubApiClient = GithubServiceGrpc.newBlockingStub(channel);
+        githubApiFutureClient = GithubServiceGrpc.newFutureStub(channel);
     }
 
     @TearDown
-    public void stopServer() throws Exception {
+    public void tearDown() throws Exception {
+        channel.shutdownNow().awaitTermination(10, TimeUnit.SECONDS);
         server.shutdown().awaitTermination();
-        channel.shutdown().awaitTermination(10, TimeUnit.SECONDS);
-    }
-
-    @Benchmark
-    public void simple(Blackhole bh) throws Exception {
-        bh.consume(githubApiClient.simple(SEARCH_RESPONSE));
-    }
-
-    @Benchmark
-    public void empty(Blackhole bh) throws Exception {
-        bh.consume(githubApiClient.empty(Empty.getDefaultInstance()));
     }
 }

--- a/settings/checkstyle/checkstyle-suppressions.xml
+++ b/settings/checkstyle/checkstyle-suppressions.xml
@@ -17,6 +17,4 @@
   <suppress checks=".*" files="[\\/]gen-java[\\/]" />
   <!-- Suppress checks in large forks to make diffing against upstream easier -->
   <suppress checks=".*" files="[\\/]grpc[\\/]ServerCallImpl.java$" />
-  <!-- Suppress visibility checks for JMH which requires public fields, etc -->
-  <suppress checks="VisibilityModifier" files="[\\/](jmh)[\\/]" />
 </suppressions>

--- a/settings/checkstyle/checkstyle-suppressions.xml
+++ b/settings/checkstyle/checkstyle-suppressions.xml
@@ -17,4 +17,6 @@
   <suppress checks=".*" files="[\\/]gen-java[\\/]" />
   <!-- Suppress checks in large forks to make diffing against upstream easier -->
   <suppress checks=".*" files="[\\/]grpc[\\/]ServerCallImpl.java$" />
+  <!-- Suppress visibility checks for JMH which requires public fields, etc -->
+  <suppress checks="VisibilityModifier" files="[\\/](jmh)[\\/]" />
 </suppressions>


### PR DESCRIPTION
Also refactors more common logic into a base class.

~~While the asynchronous version of the upstream benchmark seemed to be showing awesome performance (2-4x downstream), it doesn't complete since there seems to be a memory leak...~~
After modifying the benchmark to wait for pending requests before moving on, it works. Guess the QPS was high enough to overload the server through multiple iterations.

For #799