### PR TITLE
Add a decorator for annotated service methods

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/AbstractVirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AbstractVirtualHostBuilder.java
@@ -352,7 +352,7 @@ abstract class AbstractVirtualHostBuilder<B extends AbstractVirtualHostBuilder> 
 
         final List<AnnotatedHttpService> entries =
                 AnnotatedHttpServices.build(pathPrefix, service, converters);
-        entries.forEach(e -> service(e.pathMapping(), decorator.apply(e)));
+        entries.forEach(e -> service(e.pathMapping(), decorator.apply(e.decorator().apply(e))));
         return self();
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/AnnotatedHttpService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AnnotatedHttpService.java
@@ -20,6 +20,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.concurrent.CompletionStage;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Throwables;
@@ -45,12 +46,21 @@ final class AnnotatedHttpService implements HttpService {
     private final BiFunction<ServiceRequestContext, HttpRequest, Object> function;
 
     /**
+     * A decorator of this service.
+     */
+    private final Function<Service<HttpRequest, HttpResponse>,
+            ? extends Service<HttpRequest, HttpResponse>> decorator;
+
+    /**
      * Creates a new instance.
      */
     AnnotatedHttpService(HttpHeaderPathMapping pathMapping,
-                         BiFunction<ServiceRequestContext, HttpRequest, Object> function) {
+                         BiFunction<ServiceRequestContext, HttpRequest, Object> function,
+                         Function<Service<HttpRequest, HttpResponse>,
+                                 ? extends Service<HttpRequest, HttpResponse>> decorator) {
         this.pathMapping = requireNonNull(pathMapping, "pathMapping");
         this.function = requireNonNull(function, "function");
+        this.decorator = requireNonNull(decorator, "decorator");
     }
 
     /**
@@ -58,6 +68,14 @@ final class AnnotatedHttpService implements HttpService {
      */
     HttpHeaderPathMapping pathMapping() {
         return pathMapping;
+    }
+
+    /**
+     * Returns the decorator of this service.
+     */
+    Function<Service<HttpRequest, HttpResponse>,
+            ? extends Service<HttpRequest, HttpResponse>> decorator() {
+        return decorator;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/AnnotatedHttpServiceMethod.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AnnotatedHttpServiceMethod.java
@@ -80,6 +80,8 @@ final class AnnotatedHttpServiceMethod implements BiFunction<ServiceRequestConte
         isAsynchronous = HttpResponse.class.isAssignableFrom(returnType) ||
                          CompletionStage.class.isAssignableFrom(returnType);
         aggregationStrategy = AggregationStrategy.resolve(parameters);
+
+        this.method.setAccessible(true);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/Decorate.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/Decorate.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.server.DecoratingServiceFunction;
+
+/**
+ * Specifies {@link DecoratingServiceFunction} classes which handle a {@link HttpRequest} before invoking
+ * an annotated service method.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Decorate {
+
+    /**
+     * An array of the {@link DecoratingServiceFunction} classes. Each class specified in the {@code value}
+     * must have an accessible default constructor.
+     */
+    Class<? extends DecoratingServiceFunction<HttpRequest, HttpResponse>>[] value();
+}

--- a/core/src/test/java/com/linecorp/armeria/server/AnnotatedHttpServiceDecorationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/AnnotatedHttpServiceDecorationTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static com.linecorp.armeria.server.AnnotatedHttpServiceTest.validateContextAndRequest;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+
+import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.server.TestConverters.UnformattedStringConverter;
+import com.linecorp.armeria.server.annotation.Converter;
+import com.linecorp.armeria.server.annotation.Decorate;
+import com.linecorp.armeria.server.annotation.Get;
+import com.linecorp.armeria.server.logging.LoggingService;
+import com.linecorp.armeria.testing.server.ServerRule;
+
+public class AnnotatedHttpServiceDecorationTest {
+
+    @ClassRule
+    public static final ServerRule rule = new ServerRule() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.annotatedService("/1", new MyDecorationService1(),
+                                LoggingService.newDecorator());
+
+            sb.annotatedService("/2", new MyDecorationService2(),
+                                LoggingService.newDecorator());
+        }
+    };
+
+    @Rule
+    public TestWatcher watchman = new TestWatcher() {
+        @Override
+        protected void failed(Throwable e, Description description) {
+            rule.server().config().virtualHosts().forEach(vh -> vh.router().dump(System.err));
+        }
+    };
+
+    @Converter(target = String.class, value = UnformattedStringConverter.class)
+    public static class MyDecorationService1 {
+
+        @Get("/tooManyRequests")
+        @Decorate(AlwaysTooManyRequestsDecorator.class)
+        public String tooManyRequests(ServiceRequestContext ctx, HttpRequest req) {
+            validateContextAndRequest(ctx, req);
+            return "OK";
+        }
+
+        @Get("/locked")
+        @Decorate({ FallThroughDecorator.class, AlwaysLockedDecorator.class })
+        public String locked(ServiceRequestContext ctx, HttpRequest req) {
+            validateContextAndRequest(ctx, req);
+            return "OK";
+        }
+
+        @Get("/ok")
+        @Decorate(FallThroughDecorator.class)
+        public String ok(ServiceRequestContext ctx, HttpRequest req) {
+            validateContextAndRequest(ctx, req);
+            return "OK";
+        }
+    }
+
+    @Converter(target = String.class, value = UnformattedStringConverter.class)
+    public static class MyDecorationService2 extends MyDecorationService1 {
+
+        @Override
+        @Get("/override")
+        @Decorate(AlwaysTooManyRequestsDecorator.class)
+        public String ok(ServiceRequestContext ctx, HttpRequest req) {
+            validateContextAndRequest(ctx, req);
+            return "OK";
+        }
+
+        @Get("/added")
+        @Decorate(FallThroughDecorator.class)
+        public String added(ServiceRequestContext ctx, HttpRequest req) {
+            validateContextAndRequest(ctx, req);
+            return "OK";
+        }
+    }
+
+    public static final class AlwaysTooManyRequestsDecorator
+            implements DecoratingServiceFunction<HttpRequest, HttpResponse> {
+
+        public AlwaysTooManyRequestsDecorator() {}
+
+        @Override
+        public HttpResponse serve(Service<HttpRequest, HttpResponse> delegate,
+                                  ServiceRequestContext ctx,
+                                  HttpRequest req) throws Exception {
+            validateContextAndRequest(ctx, req);
+            throw new HttpResponseException(HttpStatus.TOO_MANY_REQUESTS);
+        }
+    }
+
+    static final class AlwaysLockedDecorator
+            implements DecoratingServiceFunction<HttpRequest, HttpResponse> {
+
+        AlwaysLockedDecorator() {}
+
+        @Override
+        public HttpResponse serve(Service<HttpRequest, HttpResponse> delegate,
+                                  ServiceRequestContext ctx,
+                                  HttpRequest req) throws Exception {
+            validateContextAndRequest(ctx, req);
+            return HttpResponse.of(HttpStatus.LOCKED);
+        }
+    }
+
+    private static final class FallThroughDecorator
+            implements DecoratingServiceFunction<HttpRequest, HttpResponse> {
+
+        private FallThroughDecorator() {}
+
+        @Override
+        public HttpResponse serve(Service<HttpRequest, HttpResponse> delegate,
+                                  ServiceRequestContext ctx,
+                                  HttpRequest req) throws Exception {
+            validateContextAndRequest(ctx, req);
+            return delegate.serve(ctx, req);
+        }
+    }
+
+    @Test
+    public void testDecoratingAnnotatedService() throws Exception {
+        final HttpClient client = HttpClient.of(rule.uri("/"));
+
+        AggregatedHttpMessage response;
+
+        response = client.execute(HttpHeaders.of(HttpMethod.GET, "/1/ok")).aggregate().get();
+        assertThat(response.headers().status(), is(HttpStatus.OK));
+
+        response = client.execute(HttpHeaders.of(HttpMethod.GET, "/1/tooManyRequests")).aggregate().get();
+        assertThat(response.headers().status(), is(HttpStatus.TOO_MANY_REQUESTS));
+
+        response = client.execute(HttpHeaders.of(HttpMethod.GET, "/1/locked")).aggregate().get();
+        assertThat(response.headers().status(), is(HttpStatus.LOCKED));
+
+        // Call inherited methods.
+        response = client.execute(HttpHeaders.of(HttpMethod.GET, "/2/tooManyRequests")).aggregate().get();
+        assertThat(response.headers().status(), is(HttpStatus.TOO_MANY_REQUESTS));
+
+        response = client.execute(HttpHeaders.of(HttpMethod.GET, "/2/locked")).aggregate().get();
+        assertThat(response.headers().status(), is(HttpStatus.LOCKED));
+
+        // Call a new method.
+        response = client.execute(HttpHeaders.of(HttpMethod.GET, "/2/added")).aggregate().get();
+        assertThat(response.headers().status(), is(HttpStatus.OK));
+
+        // Call an overriding method.
+        response = client.execute(HttpHeaders.of(HttpMethod.GET, "/2/override")).aggregate().get();
+        assertThat(response.headers().status(), is(HttpStatus.TOO_MANY_REQUESTS));
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/AnnotatedHttpServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/AnnotatedHttpServiceTest.java
@@ -578,12 +578,12 @@ public class AnnotatedHttpServiceTest {
             // Exact pattern
             testBody(hc, get("/6/exact"), "String[exact:/6/exact]");
             // Prefix pattern
-            testBody(hc, get("/6/prefix/foo"),  "String[prefix:/6/prefix/foo:/foo]");
+            testBody(hc, get("/6/prefix/foo"), "String[prefix:/6/prefix/foo:/foo]");
             // Glob pattern
-            testBody(hc, get("/6/glob1/bar"),  "String[glob1:/6/glob1/bar]");
-            testBody(hc, get("/6/baz/glob2"),  "String[glob2:/6/baz/glob2:0]");
+            testBody(hc, get("/6/glob1/bar"), "String[glob1:/6/glob1/bar]");
+            testBody(hc, get("/6/baz/glob2"), "String[glob2:/6/baz/glob2:0]");
             // Regex pattern
-            testBody(hc, get("/6/regex/foo/bar"),  "String[regex:/6/regex/foo/bar:foo/bar]");
+            testBody(hc, get("/6/regex/foo/bar"), "String[regex:/6/regex/foo/bar:foo/bar]");
         }
     }
 
