### PR TITLE
Change isEmpty() in ChildStreamMessage

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessageDuplicator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessageDuplicator.java
@@ -385,8 +385,7 @@ public abstract class AbstractStreamMessageDuplicator<T, U extends StreamMessage
                 return false;
             }
 
-            final DownstreamSubscription<T> subscription = this.subscription;
-            return subscription != null && !subscription.publishedAny;
+            return processor.upstream().isEmpty();
         }
 
         @Override
@@ -518,7 +517,6 @@ public abstract class AbstractStreamMessageDuplicator<T, U extends StreamMessage
 
         private volatile int offset;
         private long cumulativeDemand;
-        private boolean publishedAny;
 
         DownstreamSubscription(ChildStreamMessage<T> streamMessage,
                                Subscriber<? super T> subscriber, StreamMessageProcessor<T> processor,
@@ -680,7 +678,6 @@ public abstract class AbstractStreamMessageDuplicator<T, U extends StreamMessage
                         }
                     }
 
-                    publishedAny = true;
                     subscriber.onNext(obj);
                     return true;
                 }


### PR DESCRIPTION
Motivation:
Currently, `isEmpty()` and `isOpen()` in the `streamMessge` from a `duplicator` using different layer to check their return value.
This is the problem because, for example, if the `streamMessage` has 3 signals and the streamMessage’s `close()` is called, it’s status will be closed and not empty.
However, a `ChildStreamMessage`’s status will be closed(upstream’s status) and empty(downstream’s status) because `subscription.request(long)` is not called.

There are two options to solve this problems. First one is using downstream’s(or processor in the `duplicator`) status.
If we using this, the child stream will be open until it receives `onComplete()` or `onError()` even thought the upstream is closed already.

Second one is using upstream’s status with dealing the situation when ChildStream’s `abort()` is called.

I prefer second one because the `HttpRequestSubscriber` will do its work right away when it writes a http request without the body.(If I use the first one, it needs one more subscription.request(1)).

Modifications:
- Change the inside of `isEmpty()`

Result:
- Fix #842