### PR TITLE
Provide a way to inject HTTP request headers to annotated services

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/HttpHeaderNames.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpHeaderNames.java
@@ -281,6 +281,10 @@ public final class HttpHeaderNames {
      */
     public static final AsciiString PRAGMA = new AsciiString("pragma");
     /**
+     * {@code "prefer"}.
+     */
+    public static final AsciiString PREFER = new AsciiString("prefer");
+    /**
      * {@code "proxy-authenticate"}.
      */
     public static final AsciiString PROXY_AUTHENTICATE = new AsciiString("proxy-authenticate");

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/Header.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/Header.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation for mapping an HTTP request header onto a method parameter.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface Header {
+
+    /**
+     * The name of the HTTP request header to bind to.
+     */
+    String value();
+}


### PR DESCRIPTION
Motivation:
There's no way to get the value of the specific HTTP request header using annotated services.

Modifications:
- Add the `Header` annotation to represent a HTTP request header in annotated services.

Result:
- Can close #708
- Can implement the watcher in Central Dogma!!!