### PR TITLE
[WIP] Change to record the first request and the last response when …

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/Client.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Client.java
@@ -16,6 +16,10 @@
 
 package com.linecorp.armeria.client;
 
+import static java.util.Objects.requireNonNull;
+
+import java.util.Optional;
+
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.Request;
@@ -45,4 +49,17 @@ public interface Client<I extends Request, O extends Response> {
      * @return the {@link Response} to the specified {@link Request}
      */
     O execute(ClientRequestContext ctx, I req) throws Exception;
+
+    /**
+     * Undecorates this {@link Client} to find the {@link Client} which is an instance of the specified
+     * {@code clientType}.
+     *
+     * @return the {@link Client} which is an instance of {@code clientType} if this {@link Client}
+     *         decorated such a {@link Client}. {@link Optional#empty()} otherwise.
+     */
+    default <T> Optional<T> as(Class<T> clientType) {
+        requireNonNull(clientType, "clientType");
+        return clientType.isInstance(this) ? Optional.of(clientType.cast(this))
+                                           : Optional.empty();
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/DecoratingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DecoratingClient.java
@@ -18,6 +18,8 @@ package com.linecorp.armeria.client;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Optional;
+
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
 
@@ -49,6 +51,12 @@ public abstract class DecoratingClient<T_I extends Request, T_O extends Response
     @SuppressWarnings("unchecked")
     protected final <T extends Client<T_I, T_O>> T delegate() {
         return (T) delegate;
+    }
+
+    @Override
+    public final <T> Optional<T> as(Class<T> clientType) {
+        final Optional<T> result = Client.super.as(clientType);
+        return result.isPresent() ? result : delegate().as(clientType);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/Http1ResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http1ResponseDecoder.java
@@ -74,12 +74,18 @@ final class Http1ResponseDecoder extends HttpResponseDecoder implements ChannelI
                 super.addResponse(id, req, res, logBuilder, responseTimeoutMillis, maxContentLength);
 
         resWrapper.completionFuture().whenComplete((unused, cause) -> {
-            // Ensure that the scheduled timeout is not executed.
-            resWrapper.cancelTimeout();
             if (cause != null) {
+                // Ensure that the resWrapper is closed.
+                // This is needed in case the response is aborted by the client.
+                resWrapper.close(cause);
+
                 // Disconnect when the response has been closed with an exception because there's no way
                 // to recover from it in HTTP/1.
                 channel().close();
+            } else {
+                // Ensure that the resWrapper is closed.
+                // This is needed in case the response is aborted by the client.
+                resWrapper.close();
             }
         });
 

--- a/core/src/main/java/com/linecorp/armeria/common/AbstractRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AbstractRequestContext.java
@@ -153,10 +153,18 @@ public abstract class AbstractRequestContext implements RequestContext {
 
     /**
      * Marks this {@link RequestContext} as having been timed out. Any callbacks created with
-     * {code makeContextAware} that are run after this will be failed with {@link CancellationException}.
+     * {@code makeContextAware} that are run after this will be failed with {@link CancellationException}.
      */
     public void setTimedOut() {
         timedOut = true;
+    }
+
+    /**
+     * Resets the timed out value. This should be used with the mechanism that restores this context
+     * to the initial state.
+     */
+    public void resetTimedOut() {
+        timedOut = false;
     }
 
     private <T extends Future<?>> void invokeOperationComplete(

--- a/core/src/main/java/com/linecorp/armeria/common/logging/AbstractRequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/AbstractRequestLog.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.logging;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.linecorp.armeria.common.logging.RequestLogAvailability.REQUEST_CONTENT;
+import static com.linecorp.armeria.common.logging.RequestLogAvailability.REQUEST_END;
+import static com.linecorp.armeria.common.logging.RequestLogAvailability.REQUEST_HEADERS;
+import static com.linecorp.armeria.common.logging.RequestLogAvailability.REQUEST_START;
+import static com.linecorp.armeria.common.logging.RequestLogAvailability.RESPONSE_CONTENT;
+import static com.linecorp.armeria.common.logging.RequestLogAvailability.RESPONSE_END;
+import static com.linecorp.armeria.common.logging.RequestLogAvailability.RESPONSE_HEADERS;
+import static com.linecorp.armeria.common.logging.RequestLogAvailability.RESPONSE_START;
+import static com.linecorp.armeria.common.logging.RequestLogAvailability.SCHEME;
+import static java.util.Objects.requireNonNull;
+
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.common.SerializationFormat;
+import com.linecorp.armeria.common.util.TextFormatter;
+
+public abstract class AbstractRequestLog implements RequestLog, RequestLogBuilder {
+
+    private static final int STRING_BUILDER_CAPACITY = 512;
+
+    private final RequestContext ctx;
+
+    private volatile int requestStrFlags = -1;
+    private volatile int responseStrFlags = -1;
+    private String requestStr;
+    private String responseStr;
+
+    AbstractRequestLog(RequestContext ctx) {
+        this.ctx = requireNonNull(ctx, "ctx");
+    }
+
+    @Override
+    public Set<RequestLogAvailability> availabilities() {
+        return RequestLogAvailabilitySet.of(flags());
+    }
+
+    @Override
+    public boolean isAvailable(RequestLogAvailability availability) {
+        return isAvailable(availability.getterFlags());
+    }
+
+    @Override
+    public boolean isAvailable(RequestLogAvailability... availabilities) {
+        return isAvailable(RequestLogAvailability.getterFlags(availabilities));
+    }
+
+    @Override
+    public boolean isAvailable(Iterable<RequestLogAvailability> availabilities) {
+        return isAvailable(RequestLogAvailability.getterFlags(availabilities));
+    }
+
+    final boolean isAvailable(int interestedFlags) {
+        return (flags() & interestedFlags) == interestedFlags;
+    }
+
+    private static boolean isAvailable(int flags, RequestLogAvailability availability) {
+        final int interestedFlags = availability.getterFlags();
+        return (flags & interestedFlags) == interestedFlags;
+    }
+
+    @Override
+    public void addListener(RequestLogListener listener, RequestLogAvailability availability) {
+        requireNonNull(availability, "availability");
+        addListener(listener, ImmutableList.of(availability));
+    }
+
+    @Override
+    public void addListener(RequestLogListener listener, RequestLogAvailability... availabilities) {
+        requireNonNull(availabilities, "availabilities");
+        addListener(listener, Stream.of(availabilities).collect(toImmutableList()));
+    }
+
+    @Override
+    public void addListener(RequestLogListener listener, Iterable<RequestLogAvailability> availabilities) {
+        requireNonNull(listener, "listener");
+        requireNonNull(availabilities, "availabilities");
+        addListener(new ListenerEntry(listener, RequestLogAvailability.getterFlags(availabilities)));
+    }
+
+    abstract void addListener(ListenerEntry listenerEntry);
+
+    @Override
+    public RequestContext context() {
+        return ctx;
+    }
+
+    @Override
+    public String toStringRequestOnly() {
+        return toStringRequestOnly(Function.identity(), Function.identity());
+    }
+
+    @Override
+    public String toStringRequestOnly(Function<HttpHeaders, HttpHeaders> headersSanitizer,
+                                       Function<Object, Object> contentSanitizer) {
+        final int requestFlags = flags() & 0xFFFF; // Only interested in the bits related with request.
+        if (requestStrFlags == requestFlags) {
+            return requestStr;
+        }
+
+        final StringBuilder buf = new StringBuilder(STRING_BUILDER_CAPACITY);
+        buf.append('{');
+        if (isAvailable(requestFlags, REQUEST_START)) {
+            buf.append("startTime=");
+            TextFormatter.appendEpoch(buf, requestStartTimeMillis());
+
+            if (isAvailable(requestFlags, REQUEST_END)) {
+                buf.append(", length=");
+                TextFormatter.appendSize(buf, requestLength());
+                buf.append(", duration=");
+                TextFormatter.appendElapsed(buf, requestDurationNanos());
+                if (requestCause() != null) {
+                    buf.append(", cause=").append(requestCause());
+                }
+            }
+
+            buf.append(", scheme=");
+            if (isAvailable(requestFlags, SCHEME)) {
+                buf.append(scheme().uriText());
+            } else {
+                buf.append(SerializationFormat.UNKNOWN.uriText())
+                   .append('+')
+                   .append(sessionProtocol().uriText());
+            }
+
+            buf.append(", host=").append(host());
+
+            if (isAvailable(requestFlags, REQUEST_HEADERS) && requestHeaders() != null) {
+                buf.append(", headers=").append(headersSanitizer.apply(requestHeaders()));
+            }
+
+            if (isAvailable(requestFlags, REQUEST_CONTENT) && requestContent() != null) {
+                buf.append(", content=").append(contentSanitizer.apply(requestContent()));
+            }
+        }
+        buf.append('}');
+
+        requestStr = buf.toString();
+        requestStrFlags = requestFlags;
+
+        return requestStr;
+    }
+
+    @Override
+    public String toStringResponseOnly() {
+        return toStringResponseOnly(Function.identity(), Function.identity());
+    }
+
+    @Override
+    public String toStringResponseOnly(Function<HttpHeaders, HttpHeaders> headersSanitizer,
+                                        Function<Object, Object> contentSanitizer) {
+        final int responseFlags = flags() & 0xFFFF0000; // Only interested in the bits related with response.
+        if (responseStrFlags == responseFlags) {
+            return responseStr;
+        }
+
+        final StringBuilder buf = new StringBuilder(STRING_BUILDER_CAPACITY);
+        buf.append('{');
+        if (isAvailable(responseFlags, RESPONSE_START)) {
+            buf.append("startTime=");
+            TextFormatter.appendEpoch(buf, responseStartTimeMillis());
+
+            if (isAvailable(responseFlags, RESPONSE_END)) {
+                buf.append(", length=");
+                TextFormatter.appendSize(buf, responseLength());
+                buf.append(", duration=");
+                TextFormatter.appendElapsed(buf, responseDurationNanos());
+                if (responseCause() != null) {
+                    buf.append(", cause=").append(responseCause());
+                }
+            }
+
+            if (isAvailable(responseFlags, RESPONSE_HEADERS) && responseHeaders() != null) {
+                buf.append(", headers=").append(headersSanitizer.apply(responseHeaders()));
+            }
+
+            if (isAvailable(responseFlags, RESPONSE_CONTENT) && responseContent() != null) {
+                buf.append(", content=").append(contentSanitizer.apply(responseContent()));
+            }
+        }
+        buf.append('}');
+
+        responseStr = buf.toString();
+        responseStrFlags = responseFlags;
+
+        return responseStr;
+    }
+
+    @Override
+    public String toString() {
+        return toString(toStringRequestOnly(), toStringResponseOnly());
+    }
+
+    String toString(String req, String res) {
+        final StringBuilder buf = new StringBuilder(5 + req.length() + 6 + res.length() + 1);
+        return buf.append("{req=")  // 5 chars
+                  .append(req)
+                  .append(", res=") // 6 chars
+                  .append(res)
+                  .append('}')      // 1 char
+                  .toString();
+    }
+
+    static class ListenerEntry {
+        private final RequestLogListener listener;
+        private final int interestedFlags;
+
+        ListenerEntry(RequestLogListener listener, int interestedFlags) {
+            this.listener = listener;
+            this.interestedFlags = interestedFlags;
+        }
+
+        public RequestLogListener listener() {
+            return listener;
+        }
+
+        public int interestedFlags() {
+            return interestedFlags;
+        }
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestLog.java
@@ -53,6 +53,12 @@ import io.netty.channel.Channel;
 public interface RequestLog {
 
     /**
+     * Returns the unified integer value of flags that represents {@link RequestLogAvailability}s.
+     * You can restore the {@link RequestLogAvailability}s using {@link RequestLogAvailabilitySet#of(int)}.
+     */
+    int flags();
+
+    /**
      * Returns the set of satisfied {@link RequestLogAvailability}s.
      */
     Set<RequestLogAvailability> availabilities();

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogAvailability.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogAvailability.java
@@ -16,6 +16,10 @@
 
 package com.linecorp.armeria.common.logging;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+import java.util.stream.Stream;
+
 /**
  * Tells which properties are available in a {@link RequestLog}.
  */
@@ -94,7 +98,32 @@ public enum RequestLogAvailability {
         return getterFlags;
     }
 
+    /**
+     * Returns the unified integer value of getter flags from the specified {@code availabilities}.
+     */
+    public static int getterFlags(RequestLogAvailability... availabilities) {
+        return getterFlags(Stream.of(availabilities).collect(toImmutableList()));
+    }
+
+    /**
+     * Returns the unified integer value of getter flags from the specified {@code availabilities}.
+     */
+    public static int getterFlags(Iterable<RequestLogAvailability> availabilities) {
+        int flags = 0;
+        for (RequestLogAvailability a : availabilities) {
+            flags |= a.getterFlags();
+        }
+        return flags;
+    }
+
     int setterFlags() {
         return setterFlags;
+    }
+
+    /**
+     * Returns whether the specified {@code flags} contains only the availabilities related with the request.
+     */
+    public static boolean isRequestAvailabilityOnly(int flags) {
+        return (RESPONSE_END.getterFlags() & flags) == 0;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RetryingRequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RetryingRequestLog.java
@@ -1,0 +1,431 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.logging;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+
+import javax.annotation.Nullable;
+
+import com.linecorp.armeria.client.logging.LoggingClient;
+import com.linecorp.armeria.client.retry.RetryingClient;
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.common.Scheme;
+import com.linecorp.armeria.common.SerializationFormat;
+import com.linecorp.armeria.common.SessionProtocol;
+
+import io.netty.channel.Channel;
+
+/**
+ * A {@link RequestLog} implementation used for the client who has {@link RetryingClient} as its decorator.
+ * If the {@link LoggingClient} is wrapping the {@link RetryingClient}, only the first request and
+ * the last response will be recorded. If the order is the opposite, all of the requests and
+ * responses will be recorded.
+ * i.e.
+ * <ul>
+ *   <li>Client - LoggingClient - RetryingClient - Socket
+ *   (only the first request and the last response will be recorded)</li>
+ *   <li>Client - RetryingClient - LoggingClient - Socket
+ *   (all of the requests and responses will be recorded)</li>
+ * </ul>
+ */
+public class RetryingRequestLog extends AbstractRequestLog {
+
+    private final List<ListenerEntry> listeners = new ArrayList<>(4);
+    private final List<LogAndListenerEntry> logStore = new ArrayList<>(4);
+
+    private final DefaultRequestLog firstLog;
+
+    private DefaultRequestLog currentLog;
+    private boolean inRetrying;
+
+    /**
+     * Creates a new instance.
+     */
+    public RetryingRequestLog(RequestContext ctx) {
+        this(ctx, new DefaultRequestLog(requireNonNull(ctx, "ctx")));
+    }
+
+    private RetryingRequestLog(RequestContext ctx, DefaultRequestLog log) {
+        this(ctx, log, log);
+    }
+
+    private RetryingRequestLog(RequestContext ctx, DefaultRequestLog firstLog, DefaultRequestLog currentLog) {
+        super(ctx);
+        this.firstLog = firstLog;
+        this.currentLog = currentLog;
+    }
+
+    /**
+     * Creates a new {@link DefaultRequestLog} and set it as the current log. After this is invoked all of the
+     * log information will be updated to the current log.
+     */
+    public void newCurrentLog() {
+        currentLog = new DefaultRequestLog(context());
+
+        // remove the logs from the previous response
+        logStore.clear();
+
+        for (ListenerEntry entry : listeners) {
+            addDelayableListener(entry);
+        }
+    }
+
+    private void addDelayableListener(ListenerEntry entry) {
+        currentLog.addListener(
+                log -> {
+                    if (!(log instanceof DefaultRequestLog)) {
+                        throw new IllegalStateException("callback log should be a DefaultRequestLog");
+                    }
+                    final RequestLog callbackLog = new CallbackLog(firstLog, (DefaultRequestLog) log);
+                    if (inRetrying) {
+                        // store the callback logs if in retrying
+                        logStore.add(new LogAndListenerEntry(callbackLog, entry));
+                    } else {
+                        // invoke the log right away when not in retrying
+                        RequestLogListenerInvoker.invokeOnRequestLog(entry.listener(), callbackLog);
+                    }
+                },
+                RequestLogAvailabilitySet.of(entry.interestedFlags()));
+    }
+
+    /**
+     * Marks this {@link RetryingRequestLog} as in the retrying session.
+     */
+    public void inRetrying() {
+        this.inRetrying = true;
+    }
+
+    /**
+     * Should be called when retrying session ends.
+     */
+    public void endRetrying() {
+        inRetrying = false;
+        if (logStore.isEmpty()) {
+            return;
+        }
+
+        logStore.forEach(logAndListenerEntry -> {
+            RequestLogListenerInvoker.invokeOnRequestLog(
+                    logAndListenerEntry.listenerEntry.listener(), logAndListenerEntry.log);
+        });
+    }
+
+    @Override
+    public int flags() {
+        return currentLog.flags();
+    }
+
+    @Override
+    public Set<RequestLogAvailability> availabilities() {
+        return currentLog.availabilities();
+    }
+
+    void addListener(ListenerEntry entry) {
+        requireNonNull(entry, "entry");
+        if (inRetrying || RequestLogAvailability.isRequestAvailabilityOnly(entry.interestedFlags())) {
+            currentLog.addListener(entry.listener(), RequestLogAvailabilitySet.of(entry.interestedFlags()));
+        } else {
+            addDelayableListener(entry);
+            listeners.add(entry);
+        }
+    }
+
+    @Override
+    public long requestStartTimeMillis() {
+        if (inRetrying) {
+            return currentLog.requestStartTimeMillis();
+        }
+        return firstLog.requestStartTimeMillis();
+    }
+
+    @Override
+    public long requestDurationNanos() {
+        if (inRetrying) {
+            return currentLog.requestDurationNanos();
+        }
+        return firstLog.requestDurationNanos();
+    }
+
+    @Override
+    public long requestLength() {
+        if (inRetrying) {
+            return currentLog.requestLength();
+        }
+        return firstLog.requestLength();
+    }
+
+    @Override
+    public void requestLength(long requestLength) {
+        currentLog.requestLength(requestLength);
+    }
+
+    @Nullable
+    @Override
+    public Throwable requestCause() {
+        if (inRetrying) {
+            return currentLog.requestCause();
+        }
+        return firstLog.requestCause();
+    }
+
+    @Override
+    public HttpHeaders requestHeaders() {
+        if (inRetrying) {
+            return currentLog.requestHeaders();
+        }
+        return firstLog.requestHeaders();
+    }
+
+    @Override
+    public void requestHeaders(HttpHeaders requestHeaders) {
+        currentLog.requestHeaders(requestHeaders);
+    }
+
+    @Nullable
+    @Override
+    public Object requestContent() {
+        if (inRetrying) {
+            return currentLog.requestContent();
+        }
+        return firstLog.requestContent();
+    }
+
+    @Override
+    public void requestContent(@Nullable Object requestContent, @Nullable Object rawRequestContent) {
+        currentLog.requestContent(requestContent, rawRequestContent);
+    }
+
+    @Nullable
+    @Override
+    public Object rawRequestContent() {
+        if (inRetrying) {
+            return currentLog.rawRequestContent();
+        }
+        return firstLog.rawRequestContent();
+    }
+
+    @Override
+    public String toStringRequestOnly(Function<HttpHeaders, HttpHeaders> headersSanitizer,
+                                      Function<Object, Object> contentSanitizer) {
+        if (inRetrying) {
+            return currentLog.toStringRequestOnly(headersSanitizer, contentSanitizer);
+        }
+        return firstLog.toStringRequestOnly(headersSanitizer, contentSanitizer);
+    }
+
+    // The response related methods and the log builder methods are delegated to the currentLog.
+    @Override
+    public long responseStartTimeMillis() {
+        return currentLog.responseStartTimeMillis();
+    }
+
+    @Override
+    public long responseDurationNanos() {
+        return currentLog.responseDurationNanos();
+    }
+
+    @Override
+    public long responseLength() {
+        return currentLog.responseLength();
+    }
+
+    @Override
+    public void responseLength(long responseLength) {
+        currentLog.responseLength(responseLength);
+    }
+
+    @Nullable
+    @Override
+    public Throwable responseCause() {
+        return currentLog.responseCause();
+    }
+
+    @Override
+    public long totalDurationNanos() {
+        return currentLog.totalDurationNanos();
+    }
+
+    @Nullable
+    @Override
+    public Channel channel() {
+        return currentLog.channel();
+    }
+
+    @Override
+    public SessionProtocol sessionProtocol() {
+        return currentLog.sessionProtocol();
+    }
+
+    @Override
+    public SerializationFormat serializationFormat() {
+        return currentLog.serializationFormat();
+    }
+
+    @Override
+    public void serializationFormat(SerializationFormat serializationFormat) {
+        currentLog.serializationFormat(serializationFormat);
+    }
+
+    @Override
+    public Scheme scheme() {
+        return currentLog.scheme();
+    }
+
+    @Nullable
+    @Override
+    public String host() {
+        return currentLog.host();
+    }
+
+    @Override
+    public HttpHeaders responseHeaders() {
+        return currentLog.responseHeaders();
+    }
+
+    @Override
+    public void responseHeaders(HttpHeaders responseHeaders) {
+        currentLog.responseHeaders(responseHeaders);
+    }
+
+    @Nullable
+    @Override
+    public Object responseContent() {
+        return currentLog.responseHeaders();
+    }
+
+    @Override
+    public void responseContent(@Nullable Object responseContent, @Nullable Object rawResponseContent) {
+        currentLog.responseContent(responseContent, rawResponseContent);
+    }
+
+    @Nullable
+    @Override
+    public Object rawResponseContent() {
+        return currentLog.rawResponseContent();
+    }
+
+    @Override
+    public String toStringResponseOnly(Function<HttpHeaders, HttpHeaders> headersSanitizer,
+                                       Function<Object, Object> contentSanitizer) {
+        return currentLog.toStringResponseOnly(headersSanitizer, contentSanitizer);
+    }
+
+    @Override
+    public void startRequest(Channel channel, SessionProtocol sessionProtocol, String host) {
+        currentLog.startRequest(channel, sessionProtocol, host);
+    }
+
+    @Override
+    public void increaseRequestLength(long deltaBytes) {
+        currentLog.increaseRequestLength(deltaBytes);
+    }
+
+    @Override
+    public void deferRequestContent() {
+        currentLog.deferRequestContent();
+    }
+
+    @Override
+    public boolean isRequestContentDeferred() {
+        return currentLog.isRequestContentDeferred();
+    }
+
+    @Override
+    public void endRequest() {
+        currentLog.endRequest();
+    }
+
+    @Override
+    public void endRequest(Throwable requestCause) {
+        currentLog.endRequest(requestCause);
+    }
+
+    @Override
+    public void startResponse() {
+        currentLog.startResponse();
+    }
+
+    @Override
+    public void increaseResponseLength(long deltaBytes) {
+        currentLog.increaseResponseLength(deltaBytes);
+    }
+
+    @Override
+    public void deferResponseContent() {
+        currentLog.deferResponseContent();
+    }
+
+    @Override
+    public boolean isResponseContentDeferred() {
+        return currentLog.isResponseContentDeferred();
+    }
+
+    @Override
+    public void endResponse() {
+        currentLog.endResponse();
+    }
+
+    @Override
+    public void endResponse(Throwable responseCause) {
+        currentLog.endResponse(responseCause);
+    }
+
+    private static class LogAndListenerEntry {
+        final RequestLog log;
+        final ListenerEntry listenerEntry;
+
+        LogAndListenerEntry(RequestLog log, ListenerEntry listenerEntry) {
+            this.log = log;
+            this.listenerEntry = listenerEntry;
+        }
+    }
+
+    private static class CallbackLog extends RetryingRequestLog {
+        private final int callbackFlags;
+
+        CallbackLog(DefaultRequestLog firstLog, DefaultRequestLog currentLog) {
+            super(currentLog.context(), firstLog, currentLog);
+            callbackFlags = currentLog.flags();
+        }
+
+        @Override
+        public int flags() {
+            return callbackFlags;
+        }
+
+        @Override
+        public void addListener(RequestLogListener listener, RequestLogAvailability availability) {
+            throw new UnsupportedOperationException("cannot add a listener to the callback request log");
+        }
+
+        @Override
+        public void addListener(RequestLogListener listener, RequestLogAvailability... availabilities) {
+            throw new UnsupportedOperationException("cannot add a listener to the callback request log");
+        }
+
+        @Override
+        public void addListener(RequestLogListener listener, Iterable<RequestLogAvailability> availabilities) {
+            throw new UnsupportedOperationException("cannot add a listener to the callback request log");
+        }
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/internal/DefaultAttributeMap.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/DefaultAttributeMap.java
@@ -240,8 +240,8 @@ public class DefaultAttributeMap implements AttributeMap {
                 // We only update the linked-list structure if prev != null because if it is null this
                 // DefaultAttribute acts also as head. The head must never be removed completely and just be
                 // marked as removed as all synchronization is done on the head itself for each bucket.
-                // The head itself will be GC'ed once the DefaultAttributeMap is GC'ed. So at most 5 heads will
-                // be removed lazy as the array size is 5.
+                // The head itself will be GC'ed once the DefaultAttributeMap is GC'ed. So at most 4 heads will
+                // be removed lazy as the array size is 4.
                 if (prev != null) {
                     prev.next = next;
 

--- a/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClientTest.java
@@ -63,13 +63,13 @@ public class CircuitBreakerClientTest {
             new DefaultEventLoop(), NoopMeterRegistry.get(), H2C,
             Endpoint.of("dummyhost", 8080),
             HttpMethod.POST, "/", null, null, ClientOptions.DEFAULT,
-            RpcRequest.of(Object.class, "methodA", "a", "b"));
+            RpcRequest.of(Object.class, "methodA", "a", "b"), false);
 
     private static final ClientRequestContext ctxB = new DefaultClientRequestContext(
             new DefaultEventLoop(), NoopMeterRegistry.get(), H2C,
             Endpoint.of("dummyhost", 8080),
             HttpMethod.POST, "/", null, null, ClientOptions.DEFAULT,
-            RpcRequest.of(Object.class, "methodB", "c", "d"));
+            RpcRequest.of(Object.class, "methodB", "c", "d"), false);
 
     private static final RpcRequest req = ctx.request();
     private static final RpcRequest reqB = ctxB.request();

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientWithLoggingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientWithLoggingTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.retry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.linecorp.armeria.client.Client;
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.client.HttpClientBuilder;
+import com.linecorp.armeria.client.SimpleDecoratingClient;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpResponseWriter;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.logging.RequestLog;
+import com.linecorp.armeria.common.logging.RequestLogAvailability;
+import com.linecorp.armeria.common.logging.RequestLogAvailabilityException;
+import com.linecorp.armeria.common.logging.RequestLogListener;
+import com.linecorp.armeria.server.AbstractHttpService;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.testing.server.ServerRule;
+
+public class RetryingClientWithLoggingTest {
+
+    @Rule
+    public final ServerRule server = new ServerRule() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.service("/hello", new AbstractHttpService() {
+                final AtomicInteger reqCount = new AtomicInteger();
+
+                @Override
+                protected void doGet(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res)
+                        throws Exception {
+                    if (reqCount.getAndIncrement() < 2) {
+                        res.respond(HttpStatus.INTERNAL_SERVER_ERROR);
+                    } else {
+                        res.respond(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "hello");
+                    }
+                }
+            });
+        }
+    };
+
+    private final AtomicInteger logIndex = new AtomicInteger();
+    private int successLogIndex;
+    private final List<RequestLog> logResult = new ArrayList<>();
+
+    @Before
+    public void init() {
+        logIndex.set(0);
+        logResult.clear();
+    }
+
+    // HttpClient -> RetryingClient -> LoggingClient -> HttpClientDelegate
+    // In this case, all of the requests and responses are logged.
+    @Test
+    public void retryingThenLogging() {
+        successLogIndex = 5;
+        final HttpClient client = new HttpClientBuilder(server.uri("/"))
+                .decorator(loggingDecorator())
+                .decorator(RetryingHttpClient.newDecorator(RetryStrategy.onServerErrorStatus()))
+                .build();
+        assertThat(client.get("/hello").aggregate().join().content().toStringUtf8()).isEqualTo("hello");
+
+        // wait until 6 logs(3 requests and 3 responses) are called back
+        await().untilAsserted(() -> assertThat(logResult.size()).isEqualTo(successLogIndex + 1));
+    }
+
+    // HttpClient -> LoggingClient -> RetryingClient -> HttpClientDelegate
+    // In this case, only the first request and the last response are logged.
+    @Test
+    public void loggingThenRetrying() throws Exception {
+        successLogIndex = 1;
+        final HttpClient client = new HttpClientBuilder(server.uri("/"))
+                .decorator(RetryingHttpClient.newDecorator(RetryStrategy.onServerErrorStatus()))
+                .decorator(loggingDecorator())
+                .build();
+        assertThat(client.get("/hello").aggregate().join().content().toStringUtf8()).isEqualTo("hello");
+
+        // wait until 2 logs are called back
+        await().untilAsserted(() -> assertThat(logResult.size()).isEqualTo(successLogIndex + 1));
+
+        // toStringRequestOnly() is same in the request log and the response log
+        assertThat(logResult.get(0).toStringRequestOnly()).isEqualTo(logResult.get(1).toStringRequestOnly());
+    }
+
+    private Function<Client<HttpRequest, HttpResponse>, Client<HttpRequest, HttpResponse>>
+    loggingDecorator() {
+        return delegate -> new SimpleDecoratingClient<HttpRequest, HttpResponse>(delegate) {
+            @Override
+            public HttpResponse execute(ClientRequestContext ctx, HttpRequest req) throws Exception {
+                ctx.log().addListener(listener, RequestLogAvailability.REQUEST_END);
+                ctx.log().addListener(listener, RequestLogAvailability.COMPLETE);
+                return delegate().execute(ctx, req);
+            }
+        };
+    }
+
+    private final RequestLogListener listener = new RequestLogListener() {
+        @Override
+        public void onRequestLog(RequestLog log) throws Exception {
+            logResult.add(log);
+            final int index = logIndex.getAndIncrement();
+            if (index % 2 == 0) {
+                assertRequestOnlyLog(log);
+            } else {
+                assertResponseLog(log, index == successLogIndex);
+            }
+        }
+    };
+
+    private static void assertRequestOnlyLog(RequestLog log) {
+        System.err.println(log);
+        assertThat(log.requestHeaders()).isNotNull();
+        assertThat(log.requestHeaders().path()).isEqualToIgnoringCase("/hello");
+
+        assertThat(log.toStringResponseOnly()).isEqualToIgnoringCase("{}"); // empty response
+        assertThatThrownBy(log::responseStartTimeMillis).isInstanceOf(RequestLogAvailabilityException.class);
+    }
+
+    private static void assertResponseLog(RequestLog log, boolean success) {
+        System.err.println(log);
+        assertThat(log.requestHeaders()).isNotNull();
+        assertThat(log.responseHeaders()).isNotNull();
+
+        assertThat(log.responseHeaders().status()).isEqualTo(success ? HttpStatus.OK
+                                                                     : HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/internal/metric/RequestMetricSupportTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/metric/RequestMetricSupportTest.java
@@ -46,7 +46,7 @@ public class RequestMetricSupportTest {
         final ClientRequestContext ctx = new DefaultClientRequestContext(
                 mock(EventLoop.class), registry, SessionProtocol.H2C,
                 Endpoint.of("example.com", 8080), HttpMethod.POST, "/foo", null, null,
-                ClientOptions.DEFAULT, HttpRequest.of(HttpMethod.POST, "/foo"));
+                ClientOptions.DEFAULT, HttpRequest.of(HttpMethod.POST, "/foo"), false);
 
         final MeterIdPrefixFunction meterIdPrefixFunction = MeterIdPrefixFunction.ofDefault("foo");
 
@@ -117,7 +117,7 @@ public class RequestMetricSupportTest {
         final ClientRequestContext ctx = new DefaultClientRequestContext(
                 mock(EventLoop.class), registry, SessionProtocol.H2C,
                 Endpoint.of("example.com", 8080), HttpMethod.POST, "/bar", null, null,
-                ClientOptions.DEFAULT, HttpRequest.of(HttpMethod.POST, "/bar"));
+                ClientOptions.DEFAULT, HttpRequest.of(HttpMethod.POST, "/bar"), false);
 
         final MeterIdPrefixFunction meterIdPrefixFunction = MeterIdPrefixFunction.ofDefault("bar");
 

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaChannel.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaChannel.java
@@ -17,6 +17,7 @@
 package com.linecorp.armeria.client.grpc;
 
 import java.net.URI;
+import java.util.Optional;
 
 import javax.annotation.Nullable;
 
@@ -30,6 +31,7 @@ import com.linecorp.armeria.client.ClientOptions;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.DefaultClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.retry.RetryingClient;
 import com.linecorp.armeria.common.DefaultHttpRequest;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
@@ -146,6 +148,7 @@ class ArmeriaChannel extends Channel implements ClientBuilderParams {
 
     private ClientRequestContext newContext(HttpMethod method, HttpRequest req) {
         final ReleasableHolder<EventLoop> eventLoop = factory().acquireEventLoop(endpoint);
+        final Optional<RetryingClient> retryingClient = httpClient.as(RetryingClient.class);
         final ClientRequestContext ctx = new DefaultClientRequestContext(
                 eventLoop.get(),
                 meterRegistry,
@@ -156,7 +159,8 @@ class ArmeriaChannel extends Channel implements ClientBuilderParams {
                 uri().getRawQuery(),
                 null,
                 options(),
-                req);
+                req,
+                retryingClient.isPresent());
         ctx.log().addListener(log -> eventLoop.release(), RequestLogAvailability.COMPLETE);
         return ctx;
     }

--- a/logback/src/test/java/com/linecorp/armeria/common/logback/RequestContextExportingAppenderTest.java
+++ b/logback/src/test/java/com/linecorp/armeria/common/logback/RequestContextExportingAppenderTest.java
@@ -535,7 +535,7 @@ public class RequestContextExportingAppenderTest {
         final DefaultClientRequestContext ctx = new DefaultClientRequestContext(
                 mock(EventLoop.class), NoopMeterRegistry.get(), SessionProtocol.H2,
                 Endpoint.of("server.com", 8080), req.method(), path, query, null,
-                ClientOptions.DEFAULT, req) {
+                ClientOptions.DEFAULT, req, false) {
 
             @Nullable
             @Override

--- a/zipkin/src/test/java/com/linecorp/armeria/client/tracing/HttpTracingClientTest.java
+++ b/zipkin/src/test/java/com/linecorp/armeria/client/tracing/HttpTracingClientTest.java
@@ -156,7 +156,7 @@ public class HttpTracingClientTest {
         final RpcResponse rpcRes = RpcResponse.of("Hello, Armeria!");
         final ClientRequestContext ctx = new DefaultClientRequestContext(
                 new DefaultEventLoop(), NoopMeterRegistry.get(), H2C, Endpoint.of("localhost", 8080),
-                HttpMethod.POST, "/hello/armeria", null, null, ClientOptions.DEFAULT, req);
+                HttpMethod.POST, "/hello/armeria", null, null, ClientOptions.DEFAULT, req, false);
 
         ctx.logBuilder().startRequest(mock(Channel.class), H2C, "localhost");
         ctx.logBuilder().requestContent(rpcReq, req);


### PR DESCRIPTION
…retry

Motivation:
`RetryingHttpClient` currently records only the first request and response.
If the reqeust is succeeded after couple of retrying, it is recored as failed because the first reponse is failed.

Modifications:
- Use `RetryingRequestLog` when retrying
- Reset the `ClientRequestContext` when retrying

Result:
- Close #869