### PR TITLE
Prevent reentrant synchronous callback execution.

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessageDuplicator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessageDuplicator.java
@@ -217,6 +217,9 @@ public abstract class AbstractStreamMessageDuplicator<T, U extends StreamMessage
         }
 
         private void pushSignal(Object obj) {
+            if (state == State.CLOSED) {
+                return;
+            }
             if (!(obj instanceof CloseEvent)) {
                 final int dataLength = signalLengthGetter.length(obj);
                 if (dataLength > 0) {
@@ -784,10 +787,6 @@ public abstract class AbstractStreamMessageDuplicator<T, U extends StreamMessage
 
         int addAndRemoveIfRequested(Object o) {
             requireNonNull(o);
-            if (elements == null) {
-                // Stream already closed.
-                return 0;
-            }
             int removedLength = 0;
             if (headOffset < lastRemovalRequestedOffset) {
                 removedLength = removeElements();

--- a/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessageDuplicator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessageDuplicator.java
@@ -784,6 +784,10 @@ public abstract class AbstractStreamMessageDuplicator<T, U extends StreamMessage
 
         int addAndRemoveIfRequested(Object o) {
             requireNonNull(o);
+            if (elements == null) {
+                // Stream already closed.
+                return 0;
+            }
             int removedLength = 0;
             if (headOffset < lastRemovalRequestedOffset) {
                 removedLength = removeElements();

--- a/core/src/test/java/com/linecorp/armeria/common/stream/DefaultStreamMessageVerification.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/DefaultStreamMessageVerification.java
@@ -18,6 +18,8 @@ package com.linecorp.armeria.common.stream;
 
 import java.util.concurrent.atomic.AtomicLong;
 
+import org.testng.annotations.Test;
+
 public class DefaultStreamMessageVerification extends StreamMessageVerification<Long> {
 
     @Override
@@ -74,5 +76,16 @@ public class DefaultStreamMessageVerification extends StreamMessageVerification<
     @Override
     public StreamMessage<Long> createAbortedPublisher(long elements) {
         return createStreamMessage(elements, true);
+    }
+
+    // createStreamMessage creates a publisher that relies on onDemand for triggering writes - unfortunately
+    // means that it is not possible to have reads and writes to the stream happening synchronously in the same
+    // call tree, so this test passes regardless of whether DefaultStreamMessage actually correctly handles
+    // recursion. We disable it here to prevent a false sense of security and verify the behavior in
+    // DefaultStreamMessageTest.flowControlled_writeThenDemandThenProcess.
+    @Override
+    @Test(enabled = false)
+    public void required_spec303_mustNotAllowUnboundedRecursion() throws Throwable {
+        notVerified();
     }
 }


### PR DESCRIPTION
I have split this off of #836 to focus on the re-entrancy problem. Even without trying to optimize event loop access of the stream message, we should be handling it correctly for the non-executor stream case.

https://github.com/reactive-streams/reactive-streams-jvm#2-subscriber-code - 2.7

The test fails without the logic change and passes after it. Unfortunately, I'm trying to wrap my head around failures with the `testNg`. Let me know if you have any ideas what could be up.

```
PublisherBasedStreamMessageVerification.required_spec317_mustNotSignalOnErrorWhenPendingAboveLongMaxValue: FAILURE

Gradle suite > Gradle test > com.linecorp.armeria.common.stream.PublisherBasedStreamMessageVerification.required_spec317_mustNotSignalOnErrorWhenPendingAboveLongMaxValue FAILED
    java.lang.OutOfMemoryError: GC overhead limit exceeded
DefaultStreamMessageVerification.required_spec317_mustNotSignalOnErrorWhenPendingAboveLongMaxValue: FAILURE

Gradle suite > Gradle test > com.linecorp.armeria.common.stream.DefaultStreamMessageVerification.required_spec317_mustNotSignalOnErrorWhenPendingAboveLongMaxValue FAILED
    java.lang.OutOfMemoryError: GC overhead limit exceeded
DeferredStreamMessageVerification.required_abortMustNotifySubscriber: FAILURE

Gradle suite > Gradle test > com.linecorp.armeria.common.stream.DeferredStreamMessageVerification.required_abortMustNotifySubscriber FAILED
    java.lang.AssertionError: Expected onError(com.linecorp.armeria.common.stream.AbortedStreamException) within 100 ms

        Caused by:
        java.lang.AssertionError: Expected onError(com.linecorp.armeria.common.stream.AbortedStreamException) within 100 ms
DeferredStreamMessageVerification.required_spec317_mustNotSignalOnErrorWhenPendingAboveLongMaxValue: FAILURE

Gradle suite > Gradle test > com.linecorp.armeria.common.stream.DeferredStreamMessageVerification.required_spec317_mustNotSignalOnErrorWhenPendingAboveLongMaxValue FAILED
    java.lang.OutOfMemoryError: GC overhead limit exceeded

172 tests completed, 4 failed, 49 skipped

```