### PR TITLE
Add EventLoopStreamMessage, which serializes stream operations throug…

### DIFF
--- a/benchmarks/src/jmh/java/com/linecorp/armeria/benchmarks/core/StreamMessageBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/benchmarks/core/StreamMessageBenchmark.java
@@ -16,7 +16,6 @@
 
 package com.linecorp.armeria.benchmarks.core;
 
-import java.util.ArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -35,6 +34,9 @@ import org.slf4j.LoggerFactory;
 
 import com.linecorp.armeria.benchmarks.shared.EventLoopJmhExecutor;
 import com.linecorp.armeria.common.stream.DefaultStreamMessage;
+import com.linecorp.armeria.common.stream.EventLoopStreamMessage;
+import com.linecorp.armeria.common.stream.StreamMessageAndWriter;
+import com.linecorp.armeria.common.stream.StreamWriter;
 
 import io.netty.channel.DefaultEventLoop;
 import io.netty.channel.EventLoop;
@@ -47,13 +49,29 @@ public class StreamMessageBenchmark {
 
     private static final EventLoop ANOTHER_EVENT_LOOP = new DefaultEventLoop();
 
+    @TearDown(Level.Trial)
+    public void closeEventLoops() {
+        ANOTHER_EVENT_LOOP.shutdownGracefully().syncUninterruptibly();
+    }
+
     @State(Scope.Thread)
     public static class StreamObjects {
 
-        private final ArrayList<Integer> values = new ArrayList<>();
+        public enum StreamType {
+            DEFAULT_STREAM_MESSAGE,
+            EVENT_LOOP_MESSAGE,
+        }
+
+        @Param
+        private StreamType streamType;
 
         @Param({ "3", "5", "20", "100", "1000" })
         private int num;
+
+        @Param({ "false", "true" })
+        private boolean flowControl;
+
+        private Integer[] values;
 
         private long sum;
 
@@ -61,16 +79,22 @@ public class StreamMessageBenchmark {
 
         private CountDownLatch completedLatch;
 
+        private CountDownLatch wroteLatch;
+
+        private int writeIndex;
+
         @Setup(Level.Invocation)
         public void setValues() {
             completedLatch = new CountDownLatch(1);
-            values.clear();
+            wroteLatch = new CountDownLatch(1);
+            values = new Integer[num];
             sum = 0;
+            writeIndex = 0;
             for (int i = 0; i < num; i++) {
-                values.add(i);
+                values[i] = i;
                 sum += i;
             }
-            subscriber = new SummingSubscriber(completedLatch);
+            subscriber = new SummingSubscriber(completedLatch, flowControl);
         }
 
         private long computedSum() {
@@ -82,18 +106,28 @@ public class StreamMessageBenchmark {
             }
             return computedSum;
         }
-    }
 
-    @TearDown(Level.Trial)
-    public void closeEventLoop() {
-        ANOTHER_EVENT_LOOP.shutdownGracefully().syncUninterruptibly();
+        private void writeAllValues(StreamWriter<Integer> stream) {
+            for (Integer i : values) {
+                stream.write(i);
+            }
+            stream.close();
+            wroteLatch.countDown();
+        }
+
+        private void writeNextValue(StreamWriter<Integer> stream) {
+            stream.write(values[writeIndex++]);
+            if (writeIndex == values.length) {
+                stream.close();
+            }
+        }
     }
 
     @Benchmark
-    public long defaultStreamMessage_noExecutor(StreamObjects streamObjects) {
-        DefaultStreamMessage<Integer> stream = new DefaultStreamMessage<>();
+    public long noExecutor(StreamObjects streamObjects) {
+        StreamMessageAndWriter<Integer> stream = newStream(streamObjects);
         stream.subscribe(streamObjects.subscriber);
-        streamObjects.values.forEach(stream::write);
+        streamObjects.writeAllValues(stream);
         stream.close();
         // No executor, so sum will be updated inline.
         return streamObjects.computedSum();
@@ -102,10 +136,10 @@ public class StreamMessageBenchmark {
     // Isolates performance of stream operations, but requires the stream to execute events inline or it would
     // deadlock.
     @Benchmark
-    public long defaultStreamMessage_jmhEventLoop(StreamObjects streamObjects) {
-        DefaultStreamMessage<Integer> stream = new DefaultStreamMessage<>();
+    public long jmhEventLoop(StreamObjects streamObjects) {
+        StreamMessageAndWriter<Integer> stream = newStream(streamObjects);
         stream.subscribe(streamObjects.subscriber, EventLoopJmhExecutor.currentEventLoop());
-        streamObjects.values.forEach(stream::write);
+        streamObjects.writeAllValues(stream);
         stream.close();
         return streamObjects.computedSum();
     }
@@ -113,27 +147,143 @@ public class StreamMessageBenchmark {
     // Has synchronization overhead, but does not require the stream to execute events inline so can be used
     // to compare approaches.
     @Benchmark
-    public long defaultStreamMessage_notJmhEventLoop(StreamObjects streamObjects) throws Exception {
+    public long notJmhEventLoop(StreamObjects streamObjects) throws Exception {
         ANOTHER_EVENT_LOOP.execute(() -> {
-            DefaultStreamMessage<Integer> stream = new DefaultStreamMessage<>();
+            StreamMessageAndWriter<Integer> stream = newStream(streamObjects);
             stream.subscribe(streamObjects.subscriber, ANOTHER_EVENT_LOOP);
-            streamObjects.values.forEach(stream::write);
+            streamObjects.writeAllValues(stream);
             stream.close();
         });
         streamObjects.completedLatch.await(10, TimeUnit.SECONDS);
         return streamObjects.computedSum();
     }
 
+    private StreamMessageAndWriter<Integer> newStream(StreamObjects streamObjects) {
+        switch (streamObjects.streamType) {
+            case EVENT_LOOP_MESSAGE:
+                return new EventLoopStreamMessage<>(EventLoopJmhExecutor.currentEventLoop());
+            case DEFAULT_STREAM_MESSAGE:
+                return new DefaultStreamMessage<>();
+            default:
+                throw new Error();
+        }
+    }
+
+    @Fork(jvmArgsAppend = { EventLoopJmhExecutor.JVM_ARG_1, EventLoopJmhExecutor.JVM_ARG_2 })
+    @State(Scope.Benchmark)
+    public static class StreamMessageThreadingBenchmark {
+
+        private static final EventLoop EVENT_LOOP1 = new DefaultEventLoop();
+        private static final EventLoop EVENT_LOOP2 = new DefaultEventLoop();
+        private static final EventLoop EVENT_LOOP3 = new DefaultEventLoop();
+
+        @TearDown(Level.Trial)
+        public void closeEventLoops() {
+            EVENT_LOOP1.shutdownGracefully().syncUninterruptibly();
+            EVENT_LOOP2.shutdownGracefully().syncUninterruptibly();
+            EVENT_LOOP3.shutdownGracefully().syncUninterruptibly();
+        }
+
+        // To evaluate performance with various threading models, we need to use multiple event loops with
+        // synchronization. These benchmarks will not be useful for evaluating raw stream performance but can
+        // compare different implementations under similar synchronization conditions.
+        public enum EventLoopType {
+            // Both reader and writer are the stream's event loop.
+            READ_WRITE(EVENT_LOOP1, EVENT_LOOP1),
+            // Only readers are the stream's event loop.
+            READ_ONLY(EVENT_LOOP1, EVENT_LOOP2),
+            // Only writers are the stream's event loop.
+            WRITE_ONLY(EVENT_LOOP3, EVENT_LOOP1),
+            // Neither are the stream's event loop.
+            NONE(EVENT_LOOP3, EVENT_LOOP2);
+
+            private final EventLoop readLoop;
+            private final EventLoop writeLoop;
+
+            EventLoopType(EventLoop readLoop, EventLoop writeLoop) {
+                this.readLoop = readLoop;
+                this.writeLoop = writeLoop;
+            }
+        }
+
+        @Param
+        private EventLoopType eventLoopType;
+
+        @Benchmark
+        public long writeFirst(StreamObjects streamObjects) throws Exception {
+            StreamMessageAndWriter<Integer> stream = newStream(streamObjects);
+
+            eventLoopType.writeLoop.execute(() -> streamObjects.writeAllValues(stream));
+            streamObjects.wroteLatch.await(10, TimeUnit.SECONDS);
+
+            stream.subscribe(streamObjects.subscriber, eventLoopType.readLoop);
+
+            streamObjects.completedLatch.await(10, TimeUnit.SECONDS);
+
+            return streamObjects.computedSum();
+        }
+
+        @Benchmark
+        public long writeLast(StreamObjects streamObjects) throws Exception {
+            StreamMessageAndWriter<Integer> stream = newStream(streamObjects);
+
+            stream.subscribe(streamObjects.subscriber, eventLoopType.readLoop);
+
+            eventLoopType.writeLoop.execute(() -> streamObjects.writeAllValues(stream));
+            streamObjects.wroteLatch.await(10, TimeUnit.SECONDS);
+
+            streamObjects.completedLatch.await(10, TimeUnit.SECONDS);
+
+            return streamObjects.computedSum();
+        }
+
+        @Benchmark
+        public long writeOnDemand(StreamObjects streamObjects) throws Exception {
+            StreamMessageAndWriter<Integer> stream = newStream(streamObjects);
+            stream.onDemand(() -> writeOnDemand(streamObjects, stream));
+
+            stream.subscribe(streamObjects.subscriber, eventLoopType.readLoop);
+
+            streamObjects.completedLatch.await(10, TimeUnit.SECONDS);
+
+            return streamObjects.computedSum();
+        }
+
+        private void writeOnDemand(StreamObjects streamObjects, StreamMessageAndWriter<Integer> stream) {
+            eventLoopType.writeLoop.submit(() -> {
+                streamObjects.writeNextValue(stream);
+                if (stream.isOpen()) {
+                    stream.onDemand(() -> writeOnDemand(streamObjects, stream));
+                }
+            });
+        }
+
+        private StreamMessageAndWriter<Integer> newStream(StreamObjects streamObjects) {
+            switch (streamObjects.streamType) {
+                case EVENT_LOOP_MESSAGE:
+                    return new EventLoopStreamMessage<>(EVENT_LOOP1);
+                case DEFAULT_STREAM_MESSAGE:
+                    return new DefaultStreamMessage<>();
+                default:
+                    throw new Error();
+            }
+        }
+    }
+
     private static final class SummingSubscriber implements Subscriber<Integer> {
 
         private final CountDownLatch completedLatch;
+        private final boolean flowControl;
+
+        private Subscription subscription;
 
         private long sum;
         private boolean complete;
         private Throwable error;
 
-        private SummingSubscriber(CountDownLatch completedLatch) {
+        private SummingSubscriber(CountDownLatch completedLatch, boolean flowControl) {
             this.completedLatch = completedLatch;
+            this.flowControl = flowControl;
         }
 
         private long sum() {
@@ -149,13 +299,21 @@ public class StreamMessageBenchmark {
         }
 
         @Override
-        public void onSubscribe(Subscription s) {
-            s.request(Long.MAX_VALUE);
+        public void onSubscribe(Subscription subscription) {
+            this.subscription = subscription;
+            if (flowControl) {
+                subscription.request(1);
+            } else {
+                subscription.request(Long.MAX_VALUE);
+            }
         }
 
         @Override
         public void onNext(Integer value) {
             sum += value;
+            if (flowControl) {
+                subscription.request(1);
+            }
         }
 
         @Override

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/common/stream/StreamMessageBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/common/stream/StreamMessageBenchmark.java
@@ -5,7 +5,7 @@
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/common/stream/StreamMessageBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/common/stream/StreamMessageBenchmark.java
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-package com.linecorp.armeria.benchmarks.core;
+package com.linecorp.armeria.common.stream;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -32,11 +32,7 @@ import org.reactivestreams.Subscription;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.linecorp.armeria.benchmarks.shared.EventLoopJmhExecutor;
-import com.linecorp.armeria.common.stream.DefaultStreamMessage;
-import com.linecorp.armeria.common.stream.EventLoopStreamMessage;
-import com.linecorp.armeria.common.stream.StreamMessageAndWriter;
-import com.linecorp.armeria.common.stream.StreamWriter;
+import com.linecorp.armeria.shared.EventLoopJmhExecutor;
 
 import io.netty.channel.DefaultEventLoop;
 import io.netty.channel.EventLoop;

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/core/HttpServerBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/core/HttpServerBenchmark.java
@@ -5,7 +5,7 @@
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/core/HttpServerBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/core/HttpServerBenchmark.java
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-package com.linecorp.armeria.benchmarks.core;
+package com.linecorp.armeria.core;
 
 import static com.linecorp.armeria.common.SessionProtocol.HTTP;
 

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/grpc/downstream/DownstreamSimpleBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/grpc/downstream/DownstreamSimpleBenchmark.java
@@ -5,7 +5,7 @@
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/grpc/downstream/DownstreamSimpleBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/grpc/downstream/DownstreamSimpleBenchmark.java
@@ -14,18 +14,18 @@
  * under the License.
  */
 
-package com.linecorp.armeria.benchmarks.grpc.downstream;
+package com.linecorp.armeria.grpc.downstream;
 
 import static com.linecorp.armeria.common.SessionProtocol.HTTP;
 
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 
-import com.linecorp.armeria.benchmarks.grpc.GithubServiceGrpc.GithubServiceBlockingStub;
-import com.linecorp.armeria.benchmarks.grpc.GithubServiceGrpc.GithubServiceFutureStub;
-import com.linecorp.armeria.benchmarks.grpc.shared.GithubApiService;
-import com.linecorp.armeria.benchmarks.grpc.shared.SimpleBenchmarkBase;
 import com.linecorp.armeria.client.Clients;
+import com.linecorp.armeria.grpc.GithubServiceGrpc.GithubServiceBlockingStub;
+import com.linecorp.armeria.grpc.GithubServiceGrpc.GithubServiceFutureStub;
+import com.linecorp.armeria.grpc.shared.GithubApiService;
+import com.linecorp.armeria.grpc.shared.SimpleBenchmarkBase;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.ServerPort;

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/grpc/shared/ClientType.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/grpc/shared/ClientType.java
@@ -5,7 +5,7 @@
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/grpc/shared/ClientType.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/grpc/shared/ClientType.java
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-package com.linecorp.armeria.benchmarks.grpc.shared;
+package com.linecorp.armeria.grpc.shared;
 
 public enum ClientType {
     // The official client for the benchmark (armeria for downstream, grpc-netty for upstream).

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/grpc/shared/GithubApiService.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/grpc/shared/GithubApiService.java
@@ -5,7 +5,7 @@
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/grpc/shared/GithubApiService.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/grpc/shared/GithubApiService.java
@@ -14,15 +14,15 @@
  * under the License.
  */
 
-package com.linecorp.armeria.benchmarks.grpc.shared;
+package com.linecorp.armeria.grpc.shared;
 
 import java.io.IOException;
 
 import com.google.common.io.Resources;
 import com.google.protobuf.Empty;
 
-import com.linecorp.armeria.benchmarks.grpc.GithubApi.SearchResponse;
-import com.linecorp.armeria.benchmarks.grpc.GithubServiceGrpc.GithubServiceImplBase;
+import com.linecorp.armeria.grpc.GithubApi.SearchResponse;
+import com.linecorp.armeria.grpc.GithubServiceGrpc.GithubServiceImplBase;
 
 import io.grpc.stub.StreamObserver;
 

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/grpc/shared/SimpleBenchmarkBase.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/grpc/shared/SimpleBenchmarkBase.java
@@ -5,7 +5,7 @@
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/grpc/shared/SimpleBenchmarkBase.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/grpc/shared/SimpleBenchmarkBase.java
@@ -14,9 +14,9 @@
  * under the License.
  */
 
-package com.linecorp.armeria.benchmarks.grpc.shared;
+package com.linecorp.armeria.grpc.shared;
 
-import static com.linecorp.armeria.benchmarks.grpc.shared.GithubApiService.SEARCH_RESPONSE;
+import static com.linecorp.armeria.grpc.shared.GithubApiService.SEARCH_RESPONSE;
 import static org.awaitility.Awaitility.await;
 
 import java.util.concurrent.TimeUnit;
@@ -38,10 +38,10 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.protobuf.Empty;
 
-import com.linecorp.armeria.benchmarks.grpc.GithubApi.SearchResponse;
-import com.linecorp.armeria.benchmarks.grpc.GithubServiceGrpc;
-import com.linecorp.armeria.benchmarks.grpc.GithubServiceGrpc.GithubServiceBlockingStub;
-import com.linecorp.armeria.benchmarks.grpc.GithubServiceGrpc.GithubServiceFutureStub;
+import com.linecorp.armeria.grpc.GithubApi.SearchResponse;
+import com.linecorp.armeria.grpc.GithubServiceGrpc;
+import com.linecorp.armeria.grpc.GithubServiceGrpc.GithubServiceBlockingStub;
+import com.linecorp.armeria.grpc.GithubServiceGrpc.GithubServiceFutureStub;
 
 import io.grpc.ManagedChannel;
 import io.grpc.okhttp.OkHttpChannelBuilder;

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/grpc/upstream/UpstreamSimpleBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/grpc/upstream/UpstreamSimpleBenchmark.java
@@ -5,7 +5,7 @@
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/grpc/upstream/UpstreamSimpleBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/grpc/upstream/UpstreamSimpleBenchmark.java
@@ -14,18 +14,18 @@
  * under the License.
  */
 
-package com.linecorp.armeria.benchmarks.grpc.upstream;
+package com.linecorp.armeria.grpc.upstream;
 
 import java.util.concurrent.TimeUnit;
 
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 
-import com.linecorp.armeria.benchmarks.grpc.GithubServiceGrpc;
-import com.linecorp.armeria.benchmarks.grpc.GithubServiceGrpc.GithubServiceBlockingStub;
-import com.linecorp.armeria.benchmarks.grpc.GithubServiceGrpc.GithubServiceFutureStub;
-import com.linecorp.armeria.benchmarks.grpc.shared.GithubApiService;
-import com.linecorp.armeria.benchmarks.grpc.shared.SimpleBenchmarkBase;
+import com.linecorp.armeria.grpc.GithubServiceGrpc;
+import com.linecorp.armeria.grpc.GithubServiceGrpc.GithubServiceBlockingStub;
+import com.linecorp.armeria.grpc.GithubServiceGrpc.GithubServiceFutureStub;
+import com.linecorp.armeria.grpc.shared.GithubApiService;
+import com.linecorp.armeria.grpc.shared.SimpleBenchmarkBase;
 
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/shared/EventLoopJmhExecutor.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/shared/EventLoopJmhExecutor.java
@@ -5,7 +5,7 @@
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/shared/EventLoopJmhExecutor.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/shared/EventLoopJmhExecutor.java
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-package com.linecorp.armeria.benchmarks.shared;
+package com.linecorp.armeria.shared;
 
 import java.util.concurrent.Executor;
 

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/thrift/PooledResponseBufferBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/thrift/PooledResponseBufferBenchmark.java
@@ -5,7 +5,7 @@
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/thrift/PooledResponseBufferBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/thrift/PooledResponseBufferBenchmark.java
@@ -5,7 +5,7 @@
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *
- *   https://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-package com.linecorp.armeria.benchmarks.thrift;
+package com.linecorp.armeria.thrift;
 
 import static com.linecorp.armeria.common.SessionProtocol.HTTP;
 
@@ -27,8 +27,6 @@ import org.openjdk.jmh.infra.Blackhole;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
-import com.linecorp.armeria.benchmarks.thrift.services.HelloService;
-import com.linecorp.armeria.benchmarks.thrift.services.HelloService.AsyncIface;
 import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.common.DefaultHttpResponse;
 import com.linecorp.armeria.common.HttpObject;
@@ -41,6 +39,8 @@ import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.SimpleDecoratingService;
 import com.linecorp.armeria.server.thrift.THttpService;
+import com.linecorp.armeria.thrift.services.HelloService;
+import com.linecorp.armeria.thrift.services.HelloService.AsyncIface;
 
 import joptsimple.internal.Strings;
 

--- a/benchmarks/src/jmh/proto/com/linecorp/armeria/grpc/github-api.proto
+++ b/benchmarks/src/jmh/proto/com/linecorp/armeria/grpc/github-api.proto
@@ -39,9 +39,9 @@
 
 syntax = "proto3";
 
-package armeria.benchmarks;
+package armeria;
 
-option java_package = "com.linecorp.armeria.benchmarks.grpc";
+option java_package = "com.linecorp.armeria.grpc";
 
 import "google/protobuf/empty.proto";
 import "google/protobuf/timestamp.proto";

--- a/benchmarks/src/jmh/thrift/services.thrift
+++ b/benchmarks/src/jmh/thrift/services.thrift
@@ -1,4 +1,4 @@
-namespace java com.linecorp.armeria.benchmarks.thrift.services
+namespace java com.linecorp.armeria.thrift.services
 
 // Tests a non-oneway method with a return value.
 service HelloService {

--- a/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessage.java
@@ -5,7 +5,7 @@
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessage.java
@@ -1,0 +1,322 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.stream;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import com.google.common.base.MoreObjects;
+
+import com.linecorp.armeria.common.util.Exceptions;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufHolder;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.EventLoop;
+import io.netty.util.ReferenceCountUtil;
+
+abstract class AbstractStreamMessage<T> implements StreamMessage<T> {
+
+    static final CloseEvent CANCELLED_CLOSE = new CloseEvent(
+            Exceptions.clearTrace(CancelledSubscriptionException.get()));
+    static final CloseEvent ABORTED_CLOSE = new CloseEvent(
+            Exceptions.clearTrace(AbortedStreamException.get()));
+
+    private final CompletableFuture<Void> completionFuture = new CompletableFuture<>();
+
+    @Override
+    public void subscribe(Subscriber<? super T> subscriber) {
+        requireNonNull(subscriber, "subscriber");
+        subscribe(subscriber, false);
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super T> subscriber, boolean withPooledObjects) {
+        requireNonNull(subscriber, "subscriber");
+        subscribe(new SubscriptionImpl(this, subscriber, null, withPooledObjects));
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super T> subscriber, Executor executor) {
+        requireNonNull(subscriber, "subscriber");
+        requireNonNull(executor, "executor");
+        subscribe(subscriber, executor, false);
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super T> subscriber, Executor executor, boolean withPooledObjects) {
+        requireNonNull(subscriber, "subscriber");
+        requireNonNull(executor, "executor");
+        subscribe(new SubscriptionImpl(this, subscriber, executor, withPooledObjects));
+    }
+
+    /**
+     * Sets the current subscription for the stream.
+     */
+    abstract void subscribe(SubscriptionImpl subscription);
+
+    @Override
+    public final CompletableFuture<Void> completionFuture() {
+        return completionFuture;
+    }
+
+    /**
+     * Returns the current demand.
+     */
+    abstract long demand();
+
+    /**
+     * Callback invoked by {@link Subscription#request(long)} to add {@code n} to demand.
+     */
+    abstract void request(long n);
+
+    /**
+     * Callback invoked by {@link Subscription#cancel()} to cancel the stream.
+     */
+    abstract void cancel();
+
+    /**
+     * Invoked after an element is removed from the {@link StreamMessage} and before
+     * {@link Subscriber#onNext(Object)} is invoked.
+     *
+     * @param obj the removed element
+     */
+    protected void onRemoval(T obj) {}
+
+    static void failLateSubscriber(SubscriptionImpl subscription, Subscriber<?> lateSubscriber) {
+        final Subscriber<?> oldSubscriber = subscription.subscriber();
+        final Throwable cause;
+        if (oldSubscriber instanceof AbortingSubscriber) {
+            cause = AbortedStreamException.get();
+        } else {
+            cause = new IllegalStateException("subscribed by other subscriber already");
+        }
+
+        if (subscription.needsDirectInvocation()) {
+            lateSubscriber.onSubscribe(NoopSubscription.INSTANCE);
+            lateSubscriber.onError(cause);
+        } else {
+            subscription.executor().execute(() -> {
+                lateSubscriber.onSubscribe(NoopSubscription.INSTANCE);
+                lateSubscriber.onError(cause);
+            });
+        }
+    }
+
+    T prepareObjectForNotification(SubscriptionImpl subscription, T o) {
+        ReferenceCountUtil.touch(o);
+        onRemoval(o);
+        if (!subscription.withPooledObjects()) {
+            if (o instanceof ByteBufHolder) {
+                o = copyAndRelease((ByteBufHolder) o);
+            } else if (o instanceof ByteBuf) {
+                o = copyAndRelease((ByteBuf) o);
+            }
+        }
+        return o;
+    }
+
+    /**
+     * Helper method for the common case of cleaning up all elements in a queue when shutting down the stream.
+     */
+    void cleanupQueue(SubscriptionImpl subscription, Queue<Object> queue) {
+        final Throwable cause = ClosedPublisherException.get();
+        for (;;) {
+            final Object e = queue.poll();
+            if (e == null) {
+                break;
+            }
+
+            try {
+                if (e instanceof CloseEvent) {
+                    ((CloseEvent) e).notifySubscriber(subscription, completionFuture());
+                    subscription.clearSubscriber();
+                    continue;
+                }
+
+                if (e instanceof CompletableFuture) {
+                    ((CompletableFuture<?>) e).completeExceptionally(cause);
+                }
+
+                @SuppressWarnings("unchecked")
+                T obj = (T) e;
+                onRemoval(obj);
+            } finally {
+                ReferenceCountUtil.safeRelease(e);
+            }
+        }
+    }
+
+    private T copyAndRelease(ByteBufHolder o) {
+        try {
+            final ByteBuf content = Unpooled.wrappedBuffer(ByteBufUtil.getBytes(o.content()));
+            @SuppressWarnings("unchecked")
+            final T copy = (T) o.replace(content);
+            return copy;
+        } finally {
+            ReferenceCountUtil.safeRelease(o);
+        }
+    }
+
+    private T copyAndRelease(ByteBuf o) {
+        try {
+            @SuppressWarnings("unchecked")
+            final T copy = (T) Unpooled.copiedBuffer(o);
+            return copy;
+        } finally {
+            ReferenceCountUtil.safeRelease(o);
+        }
+    }
+
+    static final class SubscriptionImpl implements Subscription {
+
+        private final AbstractStreamMessage<?> publisher;
+        private Subscriber<Object> subscriber;
+        private final Executor executor;
+        private final boolean withPooledObjects;
+
+        private volatile boolean cancelRequested;
+
+        @SuppressWarnings("unchecked")
+        SubscriptionImpl(AbstractStreamMessage<?> publisher, Subscriber<?> subscriber, Executor executor,
+                         boolean withPooledObjects) {
+            this.publisher = publisher;
+            this.subscriber = (Subscriber<Object>) subscriber;
+            this.executor = executor;
+            this.withPooledObjects = withPooledObjects;
+        }
+
+        Subscriber<Object> subscriber() {
+            return subscriber;
+        }
+
+        /**
+         * Replaces the subscriber with a placeholder so that it can be garbage-collected and
+         * we conform to the Reactive Streams specification rule 3.13.
+         */
+        void clearSubscriber() {
+            if (!(subscriber instanceof AbortingSubscriber)) {
+                subscriber = NeverInvokedSubscriber.get();
+            }
+        }
+
+        Executor executor() {
+            return executor;
+        }
+
+        boolean withPooledObjects() {
+            return withPooledObjects;
+        }
+
+        boolean cancelRequested() {
+            return cancelRequested;
+        }
+
+        @Override
+        public void request(long n) {
+            if (n <= 0) {
+                invokeOnError(new IllegalArgumentException(
+                        "n: " + n + " (expected: > 0, see Reactive Streams specification rule 3.9)"));
+                return;
+            }
+
+            publisher.request(n);
+        }
+
+        @Override
+        public void cancel() {
+            cancelRequested = true;
+            publisher.cancel();
+        }
+
+        private void invokeOnError(Throwable cause) {
+            if (needsDirectInvocation()) {
+                subscriber.onError(cause);
+            } else {
+                executor.execute(() -> subscriber.onError(cause));
+            }
+        }
+
+        // We directly run callbacks for event loops if we're already on the loop, which applies to the vast
+        // majority of cases.
+        boolean needsDirectInvocation() {
+            return executor == null ||
+                   executor instanceof EventLoop && ((EventLoop) executor).inEventLoop();
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(Subscription.class)
+                              .add("publisher", publisher)
+                              .add("demand", publisher.demand())
+                              .add("executor", executor).toString();
+        }
+    }
+
+    static final class CloseEvent {
+        private final Throwable cause;
+
+        CloseEvent(Throwable cause) {
+            this.cause = cause;
+        }
+
+        void notifySubscriber(SubscriptionImpl subscription, CompletableFuture<?> completionFuture) {
+            if (completionFuture.isDone()) {
+                // Notified already
+                return;
+            }
+
+            final Subscriber<Object> subscriber = subscription.subscriber();
+            Throwable cause = this.cause;
+            if (cause == null && subscription.cancelRequested()) {
+                cause = CancelledSubscriptionException.get();
+            }
+
+            if (cause == null) {
+                try {
+                    subscriber.onComplete();
+                } finally {
+                    completionFuture.complete(null);
+                }
+            } else {
+                try {
+                    if (!(cause instanceof CancelledSubscriptionException)) {
+                        subscriber.onError(cause);
+                    }
+                } finally {
+                    completionFuture.completeExceptionally(cause);
+                }
+            }
+        }
+
+        @Override
+        public String toString() {
+            if (cause == null) {
+                return "CloseEvent";
+            } else {
+                return "CloseEvent(" + cause + ')';
+            }
+        }
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessageAndWriter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessageAndWriter.java
@@ -5,7 +5,7 @@
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessageAndWriter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessageAndWriter.java
@@ -90,12 +90,12 @@ abstract class AbstractStreamMessageAndWriter<T> extends AbstractStreamMessage<T
     }
 
     /**
-     * Add an object to publish to the stream.
+     * Adds an object to publish to the stream.
      */
     abstract void addObject(T obj);
 
     /**
-     * Add an object to publish (of type {@code T} or an event (e.g., {@link CloseEvent},
+     * Adds an object to publish (of type {@code T} or an event (e.g., {@link CloseEvent},
      * {@link AwaitDemandFuture}) to the stream.
      */
     abstract void addObjectOrEvent(Object obj);

--- a/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessageAndWriter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessageAndWriter.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.stream;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.concurrent.CompletableFuture;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufHolder;
+import io.netty.util.ReferenceCountUtil;
+import io.netty.util.ReferenceCounted;
+
+abstract class AbstractStreamMessageAndWriter<T> extends AbstractStreamMessage<T>
+        implements StreamMessageAndWriter<T> {
+
+    static final CloseEvent SUCCESSFUL_CLOSE = new CloseEvent(null);
+
+    enum State {
+        /**
+         * The initial state. Will enter {@link #CLOSED} or {@link #CLEANUP}.
+         */
+        OPEN,
+        /**
+         * {@link #close()} or {@link #close(Throwable)} has been called. Will enter {@link #CLEANUP} after
+         * {@link org.reactivestreams.Subscriber#onComplete()} or
+         * {@link org.reactivestreams.Subscriber#onError(Throwable)} is invoked.
+         */
+        CLOSED,
+        /**
+         * Anything in the queue must be cleaned up.
+         * Enters this state when there's no chance of consumption by subscriber.
+         * i.e. when any of the following methods are invoked:
+         * <ul>
+         *   <li>{@link org.reactivestreams.Subscription#cancel()}</li>
+         *   <li>{@link #abort()} (via {@link AbortingSubscriber})</li>
+         *   <li>{@link org.reactivestreams.Subscriber#onComplete()}</li>
+         *   <li>{@link org.reactivestreams.Subscriber#onError(Throwable)}</li>
+         * </ul>
+         */
+        CLEANUP
+    }
+
+    @Override
+    public boolean write(T obj) {
+        requireNonNull(obj, "obj");
+        if (obj instanceof ReferenceCounted) {
+            ((ReferenceCounted) obj).touch();
+            if (!(obj instanceof ByteBufHolder) && !(obj instanceof ByteBuf)) {
+                throw new IllegalArgumentException(
+                        "can't publish a ReferenceCounted that's not a ByteBuf or a ByteBufHolder: " + obj);
+            }
+        }
+
+        if (!isOpen()) {
+            ReferenceCountUtil.safeRelease(obj);
+            return false;
+        }
+
+        addObject(obj);
+        return true;
+    }
+
+    @Override
+    public CompletableFuture<Void> onDemand(Runnable task) {
+        requireNonNull(task, "task");
+
+        final AwaitDemandFuture f = new AwaitDemandFuture();
+        if (!isOpen()) {
+            f.completeExceptionally(ClosedPublisherException.get());
+            return f;
+        }
+
+        addObjectOrEvent(f);
+        return f.thenRun(task);
+    }
+
+    /**
+     * Add an object to publish to the stream.
+     */
+    abstract void addObject(T obj);
+
+    /**
+     * Add an object to publish (of type {@code T} or an event (e.g., {@link CloseEvent},
+     * {@link AwaitDemandFuture}) to the stream.
+     */
+    abstract void addObjectOrEvent(Object obj);
+
+    static final class AwaitDemandFuture extends CompletableFuture<Void> {}
+}

--- a/core/src/main/java/com/linecorp/armeria/common/stream/EventLoopStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/EventLoopStreamMessage.java
@@ -1,0 +1,402 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.stream;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.ArrayDeque;
+import java.util.Queue;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
+import javax.annotation.Nullable;
+
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linecorp.armeria.common.CommonPools;
+import com.linecorp.armeria.common.Flags;
+
+import io.netty.channel.EventLoop;
+
+/**
+ * A {@link StreamMessage} optimized for when writes and reads all happen on the provided {@link EventLoop},
+ * removing the need for most synchronization from the hot path. This should satisfy standard cases when using
+ * Armeria. It is not required for writes or reads to use the provided {@link EventLoop} but in such a case, it
+ * will be significantly faster to use {@link DefaultStreamMessage}.
+ *
+ * <p>Note that when {@link Subscription#cancel()} or {@link #abort()} are called from a different thread, the
+ * stream will continue to signal objects until demand is satisfied, rather than stopping in the middle. If this
+ * is an issue, it is recommended to use {@link DefaultStreamMessage}.
+ *
+ * <p>Methods in this class prefixed with 'do' must be run on the stream's event loop.
+ */
+public class EventLoopStreamMessage<T> extends AbstractStreamMessageAndWriter<T> {
+
+    @SuppressWarnings("rawtypes")
+    private static final AtomicIntegerFieldUpdater<EventLoopStreamMessage> abortedUpdater =
+            AtomicIntegerFieldUpdater.newUpdater(EventLoopStreamMessage.class, "aborted");
+    @SuppressWarnings("rawtypes")
+    private static final AtomicIntegerFieldUpdater<EventLoopStreamMessage> subscribedUpdater =
+            AtomicIntegerFieldUpdater.newUpdater(EventLoopStreamMessage.class, "subscribed");
+
+    private static final Logger logger = LoggerFactory.getLogger(EventLoopStreamMessage.class);
+
+    private final EventLoop eventLoop;
+    private final Queue<Object> queue;
+
+    private SubscriptionImpl subscription;
+    private long demand;
+    private boolean invokedOnSubscribe;
+    private boolean inOnNext;
+
+    private State state = State.OPEN;
+
+    @SuppressWarnings("unused")
+    private volatile int subscribed;  // set only via subscribedUpdater
+    @SuppressWarnings("unused")
+    private volatile int aborted;  // set only via abortedUpdater
+    private volatile boolean isOpen = true;
+    private volatile boolean wroteAny;
+
+    /**
+     * Creates a new {@link EventLoopStreamMessage} which executes all writes on an arbitrary {@link EventLoop}.
+     * It is highly recommended to use {@link #EventLoopStreamMessage(EventLoop)} instead to allow writes to
+     * happen on the same {@link EventLoop} as this stream's.
+     */
+    public EventLoopStreamMessage() {
+        this(CommonPools.workerGroup().next());
+        logger.debug("Creating EventLoopStreamMessage without specifying EventLoop. This will be very slow.");
+    }
+
+    /**
+     * Creates a new {@link EventLoopStreamMessage} which executes all writes on the provided {@link EventLoop}.
+     */
+    public EventLoopStreamMessage(EventLoop eventLoop) {
+        this.eventLoop = requireNonNull(eventLoop, "eventLoop");
+        queue = new ArrayDeque<>();
+    }
+
+    @Override
+    public boolean isOpen() {
+        return isOpen;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return !isOpen() && !wroteAny;
+    }
+
+    @Override
+    void subscribe(SubscriptionImpl subscription) {
+        Subscriber<?> subscriber = subscription.subscriber();
+        if (!subscribedUpdater.compareAndSet(this, 0, 1)) {
+            eventLoop.execute(() -> failLateSubscriber(this.subscription, subscriber));
+            return;
+        }
+
+        if (eventLoop.inEventLoop()) {
+            doSubscribe(subscription);
+        } else {
+            eventLoop.execute(() -> doSubscribe(subscription));
+        }
+    }
+
+    @Override
+    public void close() {
+        if (eventLoop.inEventLoop()) {
+            doClose(null);
+        } else {
+            eventLoop.execute(() -> doClose(null));
+        }
+    }
+
+    @Override
+    public void close(Throwable cause) {
+        requireNonNull(cause, "cause");
+        if (cause instanceof CancelledSubscriptionException) {
+            throw new IllegalArgumentException("cause: " + cause + " (must use Subscription.cancel())");
+        }
+
+        if (eventLoop.inEventLoop()) {
+            doClose(cause);
+        } else {
+            eventLoop.execute(() -> doClose(cause));
+        }
+    }
+
+    @Override
+    public void abort() {
+        if (abortedUpdater.compareAndSet(this, 0, 1)) {
+            // Let readers of isOpen know immediately that the stream was aborted.
+            isOpen = false;
+
+            if (subscribedUpdater.compareAndSet(this, 0, 1)) {
+                subscription = new SubscriptionImpl(this, AbortingSubscriber.get(), null, false);
+                // We don't need to invoke onSubscribe() for AbortingSubscriber because it's just a placeholder.
+                invokedOnSubscribe = true;
+            }
+
+            cancelOrAbort(false);
+        }
+    }
+
+    @Override
+    long demand() {
+        return demand;
+    }
+
+    @Override
+    void request(long n) {
+        if (eventLoop.inEventLoop()) {
+            doRequest(n);
+        } else {
+            eventLoop.execute(() -> doRequest(n));
+        }
+    }
+
+    @Override
+    void cancel() {
+        cancelOrAbort(true);
+    }
+
+    @Override
+    void addObject(T obj) {
+        wroteAny = true;
+        if (eventLoop.inEventLoop()) {
+            doAddObject(obj);
+        } else {
+            eventLoop.execute(() -> doAddObject(obj));
+        }
+    }
+
+    @Override
+    void addObjectOrEvent(Object obj) {
+        if (eventLoop.inEventLoop()) {
+            doAddObjectOrEvent(obj);
+        } else {
+            eventLoop.execute(() -> doAddObjectOrEvent(obj));
+        }
+    }
+
+    private void doClose(@Nullable Throwable cause) {
+        if (state != State.OPEN) {
+            return;
+        }
+        doSetState(State.CLOSED);
+        final CloseEvent event = cause == null ? SUCCESSFUL_CLOSE : new CloseEvent(cause);
+        doAddObjectOrEvent(event);
+    }
+
+    private void doSetState(State state) {
+        this.state = state;
+        isOpen = false;
+    }
+
+    private void doSubscribe(SubscriptionImpl subscription) {
+        this.subscription = subscription;
+
+        if (subscription.needsDirectInvocation()) {
+            invokedOnSubscribe = true;
+            subscription.subscriber().onSubscribe(subscription);
+        } else {
+            subscription.executor().execute(() -> {
+                subscription.subscriber().onSubscribe(subscription);
+                eventLoop.execute(() -> invokedOnSubscribe = true);
+            });
+        }
+    }
+
+    private void doRequest(long n) {
+        long oldDemand = demand;
+        final long newDemand;
+        if (oldDemand >= Long.MAX_VALUE - n) {
+            newDemand = Long.MAX_VALUE;
+        } else {
+            newDemand = oldDemand + n;
+        }
+        demand = newDemand;
+
+        if (oldDemand == 0) {
+            doNotifySubscriberIfNotEmpty();
+        }
+    }
+
+    private void doAddObject(T obj) {
+        SubscriptionImpl subscription = this.subscription;
+        if (queue.isEmpty() && demand > 0 && !inOnNext) {
+            // Nothing in the queue and the subscriber is ready for an object, so send it directly.
+            demand--;
+            notifySubscriberOfObject(subscription, obj);
+            return;
+        }
+
+        doAddObjectOrEvent(obj);
+    }
+
+    private void doAddObjectOrEvent(Object obj) {
+        queue.add(obj);
+
+        if (subscription != null) {
+            doNotifySubscriber(subscription);
+        }
+    }
+
+    private void doNotifySubscriberIfNotEmpty() {
+        final SubscriptionImpl subscription = this.subscription;
+        if (subscription == null) {
+            return;
+        }
+
+        if (queue.isEmpty()) {
+            return;
+        }
+
+        doNotifySubscriber(subscription);
+    }
+
+    private void doNotifySubscriber(SubscriptionImpl subscription) {
+        if (inOnNext) {
+            // Do not let Subscriber.onNext() reenter, because it can lead to weird-looking event ordering
+            // for a Subscriber implemented like the following:
+            //
+            //   public void onNext(Object e) {
+            //       subscription.request(1);
+            //       ... Handle 'e' ...
+            //   }
+            //
+            // Note that we do not call this method again, because we are already in the notification loop
+            // and it will consume the element we've just added in addObject() from the queue as expected.
+            //
+            // We do not need to worry about synchronizing the access to 'inOnNext' because the subscriber
+            // methods must be on the same thread, or synchronized, according to Reactive Streams spec.
+            return;
+        }
+
+        if (!invokedOnSubscribe) {
+            // Subscriber.onSubscribe() was not invoked yet.
+            // Reschedule the notification so that onSubscribe() is invoked before other events.
+            eventLoop.execute(() -> doNotifySubscriber(subscription));
+            return;
+        }
+
+        for (;;) {
+            if (state == State.CLEANUP) {
+                cleanup();
+                return;
+            }
+
+            final Object o = queue.peek();
+            if (o == null) {
+                break;
+            }
+
+            if (o instanceof CloseEvent) {
+                doNotifySubscriberWithCloseEvent(subscription, (CloseEvent) o);
+                break;
+            }
+
+            if (demand == 0) {
+                break;
+            }
+
+            if (o instanceof AwaitDemandFuture) {
+                AwaitDemandFuture f = (AwaitDemandFuture) queue.remove();
+                f.complete(null);
+                continue;
+            }
+
+            demand--;
+
+            @SuppressWarnings("unchecked")
+            T obj = (T) queue.remove();
+            notifySubscriberOfObject(subscription, obj);
+        }
+    }
+
+    private void notifySubscriberOfObject(SubscriptionImpl subscription, T obj) {
+        final Subscriber<Object> subscriber = subscription.subscriber();
+        obj = prepareObjectForNotification(subscription, obj);
+
+        if (subscription.needsDirectInvocation()) {
+            inOnNext = true;
+            subscriber.onNext(obj);
+            inOnNext = false;
+        } else {
+            final T published = obj;
+            subscription.executor().execute(() -> subscriber.onNext(published));
+        }
+    }
+
+    private void doNotifySubscriberWithCloseEvent(SubscriptionImpl subscription, CloseEvent event) {
+        if (!invokedOnSubscribe) {
+            // Subscriber.onSubscribe() was not invoked yet.
+            // Reschedule the notification so that onSubscribe() is invoked before event.
+            eventLoop.execute(() -> doNotifySubscriberWithCloseEvent(subscription, event));
+            return;
+        }
+        doSetState(State.CLEANUP);
+        try {
+            event.notifySubscriber(subscription, completionFuture());
+        } finally {
+            cleanup();
+        }
+    }
+
+    private void cancelOrAbort(boolean cancel) {
+        if (eventLoop.inEventLoop()) {
+            doCancelOrAbort(cancel);
+        } else {
+            eventLoop.execute(() -> doCancelOrAbort(cancel));
+        }
+    }
+
+    private void doCancelOrAbort(boolean cancel) {
+        if (state == State.OPEN) {
+            doSetState(State.CLEANUP);
+            final CloseEvent closeEvent;
+            if (cancel) {
+                closeEvent = Flags.verboseExceptions() ?
+                             new CloseEvent(CancelledSubscriptionException.get()) : CANCELLED_CLOSE;
+            } else {
+                closeEvent = Flags.verboseExceptions() ?
+                             new CloseEvent(AbortedStreamException.get()) : ABORTED_CLOSE;
+            }
+            doAddObjectOrEvent(closeEvent);
+            return;
+        }
+
+        switch (state) {
+            case CLOSED:
+                // close() has been called before cancel(). There's no need to push a CloseEvent,
+                // but we need to ensure the closeFuture is notified and any pending objects are removed.
+                doSetState(State.CLEANUP);
+                cleanup();
+                break;
+            case CLEANUP:
+                // Cleaned up already.
+                break;
+            default: // OPEN: should never reach here.
+                throw new Error();
+        }
+    }
+
+    private void cleanup() {
+        cleanupQueue(subscription, queue);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/common/stream/EventLoopStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/EventLoopStreamMessage.java
@@ -96,7 +96,7 @@ public class EventLoopStreamMessage<T> extends AbstractStreamMessageAndWriter<T>
             List<StackTraceElement> stackTrace = ImmutableList.copyOf(t.getStackTrace());
             UNEXPECTED_EVENT_LOOP_STACK_TRACES.computeIfAbsent(stackTrace, (unused) -> {
                 logger.debug("Creating EventLoopStreamMessage without specifying EventLoop. " +
-                             "This will be very slow.", t);
+                             "This will be very slow if writer or subscriber run in a different EventLoop.", t);
                 return MarkedStackTrace.SINGLETON;
             });
             return CommonPools.workerGroup().next();

--- a/core/src/main/java/com/linecorp/armeria/common/stream/EventLoopStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/EventLoopStreamMessage.java
@@ -52,11 +52,7 @@ import io.netty.channel.EventLoop;
 // NB: Methods in this class prefixed with 'do' must be run on the stream's event loop.
 public class EventLoopStreamMessage<T> extends AbstractStreamMessageAndWriter<T> {
 
-    private enum MarkedStackTrace {
-        SINGLETON
-    }
-
-    private static final ConcurrentHashMap<List<StackTraceElement>, MarkedStackTrace>
+    private static final ConcurrentHashMap<List<StackTraceElement>, Boolean>
             UNEXPECTED_EVENT_LOOP_STACK_TRACES = new ConcurrentHashMap<>();
 
     @SuppressWarnings("rawtypes")
@@ -97,7 +93,7 @@ public class EventLoopStreamMessage<T> extends AbstractStreamMessageAndWriter<T>
             UNEXPECTED_EVENT_LOOP_STACK_TRACES.computeIfAbsent(stackTrace, (unused) -> {
                 logger.debug("Creating EventLoopStreamMessage without specifying EventLoop. " +
                              "This will be very slow if writer or subscriber run in a different EventLoop.", t);
-                return MarkedStackTrace.SINGLETON;
+                return true;
             });
             return CommonPools.workerGroup().next();
         }));

--- a/core/src/main/java/com/linecorp/armeria/common/stream/EventLoopStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/EventLoopStreamMessage.java
@@ -88,8 +88,8 @@ public class EventLoopStreamMessage<T> extends AbstractStreamMessageAndWriter<T>
      */
     public EventLoopStreamMessage() {
         this(RequestContext.mapCurrent(RequestContext::eventLoop, () -> {
-            UnexpectedEventLoopException e = new UnexpectedEventLoopException();
-            List<StackTraceElement> stackTrace = ImmutableList.copyOf(e.getStackTrace());
+            final UnexpectedEventLoopException e = new UnexpectedEventLoopException();
+            final List<StackTraceElement> stackTrace = ImmutableList.copyOf(e.getStackTrace());
             UNEXPECTED_EVENT_LOOP_STACK_TRACES.computeIfAbsent(stackTrace, (unused) -> {
                 logger.warn("Creating EventLoopStreamMessage without specifying EventLoop. " +
                             "This will be very slow if writer or subscriber run in a different EventLoop.", e);
@@ -245,7 +245,7 @@ public class EventLoopStreamMessage<T> extends AbstractStreamMessageAndWriter<T>
     }
 
     private void doRequest(long n) {
-        long oldDemand = demand;
+        final long oldDemand = demand;
         final long newDemand;
         if (oldDemand >= Long.MAX_VALUE - n) {
             newDemand = Long.MAX_VALUE;
@@ -260,8 +260,8 @@ public class EventLoopStreamMessage<T> extends AbstractStreamMessageAndWriter<T>
     }
 
     private void doAddObject(T obj) {
-        SubscriptionImpl subscription = this.subscription;
         if (queue.isEmpty() && demand > 0 && !inOnNext) {
+            SubscriptionImpl subscription = this.subscription;
             // Nothing in the queue and the subscriber is ready for an object, so send it directly.
             demand--;
             doNotifySubscriberOfObject(subscription, obj);
@@ -338,7 +338,7 @@ public class EventLoopStreamMessage<T> extends AbstractStreamMessageAndWriter<T>
             }
 
             if (o instanceof AwaitDemandFuture) {
-                AwaitDemandFuture f = (AwaitDemandFuture) queue.remove();
+                final AwaitDemandFuture f = (AwaitDemandFuture) queue.remove();
                 f.complete(null);
                 continue;
             }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/EventLoopStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/EventLoopStreamMessage.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 
 import com.linecorp.armeria.common.CommonPools;
 import com.linecorp.armeria.common.Flags;
+import com.linecorp.armeria.common.RequestContext;
 
 import io.netty.channel.EventLoop;
 
@@ -79,8 +80,11 @@ public class EventLoopStreamMessage<T> extends AbstractStreamMessageAndWriter<T>
      * happen on the same {@link EventLoop} as this stream's.
      */
     public EventLoopStreamMessage() {
-        this(CommonPools.workerGroup().next());
-        logger.debug("Creating EventLoopStreamMessage without specifying EventLoop. This will be very slow.");
+        this(RequestContext.mapCurrent(RequestContext::eventLoop, () -> {
+            logger.debug(
+                    "Creating EventLoopStreamMessage without specifying EventLoop. This will be very slow.");
+            return CommonPools.workerGroup().next();
+        }));
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/stream/EventLoopStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/EventLoopStreamMessage.java
@@ -439,8 +439,8 @@ public class EventLoopStreamMessage<T> extends AbstractStreamMessageAndWriter<T>
     }
 
     /**
-     * Indicates an invocation of {@link #EventLoopStreamMessage()} with no available event loop, likely causing
-     * significant performance issues.
+     * Indicates an invocation of {@link EventLoopStreamMessage#EventLoopStreamMessage()} with no available
+     * event loop, likely causing significant performance issues.
      */
     private static class UnexpectedEventLoopException extends RuntimeException {}
 }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -137,7 +137,7 @@ public interface StreamMessage<T> extends Publisher<T> {
      * </ul>
      */
     @Override
-    void subscribe(Subscriber<? super T> s);
+    void subscribe(Subscriber<? super T> subscriber);
 
     /**
      * Requests to start streaming data to the specified {@link Subscriber}. If there is a problem subscribing,
@@ -152,7 +152,7 @@ public interface StreamMessage<T> extends Publisher<T> {
      *                          {@link StreamMessage#subscribe(Subscriber)}.
      * @throws IllegalStateException if there is a {@link Subscriber} who subscribed to this stream already
      */
-    void subscribe(Subscriber<? super T> s, boolean withPooledObjects);
+    void subscribe(Subscriber<? super T> subscriber, boolean withPooledObjects);
 
     /**
      * Requests to start streaming data, invoking the specified {@link Subscriber} from the specified
@@ -163,7 +163,7 @@ public interface StreamMessage<T> extends Publisher<T> {
      *   <li>{@link AbortedStreamException} if this stream has been {@linkplain #abort() aborted}.</li>
      * </ul>
      */
-    void subscribe(Subscriber<? super T> s, Executor executor);
+    void subscribe(Subscriber<? super T> subscriber, Executor executor);
 
     /**
      * Requests to start streaming data, invoking the specified {@link Subscriber} from the specified
@@ -178,7 +178,7 @@ public interface StreamMessage<T> extends Publisher<T> {
      *                          as is, without making a copy. If you don't know what this means, use
      *                          {@link StreamMessage#subscribe(Subscriber)}.
      */
-    void subscribe(Subscriber<? super T> s, Executor executor, boolean withPooledObjects);
+    void subscribe(Subscriber<? super T> subscriber, Executor executor, boolean withPooledObjects);
 
     /**
      * Closes this stream with {@link AbortedStreamException} and prevents further subscription.

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageAndWriter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageAndWriter.java
@@ -5,7 +5,7 @@
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageAndWriter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageAndWriter.java
@@ -20,5 +20,5 @@ package com.linecorp.armeria.common.stream;
  * A type which is both a {@link StreamMessage} and a {@link StreamWriter}. This type is mainly used by tests
  * which need to exercise both functionality.
  */
-public interface StreamMessageAndWriter<T> extends StreamMessage<T>, StreamWriter<T> {
+interface StreamMessageAndWriter<T> extends StreamMessage<T>, StreamWriter<T> {
 }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageAndWriter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageAndWriter.java
@@ -5,7 +5,7 @@
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *
- *   https://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
@@ -16,12 +16,9 @@
 
 package com.linecorp.armeria.common.stream;
 
-import java.util.List;
-
-public class DefaultStreamMessageTest extends AbstractStreamMessageTest {
-
-    @Override
-    <T> StreamMessageAndWriter<T> newStream(List<T> unused) {
-        return new DefaultStreamMessage<>();
-    }
+/**
+ * A type which is both a {@link StreamMessage} and a {@link StreamWriter}. This type is mainly used by tests
+ * which need to exercise both functionality.
+ */
+public interface StreamMessageAndWriter<T> extends StreamMessage<T>, StreamWriter<T> {
 }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamWriter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamWriter.java
@@ -51,7 +51,9 @@ public interface StreamWriter<T> {
      * @return {@code true} if the specified object has been scheduled for publication. {@code false} if the
      *         stream has been closed already.
      */
-    boolean write(Supplier<? extends T> o);
+    default boolean write(Supplier<? extends T> o) {
+        return write(o.get());
+    }
 
     /**
      * Performs the specified {@code task} when there's enough demans from the {@link Subscriber}.

--- a/core/src/test/java/com/linecorp/armeria/common/stream/AbstractStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/AbstractStreamMessageTest.java
@@ -1,0 +1,429 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.stream;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Executor;
+import java.util.concurrent.LinkedTransferQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.common.util.Exceptions;
+import com.linecorp.armeria.internal.ByteBufHttpData;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufHolder;
+import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.buffer.UnpooledHeapByteBuf;
+import io.netty.channel.DefaultEventLoop;
+import io.netty.channel.EventLoop;
+import io.netty.util.AbstractReferenceCounted;
+import io.netty.util.ReferenceCounted;
+
+public abstract class AbstractStreamMessageTest {
+
+    private static final List<Integer> TEN_INTEGERS = IntStream.range(0, 10).boxed().collect(toImmutableList());
+
+    private static EventLoop eventLoop;
+
+    @BeforeClass
+    public static void startEventLoop() {
+        eventLoop = new DefaultEventLoop();
+    }
+
+    @AfterClass
+    public static void stopEventLoop() {
+        eventLoop.shutdownGracefully().syncUninterruptibly();
+    }
+
+    EventLoop eventLoop() {
+        return eventLoop;
+    }
+
+    abstract <T> StreamMessageAndWriter<T> newStream(List<T> inputs);
+
+    private List<Integer> result;
+    private volatile boolean completed;
+    private volatile Throwable error;
+
+    @Before
+    public void reset() {
+        result = new ArrayList<>();
+        completed = false;
+    }
+
+    @Test
+    public void full_writeFirst() throws Exception {
+        StreamMessageAndWriter<Integer> stream = newStream(TEN_INTEGERS);
+        TEN_INTEGERS.forEach(stream::write);
+        stream.close();
+        stream.subscribe(new ResultCollectingSubscriber() {
+            @Override
+            public void onSubscribe(Subscription s) {
+                s.request(Long.MAX_VALUE);
+            }
+        });
+        assertSuccess();
+    }
+
+    @Test
+    public void full_writeAfter() throws Exception {
+        StreamMessageAndWriter<Integer> stream = newStream(TEN_INTEGERS);
+        stream.subscribe(new ResultCollectingSubscriber() {
+            @Override
+            public void onSubscribe(Subscription s) {
+                s.request(Long.MAX_VALUE);
+            }
+        });
+        TEN_INTEGERS.forEach(stream::write);
+        stream.close();
+        assertSuccess();
+    }
+
+    // Verifies that re-entrancy into onNext, e.g. calling onNext -> request -> onNext, is not allowed, as per
+    // reactive streams spec 3.03. If it were allowed, the order of processing would be incorrect and the test
+    // would fail.
+    @Test
+    public void flowControlled_writeThenDemandThenProcess() throws Exception {
+        StreamMessageAndWriter<Integer> stream = newStream(TEN_INTEGERS);
+        TEN_INTEGERS.forEach(stream::write);
+        stream.close();
+        stream.subscribe(new ResultCollectingSubscriber() {
+            private Subscription subscription;
+
+            @Override
+            public void onSubscribe(Subscription s) {
+                subscription = s;
+                subscription.request(1);
+            }
+
+            @Override
+            public void onNext(Integer value) {
+                subscription.request(1);
+                super.onNext(value);
+            }
+        });
+        assertSuccess();
+    }
+
+    @Test
+    public void flowControlled_writeThenDemandThenProcess_eventLoop() throws Exception {
+        StreamMessageAndWriter<Integer> stream = newStream(TEN_INTEGERS);
+        TEN_INTEGERS.forEach(stream::write);
+        stream.close();
+        eventLoop().submit(
+                () ->
+                        stream.subscribe(new ResultCollectingSubscriber() {
+                            private Subscription subscription;
+
+                            @Override
+                            public void onSubscribe(Subscription s) {
+                                subscription = s;
+                                subscription.request(1);
+                            }
+
+                            @Override
+                            public void onNext(Integer value) {
+                                subscription.request(1);
+                                super.onNext(value);
+                            }
+                        }, eventLoop())).syncUninterruptibly();
+        assertSuccess();
+    }
+
+    @Test
+    public void flowControlled_writeThenProcessThenDemand() throws Exception {
+        StreamMessageAndWriter<Integer> stream = newStream(TEN_INTEGERS);
+        TEN_INTEGERS.forEach(stream::write);
+        stream.close();
+        stream.subscribe(new ResultCollectingSubscriber() {
+            private Subscription subscription;
+
+            @Override
+            public void onSubscribe(Subscription s) {
+                subscription = s;
+                subscription.request(1);
+            }
+
+            @Override
+            public void onNext(Integer value) {
+                super.onNext(value);
+                subscription.request(1);
+            }
+        });
+        assertSuccess();
+    }
+
+    /**
+     * Makes sure {@link Subscriber#onComplete()} is always invoked after
+     * {@link Subscriber#onSubscribe(Subscription)} even if
+     * {@link StreamMessage#subscribe(Subscriber, Executor)} is called from non-{@link EventLoop}.
+     */
+    @Test
+    public void onSubscribeBeforeOnComplete() throws Exception {
+        final BlockingQueue<String> queue = new LinkedTransferQueue<>();
+        // Repeat to increase the chance of reproduction.
+        for (int i = 0; i < 8192; i++) {
+            StreamMessageAndWriter<Integer> stream = newStream(TEN_INTEGERS);
+            eventLoop().execute(stream::close);
+            stream.subscribe(new Subscriber<Object>() {
+                @Override
+                public void onSubscribe(Subscription s) {
+                    queue.add("onSubscribe");
+                    s.request(Long.MAX_VALUE);
+                }
+
+                @Override
+                public void onNext(Object o) {
+                    queue.add("onNext");
+                }
+
+                @Override
+                public void onError(Throwable t) {
+                    queue.add("onError");
+                }
+
+                @Override
+                public void onComplete() {
+                    queue.add("onComplete");
+                }
+            }, eventLoop());
+
+            assertThat(queue.poll(5, TimeUnit.SECONDS)).isEqualTo("onSubscribe");
+            assertThat(queue.poll(5, TimeUnit.SECONDS)).isEqualTo("onComplete");
+        }
+    }
+
+    @Test
+    public void releaseOnConsumption_ByteBuf() throws Exception {
+        final ByteBuf buf = newPooledBuffer();
+        StreamMessageAndWriter<ByteBuf> stream = newStream(ImmutableList.of(buf));
+
+        assertThat(stream.write(buf)).isTrue();
+        stream.close();
+        assertThat(buf.refCnt()).isEqualTo(1);
+
+        stream.subscribe(new Subscriber<ByteBuf>() {
+            @Override
+            public void onSubscribe(Subscription subscription) {
+                subscription.request(1);
+            }
+
+            @Override
+            public void onNext(ByteBuf o) {
+                assertThat(o).isNotSameAs(buf);
+                assertThat(o).isInstanceOf(UnpooledHeapByteBuf.class);
+                assertThat(o.refCnt()).isEqualTo(1);
+                assertThat(buf.refCnt()).isZero();
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                Exceptions.throwUnsafely(throwable);
+            }
+
+            @Override
+            public void onComplete() {
+                completed = true;
+            }
+        });
+        await().untilAsserted(() -> assertThat(completed).isTrue());
+    }
+
+    @Test
+    public void releaseOnConsumption_HttpData() throws Exception {
+        final ByteBufHttpData data = new ByteBufHttpData(newPooledBuffer(), false);
+        StreamMessageAndWriter<ByteBufHolder> stream = newStream(ImmutableList.of(data));
+
+        assertThat(stream.write(data)).isTrue();
+        stream.close();
+        assertThat(data.refCnt()).isEqualTo(1);
+
+        stream.subscribe(new Subscriber<ByteBufHolder>() {
+            @Override
+            public void onSubscribe(Subscription subscription) {
+                subscription.request(1);
+            }
+
+            @Override
+            public void onNext(ByteBufHolder o) {
+                assertThat(o).isNotSameAs(data);
+                assertThat(o).isInstanceOf(ByteBufHttpData.class);
+                assertThat(o.content()).isInstanceOf(UnpooledHeapByteBuf.class);
+                assertThat(o.refCnt()).isEqualTo(1);
+                assertThat(data.refCnt()).isZero();
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                Exceptions.throwUnsafely(throwable);
+            }
+
+            @Override
+            public void onComplete() {
+                completed = true;
+            }
+        });
+        await().untilAsserted(() -> assertThat(completed).isTrue());
+    }
+
+    @Test
+    public void rejectReferenceCounted() {
+        AbstractReferenceCounted item = new AbstractReferenceCounted() {
+            @Override
+            protected void deallocate() {}
+
+            @Override
+            public ReferenceCounted touch(Object hint) {
+                return this;
+            }
+        };
+        StreamMessageAndWriter<Object> stream = newStream(ImmutableList.of(item));
+        assertThatThrownBy(() -> stream.write(item)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void releaseWhenWritingToClosedStream_ByteBuf() {
+        StreamMessageAndWriter<Object> stream = newStream(ImmutableList.of());
+        final ByteBuf buf = PooledByteBufAllocator.DEFAULT.buffer();
+        stream.close();
+
+        await().untilAsserted(() -> assertThat(stream.write(buf)).isFalse());
+        assertThat(buf.refCnt()).isZero();
+    }
+
+    @Test
+    public void releaseWhenWritingToClosedStream_HttpData() {
+        StreamMessageAndWriter<Object> stream = newStream(ImmutableList.of());
+        final ByteBufHttpData data = new ByteBufHttpData(newPooledBuffer(), true);
+        stream.close();
+
+        await().untilAsserted(() -> assertThat(stream.write(data)).isFalse());
+        assertThat(data.refCnt()).isZero();
+    }
+
+    @Test
+    public void releaseWithZeroDemand() {
+        final ByteBufHttpData data = new ByteBufHttpData(newPooledBuffer(), true);
+        StreamMessageAndWriter<Object> stream = newStream(ImmutableList.of(data));
+        stream.write(data);
+        stream.subscribe(new Subscriber<Object>() {
+            @Override
+            public void onSubscribe(Subscription subscription) {
+                // Cancel the subscription when the demand is 0.
+                subscription.cancel();
+            }
+
+            @Override
+            public void onNext(Object o) {
+                fail();
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                fail();
+            }
+
+            @Override
+            public void onComplete() {
+                fail();
+            }
+        }, true);
+
+        await().untilAsserted(() -> assertThat(stream.isOpen()).isFalse());
+        assertThat(data.refCnt()).isZero();
+    }
+
+    @Test
+    public void releaseWithZeroDemandAndClosedStream() {
+        final ByteBufHttpData data = new ByteBufHttpData(newPooledBuffer(), true);
+        StreamMessageAndWriter<Object> stream = newStream(ImmutableList.of(data));
+        stream.write(data);
+        stream.close();
+
+        stream.subscribe(new Subscriber<Object>() {
+            @Override
+            public void onSubscribe(Subscription subscription) {
+                // Cancel the subscription when the demand is 0.
+                subscription.cancel();
+            }
+
+            @Override
+            public void onNext(Object o) {
+                fail();
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                fail();
+            }
+
+            @Override
+            public void onComplete() {
+                fail();
+            }
+        }, true);
+
+        await().untilAsserted(() -> assertThat(stream.isOpen()).isFalse());
+        assertThat(data.refCnt()).isZero();
+    }
+
+    private void assertSuccess() {
+        await().untilAsserted(() -> assertThat(completed).isTrue());
+        assertThat(error).isNull();
+        assertThat(result).containsExactlyElementsOf(TEN_INTEGERS);
+    }
+
+    private abstract class ResultCollectingSubscriber implements Subscriber<Integer> {
+
+        @Override
+        public void onNext(Integer value) {
+            result.add(value);
+        }
+
+        @Override
+        public void onComplete() {
+            completed = true;
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            error = t;
+        }
+    }
+
+    private static ByteBuf newPooledBuffer() {
+        return PooledByteBufAllocator.DEFAULT.buffer().writeByte(0);
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/common/stream/EventLoopStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/EventLoopStreamMessageTest.java
@@ -5,7 +5,7 @@
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/core/src/test/java/com/linecorp/armeria/common/stream/EventLoopStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/EventLoopStreamMessageTest.java
@@ -5,7 +5,7 @@
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *
- *   https://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
@@ -18,10 +18,10 @@ package com.linecorp.armeria.common.stream;
 
 import java.util.List;
 
-public class DefaultStreamMessageTest extends AbstractStreamMessageTest {
+public class EventLoopStreamMessageTest extends AbstractStreamMessageTest {
 
     @Override
     <T> StreamMessageAndWriter<T> newStream(List<T> unused) {
-        return new DefaultStreamMessage<>();
+        return new EventLoopStreamMessage<>(eventLoop());
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/common/stream/EventLoopStreamMessageVerification.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/EventLoopStreamMessageVerification.java
@@ -5,7 +5,7 @@
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/core/src/test/java/com/linecorp/armeria/common/stream/EventLoopStreamMessageVerification.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/EventLoopStreamMessageVerification.java
@@ -97,9 +97,9 @@ public class EventLoopStreamMessageVerification extends StreamMessageVerificatio
 
     // createStreamMessage creates a publisher that relies on onDemand for triggering writes - unfortunately
     // means that it is not possible to have reads and writes to the stream happening synchronously in the same
-    // call tree, so this test passes regardless of whether DefaultStreamMessage actually correctly handles
+    // call tree, so this test passes regardless of whether the stream message actually correctly handles
     // recursion. We disable it here to prevent a false sense of security and verify the behavior in
-    // DefaultStreamMessageTest.flowControlled_writeThenDemandThenProcess.
+    // AbstractStreamMessageTest.flowControlled_writeThenDemandThenProcess.
     @Override
     @Test(enabled = false)
     public void required_spec303_mustNotAllowUnboundedRecursion() throws Throwable {

--- a/core/src/test/java/com/linecorp/armeria/common/stream/EventLoopStreamMessageVerification.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/EventLoopStreamMessageVerification.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.stream;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import io.netty.channel.DefaultEventLoop;
+import io.netty.channel.EventLoop;
+
+public class EventLoopStreamMessageVerification extends StreamMessageVerification<Long> {
+
+    private static EventLoop eventLoop;
+
+    @BeforeClass
+    public static void startEventLoop() {
+        eventLoop = new DefaultEventLoop();
+    }
+
+    @AfterClass
+    public static void stopEventLoop() {
+        eventLoop.shutdownGracefully().syncUninterruptibly();
+    }
+
+    @Override
+    public StreamMessage<Long> createPublisher(long elements) {
+        return createStreamMessage(elements, false);
+    }
+
+    private static StreamMessage<Long> createStreamMessage(long elements, boolean abort) {
+        final EventLoopStreamMessage<Long> stream = new EventLoopStreamMessage<>(eventLoop);
+        if (elements == 0) {
+            if (abort) {
+                stream.abort();
+            } else {
+                stream.close();
+            }
+            return stream;
+        }
+
+        final AtomicLong remaining = new AtomicLong(elements);
+        stream(elements, abort, remaining, stream);
+        return stream;
+    }
+
+    private static void stream(long elements, boolean abort,
+                               AtomicLong remaining, EventLoopStreamMessage<Long> stream) {
+        stream.onDemand(() -> {
+            for (;;) {
+                final long r = remaining.decrementAndGet();
+                final boolean written = stream.write(elements - r);
+                if (r == 0) {
+                    if (abort) {
+                        stream.abort();
+                    } else {
+                        stream.close();
+                    }
+                    break;
+                }
+
+                if (!written) {
+                    stream(elements, abort, remaining, stream);
+                    break;
+                }
+            }
+        });
+    }
+
+    @Override
+    public StreamMessage<Long> createFailedPublisher() {
+        EventLoopStreamMessage<Long> stream = new EventLoopStreamMessage<Long>(eventLoop);
+        stream.subscribe(new NoopSubscriber<>());
+        return stream;
+    }
+
+    @Override
+    public StreamMessage<Long> createAbortedPublisher(long elements) {
+        return createStreamMessage(elements, true);
+    }
+
+    // createStreamMessage creates a publisher that relies on onDemand for triggering writes - unfortunately
+    // means that it is not possible to have reads and writes to the stream happening synchronously in the same
+    // call tree, so this test passes regardless of whether DefaultStreamMessage actually correctly handles
+    // recursion. We disable it here to prevent a false sense of security and verify the behavior in
+    // DefaultStreamMessageTest.flowControlled_writeThenDemandThenProcess.
+    @Override
+    @Test(enabled = false)
+    public void required_spec303_mustNotAllowUnboundedRecursion() throws Throwable {
+        notVerified();
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageVerification.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageVerification.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.common.stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
 
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicReference;
@@ -74,7 +75,7 @@ public abstract class StreamMessageVerification<T> extends PublisherVerification
 
             assertThat(stream.isOpen()).isFalse();
             assertThat(stream.isEmpty()).isTrue();
-            assertThat(stream.completionFuture()).isCompleted();
+            await().untilAsserted(() -> assertThat(stream.completionFuture()).isCompleted());
             sub.expectNone();
         });
     }
@@ -87,7 +88,7 @@ public abstract class StreamMessageVerification<T> extends PublisherVerification
             assertThat(stream.isOpen()).isTrue();
             assertThat(stream.isEmpty()).isFalse();
 
-            assertThat(stream.completionFuture()).isNotDone();
+            await().untilAsserted(() -> assertThat(stream.completionFuture()).isNotDone());
             sub.requestNextElement();
             sub.requestEndOfStream();
             assertThat(stream.completionFuture()).isCompleted();
@@ -107,7 +108,7 @@ public abstract class StreamMessageVerification<T> extends PublisherVerification
             sub.cancel();
             sub.expectNone();
 
-            assertThat(stream.completionFuture()).isCompletedExceptionally();
+            await().untilAsserted(() -> assertThat(stream.completionFuture()).isCompletedExceptionally());
             assertThatThrownBy(() -> stream.completionFuture().join())
                     .isInstanceOf(CompletionException.class)
                     .hasCauseInstanceOf(CancelledSubscriptionException.class);


### PR DESCRIPTION
…h an event loop.

As there was some back-and-forth, I have restricted this PR to only add `EventLoopStreamMessage` without using it anywhere. We can do the `DefaultHttp*` juggling in the next PR.

`EventLoopStreamMessage` is designed to have as few volatile reads as possible, going so far as to duplicate some fields to allow volatile reads in cold paths and non-volatile reads in hot paths (`state` and `isOpen` / `subscription` and `subscribed`). Notably, any `write` only has a single volatile read and store, while looping through objects has none at all.

The class is designed to be used when both the writer and reader thread are the same as the stream's. In such a case, there is no thread-switch overhead and we take advantage of it all being on the same thread to have almost no synchronization. For any other case, there will be heavy overhead from thread-switching - but Armeria is built on event loops, and it is extremely unlikely that the appropriate event loop cannot be used from writers and readers. Any case where it isn't possible probably isn't a performance sensitive application anyways.

This PR heavily refactors `DefaultStreamMessage` to allow logic-sharing between the two implementations, and any future ones (e.g., FixedStreamMessage #846 which I will rebase onto this one). One big design change is moving more logic out of `SubscriptionImpl` and into the publishers - by keeping `SubscriptionImpl` as a state-holder and method forwarder, it can be shared by any `StreamMessage` implementation.

An `AbstractStreamMessageTest` is also added to provide test cases for both implementations easily.