### PR TITLE
Close completed response before trying to abort its corresponding request

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
@@ -170,13 +170,13 @@ abstract class HttpResponseDecoder {
 
         @Override
         public void run() {
-            if (request != null) {
-                request.abort();
-            }
-
             final ResponseTimeoutException cause = ResponseTimeoutException.get();
             delegate.close(cause);
             logBuilder.endResponse(cause);
+
+            if (request != null) {
+                request.abort();
+            }
         }
 
         @Override
@@ -213,22 +213,18 @@ abstract class HttpResponseDecoder {
 
         @Override
         public void close() {
-            if (request != null) {
-                request.abort();
-            }
-
             if (cancelTimeout()) {
                 delegate.close();
                 logBuilder.endResponse();
+            }
+
+            if (request != null) {
+                request.abort();
             }
         }
 
         @Override
         public void close(Throwable cause) {
-            if (request != null) {
-                request.abort();
-            }
-
             if (cancelTimeout()) {
                 delegate.close(cause);
                 logBuilder.endResponse(cause);
@@ -236,6 +232,10 @@ abstract class HttpResponseDecoder {
                 if (!Exceptions.isExpected(cause)) {
                     logger.warn("Unexpected exception:", cause);
                 }
+            }
+
+            if (request != null) {
+                request.abort();
             }
         }
 

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamWriter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamWriter.java
@@ -56,7 +56,7 @@ public interface StreamWriter<T> {
     }
 
     /**
-     * Performs the specified {@code task} when there's enough demans from the {@link Subscriber}.
+     * Performs the specified {@code task} when there are enough demands from the {@link Subscriber}.
      *
      * @return the future that completes successfully when the {@code task} finishes or
      *         exceptionally when the {@link StreamMessage} is closed unexpectedly.

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -443,7 +443,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
                                    DecodedHttpRequest req, AggregatedHttpMessage res) {
 
         // No need to consume further since the response is ready.
-        req.abort();
+        req.close();
 
         final boolean trailingHeadersEmpty = res.trailingHeaders().isEmpty();
         final boolean contentAndTrailingHeadersEmpty = res.content().isEmpty() && trailingHeadersEmpty;


### PR DESCRIPTION
Motivation:
When HttpResponseWrapper is closed, it also aborts the corresponding request and the response is finally closed with a cause by HttpRequestSubscriber#failAndRespond via HttpRequestSubscriber#onError.
However, we should normally close it without a cause if the response has been completed. So we should give a chance to the HttpResponseWrapper to close the response normally before aborting the request.

Modifications:
- Call `request.abort()` after `delegate.close()` in HttpResponseDecoder.
- Close a request instead of aborting if the request is only handled by HttpServerHandler.

Result:
Closes #630