### PR TITLE
Specify event loop when subscribing from stream duplicator from Retry…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingHttpClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingHttpClient.java
@@ -112,7 +112,7 @@ public final class RetryingHttpClient extends RetryingClient<HttpRequest, HttpRe
     @Override
     protected HttpResponse doExecute(ClientRequestContext ctx, HttpRequest req) throws Exception {
         final DeferredHttpResponse deferredRes = new DeferredHttpResponse();
-        final HttpRequestDuplicator reqDuplicator = new HttpRequestDuplicator(req, 0);
+        final HttpRequestDuplicator reqDuplicator = new HttpRequestDuplicator(req, 0, ctx.eventLoop());
         doExecute0(ctx, reqDuplicator, deferredRes);
         return deferredRes;
     }
@@ -126,7 +126,7 @@ public final class RetryingHttpClient extends RetryingClient<HttpRequest, HttpRe
         HttpResponse response = executeDelegate(ctx, rootReqDuplicator.duplicateStream());
 
         final HttpResponseDuplicator resDuplicator =
-                new HttpResponseDuplicator(response, maxSignalLength(ctx.maxResponseLength()));
+                new HttpResponseDuplicator(response, maxSignalLength(ctx.maxResponseLength()), ctx.eventLoop());
         final ContentPreviewResponse contentPreviewResponse =
                 new ContentPreviewResponse(resDuplicator.duplicateStream(), contentPreviewLength);
         retryStrategy().shouldRetry(rootReqDuplicator.duplicateStream(), contentPreviewResponse)

--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequestDuplicator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequestDuplicator.java
@@ -18,6 +18,10 @@ package com.linecorp.armeria.common;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.concurrent.Executor;
+
+import javax.annotation.Nullable;
+
 import com.google.common.base.MoreObjects;
 
 import com.linecorp.armeria.common.stream.AbstractStreamMessageDuplicator;
@@ -69,12 +73,22 @@ public class HttpRequestDuplicator extends AbstractStreamMessageDuplicator<HttpO
      * @param maxSignalLength the maximum length of signals. {@code 0} disables the length limit
      */
     public HttpRequestDuplicator(HttpRequest req, long maxSignalLength) {
+        this(req, maxSignalLength, null);
+    }
+
+    /**
+     * Creates a new instance wrapping a {@link HttpRequest} and publishing to multiple subscribers.
+     * @param req the request that will publish data to subscribers
+     * @param maxSignalLength the maximum length of signals. {@code 0} disables the length limit
+     * @param executor the executor to use for upstream signals.
+     */
+    public HttpRequestDuplicator(HttpRequest req, long maxSignalLength, @Nullable Executor executor) {
         super(requireNonNull(req, "req"), obj -> {
             if (obj instanceof HttpData) {
                 return ((HttpData) obj).length();
             }
             return 0;
-        }, maxSignalLength);
+        }, executor, maxSignalLength);
         headers = req.headers();
         keepAlive = req.isKeepAlive();
     }

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponseDuplicator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponseDuplicator.java
@@ -87,7 +87,7 @@ public class HttpResponseDuplicator
                 return ((HttpData) obj).length();
             }
             return 0;
-        }, null, maxSignalLength);
+        }, executor, maxSignalLength);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponseDuplicator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponseDuplicator.java
@@ -18,6 +18,10 @@ package com.linecorp.armeria.common;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.concurrent.Executor;
+
+import javax.annotation.Nullable;
+
 import com.google.common.base.MoreObjects;
 
 import com.linecorp.armeria.common.stream.AbstractStreamMessageDuplicator;
@@ -68,12 +72,22 @@ public class HttpResponseDuplicator
      * @param maxSignalLength the maximum length of signals. {@code 0} disables the length limit
      */
     public HttpResponseDuplicator(HttpResponse res, long maxSignalLength) {
+        this(res, maxSignalLength, null);
+    }
+
+    /**
+     * Creates a new instance wrapping a {@link HttpResponse} and publishing to multiple subscribers.
+     * @param res the response that will publish data to subscribers
+     * @param maxSignalLength the maximum length of signals. {@code 0} disables the length limit
+     * @param executor the executor to use for upstream signals.
+     */
+    public HttpResponseDuplicator(HttpResponse res, long maxSignalLength, @Nullable Executor executor) {
         super(requireNonNull(res, "res"), obj -> {
             if (obj instanceof HttpData) {
                 return ((HttpData) obj).length();
             }
             return 0;
-        }, maxSignalLength);
+        }, null, maxSignalLength);
     }
 
     @Override

--- a/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageDuplicatorTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageDuplicatorTest.java
@@ -338,7 +338,7 @@ public class StreamMessageDuplicatorTest {
     private static class StreamMessageDuplicator
             extends AbstractStreamMessageDuplicator<String, StreamMessage<String>> {
         StreamMessageDuplicator(StreamMessage<String> publisher) {
-            super(publisher, String::length, 0);
+            super(publisher, String::length, null, 0);
         }
 
         @Override
@@ -405,7 +405,7 @@ public class StreamMessageDuplicatorTest {
     private static class ByteBufDuplicator
             extends AbstractStreamMessageDuplicator<ByteBuf, StreamMessage<ByteBuf>> {
         ByteBufDuplicator(StreamMessage<ByteBuf> publisher) {
-            super(publisher, ByteBuf::capacity, 0);
+            super(publisher, ByteBuf::capacity, null, 0);
         }
 
         @Override

--- a/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageDuplicatorVerification.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageDuplicatorVerification.java
@@ -92,7 +92,7 @@ public class StreamMessageDuplicatorVerification extends StreamMessageVerificati
     private static class StreamMessageDuplicator
             extends AbstractStreamMessageDuplicator<Long, StreamMessage<Long>> {
         StreamMessageDuplicator(StreamMessage<Long> publisher) {
-            super(publisher, l -> 8, 0);
+            super(publisher, l -> 8, null, 0);
         }
 
         @Override


### PR DESCRIPTION
…ingHttpClient.

I don't deeply know this code, so please check it out, but I guess framework code should always be specifying an event loop when subscribing to a stream, even if we handle the underlying issue of properly synchronizing subscriptions made without a subscriber as the latter will probably be suboptimal.

If my understanding of the issue is correct, this will fix #853 (actually I'm still not that sure where the multiple writes come from)