### PR TITLE
Execute stream callbacks directly when executor is the current event …

### DIFF
--- a/benchmarks/src/jmh/java/com/linecorp/armeria/benchmarks/core/StreamMessageBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/benchmarks/core/StreamMessageBenchmark.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.benchmarks.core;
+
+import java.util.ArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import com.linecorp.armeria.benchmarks.shared.EventLoopJmhExecutor;
+import com.linecorp.armeria.common.stream.DefaultStreamMessage;
+
+import io.netty.channel.DefaultEventLoop;
+import io.netty.channel.EventLoop;
+
+@Fork(jvmArgsAppend = { EventLoopJmhExecutor.JVM_ARG_1, EventLoopJmhExecutor.JVM_ARG_2 })
+@State(Scope.Benchmark)
+public class StreamMessageBenchmark {
+
+    private static final EventLoop ANOTHER_EVENT_LOOP = new DefaultEventLoop();
+
+    @State(Scope.Thread)
+    public static class StreamObjects {
+
+        private final ArrayList<Integer> values = new ArrayList<>();
+
+        @Param({ "3", "5", "20", "100", "1000" })
+        private int num;
+
+        private long sum;
+
+        private SummingSubscriber subscriber;
+
+        private CountDownLatch completedLatch;
+
+        @Setup(Level.Invocation)
+        public void setValues() {
+            completedLatch = new CountDownLatch(1);
+            values.clear();
+            sum = 0;
+            for (int i = 0; i < num; i++) {
+                values.add(i);
+                sum += i;
+            }
+            subscriber = new SummingSubscriber(completedLatch);
+        }
+
+        private long computedSum() {
+            long computedSum = subscriber.sum();
+            if (computedSum != sum) {
+                throw new IllegalStateException(
+                        "Did not compute the expected sum, the stream implementation is broken, expected: " +
+                        sum + ", got: " + computedSum);
+            }
+            return computedSum;
+        }
+    }
+
+    @TearDown(Level.Trial)
+    public void closeEventLoop() {
+        ANOTHER_EVENT_LOOP.shutdownGracefully().syncUninterruptibly();
+    }
+
+    @Benchmark
+    public long defaultStreamMessage_noExecutor(StreamObjects streamObjects) {
+        DefaultStreamMessage<Integer> stream = new DefaultStreamMessage<>();
+        stream.subscribe(streamObjects.subscriber);
+        streamObjects.values.forEach(stream::write);
+        stream.close();
+        // No executor, so sum will be updated inline.
+        return streamObjects.computedSum();
+    }
+
+    // Isolates performance of stream operations, but requires the stream to execute events inline or it would
+    // deadlock.
+    @Benchmark
+    public long defaultStreamMessage_jmhEventLoop(StreamObjects streamObjects) {
+        DefaultStreamMessage<Integer> stream = new DefaultStreamMessage<>();
+        stream.subscribe(streamObjects.subscriber, EventLoopJmhExecutor.currentEventLoop());
+        streamObjects.values.forEach(stream::write);
+        stream.close();
+        return streamObjects.computedSum();
+    }
+
+    // Has synchronization overhead, but does not require the stream to execute events inline so can be used
+    // to compare approaches.
+    @Benchmark
+    public long defaultStreamMessage_notJmhEventLoop(StreamObjects streamObjects) throws Exception {
+        ANOTHER_EVENT_LOOP.execute(() -> {
+            DefaultStreamMessage<Integer> stream = new DefaultStreamMessage<>();
+            stream.subscribe(streamObjects.subscriber, ANOTHER_EVENT_LOOP);
+            streamObjects.values.forEach(stream::write);
+            stream.close();
+        });
+        streamObjects.completedLatch.await(10, TimeUnit.SECONDS);
+        return streamObjects.computedSum();
+    }
+
+    private static final class SummingSubscriber implements Subscriber<Integer> {
+
+        private final CountDownLatch completedLatch;
+
+        private long sum;
+        private boolean complete;
+        private Throwable error;
+
+        private SummingSubscriber(CountDownLatch completedLatch) {
+            this.completedLatch = completedLatch;
+        }
+
+        private long sum() {
+            if (!complete) {
+                return -1;
+            }
+            if (error != null) {
+                return -1;
+            }
+            return sum;
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            s.request(Long.MAX_VALUE);
+        }
+
+        @Override
+        public void onNext(Integer value) {
+            sum += value;
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            error = t;
+            completedLatch.countDown();
+        }
+
+        @Override
+        public void onComplete() {
+            complete = true;
+            completedLatch.countDown();
+        }
+    }
+}

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/benchmarks/shared/EventLoopJmhExecutor.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/benchmarks/shared/EventLoopJmhExecutor.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.benchmarks.shared;
+
+import java.util.concurrent.Executor;
+
+import io.netty.channel.DefaultEventLoop;
+import io.netty.channel.EventLoop;
+import io.netty.channel.MultithreadEventLoopGroup;
+import io.netty.util.concurrent.DefaultThreadFactory;
+import io.netty.util.concurrent.FastThreadLocal;
+
+/**
+ * A {@link MultithreadEventLoopGroup} that can be used as the JMH executor for benchmarks. This allows
+ * benchmark code to be run from within a event loop thread, which can be useful when the code is specifically
+ * optimized for running inside an event loop. Without this, it would be necessary to switch between threads in
+ * the benchmark which adds significant noise to the benchmark.
+ *
+ * <p>This class is essentially the same as {@link io.netty.channel.DefaultEventLoopGroup} except it stores
+ * a reference to the {@link EventLoop} in a {@link FastThreadLocal} to allow benchmark code to reference it
+ * using {@link EventLoopJmhExecutor#currentEventLoop()}.
+ *
+ * <p>To run on the event loop, the benchmark must specify the JVM args as something like
+ * <pre>{@code
+ *   {@literal @}Fork(jvmArgsAppend = { EventLoopJmhExecutor.JVM_ARG_1, EventLoopJmhExecutor.JMH_ARG_2 })
+ * }</pre>
+ */
+public class EventLoopJmhExecutor extends MultithreadEventLoopGroup {
+
+    public static final String JVM_ARG_1 = "-Djmh.executor=CUSTOM";
+    public static final String JVM_ARG_2 =
+            "-Djmh.executor.class=com.linecorp.armeria.benchmarks.shared.EventLoopJmhExecutor";
+
+    private static final FastThreadLocal<EventLoop> CURRENT_EVENT_LOOP = new FastThreadLocal<>();
+
+    public static EventLoop currentEventLoop() {
+        return CURRENT_EVENT_LOOP.get();
+    }
+
+    public EventLoopJmhExecutor(int numThreads, String threadPrefix) {
+        super(numThreads, new DefaultThreadFactory(threadPrefix));
+    }
+
+    @Override
+    protected EventLoop newChild(Executor executor, Object... args) throws Exception {
+        EventLoop eventLoop = new DefaultEventLoop(this, executor);
+        eventLoop.submit(() -> CURRENT_EVENT_LOOP.set(eventLoop)).syncUninterruptibly();
+        return eventLoop;
+    }
+}


