### PR TITLE
Make tracing client has remote endpoint information.

### DIFF
--- a/zipkin/src/test/java/com/linecorp/armeria/client/tracing/HttpTracingClientTest.java
+++ b/zipkin/src/test/java/com/linecorp/armeria/client/tracing/HttpTracingClientTest.java
@@ -67,7 +67,14 @@ public class HttpTracingClientTest {
 
     @Test(timeout = 20000)
     public void shouldSubmitSpanWhenSampled() throws Exception {
-        SpanCollectingReporter reporter = testRemoteInvocationWithSamplingRate(1.0f);
+        SpanCollectingReporter reporter = new SpanCollectingReporter();
+
+        Tracing tracing = Tracing.newBuilder()
+                                 .localServiceName(TEST_SERVICE)
+                                 .spanReporter(reporter)
+                                 .sampler(Sampler.create(1.0f))
+                                 .build();
+        testRemoteInvocation(tracing, null);
 
         // check span name
         Span span = reporter.spans().take();
@@ -92,25 +99,55 @@ public class HttpTracingClientTest {
 
         // check service name
         assertThat(span.localServiceName()).isEqualTo(TEST_SERVICE);
+
+        // check remote service name
+        assertThat(span.remoteServiceName()).isEqualTo("localhost");
     }
 
-    @Test
-    public void shouldNotSubmitSpanWhenNotSampled() throws Exception {
-        SpanCollectingReporter reporter = testRemoteInvocationWithSamplingRate(0.0f);
-
-        assertThat(reporter.spans().poll(1, TimeUnit.SECONDS)).isNull();
-    }
-
-    private static SpanCollectingReporter testRemoteInvocationWithSamplingRate(
-            float samplingRate) throws Exception {
-
+    @Test(timeout = 20000)
+    public void shouldSubmitSpanWithCustomRemoteName() throws Exception {
         SpanCollectingReporter reporter = new SpanCollectingReporter();
 
         Tracing tracing = Tracing.newBuilder()
                                  .localServiceName(TEST_SERVICE)
                                  .spanReporter(reporter)
-                                 .sampler(Sampler.create(samplingRate))
+                                 .sampler(Sampler.create(1.0f))
                                  .build();
+        testRemoteInvocation(tracing, "foo");
+
+        // check span name
+        Span span = reporter.spans().take();
+
+        // check tags
+        assertThat(span.tags()).containsAllEntriesOf(ImmutableMap.of(
+                "http.host", "localhost",
+                "http.method", "POST",
+                "http.path", "/hello/armeria",
+                "http.status_code", "200",
+                "http.url", "none+h2c://localhost/hello/armeria"));
+
+        // check service name
+        assertThat(span.localServiceName()).isEqualTo(TEST_SERVICE);
+
+        // check remote service name
+        assertThat(span.remoteServiceName()).isEqualTo("foo");
+    }
+
+    @Test
+    public void shouldNotSubmitSpanWhenNotSampled() throws Exception {
+        SpanCollectingReporter reporter = new SpanCollectingReporter();
+        Tracing tracing = Tracing.newBuilder()
+                                 .localServiceName(TEST_SERVICE)
+                                 .spanReporter(reporter)
+                                 .sampler(Sampler.create(0.0f))
+                                 .build();
+        testRemoteInvocation(tracing, null);
+
+        assertThat(reporter.spans().poll(1, TimeUnit.SECONDS)).isNull();
+    }
+
+    private static void testRemoteInvocation(Tracing tracing, String remoteServiceName)
+            throws Exception {
 
         // prepare parameters
         final HttpRequest req = HttpRequest.of(HttpMethod.POST, "/hello/armeria");
@@ -129,7 +166,7 @@ public class HttpTracingClientTest {
         Client<HttpRequest, HttpResponse> delegate = mock(Client.class);
         when(delegate.execute(any(), any())).thenReturn(res);
 
-        HttpTracingClient stub = new HttpTracingClient(delegate, tracing);
+        HttpTracingClient stub = new HttpTracingClient(delegate, tracing, remoteServiceName);
 
         // do invoke
         HttpResponse actualRes = stub.execute(ctx, req);
@@ -141,7 +178,5 @@ public class HttpTracingClientTest {
         ctx.logBuilder().responseHeaders(HttpHeaders.of(HttpStatus.OK));
         ctx.logBuilder().responseContent(rpcRes, res);
         ctx.logBuilder().endResponse();
-
-        return reporter;
     }
 }


### PR DESCRIPTION
User can decide to add custom service name or using RequestLog#host. Setting remote endpoint make ui looks better(It will show remote name rather than local service name if exists)


--

Should we just using Tracing.current rather than pass in Tracing? I think usually 1 vm should have only 1 Tracing. Because some library like brave.mysql using Tracing#current, so if we use multiple tracing, the service name will be weird.