@@ -647,7 +647,7 @@ public class AnnotatedHttpServiceTest {
             testBodyAndContentType(hc, post(uri, "application/json"),
                                    "POST/JSON/BOTH", "application/json");
 
-            testBody(hc, post(uri),"POST");
+            testBody(hc, post(uri), "POST");
 
             // No match on 'Accept' header list.
             testStatusCode(hc, post(uri, null, "application/json"), 406);
@@ -696,43 +696,43 @@ public class AnnotatedHttpServiceTest {
         }
     }
 
-    private static void testBodyAndContentType(CloseableHttpClient hc, HttpRequestBase req,
-                                               String body, String contentType) throws IOException {
+    static void testBodyAndContentType(CloseableHttpClient hc, HttpRequestBase req,
+                                       String body, String contentType) throws IOException {
         try (CloseableHttpResponse res = hc.execute(req)) {
             checkResult(res, 200, body, null, contentType);
         }
     }
 
-    private static void testBody(CloseableHttpClient hc, HttpRequestBase req,
-                                 String body) throws IOException {
+    static void testBody(CloseableHttpClient hc, HttpRequestBase req,
+                         String body) throws IOException {
         testBody(hc, req, body, null);
     }
 
-    private static void testBody(CloseableHttpClient hc, HttpRequestBase req,
-                                 String body, @Nullable Charset encoding) throws IOException {
+    static void testBody(CloseableHttpClient hc, HttpRequestBase req,
+                         String body, @Nullable Charset encoding) throws IOException {
         try (CloseableHttpResponse res = hc.execute(req)) {
             checkResult(res, 200, body, encoding, null);
         }
     }
 
-    private static void testStatusCode(CloseableHttpClient hc, HttpRequestBase req,
-                                       int statusCode) throws IOException {
+    static void testStatusCode(CloseableHttpClient hc, HttpRequestBase req,
+                               int statusCode) throws IOException {
         try (CloseableHttpResponse res = hc.execute(req)) {
             checkResult(res, statusCode, null, null, null);
         }
     }
 
-    private static void testForm(CloseableHttpClient hc, HttpPost req) throws IOException {
+    static void testForm(CloseableHttpClient hc, HttpPost req) throws IOException {
         try (CloseableHttpResponse res = hc.execute(req)) {
             checkResult(res, 200, EntityUtils.toString(req.getEntity()), null, null);
         }
     }
 
-    private static void checkResult(org.apache.http.HttpResponse res,
-                                    int statusCode,
-                                    @Nullable String body,
-                                    @Nullable Charset encoding,
-                                    @Nullable String contentType) throws IOException {
+    static void checkResult(org.apache.http.HttpResponse res,
+                            int statusCode,
+                            @Nullable String body,
+                            @Nullable Charset encoding,
+                            @Nullable String contentType) throws IOException {
         final HttpStatus status = HttpStatus.valueOf(statusCode);
         assertThat(res.getStatusLine().toString(), is("HTTP/1.1 " + status));
         if (body != null) {
@@ -753,31 +753,31 @@ public class AnnotatedHttpServiceTest {
         }
     }
 
-    private static HttpRequestBase get(String uri) {
+    static HttpRequestBase get(String uri) {
         return request(HttpMethod.GET, uri, null, null);
     }
 
-    private static HttpRequestBase get(String uri, String accept) {
+    static HttpRequestBase get(String uri, String accept) {
         return request(HttpMethod.GET, uri, null, accept);
     }
 
-    private static HttpRequestBase post(String uri) {
+    static HttpRequestBase post(String uri) {
         return request(HttpMethod.POST, uri, null, null);
     }
 
-    private static HttpRequestBase post(String uri, String contentType) {
+    static HttpRequestBase post(String uri, String contentType) {
         return request(HttpMethod.POST, uri, contentType, null);
     }
 
-    private static HttpRequestBase post(String uri, String contentType, String accept) {
+    static HttpRequestBase post(String uri, String contentType, String accept) {
         return request(HttpMethod.POST, uri, contentType, accept);
     }
 
-    private static HttpPost form(String uri) {
+    static HttpPost form(String uri) {
         return form(uri, null, "armeria", "armeria");
     }
 
-    private static HttpPost form(String uri, Charset charset, String... kv) {
+    static HttpPost form(String uri, Charset charset, String... kv) {
         final HttpPost req = (HttpPost) request(HttpMethod.POST, uri, MediaType.FORM_DATA.toString());
 
         final List<NameValuePair> params = new ArrayList<>();
@@ -791,11 +791,11 @@ public class AnnotatedHttpServiceTest {
         return req;
     }
 
-    private static HttpRequestBase request(HttpMethod method, String uri, String contentType) {
+    static HttpRequestBase request(HttpMethod method, String uri, String contentType) {
         return request(method, uri, contentType, null);
     }
 
-    private static HttpRequestBase request(HttpMethod method, String uri, String contentType, String accept) {
+    static HttpRequestBase request(HttpMethod method, String uri, String contentType, String accept) {
         final HttpRequestBase req;
         switch (method) {
             case GET:
@@ -816,13 +816,13 @@ public class AnnotatedHttpServiceTest {
         return req;
     }
 
-    private static void validateContext(RequestContext ctx) {
+    static void validateContext(RequestContext ctx) {
         if (RequestContext.current() != ctx) {
             throw new RuntimeException("ServiceRequestContext instances are not same!");
         }
     }
 
-    private static void validateContextAndRequest(RequestContext ctx, Object req) {
+    static void validateContextAndRequest(RequestContext ctx, Object req) {
         validateContext(ctx);
         if (RequestContext.current().request() != req) {
             throw new RuntimeException("HttpRequest instances are not same!");


### PR DESCRIPTION
Motivation:
Currently there is no way to decorate a single annotated service method when an annotated service object is added by ServerBuilder#annotatedService method.

Modifications:
- Add `@Decorate` annotation to specify decorators for an annotated service method
- Use DecoratingServiceFunction and FunctionalDecoratingService to decorate the method

Result:
A user can use a decorator easily by specifying annotations over annotated service method implementations.