### PR TITLE
Set event loop when subscribing from gRPC and allow pooled objects.

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaClientCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaClientCall.java
@@ -144,7 +144,7 @@ class ArmeriaClientCall<I, O> extends ClientCall<I, O>
             close(Status.fromThrowable(e));
             return;
         }
-        res.subscribe(responseReader);
+        res.subscribe(responseReader, ctx.eventLoop(), true);
     }
 
     @Override

--- a/grpc/src/main/java/com/linecorp/armeria/internal/grpc/ArmeriaMessageDeframer.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/grpc/ArmeriaMessageDeframer.java
@@ -67,6 +67,7 @@ import io.grpc.Decompressor;
 import io.grpc.Status;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.ByteBufHolder;
 import io.netty.buffer.ByteBufInputStream;
 import io.netty.buffer.CompositeByteBuf;
 
@@ -234,8 +235,13 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
         startedDeframing = true;
 
         if (!data.isEmpty()) {
-            ByteBuf buf = alloc.buffer(data.length());
-            buf.writeBytes(data.array(), data.offset(), data.length());
+            final ByteBuf buf;
+            if (data instanceof ByteBufHolder) {
+                buf = ((ByteBufHolder) data).content();
+            } else {
+                buf = alloc.buffer(data.length());
+                buf.writeBytes(data.array(), data.offset(), data.length());
+            }
             unprocessed.addComponent(true, buf);
         }
 

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
@@ -161,7 +161,7 @@ public final class GrpcService extends AbstractHttpService
             ctx.setRequestTimeoutHandler(() -> {
                 call.close(Status.DEADLINE_EXCEEDED, EMPTY_METADATA);
             });
-            req.subscribe(call.messageReader());
+            req.subscribe(call.messageReader(), ctx.eventLoop(), true);
         }
     }
 


### PR DESCRIPTION
With the recent subscription changes, it's more important than ever to set the executor. And while our `*Decoder` don't currently write pooled objects, it will be nice to change them to do so and let the streams do the unpooling.