### PR TITLE
Add request converter to annotated http service

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/MediaType.java
+++ b/core/src/main/java/com/linecorp/armeria/common/MediaType.java
@@ -364,6 +364,7 @@ public final class MediaType {
     public static final MediaType JAVASCRIPT_UTF_8 =
             createConstantUtf8(APPLICATION_TYPE, "javascript");
     public static final MediaType JSON_UTF_8 = createConstantUtf8(APPLICATION_TYPE, "json");
+    public static final MediaType JSON = createConstant(APPLICATION_TYPE, "json");
     /**
      * Media type for the <a href="https://www.w3.org/TR/appmanifest/">Manifest for a web
      * application</a>.

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/ByteArrayRequestConverterFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/ByteArrayRequestConverterFunction.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.annotation;
+
+import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.MediaType;
+
+/**
+ * A default implementation of a {@link RequestConverterFunction} which converts a binary body of
+ * the {@link AggregatedHttpMessage} to one of {@code byte[]} or {@link HttpData}.
+ */
+public class ByteArrayRequestConverterFunction implements RequestConverterFunction {
+
+    /**
+     * Returns whether the specified {@link AggregatedHttpMessage} is able to be consumed. This converter
+     * allows only {@code byte[]} and {@link HttpData} as its return type, and {@link AggregatedHttpMessage}
+     * would be consumed only if it does not have a {@code Content-Type} header or if it has
+     * {@code Content-Type: application/octet-stream} or {@code Content-Type: application/binary}.
+     */
+    @Override
+    public boolean accept(AggregatedHttpMessage request, Class<?> expectedResultType) {
+        if (!expectedResultType.isAssignableFrom(byte[].class) &&
+            !expectedResultType.isAssignableFrom(HttpData.class)) {
+            return false;
+        }
+
+        final String contentType = request.headers().get(HttpHeaderNames.CONTENT_TYPE);
+        if (contentType == null) {
+            return true;
+        }
+
+        final MediaType mediaType = MediaType.parse(contentType);
+        return mediaType.is(MediaType.OCTET_STREAM) ||
+               mediaType.is(MediaType.APPLICATION_BINARY);
+    }
+
+    /**
+     * Converts the specified {@link AggregatedHttpMessage} to an object of {@code expectedResultType}.
+     */
+    @Override
+    public Object convert(AggregatedHttpMessage request, Class<?> expectedResultType) throws Exception {
+        if (expectedResultType.isAssignableFrom(byte[].class)) {
+            return request.content().array();
+        }
+
+        assert expectedResultType.isAssignableFrom(HttpData.class);
+        return request.content();
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/JacksonRequestConverterFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/JacksonRequestConverterFunction.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.annotation;
+
+import static java.util.Objects.requireNonNull;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+
+import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.MediaType;
+
+/**
+ * A default implementation of a {@link RequestConverterFunction} which converts a JSON body of
+ * the {@link AggregatedHttpMessage} to an object by {@link ObjectMapper}.
+ */
+public class JacksonRequestConverterFunction implements RequestConverterFunction {
+
+    private static final Logger logger = LoggerFactory.getLogger(JacksonRequestConverterFunction.class);
+
+    private final ObjectMapper mapper;
+    private final ConcurrentMap<Class<?>, ObjectReader> readers = new ConcurrentHashMap<>();
+
+    /**
+     * Creates an instance with the default {@link ObjectMapper}.
+     */
+    public JacksonRequestConverterFunction() {
+        this(new ObjectMapper());
+    }
+
+    /**
+     * Creates an instance with the specified {@link ObjectMapper}.
+     */
+    public JacksonRequestConverterFunction(ObjectMapper mapper) {
+        this.mapper = requireNonNull(mapper, "mapper");
+    }
+
+    /**
+     * Returns whether the specified {@link AggregatedHttpMessage} is able to be consumed.
+     */
+    @Override
+    public boolean accept(AggregatedHttpMessage request, Class<?> expectedResultType) {
+        final String contentType = request.headers().get(HttpHeaderNames.CONTENT_TYPE);
+        // TODO(hyangtack) Do benchmark tests to decide whether we add a cache to MediaType#parse.
+        if (contentType != null &&
+            MediaType.parse(contentType).is(MediaType.JSON)) {
+            try {
+                return readers.computeIfAbsent(expectedResultType, mapper::readerFor) != null;
+            } catch (Throwable cause) {
+                logger.warn(JacksonRequestConverterFunction.class.getName() +
+                            " cannot read a JSON of '" + request.content().toStringUtf8() +
+                            "' as a type '" + expectedResultType.getName() + '\'', cause);
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Converts the specified {@link AggregatedHttpMessage} to an object of {@code expectedResultType}.
+     */
+    @Override
+    public Object convert(AggregatedHttpMessage request, Class<?> expectedResultType) throws Exception {
+        final ObjectReader reader = readers.get(expectedResultType);
+        assert reader != null;
+        final String contentType = request.headers().get(HttpHeaderNames.CONTENT_TYPE);
+        assert contentType != null;
+
+        final Charset charset = MediaType.parse(contentType).charset()
+                                         .orElse(StandardCharsets.UTF_8);
+        return reader.readValue(request.content().toString(charset));
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/RequestConverter.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/RequestConverter.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.linecorp.armeria.common.AggregatedHttpMessage;
+
+/**
+ * Specifies a {@link RequestConverterFunction} class which converts an {@link AggregatedHttpMessage} to
+ * an object.
+ *
+ * @see RequestConverterFunction
+ * @see RequestObject
+ */
+@Repeatable(RequestConverters.class)
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE, ElementType.METHOD })
+public @interface RequestConverter {
+
+    /**
+     * {@link RequestConverterFunction} implementation type. The specified class must have an accessible
+     * default constructor.
+     */
+    Class<? extends RequestConverterFunction> value();
+}

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/RequestConverterFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/RequestConverterFunction.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.annotation;
+
+import com.linecorp.armeria.common.AggregatedHttpMessage;
+
+/**
+ * Converts an {@link AggregatedHttpMessage} to an object. The class implementing this interface would
+ * be specified as a value of a {@link RequestConverter} annotation.
+ *
+ * @see RequestConverter
+ * @see RequestObject
+ */
+@FunctionalInterface
+public interface RequestConverterFunction {
+
+    /**
+     * Returns whether this converter is able to convert the specified {@code request} to
+     * {@code expectedResultType}.
+     */
+    default boolean accept(AggregatedHttpMessage request, Class<?> expectedResultType) {
+        return true;
+    }
+
+    /**
+     * Converts the specified {@code request} to an object of {@code expectedResultType}.
+     */
+    Object convert(AggregatedHttpMessage request, Class<?> expectedResultType) throws Exception;
+}

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/RequestConverters.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/RequestConverters.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * The containing annotation type for {@link RequestConverter}.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE, ElementType.METHOD })
+public @interface RequestConverters {
+    /**
+     * An array of {@link RequestConverter}s.
+     */
+    RequestConverter[] value();
+}

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/RequestObject.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/RequestObject.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Specifies which parameter should be converted by {@link RequestConverterFunction}.
+ *
+ * @see RequestConverterFunction
+ * @see RequestConverter
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface RequestObject {}

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/StringRequestConverterFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/StringRequestConverterFunction.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.annotation;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.MediaType;
+
+/**
+ * A default implementation of a {@link RequestConverterFunction} which converts a text body of
+ * the {@link AggregatedHttpMessage} to a {@link String}.
+ */
+public class StringRequestConverterFunction implements RequestConverterFunction {
+
+    /**
+     * Returns whether the specified {@link AggregatedHttpMessage} is able to be converted to a {@link String}.
+     */
+    @Override
+    public boolean accept(AggregatedHttpMessage request, Class<?> expectedResultType) {
+        if (!expectedResultType.isAssignableFrom(String.class)) {
+            return false;
+        }
+
+        final String contentType = request.headers().get(HttpHeaderNames.CONTENT_TYPE);
+        if (contentType == null) {
+            return false;
+        }
+
+        return MediaType.parse(contentType).is(MediaType.ANY_TEXT_TYPE);
+    }
+
+    /**
+     * Converts the specified {@link AggregatedHttpMessage} to a {@link String}.
+     */
+    @Override
+    public Object convert(AggregatedHttpMessage request, Class<?> expectedResultType) throws Exception {
+        assert expectedResultType.isAssignableFrom(String.class);
+
+        final String contentType = request.headers().get(HttpHeaderNames.CONTENT_TYPE);
+        assert contentType != null;
+        // See https://tools.ietf.org/html/rfc2616#section-3.7.1
+        final Charset charset = MediaType.parse(contentType).charset()
+                                         .orElse(StandardCharsets.ISO_8859_1);
+        return request.content().toString(charset);
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/AnnotatedHttpServiceRequestConverterTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/AnnotatedHttpServiceRequestConverterTest.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.server.TestConverters.ByteArrayConverter;
+import com.linecorp.armeria.server.TestConverters.UnformattedStringConverter;
+import com.linecorp.armeria.server.annotation.Converter;
+import com.linecorp.armeria.server.annotation.Post;
+import com.linecorp.armeria.server.annotation.RequestConverter;
+import com.linecorp.armeria.server.annotation.RequestConverterFunction;
+import com.linecorp.armeria.server.annotation.RequestObject;
+import com.linecorp.armeria.server.logging.LoggingService;
+import com.linecorp.armeria.testing.server.ServerRule;
+
+public class AnnotatedHttpServiceRequestConverterTest {
+
+    @ClassRule
+    public static final ServerRule rule = new ServerRule() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.annotatedService("/1", new MyDecorationService1(),
+                                LoggingService.newDecorator());
+            sb.annotatedService("/2", new MyDecorationService2(),
+                                LoggingService.newDecorator());
+        }
+    };
+
+    @Converter(target = String.class, value = UnformattedStringConverter.class)
+    @RequestConverter(TestRequestConverter1.class)
+    public static class MyDecorationService1 {
+
+        @Post("/convert1")
+        public String convert1(@RequestObject RequestObj1 obj1) {
+            assertThat(obj1).isNotNull();
+            return obj1.toString();
+        }
+
+        @Post("/convert2")
+        @RequestConverter(TestRequestConverter2.class)
+        @RequestConverter(TestRequestConverter1A.class)
+        @RequestConverter(TestRequestConverter1.class)
+        public String convert2(@RequestObject RequestObj1 obj1) {
+            assertThat(obj1).isNotNull();
+            return obj1.toString();
+        }
+
+        @Post("/convert3")
+        @RequestConverter(TestRequestConverter1.class)
+        @RequestConverter(TestRequestConverter2.class)
+        public String convert3(@RequestObject RequestObj1 obj1,
+                               @RequestObject RequestObj2 obj2) {
+            assertThat(obj1).isNotNull();
+            assertThat(obj2).isNotNull();
+            return obj2.strVal();
+        }
+    }
+
+    @Converter(target = String.class, value = UnformattedStringConverter.class)
+    @Converter(target = byte[].class, value = ByteArrayConverter.class)
+    public static class MyDecorationService2 {
+        @Post("/default/json")
+        public String defaultJson(@RequestObject RequestObj1 obj1,
+                                  @RequestObject RequestObj2 obj2) {
+            assertThat(obj1).isNotNull();
+            assertThat(obj2).isNotNull();
+            return obj2.strVal();
+        }
+
+        @Post("/default/binary")
+        public byte[] defaultBinary(@RequestObject HttpData obj1,
+                                    @RequestObject byte[] obj2) {
+            assertThat(obj1).isNotNull();
+            assertThat(obj2).isNotNull();
+            // Actually they have the same byte array.
+            assertThat(obj1.array()).isSameAs(obj2);
+            return obj2;
+        }
+
+        @Post("/default/text")
+        public String defaultText(@RequestObject String obj1) {
+            assertThat(obj1).isNotNull();
+            return obj1;
+        }
+    }
+
+    static class RequestObj1 {
+        private final int intVal;
+        private final String strVal;
+
+        @JsonCreator
+        RequestObj1(@JsonProperty("intVal") int intVal,
+                    @JsonProperty("strVal") String strVal) {
+            this.intVal = intVal;
+            this.strVal = requireNonNull(strVal, "strVal");
+        }
+
+        @JsonProperty
+        int intVal() {
+            return intVal;
+        }
+
+        @JsonProperty
+        String strVal() {
+            return strVal;
+        }
+
+        @Override
+        public String toString() {
+            return getClass().getSimpleName() + ':' + intVal() + ':' + strVal();
+        }
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    static class RequestObj2 {
+        private final String strVal;
+
+        @JsonCreator
+        RequestObj2(@JsonProperty("strVal") String strVal) {
+            this.strVal = requireNonNull(strVal, "strVal");
+        }
+
+        @JsonProperty
+        String strVal() {
+            return strVal;
+        }
+    }
+
+    public static class TestRequestConverter1 implements RequestConverterFunction {
+
+        private final ObjectMapper mapper = new ObjectMapper();
+
+        @Override
+        public boolean accept(AggregatedHttpMessage request, Class<?> expectedResultType) {
+            return expectedResultType.isAssignableFrom(RequestObj1.class);
+        }
+
+        @Override
+        public RequestObj1 convert(AggregatedHttpMessage request,
+                                   Class<?> expectedResultType) throws Exception {
+            return mapper.readValue(request.content().toStringUtf8(), RequestObj1.class);
+        }
+    }
+
+    public static class TestRequestConverter1A implements RequestConverterFunction {
+
+        private final ObjectMapper mapper = new ObjectMapper();
+
+        @Override
+        public boolean accept(AggregatedHttpMessage request, Class<?> expectedResultType) {
+            return expectedResultType.isAssignableFrom(RequestObj1.class);
+        }
+
+        @Override
+        public RequestObj1 convert(AggregatedHttpMessage request,
+                                   Class<?> expectedResultType) throws Exception {
+            final RequestObj1 obj1 = mapper.readValue(request.content().toStringUtf8(),
+                                                      RequestObj1.class);
+            return new RequestObj1(obj1.intVal() + 1, obj1.strVal() + 'a');
+        }
+    }
+
+    public static class TestRequestConverter2 implements RequestConverterFunction {
+        @Override
+        public boolean accept(AggregatedHttpMessage request, Class<?> expectedResultType) {
+            return expectedResultType.isAssignableFrom(RequestObj2.class);
+        }
+
+        @Override
+        public RequestObj2 convert(AggregatedHttpMessage request,
+                                   Class<?> expectedResultType) throws Exception {
+            return new RequestObj2(request.headers().method().name());
+        }
+    }
+
+    @Test
+    public void testRequestConverter() throws Exception {
+        final HttpClient client = HttpClient.of(rule.uri("/"));
+        final ObjectMapper mapper = new ObjectMapper();
+
+        AggregatedHttpMessage response;
+
+        final RequestObj1 obj1 = new RequestObj1(1, "abc");
+        final String content1 = mapper.writeValueAsString(obj1);
+
+        response = client.post("/1/convert1", content1).aggregate().join();
+        assertThat(response.headers().status()).isEqualTo(HttpStatus.OK);
+        assertThat(response.content().toStringUtf8()).isEqualTo(obj1.toString());
+
+        // The order of converters
+        final RequestObj1 obj1a = new RequestObj1(2, "abca");
+        response = client.post("/1/convert2", content1).aggregate().join();
+        assertThat(response.headers().status()).isEqualTo(HttpStatus.OK);
+        assertThat(response.content().toStringUtf8()).isEqualTo(obj1a.toString());
+
+        // Multiple @RequestObject annotated parameters
+        response = client.post("/1/convert3", content1).aggregate().join();
+        assertThat(response.headers().status()).isEqualTo(HttpStatus.OK);
+        assertThat(response.content().toStringUtf8()).isEqualTo(HttpMethod.POST.name());
+    }
+
+    @Test
+    public void testDefaultRequestConverter() throws Exception {
+        final HttpClient client = HttpClient.of(rule.uri("/"));
+        final ObjectMapper mapper = new ObjectMapper();
+
+        AggregatedHttpMessage response;
+
+        final RequestObj1 obj1 = new RequestObj1(1, "abc");
+        final String content1 = mapper.writeValueAsString(obj1);
+
+        response = client.execute(AggregatedHttpMessage.of(HttpMethod.POST, "/2/default/json",
+                                                           MediaType.JSON_UTF_8, content1))
+                         .aggregate().join();
+        assertThat(response.headers().status()).isEqualTo(HttpStatus.OK);
+        assertThat(response.content().toStringUtf8()).isEqualTo("abc");
+
+        final byte[] binary = { 0x00, 0x01, 0x02 };
+        response = client.execute(AggregatedHttpMessage.of(HttpMethod.POST, "/2/default/binary",
+                                                           MediaType.OCTET_STREAM, binary))
+                         .aggregate().join();
+        assertThat(response.headers().status()).isEqualTo(HttpStatus.OK);
+        assertThat(response.content().array()).isEqualTo(binary);
+
+        final byte[] utf8 = "¥".getBytes(StandardCharsets.UTF_8);
+        response = client.execute(AggregatedHttpMessage.of(HttpMethod.POST, "/2/default/text",
+                                                           MediaType.PLAIN_TEXT_UTF_8, utf8))
+                         .aggregate().join();
+        assertThat(response.headers().status()).isEqualTo(HttpStatus.OK);
+        assertThat(response.content().array()).isEqualTo(utf8);
+
+        final MediaType textPlain = MediaType.create("text", "plain");
+        final byte[] iso8859_1 = "¥".getBytes(StandardCharsets.ISO_8859_1);
+        response = client.execute(AggregatedHttpMessage.of(HttpMethod.POST, "/2/default/text",
+                                                           textPlain, iso8859_1))
+                         .aggregate().join();
+        assertThat(response.headers().status()).isEqualTo(HttpStatus.OK);
+        // Response is encoded as UTF-8.
+        assertThat(response.content().array()).isEqualTo(utf8);
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/TestConverters.java
+++ b/core/src/test/java/com/linecorp/armeria/server/TestConverters.java
@@ -71,6 +71,16 @@ final class TestConverters {
         }
     }
 
+    public static class ByteArrayConverter implements ResponseConverter {
+        @Override
+        public HttpResponse convert(Object resObj) throws Exception {
+            if (resObj instanceof byte[]) {
+                return httpResponse(HttpData.of((byte[]) resObj));
+            }
+            throw new IllegalArgumentException("Cannot convert " + resObj.getClass().getName());
+        }
+    }
+
     private static HttpResponse httpResponse(HttpData data) {
         assert RequestContext.current() != null;
         final DefaultHttpResponse res = new DefaultHttpResponse();


### PR DESCRIPTION
Motivation:
When we are handling HTTP POST request, we usually convert its body to a Java object by some converting logic like JSON message converter. It is a general use-case for handling a request because a Java object is more convenient than a raw HTTP request itself. So it would be better if we have a request object mapping feature like Spring message converter.

Modifications:
- Add `@RequestConverter` annotation to specify a request converter of a method or a class. It is also repeatable.
- Add RequestConverterFunction interface to implement a request converter class.
- Add `@RequestObject` annotation to specify which parameter should be converted by a request converter.