### PR TITLE
Miscellaneous StreamMessage improvements

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessage.java
@@ -20,7 +20,6 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
 
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
@@ -233,7 +232,7 @@ abstract class AbstractStreamMessage<T> implements StreamMessage<T> {
             }
         }
 
-        Executor executor() {
+        EventExecutor executor() {
             return executor;
         }
 


### PR DESCRIPTION
- Change the return type of SubscriptionImpl.executor() to EventExecutor
- Make DefaultStreamMessage.demand non-volatile
- Make sure 'inOnNext' is reset to false even if Subscriber.onNext()
  raises an exception
- Simplify doRequest()
- No noticeable performance regression or improvement