### PR TITLE
Make FilteredStreamMessage and FilteredHttpResponse understand buffer pooling

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/encoding/ZlibStreamDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/encoding/ZlibStreamDecoder.java
@@ -19,6 +19,7 @@ package com.linecorp.armeria.client.encoding;
 import com.linecorp.armeria.common.HttpData;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufHolder;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
@@ -40,8 +41,12 @@ class ZlibStreamDecoder implements StreamDecoder {
 
     @Override
     public HttpData decode(HttpData obj) {
-        ByteBuf compressed = Unpooled.wrappedBuffer(obj.array(), obj.offset(), obj.length());
-        decoder.writeInbound(compressed);
+        if (obj instanceof ByteBufHolder) {
+            decoder.writeInbound(((ByteBufHolder) obj).content());
+        } else {
+            final ByteBuf compressed = Unpooled.wrappedBuffer(obj.array(), obj.offset(), obj.length());
+            decoder.writeInbound(compressed);
+        }
         return HttpData.of(fetchDecoderOutput());
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/FilteredHttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/FilteredHttpResponse.java
@@ -18,6 +18,9 @@ package com.linecorp.armeria.common;
 
 import com.linecorp.armeria.common.stream.FilteredStreamMessage;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufHolder;
+
 /**
  * An {@link HttpResponse} that filters objects as they are published. The filtering
  * will happen from an I/O thread, meaning the order of the filtering will match the
@@ -32,5 +35,17 @@ public abstract class FilteredHttpResponse
      */
     protected FilteredHttpResponse(HttpResponse delegate) {
         super(delegate);
+    }
+
+    /**
+     * Creates a new {@link FilteredHttpResponse} that filters objects published by {@code delegate}
+     * before passing to a subscriber.
+     *
+     * @param withPooledObjects if {@code true}, {@link #filter(Object)} receives the pooled {@link ByteBuf}
+     *                          and {@link ByteBufHolder} as is, without making a copy. If you don't know what
+     *                          this means, use {@link #FilteredHttpResponse(HttpResponse)}.
+     */
+    protected FilteredHttpResponse(HttpResponse delegate, boolean withPooledObjects) {
+        super(delegate, withPooledObjects);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/internal/PooledObjects.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/PooledObjects.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.internal;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufHolder;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.Unpooled;
+import io.netty.util.ReferenceCountUtil;
+
+/**
+ * Utility class that deals with pooled objects such as {@link ByteBufHolder} and {@link ByteBuf}.
+ */
+public final class PooledObjects {
+
+    /**
+     * Converts the given object to an unpooled copy and releases the given object.
+     */
+    public static <T> T toUnpooled(T o) {
+        if (o instanceof ByteBufHolder) {
+            o = copyAndRelease((ByteBufHolder) o);
+        } else if (o instanceof ByteBuf) {
+            o = copyAndRelease((ByteBuf) o);
+        }
+        return o;
+    }
+
+    private static <T> T copyAndRelease(ByteBufHolder o) {
+        try {
+            final ByteBuf content = Unpooled.wrappedBuffer(ByteBufUtil.getBytes(o.content()));
+            @SuppressWarnings("unchecked")
+            final T copy = (T) o.replace(content);
+            return copy;
+        } finally {
+            ReferenceCountUtil.safeRelease(o);
+        }
+    }
+
+    private static <T> T copyAndRelease(ByteBuf o) {
+        try {
+            @SuppressWarnings("unchecked")
+            final T copy = (T) Unpooled.copiedBuffer(o);
+            return copy;
+        } finally {
+            ReferenceCountUtil.safeRelease(o);
+        }
+    }
+
+    private PooledObjects() {}
+}

--- a/core/src/test/java/com/linecorp/armeria/client/encoding/AbstractStreamDecoderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/encoding/AbstractStreamDecoderTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client.encoding;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+import com.linecorp.armeria.internal.ByteBufHttpData;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
+abstract class AbstractStreamDecoderTest {
+
+    abstract StreamDecoder newDecoder();
+
+    @Test
+    public void decodedBufferShouldNotLeak() {
+        final StreamDecoder decoder = newDecoder();
+        final ByteBuf buf = Unpooled.buffer();
+        decoder.decode(new ByteBufHttpData(buf, false));
+        assertThat(buf.refCnt()).isZero();
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/client/encoding/ZlibStreamDecoderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/encoding/ZlibStreamDecoderTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client.encoding;
+
+import io.netty.handler.codec.compression.ZlibWrapper;
+
+public class ZlibStreamDecoderTest extends AbstractStreamDecoderTest {
+    @Override
+    StreamDecoder newDecoder() {
+        return new ZlibStreamDecoder(ZlibWrapper.NONE);
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/encoding/HttpEncodedResponseTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/encoding/HttpEncodedResponseTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.encoding;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.Test;
+
+import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.stream.NoopSubscriber;
+import com.linecorp.armeria.internal.ByteBufHttpData;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.util.concurrent.ImmediateEventExecutor;
+
+public class HttpEncodedResponseTest {
+
+    @Test
+    public void testLeak() {
+        final ByteBuf buf = Unpooled.buffer();
+        buf.writeCharSequence("foo", StandardCharsets.UTF_8);
+
+        final HttpResponse orig = AggregatedHttpMessage.of(HttpStatus.OK,
+                                                           MediaType.PLAIN_TEXT_UTF_8,
+                                                           new ByteBufHttpData(buf, true)).toHttpResponse();
+        final HttpEncodedResponse encoded = new HttpEncodedResponse(
+                orig, HttpEncodingType.DEFLATE, mediaType -> true, 1);
+
+        // Drain the stream.
+        encoded.subscribe(NoopSubscriber.get(), ImmediateEventExecutor.INSTANCE);
+
+        // 'buf' should be released.
+        assertThat(buf.refCnt()).isZero();
+    }
+}


### PR DESCRIPTION
Motivation:

FilteredStreamMessage currently passes pooled objects such as
ByteBufHttpData, ByteBufHolder and ByteBuf as they are, causing buffer
leaks when a user publishes them.

Modifications:

- Add a constructor parameter 'withPooledObjects' to
  FilteredStreamMessage and FilteredHttpResponse
- Extract the common code that converts a pooled object into an unpooled
  one into a new utility class 'PooledObjects'
- Add test cases for HttpEncodedResponse and ZlibStreamDecoder to verify
  the change

Result:

- Less leaks