### PR TITLE
Add CentralDogma base EndpointGroup

### DIFF
--- a/centraldogma/build.gradle
+++ b/centraldogma/build.gradle
@@ -1,0 +1,4 @@
+managedDependencies {
+    compile 'com.linecorp.centraldogma:centraldogma-client'
+    testCompile 'com.linecorp.centraldogma:centraldogma-testing'
+}

--- a/centraldogma/src/main/java/com/linecorp/armeria/client/centraldogma/CentralDogmaEndpointGroup.java
+++ b/centraldogma/src/main/java/com/linecorp/armeria/client/centraldogma/CentralDogmaEndpointGroup.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client.centraldogma;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.endpoint.DynamicEndpointGroup;
+import com.linecorp.armeria.client.endpoint.EndpointGroup;
+import com.linecorp.armeria.common.centraldogma.CentralDogmaCodec;
+import com.linecorp.armeria.common.centraldogma.CentralDogmaEndpointException;
+import com.linecorp.centraldogma.client.CentralDogma;
+import com.linecorp.centraldogma.client.Watcher;
+import com.linecorp.centraldogma.common.Query;
+import com.linecorp.centraldogma.common.Revision;
+
+/**
+ * A CentralDogma based {@link EndpointGroup} implementation. This {@link EndpointGroup} retrieves the list of
+ * {@link Endpoint}s from a route file served by CentralDogma, and update the list when upstream data changes.
+ * Route file could be json file or normal text file.
+ *
+ * <p>In below example, json file with below content will be served as route file:
+ *
+ * <pre>{@code
+ *  [
+ *      "host1:port1",
+ *      "host2:port2",
+ *      "host3:port3"
+ *  ]
+ * }
+ * </pre>
+ *
+ * <p>The route file could be retrieve as {@link EndpointGroup} using below code:
+ *
+ * <pre>{@code
+ *  CentralDogmaEndpointGroup<JsonNode> endpointGroup = new CentralDogmaEndpointGroup(
+ *      "tbinary+http://localhost:36462/cd/thrift/v1",
+ *      "myProject", "myRepo",
+ *      entralDogmaCodec.DEFAULT_JSON_CODEC,
+ *      Query.ofJsonPath("/route.json")
+ *  )
+ *  endpointGroup.endpoints();
+ * }
+ * </pre>
+ * @param <T> Type of CentralDomgma file (could be JsonNode or String)
+ */
+public final class CentralDogmaEndpointGroup<T> extends DynamicEndpointGroup {
+
+    private final CentralDogma dogmaClient;
+    private final Watcher<T> dogmaWatcher;
+    private final CentralDogmaCodec<T> dogmaCodec;
+    private Revision latestRev;
+
+    /**
+     * Creates a new {@link CentralDogmaEndpointGroup}.
+     * @param uri an uri of CentralDogma server
+     * @param dogmaProject CentralDogma project name
+     * @param dogmaRepo CentralDogma repository name
+     * @param dogmaCodec A {@link CentralDogmaCodec}
+     * @param dogmaQuery A {@link Query} to route file
+     */
+    public CentralDogmaEndpointGroup(String uri, String dogmaProject,
+                                     String dogmaRepo, CentralDogmaCodec<T> dogmaCodec,
+                                     Query<T> dogmaQuery) {
+        this(CentralDogma.newClient(uri), dogmaProject, dogmaRepo, dogmaCodec, dogmaQuery);
+    }
+
+    /**
+     * Creates a new {@link CentralDogmaEndpointGroup}.
+     * @param uri an uri of CentralDogma server
+     * @param dogmaProject CentralDogma project name
+     * @param dogmaRepo CentralDogma repository name
+     * @param dogmaCodec A {@link CentralDogmaCodec}
+     * @param dogmaQuery A {@link Query} to route file
+     * @param waitTime a {@code long} define how long we should wait for initial result
+     * @param waitUnit a {@link TimeUnit} define unit of wait time
+     * @throws CentralDogmaEndpointException if couldn't get initial result from CentralDogma server
+     */
+    public CentralDogmaEndpointGroup(String uri, String dogmaProject,
+                                     String dogmaRepo, CentralDogmaCodec<T> dogmaCodec,
+                                     Query<T> dogmaQuery, long waitTime, TimeUnit waitUnit)
+            throws CentralDogmaEndpointException {
+        this(CentralDogma.newClient(uri), dogmaProject, dogmaRepo, dogmaCodec, dogmaQuery, waitTime, waitUnit);
+    }
+
+    /**
+     * Creates a new {@link CentralDogmaEndpointGroup}.
+     * @param dogmaClient A {@link CentralDogma} client
+     * @param dogmaProject CentralDogma project name
+     * @param dogmaRepo CentralDogma repository name
+     * @param dogmaCodec A {@link CentralDogmaCodec}
+     * @param dogmaQuery A {@link Query} to route file
+     */
+    public CentralDogmaEndpointGroup(CentralDogma dogmaClient, String dogmaProject,
+                                     String dogmaRepo, CentralDogmaCodec<T> dogmaCodec,
+                                     Query<T> dogmaQuery) {
+        requireNonNull(dogmaProject);
+        requireNonNull(dogmaRepo);
+        this.dogmaClient = requireNonNull(dogmaClient, "dogmaClient");
+        this.dogmaCodec = requireNonNull(dogmaCodec);
+        dogmaWatcher = this.dogmaClient.fileWatcher(dogmaProject, dogmaRepo, dogmaQuery);
+        dogmaWatcher.watch((T x) -> {
+            setEndpoints(dogmaCodec.decode(x));
+        });
+    }
+
+    /**
+     * Creates a new {@link CentralDogmaEndpointGroup}.
+     * @param dogmaClient A {@link CentralDogma} client
+     * @param dogmaProject CentralDogma project name
+     * @param dogmaRepo CentralDogma repository name
+     * @param dogmaCodec A {@link CentralDogmaCodec}
+     * @param dogmaQuery A {@link Query} to route file
+     * @param waitTime a {@code long} define how long we should wait for initial result
+     * @param waitUnit a {@link TimeUnit} define unit of wait time
+     * @throws CentralDogmaEndpointException if couldn't get initial result from CentralDogma server
+     */
+    public CentralDogmaEndpointGroup(CentralDogma dogmaClient, String dogmaProject,
+                                     String dogmaRepo, CentralDogmaCodec<T> dogmaCodec,
+                                     Query<T> dogmaQuery, long waitTime, TimeUnit waitUnit)
+            throws CentralDogmaEndpointException {
+        this(dogmaClient, dogmaProject, dogmaRepo, dogmaCodec, dogmaQuery);
+        doWait(waitTime, waitUnit);
+    }
+
+    private void doWait(long waitTime, TimeUnit waitUnit) throws CentralDogmaEndpointException {
+        try {
+            this.dogmaWatcher.awaitInitialValue(waitTime, waitUnit);
+        } catch (InterruptedException | TimeoutException e) {
+            throw new CentralDogmaEndpointException(e);
+        }
+    }
+
+    @Override
+    public void close() {
+        dogmaWatcher.close();
+    }
+}

