### PR TITLE
Enforce single-threaded Subscriber in StreamMessage

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -132,6 +132,11 @@ This product depends on FastUtil, distributed by Sebastiano Vigna:
   * License: licenses/LICENSE.fastutil.al20.txt (Apache License v2.0)
   * Homepage: http://fastutil.di.unimi.it/
 
+This product depends on JCTools, distributed by Nitsan Wakart and contributors:
+
+  * License: licenses/LICENSE.jctools.al20.txt (Apache License v2.0)
+  * Homepage: http://jctools.github.io/JCTools/
+
 This product depends on FindBugs-JSR305, distributed by
 
   * License: licenses/LICENSE.jsr305.al20.txt (Apache License v2.0)

--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,7 @@ ext {
             ['com.google.guava:guava', 'com.google.thirdparty.publicsuffix', "${shadedPackage}.publicsuffix"],
             ['com.spotify:completable-futures', 'com.spotify.futures', "${shadedPackage}.futures"],
             ['it.unimi.dsi:fastutil', 'it.unimi.dsi.fastutil', "${shadedPackage}.fastutil"],
+            ['org.jctools:jctools-core', 'org.jctools', "${shadedPackage}.jctools"],
             ['org.reflections:reflections', 'org.reflections', "${shadedPackage}.reflections"]
     ]
 
