### PR TITLE
Add specialized implementations of fixed stream message to reduce all…

### DIFF
--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -29,15 +29,22 @@ jmh {
     if (jmhInclude) {
         include = jmhInclude
     }
-    forceGC = true
+
+    if (rootProject.hasProperty('jmh.forceGC')) {
+        forceGC = 'true'.equals(rootProject.findProperty('jmh.forceGC'))
+    } else {
+        forceGC = true
+    }
+
+
     duplicateClassesStrategy = DuplicatesStrategy.EXCLUDE
     jmhVersion = rootProject.ext.dependencyManagement['org.openjdk.jmh']['jmh-core'].version
 
     if (rootProject.hasProperty('jmh.params')) {
         benchmarkParameters = [:]
-        rootProject.findProperty('jmh.params').split(',').each {
+        rootProject.findProperty('jmh.params').split(';').each {
             def parts = it.split('=')
-            benchmarkParameters[parts[0]] = [parts[1]]
+            benchmarkParameters[parts[0]] = parts[1].tokenize(',')
         }
     }
 

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/common/stream/StreamMessageBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/common/stream/StreamMessageBenchmark.java
@@ -165,17 +165,17 @@ public class StreamMessageBenchmark {
             case FIXED_STREAM_MESSAGE:
                 switch (streamObjects.num) {
                     case 0:
-                        return FixedStreamMessage.of();
+                        return StreamMessage.of();
                     case 1:
-                        return FixedStreamMessage.of(streamObjects.values[0]);
+                        return StreamMessage.of(streamObjects.values[0]);
                     case 2:
-                        return FixedStreamMessage.of(streamObjects.values[0], streamObjects.values[1]);
+                        return StreamMessage.of(streamObjects.values[0], streamObjects.values[1]);
                     default:
-                        return FixedStreamMessage.of(streamObjects.values);
+                        return StreamMessage.of(streamObjects.values);
                 }
             case DEFERRED_FIXED_STREAM_MESSAGE:
                 DeferredStreamMessage<Integer> stream = new DeferredStreamMessage<>();
-                stream.delegate(FixedStreamMessage.of(streamObjects.values));
+                stream.delegate(StreamMessage.of(streamObjects.values));
                 return stream;
             default:
                 throw new Error();

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/common/stream/StreamMessageBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/common/stream/StreamMessageBenchmark.java
@@ -63,7 +63,7 @@ public class StreamMessageBenchmark {
         @Param
         private StreamType streamType;
 
-        @Param({ "3", "5", "20", "100", "1000" })
+        @Param({ "0", "1", "2", "3", "5", "20", "100", "1000" })
         private int num;
 
         @Param({ "false", "true" })
@@ -163,10 +163,19 @@ public class StreamMessageBenchmark {
             case DEFAULT_STREAM_MESSAGE:
                 return new DefaultStreamMessage<>();
             case FIXED_STREAM_MESSAGE:
-                return new FixedStreamMessage<>(streamObjects.values);
+                switch (streamObjects.num) {
+                    case 0:
+                        return FixedStreamMessage.of();
+                    case 1:
+                        return FixedStreamMessage.of(streamObjects.values[0]);
+                    case 2:
+                        return FixedStreamMessage.of(streamObjects.values[0], streamObjects.values[1]);
+                    default:
+                        return FixedStreamMessage.of(streamObjects.values);
+                }
             case DEFERRED_FIXED_STREAM_MESSAGE:
                 DeferredStreamMessage<Integer> stream = new DeferredStreamMessage<>();
-                stream.delegate(new FixedStreamMessage<>(streamObjects.values));
+                stream.delegate(FixedStreamMessage.of(streamObjects.values));
                 return stream;
             default:
                 throw new Error();

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultHttpClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultHttpClient.java
@@ -65,6 +65,6 @@ final class DefaultHttpClient extends UserClient<HttpRequest, HttpResponse> impl
     }
 
     HttpResponse execute(@Nullable EventLoop eventLoop, AggregatedHttpMessage aggregatedReq) {
-        return execute(eventLoop, aggregatedReq.toHttpRequest());
+        return execute(eventLoop, HttpRequest.of(aggregatedReq));
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/AggregatedHttpMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AggregatedHttpMessage.java
@@ -429,74 +429,20 @@ public interface AggregatedHttpMessage {
     /**
      * Converts this message into a new complete {@link HttpRequest}.
      *
-     * @return the converted {@link HttpRequest} whose stream is complete
-     * @throws IllegalStateException if this message is not a request
+     * @deprecated use {@link HttpRequest#of(AggregatedHttpMessage)}.
      */
+    @Deprecated
     default HttpRequest toHttpRequest() {
-        final HttpHeaders headers = headers();
-
-        // From the section 8.1.2.3 of RFC 7540:
-        //// All HTTP/2 requests MUST include exactly one valid value for the :method, :scheme, and :path
-        //// pseudo-header fields, unless it is a CONNECT request (Section 8.3)
-        // NB: ':scheme' will be filled when a request is written.
-        if (headers.method() == null) {
-            throw new IllegalStateException("not a request (missing :method)");
-        }
-        if (headers.path() == null) {
-            throw new IllegalStateException("not a request (missing :path)");
-        }
-
-        final HttpData content = content();
-        final HttpHeaders trailingHeaders = trailingHeaders();
-        final int numObjects = (!content.isEmpty() ? 1 : 0) +
-                               (!trailingHeaders.isEmpty() ? 1 : 0);
-        final HttpObject[] objs = new HttpObject[numObjects];
-        int writerIndex = 0;
-        if (!content.isEmpty()) {
-            objs[writerIndex++] = content;
-        }
-        if (!trailingHeaders.isEmpty()) {
-            objs[writerIndex] = trailingHeaders;
-        }
-        return FixedHttpRequest.ofWrittenHeaders(headers, objs);
+        return HttpRequest.of(this);
     }
 
     /**
      * Converts this message into a new complete {@link HttpResponse}.
      *
-     * @return the converted {@link HttpResponse} whose stream is complete
-     * @throws IllegalStateException if this message is not a response.
+     * @deprecated use {@link HttpResponse#of(AggregatedHttpMessage)}.
      */
+    @Deprecated
     default HttpResponse toHttpResponse() {
-        final List<HttpHeaders> informationals = informationals();
-        final HttpHeaders headers = headers();
-
-        // From the section 8.1.2.4 of RFC 7540:
-        //// For HTTP/2 responses, a single :status pseudo-header field is defined that carries the HTTP status
-        //// code field (see [RFC7231], Section 6). This pseudo-header field MUST be included in all responses;
-        //// otherwise, the response is malformed (Section 8.1.2.6).
-        if (headers.status() == null) {
-            throw new IllegalStateException("not a response (missing :status)");
-        }
-
-        final HttpData content = content();
-        final HttpHeaders trailingHeaders = trailingHeaders();
-        final int numObjects = informationals.size() +
-                               1 /* headers */ +
-                               (!content.isEmpty() ? 1 : 0) +
-                               (!trailingHeaders.isEmpty() ? 1 : 0);
-        final HttpObject[] objs = new HttpObject[numObjects];
-        int writerIndex = 0;
-        for (HttpHeaders informational : informationals()) {
-            objs[writerIndex++] = informational;
-        }
-        objs[writerIndex++] = headers;
-        if (!content.isEmpty()) {
-            objs[writerIndex++] = content;
-        }
-        if (!trailingHeaders.isEmpty()) {
-            objs[writerIndex] = trailingHeaders;
-        }
-        return FixedHttpResponse.of(objs);
+        return HttpResponse.of(this);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/AggregatedHttpMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AggregatedHttpMessage.java
@@ -458,7 +458,7 @@ public interface AggregatedHttpMessage {
         if (!trailingHeaders.isEmpty()) {
             objs[writerIndex] = trailingHeaders;
         }
-        return FixedHttpRequest.ofHeadersWritten(headers, objs);
+        return FixedHttpRequest.ofWrittenHeaders(headers, objs);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/AggregatedHttpMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AggregatedHttpMessage.java
@@ -429,7 +429,7 @@ public interface AggregatedHttpMessage {
     /**
      * Converts this message into a new complete {@link HttpRequest}.
      *
-     * @deprecated use {@link HttpRequest#of(AggregatedHttpMessage)}.
+     * @deprecated Use {@link HttpRequest#of(AggregatedHttpMessage)}.
      */
     @Deprecated
     default HttpRequest toHttpRequest() {
@@ -439,7 +439,7 @@ public interface AggregatedHttpMessage {
     /**
      * Converts this message into a new complete {@link HttpResponse}.
      *
-     * @deprecated use {@link HttpResponse#of(AggregatedHttpMessage)}.
+     * @deprecated Use {@link HttpResponse#of(AggregatedHttpMessage)}.
      */
     @Deprecated
     default HttpResponse toHttpResponse() {

--- a/core/src/main/java/com/linecorp/armeria/common/FixedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/FixedHttpRequest.java
@@ -19,64 +19,191 @@ package com.linecorp.armeria.common;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
-import com.linecorp.armeria.common.stream.FixedStreamMessage;
+import com.linecorp.armeria.common.stream.FixedStreamMessage.EmptyFixedStreamMessage;
+import com.linecorp.armeria.common.stream.FixedStreamMessage.OneElementFixedStreamMessage;
+import com.linecorp.armeria.common.stream.FixedStreamMessage.RegularFixedStreamMessage;
+import com.linecorp.armeria.common.stream.FixedStreamMessage.TwoElementFixedStreamMessage;
 
 /**
- * An {@link HttpResponse} optimized for when all the {@link HttpObject}s that will be published are known at
+ * An {@link HttpRequest} optimized for when all the {@link HttpObject}s that will be published are known at
  * construction time.
  */
-public final class FixedHttpRequest extends FixedStreamMessage<HttpObject> implements HttpRequest {
+public final class FixedHttpRequest {
 
     /**
-     * Creates a new {@link FixedHttpRequest} that will publish the given {@code objs}. {@code objs} is not
-     * copied so must not be mutated after this method call (it is generally meant to be used with a varargs
-     * invocation). The first element of {@code objs} must be of type {@link HttpHeaders}.
+     * Creates a new {@link HttpRequest} that will publish the given {@link HttpHeaders} with keep-alive
+     * enabled.
      */
-    public static FixedHttpRequest of(HttpObject... objs) {
+    public static HttpRequest of(HttpHeaders headers) {
+        return of(true, headers);
+    }
+
+    /**
+     * Creates a new {@link HttpRequest} that will publish the given {@link HttpHeaders} with the
+     * provided {@code keepAlive}.
+     */
+    public static HttpRequest of(boolean keepAlive, HttpHeaders headers) {
+        requireNonNull(headers, "headers");
+        return new OneElementFixedHttpRequest(headers, headers, keepAlive);
+    }
+
+    /**
+     * Creates a new {@link FixedHttpRequest} that will publish the given {@link HttpHeaders} and
+     * {@link HttpObject} with keep-alive enabled.
+     */
+    public static HttpRequest of(HttpHeaders headers, HttpObject content) {
+        return of(true, headers, content);
+    }
+
+    /**
+     * Creates a new {@link HttpRequest} that will publish the given {@link HttpHeaders} and
+     * {@link HttpObject} with the provided {@code keepAlive}.
+     */
+    public static HttpRequest of(boolean keepAlive, HttpHeaders headers, HttpObject content) {
+        requireNonNull(headers, "headers");
+        requireNonNull(content, "content");
+        return new TwoElementFixedHttpRequest(headers, headers, content, keepAlive);
+    }
+
+    /**
+     * Creates a new {@link HttpRequest} that will publish the given {@code objs}. {@code objs} is not
+     * copied so must not be mutated after this method call (it is generally meant to be used with a varargs
+     * invocation). The first element of {@code objs} must be {@link HttpHeaders}. Keep-alive is enabled.
+     */
+    public static HttpRequest of(HttpObject... objs) {
         return of(true, objs);
     }
 
     /**
-     * Creates a new {@link FixedHttpRequest} that will publish the given {@code objs}. {@code objs} is not
+     * Creates a new {@link HttpRequest} that will publish the given {@code objs}. {@code objs} is not
      * copied so must not be mutated after this method call (it is generally meant to be used with a varargs
-     * invocation). The first element of {@code objs} must be of type {@link HttpHeaders}.
-     *
-     * @param keepAlive whether to keep the connection alive after this request is handled
+     * invocation). The first element of {@code objs} must be {@link HttpHeaders}.
      */
-    public static FixedHttpRequest of(boolean keepAlive, HttpObject... objs) {
+    public static HttpRequest of(boolean keepalive, HttpObject... objs) {
         requireNonNull(objs, "objs");
-        checkArgument(objs.length > 0, "At least one HttpObject must be published.");
-        checkArgument(objs[0] instanceof HttpHeaders, "First published object must be headers.");
-        return new FixedHttpRequest((HttpHeaders) objs[0], objs, keepAlive);
+        checkArgument(objs.length > 0, "objs must be non-empty");
+        checkArgument(objs[0] instanceof HttpHeaders);
+        HttpHeaders headers = (HttpHeaders) objs[0];
+        switch (objs.length) {
+            case 1:
+                return of(keepalive, headers);
+            case 2:
+                return of(keepalive, headers, objs[0]);
+            default:
+                return new RegularFixedHttpRequest(headers, objs, keepalive);
+        }
     }
 
     /**
-     * Creates a new {@link FixedHttpRequest} that will publish the given {@code objs}. {@code objs} is not
+     * Creates a new {@link HttpRequest} that will publish the given {@code objs}. {@code objs} is not
      * copied so must not be mutated after this method call (it is generally meant to be used with a varargs
-     * invocation). {@code writtenHeaders} should have already been separately written to the recipient.
+     * invocation). It is assumed the provided {@link HttpHeaders} were already written outside this stream.
      */
-    public static FixedHttpRequest ofHeadersWritten(HttpHeaders writtenHeaders, HttpObject... objs) {
-        requireNonNull(writtenHeaders, "writtenHeaders");
+    static HttpRequest ofWrittenHeaders(HttpHeaders headers, HttpObject... objs) {
         requireNonNull(objs, "objs");
-        return new FixedHttpRequest(writtenHeaders, objs, true);
+        switch (objs.length) {
+            case 0:
+                return new EmptyFixedHttpRequest(headers, true);
+            case 1:
+                return new OneElementFixedHttpRequest(headers, objs[0], true);
+            case 2:
+                return new TwoElementFixedHttpRequest(headers, objs[0], objs[1], true);
+            default:
+                return new RegularFixedHttpRequest(headers, objs, true);
+        }
     }
 
-    private final HttpHeaders headers;
-    private final boolean keepAlive;
+    private static final class EmptyFixedHttpRequest
+            extends EmptyFixedStreamMessage<HttpObject> implements HttpRequest {
 
-    private FixedHttpRequest(HttpHeaders headers, HttpObject[] objs, boolean keepAlive) {
-        super(objs);
-        this.headers = headers;
-        this.keepAlive = keepAlive;
+        private final HttpHeaders headers;
+        private final boolean keepAlive;
+
+        private EmptyFixedHttpRequest(HttpHeaders headers, boolean keepAlive) {
+            this.headers = headers;
+            this.keepAlive = keepAlive;
+        }
+
+        @Override
+        public HttpHeaders headers() {
+            return headers;
+        }
+
+        @Override
+        public boolean isKeepAlive() {
+            return keepAlive;
+        }
     }
 
-    @Override
-    public HttpHeaders headers() {
-        return headers;
+    private static final class OneElementFixedHttpRequest
+            extends OneElementFixedStreamMessage<HttpObject> implements HttpRequest {
+
+        private final HttpHeaders headers;
+        private final boolean keepAlive;
+
+        private OneElementFixedHttpRequest(HttpHeaders headers, HttpObject obj, boolean keepAlive) {
+            super(obj);
+            this.headers = headers;
+            this.keepAlive = keepAlive;
+        }
+
+        @Override
+        public HttpHeaders headers() {
+            return headers;
+        }
+
+        @Override
+        public boolean isKeepAlive() {
+            return keepAlive;
+        }
     }
 
-    @Override
-    public boolean isKeepAlive() {
-        return keepAlive;
+    private static final class TwoElementFixedHttpRequest
+            extends TwoElementFixedStreamMessage<HttpObject> implements HttpRequest {
+
+        private final HttpHeaders headers;
+        private final boolean keepAlive;
+
+        private TwoElementFixedHttpRequest(
+                HttpHeaders headers, HttpObject obj1, HttpObject obj2, boolean keepAlive) {
+            super(obj1, obj2);
+            this.headers = headers;
+            this.keepAlive = keepAlive;
+        }
+
+        @Override
+        public HttpHeaders headers() {
+            return headers;
+        }
+
+        @Override
+        public boolean isKeepAlive() {
+            return keepAlive;
+        }
     }
+
+    private static final class RegularFixedHttpRequest
+            extends RegularFixedStreamMessage<HttpObject> implements HttpRequest {
+
+        private final HttpHeaders headers;
+        private final boolean keepAlive;
+
+        private RegularFixedHttpRequest(HttpHeaders headers, HttpObject[] objs, boolean keepAlive) {
+            super(objs);
+            this.headers = headers;
+            this.keepAlive = keepAlive;
+        }
+
+        @Override
+        public HttpHeaders headers() {
+            return headers;
+        }
+
+        @Override
+        public boolean isKeepAlive() {
+            return keepAlive;
+        }
+    }
+
+    private FixedHttpRequest() {}
 }

--- a/core/src/main/java/com/linecorp/armeria/common/FixedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/FixedHttpRequest.java
@@ -16,9 +16,6 @@
 
 package com.linecorp.armeria.common;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static java.util.Objects.requireNonNull;
-
 import com.linecorp.armeria.common.stream.FixedStreamMessage.EmptyFixedStreamMessage;
 import com.linecorp.armeria.common.stream.FixedStreamMessage.OneElementFixedStreamMessage;
 import com.linecorp.armeria.common.stream.FixedStreamMessage.RegularFixedStreamMessage;
@@ -28,98 +25,15 @@ import com.linecorp.armeria.common.stream.FixedStreamMessage.TwoElementFixedStre
  * An {@link HttpRequest} optimized for when all the {@link HttpObject}s that will be published are known at
  * construction time.
  */
-public final class FixedHttpRequest {
+final class FixedHttpRequest {
 
-    /**
-     * Creates a new {@link HttpRequest} that will publish the given {@link HttpHeaders} with keep-alive
-     * enabled.
-     */
-    public static HttpRequest of(HttpHeaders headers) {
-        return of(true, headers);
-    }
-
-    /**
-     * Creates a new {@link HttpRequest} that will publish the given {@link HttpHeaders} with the
-     * provided {@code keepAlive}.
-     */
-    public static HttpRequest of(boolean keepAlive, HttpHeaders headers) {
-        requireNonNull(headers, "headers");
-        return new OneElementFixedHttpRequest(headers, headers, keepAlive);
-    }
-
-    /**
-     * Creates a new {@link FixedHttpRequest} that will publish the given {@link HttpHeaders} and
-     * {@link HttpObject} with keep-alive enabled.
-     */
-    public static HttpRequest of(HttpHeaders headers, HttpObject content) {
-        return of(true, headers, content);
-    }
-
-    /**
-     * Creates a new {@link HttpRequest} that will publish the given {@link HttpHeaders} and
-     * {@link HttpObject} with the provided {@code keepAlive}.
-     */
-    public static HttpRequest of(boolean keepAlive, HttpHeaders headers, HttpObject content) {
-        requireNonNull(headers, "headers");
-        requireNonNull(content, "content");
-        return new TwoElementFixedHttpRequest(headers, headers, content, keepAlive);
-    }
-
-    /**
-     * Creates a new {@link HttpRequest} that will publish the given {@code objs}. {@code objs} is not
-     * copied so must not be mutated after this method call (it is generally meant to be used with a varargs
-     * invocation). The first element of {@code objs} must be {@link HttpHeaders}. Keep-alive is enabled.
-     */
-    public static HttpRequest of(HttpObject... objs) {
-        return of(true, objs);
-    }
-
-    /**
-     * Creates a new {@link HttpRequest} that will publish the given {@code objs}. {@code objs} is not
-     * copied so must not be mutated after this method call (it is generally meant to be used with a varargs
-     * invocation). The first element of {@code objs} must be {@link HttpHeaders}.
-     */
-    public static HttpRequest of(boolean keepalive, HttpObject... objs) {
-        requireNonNull(objs, "objs");
-        checkArgument(objs.length > 0, "objs must be non-empty");
-        checkArgument(objs[0] instanceof HttpHeaders);
-        HttpHeaders headers = (HttpHeaders) objs[0];
-        switch (objs.length) {
-            case 1:
-                return of(keepalive, headers);
-            case 2:
-                return of(keepalive, headers, objs[0]);
-            default:
-                return new RegularFixedHttpRequest(headers, objs, keepalive);
-        }
-    }
-
-    /**
-     * Creates a new {@link HttpRequest} that will publish the given {@code objs}. {@code objs} is not
-     * copied so must not be mutated after this method call (it is generally meant to be used with a varargs
-     * invocation). It is assumed the provided {@link HttpHeaders} were already written outside this stream.
-     */
-    static HttpRequest ofWrittenHeaders(HttpHeaders headers, HttpObject... objs) {
-        requireNonNull(objs, "objs");
-        switch (objs.length) {
-            case 0:
-                return new EmptyFixedHttpRequest(headers, true);
-            case 1:
-                return new OneElementFixedHttpRequest(headers, objs[0], true);
-            case 2:
-                return new TwoElementFixedHttpRequest(headers, objs[0], objs[1], true);
-            default:
-                return new RegularFixedHttpRequest(headers, objs, true);
-        }
-    }
-
-    private static final class EmptyFixedHttpRequest
+    static final class EmptyFixedHttpRequest
             extends EmptyFixedStreamMessage<HttpObject> implements HttpRequest {
 
         private final HttpHeaders headers;
         private final boolean keepAlive;
 
-        private EmptyFixedHttpRequest(HttpHeaders headers, boolean keepAlive) {
+        EmptyFixedHttpRequest(HttpHeaders headers, boolean keepAlive) {
             this.headers = headers;
             this.keepAlive = keepAlive;
         }
@@ -135,13 +49,13 @@ public final class FixedHttpRequest {
         }
     }
 
-    private static final class OneElementFixedHttpRequest
+    static final class OneElementFixedHttpRequest
             extends OneElementFixedStreamMessage<HttpObject> implements HttpRequest {
 
         private final HttpHeaders headers;
         private final boolean keepAlive;
 
-        private OneElementFixedHttpRequest(HttpHeaders headers, HttpObject obj, boolean keepAlive) {
+        OneElementFixedHttpRequest(HttpHeaders headers, boolean keepAlive, HttpObject obj) {
             super(obj);
             this.headers = headers;
             this.keepAlive = keepAlive;
@@ -158,14 +72,14 @@ public final class FixedHttpRequest {
         }
     }
 
-    private static final class TwoElementFixedHttpRequest
+    static final class TwoElementFixedHttpRequest
             extends TwoElementFixedStreamMessage<HttpObject> implements HttpRequest {
 
         private final HttpHeaders headers;
         private final boolean keepAlive;
 
-        private TwoElementFixedHttpRequest(
-                HttpHeaders headers, HttpObject obj1, HttpObject obj2, boolean keepAlive) {
+        TwoElementFixedHttpRequest(
+                HttpHeaders headers, boolean keepAlive, HttpObject obj1, HttpObject obj2) {
             super(obj1, obj2);
             this.headers = headers;
             this.keepAlive = keepAlive;
@@ -182,13 +96,13 @@ public final class FixedHttpRequest {
         }
     }
 
-    private static final class RegularFixedHttpRequest
+    static final class RegularFixedHttpRequest
             extends RegularFixedStreamMessage<HttpObject> implements HttpRequest {
 
         private final HttpHeaders headers;
         private final boolean keepAlive;
 
-        private RegularFixedHttpRequest(HttpHeaders headers, HttpObject[] objs, boolean keepAlive) {
+        RegularFixedHttpRequest(HttpHeaders headers, boolean keepAlive, HttpObject... objs) {
             super(objs);
             this.headers = headers;
             this.keepAlive = keepAlive;

--- a/core/src/main/java/com/linecorp/armeria/common/FixedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/FixedHttpRequest.java
@@ -16,10 +16,10 @@
 
 package com.linecorp.armeria.common;
 
-import com.linecorp.armeria.common.stream.FixedStreamMessage.EmptyFixedStreamMessage;
-import com.linecorp.armeria.common.stream.FixedStreamMessage.OneElementFixedStreamMessage;
-import com.linecorp.armeria.common.stream.FixedStreamMessage.RegularFixedStreamMessage;
-import com.linecorp.armeria.common.stream.FixedStreamMessage.TwoElementFixedStreamMessage;
+import com.linecorp.armeria.common.stream.EmptyFixedStreamMessage;
+import com.linecorp.armeria.common.stream.OneElementFixedStreamMessage;
+import com.linecorp.armeria.common.stream.RegularFixedStreamMessage;
+import com.linecorp.armeria.common.stream.TwoElementFixedStreamMessage;
 
 /**
  * An {@link HttpRequest} optimized for when all the {@link HttpObject}s that will be published are known at

--- a/core/src/main/java/com/linecorp/armeria/common/FixedHttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/FixedHttpResponse.java
@@ -16,10 +16,6 @@
 
 package com.linecorp.armeria.common;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static java.util.Objects.requireNonNull;
-
-import com.linecorp.armeria.common.stream.FixedStreamMessage.EmptyFixedStreamMessage;
 import com.linecorp.armeria.common.stream.FixedStreamMessage.OneElementFixedStreamMessage;
 import com.linecorp.armeria.common.stream.FixedStreamMessage.RegularFixedStreamMessage;
 import com.linecorp.armeria.common.stream.FixedStreamMessage.TwoElementFixedStreamMessage;
@@ -28,75 +24,25 @@ import com.linecorp.armeria.common.stream.FixedStreamMessage.TwoElementFixedStre
  * An {@link HttpResponse} optimized for when all the {@link HttpObject}s that will be published are known at
  * construction time.
  */
-public final class FixedHttpResponse {
+final class FixedHttpResponse {
 
-    /**
-     * Creates a new {@link HttpResponse} that will not publish anything.
-     */
-    public static HttpResponse of() {
-        return new EmptyFixedHttpResponse();
-    }
-
-    /**
-     * Creates a new {@link HttpResponse} that will publish the given {@link HttpHeaders}.
-     */
-    public static HttpResponse of(HttpHeaders obj) {
-        requireNonNull(obj, "obj");
-        return new OneElementFixedHttpResponse(obj);
-    }
-
-    /**
-     * Creates a new {@link HttpResponse} that will publish the given {@link HttpHeaders} and
-     * {@link HttpObject}.
-     */
-    public static HttpResponse of(HttpHeaders obj1, HttpObject obj2) {
-        requireNonNull(obj1, "obj1");
-        requireNonNull(obj2, "obj2");
-        return new TwoElementFixedHttpResponse(obj1, obj2);
-    }
-
-    /**
-     * Creates a new {@link HttpResponse} that will publish the given {@code objs}. {@code objs} is not
-     * copied so must not be mutated after this method call (it is generally meant to be used with a varargs
-     * invocation). The first element of {@code objs} must be of type {@link HttpHeaders}.
-     */
-    public static HttpResponse of(HttpObject... objs) {
-        requireNonNull(objs, "objs");
-        if (objs.length == 0) {
-            return of();
-        }
-        checkArgument(objs[0] instanceof HttpHeaders, "First published object must be headers.");
-        HttpHeaders headers = (HttpHeaders) objs[0];
-        switch (objs.length) {
-            case 1:
-                return of(headers);
-            case 2:
-                return of(headers, objs[1]);
-            default:
-                return new RegularFixedHttpResponse(objs);
-        }
-    }
-
-    private static final class EmptyFixedHttpResponse
-            extends EmptyFixedStreamMessage<HttpObject> implements HttpResponse {}
-
-    private static final class OneElementFixedHttpResponse
+    static final class OneElementFixedHttpResponse
             extends OneElementFixedStreamMessage<HttpObject> implements HttpResponse {
-        private OneElementFixedHttpResponse(HttpObject obj) {
+        OneElementFixedHttpResponse(HttpObject obj) {
             super(obj);
         }
     }
 
-    private static final class TwoElementFixedHttpResponse
+    static final class TwoElementFixedHttpResponse
             extends TwoElementFixedStreamMessage<HttpObject> implements HttpResponse {
-        private TwoElementFixedHttpResponse(HttpObject obj1, HttpObject obj2) {
+        TwoElementFixedHttpResponse(HttpObject obj1, HttpObject obj2) {
             super(obj1, obj2);
         }
     }
 
-    private static final class RegularFixedHttpResponse
+    static final class RegularFixedHttpResponse
             extends RegularFixedStreamMessage<HttpObject> implements HttpResponse {
-        private RegularFixedHttpResponse(HttpObject[] objs) {
+        RegularFixedHttpResponse(HttpObject... objs) {
             super(objs);
         }
     }

--- a/core/src/main/java/com/linecorp/armeria/common/FixedHttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/FixedHttpResponse.java
@@ -16,9 +16,9 @@
 
 package com.linecorp.armeria.common;
 
-import com.linecorp.armeria.common.stream.FixedStreamMessage.OneElementFixedStreamMessage;
-import com.linecorp.armeria.common.stream.FixedStreamMessage.RegularFixedStreamMessage;
-import com.linecorp.armeria.common.stream.FixedStreamMessage.TwoElementFixedStreamMessage;
+import com.linecorp.armeria.common.stream.OneElementFixedStreamMessage;
+import com.linecorp.armeria.common.stream.RegularFixedStreamMessage;
+import com.linecorp.armeria.common.stream.TwoElementFixedStreamMessage;
 
 /**
  * An {@link HttpResponse} optimized for when all the {@link HttpObject}s that will be published are known at

--- a/core/src/main/java/com/linecorp/armeria/common/FixedHttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/FixedHttpResponse.java
@@ -19,27 +19,88 @@ package com.linecorp.armeria.common;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
-import com.linecorp.armeria.common.stream.FixedStreamMessage;
+import com.linecorp.armeria.common.stream.FixedStreamMessage.EmptyFixedStreamMessage;
+import com.linecorp.armeria.common.stream.FixedStreamMessage.OneElementFixedStreamMessage;
+import com.linecorp.armeria.common.stream.FixedStreamMessage.RegularFixedStreamMessage;
+import com.linecorp.armeria.common.stream.FixedStreamMessage.TwoElementFixedStreamMessage;
 
 /**
  * An {@link HttpResponse} optimized for when all the {@link HttpObject}s that will be published are known at
  * construction time.
  */
-public final class FixedHttpResponse extends FixedStreamMessage<HttpObject> implements HttpResponse {
+public final class FixedHttpResponse {
 
     /**
-     * Creates a new {@link FixedHttpResponse} that will publish the given {@code objs}. {@code objs} is not
+     * Creates a new {@link HttpResponse} that will not publish anything.
+     */
+    public static HttpResponse of() {
+        return new EmptyFixedHttpResponse();
+    }
+
+    /**
+     * Creates a new {@link HttpResponse} that will publish the given {@link HttpHeaders}.
+     */
+    public static HttpResponse of(HttpHeaders obj) {
+        requireNonNull(obj, "obj");
+        return new OneElementFixedHttpResponse(obj);
+    }
+
+    /**
+     * Creates a new {@link HttpResponse} that will publish the given {@link HttpHeaders} and
+     * {@link HttpObject}.
+     */
+    public static HttpResponse of(HttpHeaders obj1, HttpObject obj2) {
+        requireNonNull(obj1, "obj1");
+        requireNonNull(obj2, "obj2");
+        return new TwoElementFixedHttpResponse(obj1, obj2);
+    }
+
+    /**
+     * Creates a new {@link HttpResponse} that will publish the given {@code objs}. {@code objs} is not
      * copied so must not be mutated after this method call (it is generally meant to be used with a varargs
      * invocation). The first element of {@code objs} must be of type {@link HttpHeaders}.
      */
-    public static FixedHttpResponse of(HttpObject... objs) {
+    public static HttpResponse of(HttpObject... objs) {
         requireNonNull(objs, "objs");
-        checkArgument(objs.length > 0, "At least one HttpObject must be published.");
+        if (objs.length == 0) {
+            return of();
+        }
         checkArgument(objs[0] instanceof HttpHeaders, "First published object must be headers.");
-        return new FixedHttpResponse(objs);
+        HttpHeaders headers = (HttpHeaders) objs[0];
+        switch (objs.length) {
+            case 1:
+                return of(headers);
+            case 2:
+                return of(headers, objs[1]);
+            default:
+                return new RegularFixedHttpResponse(objs);
+        }
     }
 
-    private FixedHttpResponse(HttpObject[] objs) {
-        super(objs);
+    private static final class EmptyFixedHttpResponse
+            extends EmptyFixedStreamMessage<HttpObject> implements HttpResponse {}
+
+    private static final class OneElementFixedHttpResponse
+            extends OneElementFixedStreamMessage<HttpObject> implements HttpResponse {
+        private OneElementFixedHttpResponse(HttpObject obj) {
+            super(obj);
+        }
     }
+
+    private static final class TwoElementFixedHttpResponse
+            extends TwoElementFixedStreamMessage<HttpObject> implements HttpResponse {
+        private TwoElementFixedHttpResponse(HttpObject obj1, HttpObject obj2) {
+            super(obj1, obj2);
+        }
+    }
+
+    private static final class RegularFixedHttpResponse
+            extends RegularFixedStreamMessage<HttpObject> implements HttpResponse {
+        private RegularFixedHttpResponse(HttpObject[] objs) {
+            super(objs);
+        }
+    }
+
+    private FixedHttpResponse() {}
 }
+

--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
@@ -239,6 +239,11 @@ public interface HttpRequest extends Request, StreamMessage<HttpObject> {
             case 2:
                 return new TwoElementFixedHttpRequest(headers, keepAlive, objs[0], objs[1]);
             default:
+                for (int i = 0; i < objs.length; i++) {
+                    if (objs[i] == null) {
+                        throw new NullPointerException("objs[" + i + "] is null");
+                    }
+                }
                 return new RegularFixedHttpRequest(headers, keepAlive, objs);
         }
     }

--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
@@ -69,8 +69,6 @@ public interface HttpRequest extends Request, StreamMessage<HttpObject> {
      * @param content the content of the request
      */
     static HttpRequest of(HttpMethod method, String path, MediaType mediaType, String content) {
-        requireNonNull(method, "method");
-        requireNonNull(path, "path");
         requireNonNull(content, "content");
         requireNonNull(mediaType, "mediaType");
         return of(method, path,
@@ -90,9 +88,6 @@ public interface HttpRequest extends Request, StreamMessage<HttpObject> {
     static HttpRequest of(HttpMethod method, String path, MediaType mediaType, String format, Object... args) {
         requireNonNull(method, "method");
         requireNonNull(path, "path");
-        requireNonNull(mediaType, "mediaType");
-        requireNonNull(format, "format");
-        requireNonNull(args, "args");
         return of(method,
                   path,
                   mediaType,
@@ -109,9 +104,6 @@ public interface HttpRequest extends Request, StreamMessage<HttpObject> {
      * @param content the content of the request
      */
     static HttpRequest of(HttpMethod method, String path, MediaType mediaType, byte[] content) {
-        requireNonNull(method, "method");
-        requireNonNull(path, "path");
-        requireNonNull(mediaType, "mediaType");
         requireNonNull(content, "content");
         return of(method, path, mediaType, HttpData.of(content));
     }
@@ -128,9 +120,6 @@ public interface HttpRequest extends Request, StreamMessage<HttpObject> {
      */
     static HttpRequest of(
             HttpMethod method, String path, MediaType mediaType, byte[] content, int offset, int length) {
-        requireNonNull(method, "method");
-        requireNonNull(path, "path");
-        requireNonNull(mediaType, "mediaType");
         requireNonNull(content, "content");
         return of(method, path, mediaType, HttpData.of(content, offset, length));
     }
@@ -144,10 +133,6 @@ public interface HttpRequest extends Request, StreamMessage<HttpObject> {
      * @param content the content of the request
      */
     static HttpRequest of(HttpMethod method, String path, MediaType mediaType, HttpData content) {
-        requireNonNull(method, "method");
-        requireNonNull(path, "path");
-        requireNonNull(mediaType, "mediaType");
-        requireNonNull(content, "content");
         return of(method, path, mediaType, content, HttpHeaders.EMPTY_HEADERS);
     }
 
@@ -165,9 +150,6 @@ public interface HttpRequest extends Request, StreamMessage<HttpObject> {
         requireNonNull(method, "method");
         requireNonNull(path, "path");
         requireNonNull(mediaType, "mediaType");
-        requireNonNull(content, "content");
-        requireNonNull(trailingHeaders, "trailingHeaders");
-
         return of(HttpHeaders.of(method, path).setObject(CONTENT_TYPE, mediaType), content, trailingHeaders);
     }
 
@@ -175,7 +157,6 @@ public interface HttpRequest extends Request, StreamMessage<HttpObject> {
      * Creates a new {@link HttpRequest} with empty content and closes the stream.
      */
     static HttpRequest of(HttpHeaders headers) {
-        requireNonNull(headers, "headers");
         return of(headers, HttpData.EMPTY_DATA);
     }
 
@@ -183,8 +164,6 @@ public interface HttpRequest extends Request, StreamMessage<HttpObject> {
      * Creates a new {@link HttpRequest} and closes the stream.
      */
     static HttpRequest of(HttpHeaders headers, HttpData content) {
-        requireNonNull(headers, "headers");
-        requireNonNull(content, "content");
         return of(headers, content, HttpHeaders.EMPTY_HEADERS);
     }
 
@@ -192,9 +171,6 @@ public interface HttpRequest extends Request, StreamMessage<HttpObject> {
      * Creates a new {@link HttpRequest} and closes the stream.
      */
     static HttpRequest of(HttpHeaders headers, HttpData content, HttpHeaders trailingHeaders) {
-        requireNonNull(headers, "headers");
-        requireNonNull(content, "content");
-        requireNonNull(trailingHeaders, "trailingHeaders");
         return of(headers, content, trailingHeaders, true);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -141,7 +141,6 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
         requireNonNull(status, "status");
         requireNonNull(mediaType, "mediaType");
         requireNonNull(content, "content");
-        requireNonNull(trailingHeaders, "trailingHeaders");
 
         final HttpHeaders headers =
                 HttpHeaders.of(status)

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -22,6 +22,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Formatter;
+import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -30,6 +31,9 @@ import org.reactivestreams.Publisher;
 
 import com.google.common.base.Throwables;
 
+import com.linecorp.armeria.common.FixedHttpResponse.OneElementFixedHttpResponse;
+import com.linecorp.armeria.common.FixedHttpResponse.RegularFixedHttpResponse;
+import com.linecorp.armeria.common.FixedHttpResponse.TwoElementFixedHttpResponse;
 import com.linecorp.armeria.common.stream.StreamMessage;
 
 import io.netty.util.concurrent.EventExecutor;
@@ -61,7 +65,7 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
             res.write(HttpHeaders.of(status));
             return res;
         } else if (isContentAlwaysEmpty(status)) {
-            return FixedHttpResponse.of(HttpHeaders.of(status));
+            return new OneElementFixedHttpResponse(HttpHeaders.of(status));
         } else {
             return of(status, MediaType.PLAIN_TEXT_UTF_8, status.toHttpData());
         }
@@ -143,40 +147,74 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
                 HttpHeaders.of(status)
                            .setObject(HttpHeaderNames.CONTENT_TYPE, mediaType)
                            .setInt(HttpHeaderNames.CONTENT_LENGTH, content.length());
-        return of(headers, status, content, trailingHeaders);
-    }
-
-    /**
-     * Creates the specified HTTP response and closes the stream.
-     */
-    static HttpResponse of(AggregatedHttpMessage res) {
-        requireNonNull(res, "res");
-        return res.toHttpResponse();
+        return of(headers, content, trailingHeaders);
     }
 
     /**
      * Creates a new HTTP response of the specified objects and closes the stream.
      */
-    static HttpResponse of(
-            HttpHeaders headers, HttpStatus status, HttpData content, HttpHeaders trailingHeaders) {
+    static HttpResponse of(HttpHeaders headers, HttpData content, HttpHeaders trailingHeaders) {
         requireNonNull(headers, "headers");
-        requireNonNull(status, "status");
         requireNonNull(content, "content");
         requireNonNull(trailingHeaders, "trailingHeaders");
 
+        final HttpStatus status = headers.status();
+
+        // From the section 8.1.2.4 of RFC 7540:
+        //// For HTTP/2 responses, a single :status pseudo-header field is defined that carries the HTTP status
+        //// code field (see [RFC7231], Section 6). This pseudo-header field MUST be included in all responses;
+        //// otherwise, the response is malformed (Section 8.1.2.6).
+        if (status == null) {
+            throw new IllegalStateException("not a response (missing :status)");
+        }
+
         if (isContentAlwaysEmptyWithValidation(status, content, trailingHeaders)) {
-            return FixedHttpResponse.of(headers);
+            return new OneElementFixedHttpResponse(headers);
         } else if (!content.isEmpty()) {
             if (trailingHeaders.isEmpty()) {
-                return FixedHttpResponse.of(headers, content);
+                return new TwoElementFixedHttpResponse(headers, content);
             } else {
-                return FixedHttpResponse.of(headers, content, trailingHeaders);
+                return new RegularFixedHttpResponse(headers, content, trailingHeaders);
             }
         } else if (!trailingHeaders.isEmpty()) {
-            return FixedHttpResponse.of(headers, trailingHeaders);
+            return new TwoElementFixedHttpResponse(headers, trailingHeaders);
         } else {
-            return FixedHttpResponse.of(headers);
+            return new OneElementFixedHttpResponse(headers);
         }
+    }
+
+    /**
+     * Converts the {@link AggregatedHttpMessage} into a new complete {@link HttpResponse}.
+     */
+    static HttpResponse of(AggregatedHttpMessage res) {
+        requireNonNull(res, "res");
+
+        final List<HttpHeaders> informationals = res.informationals();
+        final HttpHeaders headers = res.headers();
+        final HttpData content = res.content();
+        final HttpHeaders trailingHeaders = res.trailingHeaders();
+
+        if (informationals.isEmpty()) {
+            return of(headers, content, trailingHeaders);
+        }
+
+        final int numObjects = informationals.size() +
+                               1 /* headers */ +
+                               (!content.isEmpty() ? 1 : 0) +
+                               (!trailingHeaders.isEmpty() ? 1 : 0);
+        final HttpObject[] objs = new HttpObject[numObjects];
+        int writerIndex = 0;
+        for (HttpHeaders informational : informationals) {
+            objs[writerIndex++] = informational;
+        }
+        objs[writerIndex++] = headers;
+        if (!content.isEmpty()) {
+            objs[writerIndex++] = content;
+        }
+        if (!trailingHeaders.isEmpty()) {
+            objs[writerIndex] = trailingHeaders;
+        }
+        return new RegularFixedHttpResponse(objs);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -184,6 +184,13 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
     }
 
     /**
+     * Creates a new HTTP response of the specified objects and closes the stream.
+     */
+    static HttpResponse of(HttpObject... objs) {
+        return new RegularFixedHttpResponse(objs);
+    }
+
+    /**
      * Converts the {@link AggregatedHttpMessage} into a new complete {@link HttpResponse}.
      */
     static HttpResponse of(AggregatedHttpMessage res) {

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -186,6 +186,12 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
      * Creates a new HTTP response of the specified objects and closes the stream.
      */
     static HttpResponse of(HttpObject... objs) {
+        requireNonNull(objs, "objs");
+        for (int i = 0; i < objs.length; i++) {
+            if (objs[i] == null) {
+                throw new NullPointerException("objs[" + i + "] is null");
+            }
+        }
         return new RegularFixedHttpResponse(objs);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/stream/EmptyFixedStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/EmptyFixedStreamMessage.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.stream;
+
+/**
+ * A {@link FixedStreamMessage} that publishes no objects, just a close event.
+ */
+public class EmptyFixedStreamMessage<T> extends FixedStreamMessage<T> {
+
+    // No objects, so just notify of close as soon as there is demand.
+    @Override
+    final void doRequest(SubscriptionImpl subscription, long unused) {
+        if (requested() != 0) {
+            // Already have demand so don't need to do anything.
+            return;
+        }
+        setRequested(1);
+        notifySubscriberOfCloseEvent(subscription, SUCCESSFUL_CLOSE);
+    }
+
+    @Override
+    public final boolean isEmpty() {
+        return true;
+    }
+
+    @Override
+    final void cleanupObjects() {
+        // Empty streams have no objects to clean.
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/common/stream/FixedStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/FixedStreamMessage.java
@@ -21,6 +21,8 @@ import static java.util.Objects.requireNonNull;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
+import javax.annotation.Nullable;
+
 import org.reactivestreams.Subscriber;
 
 import com.linecorp.armeria.common.Flags;
@@ -33,277 +35,467 @@ import io.netty.util.concurrent.ImmediateEventExecutor;
  * Reduced synchronization and allocation allow for much higher performance than {@link DefaultStreamMessage},
  * so this class should generally be used when the objects are known.
  */
-public class FixedStreamMessage<T> extends AbstractStreamMessage<T> {
-
-    @SuppressWarnings("rawtypes")
-    private static final AtomicReferenceFieldUpdater<FixedStreamMessage, SubscriptionImpl>
-            subscriptionUpdater = AtomicReferenceFieldUpdater.newUpdater(
-            FixedStreamMessage.class, SubscriptionImpl.class, "subscription");
-
-    @SuppressWarnings("rawtypes")
-    private static final AtomicReferenceFieldUpdater<FixedStreamMessage, CloseEvent>
-            closeEventUpdater = AtomicReferenceFieldUpdater.newUpdater(
-            FixedStreamMessage.class, CloseEvent.class, "closeEvent");
+public final class FixedStreamMessage {
 
     /**
-     * Creates a new {@link FixedStreamMessage} that will publish the given {@code objs}. {@code objs} is not
+     * Creates a new {@link StreamMessage} that will publish no objects, just a close event.
+     */
+    public static <T> StreamMessage<T> of() {
+        return new EmptyFixedStreamMessage<>();
+    }
+
+    /**
+     * Creates a new {@link StreamMessage} that will publish the single {@code obj}.
+     */
+    public static <T> StreamMessage<T> of(T obj) {
+        requireNonNull(obj, "obj");
+        return new OneElementFixedStreamMessage<>(obj);
+    }
+
+    /**
+     * Creates a new {@link StreamMessage} that will publish the two {@code obj1} and {@code obj2}.
+     */
+    public static <T> StreamMessage<T> of(T obj1, T obj2) {
+        requireNonNull(obj1, "obj1");
+        requireNonNull(obj2, "obj2");
+        return new TwoElementFixedStreamMessage<>(obj1, obj2);
+    }
+
+    /**
+     * Creates a new {@link StreamMessage} that will publish the given {@code objs}. {@code objs} is not
      * copied so must not be mutated after this method call (it is generally meant to be used with a varargs
      * invocation).
      */
     @SafeVarargs
-    public static <T> FixedStreamMessage<T> of(T... objs) {
+    public static <T> StreamMessage<T> of(T... objs) {
         requireNonNull(objs, "objs");
-        return new FixedStreamMessage<>(objs);
-    }
-
-    private final T[] objs;
-
-    @SuppressWarnings("unused")
-    private volatile SubscriptionImpl subscription; // set only via subscriptionUpdater
-
-    private volatile CloseEvent closeEvent;
-
-    private int requested;
-    private int fulfilled;
-
-    private boolean inOnNext;
-    private boolean invokedOnSubscribe;
-
-    /**
-     * Initializes a {@link FixedStreamMessage} that will publish the given {@code objs}.
-     */
-    protected FixedStreamMessage(T[] objs) {
-        this.objs = requireNonNull(objs, "objs");
-    }
-
-    @Override
-    public boolean isOpen() {
-        // Fixed streams are closed on construction.
-        return false;
-    }
-
-    @Override
-    public boolean isEmpty() {
-        return objs.length == 0;
-    }
-
-    @Override
-    public void abort() {
-        final SubscriptionImpl currentSubscription = subscription;
-        if (currentSubscription != null) {
-            cancelOrAbort(false);
-            return;
-        }
-
-        final SubscriptionImpl newSubscription = new SubscriptionImpl(
-                this, AbortingSubscriber.get(), ImmediateEventExecutor.INSTANCE, false);
-        if (subscriptionUpdater.compareAndSet(this, null, newSubscription)) {
-            // We don't need to invoke onSubscribe() for AbortingSubscriber because it's just a placeholder.
-            invokedOnSubscribe = true;
-        }
-        cancelOrAbort(false);
-    }
-
-    @Override
-    void subscribe(SubscriptionImpl subscription) {
-        final Subscriber<Object> subscriber = subscription.subscriber();
-        final Executor executor = subscription.executor();
-
-        if (!subscriptionUpdater.compareAndSet(this, null, subscription)) {
-            failLateSubscriber(this.subscription, subscriber);
-            return;
-        }
-
-        if (subscription.needsDirectInvocation()) {
-            invokedOnSubscribe = true;
-            subscriber.onSubscribe(subscription);
-        } else {
-            executor.execute(() -> {
-                invokedOnSubscribe = true;
-                subscriber.onSubscribe(subscription);
-            });
+        switch (objs.length) {
+            case 0:
+                return of();
+            case 1:
+                return of(objs[0]);
+            case 2:
+                return of(objs[0], objs[1]);
+            default:
+                return new RegularFixedStreamMessage<>(objs);
         }
     }
 
-    @Override
-    long demand() {
-        return requested;
-    }
+    abstract static class AbstractFixedStreamMessage<T> extends AbstractStreamMessage<T> {
 
-    @Override
-    void request(long n) {
-        final SubscriptionImpl subscription = this.subscription;
-        // A user cannot access subscription without subscribing.
-        assert subscription != null;
+        @SuppressWarnings("rawtypes")
+        private static final AtomicReferenceFieldUpdater<AbstractFixedStreamMessage, SubscriptionImpl>
+                subscriptionUpdater = AtomicReferenceFieldUpdater.newUpdater(
+                AbstractFixedStreamMessage.class, SubscriptionImpl.class, "subscription");
 
-        if (subscription.needsDirectInvocation()) {
-            doRequest(n);
-        } else {
-            subscription.executor().execute(() -> doRequest(n));
-        }
-    }
+        @SuppressWarnings("rawtypes")
+        private static final AtomicReferenceFieldUpdater<AbstractFixedStreamMessage, CloseEvent>
+                closeEventUpdater = AtomicReferenceFieldUpdater.newUpdater(
+                AbstractFixedStreamMessage.class, CloseEvent.class, "closeEvent");
 
-    private void doRequest(long n) {
-        final long oldDemand = requested;
-        // If this is an empty stream, any demand is enough to complete it. We special case it to allow other
-        // assumptions on size to work correctly for the non-empty case.
-        if (isEmpty() && oldDemand == 0) {
-            requested = 1;
-            notifySubscriber();
-            return;
-        }
-        if (oldDemand >= objs.length) {
-            // Already enough demand to finish the stream so don't need to do anything.
-            return;
-        }
-        // As objs.length is fixed, we can safely cap the demand to it here.
-        if (n >= objs.length) {
-            requested = objs.length;
-        } else {
-            // As objs.length is an int, large demand will always fall into the above branch and there is no
-            // chance of overflow, so just simply add the demand.
-            requested = (int) Math.min(oldDemand + n, objs.length);
-        }
-        if (requested > oldDemand) {
-            notifySubscriber();
-        }
-    }
+        @SuppressWarnings("unused")
+        @Nullable
+        private volatile SubscriptionImpl subscription; // set only via subscriptionUpdater
 
-    @Override
-    void cancel() {
-        cancelOrAbort(true);
-    }
+        @Nullable
+        private volatile CloseEvent closeEvent;
 
-    @Override
-    void notifySubscriberOfCloseEvent(SubscriptionImpl subscription, CloseEvent event) {
-        try {
-            event.notifySubscriber(subscription, completionFuture());
-        } finally {
-            subscription.clearSubscriber();
-            cleanup();
-        }
-    }
+        private int requested;
 
-    private void notifySubscriber() {
-        final SubscriptionImpl subscription = this.subscription;
-        if (subscription == null) {
-            return;
+        abstract void cleanupObjects();
+
+        abstract void doRequest(SubscriptionImpl subscription, long n);
+
+        @Nullable
+        final CloseEvent closeEvent() {
+            return closeEvent;
         }
 
-        if (fulfilled == requested) {
-            return;
-        }
-
-        if (subscription.needsDirectInvocation()) {
-            notifySubscriber0(subscription);
-        } else {
-            subscription.executor().execute(() -> notifySubscriber0(subscription));
-        }
-    }
-
-    private void notifySubscriber0(SubscriptionImpl subscription) {
-        if (inOnNext) {
-            // Do not let Subscriber.onNext() reenter, because it can lead to weird-looking event ordering
-            // for a Subscriber implemented like the following:
-            //
-            //   public void onNext(Object e) {
-            //       subscription.request(1);
-            //       ... Handle 'e' ...
-            //   }
-            //
-            // Note that we do not call this method again, because we are already in the notification loop
-            // and it will consume the element we've just added in addObjectOrEvent() from the queue as
-            // expected.
-            //
-            // We do not need to worry about synchronizing the access to 'inOnNext' because the subscriber
-            // methods must be on the same thread, or synchronized, according to Reactive Streams spec.
-            return;
-        }
-
-        if (!invokedOnSubscribe) {
-            // Subscriber.onSubscribe() was not invoked yet.
-            // Reschedule the notification so that onSubscribe() is invoked before other events.
-            //
-            // Note:
-            // The rescheduling will occur at most once because the invocation of onSubscribe() must have been
-            // scheduled already by subscribe(), given that this.subscription is not null at this point and
-            // subscribe() is the only place that sets this.subscription.
-
-            subscription.executor().execute(() -> this.notifySubscriber0(subscription));
-            return;
-        }
-
-        final Subscriber<Object> subscriber = subscription.subscriber();
-        for (;;) {
+        final void cleanup(SubscriptionImpl subscription) {
+            final CloseEvent closeEvent = this.closeEvent;
+            this.closeEvent = null;
             if (closeEvent != null) {
-                cleanup();
+                notifySubscriberOfCloseEvent(subscription, closeEvent);
+                // Close event will cleanup.
+                return;
+            }
+            cleanupObjects();
+        }
+
+        final int requested() {
+            return requested;
+        }
+
+        final void setRequested(int n) {
+            requested = n;
+        }
+
+        @Override
+        final void request(long n) {
+            final SubscriptionImpl subscription = this.subscription;
+            // A user cannot access subscription without subscribing.
+            assert subscription != null;
+
+            if (subscription.needsDirectInvocation()) {
+                doRequest(subscription, n);
+            } else {
+                subscription.executor().execute(() -> doRequest(subscription, n));
+            }
+        }
+
+        @Override
+        final long demand() {
+            return requested;
+        }
+
+        @Override
+        public final boolean isOpen() {
+            // Fixed streams are closed on construction.
+            return false;
+        }
+
+        @Override
+        final void subscribe(SubscriptionImpl subscription) {
+            final Subscriber<Object> subscriber = subscription.subscriber();
+            final Executor executor = subscription.executor();
+
+            if (!subscriptionUpdater.compareAndSet(this, null, subscription)) {
+                failLateSubscriber(this.subscription, subscriber);
                 return;
             }
 
-            if (fulfilled == objs.length) {
+            if (subscription.needsDirectInvocation()) {
+                subscriber.onSubscribe(subscription);
+            } else {
+                executor.execute(() -> subscriber.onSubscribe(subscription));
+            }
+        }
+
+        @Override
+        final void notifySubscriberOfCloseEvent(SubscriptionImpl subscription, CloseEvent event) {
+            try {
+                event.notifySubscriber(subscription, completionFuture());
+            } finally {
+                subscription.clearSubscriber();
+                cleanup(subscription);
+            }
+        }
+
+        @Override
+        final void cancel() {
+            cancelOrAbort(true);
+        }
+
+        @Override
+        public final void abort() {
+            final SubscriptionImpl currentSubscription = subscription;
+            if (currentSubscription != null) {
+                cancelOrAbort(false);
+                return;
+            }
+
+            final SubscriptionImpl newSubscription = new SubscriptionImpl(
+                    this, AbortingSubscriber.get(), ImmediateEventExecutor.INSTANCE, false);
+            subscriptionUpdater.compareAndSet(this, null, newSubscription);
+            cancelOrAbort(false);
+        }
+
+        private void cancelOrAbort(boolean cancel) {
+            final CloseEvent closeEvent;
+            if (cancel) {
+                closeEvent = Flags.verboseExceptions() ?
+                             new CloseEvent(CancelledSubscriptionException.get()) : CANCELLED_CLOSE;
+            } else {
+                closeEvent = Flags.verboseExceptions() ?
+                             new CloseEvent(AbortedStreamException.get()) : ABORTED_CLOSE;
+            }
+            if (closeEventUpdater.compareAndSet(this, null, closeEvent)) {
+                if (subscription.needsDirectInvocation()) {
+                    cleanup(subscription);
+                } else {
+                    subscription.executor().execute(() -> cleanup(subscription));
+                }
+            }
+        }
+    }
+
+    public static class EmptyFixedStreamMessage<T> extends AbstractFixedStreamMessage<T> {
+
+        // No objects, so just notify of close as soon as there is demand.
+        @Override
+        final void doRequest(SubscriptionImpl subscription, long unused) {
+            if (requested() != 0) {
+                // Already have demand so don't need to do anything.
+                return;
+            }
+            setRequested(1);
+            notifySubscriberOfCloseEvent(subscription, SUCCESSFUL_CLOSE);
+        }
+
+        @Override
+        public final boolean isEmpty() {
+            return true;
+        }
+
+        @Override
+        final void cleanupObjects() {
+            // Empty streams have no objects to clean.
+        }
+    }
+
+    public static class OneElementFixedStreamMessage<T> extends AbstractFixedStreamMessage<T> {
+
+        private T obj;
+
+        protected OneElementFixedStreamMessage(T obj) {
+            this.obj = obj;
+        }
+
+        @Override
+        final void cleanupObjects() {
+            if (obj != null) {
+                try {
+                    onRemoval(obj);
+                } finally {
+                    ReferenceCountUtil.safeRelease(obj);
+                }
+                obj = null;
+            }
+        }
+
+        @Override
+        final void doRequest(SubscriptionImpl subscription, long unused) {
+            if (requested() != 0) {
+                // Already have demand, so don't need to do anything, the current demand will complete the
+                // stream.
+                return;
+            }
+            setRequested(1);
+            doNotify(subscription);
+        }
+
+        @Override
+        public final boolean isEmpty() {
+            return false;
+        }
+
+        private void doNotify(SubscriptionImpl subscription) {
+            // Only called with correct demand, so no need to even check it.
+            T published = prepareObjectForNotification(subscription, obj);
+            obj = null;
+            // Not possible to have re-entrant onNext with only one item, so no need to keep track of it.
+            subscription.subscriber().onNext(published);
+            notifySubscriberOfCloseEvent(subscription, SUCCESSFUL_CLOSE);
+        }
+    }
+
+    public static class TwoElementFixedStreamMessage<T> extends AbstractFixedStreamMessage<T> {
+
+        private T obj1;
+        private T obj2;
+
+        private boolean inOnNext;
+
+        /**
+         * Constructs a new {@link TwoElementFixedStreamMessage} for the given objects.
+         */
+        protected TwoElementFixedStreamMessage(T obj1, T obj2) {
+            this.obj1 = obj1;
+            this.obj2 = obj2;
+        }
+
+        @Override
+        final void cleanupObjects() {
+            if (obj1 != null) {
+                try {
+                    onRemoval(obj1);
+                } finally {
+                    ReferenceCountUtil.safeRelease(obj1);
+                }
+                obj1 = null;
+            }
+            if (obj2 != null) {
+                try {
+                    onRemoval(obj2);
+                } finally {
+                    ReferenceCountUtil.safeRelease(obj2);
+                }
+                obj2 = null;
+            }
+        }
+
+        @Override
+        final void doRequest(SubscriptionImpl subscription, long n) {
+            int oldDemand = requested();
+            if (oldDemand >= 2) {
+                // Already have demand, so don't need to do anything, the current demand will complete the
+                // stream.
+                return;
+            }
+            setRequested(n >= 2 ? oldDemand + 2 : oldDemand + 1);
+            doNotify(subscription);
+        }
+
+        @Override
+        public final boolean isEmpty() {
+            return false;
+        }
+
+        private void doNotify(SubscriptionImpl subscription) {
+            if (inOnNext) {
+                // Do not let Subscriber.onNext() reenter, because it can lead to weird-looking event ordering
+                // for a Subscriber implemented like the following:
+                //
+                //   public void onNext(Object e) {
+                //       subscription.request(1);
+                //       ... Handle 'e' ...
+                //   }
+                //
+                // Note that we do not call this method again, because we are already in the notification loop
+                // and it will consume the element we've just added in addObjectOrEvent() from the queue as
+                // expected.
+                //
+                // We do not need to worry about synchronizing the access to 'inOnNext' because the subscriber
+                // methods must be on the same thread, or synchronized, according to Reactive Streams spec.
+                return;
+            }
+
+            // Demand is always positive, so no need to check it.
+            if (obj1 != null) {
+                try {
+                    doNotifyObject(subscription, obj1);
+                } finally {
+                    obj1 = null;
+                }
+            }
+
+            if (requested() >= 2 && obj2 != null) {
+                try {
+                    doNotifyObject(subscription, obj2);
+                } finally {
+                    obj2 = null;
+                }
                 notifySubscriberOfCloseEvent(subscription, SUCCESSFUL_CLOSE);
+            }
+        }
+
+        private void doNotifyObject(SubscriptionImpl subscription, T obj) {
+            T published = prepareObjectForNotification(subscription, obj);
+            inOnNext = true;
+            try {
+                subscription.subscriber().onNext(published);
+            } finally {
+                inOnNext = false;
+            }
+        }
+    }
+
+    public static class RegularFixedStreamMessage<T> extends AbstractFixedStreamMessage<T> {
+
+        private final T[] objs;
+
+        private int fulfilled;
+
+        private boolean inOnNext;
+
+        protected RegularFixedStreamMessage(T[] objs) {
+            this.objs = objs;
+        }
+
+        @Override
+        final void cleanupObjects() {
+            while (fulfilled < objs.length) {
+                T obj = objs[fulfilled];
+                objs[fulfilled++] = null;
+                try {
+                    onRemoval(obj);
+                } finally {
+                    ReferenceCountUtil.safeRelease(obj);
+                }
+            }
+        }
+
+        @Override
+        final void doRequest(SubscriptionImpl subscription, long n) {
+            final int oldDemand = requested();
+            if (oldDemand >= objs.length) {
+                // Already enough demand to finish the stream so don't need to do anything.
+                return;
+            }
+            // As objs.length is fixed, we can safely cap the demand to it here.
+            if (n >= objs.length) {
+                setRequested(objs.length);
+            } else {
+                // As objs.length is an int, large demand will always fall into the above branch and there is no
+                // chance of overflow, so just simply add the demand.
+                setRequested((int) Math.min(oldDemand + n, objs.length));
+            }
+            if (requested() > oldDemand) {
+                doNotify(subscription);
+            }
+        }
+
+        private void doNotify(SubscriptionImpl subscription) {
+            if (inOnNext) {
+                // Do not let Subscriber.onNext() reenter, because it can lead to weird-looking event ordering
+                // for a Subscriber implemented like the following:
+                //
+                //   public void onNext(Object e) {
+                //       subscription.request(1);
+                //       ... Handle 'e' ...
+                //   }
+                //
+                // Note that we do not call this method again, because we are already in the notification loop
+                // and it will consume the element we've just added in addObjectOrEvent() from the queue as
+                // expected.
+                //
+                // We do not need to worry about synchronizing the access to 'inOnNext' because the subscriber
+                // methods must be on the same thread, or synchronized, according to Reactive Streams spec.
                 return;
             }
 
-            final long requested = this.requested;
-
-            if (fulfilled == requested) {
-                break;
-            }
-
-            while (fulfilled < requested) {
-                if (closeEvent != null) {
-                    cleanup();
+            final Subscriber<Object> subscriber = subscription.subscriber();
+            for (;;) {
+                if (closeEvent() != null) {
+                    cleanup(subscription);
                     return;
                 }
 
-                T o = objs[fulfilled];
-                objs[fulfilled++] = null;
-                o = prepareObjectForNotification(subscription, o);
-                inOnNext = true;
-                try {
-                    subscriber.onNext(o);
-                } finally {
-                    inOnNext = false;
+                if (fulfilled == objs.length) {
+                    notifySubscriberOfCloseEvent(subscription, SUCCESSFUL_CLOSE);
+                    return;
+                }
+
+                final int requested = requested();
+
+                if (fulfilled == requested) {
+                    break;
+                }
+
+                while (fulfilled < requested) {
+                    if (closeEvent() != null) {
+                        cleanup(subscription);
+                        return;
+                    }
+
+                    T o = objs[fulfilled];
+                    objs[fulfilled++] = null;
+                    o = prepareObjectForNotification(subscription, o);
+                    inOnNext = true;
+                    try {
+                        subscriber.onNext(o);
+                    } finally {
+                        inOnNext = false;
+                    }
                 }
             }
         }
-    }
 
-    private void cancelOrAbort(boolean cancel) {
-        final CloseEvent closeEvent;
-        if (cancel) {
-            closeEvent = Flags.verboseExceptions() ?
-                         new CloseEvent(CancelledSubscriptionException.get()) : CANCELLED_CLOSE;
-        } else {
-            closeEvent = Flags.verboseExceptions() ?
-                         new CloseEvent(AbortedStreamException.get()) : ABORTED_CLOSE;
-        }
-        if (closeEventUpdater.compareAndSet(this, null, closeEvent)) {
-            if (subscription.needsDirectInvocation()) {
-                cleanup();
-            } else {
-                subscription.executor().execute(this::cleanup);
-            }
+        @Override
+        public boolean isEmpty() {
+            return false;
         }
     }
 
-    private void cleanup() {
-        final CloseEvent closeEvent = this.closeEvent;
-        this.closeEvent = null;
-        if (closeEvent != null) {
-            notifySubscriberOfCloseEvent(subscription, closeEvent);
-            // Close event will cleanup.
-            return;
-        }
-        while (fulfilled < objs.length) {
-            T obj = objs[fulfilled];
-            objs[fulfilled++] = null;
-            try {
-                onRemoval(obj);
-            } finally {
-                ReferenceCountUtil.safeRelease(obj);
-            }
-        }
-    }
+    private FixedStreamMessage() {}
 }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/FixedStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/FixedStreamMessage.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.common.stream;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Arrays;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
@@ -62,9 +63,7 @@ public final class FixedStreamMessage {
     }
 
     /**
-     * Creates a new {@link StreamMessage} that will publish the given {@code objs}. {@code objs} is not
-     * copied so must not be mutated after this method call (it is generally meant to be used with a varargs
-     * invocation).
+     * Creates a new {@link StreamMessage} that will publish the given {@code objs}.
      */
     @SafeVarargs
     public static <T> StreamMessage<T> of(T... objs) {
@@ -399,7 +398,7 @@ public final class FixedStreamMessage {
         private boolean inOnNext;
 
         protected RegularFixedStreamMessage(T[] objs) {
-            this.objs = objs;
+            this.objs = Arrays.copyOf(objs, objs.length);
         }
 
         @Override

--- a/core/src/main/java/com/linecorp/armeria/common/stream/FixedStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/FixedStreamMessage.java
@@ -28,7 +28,7 @@ import com.linecorp.armeria.common.Flags;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 
 /**
- * A {@link AbstractStreamMessage} which only publishes a fixed number of objects known at construction time.
+ * An {@link AbstractStreamMessage} which only publishes a fixed number of objects known at construction time.
  */
 abstract class FixedStreamMessage<T> extends AbstractStreamMessage<T> {
 

--- a/core/src/main/java/com/linecorp/armeria/common/stream/FixedStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/FixedStreamMessage.java
@@ -16,9 +16,6 @@
 
 package com.linecorp.armeria.common.stream;
 
-import static java.util.Objects.requireNonNull;
-
-import java.util.Arrays;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
@@ -28,473 +25,145 @@ import org.reactivestreams.Subscriber;
 
 import com.linecorp.armeria.common.Flags;
 
-import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 
 /**
- * A {@link StreamMessage} used when all the objects that will be published are known at construction time.
- * Reduced synchronization and allocation allow for much higher performance than {@link DefaultStreamMessage},
- * so this class should generally be used when the objects are known.
+ * A {@link AbstractStreamMessage} which only publishes a fixed number of objects known at construction time.
  */
-public final class FixedStreamMessage {
+abstract class FixedStreamMessage<T> extends AbstractStreamMessage<T> {
 
-    /**
-     * Creates a new {@link StreamMessage} that will publish no objects, just a close event.
-     */
-    public static <T> StreamMessage<T> of() {
-        return new EmptyFixedStreamMessage<>();
+    @SuppressWarnings("rawtypes")
+    private static final AtomicReferenceFieldUpdater<FixedStreamMessage, SubscriptionImpl>
+            subscriptionUpdater = AtomicReferenceFieldUpdater.newUpdater(
+            FixedStreamMessage.class, SubscriptionImpl.class, "subscription");
+
+    @SuppressWarnings("rawtypes")
+    private static final AtomicReferenceFieldUpdater<FixedStreamMessage, CloseEvent>
+            closeEventUpdater = AtomicReferenceFieldUpdater.newUpdater(
+            FixedStreamMessage.class, CloseEvent.class, "closeEvent");
+
+    @SuppressWarnings("unused")
+    @Nullable
+    private volatile SubscriptionImpl subscription; // set only via subscriptionUpdater
+
+    @Nullable
+    private volatile CloseEvent closeEvent;
+
+    private int requested;
+
+    abstract void cleanupObjects();
+
+    abstract void doRequest(SubscriptionImpl subscription, long n);
+
+    @Nullable
+    final CloseEvent closeEvent() {
+        return closeEvent;
     }
 
-    /**
-     * Creates a new {@link StreamMessage} that will publish the single {@code obj}.
-     */
-    public static <T> StreamMessage<T> of(T obj) {
-        requireNonNull(obj, "obj");
-        return new OneElementFixedStreamMessage<>(obj);
+    final void cleanup(SubscriptionImpl subscription) {
+        final CloseEvent closeEvent = this.closeEvent;
+        this.closeEvent = null;
+        if (closeEvent != null) {
+            notifySubscriberOfCloseEvent(subscription, closeEvent);
+            // Close event will cleanup.
+            return;
+        }
+        cleanupObjects();
     }
 
-    /**
-     * Creates a new {@link StreamMessage} that will publish the two {@code obj1} and {@code obj2}.
-     */
-    public static <T> StreamMessage<T> of(T obj1, T obj2) {
-        requireNonNull(obj1, "obj1");
-        requireNonNull(obj2, "obj2");
-        return new TwoElementFixedStreamMessage<>(obj1, obj2);
+    final int requested() {
+        return requested;
     }
 
-    /**
-     * Creates a new {@link StreamMessage} that will publish the given {@code objs}.
-     */
-    @SafeVarargs
-    public static <T> StreamMessage<T> of(T... objs) {
-        requireNonNull(objs, "objs");
-        switch (objs.length) {
-            case 0:
-                return of();
-            case 1:
-                return of(objs[0]);
-            case 2:
-                return of(objs[0], objs[1]);
-            default:
-                return new RegularFixedStreamMessage<>(objs);
+    final void setRequested(int n) {
+        requested = n;
+    }
+
+    @Override
+    final void request(long n) {
+        final SubscriptionImpl subscription = this.subscription;
+        // A user cannot access subscription without subscribing.
+        assert subscription != null;
+
+        if (subscription.needsDirectInvocation()) {
+            doRequest(subscription, n);
+        } else {
+            subscription.executor().execute(() -> doRequest(subscription, n));
         }
     }
 
-    abstract static class AbstractFixedStreamMessage<T> extends AbstractStreamMessage<T> {
+    @Override
+    final long demand() {
+        return requested;
+    }
 
-        @SuppressWarnings("rawtypes")
-        private static final AtomicReferenceFieldUpdater<AbstractFixedStreamMessage, SubscriptionImpl>
-                subscriptionUpdater = AtomicReferenceFieldUpdater.newUpdater(
-                AbstractFixedStreamMessage.class, SubscriptionImpl.class, "subscription");
+    @Override
+    public final boolean isOpen() {
+        // Fixed streams are closed on construction.
+        return false;
+    }
 
-        @SuppressWarnings("rawtypes")
-        private static final AtomicReferenceFieldUpdater<AbstractFixedStreamMessage, CloseEvent>
-                closeEventUpdater = AtomicReferenceFieldUpdater.newUpdater(
-                AbstractFixedStreamMessage.class, CloseEvent.class, "closeEvent");
+    @Override
+    final void subscribe(SubscriptionImpl subscription) {
+        final Subscriber<Object> subscriber = subscription.subscriber();
+        final Executor executor = subscription.executor();
 
-        @SuppressWarnings("unused")
-        @Nullable
-        private volatile SubscriptionImpl subscription; // set only via subscriptionUpdater
-
-        @Nullable
-        private volatile CloseEvent closeEvent;
-
-        private int requested;
-
-        abstract void cleanupObjects();
-
-        abstract void doRequest(SubscriptionImpl subscription, long n);
-
-        @Nullable
-        final CloseEvent closeEvent() {
-            return closeEvent;
+        if (!subscriptionUpdater.compareAndSet(this, null, subscription)) {
+            failLateSubscriber(this.subscription, subscriber);
+            return;
         }
 
-        final void cleanup(SubscriptionImpl subscription) {
-            final CloseEvent closeEvent = this.closeEvent;
-            this.closeEvent = null;
-            if (closeEvent != null) {
-                notifySubscriberOfCloseEvent(subscription, closeEvent);
-                // Close event will cleanup.
-                return;
-            }
-            cleanupObjects();
+        if (subscription.needsDirectInvocation()) {
+            subscriber.onSubscribe(subscription);
+        } else {
+            executor.execute(() -> subscriber.onSubscribe(subscription));
         }
+    }
 
-        final int requested() {
-            return requested;
+    @Override
+    final void notifySubscriberOfCloseEvent(SubscriptionImpl subscription, CloseEvent event) {
+        try {
+            event.notifySubscriber(subscription, completionFuture());
+        } finally {
+            subscription.clearSubscriber();
+            cleanup(subscription);
         }
+    }
 
-        final void setRequested(int n) {
-            requested = n;
-        }
+    @Override
+    final void cancel() {
+        cancelOrAbort(true);
+    }
 
-        @Override
-        final void request(long n) {
-            final SubscriptionImpl subscription = this.subscription;
-            // A user cannot access subscription without subscribing.
-            assert subscription != null;
-
-            if (subscription.needsDirectInvocation()) {
-                doRequest(subscription, n);
-            } else {
-                subscription.executor().execute(() -> doRequest(subscription, n));
-            }
-        }
-
-        @Override
-        final long demand() {
-            return requested;
-        }
-
-        @Override
-        public final boolean isOpen() {
-            // Fixed streams are closed on construction.
-            return false;
-        }
-
-        @Override
-        final void subscribe(SubscriptionImpl subscription) {
-            final Subscriber<Object> subscriber = subscription.subscriber();
-            final Executor executor = subscription.executor();
-
-            if (!subscriptionUpdater.compareAndSet(this, null, subscription)) {
-                failLateSubscriber(this.subscription, subscriber);
-                return;
-            }
-
-            if (subscription.needsDirectInvocation()) {
-                subscriber.onSubscribe(subscription);
-            } else {
-                executor.execute(() -> subscriber.onSubscribe(subscription));
-            }
-        }
-
-        @Override
-        final void notifySubscriberOfCloseEvent(SubscriptionImpl subscription, CloseEvent event) {
-            try {
-                event.notifySubscriber(subscription, completionFuture());
-            } finally {
-                subscription.clearSubscriber();
-                cleanup(subscription);
-            }
-        }
-
-        @Override
-        final void cancel() {
-            cancelOrAbort(true);
-        }
-
-        @Override
-        public final void abort() {
-            final SubscriptionImpl currentSubscription = subscription;
-            if (currentSubscription != null) {
-                cancelOrAbort(false);
-                return;
-            }
-
-            final SubscriptionImpl newSubscription = new SubscriptionImpl(
-                    this, AbortingSubscriber.get(), ImmediateEventExecutor.INSTANCE, false);
-            subscriptionUpdater.compareAndSet(this, null, newSubscription);
+    @Override
+    public final void abort() {
+        final SubscriptionImpl currentSubscription = subscription;
+        if (currentSubscription != null) {
             cancelOrAbort(false);
+            return;
         }
 
-        private void cancelOrAbort(boolean cancel) {
-            final CloseEvent closeEvent;
-            if (cancel) {
-                closeEvent = Flags.verboseExceptions() ?
-                             new CloseEvent(CancelledSubscriptionException.get()) : CANCELLED_CLOSE;
+        final SubscriptionImpl newSubscription = new SubscriptionImpl(
+                this, AbortingSubscriber.get(), ImmediateEventExecutor.INSTANCE, false);
+        subscriptionUpdater.compareAndSet(this, null, newSubscription);
+        cancelOrAbort(false);
+    }
+
+    private void cancelOrAbort(boolean cancel) {
+        final CloseEvent closeEvent;
+        if (cancel) {
+            closeEvent = Flags.verboseExceptions() ?
+                         new CloseEvent(CancelledSubscriptionException.get()) : CANCELLED_CLOSE;
+        } else {
+            closeEvent = Flags.verboseExceptions() ?
+                         new CloseEvent(AbortedStreamException.get()) : ABORTED_CLOSE;
+        }
+        if (closeEventUpdater.compareAndSet(this, null, closeEvent)) {
+            if (subscription.needsDirectInvocation()) {
+                cleanup(subscription);
             } else {
-                closeEvent = Flags.verboseExceptions() ?
-                             new CloseEvent(AbortedStreamException.get()) : ABORTED_CLOSE;
-            }
-            if (closeEventUpdater.compareAndSet(this, null, closeEvent)) {
-                if (subscription.needsDirectInvocation()) {
-                    cleanup(subscription);
-                } else {
-                    subscription.executor().execute(() -> cleanup(subscription));
-                }
+                subscription.executor().execute(() -> cleanup(subscription));
             }
         }
     }
-
-    public static class EmptyFixedStreamMessage<T> extends AbstractFixedStreamMessage<T> {
-
-        // No objects, so just notify of close as soon as there is demand.
-        @Override
-        final void doRequest(SubscriptionImpl subscription, long unused) {
-            if (requested() != 0) {
-                // Already have demand so don't need to do anything.
-                return;
-            }
-            setRequested(1);
-            notifySubscriberOfCloseEvent(subscription, SUCCESSFUL_CLOSE);
-        }
-
-        @Override
-        public final boolean isEmpty() {
-            return true;
-        }
-
-        @Override
-        final void cleanupObjects() {
-            // Empty streams have no objects to clean.
-        }
-    }
-
-    public static class OneElementFixedStreamMessage<T> extends AbstractFixedStreamMessage<T> {
-
-        private T obj;
-
-        protected OneElementFixedStreamMessage(T obj) {
-            this.obj = obj;
-        }
-
-        @Override
-        final void cleanupObjects() {
-            if (obj != null) {
-                try {
-                    onRemoval(obj);
-                } finally {
-                    ReferenceCountUtil.safeRelease(obj);
-                }
-                obj = null;
-            }
-        }
-
-        @Override
-        final void doRequest(SubscriptionImpl subscription, long unused) {
-            if (requested() != 0) {
-                // Already have demand, so don't need to do anything, the current demand will complete the
-                // stream.
-                return;
-            }
-            setRequested(1);
-            doNotify(subscription);
-        }
-
-        @Override
-        public final boolean isEmpty() {
-            return false;
-        }
-
-        private void doNotify(SubscriptionImpl subscription) {
-            // Only called with correct demand, so no need to even check it.
-            T published = prepareObjectForNotification(subscription, obj);
-            obj = null;
-            // Not possible to have re-entrant onNext with only one item, so no need to keep track of it.
-            subscription.subscriber().onNext(published);
-            notifySubscriberOfCloseEvent(subscription, SUCCESSFUL_CLOSE);
-        }
-    }
-
-    public static class TwoElementFixedStreamMessage<T> extends AbstractFixedStreamMessage<T> {
-
-        private T obj1;
-        private T obj2;
-
-        private boolean inOnNext;
-
-        /**
-         * Constructs a new {@link TwoElementFixedStreamMessage} for the given objects.
-         */
-        protected TwoElementFixedStreamMessage(T obj1, T obj2) {
-            this.obj1 = obj1;
-            this.obj2 = obj2;
-        }
-
-        @Override
-        final void cleanupObjects() {
-            if (obj1 != null) {
-                try {
-                    onRemoval(obj1);
-                } finally {
-                    ReferenceCountUtil.safeRelease(obj1);
-                }
-                obj1 = null;
-            }
-            if (obj2 != null) {
-                try {
-                    onRemoval(obj2);
-                } finally {
-                    ReferenceCountUtil.safeRelease(obj2);
-                }
-                obj2 = null;
-            }
-        }
-
-        @Override
-        final void doRequest(SubscriptionImpl subscription, long n) {
-            int oldDemand = requested();
-            if (oldDemand >= 2) {
-                // Already have demand, so don't need to do anything, the current demand will complete the
-                // stream.
-                return;
-            }
-            setRequested(n >= 2 ? oldDemand + 2 : oldDemand + 1);
-            doNotify(subscription);
-        }
-
-        @Override
-        public final boolean isEmpty() {
-            return false;
-        }
-
-        private void doNotify(SubscriptionImpl subscription) {
-            if (inOnNext) {
-                // Do not let Subscriber.onNext() reenter, because it can lead to weird-looking event ordering
-                // for a Subscriber implemented like the following:
-                //
-                //   public void onNext(Object e) {
-                //       subscription.request(1);
-                //       ... Handle 'e' ...
-                //   }
-                //
-                // Note that we do not call this method again, because we are already in the notification loop
-                // and it will consume the element we've just added in addObjectOrEvent() from the queue as
-                // expected.
-                //
-                // We do not need to worry about synchronizing the access to 'inOnNext' because the subscriber
-                // methods must be on the same thread, or synchronized, according to Reactive Streams spec.
-                return;
-            }
-
-            // Demand is always positive, so no need to check it.
-            if (obj1 != null) {
-                try {
-                    doNotifyObject(subscription, obj1);
-                } finally {
-                    obj1 = null;
-                }
-            }
-
-            if (requested() >= 2 && obj2 != null) {
-                try {
-                    doNotifyObject(subscription, obj2);
-                } finally {
-                    obj2 = null;
-                }
-                notifySubscriberOfCloseEvent(subscription, SUCCESSFUL_CLOSE);
-            }
-        }
-
-        private void doNotifyObject(SubscriptionImpl subscription, T obj) {
-            T published = prepareObjectForNotification(subscription, obj);
-            inOnNext = true;
-            try {
-                subscription.subscriber().onNext(published);
-            } finally {
-                inOnNext = false;
-            }
-        }
-    }
-
-    public static class RegularFixedStreamMessage<T> extends AbstractFixedStreamMessage<T> {
-
-        private final T[] objs;
-
-        private int fulfilled;
-
-        private boolean inOnNext;
-
-        protected RegularFixedStreamMessage(T[] objs) {
-            this.objs = Arrays.copyOf(objs, objs.length);
-        }
-
-        @Override
-        final void cleanupObjects() {
-            while (fulfilled < objs.length) {
-                T obj = objs[fulfilled];
-                objs[fulfilled++] = null;
-                try {
-                    onRemoval(obj);
-                } finally {
-                    ReferenceCountUtil.safeRelease(obj);
-                }
-            }
-        }
-
-        @Override
-        final void doRequest(SubscriptionImpl subscription, long n) {
-            final int oldDemand = requested();
-            if (oldDemand >= objs.length) {
-                // Already enough demand to finish the stream so don't need to do anything.
-                return;
-            }
-            // As objs.length is fixed, we can safely cap the demand to it here.
-            if (n >= objs.length) {
-                setRequested(objs.length);
-            } else {
-                // As objs.length is an int, large demand will always fall into the above branch and there is no
-                // chance of overflow, so just simply add the demand.
-                setRequested((int) Math.min(oldDemand + n, objs.length));
-            }
-            if (requested() > oldDemand) {
-                doNotify(subscription);
-            }
-        }
-
-        private void doNotify(SubscriptionImpl subscription) {
-            if (inOnNext) {
-                // Do not let Subscriber.onNext() reenter, because it can lead to weird-looking event ordering
-                // for a Subscriber implemented like the following:
-                //
-                //   public void onNext(Object e) {
-                //       subscription.request(1);
-                //       ... Handle 'e' ...
-                //   }
-                //
-                // Note that we do not call this method again, because we are already in the notification loop
-                // and it will consume the element we've just added in addObjectOrEvent() from the queue as
-                // expected.
-                //
-                // We do not need to worry about synchronizing the access to 'inOnNext' because the subscriber
-                // methods must be on the same thread, or synchronized, according to Reactive Streams spec.
-                return;
-            }
-
-            final Subscriber<Object> subscriber = subscription.subscriber();
-            for (;;) {
-                if (closeEvent() != null) {
-                    cleanup(subscription);
-                    return;
-                }
-
-                if (fulfilled == objs.length) {
-                    notifySubscriberOfCloseEvent(subscription, SUCCESSFUL_CLOSE);
-                    return;
-                }
-
-                final int requested = requested();
-
-                if (fulfilled == requested) {
-                    break;
-                }
-
-                while (fulfilled < requested) {
-                    if (closeEvent() != null) {
-                        cleanup(subscription);
-                        return;
-                    }
-
-                    T o = objs[fulfilled];
-                    objs[fulfilled++] = null;
-                    o = prepareObjectForNotification(subscription, o);
-                    inOnNext = true;
-                    try {
-                        subscriber.onNext(o);
-                    } finally {
-                        inOnNext = false;
-                    }
-                }
-            }
-        }
-
-        @Override
-        public boolean isEmpty() {
-            return false;
-        }
-    }
-
-    private FixedStreamMessage() {}
 }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/OneElementFixedStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/OneElementFixedStreamMessage.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.stream;
+
+import io.netty.util.ReferenceCountUtil;
+
+/**
+ * A {@link FixedStreamMessage} that only publishes one object.
+ */
+public class OneElementFixedStreamMessage<T> extends FixedStreamMessage<T> {
+
+    private T obj;
+
+    protected OneElementFixedStreamMessage(T obj) {
+        this.obj = obj;
+    }
+
+    @Override
+    final void cleanupObjects() {
+        if (obj != null) {
+            try {
+                onRemoval(obj);
+            } finally {
+                ReferenceCountUtil.safeRelease(obj);
+            }
+            obj = null;
+        }
+    }
+
+    @Override
+    final void doRequest(SubscriptionImpl subscription, long unused) {
+        if (requested() != 0) {
+            // Already have demand, so don't need to do anything, the current demand will complete the
+            // stream.
+            return;
+        }
+        setRequested(1);
+        doNotify(subscription);
+    }
+
+    @Override
+    public final boolean isEmpty() {
+        return false;
+    }
+
+    private void doNotify(SubscriptionImpl subscription) {
+        // Only called with correct demand, so no need to even check it.
+        T published = prepareObjectForNotification(subscription, obj);
+        obj = null;
+        // Not possible to have re-entrant onNext with only one item, so no need to keep track of it.
+        subscription.subscriber().onNext(published);
+        notifySubscriberOfCloseEvent(subscription, SUCCESSFUL_CLOSE);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/common/stream/RegularFixedStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/RegularFixedStreamMessage.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.stream;
+
+import org.reactivestreams.Subscriber;
+
+import io.netty.util.ReferenceCountUtil;
+
+/**
+ * A {@link FixedStreamMessage} that publishes an arbitrary number of objects. It is recommended to use
+ * {@link EmptyFixedStreamMessage}, {@link OneElementFixedStreamMessage}, or
+ * {@link TwoElementFixedStreamMessage} when publishing less than three objects.
+ */
+public class RegularFixedStreamMessage<T> extends FixedStreamMessage<T> {
+
+    private final T[] objs;
+
+    private int fulfilled;
+
+    private boolean inOnNext;
+
+    protected RegularFixedStreamMessage(T[] objs) {
+        this.objs = objs.clone();
+    }
+
+    @Override
+    final void cleanupObjects() {
+        while (fulfilled < objs.length) {
+            T obj = objs[fulfilled];
+            objs[fulfilled++] = null;
+            try {
+                onRemoval(obj);
+            } finally {
+                ReferenceCountUtil.safeRelease(obj);
+            }
+        }
+    }
+
+    @Override
+    final void doRequest(SubscriptionImpl subscription, long n) {
+        final int oldDemand = requested();
+        if (oldDemand >= objs.length) {
+            // Already enough demand to finish the stream so don't need to do anything.
+            return;
+        }
+        // As objs.length is fixed, we can safely cap the demand to it here.
+        if (n >= objs.length) {
+            setRequested(objs.length);
+        } else {
+            // As objs.length is an int, large demand will always fall into the above branch and there is no
+            // chance of overflow, so just simply add the demand.
+            setRequested((int) Math.min(oldDemand + n, objs.length));
+        }
+        if (requested() > oldDemand) {
+            doNotify(subscription);
+        }
+    }
+
+    private void doNotify(SubscriptionImpl subscription) {
+        if (inOnNext) {
+            // Do not let Subscriber.onNext() reenter, because it can lead to weird-looking event ordering
+            // for a Subscriber implemented like the following:
+            //
+            //   public void onNext(Object e) {
+            //       subscription.request(1);
+            //       ... Handle 'e' ...
+            //   }
+            //
+            // Note that we do not call this method again, because we are already in the notification loop
+            // and it will consume the element we've just added in addObjectOrEvent() from the queue as
+            // expected.
+            //
+            // We do not need to worry about synchronizing the access to 'inOnNext' because the subscriber
+            // methods must be on the same thread, or synchronized, according to Reactive Streams spec.
+            return;
+        }
+
+        final Subscriber<Object> subscriber = subscription.subscriber();
+        for (;;) {
+            if (closeEvent() != null) {
+                cleanup(subscription);
+                return;
+            }
+
+            if (fulfilled == objs.length) {
+                notifySubscriberOfCloseEvent(subscription, SUCCESSFUL_CLOSE);
+                return;
+            }
+
+            final int requested = requested();
+
+            if (fulfilled == requested) {
+                break;
+            }
+
+            while (fulfilled < requested) {
+                if (closeEvent() != null) {
+                    cleanup(subscription);
+                    return;
+                }
+
+                T o = objs[fulfilled];
+                objs[fulfilled++] = null;
+                o = prepareObjectForNotification(subscription, o);
+                inOnNext = true;
+                try {
+                    subscriber.onNext(o);
+                } finally {
+                    inOnNext = false;
+                }
+            }
+        }
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return false;
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/common/stream/TwoElementFixedStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/TwoElementFixedStreamMessage.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.stream;
+
+import io.netty.util.ReferenceCountUtil;
+
+/**
+ * A {@link FixedStreamMessage} that publishes two objects.
+ */
+public class TwoElementFixedStreamMessage<T> extends FixedStreamMessage<T> {
+
+    private T obj1;
+    private T obj2;
+
+    private boolean inOnNext;
+
+    /**
+     * Constructs a new {@link TwoElementFixedStreamMessage} for the given objects.
+     */
+    protected TwoElementFixedStreamMessage(T obj1, T obj2) {
+        this.obj1 = obj1;
+        this.obj2 = obj2;
+    }
+
+    @Override
+    final void cleanupObjects() {
+        if (obj1 != null) {
+            try {
+                onRemoval(obj1);
+            } finally {
+                ReferenceCountUtil.safeRelease(obj1);
+            }
+            obj1 = null;
+        }
+        if (obj2 != null) {
+            try {
+                onRemoval(obj2);
+            } finally {
+                ReferenceCountUtil.safeRelease(obj2);
+            }
+            obj2 = null;
+        }
+    }
+
+    @Override
+    final void doRequest(SubscriptionImpl subscription, long n) {
+        int oldDemand = requested();
+        if (oldDemand >= 2) {
+            // Already have demand, so don't need to do anything, the current demand will complete the
+            // stream.
+            return;
+        }
+        setRequested(n >= 2 ? oldDemand + 2 : oldDemand + 1);
+        doNotify(subscription);
+    }
+
+    @Override
+    public final boolean isEmpty() {
+        return false;
+    }
+
+    private void doNotify(SubscriptionImpl subscription) {
+        if (inOnNext) {
+            // Do not let Subscriber.onNext() reenter, because it can lead to weird-looking event ordering
+            // for a Subscriber implemented like the following:
+            //
+            //   public void onNext(Object e) {
+            //       subscription.request(1);
+            //       ... Handle 'e' ...
+            //   }
+            //
+            // Note that we do not call this method again, because we are already in the notification loop
+            // and it will consume the element we've just added in addObjectOrEvent() from the queue as
+            // expected.
+            //
+            // We do not need to worry about synchronizing the access to 'inOnNext' because the subscriber
+            // methods must be on the same thread, or synchronized, according to Reactive Streams spec.
+            return;
+        }
+
+        // Demand is always positive, so no need to check it.
+        if (obj1 != null) {
+            try {
+                doNotifyObject(subscription, obj1);
+            } finally {
+                obj1 = null;
+            }
+        }
+
+        if (requested() >= 2 && obj2 != null) {
+            try {
+                doNotifyObject(subscription, obj2);
+            } finally {
+                obj2 = null;
+            }
+            notifySubscriberOfCloseEvent(subscription, SUCCESSFUL_CLOSE);
+        }
+    }
+
+    private void doNotifyObject(SubscriptionImpl subscription, T obj) {
+        T published = prepareObjectForNotification(subscription, obj);
+        inOnNext = true;
+        try {
+            subscription.subscriber().onNext(published);
+        } finally {
+            inOnNext = false;
+        }
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/AnnotatedHttpServiceMethod.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AnnotatedHttpServiceMethod.java
@@ -483,7 +483,7 @@ final class AnnotatedHttpServiceMethod implements BiFunction<ServiceRequestConte
         if (object instanceof HttpResponse) {
             return (HttpResponse) object;
         } else if (object instanceof AggregatedHttpMessage) {
-            return ((AggregatedHttpMessage) object).toHttpResponse();
+            return HttpResponse.of(((AggregatedHttpMessage) object));
         } else {
             final Class<?> clazz = object != null ? object.getClass() : Object.class;
             final ResponseConverter converter = findResponseConverter(clazz, converters);
@@ -504,7 +504,7 @@ final class AnnotatedHttpServiceMethod implements BiFunction<ServiceRequestConte
         if (object instanceof HttpResponse) {
             return (HttpResponse) object;
         } else if (object instanceof AggregatedHttpMessage) {
-            return ((AggregatedHttpMessage) object).toHttpResponse();
+            return HttpResponse.of(((AggregatedHttpMessage) object));
         } else {
             try {
                 return converter.convert(object);

--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseException.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseException.java
@@ -50,7 +50,7 @@ public class HttpResponseException extends RuntimeException {
      * Returns a new {@link HttpResponseException} instance with the specified {@link AggregatedHttpMessage}.
      */
     public static HttpResponseException of(AggregatedHttpMessage httpMessage) {
-        return of(requireNonNull(httpMessage, "httpMessage").toHttpResponse());
+        return of(HttpResponse.of(requireNonNull(httpMessage, "httpMessage")));
     }
 
     /**

--- a/core/src/test/java/com/linecorp/armeria/common/DefaultAggregatedHttpMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/DefaultAggregatedHttpMessageTest.java
@@ -42,7 +42,7 @@ public class DefaultAggregatedHttpMessageTest {
     public void toHttpRequest() throws Exception {
         final AggregatedHttpMessage aReq = AggregatedHttpMessage.of(
                 HttpMethod.POST, "/foo", PLAIN_TEXT_UTF_8, "bar");
-        final HttpRequest req = aReq.toHttpRequest();
+        final HttpRequest req = HttpRequest.of(aReq);
         final List<HttpObject> unaggregated = unaggregate(req);
 
         assertThat(req.headers()).isEqualTo(HttpHeaders.of(HttpMethod.POST, "/foo")
@@ -54,7 +54,7 @@ public class DefaultAggregatedHttpMessageTest {
     @Test
     public void toHttpRequestWithoutContent() throws Exception {
         final AggregatedHttpMessage aReq = AggregatedHttpMessage.of(HttpMethod.GET, "/bar");
-        final HttpRequest req = aReq.toHttpRequest();
+        final HttpRequest req = HttpRequest.of(aReq);
         final List<HttpObject> unaggregated = unaggregate(req);
 
         assertThat(req.headers()).isEqualTo(HttpHeaders.of(HttpMethod.GET, "/bar"));
@@ -66,7 +66,7 @@ public class DefaultAggregatedHttpMessageTest {
         final AggregatedHttpMessage aReq = AggregatedHttpMessage.of(
                 HttpMethod.PUT, "/baz", PLAIN_TEXT_UTF_8, HttpData.ofUtf8("bar"),
                 HttpHeaders.of(CONTENT_MD5, "37b51d194a7513e45b56f6524f2d51f2"));
-        final HttpRequest req = aReq.toHttpRequest();
+        final HttpRequest req = HttpRequest.of(aReq);
         final List<HttpObject> unaggregated = unaggregate(req);
 
         assertThat(req.headers()).isEqualTo(HttpHeaders.of(HttpMethod.PUT, "/baz")
@@ -80,19 +80,19 @@ public class DefaultAggregatedHttpMessageTest {
     @Test
     public void toHttpRequestAgainstResponse() {
         final AggregatedHttpMessage aRes = AggregatedHttpMessage.of(200);
-        assertThatThrownBy(aRes::toHttpRequest).isInstanceOf(IllegalStateException.class);
+        assertThatThrownBy(() -> HttpRequest.of(aRes)).isInstanceOf(IllegalStateException.class);
     }
 
     @Test
     public void toHttpRequestWithoutPath() {
         // Method only
-        assertThatThrownBy(() -> AggregatedHttpMessage.of(HttpHeaders.of(HttpHeaderNames.METHOD, "GET"))
-                                                      .toHttpRequest())
+        assertThatThrownBy(() -> HttpRequest.of(
+                AggregatedHttpMessage.of(HttpHeaders.of(HttpHeaderNames.METHOD, "GET"))))
                 .isInstanceOf(IllegalStateException.class);
 
         // Path only
-        assertThatThrownBy(() -> AggregatedHttpMessage.of(HttpHeaders.of(HttpHeaderNames.PATH, "/charlie"))
-                                                      .toHttpRequest())
+        assertThatThrownBy(() -> HttpRequest.of(
+                AggregatedHttpMessage.of(HttpHeaders.of(HttpHeaderNames.PATH, "/charlie"))))
                 .isInstanceOf(IllegalStateException.class);
     }
 
@@ -100,7 +100,7 @@ public class DefaultAggregatedHttpMessageTest {
     public void toHttpResponse() throws Exception {
         final AggregatedHttpMessage aRes = AggregatedHttpMessage.of(
                 HttpStatus.OK, PLAIN_TEXT_UTF_8, "alice");
-        final HttpResponse res = aRes.toHttpResponse();
+        final HttpResponse res = HttpResponse.of(aRes);
         final List<HttpObject> unaggregated = unaggregate(res);
 
         assertThat(unaggregated).containsExactly(
@@ -114,7 +114,7 @@ public class DefaultAggregatedHttpMessageTest {
     public void toHttpResponseWithoutContent() throws Exception {
         final AggregatedHttpMessage aRes = AggregatedHttpMessage.of(HttpStatus.OK, PLAIN_TEXT_UTF_8,
                                                                     HttpData.EMPTY_DATA);
-        final HttpResponse res = aRes.toHttpResponse();
+        final HttpResponse res = HttpResponse.of(aRes);
         final List<HttpObject> unaggregated = unaggregate(res);
 
         assertThat(unaggregated).containsExactly(
@@ -128,7 +128,7 @@ public class DefaultAggregatedHttpMessageTest {
         final AggregatedHttpMessage aRes = AggregatedHttpMessage.of(
                 HttpStatus.OK, PLAIN_TEXT_UTF_8, HttpData.ofUtf8("bob"),
                 HttpHeaders.of(CONTENT_MD5, "9f9d51bc70ef21ca5c14f307980a29d8"));
-        final HttpResponse res = aRes.toHttpResponse();
+        final HttpResponse res = HttpResponse.of(aRes);
         final List<HttpObject> unaggregated = unaggregate(res);
 
         assertThat(unaggregated).containsExactly(
@@ -145,7 +145,7 @@ public class DefaultAggregatedHttpMessageTest {
                 ImmutableList.of(HttpHeaders.of(HttpStatus.CONTINUE)),
                 HttpHeaders.of(HttpStatus.OK), HttpData.EMPTY_DATA, HttpHeaders.EMPTY_HEADERS);
 
-        final HttpResponse res = aRes.toHttpResponse();
+        final HttpResponse res = HttpResponse.of(aRes);
         final List<HttpObject> unaggregated = unaggregate(res);
 
         assertThat(unaggregated).containsExactly(
@@ -157,7 +157,7 @@ public class DefaultAggregatedHttpMessageTest {
     @Test
     public void toHttpResponseAgainstRequest() {
         final AggregatedHttpMessage aReq = AggregatedHttpMessage.of(HttpMethod.GET, "/qux");
-        assertThatThrownBy(aReq::toHttpResponse).isInstanceOf(IllegalStateException.class);
+        assertThatThrownBy(() -> HttpResponse.of(aReq)).isInstanceOf(IllegalStateException.class);
     }
 
     private static List<HttpObject> unaggregate(StreamMessage<HttpObject> req) throws Exception {

--- a/core/src/test/java/com/linecorp/armeria/common/HttpRequestDuplicatorTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/HttpRequestDuplicatorTest.java
@@ -34,7 +34,7 @@ public class HttpRequestDuplicatorTest {
                 HttpMethod.PUT, "/foo", PLAIN_TEXT_UTF_8, HttpData.ofUtf8("bar"),
                 HttpHeaders.of(CONTENT_MD5, "37b51d194a7513e45b56f6524f2d51f2"));
 
-        final HttpRequest publisher = aReq.toHttpRequest();
+        final HttpRequest publisher = HttpRequest.of(aReq);
         final HttpRequestDuplicator reqDuplicator = new HttpRequestDuplicator(publisher);
 
         final AggregatedHttpMessage req1 = reqDuplicator.duplicateStream().aggregate().join();

--- a/core/src/test/java/com/linecorp/armeria/common/stream/AbstractStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/AbstractStreamMessageTest.java
@@ -67,6 +67,10 @@ public abstract class AbstractStreamMessageTest {
 
     abstract <T> StreamMessage<T> newStream(List<T> inputs);
 
+    List<Integer> streamValues() {
+        return TEN_INTEGERS;
+    }
+
     private List<Integer> result;
     private volatile boolean completed;
     private volatile Throwable error;
@@ -79,7 +83,7 @@ public abstract class AbstractStreamMessageTest {
 
     @Test
     public void full_writeFirst() throws Exception {
-        StreamMessage<Integer> stream = newStream(TEN_INTEGERS);
+        StreamMessage<Integer> stream = newStream(streamValues());
         writeTenIntegers(stream);
         stream.subscribe(new ResultCollectingSubscriber() {
             @Override
@@ -92,7 +96,7 @@ public abstract class AbstractStreamMessageTest {
 
     @Test
     public void full_writeAfter() throws Exception {
-        StreamMessage<Integer> stream = newStream(TEN_INTEGERS);
+        StreamMessage<Integer> stream = newStream(streamValues());
         stream.subscribe(new ResultCollectingSubscriber() {
             @Override
             public void onSubscribe(Subscription s) {
@@ -108,7 +112,7 @@ public abstract class AbstractStreamMessageTest {
     // would fail.
     @Test
     public void flowControlled_writeThenDemandThenProcess() throws Exception {
-        StreamMessage<Integer> stream = newStream(TEN_INTEGERS);
+        StreamMessage<Integer> stream = newStream(streamValues());
         writeTenIntegers(stream);
         stream.subscribe(new ResultCollectingSubscriber() {
             private Subscription subscription;
@@ -130,7 +134,7 @@ public abstract class AbstractStreamMessageTest {
 
     @Test
     public void flowControlled_writeThenDemandThenProcess_eventLoop() throws Exception {
-        StreamMessage<Integer> stream = newStream(TEN_INTEGERS);
+        StreamMessage<Integer> stream = newStream(streamValues());
         writeTenIntegers(stream);
         eventLoop().submit(
                 () ->
@@ -154,7 +158,7 @@ public abstract class AbstractStreamMessageTest {
 
     @Test
     public void flowControlled_writeThenProcessThenDemand() throws Exception {
-        StreamMessage<Integer> stream = newStream(TEN_INTEGERS);
+        StreamMessage<Integer> stream = newStream(streamValues());
         writeTenIntegers(stream);
         stream.subscribe(new ResultCollectingSubscriber() {
             private Subscription subscription;
@@ -324,7 +328,7 @@ public abstract class AbstractStreamMessageTest {
     private void assertSuccess() {
         await().untilAsserted(() -> assertThat(completed).isTrue());
         assertThat(error).isNull();
-        assertThat(result).containsExactlyElementsOf(TEN_INTEGERS);
+        assertThat(result).containsExactlyElementsOf(streamValues());
     }
 
     private abstract class ResultCollectingSubscriber implements Subscriber<Integer> {
@@ -349,10 +353,10 @@ public abstract class AbstractStreamMessageTest {
         return PooledByteBufAllocator.DEFAULT.buffer().writeByte(0);
     }
 
-    private static void writeTenIntegers(StreamMessage<Integer> stream) {
+    private void writeTenIntegers(StreamMessage<Integer> stream) {
         if (stream instanceof StreamWriter) {
             StreamWriter<Integer> writer = (StreamWriter<Integer>) stream;
-            TEN_INTEGERS.forEach(writer::write);
+            streamValues().forEach(writer::write);
             writer.close();
         }
     }

--- a/core/src/test/java/com/linecorp/armeria/common/stream/FixedStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/FixedStreamMessageTest.java
@@ -45,7 +45,7 @@ public class FixedStreamMessageTest extends AbstractStreamMessageTest {
     @SuppressWarnings("unchecked")
     @Override
     <T> StreamMessage<T> newStream(List<T> inputs) {
-        return FixedStreamMessage.of((T[]) inputs.toArray());
+        return StreamMessage.of((T[]) inputs.toArray());
     }
 
     @Override

--- a/core/src/test/java/com/linecorp/armeria/common/stream/FixedStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/FixedStreamMessageTest.java
@@ -16,13 +16,40 @@
 
 package com.linecorp.armeria.common.stream;
 
-import java.util.List;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.google.common.collect.ImmutableList;
+
+@RunWith(Parameterized.class)
 public class FixedStreamMessageTest extends AbstractStreamMessageTest {
+
+    @Parameters(name = "{index}: num={0}")
+    public static Collection<Integer> parameters() {
+        return ImmutableList.of(0, 1, 2, 10);
+    }
+
+    private final int num;
+
+    public FixedStreamMessageTest(int num) {
+        this.num = num;
+    }
 
     @SuppressWarnings("unchecked")
     @Override
     <T> StreamMessage<T> newStream(List<T> inputs) {
-        return new FixedStreamMessage<>((T[]) inputs.toArray());
+        return FixedStreamMessage.of((T[]) inputs.toArray());
+    }
+
+    @Override
+    List<Integer> streamValues() {
+        return IntStream.range(0, num).boxed().collect(toImmutableList());
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/common/stream/FixedStreamMessageVerification.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/FixedStreamMessageVerification.java
@@ -23,7 +23,7 @@ import org.testng.annotations.Test;
 public class FixedStreamMessageVerification extends StreamMessageVerification<Long> {
     @Override
     public StreamMessage<Long> createPublisher(long elements) {
-        return FixedStreamMessage.of(LongStream.range(0, elements).boxed().toArray(Long[]::new));
+        return StreamMessage.of(LongStream.range(0, elements).boxed().toArray(Long[]::new));
     }
 
     // A fixed stream cannot fail.

--- a/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageVerification.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageVerification.java
@@ -36,6 +36,8 @@ import org.reactivestreams.tck.TestEnvironment.TestSubscriber;
 import org.testng.SkipException;
 import org.testng.annotations.Test;
 
+import com.linecorp.armeria.common.stream.FixedStreamMessage.AbstractFixedStreamMessage;
+
 public abstract class StreamMessageVerification<T> extends PublisherVerification<T> {
 
     private final TestEnvironment env;
@@ -86,7 +88,7 @@ public abstract class StreamMessageVerification<T> extends PublisherVerification
         activePublisherTest(1, true, pub -> {
             final ManualSubscriber<T> sub = env.newManualSubscriber(pub);
             final StreamMessage<?> stream = (StreamMessage<?>) pub;
-            if (!(pub instanceof FixedStreamMessage)) {
+            if (!(pub instanceof AbstractFixedStreamMessage)) {
                 // Fixed streams are never open.
                 assertThat(stream.isOpen()).isTrue();
             }
@@ -170,7 +172,7 @@ public abstract class StreamMessageVerification<T> extends PublisherVerification
             notVerified();
         }
         assumeAbortedPublisherAvailable(pub);
-        if (!(pub instanceof FixedStreamMessage)) {
+        if (!(pub instanceof AbstractFixedStreamMessage)) {
             // A fixed stream is never open.
             assertThat(pub.isOpen()).isTrue();
         }

--- a/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageVerification.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageVerification.java
@@ -36,8 +36,6 @@ import org.reactivestreams.tck.TestEnvironment.TestSubscriber;
 import org.testng.SkipException;
 import org.testng.annotations.Test;
 
-import com.linecorp.armeria.common.stream.FixedStreamMessage.AbstractFixedStreamMessage;
-
 public abstract class StreamMessageVerification<T> extends PublisherVerification<T> {
 
     private final TestEnvironment env;
@@ -88,7 +86,7 @@ public abstract class StreamMessageVerification<T> extends PublisherVerification
         activePublisherTest(1, true, pub -> {
             final ManualSubscriber<T> sub = env.newManualSubscriber(pub);
             final StreamMessage<?> stream = (StreamMessage<?>) pub;
-            if (!(pub instanceof AbstractFixedStreamMessage)) {
+            if (!(pub instanceof FixedStreamMessage)) {
                 // Fixed streams are never open.
                 assertThat(stream.isOpen()).isTrue();
             }
@@ -172,7 +170,7 @@ public abstract class StreamMessageVerification<T> extends PublisherVerification
             notVerified();
         }
         assumeAbortedPublisherAvailable(pub);
-        if (!(pub instanceof AbstractFixedStreamMessage)) {
+        if (!(pub instanceof FixedStreamMessage)) {
             // A fixed stream is never open.
             assertThat(pub.isOpen()).isTrue();
         }

--- a/core/src/test/java/com/linecorp/armeria/server/encoding/HttpEncodedResponseTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/encoding/HttpEncodedResponseTest.java
@@ -39,9 +39,10 @@ public class HttpEncodedResponseTest {
         final ByteBuf buf = Unpooled.buffer();
         buf.writeCharSequence("foo", StandardCharsets.UTF_8);
 
-        final HttpResponse orig = AggregatedHttpMessage.of(HttpStatus.OK,
-                                                           MediaType.PLAIN_TEXT_UTF_8,
-                                                           new ByteBufHttpData(buf, true)).toHttpResponse();
+        final HttpResponse orig = HttpResponse.of(
+                AggregatedHttpMessage.of(HttpStatus.OK,
+                                         MediaType.PLAIN_TEXT_UTF_8,
+                                         new ByteBufHttpData(buf, true)));
         final HttpEncodedResponse encoded = new HttpEncodedResponse(
                 orig, HttpEncodingType.DEFLATE, mediaType -> true, 1);
 


### PR DESCRIPTION
…ocations for common cases.

It's very common to allocate stream messages with 0-2 objects, so it's nice to have specializations to avoid the extra garbage of an object array. 

Unfortunately, the duplicate implementations introduce a lot of complexity. Let me know if you think it's worth it. `FixedHttpRequest` turned out much worse than I had originally expected.

The total allocation of each is
- Empty: 16 bytes (3 fields in base class)
- One element: 16 bytes (3 fields in base, one in sub)
- Two elements: 24 bytes (3 fields in base, 3 in sub)
- Three elements: 24 + 36 (3 fields in base, 3 in sub, 24 bytes array overhead, 12 bytes in array)

Also unrelated, removed `invokedOnSubscribe` as it's unnecessary for fixed streams which have no writes.

Benchmarks. Not totally apple-to-apple due to the `switch` overhead in `After` from what I can tell - I think the overhead is shown by `num=3`, where the implementation hasn't really changed, so presumably `After` should be treated a little higher than they look. But still pretty minor, let me know what you think.

```
After

Benchmark                            (flowControl)  (num)          (streamType)   Mode  Cnt         Score        Error  Units
StreamMessageBenchmark.jmhEventLoop          false      0  FIXED_STREAM_MESSAGE  thrpt   20  11644168.631 ± 152677.634  ops/s
StreamMessageBenchmark.jmhEventLoop          false      1  FIXED_STREAM_MESSAGE  thrpt   20   8573895.575 ±  34659.073  ops/s
StreamMessageBenchmark.jmhEventLoop          false      2  FIXED_STREAM_MESSAGE  thrpt   20   6602223.767 ±  24179.698  ops/s
StreamMessageBenchmark.jmhEventLoop          false      3  FIXED_STREAM_MESSAGE  thrpt   20   5326205.531 ±  17208.362  ops/s

Before

Benchmark                            (flowControl)  (num)          (streamType)   Mode  Cnt         Score       Error  Units
StreamMessageBenchmark.jmhEventLoop          false      0  FIXED_STREAM_MESSAGE  thrpt   20  11338855.960 ± 56332.436  ops/s
StreamMessageBenchmark.jmhEventLoop          false      1  FIXED_STREAM_MESSAGE  thrpt   20   8165172.831 ± 22656.208  ops/s
StreamMessageBenchmark.jmhEventLoop          false      2  FIXED_STREAM_MESSAGE  thrpt   20   6681994.146 ± 32692.861  ops/s
StreamMessageBenchmark.jmhEventLoop          false      3  FIXED_STREAM_MESSAGE  thrpt   20   5441368.221 ± 20874.088  ops/s

```