### PR TITLE
Revert "Make endpoint selection asynchronous (#819)"

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
@@ -18,8 +18,6 @@ package com.linecorp.armeria.client;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.concurrent.CompletableFuture;
-
 import com.google.common.net.HostAndPort;
 
 import com.linecorp.armeria.client.endpoint.EndpointGroupRegistry;
@@ -119,17 +117,17 @@ public final class Endpoint {
     }
 
     /**
-     * Asynchronously resolves this endpoint into a host endpoint associated with the specified
+     * Resolves this endpoint into a host endpoint associated with the specified
      * {@link ClientRequestContext}.
      *
-     * @return the {@link CompletableFuture} of {@link Endpoint} resolved by {@link EndpointGroupRegistry}.
+     * @return the {@link Endpoint} resolved by {@link EndpointGroupRegistry}.
      *         {@code this} if this endpoint is already a host endpoint.
      */
-    public CompletableFuture<Endpoint> resolve(ClientRequestContext ctx) {
+    public Endpoint resolve(ClientRequestContext ctx) {
         if (isGroup()) {
             return EndpointGroupRegistry.selectNode(ctx, groupName);
         } else {
-            return CompletableFuture.completedFuture(this);
+            return this;
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientDelegate.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientDelegate.java
@@ -15,7 +15,6 @@
  */
 package com.linecorp.armeria.client;
 
-import static com.linecorp.armeria.common.util.Functions.voidFunction;
 import static com.linecorp.armeria.internal.ArmeriaHttpUtil.splitPathAndQuery;
 import static java.util.Objects.requireNonNull;
 
@@ -50,43 +49,36 @@ final class HttpClientDelegate implements Client<HttpRequest, HttpResponse> {
 
     @Override
     public HttpResponse execute(ClientRequestContext ctx, HttpRequest req) throws Exception {
-        final int defaultPort = ctx.sessionProtocol().defaultPort();
-        final CompletableFuture<Endpoint> endpointFuture = ctx.endpoint().resolve(ctx);
+        final Endpoint endpoint = ctx.endpoint().resolve(ctx)
+                                     .withDefaultPort(ctx.sessionProtocol().defaultPort());
+        autoFillHeaders(ctx, endpoint, req);
         if (!sanitizePath(req)) {
             req.abort();
             return HttpResponse.ofFailure(new IllegalArgumentException("invalid path: " + req.path()));
         }
+
         final EventLoop eventLoop = ctx.eventLoop();
+        final PoolKey poolKey = new PoolKey(endpoint.host(), endpoint.port(), ctx.sessionProtocol());
+        final Future<Channel> channelFuture = factory.pool(eventLoop).acquire(poolKey);
         final DecodedHttpResponse res = new DecodedHttpResponse(eventLoop);
-        endpointFuture.handle(voidFunction((endpoint, thrown) -> {
-            endpoint = endpoint.withDefaultPort(defaultPort);
-            if (thrown != null) {
-                req.abort();
-                res.close(thrown);
+
+        if (channelFuture.isDone()) {
+            if (channelFuture.isSuccess()) {
+                Channel ch = channelFuture.getNow();
+                invoke0(ch, ctx, req, res, poolKey);
+            } else {
+                res.close(channelFuture.cause());
             }
-            autoFillHeaders(ctx, endpoint, req);
-
-            final PoolKey poolKey = new PoolKey(endpoint.host(), endpoint.port(), ctx.sessionProtocol());
-            final Future<Channel> channelFuture = factory.pool(eventLoop).acquire(poolKey);
-
-            if (channelFuture.isDone()) {
-                if (channelFuture.isSuccess()) {
-                    Channel ch = channelFuture.getNow();
+        } else {
+            channelFuture.addListener((Future<Channel> future) -> {
+                if (future.isSuccess()) {
+                    Channel ch = future.getNow();
                     invoke0(ch, ctx, req, res, poolKey);
                 } else {
                     res.close(channelFuture.cause());
                 }
-            } else {
-                channelFuture.addListener((Future<Channel> future) -> {
-                    if (future.isSuccess()) {
-                        Channel ch = future.getNow();
-                        invoke0(ch, ctx, req, res, poolKey);
-                    } else {
-                        res.close(channelFuture.cause());
-                    }
-                });
-            }
-        }));
+            });
+        }
 
         return res;
     }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/EndpointGroupRegistry.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/EndpointGroupRegistry.java
@@ -19,7 +19,6 @@ package com.linecorp.armeria.client.endpoint;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 
@@ -104,10 +103,10 @@ public final class EndpointGroupRegistry {
     }
 
     /**
-     * Asynchronously selects an {@link Endpoint} from the {@link EndpointGroup} associated with the specified
+     * Selects an {@link Endpoint} from the {@link EndpointGroup} associated with the specified
      * {@link ClientRequestContext} and case-insensitive {@code groupName}.
      */
-    public static CompletableFuture<Endpoint> selectNode(ClientRequestContext ctx, String groupName) {
+    public static Endpoint selectNode(ClientRequestContext ctx, String groupName) {
         groupName = normalizeGroupName(groupName);
         EndpointSelector endpointSelector = getNodeSelector(groupName);
         if (endpointSelector == null) {

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/EndpointSelector.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/EndpointSelector.java
@@ -16,8 +16,6 @@
 
 package com.linecorp.armeria.client.endpoint;
 
-import java.util.concurrent.CompletableFuture;
-
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
 
@@ -36,11 +34,10 @@ public interface EndpointSelector {
     EndpointSelectionStrategy strategy();
 
     /**
-     * Asynchronously selects an {@link Endpoint} from the {@link EndpointGroup} associated with the specified
+     * Selects an {@link Endpoint} from the {@link EndpointGroup} associated with the specified
      * {@link ClientRequestContext}.
      *
-     * @return the {@link CompletableFuture} of {@link Endpoint} selected by this {@link EndpointSelector}'s
-     *         selection strategy.
+     * @return the {@link Endpoint} selected by this {@link EndpointSelector}'s selection strategy
      */
-    CompletableFuture<Endpoint> select(ClientRequestContext ctx);
+    Endpoint select(ClientRequestContext ctx);
 }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/RoundRobinStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/RoundRobinStrategy.java
@@ -17,10 +17,8 @@
 package com.linecorp.armeria.client.endpoint;
 
 import static java.util.Objects.requireNonNull;
-import static java.util.concurrent.CompletableFuture.completedFuture;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import com.linecorp.armeria.client.ClientRequestContext;
@@ -59,14 +57,15 @@ final class RoundRobinStrategy implements EndpointSelectionStrategy {
         }
 
         @Override
-        public CompletableFuture<Endpoint> select(ClientRequestContext ctx) {
+        public Endpoint select(ClientRequestContext ctx) {
+
             List<Endpoint> endpoints = endpointGroup.endpoints();
             int currentSequence = sequence.getAndIncrement();
 
             if (endpoints.isEmpty()) {
                 throw new EndpointGroupException(endpointGroup + " is empty");
             }
-            return completedFuture(endpoints.get(Math.abs(currentSequence % endpoints.size())));
+            return endpoints.get(Math.abs(currentSequence % endpoints.size()));
         }
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/StickyEndpointSelectionStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/StickyEndpointSelectionStrategy.java
@@ -16,10 +16,8 @@
 package com.linecorp.armeria.client.endpoint;
 
 import static java.util.Objects.requireNonNull;
-import static java.util.concurrent.CompletableFuture.completedFuture;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import java.util.function.ToLongFunction;
 
 import com.google.common.hash.Hashing;
@@ -93,7 +91,7 @@ public final class StickyEndpointSelectionStrategy implements EndpointSelectionS
         }
 
         @Override
-        public CompletableFuture<Endpoint> select(ClientRequestContext ctx) {
+        public Endpoint select(ClientRequestContext ctx) {
 
             final List<Endpoint> endpoints = endpointGroup.endpoints();
             if (endpoints.isEmpty()) {
@@ -102,7 +100,7 @@ public final class StickyEndpointSelectionStrategy implements EndpointSelectionS
 
             long key = requestContextHasher.applyAsLong(ctx);
             int nearest = Hashing.consistentHash(key, endpoints.size());
-            return completedFuture(endpoints.get(nearest));
+            return endpoints.get(nearest);
         }
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightedRoundRobinStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightedRoundRobinStrategy.java
@@ -16,10 +16,7 @@
 
 package com.linecorp.armeria.client.endpoint;
 
-import static java.util.concurrent.CompletableFuture.completedFuture;
-
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import com.google.common.collect.ImmutableList;
@@ -66,9 +63,9 @@ final class WeightedRoundRobinStrategy implements EndpointSelectionStrategy {
         }
 
         @Override
-        public CompletableFuture<Endpoint> select(ClientRequestContext ctx) {
+        public Endpoint select(ClientRequestContext ctx) {
             int currentSequence = sequence.getAndIncrement();
-            return completedFuture(endpointsAndWeights.selectEndpoint(currentSequence));
+            return endpointsAndWeights.selectEndpoint(currentSequence);
         }
 
         private static final class EndpointsAndWeights {

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/RoundRobinStrategyTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/RoundRobinStrategyTest.java
@@ -50,19 +50,19 @@ public class RoundRobinStrategyTest {
 
     @Test
     public void select() {
-        assertThat(EndpointGroupRegistry.selectNode(ctx, "endpoint").join())
+        assertThat(EndpointGroupRegistry.selectNode(ctx, "endpoint"))
                 .isEqualTo(ENDPOINT_GROUP.endpoints().get(0));
-        assertThat(EndpointGroupRegistry.selectNode(ctx, "endpoint").join())
+        assertThat(EndpointGroupRegistry.selectNode(ctx, "endpoint"))
                 .isEqualTo(ENDPOINT_GROUP.endpoints().get(1));
-        assertThat(EndpointGroupRegistry.selectNode(ctx, "endpoint").join())
+        assertThat(EndpointGroupRegistry.selectNode(ctx, "endpoint"))
                 .isEqualTo(ENDPOINT_GROUP.endpoints().get(0));
-        assertThat(EndpointGroupRegistry.selectNode(ctx, "endpoint").join())
+        assertThat(EndpointGroupRegistry.selectNode(ctx, "endpoint"))
                 .isEqualTo(ENDPOINT_GROUP.endpoints().get(1));
     }
 
     @Test
     public void select_empty() {
-        assertThat(EndpointGroupRegistry.selectNode(ctx, "endpoint").join()).isNotNull();
+        assertThat(EndpointGroupRegistry.selectNode(ctx, "endpoint")).isNotNull();
 
         assertThat(catchThrowable(() -> EndpointGroupRegistry.selectNode(ctx, "empty")))
                 .isInstanceOf(EndpointGroupException.class);

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/StickyEndpointSelectionStrategyTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/StickyEndpointSelectionStrategyTest.java
@@ -16,7 +16,6 @@
 
 package com.linecorp.armeria.client.endpoint;
 
-import static com.linecorp.armeria.client.endpoint.EndpointGroupRegistry.selectNode;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
@@ -65,36 +64,37 @@ public class StickyEndpointSelectionStrategyTest {
 
     @Test
     public void select() {
+        final EndpointSelector selector = strategy.newSelector(STATIC_ENDPOINT_GROUP);
         final int selectTime = 5;
 
-        Endpoint ep1 = selectNode(
-                contextWithHeader(STICKY_HEADER_NAME, "armeria1"), "static").join();
-        Endpoint ep2 = selectNode(
-                contextWithHeader(STICKY_HEADER_NAME, "armeria2"), "static").join();
-        Endpoint ep3 = selectNode(
-                contextWithHeader(STICKY_HEADER_NAME, "armeria3"), "static").join();
+        Endpoint ep1 = EndpointGroupRegistry.selectNode(
+                contextWithHeader(STICKY_HEADER_NAME, "armeria1"), "static");
+        Endpoint ep2 = EndpointGroupRegistry.selectNode(
+                contextWithHeader(STICKY_HEADER_NAME, "armeria2"), "static");
+        Endpoint ep3 = EndpointGroupRegistry.selectNode(
+                contextWithHeader(STICKY_HEADER_NAME, "armeria3"), "static");
 
         // select few times to confirm that same header will be routed to same endpoint
         for (int i = 0; i < selectTime; i++) {
-            assertThat(selectNode(contextWithHeader(STICKY_HEADER_NAME, "armeria1"), "static").join())
-                    .isEqualTo(ep1);
-            assertThat(selectNode(contextWithHeader(STICKY_HEADER_NAME, "armeria2"), "static").join())
-                    .isEqualTo(ep2);
-            assertThat(selectNode(contextWithHeader(STICKY_HEADER_NAME, "armeria3"), "static").join())
-                    .isEqualTo(ep3);
+            assertThat(EndpointGroupRegistry.selectNode(
+                contextWithHeader(STICKY_HEADER_NAME, "armeria1"), "static")).isEqualTo(ep1);
+            assertThat(EndpointGroupRegistry.selectNode(
+                contextWithHeader(STICKY_HEADER_NAME, "armeria2"), "static")).isEqualTo(ep2);
+            assertThat(EndpointGroupRegistry.selectNode(
+                contextWithHeader(STICKY_HEADER_NAME, "armeria3"), "static")).isEqualTo(ep3);
         }
 
         //confirm rebuild tree of dynamic
         Endpoint ep4 = Endpoint.of("localhost:9494");
         DYNAMIC_ENDPOINT_GROUP.addEndpoint(ep4);
-        assertThat(selectNode(contextWithHeader(STICKY_HEADER_NAME, "armeria1"), "dynamic").join())
-                .isEqualTo(ep4);
+        assertThat(EndpointGroupRegistry.selectNode(
+                contextWithHeader(STICKY_HEADER_NAME, "armeria1"), "dynamic")).isEqualTo(ep4);
 
         DYNAMIC_ENDPOINT_GROUP.removeEndpoint(ep4);
         assertThatThrownBy(
-                () -> selectNode(contextWithHeader(STICKY_HEADER_NAME, "armeria1"), "dynamic")
-                        .join())
-                .isInstanceOf(EndpointGroupException.class);
+                () -> EndpointGroupRegistry.selectNode(
+                        contextWithHeader(STICKY_HEADER_NAME, "armeria1"), "dynamic")
+        ).isInstanceOf(EndpointGroupException.class);
     }
 
     private static ClientRequestContext contextWithHeader(String k, String v) {

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/WeightedRoundRobinStrategyTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/WeightedRoundRobinStrategyTest.java
@@ -16,7 +16,6 @@
 
 package com.linecorp.armeria.client.endpoint;
 
-import static com.linecorp.armeria.client.endpoint.EndpointGroupRegistry.selectNode;
 import static com.linecorp.armeria.client.endpoint.EndpointSelectionStrategy.WEIGHTED_ROUND_ROBIN;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
@@ -56,9 +55,9 @@ public class WeightedRoundRobinStrategyTest {
 
     @Test
     public void select() {
-        assertThat(selectNode(ctx, "endpoint")).isNotNull();
+        assertThat(EndpointGroupRegistry.selectNode(ctx, "endpoint")).isNotNull();
 
-        assertThat(catchThrowable(() -> selectNode(ctx, "empty")))
+        assertThat(catchThrowable(() -> EndpointGroupRegistry.selectNode(ctx, "empty")))
                 .isInstanceOf(EndpointGroupException.class);
     }
 
@@ -72,12 +71,12 @@ public class WeightedRoundRobinStrategyTest {
 
         EndpointGroupRegistry.register(groupName, endpointGroup, WEIGHTED_ROUND_ROBIN);
 
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:1234");
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:2345");
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:3456");
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:1234");
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:2345");
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:1234");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:2345");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:1234");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:2345");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:3456");
     }
 
     @Test
@@ -91,19 +90,19 @@ public class WeightedRoundRobinStrategyTest {
 
         EndpointGroupRegistry.register(groupName, endpointGroup, WEIGHTED_ROUND_ROBIN);
 
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:1234");
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:2345");
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:3456");
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:2345");
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:3456");
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:1234");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:2345");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:2345");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:3456");
 
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:1234");
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:2345");
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:3456");
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:2345");
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:3456");
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:1234");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:2345");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:2345");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:3456");
 
         //weight 3,2,2
         EndpointGroup endpointGroup2 = new StaticEndpointGroup(
@@ -112,21 +111,21 @@ public class WeightedRoundRobinStrategyTest {
                 Endpoint.of("127.0.0.1", 3456, 2));
         EndpointGroupRegistry.register(groupName, endpointGroup2, WEIGHTED_ROUND_ROBIN);
 
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:1234");
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:2345");
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:3456");
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:1234");
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:2345");
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:3456");
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:1234");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:1234");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:2345");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:1234");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:2345");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:1234");
 
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:1234");
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:2345");
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:3456");
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:1234");
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:2345");
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:3456");
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:1234");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:1234");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:2345");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:1234");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:2345");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:1234");
 
         //weight 4,4,4
         EndpointGroup endpointGroup3 = new StaticEndpointGroup(
@@ -135,12 +134,12 @@ public class WeightedRoundRobinStrategyTest {
                 Endpoint.of("127.0.0.1", 3456, 4));
         EndpointGroupRegistry.register(groupName, endpointGroup3, WEIGHTED_ROUND_ROBIN);
 
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:1234");
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:2345");
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:3456");
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:1234");
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:2345");
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:1234");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:2345");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:1234");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:2345");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:3456");
 
         //weight 2,4,6
         EndpointGroup endpointGroup4 = new StaticEndpointGroup(
@@ -149,31 +148,31 @@ public class WeightedRoundRobinStrategyTest {
                 Endpoint.of("127.0.0.1", 3456, 6));
         EndpointGroupRegistry.register(groupName, endpointGroup4, WEIGHTED_ROUND_ROBIN);
 
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:1234");
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:2345");
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:3456");
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:1234");
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:2345");
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:3456");
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:2345");
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:3456");
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:2345");
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:3456");
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:3456");
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:1234");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:2345");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:1234");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:2345");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:2345");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:2345");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:3456");
         //new round
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:1234");
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:2345");
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:3456");
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:1234");
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:2345");
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:3456");
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:2345");
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:3456");
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:2345");
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:3456");
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:3456");
-        assertThat(selectNode(ctx, groupName).join().authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:1234");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:2345");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:1234");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:2345");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:2345");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:2345");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:3456");
+        assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:3456");
     }
 
     @Test
@@ -183,17 +182,17 @@ public class WeightedRoundRobinStrategyTest {
         endpointGroup.updateEndpoints(ImmutableList.of(Endpoint.of("127.0.0.1", 1000)));
 
         EndpointSelector selector = EndpointGroupRegistry.getNodeSelector("dynamic");
-        assertThat(selector.select(ctx).join()).isEqualTo(Endpoint.of("127.0.0.1", 1000));
+        assertThat(selector.select(ctx)).isEqualTo(Endpoint.of("127.0.0.1", 1000));
 
         endpointGroup.updateEndpoints(ImmutableList.of(Endpoint.of("127.0.0.1", 1111, 1),
                                                        Endpoint.of("127.0.0.1", 2222, 2)));
 
-        assertThat(selector.select(ctx).join()).isEqualTo(Endpoint.of("127.0.0.1", 2222, 2));
-        assertThat(selector.select(ctx).join()).isEqualTo(Endpoint.of("127.0.0.1", 2222, 2));
-        assertThat(selector.select(ctx).join()).isEqualTo(Endpoint.of("127.0.0.1", 1111, 1));
-        assertThat(selector.select(ctx).join()).isEqualTo(Endpoint.of("127.0.0.1", 2222, 2));
-        assertThat(selector.select(ctx).join()).isEqualTo(Endpoint.of("127.0.0.1", 2222, 2));
-        assertThat(selector.select(ctx).join()).isEqualTo(Endpoint.of("127.0.0.1", 1111, 1));
+        assertThat(selector.select(ctx)).isEqualTo(Endpoint.of("127.0.0.1", 2222, 2));
+        assertThat(selector.select(ctx)).isEqualTo(Endpoint.of("127.0.0.1", 2222, 2));
+        assertThat(selector.select(ctx)).isEqualTo(Endpoint.of("127.0.0.1", 1111, 1));
+        assertThat(selector.select(ctx)).isEqualTo(Endpoint.of("127.0.0.1", 2222, 2));
+        assertThat(selector.select(ctx)).isEqualTo(Endpoint.of("127.0.0.1", 2222, 2));
+        assertThat(selector.select(ctx)).isEqualTo(Endpoint.of("127.0.0.1", 1111, 1));
     }
 
     private static final class TestDynamicEndpointGroup extends DynamicEndpointGroup {


### PR DESCRIPTION
This reverts commit 429b658cf057be454691b2489270cc4ca4f55fb6.

Because we realized that it does not provide any merits for now, make endpoint selection synchronous again.