### PR TITLE
Remove closeevent when notifying it to make sure it is not notified t…

### DIFF
--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -33,6 +33,14 @@ jmh {
     duplicateClassesStrategy = DuplicatesStrategy.EXCLUDE
     jmhVersion = rootProject.ext.dependencyManagement['org.openjdk.jmh']['jmh-core'].version
 
+    if (rootProject.hasProperty('jmh.params')) {
+        benchmarkParameters = [:]
+        rootProject.findProperty('jmh.params').split(',').each {
+            def parts = it.split('=')
+            benchmarkParameters[parts[0]] = [parts[1]]
+        }
+    }
+
     if (rootProject.hasProperty('jmh.fork')) {
         fork = Integer.parseInt(String.valueOf(rootProject.findProperty('jmh.fork')))
     } else {

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/common/stream/StreamMessageBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/common/stream/StreamMessageBenchmark.java
@@ -32,8 +32,6 @@ import org.reactivestreams.Subscription;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.linecorp.armeria.common.stream.StreamMessageBenchmark.StreamMessageThreadingBenchmark.EventLoopType;
-import com.linecorp.armeria.common.stream.StreamMessageBenchmark.StreamObjects.StreamType;
 import com.linecorp.armeria.shared.EventLoopJmhExecutor;
 
 import io.netty.channel.DefaultEventLoop;
@@ -275,16 +273,16 @@ public class StreamMessageBenchmark {
 
         private Subscription subscription;
 
-        private volatile long sum;
-        private volatile boolean complete;
-        private volatile Throwable error;
+        private long sum;
+        private boolean complete;
+        private Throwable error;
 
         private SummingSubscriber(CountDownLatch completedLatch, boolean flowControl) {
             this.completedLatch = completedLatch;
             this.flowControl = flowControl;
         }
 
-        private long sum() {
+        private synchronized long sum() {
             if (!complete) {
                 logger.warn("Stream not completed");
                 return -1;

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/common/stream/StreamMessageBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/common/stream/StreamMessageBenchmark.java
@@ -32,6 +32,8 @@ import org.reactivestreams.Subscription;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.linecorp.armeria.common.stream.StreamMessageBenchmark.StreamMessageThreadingBenchmark.EventLoopType;
+import com.linecorp.armeria.common.stream.StreamMessageBenchmark.StreamObjects.StreamType;
 import com.linecorp.armeria.shared.EventLoopJmhExecutor;
 
 import io.netty.channel.DefaultEventLoop;
@@ -273,9 +275,9 @@ public class StreamMessageBenchmark {
 
         private Subscription subscription;
 
-        private long sum;
-        private boolean complete;
-        private Throwable error;
+        private volatile long sum;
+        private volatile boolean complete;
+        private volatile Throwable error;
 
         private SummingSubscriber(CountDownLatch completedLatch, boolean flowControl) {
             this.completedLatch = completedLatch;

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/shared/EventLoopJmhExecutor.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/shared/EventLoopJmhExecutor.java
@@ -43,7 +43,7 @@ public class EventLoopJmhExecutor extends MultithreadEventLoopGroup {
 
     public static final String JVM_ARG_1 = "-Djmh.executor=CUSTOM";
     public static final String JVM_ARG_2 =
-            "-Djmh.executor.class=com.linecorp.armeria.benchmarks.shared.EventLoopJmhExecutor";
+            "-Djmh.executor.class=com.linecorp.armeria.shared.EventLoopJmhExecutor";
 
     private static final FastThreadLocal<EventLoop> CURRENT_EVENT_LOOP = new FastThreadLocal<>();
 

--- a/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessage.java
@@ -97,6 +97,12 @@ abstract class AbstractStreamMessage<T> implements StreamMessage<T> {
     abstract void cancel();
 
     /**
+     * Callback invoked to notify a {@link Subscriber} of a {@link CloseEvent}. The
+     * {@link AbstractStreamMessage} needs to ensure the notification happens on the correct thread.
+     */
+    abstract void notifySubscriberOfCloseEvent(SubscriptionImpl subscription, CloseEvent event);
+
+    /**
      * Invoked after an element is removed from the {@link StreamMessage} and before
      * {@link Subscriber#onNext(Object)} is invoked.
      *
@@ -150,8 +156,7 @@ abstract class AbstractStreamMessage<T> implements StreamMessage<T> {
 
             try {
                 if (e instanceof CloseEvent) {
-                    ((CloseEvent) e).notifySubscriber(subscription, completionFuture());
-                    subscription.clearSubscriber();
+                    notifySubscriberOfCloseEvent(subscription, (CloseEvent) e);
                     continue;
                 }
 

--- a/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
@@ -302,7 +302,7 @@ public class DefaultStreamMessage<T> extends AbstractStreamMessageAndWriter<T> {
             }
 
             if (o instanceof CloseEvent) {
-                notifySubscriberWithCloseEvent(subscription, (CloseEvent) o);
+                notifySubscriberWithCloseEvent(subscription, (CloseEvent) queue.remove());
                 break;
             }
 

--- a/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
@@ -189,6 +189,17 @@ public class DefaultStreamMessage<T> extends AbstractStreamMessageAndWriter<T> {
         cancelOrAbort(true);
     }
 
+    @Override
+    void notifySubscriberOfCloseEvent(SubscriptionImpl subscription, CloseEvent event) {
+        // Always called from the subscriber thread.
+        try {
+            event.notifySubscriber(subscription, completionFuture());
+        } finally {
+            subscription.clearSubscriber();
+            cleanup();
+        }
+    }
+
     private void cancelOrAbort(boolean cancel) {
         if (setState(State.OPEN, State.CLEANUP)) {
             final CloseEvent closeEvent;
@@ -302,7 +313,7 @@ public class DefaultStreamMessage<T> extends AbstractStreamMessageAndWriter<T> {
             }
 
             if (o instanceof CloseEvent) {
-                notifySubscriberWithCloseEvent(subscription, (CloseEvent) queue.remove());
+                handleCloseEvent(subscription, (CloseEvent) queue.remove());
                 break;
             }
 
@@ -357,13 +368,9 @@ public class DefaultStreamMessage<T> extends AbstractStreamMessageAndWriter<T> {
         return true;
     }
 
-    private void notifySubscriberWithCloseEvent(SubscriptionImpl subscription, CloseEvent o) {
+    private void handleCloseEvent(SubscriptionImpl subscription, CloseEvent o) {
         setState(State.OPEN, State.CLEANUP);
-        try {
-            o.notifySubscriber(subscription, completionFuture());
-        } finally {
-            cleanup();
-        }
+        notifySubscriberOfCloseEvent(subscription, o);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/stream/EventLoopStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/EventLoopStreamMessage.java
@@ -329,7 +329,7 @@ public class EventLoopStreamMessage<T> extends AbstractStreamMessageAndWriter<T>
             }
 
             if (o instanceof CloseEvent) {
-                doNotifySubscriberWithCloseEvent(subscription, (CloseEvent) o);
+                doNotifySubscriberWithCloseEvent(subscription, (CloseEvent) queue.remove());
                 break;
             }
 


### PR DESCRIPTION
…wice.

During the `EventLoopStreamMessage` code review, I fixed an issue where close events were always notified from the event loop, not the subscriber thread. But unfortunately never re-ran the benchmarks, this had broken `WRITE_ONLY`. The reason is that while the close event is being notified, the event loop also cleans up the queue since the state was set to cleanup (this is because we moved the CLEANUP check into the loop to allow early termination of signals).

The original `DefaultStreamMessage` didn't remove the `CloseEvent` from the queue before notifying it, which happened to work fine since it was running everything on the subscriber thread, but using the same code in `EventLoopStreamMessage` didn't work due to the above issue. As it seems like a bad practice to leave something on the queue that is being notified, I went ahead and made it so both implementations remove the close event from the queue before notifying it, ensuring no double-notification and unexpected notification from an unexpected thread.

Also made it easier to specify benchmark parameters, fixed a bug introduced by my package move, and made variables volatile to ensure benchmark thread reads them correctly. 

For posterity, threading benchmarks after this fix
```
Benchmark                                                             (eventLoopType)  (flowControl)  (num)            (streamType)   Mode  Cnt      Score      Error  Units
StreamMessageBenchmark.StreamMessageThreadingBenchmark.writeFirst          READ_WRITE          false   1000  DEFAULT_STREAM_MESSAGE  thrpt   20   7203.209 ±  232.095  ops/s
StreamMessageBenchmark.StreamMessageThreadingBenchmark.writeFirst          READ_WRITE          false   1000      EVENT_LOOP_MESSAGE  thrpt   20   8966.020 ± 1436.622  ops/s
StreamMessageBenchmark.StreamMessageThreadingBenchmark.writeFirst           READ_ONLY          false   1000  DEFAULT_STREAM_MESSAGE  thrpt   20   7196.930 ±  248.776  ops/s
StreamMessageBenchmark.StreamMessageThreadingBenchmark.writeFirst           READ_ONLY          false   1000      EVENT_LOOP_MESSAGE  thrpt   20   3262.960 ±  187.758  ops/s
StreamMessageBenchmark.StreamMessageThreadingBenchmark.writeFirst          WRITE_ONLY          false   1000  DEFAULT_STREAM_MESSAGE  thrpt   20   6857.878 ±  329.354  ops/s
StreamMessageBenchmark.StreamMessageThreadingBenchmark.writeFirst          WRITE_ONLY          false   1000      EVENT_LOOP_MESSAGE  thrpt   20   3277.533 ±   86.698  ops/s
StreamMessageBenchmark.StreamMessageThreadingBenchmark.writeFirst                NONE          false   1000  DEFAULT_STREAM_MESSAGE  thrpt   20   6974.939 ±  182.180  ops/s
StreamMessageBenchmark.StreamMessageThreadingBenchmark.writeFirst                NONE          false   1000      EVENT_LOOP_MESSAGE  thrpt   20   2018.282 ±   36.596  ops/s
StreamMessageBenchmark.StreamMessageThreadingBenchmark.writeLast           READ_WRITE          false   1000  DEFAULT_STREAM_MESSAGE  thrpt   20   7637.737 ±  200.211  ops/s
StreamMessageBenchmark.StreamMessageThreadingBenchmark.writeLast           READ_WRITE          false   1000      EVENT_LOOP_MESSAGE  thrpt   20  11181.897 ± 1016.259  ops/s
StreamMessageBenchmark.StreamMessageThreadingBenchmark.writeLast            READ_ONLY          false   1000  DEFAULT_STREAM_MESSAGE  thrpt   20   3195.350 ±  138.980  ops/s
StreamMessageBenchmark.StreamMessageThreadingBenchmark.writeLast            READ_ONLY          false   1000      EVENT_LOOP_MESSAGE  thrpt   20   3732.755 ±  152.473  ops/s
StreamMessageBenchmark.StreamMessageThreadingBenchmark.writeLast           WRITE_ONLY          false   1000  DEFAULT_STREAM_MESSAGE  thrpt   20   2878.641 ±   74.282  ops/s
StreamMessageBenchmark.StreamMessageThreadingBenchmark.writeLast           WRITE_ONLY          false   1000      EVENT_LOOP_MESSAGE  thrpt   20   2626.225 ±  135.280  ops/s
StreamMessageBenchmark.StreamMessageThreadingBenchmark.writeLast                 NONE          false   1000  DEFAULT_STREAM_MESSAGE  thrpt   20   2909.879 ±   46.387  ops/s
StreamMessageBenchmark.StreamMessageThreadingBenchmark.writeLast                 NONE          false   1000      EVENT_LOOP_MESSAGE  thrpt   20   2095.070 ±  152.336  ops/s
StreamMessageBenchmark.StreamMessageThreadingBenchmark.writeOnDemand       READ_WRITE          false   1000  DEFAULT_STREAM_MESSAGE  thrpt   20   2445.310 ±  118.734  ops/s
StreamMessageBenchmark.StreamMessageThreadingBenchmark.writeOnDemand       READ_WRITE          false   1000      EVENT_LOOP_MESSAGE  thrpt   20   3027.307 ±   65.607  ops/s
StreamMessageBenchmark.StreamMessageThreadingBenchmark.writeOnDemand        READ_ONLY          false   1000  DEFAULT_STREAM_MESSAGE  thrpt   20    109.823 ±    3.481  ops/s
StreamMessageBenchmark.StreamMessageThreadingBenchmark.writeOnDemand        READ_ONLY          false   1000      EVENT_LOOP_MESSAGE  thrpt   20    102.186 ±    8.582  ops/s
StreamMessageBenchmark.StreamMessageThreadingBenchmark.writeOnDemand       WRITE_ONLY          false   1000  DEFAULT_STREAM_MESSAGE  thrpt   20    111.457 ±    3.991  ops/s
StreamMessageBenchmark.StreamMessageThreadingBenchmark.writeOnDemand       WRITE_ONLY          false   1000      EVENT_LOOP_MESSAGE  thrpt   20   1549.171 ±   19.629  ops/s
StreamMessageBenchmark.StreamMessageThreadingBenchmark.writeOnDemand             NONE          false   1000  DEFAULT_STREAM_MESSAGE  thrpt   20    107.326 ±    2.703  ops/s
StreamMessageBenchmark.StreamMessageThreadingBenchmark.writeOnDemand             NONE          false   1000      EVENT_LOOP_MESSAGE  thrpt   20     72.059 ±    3.720  ops/s
```