--- a/centraldogma/src/main/java/com/linecorp/armeria/client/centraldogma/package-info.java
+++ b/centraldogma/src/main/java/com/linecorp/armeria/client/centraldogma/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * CentralDogma-based {@link com.linecorp.armeria.client.endpoint.EndpointGroup} implementation.
+ */
+package com.linecorp.armeria.client.centraldogma;

--- a/centraldogma/src/main/java/com/linecorp/armeria/common/centraldogma/CentralDogmaCodec.java
+++ b/centraldogma/src/main/java/com/linecorp/armeria/common/centraldogma/CentralDogmaCodec.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common.centraldogma;
+
+import java.util.List;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import com.linecorp.armeria.client.Endpoint;
+
+/**
+ * Decode and encode between CentralDogma upstream file content and list of {@link Endpoint}s.
+ * @param <T> Type of CentralDomgma file (could be JsonNode or String)
+ */
+public interface CentralDogmaCodec<T> {
+
+    /**
+     * Default {@link CentralDogmaCodec} implementation for JsonNode object.
+     * Retrive object must be a json array (which has format as "[ \"segment1\", \"segment2\" ]"
+     * Each segment represents an endpoint whose format is
+     * {@code <host>[:<port_number>[:weight]]}, such as:
+     * <ul>
+     *   <li>{@code "foo.com"} - default port number, default weight (1000)</li>
+     *   <li>{@code "bar.com:8080} - port number 8080, default weight (1000)</li>
+     *   <li>{@code "10.0.2.15:0:500} - default port number, weight 500</li>
+     *   <li>{@code "192.168.1.2:8443:700} - port number 8443, weight 700</li>
+     * </ul>
+     * Note that the port number must be specified when you want to specify the weight.
+     */
+    CentralDogmaCodec<JsonNode> DEFAULT_JSON_CODEC = new DefaultCentralDogmaJsonCodec();
+
+    /**
+     * Default {@link CentralDogmaCodec} implementation for String object.
+     * Retrive object must be a string which is a list of segments separated by newline.
+     * Each segment represents an endpoint whose format is
+     * {@code <host>[:<port_number>[:weight]]}, such as:
+     * <ul>
+     *   <li>{@code "foo.com"} - default port number, default weight (1000)</li>
+     *   <li>{@code "bar.com:8080} - port number 8080, default weight (1000)</li>
+     *   <li>{@code "10.0.2.15:0:500} - default port number, weight 500</li>
+     *   <li>{@code "192.168.1.2:8443:700} - port number 8443, weight 700</li>
+     * </ul>
+     * Note that the port number must be specified when you want to specify the weight.
+     */
+    CentralDogmaCodec<String> DEFAULT_STRING_CODEC = new DefaultCentralDogmaTextCodec();
+
+    /**
+     * Decode an object into a set of {@link Endpoint}s.
+     * @param object An object retrieve from CentralDogma (could be JsonNode or String)
+     * @return the list of {@link Endpoint}s
+     */
+    List<Endpoint> decode(T object);
+
+    /**
+     * Encode a set of {@link Endpoint}s into an object.
+     * @param endpoints set of {@link Endpoint}s
+     * @return An object that could be pushed to CentralDogma server
+     */
+    T encode(List<Endpoint> endpoints);
+}

