### PR TITLE
Fix buffer leak in Http(Encoded|Decoded)Response

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/encoding/HttpEncodedResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/server/encoding/HttpEncodedResponse.java
@@ -37,6 +37,8 @@ import com.linecorp.armeria.common.HttpStatusClass;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.stream.FilteredStreamMessage;
 
+import io.netty.util.ReferenceCountUtil;
+
 /**
  * A {@link FilteredStreamMessage} that applies HTTP encoding to {@link HttpObject}s as they are published.
  */
@@ -108,7 +110,7 @@ class HttpEncodedResponse extends FilteredHttpResponse {
             return obj;
         }
 
-        HttpData data = (HttpData) obj;
+        final HttpData data = (HttpData) obj;
         try {
             encodingStream.write(data.array(), data.offset(), data.length());
             encodingStream.flush();
@@ -119,6 +121,7 @@ class HttpEncodedResponse extends FilteredHttpResponse {
                     e);
         } finally {
             encodedStream.reset();
+            ReferenceCountUtil.safeRelease(data);
         }
     }
 

--- a/core/src/test/java/com/linecorp/armeria/client/encoding/ZlibStreamDecoderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/encoding/ZlibStreamDecoderTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client.encoding;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+import com.linecorp.armeria.internal.ByteBufHttpData;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.compression.ZlibWrapper;
+
+public class ZlibStreamDecoderTest {
+    @Test
+    public void testLeak() {
+        final ZlibStreamDecoder decoder = new ZlibStreamDecoder(ZlibWrapper.NONE);
+        final ByteBuf buf = Unpooled.buffer();
+        decoder.decode(new ByteBufHttpData(buf, false));
+        assertThat(buf.refCnt()).isZero();
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/encoding/HttpEncodedResponseTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/encoding/HttpEncodedResponseTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.encoding;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.Test;
+
+import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.stream.NoopSubscriber;
+import com.linecorp.armeria.internal.ByteBufHttpData;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.util.concurrent.ImmediateEventExecutor;
+
+public class HttpEncodedResponseTest {
+
+    @Test
+    public void testLeak() {
+        final ByteBuf buf = Unpooled.buffer();
+        buf.writeCharSequence("foo", StandardCharsets.UTF_8);
+
+        final HttpResponse orig = AggregatedHttpMessage.of(HttpStatus.OK,
+                                                           MediaType.PLAIN_TEXT_UTF_8,
+                                                           new ByteBufHttpData(buf, true)).toHttpResponse();
+        final HttpEncodedResponse encoded = new HttpEncodedResponse(
+                orig, HttpEncodingType.DEFLATE, mediaType -> true, 1);
+
+        // Drain the stream.
+        encoded.subscribe(NoopSubscriber.get(), ImmediateEventExecutor.INSTANCE);
+
+        // 'buf' should be released.
+        assertThat(buf.refCnt()).isZero();
+    }
+}


### PR DESCRIPTION
Handle the case where HttpData is a ByteBufHttpData.