### PR TITLE
Update dependencies

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
@@ -43,7 +43,7 @@ import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.socket.ChannelInputShutdownReadComplete;
 import io.netty.handler.codec.http2.Http2ConnectionHandler;
-import io.netty.handler.codec.http2.Http2ConnectionPrefaceWrittenEvent;
+import io.netty.handler.codec.http2.Http2ConnectionPrefaceAndSettingsFrameWrittenEvent;
 import io.netty.handler.codec.http2.Http2Settings;
 import io.netty.handler.ssl.SslCloseCompletionEvent;
 import io.netty.util.ReferenceCountUtil;
@@ -221,7 +221,7 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
             return;
         }
 
-        if (evt instanceof Http2ConnectionPrefaceWrittenEvent ||
+        if (evt instanceof Http2ConnectionPrefaceAndSettingsFrameWrittenEvent ||
             evt instanceof SslCloseCompletionEvent ||
             evt instanceof ChannelInputShutdownReadComplete) {
             // Expected events

--- a/core/src/main/java/com/linecorp/armeria/common/HttpHeadersJsonDeserializer.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpHeadersJsonDeserializer.java
@@ -49,7 +49,7 @@ public final class HttpHeadersJsonDeserializer extends StdDeserializer<HttpHeade
             throws IOException {
         final JsonNode tree = p.getCodec().readTree(p);
         if (!tree.isObject()) {
-            ctx.reportMappingException("HTTP headers must be an object.");
+            ctx.reportInputMismatch(HttpHeaders.class, "HTTP headers must be an object.");
             return null;
         }
 
@@ -78,8 +78,9 @@ public final class HttpHeadersJsonDeserializer extends StdDeserializer<HttpHeade
     private static void addHeader(DeserializationContext ctx, HttpHeaders headers,
                                   AsciiString name, JsonNode valueNode) throws JsonMappingException {
         if (!valueNode.isTextual()) {
-            ctx.reportMappingException("HTTP header '%s' contains %s (%s); only strings are allowed.",
-                                       name, valueNode.getNodeType(), valueNode);
+            ctx.reportInputMismatch(HttpHeaders.class,
+                                    "HTTP header '%s' contains %s (%s); only strings are allowed.",
+                                    name, valueNode.getNodeType(), valueNode);
         }
 
         headers.add(name, valueNode.asText());

--- a/core/src/main/java/com/linecorp/armeria/common/MediaTypeJsonDeserializer.java
+++ b/core/src/main/java/com/linecorp/armeria/common/MediaTypeJsonDeserializer.java
@@ -42,7 +42,7 @@ public final class MediaTypeJsonDeserializer extends StdDeserializer<MediaType> 
             throws IOException {
         final JsonNode tree = p.getCodec().readTree(p);
         if (!tree.isTextual()) {
-            ctx.reportMappingException("media type must be a string.");
+            ctx.reportInputMismatch(MediaType.class, "media type must be a string.");
             return null;
         }
 
@@ -51,7 +51,7 @@ public final class MediaTypeJsonDeserializer extends StdDeserializer<MediaType> 
             return MediaType.parse(textValue);
         } catch (IllegalArgumentException unused) {
             // Failed to parse.
-            ctx.reportMappingException("malformed media type: " + textValue);
+            ctx.reportInputMismatch(MediaType.class, "malformed media type: " + textValue);
             return null;
         }
     }

--- a/core/src/test/java/com/linecorp/armeria/client/ClientOptionsBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientOptionsBuilderTest.java
@@ -62,7 +62,7 @@ public class ClientOptionsBuilderTest {
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public void testDecorators() {
         final ClientOptionsBuilder b = new ClientOptionsBuilder();
-        final Function decorator = service -> new LoggingClient((Client) service);
+        final Function decorator = LoggingClient.newDecorator();
 
         b.option(ClientOption.DECORATION.newValue(
                 new ClientDecorationBuilder()

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -12,14 +12,14 @@ com.fasterxml.jackson.core:
   jackson-databind: { version: *JACKSON_VERSION }
 
 com.github.ben-manes.caffeine:
-  caffeine: { version: '2.5.6' }
+  caffeine: { version: '2.6.0' }
 
 com.google.code.findbugs:
   jsr305: { version: '3.0.2' }
 
 com.google.guava:
   guava:
-    version: &GUAVA_VERSION '23.2-jre'
+    version: &GUAVA_VERSION '23.4-jre'
     exclusions:
     - com.google.code.findbugs:jsr305
     - com.google.errorprone:error_prone_annotations
@@ -33,7 +33,7 @@ com.google.guava:
     - com.google.j2objc:j2objc-annotations
 
 com.puppycrawl.tools:
-  checkstyle: { version: '8.3' }
+  checkstyle: { version: '8.4' }
 
 com.spotify:
   completable-futures: { version: '0.3.2' }
@@ -79,19 +79,19 @@ io.micrometer:
     - org.springframework:spring-webmvc
 
 io.netty:
-  netty-codec-http2: { version: &NETTY_VERSION '4.1.16.Final' }
+  netty-codec-http2: { version: &NETTY_VERSION '4.1.17.Final' }
   netty-handler: { version: *NETTY_VERSION }
   netty-resolver-dns: { version: *NETTY_VERSION }
   netty-transport: { version: *NETTY_VERSION }
   netty-transport-native-epoll: { version: *NETTY_VERSION }
   netty-transport-native-unix-common: { version: *NETTY_VERSION }
-  netty-tcnative-boringssl-static: { version: '2.0.6.Final' }
+  netty-tcnative-boringssl-static: { version: '2.0.7.Final' }
 
 io.prometheus:
   simpleclient_common: { version: '0.1.0' }
 
 io.zipkin.brave:
-  brave: { version: &BRAVE_VERSION '4.9.0' }
+  brave: { version: &BRAVE_VERSION '4.9.2' }
 
 it.unimi.dsi:
   fastutil: { version: '8.1.0' }
@@ -106,7 +106,7 @@ junit:
   junit: { version: '4.12' }
 
 net.javacrumbs.json-unit:
-  json-unit: { version: &JSON_UNIT_VERSION '1.25.0' }
+  json-unit: { version: &JSON_UNIT_VERSION '1.25.1' }
   json-unit-fluent: { version: *JSON_UNIT_VERSION }
 
 org.apache.hbase:
@@ -125,7 +125,7 @@ org.apache.httpcomponents:
     - commons-logging:commons-logging
 
 org.apache.kafka:
-  kafka-clients: { version: '0.11.0.1' }
+  kafka-clients: { version: '1.0.0' }
 
 org.apache.thrift:
   libthrift:
@@ -141,7 +141,7 @@ org.apache.tomcat.embed:
 
 org.apache.zookeeper:
   zookeeper:
-    version: '3.4.10'
+    version: '3.4.11'
     exclusions:
     - jline:jline
     - log4j:log4j
@@ -179,13 +179,13 @@ org.hdrhistogram:
   HdrHistogram: { version: '2.1.10' }
 
 org.hibernate.validator:
-  hibernate-validator: { version: '6.0.3.Final' }
+  hibernate-validator: { version: '6.0.5.Final' }
 
 org.javassist:
   javassist: { version: '3.22.0-GA' }
 
 org.mockito:
-  mockito-core: { version: '2.11.0' }
+  mockito-core: { version: '2.12.0' }
 
 org.mortbay.jetty.alpn:
   jetty-alpn-agent: { version: '2.0.6' }


### PR DESCRIPTION
- Caffeine 2.5.6 -> 2.6.0
- Guave 23.2 -> 23.4
- Checkstyle 8.3 -> 8.4
- Netty 4.1.16 -> 4.1.17
  - TCNative BoringSSL 2.0.6 -> 2.0.7
- Brave 4.9.0 -> 4.9.2
- JSON-unit 1.25.0 -> 1.25.1
- Kafka 0.11.0.1 -> 1.0.0
- ZooKeeper 3.4.10 -> 3.4.11
- Hibernate Validator 6.0.3 -> 6.0.5
- Mockito 2.11.0 -> 2.12.0