### PR TITLE
Provide a way to create a derived RequestContext

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
@@ -34,6 +34,9 @@ import io.netty.util.AttributeKey;
  */
 public interface ClientRequestContext extends RequestContext {
 
+    @Override
+    ClientRequestContext newDerivedContext();
+
     /**
      * The {@link AttributeKey} of the {@link HttpHeaders} to include when a {@link Client} sends an
      * {@link HttpRequest}. This {@link Attribute} is initially populated from

--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextWrapper.java
@@ -35,6 +35,11 @@ public class ClientRequestContextWrapper
     }
 
     @Override
+    public ClientRequestContext newDerivedContext() {
+        return delegate().newDerivedContext();
+    }
+
+    @Override
     public Endpoint endpoint() {
         return delegate().endpoint();
     }

--- a/core/src/main/java/com/linecorp/armeria/common/AbstractRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AbstractRequestContext.java
@@ -153,7 +153,7 @@ public abstract class AbstractRequestContext implements RequestContext {
 
     /**
      * Marks this {@link RequestContext} as having been timed out. Any callbacks created with
-     * {code makeContextAware} that are run after this will be failed with {@link CancellationException}.
+     * {@code makeContextAware} that are run after this will be failed with {@link CancellationException}.
      */
     public void setTimedOut() {
         timedOut = true;

--- a/core/src/main/java/com/linecorp/armeria/common/RequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestContext.java
@@ -65,6 +65,13 @@ import io.netty.util.concurrent.Promise;
 public interface RequestContext extends AttributeMap {
 
     /**
+     * Creates a new derived {@link RequestContext} which only the {@link RequestLog}
+     * is different from the deriving context. Note that the references of {@link Attribute}s
+     * in the {@link #attrs()} are copied as well.
+     */
+    RequestContext newDerivedContext();
+
+    /**
      * Returns the context of the {@link Request} that is being handled in the current thread.
      *
      * @throws IllegalStateException if the context is unavailable in the current thread

--- a/core/src/main/java/com/linecorp/armeria/internal/DefaultAttributeMap.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/DefaultAttributeMap.java
@@ -240,8 +240,8 @@ public class DefaultAttributeMap implements AttributeMap {
                 // We only update the linked-list structure if prev != null because if it is null this
                 // DefaultAttribute acts also as head. The head must never be removed completely and just be
                 // marked as removed as all synchronization is done on the head itself for each bucket.
-                // The head itself will be GC'ed once the DefaultAttributeMap is GC'ed. So at most 5 heads will
-                // be removed lazy as the array size is 5.
+                // The head itself will be GC'ed once the DefaultAttributeMap is GC'ed. So at most 4 heads will
+                // be removed lazy as the array size is 4.
                 if (prev != null) {
                     prev.next = next;
 

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
@@ -39,6 +39,9 @@ import com.linecorp.armeria.common.RequestContext;
  */
 public interface ServiceRequestContext extends RequestContext {
 
+    @Override
+    ServiceRequestContext newDerivedContext();
+
     /**
      * Returns the {@link Server} that is handling the current {@link Request}.
      */

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
@@ -43,6 +43,11 @@ public class ServiceRequestContextWrapper
     }
 
     @Override
+    public ServiceRequestContext newDerivedContext() {
+        return delegate().newDerivedContext();
+    }
+
+    @Override
     public Server server() {
         return delegate().server();
     }

--- a/core/src/main/java/com/linecorp/armeria/server/composition/AbstractCompositeService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/composition/AbstractCompositeService.java
@@ -170,6 +170,12 @@ public abstract class AbstractCompositeService<I extends Request, O extends Resp
         }
 
         @Override
+        public ServiceRequestContext newDerivedContext() {
+            final ServiceRequestContext derivedCtx = super.newDerivedContext();
+            return new CompositeServiceRequestContext(derivedCtx, pathMapping, mappedPath);
+        }
+
+        @Override
         public PathMapping pathMapping() {
             return pathMapping;
         }

--- a/core/src/test/java/com/linecorp/armeria/client/DefaultClientRequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/DefaultClientRequestContextTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import org.junit.Test;
+
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.metric.NoopMeterRegistry;
+
+import io.netty.channel.EventLoop;
+import io.netty.util.AttributeKey;
+
+public class DefaultClientRequestContextTest {
+
+    @Test
+    public void deriveContext() {
+        final DefaultClientRequestContext originalCtx = new DefaultClientRequestContext(
+                mock(EventLoop.class), NoopMeterRegistry.get(), SessionProtocol.H2C,
+                Endpoint.of("example.com", 8080), HttpMethod.POST, "/foo", null, null,
+                ClientOptions.DEFAULT, HttpRequest.of(HttpMethod.POST, "/foo"));
+        final AttributeKey<String> foo = AttributeKey.valueOf(DefaultClientRequestContextTest.class, "foo");
+        originalCtx.attr(foo).set("foo");
+
+        final ClientRequestContext derivedCtx = originalCtx.newDerivedContext();
+        assertThat(derivedCtx.endpoint()).isSameAs(originalCtx.endpoint());
+        assertThat(derivedCtx.sessionProtocol()).isSameAs(originalCtx.sessionProtocol());
+        assertThat(derivedCtx.method()).isSameAs(originalCtx.method());
+        assertThat(derivedCtx.options()).isSameAs(originalCtx.options());
+        assertThat(derivedCtx.<Object>request()).isSameAs(originalCtx.request());
+
+        assertThat(derivedCtx.path()).isEqualTo(originalCtx.path());
+        assertThat(derivedCtx.maxResponseLength()).isEqualTo(originalCtx.maxResponseLength());
+        assertThat(derivedCtx.responseTimeoutMillis()).isEqualTo(originalCtx.responseTimeoutMillis());
+        assertThat(derivedCtx.writeTimeoutMillis()).isEqualTo(originalCtx.writeTimeoutMillis());
+        // the attribute is derived as well
+        assertThat(derivedCtx.attr(foo).get()).isEqualTo("foo");
+
+        // log is different
+        assertThat(derivedCtx.log()).isNotSameAs(originalCtx.log());
+
+        final AttributeKey<String> bar = AttributeKey.valueOf(DefaultClientRequestContextTest.class, "bar");
+        originalCtx.attr(bar).set("bar");
+
+        // the Attribute added to the original context after creation is not propagated to the derived context
+        assertThat(derivedCtx.attr(bar).get()).isEqualTo(null);
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/common/RequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/RequestContextTest.java
@@ -412,6 +412,11 @@ public class RequestContextTest {
         }
 
         @Override
+        public RequestContext newDerivedContext() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
         public EventLoop eventLoop() {
             return channel.eventLoop();
         }

--- a/core/src/test/java/com/linecorp/armeria/server/DefaultServiceRequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/DefaultServiceRequestContextTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.metric.NoopMeterRegistry;
+
+import io.netty.channel.Channel;
+import io.netty.util.AttributeKey;
+
+public class DefaultServiceRequestContextTest {
+
+    @Test
+    public void deriveContext() {
+        final VirtualHost virtualHost = virtualHost();
+        final DefaultPathMappingContext mappingCtx = new DefaultPathMappingContext(
+                virtualHost, "example.com", HttpMethod.GET, "/hello", null, MediaType.JSON_UTF_8,
+                ImmutableList.of(MediaType.JSON_UTF_8, MediaType.XML_UTF_8));
+
+        final ServiceRequestContext originalCtx = new DefaultServiceRequestContext(
+                virtualHost.serviceConfigs().get(0), mock(Channel.class), NoopMeterRegistry.get(),
+                SessionProtocol.H2,
+                mappingCtx, PathMappingResult.of("/foo", null, ImmutableMap.of()),
+                HttpRequest.of(HttpMethod.POST, "/foo"), null);
+
+        final AttributeKey<String> foo = AttributeKey.valueOf(DefaultServiceRequestContextTest.class, "foo");
+        originalCtx.attr(foo).set("foo");
+
+        final ServiceRequestContext derivedCtx = originalCtx.newDerivedContext();
+        assertThat(derivedCtx.server()).isSameAs(originalCtx.server());
+        assertThat(derivedCtx.sessionProtocol()).isSameAs(originalCtx.sessionProtocol());
+        assertThat(derivedCtx.<Service<HttpRequest, HttpResponse>>service()).isSameAs(originalCtx.service());
+        assertThat(derivedCtx.pathMapping()).isSameAs(originalCtx.pathMapping());
+        assertThat(derivedCtx.<Object>request()).isSameAs(originalCtx.request());
+
+        assertThat(derivedCtx.path()).isEqualTo(originalCtx.path());
+        assertThat(derivedCtx.maxRequestLength()).isEqualTo(originalCtx.maxRequestLength());
+        assertThat(derivedCtx.requestTimeoutMillis()).isEqualTo(originalCtx.requestTimeoutMillis());
+        // the attribute is derived as well
+        assertThat(derivedCtx.attr(foo).get()).isEqualTo("foo");
+
+        // log is different
+        assertThat(derivedCtx.log()).isNotSameAs(originalCtx.log());
+
+        final AttributeKey<String> bar = AttributeKey.valueOf(DefaultServiceRequestContextTest.class, "bar");
+        originalCtx.attr(bar).set("bar");
+
+        // the Attribute added to the original context after creation is not propagated to the derived context
+        assertThat(derivedCtx.attr(bar).get()).isEqualTo(null);
+    }
+
+    private static VirtualHost virtualHost() {
+        final HttpService service = mock(HttpService.class);
+        final Server server = new ServerBuilder().withVirtualHost("example.com")
+                                                 .serviceUnder("/", service)
+                                                 .and().build();
+        return server.config().findVirtualHost("example.com");
+    }
+}


### PR DESCRIPTION
Motivation:
A user may want to create a new context whose properties and attribute map are derived from an existing context.

Modification:
- Add a `newDerivedContext()` to `RequestContext` and implement it in `DefaultClientRequestContext`, `DefaultServiceRequestContext` and `CompositeServiceRequestContext`

Result:
- Close #870