### PR TITLE
Allow null value as a return value of annotated http service methods

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/AnnotatedHttpServiceMethod.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AnnotatedHttpServiceMethod.java
@@ -371,7 +371,7 @@ final class AnnotatedHttpServiceMethod implements BiFunction<ServiceRequestConte
      */
     @Nullable
     private static String httpParameterValue(HttpParameters httpParameters, Parameter entry) {
-        String value = httpParameters.get(entry.name());
+        final String value = httpParameters.get(entry.name());
         if (value != null) {
             // The first decoded value.
             return value;
@@ -485,7 +485,8 @@ final class AnnotatedHttpServiceMethod implements BiFunction<ServiceRequestConte
         } else if (object instanceof AggregatedHttpMessage) {
             return ((AggregatedHttpMessage) object).toHttpResponse();
         } else {
-            ResponseConverter converter = findResponseConverter(object.getClass(), converters);
+            final Class<?> clazz = object != null ? object.getClass() : Object.class;
+            final ResponseConverter converter = findResponseConverter(clazz, converters);
             try {
                 return converter.convert(object);
             } catch (Exception e) {
@@ -524,20 +525,21 @@ final class AnnotatedHttpServiceMethod implements BiFunction<ServiceRequestConte
             Class<?> type, Map<Class<?>, ResponseConverter> converters) {
 
         // Search for the converter mapped to itself or one of its superclasses, except Object.class.
-        Class<?> current = type;
-        while (current != Object.class) {
-            ResponseConverter converter = converters.get(current);
-            if (converter != null) {
-                return converter;
-            }
-            current = current.getSuperclass();
-        }
+        if (type != Object.class) {
+            Class<?> current = type;
+            do {
+                final ResponseConverter converter = converters.get(current);
+                if (converter != null) {
+                    return converter;
+                }
+            } while ((current = current.getSuperclass()) != Object.class);
 
-        // Search for the converter mapped to one of its interface.
-        for (Class<?> iface : Types.getAllInterfaces(type)) {
-            ResponseConverter converter = converters.get(iface);
-            if (converter != null) {
-                return converter;
+            // Search for the converter mapped to one of its interface.
+            for (Class<?> iface : Types.getAllInterfaces(type)) {
+                final ResponseConverter converter = converters.get(iface);
+                if (converter != null) {
+                    return converter;
+                }
             }
         }
 

--- a/core/src/test/java/com/linecorp/armeria/server/AnnotatedHttpServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/AnnotatedHttpServiceTest.java
@@ -220,6 +220,7 @@ public class AnnotatedHttpServiceTest {
 
     @Converter(target = Number.class, value = TypedNumberConverter.class)
     @Converter(target = String.class, value = TypedStringConverter.class)
+    @Converter(target = Object.class, value = UnformattedStringConverter.class)
     public static class MyAnnotatedService2 {
         // Case 4: returns Integer type and handled by class-default Number -> HttpResponse converter.
         @Get
@@ -247,6 +248,16 @@ public class AnnotatedHttpServiceTest {
         @Path("/boolean/{var}")
         public String returnBoolean(@Param("var") boolean var) {
             return Boolean.toString(var);
+        }
+
+        @Get("/null1")
+        public Object returnNull1() {
+            return null;
+        }
+
+        @Get("/null2")
+        public CompletionStage<Object> returnNull2() {
+            return CompletableFuture.completedFuture(null);
         }
     }
 
@@ -612,6 +623,9 @@ public class AnnotatedHttpServiceTest {
             testStatusCode(hc, post("/2/long/"), 404);
             // Not-mapped HTTP method (Post).
             testStatusCode(hc, post("/2/string/blah"), 405);
+
+            testBody(hc, get("/2/null1"), "(null)");
+            testBody(hc, get("/2/null2"), "(null)");
 
             // Test the case where multiple annotated services are bound under the same path prefix.
             testBody(hc, get("/3/int/42"), "Number[42]");

--- a/core/src/test/java/com/linecorp/armeria/server/TestConverters.java
+++ b/core/src/test/java/com/linecorp/armeria/server/TestConverters.java
@@ -66,7 +66,8 @@ final class TestConverters {
     public static class UnformattedStringConverter implements ResponseConverter {
         @Override
         public HttpResponse convert(Object resObj) throws Exception {
-            return httpResponse(HttpData.ofUtf8(resObj.toString()));
+            return httpResponse(HttpData.ofUtf8(resObj != null ? resObj.toString()
+                                                               : "(null)"));
         }
     }
 


### PR DESCRIPTION
Motivation:
When an annotated method wants to return null, now it should return an empty object instead because returning null would make NPE.

Modifications:
- Find a converter which handles Object.class for the return value of null.
- Avoid NPE.