### PR TITLE
Add a first pass at matching gRPC content types without parsing, whic…

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
@@ -226,6 +226,18 @@ public final class GrpcService extends AbstractHttpService
             return null;
         }
 
+        for (SerializationFormat format : supportedSerializationFormats) {
+            for (MediaType formatType : format.mediaTypes()) {
+                if (contentType.equals(formatType.toString())) {
+                    return format;
+                }
+            }
+        }
+
+        // It's very unlikely that gRPC content types will be introduced that do not statically match our known
+        // content types, so we only bother properly parsing it if we couldn't find a match. In practice, this
+        // should never happen.
+
         final MediaType mediaType;
         try {
             mediaType = MediaType.parse(contentType);


### PR DESCRIPTION
…h should almost always be enough.

See #799