### PR DESCRIPTION
…loop.

TBH, haven't been able to reason through whether this is a correct change, but tests seem fine, and the benchmarks show that we need to do something along these lines to optimize `StreamMessage` performance for the standard case where everything happens on a server event loop thread. Curious what you think.

Benchmarks (due to synchronization overhead, only high values of `num` are relevant). Probably about 1.5-2x better stream performance in practice.

After:
```
Benchmark                                                    (num)   Mode  Cnt       Score       Error  Units
StreamMessageBenchmark.defaultStreamMessage_notJmhEventLoop      3  thrpt   20  238282.293 ± 11059.030  ops/s
StreamMessageBenchmark.defaultStreamMessage_notJmhEventLoop      5  thrpt   20  223524.752 ±  5595.936  ops/s
StreamMessageBenchmark.defaultStreamMessage_notJmhEventLoop     20  thrpt   20  170606.288 ±  4851.481  ops/s
StreamMessageBenchmark.defaultStreamMessage_notJmhEventLoop    100  thrpt   20   78263.884 ±  1800.286  ops/s
StreamMessageBenchmark.defaultStreamMessage_notJmhEventLoop   1000  thrpt   20   10792.808 ±   216.650  ops/s
```

Before:
```
Benchmark                                                    (num)   Mode  Cnt       Score      Error  Units
StreamMessageBenchmark.defaultStreamMessage_notJmhEventLoop      3  thrpt   20  222284.597 ± 6456.982  ops/s
StreamMessageBenchmark.defaultStreamMessage_notJmhEventLoop      5  thrpt   20  215316.254 ± 6570.347  ops/s
StreamMessageBenchmark.defaultStreamMessage_notJmhEventLoop     20  thrpt   20  173076.370 ± 5739.022  ops/s
StreamMessageBenchmark.defaultStreamMessage_notJmhEventLoop    100  thrpt   20   60886.142 ± 1018.291  ops/s
StreamMessageBenchmark.defaultStreamMessage_notJmhEventLoop   1000  thrpt   20    6617.666 ±  118.178  ops/s
```