### PR TITLE
Wait for refcnt assertions.

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/common/stream/AbstractStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/AbstractStreamMessageTest.java
@@ -362,7 +362,7 @@ public abstract class AbstractStreamMessageTest {
         }, true);
 
         await().untilAsserted(() -> assertThat(stream.isOpen()).isFalse());
-        assertThat(data.refCnt()).isZero();
+        await().untilAsserted(() -> assertThat(data.refCnt()).isZero());
     }
 
     @Test
@@ -396,7 +396,7 @@ public abstract class AbstractStreamMessageTest {
         }, true);
 
         await().untilAsserted(() -> assertThat(stream.isOpen()).isFalse());
-        assertThat(data.refCnt()).isZero();
+        await().untilAsserted(() -> assertThat(data.refCnt()).isZero());
     }
 
     private void assertSuccess() {


### PR DESCRIPTION
Since `isOpen` is usually updated immediately, it's not a sufficient guard for item processing, so add await to the refcnt assertions too. 