--- a/centraldogma/src/main/java/com/linecorp/armeria/common/centraldogma/CentralDogmaEndpointException.java
+++ b/centraldogma/src/main/java/com/linecorp/armeria/common/centraldogma/CentralDogmaEndpointException.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common.centraldogma;
+
+/**
+ * An exception used in CentralDogma communication.
+ */
+public class CentralDogmaEndpointException extends Exception {
+    private static final long serialVersionUID = 8514828772678626593L;
+
+    public CentralDogmaEndpointException() {
+    }
+
+    public CentralDogmaEndpointException(String message) {
+        super(message);
+    }
+
+    public CentralDogmaEndpointException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public CentralDogmaEndpointException(Throwable cause) {
+        super(cause);
+    }
+
+    public CentralDogmaEndpointException(String message, Throwable cause, boolean enableSuppression,
+                                         boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/centraldogma/src/main/java/com/linecorp/armeria/common/centraldogma/CodecUtil.java
+++ b/centraldogma/src/main/java/com/linecorp/armeria/common/centraldogma/CodecUtil.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common.centraldogma;
+
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.endpoint.EndpointGroupException;
+
+final class CodecUtil {
+
+    static final String fieldDelimiter = ":";
+    static final String segmentDelimiter = System.lineSeparator();
+
+    private CodecUtil() {}
+
+    static String endpointToString(Endpoint endpoint) {
+        return endpoint.host() + fieldDelimiter + endpoint.port() + fieldDelimiter + endpoint.weight();
+    }
+
+    static Endpoint endpointFromString(String segment) {
+        final String[] tokens = segment.split(fieldDelimiter);
+        final Endpoint endpoint;
+
+        switch (tokens.length) {
+            case 1: //host
+                endpoint = Endpoint.of(segment);
+                break;
+            case 2: { //host and port
+                final String host = tokens[0];
+                final int port = Integer.parseInt(tokens[1]);
+                if (port == 0) {
+                    endpoint = Endpoint.of(host);
+                } else {
+                    endpoint = Endpoint.of(host, port);
+                }
+                break;
+            }
+            case 3: { //host , port , weight
+                final String host = tokens[0];
+                final int port = Integer.parseInt(tokens[1]);
+                final int weight = Integer.parseInt(tokens[2]);
+                if (port == 0) {
+                    endpoint = Endpoint.of(host).withWeight(weight);
+                } else {
+                    endpoint = Endpoint.of(host, port, weight);
+                }
+                break;
+            }
+            default: //unknown
+                throw new EndpointGroupException(
+                        "invalid endpoint list: " + segment);
+        }
+        return endpoint;
+    }
+}

--- a/centraldogma/src/main/java/com/linecorp/armeria/common/centraldogma/DefaultCentralDogmaJsonCodec.java
+++ b/centraldogma/src/main/java/com/linecorp/armeria/common/centraldogma/DefaultCentralDogmaJsonCodec.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common.centraldogma;
+
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import com.linecorp.armeria.client.Endpoint;
+
+class DefaultCentralDogmaJsonCodec implements CentralDogmaCodec<JsonNode> {
+    private static final ObjectMapper objectMapper =
+            new ObjectMapper().disable(FAIL_ON_UNKNOWN_PROPERTIES);
+
+    @Override
+    public List<Endpoint> decode(JsonNode jsonNodes) {
+        try {
+            List<String> nodes = objectMapper.treeToValue(jsonNodes, List.class);
+            return nodes.stream()
+                    .map(String::trim)
+                    .map(CodecUtil::endpointFromString).collect(Collectors.toList());
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public JsonNode encode(List<Endpoint> endpoints) {
+        List<String> endpointStr = endpoints.stream()
+                                                .map(CodecUtil::endpointToString)
+                                                .collect(Collectors.toList());
+        return objectMapper.valueToTree(endpointStr);
+    }
+}

--- a/centraldogma/src/main/java/com/linecorp/armeria/common/centraldogma/DefaultCentralDogmaTextCodec.java
+++ b/centraldogma/src/main/java/com/linecorp/armeria/common/centraldogma/DefaultCentralDogmaTextCodec.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common.centraldogma;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.linecorp.armeria.client.Endpoint;
+
+class DefaultCentralDogmaTextCodec implements CentralDogmaCodec<String> {
+
+    @Override
+    public List<Endpoint> decode(String content) {
+        String[] lines = content.split(CodecUtil.segmentDelimiter);
+        return Arrays.stream(lines)
+                     .map(String::trim)
+                     .map(CodecUtil::endpointFromString)
+                     .collect(Collectors.toList());
+    }
+
+    @Override
+    public String encode(List<Endpoint> endpoints) {
+        return String.join(CodecUtil.segmentDelimiter,
+                endpoints.stream().map(CodecUtil::endpointToString)
+                 .collect(Collectors.toList()));
+    }
+}

--- a/centraldogma/src/main/java/com/linecorp/armeria/common/centraldogma/package-info.java
+++ b/centraldogma/src/main/java/com/linecorp/armeria/common/centraldogma/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * CentralDogma-based {@link com.linecorp.armeria.client.endpoint.EndpointGroup} implementation.
+ */
+package com.linecorp.armeria.common.centraldogma;

--- a/centraldogma/src/test/java/com/linecorp/armeria/client/centraldogma/CentralDogmaEndpointGroupTest.java
+++ b/centraldogma/src/test/java/com/linecorp/armeria/client/centraldogma/CentralDogmaEndpointGroupTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client.centraldogma;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.common.centraldogma.CentralDogmaCodec;
+import com.linecorp.centraldogma.client.CentralDogma;
+import com.linecorp.centraldogma.common.Author;
+import com.linecorp.centraldogma.common.Change;
+import com.linecorp.centraldogma.common.Query;
+import com.linecorp.centraldogma.common.Revision;
+import com.linecorp.centraldogma.testing.CentralDogmaRule;
+
+public class CentralDogmaEndpointGroupTest {
+
+    @ClassRule
+    public static final CentralDogmaRule dogma = new CentralDogmaRule() {
+        @Override
+        protected void scaffold(CentralDogma client) {
+            client.createProject("a").join();
+            client.createRepository("a", "b").join();
+        }
+    };
+
+    @Test
+    public void testJson() throws Exception {
+        dogma.client().push("a", "b", Revision.HEAD, Author.SYSTEM, "Add route.json",
+                    Change.ofJsonUpsert("/route.json",
+                                        '[' +
+                                            "\"foo.com:9999\" ," +
+                                            "\"bar.com:1234:1234\" ," +
+                                            "\"foo.bar:11111:3333\"" +
+                                        ']'))
+              .join();
+
+        CentralDogmaEndpointGroup<JsonNode> eg = new CentralDogmaEndpointGroup(
+                dogma.client(), "a", "b",
+                CentralDogmaCodec.DEFAULT_JSON_CODEC,
+                Query.identity("/route.json"),
+                2, TimeUnit.SECONDS
+        );
+
+        assertThat(eg.endpoints()).containsExactlyInAnyOrder(
+                Endpoint.of("foo.com", 9999),
+                Endpoint.of("bar.com", 1234, 1234),
+                Endpoint.of("foo.bar", 11111, 3333)
+        );
+
+        eg.close();
+    }
+
+    @Test
+    public void testText() throws Exception {
+        dogma.client().push("a", "b", Revision.HEAD, Author.SYSTEM, "Add route.txt",
+                    Change.ofTextUpsert("/route.txt",
+                                            "localhost:9999 \n" +
+                                            "localhost:1234:1234 \n" +
+                                            "localhost:11111:3333"))
+              .join();
+
+        CentralDogmaEndpointGroup<String> eg = new CentralDogmaEndpointGroup(
+                dogma.client(), "a", "b",
+                CentralDogmaCodec.DEFAULT_STRING_CODEC,
+                Query.identity("/route.txt"),
+                2, TimeUnit.SECONDS
+        );
+
+        assertThat(eg.endpoints()).containsExactlyInAnyOrder(
+                Endpoint.of("localhost", 9999),
+                Endpoint.of("localhost", 1234, 1234),
+                Endpoint.of("localhost", 11111, 3333)
+        );
+
+        eg.close();
+    }
+}

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -214,3 +214,7 @@ org.springframework.boot:
   spring-boot-starter-logging: { version: *SPRING_BOOT_VERSION }
   spring-boot-starter-test: { version: *SPRING_BOOT_VERSION }
   spring-boot-starter-web: { version: *SPRING_BOOT_VERSION }
+
+com.linecorp.centraldogma:
+  centraldogma-client: { version: '0.17.0' }
+  centraldogma-testing: { version: '0.17.0' }

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,6 +16,7 @@ include 'tomcat'
 include 'tomcat8.0'
 include 'zipkin'
 include 'zookeeper'
+include 'centraldogma'
 
 // Unpublished Java projects
 include 'it'


### PR DESCRIPTION
## Motivation
Use single file, or any part of file which served by CentralDogma as EndpointGroup.
I tried to add ServerListener to auto add/remove Endpoint as well, but CentralDogma seems not support atomic operation, so it leads to race condition when multiple armeria servers are woken up at the same time. This conditon leads to very weird state and many unexpected error, so this patch is for read-only operation.

I copied some code from ZooKeeperEndpoint (parser logic) because I can't find any place good for put those logic for reuse.

One more small things that I don't know my patch is enough for publish `armeria-centraldogma` artifacts, if I miss something please leave comments. 

Thanks