### PR TITLE
[WIP] Switch the default StreamMessage to EventLoopStreamMessage

### DIFF
--- a/benchmarks/src/jmh/java/com/linecorp/armeria/common/stream/StreamMessageBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/common/stream/StreamMessageBenchmark.java
@@ -54,8 +54,8 @@ public class StreamMessageBenchmark {
     public static class StreamObjects {
 
         public enum StreamType {
-            DEFAULT_STREAM_MESSAGE,
-            EVENT_LOOP_MESSAGE,
+            CONCURRENT,
+            EVENT_LOOP,
         }
 
         @Param
@@ -156,10 +156,10 @@ public class StreamMessageBenchmark {
 
     private StreamMessageAndWriter<Integer> newStream(StreamObjects streamObjects) {
         switch (streamObjects.streamType) {
-            case EVENT_LOOP_MESSAGE:
+            case EVENT_LOOP:
                 return new EventLoopStreamMessage<>(EventLoopJmhExecutor.currentEventLoop());
-            case DEFAULT_STREAM_MESSAGE:
-                return new DefaultStreamMessage<>();
+            case CONCURRENT:
+                return new ConcurrentStreamMessage<>();
             default:
                 throw new Error();
         }
@@ -256,10 +256,10 @@ public class StreamMessageBenchmark {
 
         private StreamMessageAndWriter<Integer> newStream(StreamObjects streamObjects) {
             switch (streamObjects.streamType) {
-                case EVENT_LOOP_MESSAGE:
+                case EVENT_LOOP:
                     return new EventLoopStreamMessage<>(EVENT_LOOP1);
-                case DEFAULT_STREAM_MESSAGE:
-                    return new DefaultStreamMessage<>();
+                case CONCURRENT:
+                    return new ConcurrentStreamMessage<>();
                 default:
                     throw new Error();
             }

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultHttpRequest.java
@@ -20,13 +20,13 @@ import static java.util.Objects.requireNonNull;
 
 import com.google.common.base.MoreObjects;
 
-import com.linecorp.armeria.common.stream.DefaultStreamMessage;
+import com.linecorp.armeria.common.stream.EventLoopStreamMessage;
 
 /**
  * Default {@link HttpRequest} implementation.
  */
 public class DefaultHttpRequest
-        extends DefaultStreamMessage<HttpObject> implements HttpRequest, HttpRequestWriter {
+        extends EventLoopStreamMessage<HttpObject> implements HttpRequest, HttpRequestWriter {
 
     private final HttpHeaders headers;
     private final boolean keepAlive;

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultHttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultHttpResponse.java
@@ -18,13 +18,13 @@ package com.linecorp.armeria.common;
 
 import com.google.common.base.MoreObjects;
 
-import com.linecorp.armeria.common.stream.DefaultStreamMessage;
+import com.linecorp.armeria.common.stream.EventLoopStreamMessage;
 
 /**
  * Default {@link HttpResponse} instance.
  */
 public class DefaultHttpResponse
-        extends DefaultStreamMessage<HttpObject> implements HttpResponse, HttpResponseWriter {
+        extends EventLoopStreamMessage<HttpObject> implements HttpResponse, HttpResponseWriter {
 
     @Override
     public String toString() {

--- a/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessageDuplicator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessageDuplicator.java
@@ -48,7 +48,7 @@ import io.netty.util.ReferenceCountUtil;
 /**
  * Allows subscribing to a {@link StreamMessage} multiple times by duplicating the stream.
  * <p>
- * Only one subscriber can subscribe other stream messages such as {@link DefaultStreamMessage},
+ * Only one subscriber can subscribe other stream messages such as {@link ConcurrentStreamMessage},
  * {@link DeferredStreamMessage}, etc.
  * This factory is wrapping one of those {@link StreamMessage}s and spawns duplicated stream messages
  * which are created using {@link AbstractStreamMessageDuplicator#duplicateStream()} and subscribed

--- a/core/src/main/java/com/linecorp/armeria/common/stream/ConcurrentStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/ConcurrentStreamMessage.java
@@ -60,20 +60,20 @@ import com.linecorp.armeria.common.Flags;
  *
  * @param <T> the type of element signaled
  */
-public class DefaultStreamMessage<T> extends AbstractStreamMessageAndWriter<T> {
+public class ConcurrentStreamMessage<T> extends AbstractStreamMessageAndWriter<T> {
 
     @SuppressWarnings("rawtypes")
-    private static final AtomicReferenceFieldUpdater<DefaultStreamMessage, SubscriptionImpl>
+    private static final AtomicReferenceFieldUpdater<ConcurrentStreamMessage, SubscriptionImpl>
             subscriptionUpdater = AtomicReferenceFieldUpdater.newUpdater(
-                    DefaultStreamMessage.class, SubscriptionImpl.class, "subscription");
+            ConcurrentStreamMessage.class, SubscriptionImpl.class, "subscription");
 
     @SuppressWarnings("rawtypes")
-    private static final AtomicLongFieldUpdater<DefaultStreamMessage> demandUpdater =
-            AtomicLongFieldUpdater.newUpdater(DefaultStreamMessage.class, "demand");
+    private static final AtomicLongFieldUpdater<ConcurrentStreamMessage> demandUpdater =
+            AtomicLongFieldUpdater.newUpdater(ConcurrentStreamMessage.class, "demand");
 
     @SuppressWarnings("rawtypes")
-    private static final AtomicReferenceFieldUpdater<DefaultStreamMessage, State> stateUpdater =
-            AtomicReferenceFieldUpdater.newUpdater(DefaultStreamMessage.class, State.class, "state");
+    private static final AtomicReferenceFieldUpdater<ConcurrentStreamMessage, State> stateUpdater =
+            AtomicReferenceFieldUpdater.newUpdater(ConcurrentStreamMessage.class, State.class, "state");
 
     private final Queue<Object> queue;
 
@@ -94,14 +94,14 @@ public class DefaultStreamMessage<T> extends AbstractStreamMessageAndWriter<T> {
     /**
      * Creates a new instance with a new {@link ConcurrentLinkedQueue}.
      */
-    public DefaultStreamMessage() {
+    public ConcurrentStreamMessage() {
         this(new ConcurrentLinkedQueue<>());
     }
 
     /**
      * Creates a new instance with the specified {@link Queue}.
      */
-    public DefaultStreamMessage(Queue<Object> queue) {
+    public ConcurrentStreamMessage(Queue<Object> queue) {
         this.queue = requireNonNull(queue, "queue");
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/stream/DeferredStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/DeferredStreamMessage.java
@@ -94,7 +94,7 @@ public class DeferredStreamMessage<T> implements StreamMessage<T> {
      *                               if {@link #close()} or {@link #close(Throwable)} was called already.
      */
     public void close() {
-        final DefaultStreamMessage<T> m = new DefaultStreamMessage<>();
+        final ConcurrentStreamMessage<T> m = new ConcurrentStreamMessage<>();
         m.close();
         delegate(m);
     }
@@ -107,7 +107,7 @@ public class DeferredStreamMessage<T> implements StreamMessage<T> {
      */
     public void close(Throwable cause) {
         requireNonNull(cause, "cause");
-        final DefaultStreamMessage<T> m = new DefaultStreamMessage<>();
+        final ConcurrentStreamMessage<T> m = new ConcurrentStreamMessage<>();
         m.close(cause);
         delegate(m);
     }

--- a/core/src/test/java/com/linecorp/armeria/common/DefaultHttpRequestTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/DefaultHttpRequestTest.java
@@ -55,8 +55,11 @@ public class DefaultHttpRequestTest {
         });
 
         req.abort();
+
+        future.join();
         assertThat(future).isCompletedExceptionally();
-        assertThat(callbackThread.get()).isSameAs(mainThread);
+        // Notification will take place from an EventLoop.
+        assertThat(callbackThread.get()).isNotSameAs(mainThread);
     }
 
     /**

--- a/core/src/test/java/com/linecorp/armeria/common/stream/ConcurrentStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/ConcurrentStreamMessageTest.java
@@ -18,10 +18,10 @@ package com.linecorp.armeria.common.stream;
 
 import java.util.List;
 
-public class DefaultStreamMessageTest extends AbstractStreamMessageTest {
+public class ConcurrentStreamMessageTest extends AbstractStreamMessageTest {
 
     @Override
     <T> StreamMessageAndWriter<T> newStream(List<T> unused) {
-        return new DefaultStreamMessage<>();
+        return new ConcurrentStreamMessage<>();
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/common/stream/ConcurrentStreamMessageVerification.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/ConcurrentStreamMessageVerification.java
@@ -20,7 +20,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.testng.annotations.Test;
 
-public class DefaultStreamMessageVerification extends StreamMessageVerification<Long> {
+public class ConcurrentStreamMessageVerification extends StreamMessageVerification<Long> {
 
     @Override
     public StreamMessage<Long> createPublisher(long elements) {
@@ -28,7 +28,7 @@ public class DefaultStreamMessageVerification extends StreamMessageVerification<
     }
 
     static StreamMessage<Long> createStreamMessage(long elements, boolean abort) {
-        final DefaultStreamMessage<Long> stream = new DefaultStreamMessage<>();
+        final ConcurrentStreamMessage<Long> stream = new ConcurrentStreamMessage<>();
         if (elements == 0) {
             if (abort) {
                 stream.abort();
@@ -44,7 +44,7 @@ public class DefaultStreamMessageVerification extends StreamMessageVerification<
     }
 
     private static void stream(long elements, boolean abort,
-                               AtomicLong remaining, DefaultStreamMessage<Long> stream) {
+                               AtomicLong remaining, ConcurrentStreamMessage<Long> stream) {
         stream.onDemand(() -> {
             for (;;) {
                 final long r = remaining.decrementAndGet();
@@ -68,7 +68,7 @@ public class DefaultStreamMessageVerification extends StreamMessageVerification<
 
     @Override
     public StreamMessage<Long> createFailedPublisher() {
-        DefaultStreamMessage<Long> stream = new DefaultStreamMessage<>();
+        ConcurrentStreamMessage<Long> stream = new ConcurrentStreamMessage<>();
         stream.subscribe(new NoopSubscriber<>());
         return stream;
     }
@@ -80,9 +80,9 @@ public class DefaultStreamMessageVerification extends StreamMessageVerification<
 
     // createStreamMessage creates a publisher that relies on onDemand for triggering writes - unfortunately
     // means that it is not possible to have reads and writes to the stream happening synchronously in the same
-    // call tree, so this test passes regardless of whether DefaultStreamMessage actually correctly handles
+    // call tree, so this test passes regardless of whether ConcurrentStreamMessage actually correctly handles
     // recursion. We disable it here to prevent a false sense of security and verify the behavior in
-    // DefaultStreamMessageTest.flowControlled_writeThenDemandThenProcess.
+    // ConcurrentStreamMessageTest.flowControlled_writeThenDemandThenProcess.
     @Override
     @Test(enabled = false)
     public void required_spec303_mustNotAllowUnboundedRecursion() throws Throwable {

--- a/core/src/test/java/com/linecorp/armeria/common/stream/DeferredStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/DeferredStreamMessageTest.java
@@ -47,8 +47,8 @@ public class DeferredStreamMessageTest {
     @Test
     public void testSetDelegate() throws Exception {
         final DeferredStreamMessage<Object> m = new DeferredStreamMessage<>();
-        m.delegate(new DefaultStreamMessage<>());
-        assertThatThrownBy(() -> m.delegate(new DefaultStreamMessage<>()))
+        m.delegate(new ConcurrentStreamMessage<>());
+        assertThatThrownBy(() -> m.delegate(new ConcurrentStreamMessage<>()))
                 .isInstanceOf(IllegalStateException.class);
         assertThatThrownBy(() -> m.delegate(null)).isInstanceOf(NullPointerException.class);
     }
@@ -68,7 +68,7 @@ public class DeferredStreamMessageTest {
         m.abort();
         assertAborted(m);
 
-        final DefaultStreamMessage<Object> d = new DefaultStreamMessage<>();
+        final ConcurrentStreamMessage<Object> d = new ConcurrentStreamMessage<>();
         m.delegate(d);
         assertAborted(d);
     }
@@ -76,7 +76,7 @@ public class DeferredStreamMessageTest {
     @Test
     public void testLateAbort() throws Exception {
         final DeferredStreamMessage<Object> m = new DeferredStreamMessage<>();
-        final DefaultStreamMessage<Object> d = new DefaultStreamMessage<>();
+        final ConcurrentStreamMessage<Object> d = new ConcurrentStreamMessage<>();
 
         m.delegate(d);
         m.abort();
@@ -88,7 +88,7 @@ public class DeferredStreamMessageTest {
     @Test
     public void testLateAbortWithSubscriber() throws Exception {
         final DeferredStreamMessage<Object> m = new DeferredStreamMessage<>();
-        final DefaultStreamMessage<Object> d = new DefaultStreamMessage<>();
+        final ConcurrentStreamMessage<Object> d = new ConcurrentStreamMessage<>();
         @SuppressWarnings("unchecked")
         final Subscriber<Object> subscriber = mock(Subscriber.class);
 
@@ -106,7 +106,7 @@ public class DeferredStreamMessageTest {
     @Test
     public void testEarlySubscription() throws Exception {
         final DeferredStreamMessage<Object> m = new DeferredStreamMessage<>();
-        final DefaultStreamMessage<Object> d = new DefaultStreamMessage<>();
+        final ConcurrentStreamMessage<Object> d = new ConcurrentStreamMessage<>();
         @SuppressWarnings("unchecked")
         final Subscriber<Object> subscriber = mock(Subscriber.class);
 
@@ -120,7 +120,7 @@ public class DeferredStreamMessageTest {
     @Test
     public void testLateSubscription() throws Exception {
         final DeferredStreamMessage<Object> m = new DeferredStreamMessage<>();
-        final DefaultStreamMessage<Object> d = new DefaultStreamMessage<>();
+        final ConcurrentStreamMessage<Object> d = new ConcurrentStreamMessage<>();
 
         m.delegate(d);
 
@@ -160,7 +160,7 @@ public class DeferredStreamMessageTest {
 
     private void testStreaming(boolean useExecutor) {
         final DeferredStreamMessage<Object> m = new DeferredStreamMessage<>();
-        final DefaultStreamMessage<Object> d = new DefaultStreamMessage<>();
+        final ConcurrentStreamMessage<Object> d = new ConcurrentStreamMessage<>();
         m.delegate(d);
 
         final List<Object> streamed = new ArrayList<>();

--- a/core/src/test/java/com/linecorp/armeria/common/stream/DeferredStreamMessageVerification.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/DeferredStreamMessageVerification.java
@@ -16,7 +16,7 @@
 
 package com.linecorp.armeria.common.stream;
 
-import static com.linecorp.armeria.common.stream.DefaultStreamMessageVerification.createStreamMessage;
+import static com.linecorp.armeria.common.stream.ConcurrentStreamMessageVerification.createStreamMessage;
 
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
@@ -33,7 +33,7 @@ public class DeferredStreamMessageVerification extends StreamMessageVerification
     @Override
     public StreamMessage<Long> createFailedPublisher() {
         final DeferredStreamMessage<Long> stream = new DeferredStreamMessage<>();
-        DefaultStreamMessage<Long> delegate = new DefaultStreamMessage<>();
+        ConcurrentStreamMessage<Long> delegate = new ConcurrentStreamMessage<>();
         delegate.subscribe(new NoopSubscriber<>());
         stream.delegate(delegate);
         return stream;

--- a/core/src/test/java/com/linecorp/armeria/common/stream/PublisherBasedStreamMessageVerification.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/PublisherBasedStreamMessageVerification.java
@@ -16,7 +16,7 @@
 
 package com.linecorp.armeria.common.stream;
 
-import static com.linecorp.armeria.common.stream.DefaultStreamMessageVerification.createStreamMessage;
+import static com.linecorp.armeria.common.stream.ConcurrentStreamMessageVerification.createStreamMessage;
 
 import java.util.concurrent.atomic.AtomicReference;
 

--- a/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageDuplicatorTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageDuplicatorTest.java
@@ -96,7 +96,7 @@ public class StreamMessageDuplicatorTest {
 
     @Test
     public void closePublisherNormally() throws Exception {
-        final DefaultStreamMessage<String> publisher = new DefaultStreamMessage<>();
+        final ConcurrentStreamMessage<String> publisher = new ConcurrentStreamMessage<>();
         final StreamMessageDuplicator duplicator = new StreamMessageDuplicator(publisher);
 
         final CompletableFuture<String> future1 = subscribe(duplicator.duplicateStream());
@@ -110,7 +110,7 @@ public class StreamMessageDuplicatorTest {
         duplicator.close();
     }
 
-    private static void writeData(DefaultStreamMessage<String> publisher) {
+    private static void writeData(ConcurrentStreamMessage<String> publisher) {
         publisher.write("Armeria ");
         publisher.write("is ");
         publisher.write("awesome.");
@@ -130,7 +130,7 @@ public class StreamMessageDuplicatorTest {
 
     @Test
     public void closePublisherExceptionally() throws Exception {
-        final DefaultStreamMessage<String> publisher = new DefaultStreamMessage<>();
+        final ConcurrentStreamMessage<String> publisher = new ConcurrentStreamMessage<>();
         final StreamMessageDuplicator duplicator = new StreamMessageDuplicator(publisher);
 
         final CompletableFuture<String> future1 = subscribe(duplicator.duplicateStream());
@@ -148,7 +148,7 @@ public class StreamMessageDuplicatorTest {
 
     @Test
     public void subscribeAfterPublisherClosed() throws Exception {
-        final DefaultStreamMessage<String> publisher = new DefaultStreamMessage<>();
+        final ConcurrentStreamMessage<String> publisher = new ConcurrentStreamMessage<>();
         final StreamMessageDuplicator duplicator = new StreamMessageDuplicator(publisher);
 
         final CompletableFuture<String> future1 = subscribe(duplicator.duplicateStream());
@@ -165,7 +165,7 @@ public class StreamMessageDuplicatorTest {
 
     @Test
     public void childStreamIsNotClosedWhenDemandIsNotEnough() throws Exception {
-        final DefaultStreamMessage<String> publisher = new DefaultStreamMessage<>();
+        final ConcurrentStreamMessage<String> publisher = new ConcurrentStreamMessage<>();
         final StreamMessageDuplicator duplicator = new StreamMessageDuplicator(publisher);
 
         final CompletableFuture<String> future1 = new CompletableFuture<>();
@@ -189,7 +189,7 @@ public class StreamMessageDuplicatorTest {
 
     @Test
     public void abortPublisherWithSubscribers() {
-        final DefaultStreamMessage<String> publisher = new DefaultStreamMessage<>();
+        final ConcurrentStreamMessage<String> publisher = new ConcurrentStreamMessage<>();
         final StreamMessageDuplicator duplicator = new StreamMessageDuplicator(publisher);
 
         final CompletableFuture<String> future = subscribe(duplicator.duplicateStream());
@@ -202,7 +202,7 @@ public class StreamMessageDuplicatorTest {
 
     @Test
     public void abortPublisherWithoutSubscriber() {
-        final DefaultStreamMessage<String> publisher = new DefaultStreamMessage<>();
+        final ConcurrentStreamMessage<String> publisher = new ConcurrentStreamMessage<>();
         final StreamMessageDuplicator duplicator = new StreamMessageDuplicator(publisher);
         publisher.abort();
 
@@ -215,7 +215,7 @@ public class StreamMessageDuplicatorTest {
 
     @Test
     public void abortChildStream() {
-        final DefaultStreamMessage<String> publisher = new DefaultStreamMessage<>();
+        final ConcurrentStreamMessage<String> publisher = new ConcurrentStreamMessage<>();
         final StreamMessageDuplicator duplicator = new StreamMessageDuplicator(publisher);
 
         final StreamMessage<String> sm1 = duplicator.duplicateStream();
@@ -238,7 +238,7 @@ public class StreamMessageDuplicatorTest {
 
     @Test
     public void closeMulticastStreamFactory() {
-        final DefaultStreamMessage<String> publisher = new DefaultStreamMessage<>();
+        final ConcurrentStreamMessage<String> publisher = new ConcurrentStreamMessage<>();
         final StreamMessageDuplicator duplicator = new StreamMessageDuplicator(publisher);
 
         duplicator.close();
@@ -305,7 +305,7 @@ public class StreamMessageDuplicatorTest {
 
     @Test
     public void lastDuplicateStream() {
-        final DefaultStreamMessage<ByteBuf> publisher = new DefaultStreamMessage<>();
+        final ConcurrentStreamMessage<ByteBuf> publisher = new ConcurrentStreamMessage<>();
         final ByteBufDuplicator duplicator = new ByteBufDuplicator(publisher);
 
         duplicator.duplicateStream().subscribe(new ByteBufSubscriber());

--- a/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageDuplicatorVerification.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageDuplicatorVerification.java
@@ -16,7 +16,7 @@
 
 package com.linecorp.armeria.common.stream;
 
-import static com.linecorp.armeria.common.stream.DefaultStreamMessageVerification.createStreamMessage;
+import static com.linecorp.armeria.common.stream.ConcurrentStreamMessageVerification.createStreamMessage;
 
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
@@ -33,7 +33,7 @@ public class StreamMessageDuplicatorVerification extends StreamMessageVerificati
 
     @Override
     public StreamMessage<Long> createFailedPublisher() {
-        final StreamMessage<Long> source = new DefaultStreamMessage<>();
+        final StreamMessage<Long> source = new ConcurrentStreamMessage<>();
         final StreamMessageDuplicator duplicator = new StreamMessageDuplicator(source);
         final StreamMessage<Long> duplicate = duplicator.duplicateStream();
         duplicate.subscribe(new NoopSubscriber<>());


### PR DESCRIPTION
Findings so far:

- There are test failures that need investigation.
- Sometimes we just don't know from which `EventLoop` we will publish the events, especially for client-side. i.e. It may be hard to specify an `EventLoop` at construction time.
  - Loggging when a user does not specify an `EventLoop` may not be a good idea.
  - Choosing from `CommonPools.workerGroup()` may not work either because the client will use a different `EventLoop`.