### PR TITLE
Add a FixedStreamMessage which can be used to publish objects from a …

### DIFF
--- a/benchmarks/src/jmh/java/com/linecorp/armeria/common/stream/StreamMessageBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/common/stream/StreamMessageBenchmark.java
@@ -57,6 +57,7 @@ public class StreamMessageBenchmark {
             DEFAULT_STREAM_MESSAGE,
             EVENT_LOOP_MESSAGE,
             FIXED_STREAM_MESSAGE,
+            DEFERRED_FIXED_STREAM_MESSAGE,
         }
 
         @Param
@@ -163,6 +164,10 @@ public class StreamMessageBenchmark {
                 return new DefaultStreamMessage<>();
             case FIXED_STREAM_MESSAGE:
                 return new FixedStreamMessage<>(streamObjects.values);
+            case DEFERRED_FIXED_STREAM_MESSAGE:
+                DeferredStreamMessage<Integer> stream = new DeferredStreamMessage<>();
+                stream.delegate(new FixedStreamMessage<>(streamObjects.values));
+                return stream;
             default:
                 throw new Error();
         }

--- a/core/src/main/java/com/linecorp/armeria/common/FixedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/FixedHttpRequest.java
@@ -22,7 +22,7 @@ import static java.util.Objects.requireNonNull;
 import com.linecorp.armeria.common.stream.FixedStreamMessage;
 
 /**
- * A {@link HttpResponse} optimized for when all the {@link HttpObject} that will be published are known at
+ * An {@link HttpResponse} optimized for when all the {@link HttpObject}s that will be published are known at
  * construction time.
  */
 public final class FixedHttpRequest extends FixedStreamMessage<HttpObject> implements HttpRequest {

--- a/core/src/main/java/com/linecorp/armeria/common/FixedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/FixedHttpRequest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+import com.linecorp.armeria.common.stream.FixedStreamMessage;
+
+/**
+ * A {@link HttpResponse} optimized for when all the {@link HttpObject} that will be published are known at
+ * construction time.
+ */
+public final class FixedHttpRequest extends FixedStreamMessage<HttpObject> implements HttpRequest {
+
+    /**
+     * Creates a new {@link FixedHttpRequest} that will publish the given {@code objs}. {@code objs} is not
+     * copied so must not be mutated after this method call (it is generally meant to be used with a varargs
+     * invocation). The first element of {@code objs} must be of type {@link HttpHeaders}.
+     */
+    public static FixedHttpRequest of(HttpObject... objs) {
+        return of(true, objs);
+    }
+
+    /**
+     * Creates a new {@link FixedHttpRequest} that will publish the given {@code objs}. {@code objs} is not
+     * copied so must not be mutated after this method call (it is generally meant to be used with a varargs
+     * invocation). The first element of {@code objs} must be of type {@link HttpHeaders}.
+     *
+     * @param keepAlive whether to keep the connection alive after this request is handled
+     */
+    public static FixedHttpRequest of(boolean keepAlive, HttpObject... objs) {
+        requireNonNull(objs, "objs");
+        checkArgument(objs.length > 0, "At least one HttpObject must be published.");
+        checkArgument(objs[0] instanceof HttpHeaders, "First published object must be headers.");
+        return new FixedHttpRequest((HttpHeaders) objs[0], objs, keepAlive);
+    }
+
+    /**
+     * Creates a new {@link FixedHttpRequest} that will publish the given {@code objs}. {@code objs} is not
+     * copied so must not be mutated after this method call (it is generally meant to be used with a varargs
+     * invocation). {@code writtenHeaders} should have already been separately written to the recipient.
+     */
+    public static FixedHttpRequest ofHeadersWritten(HttpHeaders writtenHeaders, HttpObject... objs) {
+        requireNonNull(writtenHeaders, "writtenHeaders");
+        requireNonNull(objs, "objs");
+        return new FixedHttpRequest(writtenHeaders, objs, true);
+    }
+
+    private final HttpHeaders headers;
+    private final boolean keepAlive;
+
+    private FixedHttpRequest(HttpHeaders headers, HttpObject[] objs, boolean keepAlive) {
+        super(objs);
+        this.headers = headers;
+        this.keepAlive = keepAlive;
+    }
+
+    @Override
+    public HttpHeaders headers() {
+        return headers;
+    }
+
+    @Override
+    public boolean isKeepAlive() {
+        return keepAlive;
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/common/FixedHttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/FixedHttpResponse.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+import com.linecorp.armeria.common.stream.FixedStreamMessage;
+
+/**
+ * A {@link HttpResponse} optimized for when all the {@link HttpObject} that will be published are known at
+ * construction time.
+ */
+public final class FixedHttpResponse extends FixedStreamMessage<HttpObject> implements HttpResponse {
+
+    /**
+     * Creates a new {@link FixedHttpResponse} that will publish the given {@code objs}. {@code objs} is not
+     * copied so must not be mutated after this method call (it is generally meant to be used with a varargs
+     * invocation). The first element of {@code objs} must be of type {@link HttpHeaders}.
+     */
+    public static FixedHttpResponse of(HttpObject... objs) {
+        requireNonNull(objs, "objs");
+        checkArgument(objs.length > 0, "At least one HttpObject must be published.");
+        checkArgument(objs[0] instanceof HttpHeaders, "First published object must be headers.");
+        return new FixedHttpResponse(objs);
+    }
+
+    private FixedHttpResponse(HttpObject[] objs) {
+        super(objs);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/common/FixedHttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/FixedHttpResponse.java
@@ -22,7 +22,7 @@ import static java.util.Objects.requireNonNull;
 import com.linecorp.armeria.common.stream.FixedStreamMessage;
 
 /**
- * A {@link HttpResponse} optimized for when all the {@link HttpObject} that will be published are known at
+ * An {@link HttpResponse} optimized for when all the {@link HttpObject}s that will be published are known at
  * construction time.
  */
 public final class FixedHttpResponse extends FixedStreamMessage<HttpObject> implements HttpResponse {

--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
@@ -197,15 +197,17 @@ public interface HttpRequest extends Request, StreamMessage<HttpObject> {
             headers.setInt(CONTENT_LENGTH, content.length());
         }
 
-        final DefaultHttpRequest req = new DefaultHttpRequest(headers);
         if (!content.isEmpty()) {
-            req.write(content);
+            if (trailingHeaders.isEmpty()) {
+                return FixedHttpRequest.of(headers, content);
+            } else {
+                return FixedHttpRequest.of(headers, content, trailingHeaders);
+            }
+        } else if (!trailingHeaders.isEmpty()) {
+            return FixedHttpRequest.of(headers, trailingHeaders);
+        } else {
+            return FixedHttpRequest.of(headers);
         }
-        if (!trailingHeaders.isEmpty()) {
-            req.write(trailingHeaders);
-        }
-        req.close();
-        return req;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessage.java
@@ -36,6 +36,7 @@ import io.netty.util.concurrent.EventExecutor;
 
 abstract class AbstractStreamMessage<T> implements StreamMessage<T> {
 
+    static final CloseEvent SUCCESSFUL_CLOSE = new CloseEvent(null);
     static final CloseEvent CANCELLED_CLOSE = new CloseEvent(
             Exceptions.clearTrace(CancelledSubscriptionException.get()));
     static final CloseEvent ABORTED_CLOSE = new CloseEvent(

--- a/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessageAndWriter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessageAndWriter.java
@@ -28,8 +28,6 @@ import io.netty.util.ReferenceCounted;
 abstract class AbstractStreamMessageAndWriter<T> extends AbstractStreamMessage<T>
         implements StreamMessageAndWriter<T> {
 
-    static final CloseEvent SUCCESSFUL_CLOSE = new CloseEvent(null);
-
     enum State {
         /**
          * The initial state. Will enter {@link #CLOSED} or {@link #CLEANUP}.

--- a/core/src/main/java/com/linecorp/armeria/common/stream/FixedStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/FixedStreamMessage.java
@@ -26,6 +26,7 @@ import org.reactivestreams.Subscriber;
 import com.linecorp.armeria.common.Flags;
 
 import io.netty.util.ReferenceCountUtil;
+import io.netty.util.concurrent.ImmediateEventExecutor;
 
 /**
  * A {@link StreamMessage} used when all the objects that will be published are known at construction time.
@@ -95,7 +96,7 @@ public class FixedStreamMessage<T> extends AbstractStreamMessage<T> {
         }
 
         final SubscriptionImpl newSubscription = new SubscriptionImpl(
-                this, AbortingSubscriber.get(), null, false);
+                this, AbortingSubscriber.get(), ImmediateEventExecutor.INSTANCE, false);
         if (subscriptionUpdater.compareAndSet(this, null, newSubscription)) {
             // We don't need to invoke onSubscribe() for AbortingSubscriber because it's just a placeholder.
             invokedOnSubscribe = true;

--- a/core/src/main/java/com/linecorp/armeria/common/stream/FixedStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/FixedStreamMessage.java
@@ -1,0 +1,308 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.stream;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+
+import org.reactivestreams.Subscriber;
+
+import com.linecorp.armeria.common.Flags;
+
+import io.netty.util.ReferenceCountUtil;
+
+/**
+ * A {@link StreamMessage} used when all the objects that will be published are known at construction time.
+ * Reduced synchronization and allocation allow for much higher performance than {@link DefaultStreamMessage},
+ * so this class should generally be used when the objects are known.
+ */
+public class FixedStreamMessage<T> extends AbstractStreamMessage<T> {
+
+    @SuppressWarnings("rawtypes")
+    private static final AtomicReferenceFieldUpdater<FixedStreamMessage, SubscriptionImpl>
+            subscriptionUpdater = AtomicReferenceFieldUpdater.newUpdater(
+            FixedStreamMessage.class, SubscriptionImpl.class, "subscription");
+
+    @SuppressWarnings("rawtypes")
+    private static final AtomicReferenceFieldUpdater<FixedStreamMessage, CloseEvent>
+            closeEventUpdater = AtomicReferenceFieldUpdater.newUpdater(
+            FixedStreamMessage.class, CloseEvent.class, "closeEvent");
+
+    /**
+     * Creates a new {@link FixedStreamMessage} that will publish the given {@code objs}. {@code objs} is not
+     * copied so must not be mutated after this method call (it is generally meant to be used with a varargs
+     * invocation).
+     */
+    @SafeVarargs
+    public static <T> FixedStreamMessage<T> of(T... objs) {
+        requireNonNull(objs, "objs");
+        return new FixedStreamMessage<>(objs);
+    }
+
+    private final T[] objs;
+
+    @SuppressWarnings("unused")
+    private volatile SubscriptionImpl subscription; // set only via subscriptionUpdater
+
+    private volatile CloseEvent closeEvent;
+
+    private int requested;
+    private int fulfilled;
+
+    private boolean inOnNext;
+    private boolean invokedOnSubscribe;
+
+    /**
+     * Initializes a {@link FixedStreamMessage} that will publish the given {@code objs}.
+     */
+    protected FixedStreamMessage(T[] objs) {
+        this.objs = requireNonNull(objs, "objs");
+    }
+
+    @Override
+    public boolean isOpen() {
+        // Fixed streams are closed on construction.
+        return false;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return objs.length == 0;
+    }
+
+    @Override
+    public void abort() {
+        final SubscriptionImpl currentSubscription = subscription;
+        if (currentSubscription != null) {
+            cancelOrAbort(false);
+            return;
+        }
+
+        final SubscriptionImpl newSubscription = new SubscriptionImpl(
+                this, AbortingSubscriber.get(), null, false);
+        if (subscriptionUpdater.compareAndSet(this, null, newSubscription)) {
+            // We don't need to invoke onSubscribe() for AbortingSubscriber because it's just a placeholder.
+            invokedOnSubscribe = true;
+        }
+        cancelOrAbort(false);
+    }
+
+    @Override
+    void subscribe(SubscriptionImpl subscription) {
+        final Subscriber<Object> subscriber = subscription.subscriber();
+        final Executor executor = subscription.executor();
+
+        if (!subscriptionUpdater.compareAndSet(this, null, subscription)) {
+            failLateSubscriber(this.subscription, subscriber);
+            return;
+        }
+
+        if (subscription.needsDirectInvocation()) {
+            invokedOnSubscribe = true;
+            subscriber.onSubscribe(subscription);
+        } else {
+            executor.execute(() -> {
+                invokedOnSubscribe = true;
+                subscriber.onSubscribe(subscription);
+            });
+        }
+    }
+
+    @Override
+    long demand() {
+        return requested;
+    }
+
+    @Override
+    void request(long n) {
+        final SubscriptionImpl subscription = this.subscription;
+        // A user cannot access subscription without subscribing.
+        assert subscription != null;
+
+        if (subscription.needsDirectInvocation()) {
+            doRequest(n);
+        } else {
+            subscription.executor().execute(() -> doRequest(n));
+        }
+    }
+
+    private void doRequest(long n) {
+        final long oldDemand = requested;
+        // If this is an empty stream, any demand is enough to complete it. We special case it to allow other
+        // assumptions on size to work correctly for the non-empty case.
+        if (isEmpty() && oldDemand == 0) {
+            requested = 1;
+            notifySubscriber();
+            return;
+        }
+        if (oldDemand >= objs.length) {
+            // Already enough demand to finish the stream so don't need to do anything.
+            return;
+        }
+        // As objs.length is fixed, we can safely cap the demand to it here.
+        if (n >= objs.length) {
+            requested = objs.length;
+        } else {
+            // As objs.length is an int, large demand will always fall into the above branch and there is no
+            // chance of overflow, so just simply add the demand.
+            requested = (int) Math.min(oldDemand + n, objs.length);
+        }
+        if (requested > oldDemand) {
+            notifySubscriber();
+        }
+    }
+
+    @Override
+    void cancel() {
+        cancelOrAbort(true);
+    }
+
+    @Override
+    void notifySubscriberOfCloseEvent(SubscriptionImpl subscription, CloseEvent event) {
+        try {
+            event.notifySubscriber(subscription, completionFuture());
+        } finally {
+            subscription.clearSubscriber();
+            cleanup();
+        }
+    }
+
+    private void notifySubscriber() {
+        final SubscriptionImpl subscription = this.subscription;
+        if (subscription == null) {
+            return;
+        }
+
+        if (fulfilled == requested) {
+            return;
+        }
+
+        if (subscription.needsDirectInvocation()) {
+            notifySubscriber0(subscription);
+        } else {
+            subscription.executor().execute(() -> notifySubscriber0(subscription));
+        }
+    }
+
+    private void notifySubscriber0(SubscriptionImpl subscription) {
+        if (inOnNext) {
+            // Do not let Subscriber.onNext() reenter, because it can lead to weird-looking event ordering
+            // for a Subscriber implemented like the following:
+            //
+            //   public void onNext(Object e) {
+            //       subscription.request(1);
+            //       ... Handle 'e' ...
+            //   }
+            //
+            // Note that we do not call this method again, because we are already in the notification loop
+            // and it will consume the element we've just added in addObjectOrEvent() from the queue as
+            // expected.
+            //
+            // We do not need to worry about synchronizing the access to 'inOnNext' because the subscriber
+            // methods must be on the same thread, or synchronized, according to Reactive Streams spec.
+            return;
+        }
+
+        if (!invokedOnSubscribe) {
+            // Subscriber.onSubscribe() was not invoked yet.
+            // Reschedule the notification so that onSubscribe() is invoked before other events.
+            //
+            // Note:
+            // The rescheduling will occur at most once because the invocation of onSubscribe() must have been
+            // scheduled already by subscribe(), given that this.subscription is not null at this point and
+            // subscribe() is the only place that sets this.subscription.
+
+            subscription.executor().execute(() -> this.notifySubscriber0(subscription));
+            return;
+        }
+
+        final Subscriber<Object> subscriber = subscription.subscriber();
+        for (;;) {
+            if (closeEvent != null) {
+                cleanup();
+                return;
+            }
+
+            if (fulfilled == objs.length) {
+                notifySubscriberOfCloseEvent(subscription, SUCCESSFUL_CLOSE);
+                return;
+            }
+
+            final long requested = this.requested;
+
+            if (fulfilled == requested) {
+                break;
+            }
+
+            while (fulfilled < requested) {
+                if (closeEvent != null) {
+                    cleanup();
+                    return;
+                }
+
+                T o = objs[fulfilled];
+                objs[fulfilled++] = null;
+                o = prepareObjectForNotification(subscription, o);
+                inOnNext = true;
+                try {
+                    subscriber.onNext(o);
+                } finally {
+                    inOnNext = false;
+                }
+            }
+        }
+    }
+
+    private void cancelOrAbort(boolean cancel) {
+        final CloseEvent closeEvent;
+        if (cancel) {
+            closeEvent = Flags.verboseExceptions() ?
+                         new CloseEvent(CancelledSubscriptionException.get()) : CANCELLED_CLOSE;
+        } else {
+            closeEvent = Flags.verboseExceptions() ?
+                         new CloseEvent(AbortedStreamException.get()) : ABORTED_CLOSE;
+        }
+        if (closeEventUpdater.compareAndSet(this, null, closeEvent)) {
+            if (subscription.needsDirectInvocation()) {
+                cleanup();
+            } else {
+                subscription.executor().execute(this::cleanup);
+            }
+        }
+    }
+
+    private void cleanup() {
+        final CloseEvent closeEvent = this.closeEvent;
+        this.closeEvent = null;
+        if (closeEvent != null) {
+            notifySubscriberOfCloseEvent(subscription, closeEvent);
+            // Close event will cleanup.
+            return;
+        }
+        while (fulfilled < objs.length) {
+            T obj = objs[fulfilled];
+            objs[fulfilled++] = null;
+            try {
+                onRemoval(obj);
+            } finally {
+                ReferenceCountUtil.safeRelease(obj);
+            }
+        }
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/common/stream/AbstractStreamMessageAndWriterTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/AbstractStreamMessageAndWriterTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Executor;
+import java.util.concurrent.LinkedTransferQueue;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.internal.ByteBufHttpData;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.channel.EventLoop;
+import io.netty.util.AbstractReferenceCounted;
+import io.netty.util.ReferenceCounted;
+
+public abstract class AbstractStreamMessageAndWriterTest extends AbstractStreamMessageTest {
+
+    abstract <T> StreamMessageAndWriter<T> newStreamWriter(List<T> inputs);
+
+    @Override
+    final <T> StreamMessage<T> newStream(List<T> inputs) {
+        return newStreamWriter(inputs);
+    }
+
+    /**
+     * Makes sure {@link Subscriber#onComplete()} is always invoked after
+     * {@link Subscriber#onSubscribe(Subscription)} even if
+     * {@link StreamMessage#subscribe(Subscriber, Executor)}  is called from non-{@link EventLoop}.
+     */
+    @Test
+    public void onSubscribeBeforeOnComplete() throws Exception {
+        final BlockingQueue<String> queue = new LinkedTransferQueue<>();
+        // Repeat to increase the chance of reproduction.
+        for (int i = 0; i < 8192; i++) {
+            StreamMessageAndWriter<Integer> stream = newStreamWriter(TEN_INTEGERS);
+            eventLoop().execute(stream::close);
+            stream.subscribe(new Subscriber<Object>() {
+                @Override
+                public void onSubscribe(Subscription s) {
+                    queue.add("onSubscribe");
+                    s.request(Long.MAX_VALUE);
+                }
+
+                @Override
+                public void onNext(Object o) {
+                    queue.add("onNext");
+                }
+
+                @Override
+                public void onError(Throwable t) {
+                    queue.add("onError");
+                }
+
+                @Override
+                public void onComplete() {
+                    queue.add("onComplete");
+                }
+            }, eventLoop());
+
+            assertThat(queue.poll(5, TimeUnit.SECONDS)).isEqualTo("onSubscribe");
+            assertThat(queue.poll(5, TimeUnit.SECONDS)).isEqualTo("onComplete");
+        }
+    }
+
+    @Test
+    public void rejectReferenceCounted() {
+        AbstractReferenceCounted item = new AbstractReferenceCounted() {
+            @Override
+            protected void deallocate() {}
+
+            @Override
+            public ReferenceCounted touch(Object hint) {
+                return this;
+            }
+        };
+        StreamMessageAndWriter<Object> stream = newStreamWriter(ImmutableList.of(item));
+        assertThatThrownBy(() -> stream.write(item)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void releaseWhenWritingToClosedStream_ByteBuf() {
+        StreamMessageAndWriter<Object> stream = newStreamWriter(ImmutableList.of());
+        final ByteBuf buf = PooledByteBufAllocator.DEFAULT.buffer();
+        stream.close();
+
+        await().untilAsserted(() -> assertThat(stream.write(buf)).isFalse());
+        assertThat(buf.refCnt()).isZero();
+    }
+
+    @Test
+    public void releaseWhenWritingToClosedStream_HttpData() {
+        StreamMessageAndWriter<Object> stream = newStreamWriter(ImmutableList.of());
+        final ByteBufHttpData data = new ByteBufHttpData(newPooledBuffer(), true);
+        stream.close();
+
+        await().untilAsserted(() -> assertThat(stream.write(data)).isFalse());
+        assertThat(data.refCnt()).isZero();
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/common/stream/EventLoopStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/EventLoopStreamMessageTest.java
@@ -18,10 +18,10 @@ package com.linecorp.armeria.common.stream;
 
 import java.util.List;
 
-public class EventLoopStreamMessageTest extends AbstractStreamMessageTest {
+public class EventLoopStreamMessageTest extends AbstractStreamMessageAndWriterTest {
 
     @Override
-    <T> StreamMessageAndWriter<T> newStream(List<T> unused) {
+    <T> StreamMessageAndWriter<T> newStreamWriter(List<T> unused) {
         return new EventLoopStreamMessage<>(eventLoop());
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/common/stream/FixedStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/FixedStreamMessageTest.java
@@ -18,10 +18,11 @@ package com.linecorp.armeria.common.stream;
 
 import java.util.List;
 
-public class DefaultStreamMessageTest extends AbstractStreamMessageAndWriterTest {
+public class FixedStreamMessageTest extends AbstractStreamMessageTest {
 
+    @SuppressWarnings("unchecked")
     @Override
-    <T> StreamMessageAndWriter<T> newStreamWriter(List<T> unused) {
-        return new DefaultStreamMessage<>();
+    <T> StreamMessage<T> newStream(List<T> inputs) {
+        return new FixedStreamMessage<>((T[]) inputs.toArray());
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/common/stream/FixedStreamMessageVerification.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/FixedStreamMessageVerification.java
@@ -26,8 +26,7 @@ public class FixedStreamMessageVerification extends StreamMessageVerification<Lo
         return FixedStreamMessage.of(LongStream.range(0, elements).boxed().toArray(Long[]::new));
     }
 
-    // A fixed stream cannot fail. It can be aborted, but verification does not support abortion on a closed
-    // stream, while fixed streams are always closed.
+    // A fixed stream cannot fail.
 
     @Override
     public StreamMessage<Long> createFailedPublisher() {
@@ -36,7 +35,17 @@ public class FixedStreamMessageVerification extends StreamMessageVerification<Lo
 
     @Override
     public StreamMessage<Long> createAbortedPublisher(long elements) {
-        return null;
+        StreamMessage<Long> stream = createPublisher(elements);
+        stream.abort();
+        return stream;
+    }
+
+    @Override
+    @Test(enabled = false)
+    public void required_abortMustNotifySubscriber() throws Throwable {
+        // Fixed streams are closed from the start and there isn't a good way to abort after onSubscribe in this
+        // test (fixed streams do not have an onDemand method).
+        notVerified();
     }
 
     @Override

--- a/core/src/test/java/com/linecorp/armeria/common/stream/FixedStreamMessageVerification.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/FixedStreamMessageVerification.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.stream;
+
+import java.util.stream.LongStream;
+
+import org.testng.annotations.Test;
+
+public class FixedStreamMessageVerification extends StreamMessageVerification<Long> {
+    @Override
+    public StreamMessage<Long> createPublisher(long elements) {
+        return FixedStreamMessage.of(LongStream.range(0, elements).boxed().toArray(Long[]::new));
+    }
+
+    // A fixed stream cannot fail. It can be aborted, but verification does not support abortion on a closed
+    // stream, while fixed streams are always closed.
+
+    @Override
+    public StreamMessage<Long> createFailedPublisher() {
+        return null;
+    }
+
+    @Override
+    public StreamMessage<Long> createAbortedPublisher(long elements) {
+        return null;
+    }
+
+    @Override
+    @Test(enabled = false)
+    public void required_spec317_mustNotSignalOnErrorWhenPendingAboveLongMaxValue() throws Throwable {
+        // Publishes Integer.MAX_VALUE values, which is not feasible with a FixedStreamMessage where the values
+        // are all pre-allocated.
+        notVerified();
+    }
+}


### PR DESCRIPTION
…stream fixed at construction time.

It is very common for an `HttpRequest` or `HttpResponse` to be constructed with all its objects known, e.g. using the `respond` family of methods. When all the objects are known, the synchronization overhead of `DefaultStreamMessage` is very wasteful and we can optimize this common use case.

This adds `FixedStreamMessage`, which serves objects straight from an indexed array. Since per reactive streams spec, only one thread can be used when notifying subscribers, we don't need synchronization when accessing the array and can iterate through these very quickly.

In the future, I would like to

- Add extra-optimized `FixedStreamMessage` implementations for one or two object cases. Headers-only or Headers+content only are extremely common uses of `FixedStreamMessage` and it's worth removing the array for them.

Benchmarks

```
Benchmark                            (flowControl)  (num)                   (streamType)   Mode  Cnt        Score        Error  Units
StreamMessageBenchmark.jmhEventLoop          false      3         DEFAULT_STREAM_MESSAGE  thrpt   20  2447995.498 ±  76571.326  ops/s
StreamMessageBenchmark.jmhEventLoop          false      3             EVENT_LOOP_MESSAGE  thrpt   20  3998523.391 ±  65931.260  ops/s
StreamMessageBenchmark.jmhEventLoop          false      3           FIXED_STREAM_MESSAGE  thrpt   20  5244650.672 ± 118638.870  ops/s
StreamMessageBenchmark.jmhEventLoop          false      3  DEFERRED_FIXED_STREAM_MESSAGE  thrpt   20  3388117.744 ±  50573.722  ops/s
StreamMessageBenchmark.jmhEventLoop          false      5         DEFAULT_STREAM_MESSAGE  thrpt   20  1735894.712 ±  51988.264  ops/s
StreamMessageBenchmark.jmhEventLoop          false      5             EVENT_LOOP_MESSAGE  thrpt   20  2791565.534 ± 105005.742  ops/s
StreamMessageBenchmark.jmhEventLoop          false      5           FIXED_STREAM_MESSAGE  thrpt   20  3808046.875 ±  92248.136  ops/s
StreamMessageBenchmark.jmhEventLoop          false      5  DEFERRED_FIXED_STREAM_MESSAGE  thrpt   20  2702439.823 ±  76267.413  ops/s
StreamMessageBenchmark.jmhEventLoop          false     20         DEFAULT_STREAM_MESSAGE  thrpt   20   533709.375 ±  23447.614  ops/s
StreamMessageBenchmark.jmhEventLoop          false     20             EVENT_LOOP_MESSAGE  thrpt   20   848931.136 ±  31648.305  ops/s
StreamMessageBenchmark.jmhEventLoop          false     20           FIXED_STREAM_MESSAGE  thrpt   20  1346320.251 ±  34699.286  ops/s
StreamMessageBenchmark.jmhEventLoop          false     20  DEFERRED_FIXED_STREAM_MESSAGE  thrpt   20  1157837.228 ±  28618.524  ops/s
StreamMessageBenchmark.jmhEventLoop          false    100         DEFAULT_STREAM_MESSAGE  thrpt   20   115800.602 ±   2576.071  ops/s
StreamMessageBenchmark.jmhEventLoop          false    100             EVENT_LOOP_MESSAGE  thrpt   20   195456.115 ±   9756.049  ops/s
StreamMessageBenchmark.jmhEventLoop          false    100           FIXED_STREAM_MESSAGE  thrpt   20   280064.855 ±   7855.266  ops/s
StreamMessageBenchmark.jmhEventLoop          false    100  DEFERRED_FIXED_STREAM_MESSAGE  thrpt   20   278691.518 ±   4590.499  ops/s
StreamMessageBenchmark.jmhEventLoop          false   1000         DEFAULT_STREAM_MESSAGE  thrpt   20    11269.294 ±    257.463  ops/s
StreamMessageBenchmark.jmhEventLoop          false   1000             EVENT_LOOP_MESSAGE  thrpt   20    19078.951 ±    464.986  ops/s
StreamMessageBenchmark.jmhEventLoop          false   1000           FIXED_STREAM_MESSAGE  thrpt   20    29473.865 ±    954.875  ops/s
StreamMessageBenchmark.jmhEventLoop          false   1000  DEFERRED_FIXED_STREAM_MESSAGE  thrpt   20    29092.165 ±    771.308  ops/s
StreamMessageBenchmark.jmhEventLoop           true      3         DEFAULT_STREAM_MESSAGE  thrpt   20  2244284.764 ±  58589.504  ops/s
StreamMessageBenchmark.jmhEventLoop           true      3             EVENT_LOOP_MESSAGE  thrpt   20  3650244.374 ±  71347.146  ops/s
StreamMessageBenchmark.jmhEventLoop           true      3           FIXED_STREAM_MESSAGE  thrpt   20  4681022.082 ±  80635.384  ops/s
StreamMessageBenchmark.jmhEventLoop           true      3  DEFERRED_FIXED_STREAM_MESSAGE  thrpt   20  3086264.704 ±  54498.351  ops/s
StreamMessageBenchmark.jmhEventLoop           true      5         DEFAULT_STREAM_MESSAGE  thrpt   20  1609321.174 ±  31602.833  ops/s
StreamMessageBenchmark.jmhEventLoop           true      5             EVENT_LOOP_MESSAGE  thrpt   20  2641311.855 ±  50005.135  ops/s
StreamMessageBenchmark.jmhEventLoop           true      5           FIXED_STREAM_MESSAGE  thrpt   20  3208739.351 ± 102731.044  ops/s
StreamMessageBenchmark.jmhEventLoop           true      5  DEFERRED_FIXED_STREAM_MESSAGE  thrpt   20  2508418.284 ±  43503.092  ops/s
StreamMessageBenchmark.jmhEventLoop           true     20         DEFAULT_STREAM_MESSAGE  thrpt   20   492543.794 ±   6985.554  ops/s
StreamMessageBenchmark.jmhEventLoop           true     20             EVENT_LOOP_MESSAGE  thrpt   20   870833.025 ±  12392.310  ops/s
StreamMessageBenchmark.jmhEventLoop           true     20           FIXED_STREAM_MESSAGE  thrpt   20  1103808.049 ±  13447.702  ops/s
StreamMessageBenchmark.jmhEventLoop           true     20  DEFERRED_FIXED_STREAM_MESSAGE  thrpt   20   996201.721 ±   5123.903  ops/s
StreamMessageBenchmark.jmhEventLoop           true    100         DEFAULT_STREAM_MESSAGE  thrpt   20   105440.328 ±   1086.096  ops/s
StreamMessageBenchmark.jmhEventLoop           true    100             EVENT_LOOP_MESSAGE  thrpt   20   182978.314 ±   2408.543  ops/s
StreamMessageBenchmark.jmhEventLoop           true    100           FIXED_STREAM_MESSAGE  thrpt   20   243385.668 ±   2345.675  ops/s
StreamMessageBenchmark.jmhEventLoop           true    100  DEFERRED_FIXED_STREAM_MESSAGE  thrpt   20   230239.948 ±   3240.387  ops/s
StreamMessageBenchmark.jmhEventLoop           true   1000         DEFAULT_STREAM_MESSAGE  thrpt   20    10535.803 ±    144.034  ops/s
StreamMessageBenchmark.jmhEventLoop           true   1000             EVENT_LOOP_MESSAGE  thrpt   20    18900.268 ±    148.677  ops/s
StreamMessageBenchmark.jmhEventLoop           true   1000           FIXED_STREAM_MESSAGE  thrpt   20    24392.229 ±    201.141  ops/s
StreamMessageBenchmark.jmhEventLoop           true   1000  DEFERRED_FIXED_STREAM_MESSAGE  thrpt   20    24370.086 ±    137.853  ops/s
```