@@ -216,6 +217,9 @@ configure(javaProjects) {
 
         // JSR305 (Can't use compileOnly due to Javadoc errors)
         compile 'com.google.code.findbugs:jsr305'
+
+        // JCTools
+        compile 'org.jctools:jctools-core'
 
         // Jetty ALPN support
         compileOnly 'org.eclipse.jetty.alpn:alpn-api'
@@ -382,6 +386,9 @@ configure(javaProjects) {
 
         // Use larger heap when test coverage is enabled.
         maxHeapSize = jacocoEnabled ? '384m' : '128m'
+
+        // Use verbose exception reporting for easier debugging.
+        systemProperties 'com.linecorp.armeria.verboseExceptions': 'true'
 
         // Enable leak detection when '-Pleak' option is specified.
         if (project.hasProperty('leak')) {

--- a/core/src/main/java/com/linecorp/armeria/client/DecodedHttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DecodedHttpResponse.java
@@ -16,14 +16,13 @@
 
 package com.linecorp.armeria.client;
 
-import org.reactivestreams.Subscriber;
-
 import com.linecorp.armeria.common.DefaultHttpResponse;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpObject;
 import com.linecorp.armeria.internal.InboundTrafficController;
 
 import io.netty.channel.EventLoop;
+import io.netty.util.concurrent.EventExecutor;
 
 final class DecodedHttpResponse extends DefaultHttpResponse {
 
@@ -44,8 +43,8 @@ final class DecodedHttpResponse extends DefaultHttpResponse {
     }
 
     @Override
-    public void subscribe(Subscriber<? super HttpObject> subscriber) {
-        subscribe(subscriber, eventLoop);
+    protected EventExecutor defaultSubscriberExecutor() {
+        return eventLoop;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
@@ -24,12 +24,13 @@ import java.nio.charset.StandardCharsets;
 import java.util.Formatter;
 import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
 
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 
 import com.linecorp.armeria.common.stream.StreamMessage;
+
+import io.netty.util.concurrent.EventExecutor;
 
 /**
  * A streamed HTTP/2 {@link Request}.
@@ -309,7 +310,7 @@ public interface HttpRequest extends Request, StreamMessage<HttpObject> {
      * Aggregates this request. The returned {@link CompletableFuture} will be notified when the content and
      * the trailing headers of the request is received fully.
      */
-    default CompletableFuture<AggregatedHttpMessage> aggregate(Executor executor) {
+    default CompletableFuture<AggregatedHttpMessage> aggregate(EventExecutor executor) {
         final CompletableFuture<AggregatedHttpMessage> future = new CompletableFuture<>();
         final HttpRequestAggregator aggregator = new HttpRequestAggregator(this, future);
         completionFuture().whenCompleteAsync(aggregator, executor);

--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequestDuplicator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequestDuplicator.java
@@ -18,8 +18,6 @@ package com.linecorp.armeria.common;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.concurrent.Executor;
-
 import javax.annotation.Nullable;
 
 import com.google.common.base.MoreObjects;
@@ -27,6 +25,8 @@ import com.google.common.base.MoreObjects;
 import com.linecorp.armeria.common.stream.AbstractStreamMessageDuplicator;
 import com.linecorp.armeria.common.stream.StreamMessage;
 import com.linecorp.armeria.common.stream.StreamMessageWrapper;
+
+import io.netty.util.concurrent.EventExecutor;
 
 /**
  * Allows subscribing to a {@link HttpRequest} multiple times by duplicating the stream.
@@ -82,7 +82,7 @@ public class HttpRequestDuplicator extends AbstractStreamMessageDuplicator<HttpO
      * @param maxSignalLength the maximum length of signals. {@code 0} disables the length limit
      * @param executor the executor to use for upstream signals.
      */
-    public HttpRequestDuplicator(HttpRequest req, long maxSignalLength, @Nullable Executor executor) {
+    public HttpRequestDuplicator(HttpRequest req, long maxSignalLength, @Nullable EventExecutor executor) {
         super(requireNonNull(req, "req"), obj -> {
             if (obj instanceof HttpData) {
                 return ((HttpData) obj).length();

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -22,13 +22,14 @@ import java.util.Formatter;
 import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import java.util.concurrent.Executor;
 
 import org.reactivestreams.Publisher;
 
 import com.google.common.base.Throwables;
 
 import com.linecorp.armeria.common.stream.StreamMessage;
+
+import io.netty.util.concurrent.EventExecutor;
 
 /**
  * A streamed HTTP/2 {@link Response}.
@@ -207,7 +208,7 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
      * Aggregates this response. The returned {@link CompletableFuture} will be notified when the content and
      * the trailing headers of the response are received fully.
      */
-    default CompletableFuture<AggregatedHttpMessage> aggregate(Executor executor) {
+    default CompletableFuture<AggregatedHttpMessage> aggregate(EventExecutor executor) {
         final CompletableFuture<AggregatedHttpMessage> future = new CompletableFuture<>();
         final HttpResponseAggregator aggregator = new HttpResponseAggregator(future);
         completionFuture().whenCompleteAsync(aggregator, executor);

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponseAggregator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponseAggregator.java
@@ -17,6 +17,7 @@
 package com.linecorp.armeria.common;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Preconditions.checkState;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -51,6 +52,7 @@ final class HttpResponseAggregator extends HttpMessageAggregator {
 
     @Override
     protected AggregatedHttpMessage onSuccess(HttpData content) {
+        checkState(headers != null, "An aggregated message does not have headers.");
         return AggregatedHttpMessage.of(firstNonNull(informationals, Collections.emptyList()),
                                         headers, content, trailingHeaders);
     }

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponseDuplicator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponseDuplicator.java
@@ -18,8 +18,6 @@ package com.linecorp.armeria.common;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.concurrent.Executor;
-
 import javax.annotation.Nullable;
 
 import com.google.common.base.MoreObjects;
@@ -27,6 +25,8 @@ import com.google.common.base.MoreObjects;
 import com.linecorp.armeria.common.stream.AbstractStreamMessageDuplicator;
 import com.linecorp.armeria.common.stream.StreamMessage;
 import com.linecorp.armeria.common.stream.StreamMessageWrapper;
+
+import io.netty.util.concurrent.EventExecutor;
 
 /**
  * Allows subscribing to a {@link HttpResponse} multiple times by duplicating the stream.
@@ -81,7 +81,7 @@ public class HttpResponseDuplicator
      * @param maxSignalLength the maximum length of signals. {@code 0} disables the length limit
      * @param executor the executor to use for upstream signals.
      */
-    public HttpResponseDuplicator(HttpResponse res, long maxSignalLength, @Nullable Executor executor) {
+    public HttpResponseDuplicator(HttpResponse res, long maxSignalLength, @Nullable EventExecutor executor) {
         super(requireNonNull(res, "res"), obj -> {
             if (obj instanceof HttpData) {
                 return ((HttpData) obj).length();

--- a/core/src/main/java/com/linecorp/armeria/common/stream/EventLoopStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/EventLoopStreamMessage.java
@@ -38,6 +38,8 @@ import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.RequestContext;
 
 import io.netty.channel.EventLoop;
+import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.concurrent.ImmediateEventExecutor;
 
 /**
  * A {@link StreamMessage} optimized for when writes and reads all happen on the provided {@link EventLoop},
@@ -115,6 +117,11 @@ public class EventLoopStreamMessage<T> extends AbstractStreamMessageAndWriter<T>
     @Override
     public boolean isEmpty() {
         return !isOpen() && !wroteAny;
+    }
+
+    @Override
+    protected EventExecutor defaultSubscriberExecutor() {
+        return eventLoop;
     }
 
     @Override
@@ -436,7 +443,8 @@ public class EventLoopStreamMessage<T> extends AbstractStreamMessageAndWriter<T>
     }
 
     private void doSetAbortedSubscription() {
-        subscription = new SubscriptionImpl(this, AbortingSubscriber.get(), null, false);
+        subscription = new SubscriptionImpl(this, AbortingSubscriber.get(),
+                                            ImmediateEventExecutor.INSTANCE, false);
         // We don't need to invoke onSubscribe() for AbortingSubscriber because it's just a placeholder.
         invokedOnSubscribe = true;
     }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/FilteredStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/FilteredStreamMessage.java
@@ -19,12 +19,13 @@ package com.linecorp.armeria.common.stream;
 import static java.util.Objects.requireNonNull;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
 
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import io.netty.util.concurrent.EventExecutor;
 
 /**
  * A {@link StreamMessage} that filters objects as they are published. The filtering
@@ -103,14 +104,15 @@ public abstract class FilteredStreamMessage<T, U> implements StreamMessage<U> {
     }
 
     @Override
-    public void subscribe(Subscriber<? super U> subscriber, Executor executor) {
+    public void subscribe(Subscriber<? super U> subscriber, EventExecutor executor) {
         requireNonNull(subscriber, "subscriber");
         requireNonNull(executor, "executor");
         delegate.subscribe(new FilteringSubscriber(subscriber), executor);
     }
 
     @Override
-    public void subscribe(Subscriber<? super U> subscriber, Executor executor, boolean withPooledObjects) {
+    public void subscribe(Subscriber<? super U> subscriber, EventExecutor executor,
+                          boolean withPooledObjects) {
         requireNonNull(subscriber, "subscriber");
         requireNonNull(executor, "executor");
         delegate.subscribe(new FilteringSubscriber(subscriber), executor, withPooledObjects);

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -26,6 +26,7 @@ import org.reactivestreams.Subscription;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
 import io.netty.util.ReferenceCounted;
+import io.netty.util.concurrent.EventExecutor;
 
 /**
  * A variant of <a href="http://www.reactive-streams.org/">Reactive Streams</a> {@link Publisher}, which allows
@@ -65,7 +66,7 @@ import io.netty.util.ReferenceCounted;
  * leaks.
  *
  * <p>If a {@link Subscriber} does not want a {@link StreamMessage} to make a copy of a {@link ByteBufHolder},
- * use {@link #subscribe(Subscriber, boolean)} or {@link #subscribe(Subscriber, Executor, boolean)} and
+ * use {@link #subscribe(Subscriber, boolean)} or {@link #subscribe(Subscriber, EventExecutor, boolean)} and
  * specify {@code true} for {@code withPooledObjects}. Note that the {@link Subscriber} is responsible for
  * releasing the objects given with {@link Subscriber#onNext(Object)}.
  *
@@ -163,7 +164,7 @@ public interface StreamMessage<T> extends Publisher<T> {
      *   <li>{@link AbortedStreamException} if this stream has been {@linkplain #abort() aborted}.</li>
      * </ul>
      */
-    void subscribe(Subscriber<? super T> subscriber, Executor executor);
+    void subscribe(Subscriber<? super T> subscriber, EventExecutor executor);
 
     /**
      * Requests to start streaming data, invoking the specified {@link Subscriber} from the specified
@@ -178,7 +179,7 @@ public interface StreamMessage<T> extends Publisher<T> {
      *                          as is, without making a copy. If you don't know what this means, use
      *                          {@link StreamMessage#subscribe(Subscriber)}.
      */
-    void subscribe(Subscriber<? super T> subscriber, Executor executor, boolean withPooledObjects);
+    void subscribe(Subscriber<? super T> subscriber, EventExecutor executor, boolean withPooledObjects);
 
     /**
      * Closes this stream with {@link AbortedStreamException} and prevents further subscription.

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageWrapper.java
@@ -19,11 +19,12 @@ package com.linecorp.armeria.common.stream;
 import static java.util.Objects.requireNonNull;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
 
 import org.reactivestreams.Subscriber;
 
 import com.google.common.base.MoreObjects;
+
+import io.netty.util.concurrent.EventExecutor;
 
 /**
  * Wraps a {@link StreamMessage} and forwards its method invocations to {@code delegate}.
@@ -74,12 +75,12 @@ public class StreamMessageWrapper<T> implements StreamMessage<T> {
     }
 
     @Override
-    public void subscribe(Subscriber<? super T> s, Executor executor) {
+    public void subscribe(Subscriber<? super T> s, EventExecutor executor) {
         delegate().subscribe(s, executor);
     }
 
     @Override
-    public void subscribe(Subscriber<? super T> s, Executor executor, boolean withPooledObjects) {
+    public void subscribe(Subscriber<? super T> s, EventExecutor executor, boolean withPooledObjects) {
         delegate().subscribe(s, executor, withPooledObjects);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/DecodedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DecodedHttpRequest.java
@@ -16,8 +16,6 @@
 
 package com.linecorp.armeria.server;
 
-import org.reactivestreams.Subscriber;
-
 import com.linecorp.armeria.common.DefaultHttpRequest;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaders;
@@ -78,8 +76,8 @@ final class DecodedHttpRequest extends DefaultHttpRequest {
     }
 
     @Override
-    public void subscribe(Subscriber<? super HttpObject> subscriber) {
-        subscribe(subscriber, eventLoop);
+    protected EventLoop defaultSubscriberExecutor() {
+        return eventLoop;
     }
 
     @Override

--- a/core/src/test/java/com/linecorp/armeria/common/DefaultHttpResponseTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/DefaultHttpResponseTest.java
@@ -17,12 +17,10 @@
 package com.linecorp.armeria.common;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -31,60 +29,56 @@ import org.junit.Test;
 import org.junit.rules.DisableOnDebug;
 import org.junit.rules.TestRule;
 import org.junit.rules.Timeout;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.common.stream.AbortedStreamException;
 
+@RunWith(Parameterized.class)
 public class DefaultHttpResponseTest {
 
     @Rule
     public TestRule globalTimeout = new DisableOnDebug(new Timeout(10, TimeUnit.SECONDS));
 
+    @Parameters(name = "{index}: executorSpecified={0}")
+    public static Collection<Boolean> parameters() {
+        return ImmutableList.of(true, false);
+    }
+
+    private final boolean executorSpecified;
+
+    public DefaultHttpResponseTest(boolean executorSpecified) {
+        this.executorSpecified = executorSpecified;
+    }
+
     /**
      * The aggregation future must be completed even if the response being aggregated has been aborted.
      */
     @Test
-    public void abortedAggregationWithoutExecutor() {
+    public void abortedAggregation() {
         final Thread mainThread = Thread.currentThread();
         final DefaultHttpResponse res = new DefaultHttpResponse();
-        final CompletableFuture<AggregatedHttpMessage> future = res.aggregate();
+        final CompletableFuture<AggregatedHttpMessage> future;
+
+        // Practically same execution, but we need to test the both case due to code duplication.
+        if (executorSpecified) {
+            future = res.aggregate(CommonPools.workerGroup().next());
+        } else {
+            future = res.aggregate();
+        }
+
         final AtomicReference<Thread> callbackThread = new AtomicReference<>();
 
-        future.whenComplete((unused, cause) -> {
-            callbackThread.set(Thread.currentThread());
-            assertThat(cause).isInstanceOf(AbortedStreamException.class);
-        });
-
-        res.abort();
-        assertThat(future).isCompletedExceptionally();
-        assertThat(callbackThread.get()).isSameAs(mainThread);
-    }
-
-    /**
-     * Same with {@link #abortedAggregationWithoutExecutor()} but with an {@link Executor}.
-     */
-    @Test
-    public void abortedAggregationWithExecutor() {
-        final ExecutorService executor = Executors.newSingleThreadExecutor();
-        final Thread mainThread = Thread.currentThread();
-        try {
-            final DefaultHttpResponse res = new DefaultHttpResponse();
-            final CompletableFuture<AggregatedHttpMessage> future = res.aggregate(executor);
-            final AtomicReference<Thread> callbackThread = new AtomicReference<>();
-            final AtomicReference<Throwable> callbackCause = new AtomicReference<>();
-
-            future.whenComplete((unused, cause) -> {
-                callbackCause.set(cause);
-                callbackThread.set(Thread.currentThread());
-            });
-
+        assertThatThrownBy(() -> {
+            final CompletableFuture<AggregatedHttpMessage> f =
+                    future.whenComplete((unused, cause) -> callbackThread.set(Thread.currentThread()));
             res.abort();
-            await().until(() -> callbackThread.get() != null);
+            f.join();
+        }).hasCauseInstanceOf(AbortedStreamException.class);
 
-            assertThat(callbackThread.get()).isNotSameAs(mainThread);
-            assertThat(callbackCause.get()).isInstanceOf(AbortedStreamException.class);
-            assertThat(future).isCompletedExceptionally();
-        } finally {
-            executor.shutdownNow();
-        }
+        assertThat(callbackThread.get()).isNotSameAs(mainThread);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/common/stream/DeferredStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/DeferredStreamMessageTest.java
@@ -32,7 +32,8 @@ import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
 import com.google.common.base.Throwables;
-import com.google.common.util.concurrent.MoreExecutors;
+
+import io.netty.util.concurrent.ImmediateEventExecutor;
 
 public class DeferredStreamMessageTest {
 
@@ -92,7 +93,7 @@ public class DeferredStreamMessageTest {
         @SuppressWarnings("unchecked")
         final Subscriber<Object> subscriber = mock(Subscriber.class);
 
-        m.subscribe(subscriber);
+        m.subscribe(subscriber, ImmediateEventExecutor.INSTANCE);
         m.delegate(d);
         verify(subscriber).onSubscribe(any());
 
@@ -110,7 +111,7 @@ public class DeferredStreamMessageTest {
         @SuppressWarnings("unchecked")
         final Subscriber<Object> subscriber = mock(Subscriber.class);
 
-        m.subscribe(subscriber);
+        m.subscribe(subscriber, ImmediateEventExecutor.INSTANCE);
         assertFailedSubscription(m, IllegalStateException.class);
 
         m.delegate(d);
@@ -127,7 +128,7 @@ public class DeferredStreamMessageTest {
         @SuppressWarnings("unchecked")
         final Subscriber<Object> subscriber = mock(Subscriber.class);
 
-        m.subscribe(subscriber);
+        m.subscribe(subscriber, ImmediateEventExecutor.INSTANCE);
         verify(subscriber).onSubscribe(any());
 
         assertFailedSubscription(m, IllegalStateException.class);
@@ -149,16 +150,7 @@ public class DeferredStreamMessageTest {
     }
 
     @Test
-    public void testStreamingWithoutExecutor() throws Exception {
-        testStreaming(false);
-    }
-
-    @Test
-    public void testStreamingWithExecutor() throws Exception {
-        testStreaming(true);
-    }
-
-    private void testStreaming(boolean useExecutor) {
+    public void testStreaming() throws Exception {
         final DeferredStreamMessage<Object> m = new DeferredStreamMessage<>();
         final DefaultStreamMessage<Object> d = new DefaultStreamMessage<>();
         m.delegate(d);
@@ -186,11 +178,8 @@ public class DeferredStreamMessageTest {
                 streamed.add("onComplete");
             }
         };
-        if (useExecutor) {
-            m.subscribe(subscriber, MoreExecutors.directExecutor());
-        } else {
-            m.subscribe(subscriber);
-        }
+
+        m.subscribe(subscriber, ImmediateEventExecutor.INSTANCE);
 
         assertThat(streamed).containsExactly("onSubscribe");
         d.write("A");

--- a/core/src/test/java/com/linecorp/armeria/common/stream/PublisherBasedStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/PublisherBasedStreamMessageTest.java
@@ -43,11 +43,11 @@ public class PublisherBasedStreamMessageTest {
         final AbortTest test = new AbortTest();
         test.prepare();
         test.invokeOnSubscribe();
-        test.abort();
+        test.abortAndAwait();
         test.verify();
 
         // Try to abort again, which should do nothing.
-        test.abort();
+        test.abortAndAwait();
         test.verify();
     }
 
@@ -62,6 +62,7 @@ public class PublisherBasedStreamMessageTest {
         test.prepare();
         test.abort();
         test.invokeOnSubscribe();
+        test.awaitAbort();
         test.verify();
     }
 
@@ -115,6 +116,16 @@ public class PublisherBasedStreamMessageTest {
 
         void abort() {
             publisher.abort();
+        }
+
+        void abortAndAwait() {
+            abort();
+            awaitAbort();
+        }
+
+        void awaitAbort() {
+            assertThatThrownBy(() -> publisher.completionFuture().join())
+                    .hasCauseInstanceOf(AbortedStreamException.class);
         }
 
         void verify() {

--- a/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageVerification.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageVerification.java
@@ -73,9 +73,9 @@ public abstract class StreamMessageVerification<T> extends PublisherVerification
             assertThat(stream.completionFuture()).isNotDone();
             sub.requestEndOfStream();
 
+            await().untilAsserted(() -> assertThat(stream.completionFuture()).isCompleted());
             assertThat(stream.isOpen()).isFalse();
             assertThat(stream.isEmpty()).isTrue();
-            await().untilAsserted(() -> assertThat(stream.completionFuture()).isCompleted());
             sub.expectNone();
         });
     }
@@ -87,11 +87,12 @@ public abstract class StreamMessageVerification<T> extends PublisherVerification
             final StreamMessage<?> stream = (StreamMessage<?>) pub;
             assertThat(stream.isOpen()).isTrue();
             assertThat(stream.isEmpty()).isFalse();
+            assertThat(stream.completionFuture()).isNotDone();
 
-            await().untilAsserted(() -> assertThat(stream.completionFuture()).isNotDone());
             sub.requestNextElement();
             sub.requestEndOfStream();
-            assertThat(stream.completionFuture()).isCompleted();
+
+            stream.completionFuture().join();
             sub.expectNone();
         });
     }
@@ -177,5 +178,38 @@ public abstract class StreamMessageVerification<T> extends PublisherVerification
         if (pub == null) {
             throw new SkipException("Skipping because no aborted StreamMessage provided.");
         }
+    }
+
+    @Override
+    public void optional_spec111_maySupportMultiSubscribe() throws Throwable {
+        multiSubscribeUnsupported();
+    }
+
+    @Override
+    public void optional_spec111_registeredSubscribersMustReceiveOnNextOrOnCompleteSignals() throws Throwable {
+        multiSubscribeUnsupported();
+    }
+
+    @Override
+    @SuppressWarnings("checkstyle:LineLength")
+    public void optional_spec111_multicast_mustProduceTheSameElementsInTheSameSequenceToAllOfItsSubscribersWhenRequestingOneByOne() throws Throwable {
+        multiSubscribeUnsupported();
+    }
+
+    @Override
+    @SuppressWarnings("checkstyle:LineLength")
+    public void optional_spec111_multicast_mustProduceTheSameElementsInTheSameSequenceToAllOfItsSubscribersWhenRequestingManyUpfront() throws Throwable {
+        multiSubscribeUnsupported();
+    }
+
+    @Override
+    @SuppressWarnings("checkstyle:LineLength")
+    public void optional_spec111_multicast_mustProduceTheSameElementsInTheSameSequenceToAllOfItsSubscribersWhenRequestingManyUpfrontAndCompleteAsExpected() throws Throwable {
+        multiSubscribeUnsupported();
+    }
+
+    private static void multiSubscribeUnsupported() {
+        throw new SkipException(StreamMessage.class.getSimpleName() +
+                                " does not support multiple subscribers.");
     }
 }

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -181,6 +181,9 @@ org.hibernate.validator:
 org.javassist:
   javassist: { version: '3.22.0-GA' }
 
+org.jctools:
+  jctools-core: { version: '2.1.1' }
+
 org.mockito:
   mockito-core: { version: '2.12.0' }
 

--- a/licenses/LICENSE.jctools.al20.txt
+++ b/licenses/LICENSE.jctools.al20.txt
@@ -1,0 +1,202 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+


### PR DESCRIPTION
Motivation:

In the current API, subscribing to a StreamMessage without specifying an
Executor will leave no guarantee on which thread will invoke Subscriber.
This introduces various complication such as thread-safety issues.

Modifications:

- Choose the EventLoop of the current RequestContext or one of
  CommonPools.workerGroup() EventLoops when subscribing without
  specifing an Executor.
- Use EventExecutor instead of Executor so that we have fair confidence
  that the signals will be handled in a single thread.
- Miscellaneous:
  - Fix a race condition in AbstrctStreamMessageDuplicator.requestDemand(),
    which passes a non-positive demand to Subscription.request()
  - Skip the multi-subscriber tests in Reactive Streams TCK

Result:

- Thread-safety
- Less error-prone
- Fixes #853
