### PR TITLE
Treat RpcResponse.cause as log's cause if not explicitly set.

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
@@ -427,7 +427,13 @@ public class DefaultRequestLog implements RequestLog, RequestLogBuilder {
     @Override
     public Throwable responseCause() {
         ensureAvailability(RESPONSE_END);
-        return responseCause;
+        if (responseCause != null) {
+            return responseCause;
+        }
+        if (responseContent instanceof RpcResponse) {
+            return ((RpcResponse) responseContent).cause();
+        }
+        return null;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
@@ -427,13 +427,7 @@ public class DefaultRequestLog implements RequestLog, RequestLogBuilder {
     @Override
     public Throwable responseCause() {
         ensureAvailability(RESPONSE_END);
-        if (responseCause != null) {
-            return responseCause;
-        }
-        if (responseContent instanceof RpcResponse) {
-            return ((RpcResponse) responseContent).cause();
-        }
-        return null;
+        return responseCause;
     }
 
     @Override
@@ -527,7 +521,7 @@ public class DefaultRequestLog implements RequestLog, RequestLogBuilder {
 
     @Override
     public void endResponse() {
-        endResponse0(null);
+        endResponse0(responseContent instanceof RpcResponse ? ((RpcResponse) responseContent).cause() : null);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogBuilder.java
@@ -141,7 +141,9 @@ public interface RequestLogBuilder {
     boolean isResponseContentDeferred();
 
     /**
-     * Sets {@link RequestLog#responseDurationNanos()} and finishes the collection of the information.
+     * Sets {@link RequestLog#responseDurationNanos()} and finishes the collection of the information. If a
+     * {@link Throwable} cause has been set with {@link #responseContent(Object, Object)}, it will be treated
+     * as the {@code responseCause} for this log.
      */
     void endResponse();
 

--- a/core/src/test/java/com/linecorp/armeria/common/logging/DefaultRequestLogTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/logging/DefaultRequestLogTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.common.RpcResponse;
+
+public class DefaultRequestLogTest {
+
+    @Rule
+    public MockitoRule mocks = MockitoJUnit.rule();
+
+    @Mock
+    private RequestContext ctx;
+
+    private DefaultRequestLog log;
+
+    @Before
+    public void setUp() {
+        log = new DefaultRequestLog(ctx);
+    }
+
+    @Test
+    public void endResponseSuccess() {
+        log.endResponse();
+        assertThat(log.responseCause()).isNull();
+    }
+
+    @Test
+    public void endResponseFailure() {
+        Throwable error = new Throwable("response failed");
+        log.endResponse(error);
+        assertThat(log.responseCause()).isSameAs(error);
+    }
+
+    @Test
+    public void rpcFailure_endResponseWithoutCause() {
+        Throwable error = new Throwable("response failed");
+        log.responseContent(RpcResponse.ofFailure(error), null);
+        // If user code doesn't call endResponse, the framework automatically does with no cause.
+        log.endResponse();
+        assertThat(log.responseCause()).isSameAs(error);
+    }
+
+    @Test
+    public void rpcFailure_endResponseDifferentCause() {
+        Throwable error = new Throwable("response failed one way");
+        Throwable error2 = new Throwable("response failed a different way?");
+        log.responseContent(RpcResponse.ofFailure(error), null);
+        log.endResponse(error2);
+        assertThat(log.responseCause()).isSameAs(error2);
+    }
+}


### PR DESCRIPTION
In `GrpcService`, I call `responseContent` but not `endResponse`, and as a result `LoggingService` never sees any exception. While I could call `endResponse` as well, it was very unintuitive to me that setting a failure response wasn't enough to log the error, and feels repetitive to have to call twice with the same exception. WDYT?