### PR TITLE
Rename StreamMessage.closeFuture() to completionFuture() and revise Javadoc

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/Http1ResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http1ResponseDecoder.java
@@ -73,7 +73,7 @@ final class Http1ResponseDecoder extends HttpResponseDecoder implements ChannelI
         final HttpResponseWrapper resWrapper =
                 super.addResponse(id, req, res, logBuilder, responseTimeoutMillis, maxContentLength);
 
-        resWrapper.closeFuture().whenComplete((unused, cause) -> {
+        resWrapper.completionFuture().whenComplete((unused, cause) -> {
             // Ensure that the scheduled timeout is not executed.
             resWrapper.cancelTimeout();
             if (cause != null) {

--- a/core/src/main/java/com/linecorp/armeria/client/Http2ResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http2ResponseDecoder.java
@@ -66,7 +66,7 @@ final class Http2ResponseDecoder extends HttpResponseDecoder implements Http2Con
         final HttpResponseWrapper resWrapper =
                 super.addResponse(id, req, res, logBuilder, responseTimeoutMillis, maxContentLength);
 
-        resWrapper.closeFuture().whenCompleteAsync((unused, cause) -> {
+        resWrapper.completionFuture().whenCompleteAsync((unused, cause) -> {
             // Ensure that the scheduled timeout is not executed.
             resWrapper.cancelTimeout();
             if (cause != null) {

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientDelegate.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientDelegate.java
@@ -171,9 +171,9 @@ final class HttpClientDelegate implements Client<HttpRequest, HttpResponse> {
                 } else {
                     // If pipelining is enabled, return as soon as the request is fully sent.
                     // If pipelining is disabled, return after the response is fully received.
-                    final CompletableFuture<Void> closeFuture =
-                            factory.useHttp1Pipelining() ? req.closeFuture() : res.closeFuture();
-                    closeFuture.whenComplete((ret, cause) -> release(pool, poolKey, channel));
+                    final CompletableFuture<Void> completionFuture =
+                            factory.useHttp1Pipelining() ? req.completionFuture() : res.completionFuture();
+                    completionFuture.whenComplete((ret, cause) -> release(pool, poolKey, channel));
                 }
             }
         } finally {

--- a/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
@@ -133,8 +133,8 @@ abstract class HttpResponseDecoder {
             this.maxContentLength = maxContentLength;
         }
 
-        CompletableFuture<Void> closeFuture() {
-            return delegate.closeFuture();
+        CompletableFuture<Void> completionFuture() {
+            return delegate.completionFuture();
         }
 
         void scheduleTimeout(ChannelHandlerContext ctx) {

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClient.java
@@ -126,7 +126,7 @@ public final class CircuitBreakerClient<I extends Request, O extends Response>
                 throw cause;
             }
 
-            response.closeFuture().handle(voidFunction((res, cause) -> {
+            response.completionFuture().handle(voidFunction((res, cause) -> {
                 // Report whether the invocation has succeeded or failed.
                 if (cause == null) {
                     circuitBreaker.onSuccess();

--- a/core/src/main/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingClient.java
@@ -138,7 +138,7 @@ public abstract class ConcurrencyLimitingClient<I extends Request, O extends Res
         boolean success = false;
         try {
             final O res = delegate().execute(ctx, req);
-            res.closeFuture().whenComplete((unused, cause) -> numActiveRequests.decrementAndGet());
+            res.completionFuture().whenComplete((unused, cause) -> numActiveRequests.decrementAndGet());
             success = true;
             return res;
         } finally {
@@ -240,7 +240,7 @@ public abstract class ConcurrencyLimitingClient<I extends Request, O extends Res
             try (SafeCloseable ignored = RequestContext.push(ctx)) {
                 try {
                     final O actualRes = delegate().execute(ctx, req);
-                    actualRes.closeFuture().whenCompleteAsync((unused, cause) -> {
+                    actualRes.completionFuture().whenCompleteAsync((unused, cause) -> {
                         numActiveRequests.decrementAndGet();
                         drain();
                     }, ctx.eventLoop());

--- a/core/src/main/java/com/linecorp/armeria/client/retry/HttpStatusBasedRetryStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/HttpStatusBasedRetryStrategy.java
@@ -48,7 +48,7 @@ final class HttpStatusBasedRetryStrategy implements RetryStrategy<HttpRequest, H
     public CompletableFuture<Optional<Backoff>> shouldRetry(HttpRequest request, HttpResponse response) {
         final CompletableFuture<HttpHeaders> future = new CompletableFuture<>();
         final HttpHeaderSubscriber subscriber = new HttpHeaderSubscriber(future);
-        response.closeFuture().whenComplete(subscriber);
+        response.completionFuture().whenComplete(subscriber);
         response.subscribe(subscriber);
 
         return future.handle((headers, unused) -> {

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingHttpClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingHttpClient.java
@@ -200,7 +200,7 @@ public final class RetryingHttpClient extends RetryingClient<HttpRequest, HttpRe
     private static HttpHeaders getHttpHeaders(HttpResponse res) {
         final CompletableFuture<HttpHeaders> future = new CompletableFuture<>();
         final HttpHeaderSubscriber subscriber = new HttpHeaderSubscriber(future);
-        res.closeFuture().whenComplete(subscriber);
+        res.completionFuture().whenComplete(subscriber);
         res.subscribe(subscriber);
         // Neither blocks here nor throws an exception because it already has headers.
         return future.join();

--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
@@ -300,7 +300,7 @@ public interface HttpRequest extends Request, StreamMessage<HttpObject> {
     default CompletableFuture<AggregatedHttpMessage> aggregate() {
         final CompletableFuture<AggregatedHttpMessage> future = new CompletableFuture<>();
         final HttpRequestAggregator aggregator = new HttpRequestAggregator(this, future);
-        closeFuture().whenComplete(aggregator);
+        completionFuture().whenComplete(aggregator);
         subscribe(aggregator);
         return future;
     }
@@ -312,7 +312,7 @@ public interface HttpRequest extends Request, StreamMessage<HttpObject> {
     default CompletableFuture<AggregatedHttpMessage> aggregate(Executor executor) {
         final CompletableFuture<AggregatedHttpMessage> future = new CompletableFuture<>();
         final HttpRequestAggregator aggregator = new HttpRequestAggregator(this, future);
-        closeFuture().whenCompleteAsync(aggregator, executor);
+        completionFuture().whenCompleteAsync(aggregator, executor);
         subscribe(aggregator, executor);
         return future;
     }

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -184,7 +184,12 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
     }
 
     @Override
-    CompletableFuture<Void> closeFuture();
+    default CompletableFuture<Void> closeFuture() {
+        return completionFuture();
+    }
+
+    @Override
+    CompletableFuture<Void> completionFuture();
 
     /**
      * Aggregates this response. The returned {@link CompletableFuture} will be notified when the content and
@@ -193,7 +198,7 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
     default CompletableFuture<AggregatedHttpMessage> aggregate() {
         final CompletableFuture<AggregatedHttpMessage> future = new CompletableFuture<>();
         final HttpResponseAggregator aggregator = new HttpResponseAggregator(future);
-        closeFuture().whenComplete(aggregator);
+        completionFuture().whenComplete(aggregator);
         subscribe(aggregator);
         return future;
     }
@@ -205,7 +210,7 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
     default CompletableFuture<AggregatedHttpMessage> aggregate(Executor executor) {
         final CompletableFuture<AggregatedHttpMessage> future = new CompletableFuture<>();
         final HttpResponseAggregator aggregator = new HttpResponseAggregator(future);
-        closeFuture().whenCompleteAsync(aggregator, executor);
+        completionFuture().whenCompleteAsync(aggregator, executor);
         subscribe(aggregator, executor);
         return future;
     }

--- a/core/src/main/java/com/linecorp/armeria/common/Response.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Response.java
@@ -29,12 +29,24 @@ public interface Response {
 
     /**
      * Returns a {@link CompletableFuture} which completes when
-     * 1) the response stream has been closed (the {@link StreamMessage} has been closed) or
+     * 1) the response stream has been closed (the {@link StreamMessage} has been completed) or
+     * 2) the result value is set (the {@link CompletionStage} has completed.)
+     *
+     * @deprecated Use {@link #completionFuture()} instead.
+     */
+    @Deprecated
+    default CompletableFuture<?> closeFuture() {
+        return completionFuture();
+    }
+
+    /**
+     * Returns a {@link CompletableFuture} which completes when
+     * 1) the response stream has been closed (the {@link StreamMessage} has been completed) or
      * 2) the result value is set (the {@link CompletionStage} has completed.)
      */
-    default CompletableFuture<?> closeFuture() {
+    default CompletableFuture<?> completionFuture() {
         if (this instanceof StreamMessage) {
-            return ((StreamMessage<?>) this).closeFuture();
+            return ((StreamMessage<?>) this).completionFuture();
         }
 
         if (this instanceof CompletionStage) {

--- a/core/src/main/java/com/linecorp/armeria/common/RpcResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RpcResponse.java
@@ -96,7 +96,7 @@ public interface RpcResponse extends Response, Future<Object>, CompletionStage<O
      * Returns a {@link CompletableFuture} which completes when this {@link RpcResponse} completes.
      */
     @Override
-    default CompletableFuture<?> closeFuture() {
+    default CompletableFuture<?> completionFuture() {
         return toCompletableFuture();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/CancelledSubscriptionException.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/CancelledSubscriptionException.java
@@ -23,7 +23,7 @@ import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.util.Exceptions;
 
 /**
- * A {@link RuntimeException} that is raised to notify {@link StreamMessage#closeFuture()} when a
+ * A {@link RuntimeException} that is raised to notify {@link StreamMessage#completionFuture()} when a
  * {@link Subscriber} has cancelled its {@link Subscription}.
  */
 public final class CancelledSubscriptionException extends RuntimeException {

--- a/core/src/main/java/com/linecorp/armeria/common/stream/FilteredStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/FilteredStreamMessage.java
@@ -79,8 +79,8 @@ public abstract class FilteredStreamMessage<T, U> implements StreamMessage<U> {
     }
 
     @Override
-    public CompletableFuture<Void> closeFuture() {
-        return delegate.closeFuture();
+    public CompletableFuture<Void> completionFuture() {
+        return delegate.completionFuture();
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageWrapper.java
@@ -59,8 +59,8 @@ public class StreamMessageWrapper<T> implements StreamMessage<T> {
     }
 
     @Override
-    public CompletableFuture<Void> closeFuture() {
-        return delegate().closeFuture();
+    public CompletableFuture<Void> completionFuture() {
+        return delegate().completionFuture();
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -310,7 +310,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
             gracefulShutdownSupport.inc();
             unfinishedRequests++;
 
-            req.closeFuture().handle(voidFunction((ret, cause) -> {
+            req.completionFuture().handle(voidFunction((ret, cause) -> {
                 if (cause == null) {
                     logBuilder.endRequest();
                 } else {
@@ -318,7 +318,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
                 }
             })).exceptionally(CompletionActions::log);
 
-            res.closeFuture().handle(voidFunction((ret, cause) -> {
+            res.completionFuture().handle(voidFunction((ret, cause) -> {
                 req.abort();
                 // NB: logBuilder.endResponse() is called by HttpResponseSubscriber below.
                 eventLoop.execute(() -> {

--- a/core/src/test/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingHttpClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingHttpClientTest.java
@@ -150,13 +150,14 @@ public class ConcurrencyLimitingHttpClientTest {
         Thread.sleep(1000);
         res2.subscribe(NoopSubscriber.get());
         assertThat(res2.isOpen()).isFalse();
-        assertThat(res2.closeFuture()).isCompletedExceptionally();
-        assertThatThrownBy(() -> res2.closeFuture().get()).hasCauseInstanceOf(ResponseTimeoutException.class);
+        assertThat(res2.completionFuture()).isCompletedExceptionally();
+        assertThatThrownBy(() -> res2.completionFuture().get())
+                .hasCauseInstanceOf(ResponseTimeoutException.class);
 
         // req1 should not time out because it's been delegated already.
         res1.subscribe(NoopSubscriber.get());
         assertThat(res1.isOpen()).isTrue();
-        assertThat(res1.closeFuture()).isNotDone();
+        assertThat(res1.completionFuture()).isNotDone();
 
         // Close req1 and make sure req2 does not affect numActiveRequests.
         actualRes1.close();
@@ -187,8 +188,8 @@ public class ConcurrencyLimitingHttpClientTest {
 
         assertThat(res).isInstanceOf(DeferredHttpResponse.class);
         assertThat(res.isOpen()).isFalse();
-        assertThat(res.closeFuture()).isCompletedExceptionally();
-        assertThatThrownBy(() -> res.closeFuture().get()).hasCauseInstanceOf(Exception.class);
+        assertThat(res.completionFuture()).isCompletedExceptionally();
+        assertThatThrownBy(() -> res.completionFuture().get()).hasCauseInstanceOf(Exception.class);
         assertThat(client.numActiveRequests()).isZero();
     }
 

--- a/core/src/test/java/com/linecorp/armeria/common/DefaultAggregatedHttpMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/DefaultAggregatedHttpMessageTest.java
@@ -180,7 +180,7 @@ public class DefaultAggregatedHttpMessageTest {
             public void onComplete() {}
         });
 
-        req.closeFuture().get(10, TimeUnit.SECONDS);
+        req.completionFuture().get(10, TimeUnit.SECONDS);
         return unaggregated;
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/common/stream/DeferredStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/DeferredStreamMessageTest.java
@@ -41,7 +41,7 @@ public class DeferredStreamMessageTest {
         final DeferredStreamMessage<Object> m = new DeferredStreamMessage<>();
         assertThat(m.isOpen()).isTrue();
         assertThat(m.isEmpty()).isFalse();
-        assertThat(m.closeFuture()).isNotDone();
+        assertThat(m.completionFuture()).isNotDone();
     }
 
     @Test
@@ -136,8 +136,8 @@ public class DeferredStreamMessageTest {
     private static void assertAborted(StreamMessage<?> m) {
         assertThat(m.isOpen()).isFalse();
         assertThat(m.isEmpty()).isTrue();
-        assertThat(m.closeFuture()).isCompletedExceptionally();
-        assertThatThrownBy(() -> m.closeFuture().get())
+        assertThat(m.completionFuture()).isCompletedExceptionally();
+        assertThatThrownBy(() -> m.completionFuture().get())
                 .hasCauseInstanceOf(AbortedStreamException.class);
     }
 
@@ -200,10 +200,10 @@ public class DeferredStreamMessageTest {
 
         assertThat(m.isOpen()).isFalse();
         assertThat(m.isEmpty()).isFalse();
-        assertThat(m.closeFuture()).isCompletedWithValue(null);
+        assertThat(m.completionFuture()).isCompletedWithValue(null);
 
         assertThat(d.isOpen()).isFalse();
         assertThat(d.isEmpty()).isFalse();
-        assertThat(d.closeFuture()).isCompletedWithValue(null);
+        assertThat(d.completionFuture()).isCompletedWithValue(null);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/common/stream/PublisherBasedStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/PublisherBasedStreamMessageTest.java
@@ -121,9 +121,9 @@ public class PublisherBasedStreamMessageTest {
             // Ensure subscription.cancel() has been invoked.
             Mockito.verify(subscription).cancel();
 
-            // Ensure closeFuture is complete exceptionally.
-            assertThat(publisher.closeFuture()).isCompletedExceptionally();
-            assertThatThrownBy(() -> publisher.closeFuture().get())
+            // Ensure completionFuture is complete exceptionally.
+            assertThat(publisher.completionFuture()).isCompletedExceptionally();
+            assertThatThrownBy(() -> publisher.completionFuture().get())
                     .hasCauseExactlyInstanceOf(AbortedStreamException.class);
         }
     }

--- a/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageDuplicatorTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageDuplicatorTest.java
@@ -60,7 +60,7 @@ public class StreamMessageDuplicatorTest {
     public void subscribeTwice() {
         @SuppressWarnings("unchecked")
         final StreamMessage<String> publisher = mock(StreamMessage.class);
-        when(publisher.closeFuture()).thenReturn(new CompletableFuture<>());
+        when(publisher.completionFuture()).thenReturn(new CompletableFuture<>());
 
         final StreamMessageDuplicator duplicator = new StreamMessageDuplicator(publisher);
 
@@ -123,7 +123,7 @@ public class StreamMessageDuplicatorTest {
     private static CompletableFuture<String> subscribe(StreamMessage<String> streamMessage, long demand) {
         final CompletableFuture<String> future = new CompletableFuture<>();
         final StringSubscriber subscriber = new StringSubscriber(future, demand);
-        streamMessage.closeFuture().whenComplete(subscriber);
+        streamMessage.completionFuture().whenComplete(subscriber);
         streamMessage.subscribe(subscriber);
         return future;
     }
@@ -171,7 +171,7 @@ public class StreamMessageDuplicatorTest {
         final CompletableFuture<String> future1 = new CompletableFuture<>();
         final StringSubscriber subscriber = new StringSubscriber(future1, 2);
         final StreamMessage<String> sm = duplicator.duplicateStream();
-        sm.closeFuture().whenComplete(subscriber);
+        sm.completionFuture().whenComplete(subscriber);
         sm.subscribe(subscriber);
 
         final CompletableFuture<String> future2 = subscribe(duplicator.duplicateStream(), 3);
@@ -384,7 +384,7 @@ public class StreamMessageDuplicatorTest {
 
         @Override
         public void accept(Void aVoid, Throwable cause) {
-            logger.debug("{}: closeFuture({})", this, String.valueOf(cause), cause);
+            logger.debug("{}: completionFuture({})", this, String.valueOf(cause), cause);
             if (cause != null) {
                 future.completeExceptionally(cause);
             } else {

--- a/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageVerification.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageVerification.java
@@ -57,7 +57,7 @@ public abstract class StreamMessageVerification<T> extends PublisherVerification
     public abstract StreamMessage<T> createAbortedPublisher(long elements);
 
     @Test
-    public void required_closeFutureMustCompleteOnTermination0() throws Throwable {
+    public void required_completionFutureMustCompleteOnTermination0() throws Throwable {
         activePublisherTest(0, true, pub -> {
             final ManualSubscriber<T> sub = env.newManualSubscriber(pub);
             final StreamMessage<?> stream = (StreamMessage<?>) pub;
@@ -69,46 +69,46 @@ public abstract class StreamMessageVerification<T> extends PublisherVerification
                 assertThat(stream.isEmpty()).isTrue();
             }
 
-            assertThat(stream.closeFuture()).isNotDone();
+            assertThat(stream.completionFuture()).isNotDone();
             sub.requestEndOfStream();
 
             assertThat(stream.isOpen()).isFalse();
             assertThat(stream.isEmpty()).isTrue();
-            assertThat(stream.closeFuture()).isCompleted();
+            assertThat(stream.completionFuture()).isCompleted();
             sub.expectNone();
         });
     }
 
     @Test
-    public void required_closeFutureMustCompleteOnTermination1() throws Throwable {
+    public void required_completionFutureMustCompleteOnTermination1() throws Throwable {
         activePublisherTest(1, true, pub -> {
             final ManualSubscriber<T> sub = env.newManualSubscriber(pub);
             final StreamMessage<?> stream = (StreamMessage<?>) pub;
             assertThat(stream.isOpen()).isTrue();
             assertThat(stream.isEmpty()).isFalse();
 
-            assertThat(stream.closeFuture()).isNotDone();
+            assertThat(stream.completionFuture()).isNotDone();
             sub.requestNextElement();
             sub.requestEndOfStream();
-            assertThat(stream.closeFuture()).isCompleted();
+            assertThat(stream.completionFuture()).isCompleted();
             sub.expectNone();
         });
     }
 
     @Test
-    public void required_closeFutureMustCompleteOnCancellation() throws Throwable {
+    public void required_completionFutureMustCompleteOnCancellation() throws Throwable {
         activePublisherTest(10, true, pub -> {
             final ManualSubscriber<T> sub = env.newManualSubscriber(pub);
             final StreamMessage<?> stream = (StreamMessage<?>) pub;
 
-            assertThat(stream.closeFuture()).isNotDone();
+            assertThat(stream.completionFuture()).isNotDone();
             sub.requestNextElement();
-            assertThat(stream.closeFuture()).isNotDone();
+            assertThat(stream.completionFuture()).isNotDone();
             sub.cancel();
             sub.expectNone();
 
-            assertThat(stream.closeFuture()).isCompletedExceptionally();
-            assertThatThrownBy(() -> stream.closeFuture().join())
+            assertThat(stream.completionFuture()).isCompletedExceptionally();
+            assertThatThrownBy(() -> stream.completionFuture().join())
                     .isInstanceOf(CompletionException.class)
                     .hasCauseInstanceOf(CancelledSubscriptionException.class);
         });
@@ -122,7 +122,7 @@ public abstract class StreamMessageVerification<T> extends PublisherVerification
         final StreamMessage<T> pub = createAbortedPublisher(0);
         assumeAbortedPublisherAvailable(pub);
         assertThat(pub.isOpen()).isFalse();
-        assertThatThrownBy(() -> pub.closeFuture().join())
+        assertThatThrownBy(() -> pub.completionFuture().join())
                 .isInstanceOf(CompletionException.class)
                 .hasCauseInstanceOf(AbortedStreamException.class);
 
@@ -167,7 +167,7 @@ public abstract class StreamMessageVerification<T> extends PublisherVerification
         sub.expectError(AbortedStreamException.class);
 
         env.verifyNoAsyncErrorsNoDelay();
-        assertThatThrownBy(() -> pub.closeFuture().join())
+        assertThatThrownBy(() -> pub.completionFuture().join())
                 .isInstanceOf(CompletionException.class)
                 .hasCauseInstanceOf(AbortedStreamException.class);
     }

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerTest.java
@@ -778,7 +778,7 @@ public class HttpServerTest {
 
         res.subscribe(consumer);
 
-        res.closeFuture().get();
+        res.completionFuture().get();
         assertThat(status.get(), is(HttpStatus.OK));
         assertThat(consumer.numReceivedBytes(), is(STREAMING_CONTENT_LENGTH));
     }


### PR DESCRIPTION
Motivation:

StreamMessage.closeFuture() has a confusing name because it conflicts
with the semantic of isOpen(). It is obviously possible that isOpen() is
false when closeFuture() is not complete.

Modifications:

- Add StreamMessage.completionFuture()
- Add StreamMessage.isComplete()
- Deprecate StreamMessage.closeFuture()
- Update the Javadoc of StreamMessage

Result:

- Less confusing API

/cc @anuraaga 