### PR TITLE
Add access logging feature to Server

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/HttpRequestSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpRequestSubscriber.java
@@ -16,7 +16,6 @@
 
 package com.linecorp.armeria.client;
 
-import java.net.InetSocketAddress;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -37,6 +36,7 @@ import com.linecorp.armeria.common.stream.AbortedStreamException;
 import com.linecorp.armeria.common.stream.ClosedPublisherException;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.internal.HttpObjectEncoder;
+import com.linecorp.armeria.internal.logging.LoggingUtil;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
@@ -141,15 +141,7 @@ final class HttpRequestSubscriber implements Subscriber<HttpObject>, ChannelFutu
         }
 
         final HttpHeaders firstHeaders = request.headers();
-        String host = firstHeaders.authority();
-        if (host == null) {
-            host = ((InetSocketAddress) ch.remoteAddress()).getHostString();
-        } else {
-            final int colonIdx = host.lastIndexOf(':');
-            if (colonIdx > 0) {
-                host = host.substring(0, colonIdx);
-            }
-        }
+        final String host = LoggingUtil.remoteHost(firstHeaders, ch);
 
         logBuilder.startRequest(ch, session.protocol(), host);
         logBuilder.requestHeaders(firstHeaders);

--- a/core/src/main/java/com/linecorp/armeria/internal/TrafficLoggingHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/TrafficLoggingHandler.java
@@ -31,7 +31,7 @@ public final class TrafficLoggingHandler extends LoggingHandler {
     public static final TrafficLoggingHandler CLIENT = new TrafficLoggingHandler(false);
 
     private TrafficLoggingHandler(boolean server) {
-        super("com.linecorp.armeria.traffic." + (server ? "server" : "client"), LogLevel.TRACE);
+        super("com.linecorp.armeria.logging.traffic." + (server ? "server" : "client"), LogLevel.TRACE);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/internal/logging/LoggingUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/logging/LoggingUtil.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.logging;
+
+import static java.util.Objects.requireNonNull;
+
+import java.net.InetSocketAddress;
+
+import com.linecorp.armeria.common.HttpHeaders;
+
+import io.netty.channel.Channel;
+
+/**
+ * A utility class for logging.
+ */
+public final class LoggingUtil {
+
+    /**
+     * Returns a remote host from the specified {@link HttpHeaders} and {@link Channel}.
+     */
+    public static String remoteHost(HttpHeaders headers, Channel channel) {
+        requireNonNull(headers, "headers");
+        requireNonNull(channel, "channel");
+        String host = headers.authority();
+        if (host == null) {
+            host = ((InetSocketAddress) channel.remoteAddress()).getHostString();
+        } else {
+            final int colonIdx = host.lastIndexOf(':');
+            if (colonIdx > 0) {
+                host = host.substring(0, colonIdx);
+            }
+        }
+        return host;
+    }
+
+    private LoggingUtil() {}
+}

--- a/core/src/main/java/com/linecorp/armeria/server/logging/AccessLogComponent.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/AccessLogComponent.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.logging;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+import java.util.function.Function;
+
+import javax.annotation.Nullable;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.logging.RequestLog;
+
+import io.netty.util.AsciiString;
+import io.netty.util.Attribute;
+import io.netty.util.AttributeKey;
+
+/**
+ * An access log component to generate a log message.
+ */
+@FunctionalInterface
+interface AccessLogComponent {
+
+    /**
+     * Returns a part of a log message.
+     */
+    @Nullable
+    Object getMessage(RequestLog log);
+
+    /**
+     * Returns whether adding quotes between a log message.
+     */
+    default boolean addQuote() {
+        return false;
+    }
+
+    static AccessLogComponent ofText(String text) {
+        return new TextComponent(text);
+    }
+
+    static AccessLogComponent ofPredefinedCommon(AccessLogType type) {
+        return new CommonComponent(type, type == AccessLogType.REQUEST_LINE, null);
+    }
+
+    static AccessLogComponent ofQuotedRequestHeader(AsciiString headerName) {
+        return new RequestHeaderComponent(headerName, true, null);
+    }
+
+    /**
+     * A text component of a log message.
+     */
+    class TextComponent implements AccessLogComponent {
+
+        static boolean isSupported(AccessLogType type) {
+            return type == AccessLogType.TEXT;
+        }
+
+        private final String text;
+
+        TextComponent(String text) {
+            this.text = requireNonNull(text, "text");
+        }
+
+        @Override
+        public Object getMessage(RequestLog log) {
+            return text;
+        }
+    }
+
+    /**
+     * An abstract class to support a condition whether a log component is applied or not.
+     */
+    abstract class ResponseHeaderConditional implements AccessLogComponent {
+
+        private final Function<HttpHeaders, Boolean> condition;
+
+        protected ResponseHeaderConditional(@Nullable Function<HttpHeaders, Boolean> condition) {
+            this.condition = condition;
+        }
+
+        @VisibleForTesting
+        Function<HttpHeaders, Boolean> condition() {
+            return condition;
+        }
+
+        @Override
+        public final Object getMessage(RequestLog log) {
+            if (condition != null &&
+                !condition.apply(log.responseHeaders())) {
+                return null;
+            }
+            return getMessage0(log);
+        }
+
+        @Nullable
+        abstract Object getMessage0(RequestLog log);
+    }
+
+    /**
+     * Common log components of a log message.
+     */
+    class CommonComponent extends ResponseHeaderConditional {
+
+        @VisibleForTesting
+        static final DateTimeFormatter dateTimeFormatter =
+                DateTimeFormatter.ofPattern("dd/MMM/yyyy:HH:mm:ss Z", Locale.ENGLISH);
+        @VisibleForTesting
+        static final ZoneId defaultZoneId = ZoneId.systemDefault();
+
+        static boolean isSupported(AccessLogType type) {
+            switch (type) {
+                case REMOTE_HOST:
+                case RFC931:
+                case AUTHENTICATED_USER:
+                case REQUEST_TIMESTAMP:
+                case REQUEST_LINE:
+                case RESPONSE_STATUS_CODE:
+                case RESPONSE_LENGTH:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        private final AccessLogType type;
+        private final boolean addQuote;
+
+        CommonComponent(AccessLogType type, boolean addQuote,
+                        @Nullable Function<HttpHeaders, Boolean> condition) {
+            super(condition);
+            checkArgument(isSupported(requireNonNull(type, "type")),
+                          "Type '" + type + "' is not acceptable by " +
+                          CommonComponent.class.getName());
+            this.type = type;
+            this.addQuote = addQuote;
+        }
+
+        @Override
+        public Object getMessage0(RequestLog log) {
+            switch (type) {
+                case REMOTE_HOST:
+                    final SocketAddress ra = log.context().remoteAddress();
+                    return ra instanceof InetSocketAddress ? ((InetSocketAddress) ra).getHostString() : null;
+
+                case RFC931:
+                case AUTHENTICATED_USER:
+                    // We do not support these kinds of log types now.
+                    return null;
+
+                case REQUEST_TIMESTAMP:
+                    return dateTimeFormatter.format(ZonedDateTime.ofInstant(
+                            Instant.ofEpochMilli(log.requestStartTimeMillis()), defaultZoneId));
+                case REQUEST_LINE:
+                    final HttpHeaders headers = log.requestHeaders();
+                    return headers.method().name() + ' ' +
+                           headers.path() + ' ' +
+                           firstNonNull(log.sessionProtocol(), log.context().sessionProtocol()).uriText();
+
+                case RESPONSE_STATUS_CODE:
+                    return log.responseHeaders().status().code();
+
+                case RESPONSE_LENGTH:
+                    return log.responseLength();
+            }
+            return null;
+        }
+
+        @Override
+        public boolean addQuote() {
+            return addQuote;
+        }
+    }
+
+    /**
+     * A request header component of a log message.
+     */
+    class RequestHeaderComponent extends ResponseHeaderConditional {
+
+        static boolean isSupported(AccessLogType type) {
+            return type == AccessLogType.REQUEST_HEADER;
+        }
+
+        private final AsciiString headerName;
+        private final boolean addQuote;
+
+        RequestHeaderComponent(AsciiString headerName, boolean addQuote,
+                               @Nullable Function<HttpHeaders, Boolean> condition) {
+            super(condition);
+            this.headerName = requireNonNull(headerName, "headerName");
+            this.addQuote = addQuote;
+        }
+
+        @VisibleForTesting
+        AsciiString headerName() {
+            return headerName;
+        }
+
+        @Override
+        public Object getMessage0(RequestLog log) {
+            return log.requestHeaders().get(headerName);
+        }
+
+        @Override
+        public boolean addQuote() {
+            return addQuote;
+        }
+    }
+
+    /**
+     * An attribute component of a log message.
+     */
+    class AttributeComponent extends ResponseHeaderConditional {
+
+        static boolean isSupported(AccessLogType type) {
+            return type == AccessLogType.ATTRIBUTE;
+        }
+
+        private final AttributeKey<?> key;
+        private final Function<Object, String> stringifer;
+        private final boolean addQuote;
+
+        AttributeComponent(String attributeName, Function<Object, String> stringifer, boolean addQuote,
+                           @Nullable Function<HttpHeaders, Boolean> condition) {
+            super(condition);
+            key = AttributeKey.valueOf(requireNonNull(attributeName, "attributeName"));
+            this.stringifer = requireNonNull(stringifer, "stringifer");
+            this.addQuote = addQuote;
+        }
+
+        @VisibleForTesting
+        AttributeKey<?> key() {
+            return key;
+        }
+
+        @Override
+        Object getMessage0(RequestLog log) {
+            final Attribute<?> value = log.context().attr(key);
+            return value != null ? stringifer.apply(value.get()) : null;
+        }
+
+        @Override
+        public boolean addQuote() {
+            return addQuote;
+        }
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/logging/AccessLogFormats.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/AccessLogFormats.java
@@ -1,0 +1,328 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.logging;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.linecorp.armeria.server.logging.AccessLogComponent.ofPredefinedCommon;
+import static com.linecorp.armeria.server.logging.AccessLogComponent.ofQuotedRequestHeader;
+import static com.linecorp.armeria.server.logging.AccessLogComponent.ofText;
+import static com.linecorp.armeria.server.logging.AccessLogType.AUTHENTICATED_USER;
+import static com.linecorp.armeria.server.logging.AccessLogType.REMOTE_HOST;
+import static com.linecorp.armeria.server.logging.AccessLogType.REQUEST_LINE;
+import static com.linecorp.armeria.server.logging.AccessLogType.REQUEST_TIMESTAMP;
+import static com.linecorp.armeria.server.logging.AccessLogType.RESPONSE_LENGTH;
+import static com.linecorp.armeria.server.logging.AccessLogType.RESPONSE_STATUS_CODE;
+import static com.linecorp.armeria.server.logging.AccessLogType.RFC931;
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+
+import javax.annotation.Nullable;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.server.logging.AccessLogComponent.AttributeComponent;
+import com.linecorp.armeria.server.logging.AccessLogComponent.CommonComponent;
+import com.linecorp.armeria.server.logging.AccessLogComponent.RequestHeaderComponent;
+import com.linecorp.armeria.server.logging.AccessLogComponent.TextComponent;
+
+import io.netty.util.AsciiString;
+
+/**
+ * Pre-defined access log formats and the utility methods for {@link AccessLogComponent}.
+ */
+final class AccessLogFormats {
+
+    private static final AccessLogComponent BLANK = ofText(" ");
+
+    /**
+     * A common log format.
+     */
+    static final List<AccessLogComponent> COMMON =
+            ImmutableList.of(ofPredefinedCommon(REMOTE_HOST), BLANK,
+                             ofPredefinedCommon(RFC931), BLANK,
+                             ofPredefinedCommon(AUTHENTICATED_USER), BLANK,
+                             ofPredefinedCommon(REQUEST_TIMESTAMP), BLANK,
+                             ofPredefinedCommon(REQUEST_LINE), BLANK,
+                             ofPredefinedCommon(RESPONSE_STATUS_CODE), BLANK,
+                             ofPredefinedCommon(RESPONSE_LENGTH));
+
+    /**
+     * A combined log format.
+     */
+    static final List<AccessLogComponent> COMBINED =
+            ImmutableList.of(ofPredefinedCommon(REMOTE_HOST), BLANK,
+                             ofPredefinedCommon(RFC931), BLANK,
+                             ofPredefinedCommon(AUTHENTICATED_USER), BLANK,
+                             ofPredefinedCommon(REQUEST_TIMESTAMP), BLANK,
+                             ofPredefinedCommon(REQUEST_LINE), BLANK,
+                             ofPredefinedCommon(RESPONSE_STATUS_CODE), BLANK,
+                             ofPredefinedCommon(RESPONSE_LENGTH), BLANK,
+                             ofQuotedRequestHeader(HttpHeaderNames.REFERER), BLANK,
+                             ofQuotedRequestHeader(HttpHeaderNames.USER_AGENT), BLANK,
+                             ofQuotedRequestHeader(HttpHeaderNames.COOKIE));
+
+    @VisibleForTesting
+    static List<AccessLogComponent> parseCustom(String formatStr) {
+        requireNonNull(formatStr, "formatStr");
+        final ImmutableList.Builder<AccessLogComponent> builder = ImmutableList.builder();
+
+        final StringBuilder textBuilder = new StringBuilder();
+        Condition.Builder condBuilder = null;
+        String variable = null;
+
+        State state = State.TEXT;
+        for (int i = 0; i < formatStr.length();/* Increase 'i' at the end of the loop. */) {
+            final char ch = formatStr.charAt(i);
+            switch (state) {
+                case TEXT:
+                    if (ch == '%') {
+                        if (textBuilder.length() > 0) {
+                            builder.add(ofText(newStringAndReset(textBuilder)));
+                        }
+                        condBuilder = null;
+                        variable = null;
+
+                        state = State.PERCENT;
+                    } else {
+                        textBuilder.append(ch);
+                    }
+                    break;
+                case PERCENT:
+                    // Loop again.
+                    if (Character.isAlphabetic(ch)) {
+                        state = State.TOKEN;
+                        continue;
+                    }
+                    // Loop again.
+                    if (Character.isDigit(ch)) {
+                        condBuilder = Condition.builder();
+                        state = State.CONDITION;
+                        continue;
+                    }
+
+                    if (ch == '!') {
+                        condBuilder = Condition.builder().setSign(false);
+                        state = State.CONDITION;
+                    } else if (ch == '{') {
+                        state = State.VARIABLE;
+                    }
+                    break;
+                case CONDITION:
+                    assert condBuilder != null;
+                    if (Character.isDigit(ch)) {
+                        textBuilder.append(ch);
+                    } else {
+                        if (textBuilder.length() > 0) {
+                            condBuilder.addHttpStatus(newStringAndReset(textBuilder));
+                        }
+                        // Loop again.
+                        if (Character.isAlphabetic(ch)) {
+                            state = State.TOKEN;
+                            continue;
+                        }
+                        if (ch == '{') {
+                            state = State.VARIABLE;
+                        } else if (ch != ',') {
+                            throw new IllegalArgumentException("Unexpected character in condition:" + ch);
+                        }
+                    }
+                    break;
+                case VARIABLE:
+                    if (ch != '}') {
+                        textBuilder.append(ch);
+                    } else {
+                        if (textBuilder.length() > 0) {
+                            variable = newStringAndReset(textBuilder);
+                        }
+                        state = State.TOKEN;
+                    }
+                    break;
+                case TOKEN:
+                    builder.add(newAccessLogComponent(ch, variable, condBuilder));
+                    state = State.TEXT;
+                    break;
+            }
+
+            // Go to the next index only if the 'switch' statement exits by 'break' statement.
+            ++i;
+        }
+
+        if (state != State.TEXT) {
+            throw new IllegalArgumentException("Unexpected access log format: " + formatStr);
+        }
+
+        if (textBuilder.length() > 0) {
+            builder.add(ofText(newStringAndReset(textBuilder)));
+        }
+
+        return builder.build();
+    }
+
+    private static AccessLogComponent newAccessLogComponent(char token,
+                                                            @Nullable String variable,
+                                                            @Nullable Condition.Builder condBuilder) {
+        final AccessLogType type = AccessLogType.find(token).orElseThrow(
+                () -> new IllegalArgumentException("Unexpected token character: '" + token + '\''));
+        if (type.isVariableRequired()) {
+            checkArgument(variable != null,
+                          "Token " + type.token() + " requires a variable.");
+        }
+        if (type.isConditionAvailable()) {
+            if (condBuilder != null) {
+                checkArgument(!condBuilder.isEmpty(),
+                              "Token " + type.token() + " has an invalid condition.");
+            }
+        } else {
+            checkArgument(condBuilder == null,
+                          "Token " + type.token() + " does not support a condition.");
+        }
+
+        if (TextComponent.isSupported(type)) {
+            return ofText(variable);
+        }
+
+        // Do not add quotes when parsing a user-provided custom format.
+        final boolean addQuote = false;
+
+        final Function<HttpHeaders, Boolean> condition = condBuilder != null ? condBuilder.build() : null;
+        if (CommonComponent.isSupported(type)) {
+            return new CommonComponent(type, addQuote, condition);
+        }
+        if (RequestHeaderComponent.isSupported(type)) {
+            return new RequestHeaderComponent(AsciiString.of(variable), addQuote, condition);
+        }
+        if (AttributeComponent.isSupported(type)) {
+            final Function<Object, String> stringifier;
+            final String[] components = variable.split(":");
+            if (components.length == 2) {
+                stringifier = newStringifier(components[0], components[1]);
+            } else {
+                stringifier = Object::toString;
+            }
+            return new AttributeComponent(components[0], stringifier, addQuote, condition);
+        }
+
+        // Should not reach here.
+        throw new Error("Unexpected access log type: " + type.name());
+    }
+
+    private static String newStringAndReset(StringBuilder textBuilder) {
+        final String str = textBuilder.toString();
+        textBuilder.setLength(0);
+        return str;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Function<Object, String> newStringifier(String attrName, String className) {
+        final Function<Object, String> stringifier;
+        try {
+            stringifier = (Function<Object, String>) Class.forName(
+                    className, true, AccessLogFormats.class.getClassLoader()).newInstance();
+        } catch (Exception e) {
+            throw new IllegalArgumentException("failed to instantiate a stringifier function: " +
+                                               attrName, e);
+        }
+        return stringifier;
+    }
+
+    /**
+     * A condition based on {@link HttpStatus} of the HTTP response.
+     */
+    private static final class Condition implements Function<HttpHeaders, Boolean> {
+
+        private final Set<HttpStatus> statusSet;
+        private final boolean sign;
+
+        Condition(Set<HttpStatus> statusSet, boolean sign) {
+            this.statusSet = statusSet;
+            this.sign = sign;
+        }
+
+        public Set<HttpStatus> statusSet() {
+            return statusSet;
+        }
+
+        public boolean isSign() {
+            return sign;
+        }
+
+        @Override
+        public Boolean apply(HttpHeaders headers) {
+            return statusSet.contains(headers.status()) == sign;
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(this)
+                              .add("sign", isSign())
+                              .add("statusSet", statusSet())
+                              .toString();
+        }
+
+        static Builder builder() {
+            return new Builder();
+        }
+
+        static final class Builder {
+            private final ImmutableSet.Builder<HttpStatus> statusSet = ImmutableSet.builder();
+            private boolean sign = true;
+            private boolean isEmpty = true;
+
+            Builder setSign(boolean sign) {
+                this.sign = sign;
+                return this;
+            }
+
+            Builder addHttpStatus(String text) {
+                final HttpStatus s = HttpStatus.valueOf(Integer.valueOf(text));
+                statusSet.add(s);
+                isEmpty = false;
+                return this;
+            }
+
+            boolean isEmpty() {
+                return isEmpty;
+            }
+
+            Function<HttpHeaders, Boolean> build() {
+                return new Condition(statusSet.build(), sign);
+            }
+        }
+    }
+
+    /**
+     * Parsing states.
+     */
+    private enum State {
+        TEXT,
+        PERCENT,
+        CONDITION,
+        VARIABLE,
+        TOKEN
+    }
+
+    private AccessLogFormats() {}
+}

--- a/core/src/main/java/com/linecorp/armeria/server/logging/AccessLogType.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/AccessLogType.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.logging;
+
+import java.util.Map;
+import java.util.Optional;
+
+import com.google.common.collect.ImmutableMap;
+
+import com.linecorp.armeria.common.RequestContext;
+
+import io.netty.util.AttributeMap;
+
+/**
+ * Access log component types which are used to specify a log message format. Some components can be
+ * omitted with a condition. For example:
+ *
+ * <table summary="Example of a condition">
+ * <tr><th>format</th><th>description</th></tr>
+ *
+ * <tr><td>{@code %200,304{User-Agent}i}</td>
+ * <td>Write {@code User-Agent} header value only if the response code is {@code 200} or {@code 304}.</td></tr>
+ *
+ * <tr><td>{@code %!200,304{com.example.armeria.Attribute#KEY}j}</td>
+ * <td>Write the value of the specified attribute only if the response code is neither {@code 200} nor
+ * {@code 304}.</td></tr>
+ *
+ * </table>
+ */
+enum AccessLogType {
+    /**
+     * {@code "%h"} - the remote hostname or IP address if DNS hostname lookup is not available.
+     */
+    REMOTE_HOST('h', false, false),
+
+    /**
+     * {@code "%l"} - the remote logname of the user.
+     */
+    RFC931('l', false, false),
+
+    /**
+     * {@code "%u"} - the name of the authenticated remote user.
+     */
+    AUTHENTICATED_USER('u', false, false),
+
+    /**
+     * {@code "%t"} - the date, time and time zone that the request was received.
+     */
+    REQUEST_TIMESTAMP('t', false, false),
+
+    /**
+     * {@code "%r"} - the request line from the client.
+     */
+    REQUEST_LINE('r', true, false),
+
+    /**
+     * {@code "%s"} - the HTTP status code returned to the client.
+     */
+    RESPONSE_STATUS_CODE('s', false, false),
+
+    /**
+     * {@code "%b"} - the size of the object returned to the client, measured in bytes.
+     */
+    RESPONSE_LENGTH('b', true, false),
+
+    /**
+     * {@code "%{HEADER_NAME}i"} - the name of HTTP request header.
+     */
+    REQUEST_HEADER('i', true, true),
+
+    /**
+     * {@code "%{ATTRIBUTE_NAME}j"} - the attribute name of the {@link AttributeMap} of the
+     * {@link RequestContext}.
+     */
+    ATTRIBUTE('j', true, true),
+
+    /**
+     * A plain text which would be written to access log message.
+     */
+    TEXT('%', false, true);
+
+    private static final Map<Character, AccessLogType> tokenToEnum;
+
+    static {
+        ImmutableMap.Builder<Character, AccessLogType> builder = ImmutableMap.builder();
+        for (AccessLogType k : AccessLogType.values()) {
+            builder.put(k.token, k);
+        }
+        tokenToEnum = builder.build();
+    }
+
+    static Optional<AccessLogType> find(char token) {
+        return Optional.ofNullable(tokenToEnum.get(token));
+    }
+
+    private final char token;
+    private final boolean isConditionAvailable;
+    private final boolean isVariableRequired;
+
+    AccessLogType(char token, boolean isConditionAvailable, boolean isVariableRequired) {
+        this.token = token;
+        this.isConditionAvailable = isConditionAvailable;
+        this.isVariableRequired = isVariableRequired;
+    }
+
+    public char token() {
+        return token;
+    }
+
+    public boolean isConditionAvailable() {
+        return isConditionAvailable;
+    }
+
+    public boolean isVariableRequired() {
+        return isVariableRequired;
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/logging/AccessLogWriters.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/AccessLogWriters.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.logging;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.linecorp.armeria.server.logging.AccessLogFormats.parseCustom;
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+import com.linecorp.armeria.common.logging.RequestLog;
+
+/**
+ * Access log writers.
+ */
+public final class AccessLogWriters {
+
+    /**
+     * Returns an access log writer with a common format.
+     */
+    public static Consumer<RequestLog> common() {
+        return requestLog -> AccessLogger.write(AccessLogFormats.COMMON, requestLog);
+    }
+
+    /**
+     * Returns an access log writer with a combined format.
+     */
+    public static Consumer<RequestLog> combined() {
+        return requestLog -> AccessLogger.write(AccessLogFormats.COMBINED, requestLog);
+    }
+
+    /**
+     * Returns disabled access log writer.
+     */
+    public static Consumer<RequestLog> disabled() {
+        return requestLog -> { /* No operation. */ };
+    }
+
+    /**
+     * Returns an access log writer with the specified {@code formatStr}.
+     */
+    public static Consumer<RequestLog> custom(String formatStr) {
+        final List<AccessLogComponent> accessLogFormat = parseCustom(requireNonNull(formatStr, "formatStr"));
+        checkArgument(!accessLogFormat.isEmpty(), "Invalid access log format string: " + formatStr);
+        return requestLog -> AccessLogger.write(accessLogFormat, requestLog);
+    }
+
+    private AccessLogWriters() {}
+}

--- a/core/src/main/java/com/linecorp/armeria/server/logging/AccessLogger.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/AccessLogger.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.logging;
+
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import com.linecorp.armeria.common.logging.RequestLog;
+
+/**
+ * A user may configure an access logger as follows.
+ *
+ * <p>For logback.xml:
+ * <pre>{@code
+ * <configuration>
+ *   <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+ *     <encoder>
+ *       <pattern>%-4relative [%thread] %-5level %logger{35} - %msg%n</pattern>
+ *     </encoder>
+ *   </appender>
+ *
+ *   <appender name="ACCESS" class="ch.qos.logback.core.rolling.RollingFileAppender">
+ *     <file>access.log</file>
+ *     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+ *       <!-- daily rollover -->
+ *       <fileNamePattern>access.%d{yyyy-MM-dd}-%i.log</fileNamePattern>
+ *       <!-- each file should be at most 1GB, keep 30 days worth of history, but at most 30GB -->
+ *       <maxFileSize>1GB</maxFileSize>
+ *       <maxHistory>30</maxHistory>
+ *       <totalSizeCap>30GB</totalSizeCap>
+ *     </rollingPolicy>
+ *     <encoder>
+ *       <pattern>%msg%n</pattern>
+ *     </encoder>
+ *   </appender>
+ *
+ *   <logger name="com.linecorp.armeria.logging.access" level="INFO" additivity="false">
+ *     <appender-ref ref="ACCESS"/>
+ *   </logger>
+ *
+ *   <root level="DEBUG">
+ *     <appender-ref ref="CONSOLE"/>
+ *   </root>
+ * </configuration>
+ * }</pre>
+ *
+ * <p>For log4j2.xml:
+ * <pre>{@code
+ * <?xml version="1.0" encoding="UTF-8"?>
+ * <Configuration status="WARN">
+ *   <Appenders>
+ *     <Console name="CONSOLE" target="SYSTEM_OUT">
+ *       <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+ *     </Console>
+ *     <RollingFile name="ACCESS" fileName="access.log" filePattern="access.%d{MM-dd-yyyy}-%i.log.gz">
+ *       <PatternLayout>
+ *         <Pattern>%m%n</Pattern>
+ *       </PatternLayout>
+ *
+ *       <Policies>
+ *         <!-- daily rollover -->
+ *         <TimeBasedTriggeringPolicy/>
+ *         <!-- each file should be at most 1GB -->
+ *         <SizeBasedTriggeringPolicy size="1GB"/>
+ *       </Policies>
+ *       <-- keep 30 archives -->
+ *       <DefaultRolloverStrategy max="30"/>
+ *     </RollingFile>
+ *   </Appenders>
+ *
+ *   <Loggers>
+ *     <Logger name="com.linecorp.armeria.logging.access" level="INFO" additivity="false">
+ *       <AppenderRef ref="ACCESS"/>
+ *     </Logger>
+ *     <Root level="DEBUG">
+ *       <AppenderRef ref="CONSOLE"/>
+ *     </Root>
+ *   </Loggers>
+ * </Configuration>
+ * }</pre>
+ */
+final class AccessLogger {
+    private static final Logger logger = LoggerFactory.getLogger(AccessLogger.class);
+
+    private static final Logger accessLogger =
+            LoggerFactory.getLogger("com.linecorp.armeria.logging.access");
+
+    /**
+     * Writes an access log for the specified {@link RequestLog}.
+     */
+    static void write(List<AccessLogComponent> format, RequestLog log) {
+        if (!format.isEmpty()) {
+            accessLogger.info(format(format, log));
+        }
+    }
+
+    static String format(List<AccessLogComponent> format, RequestLog log) {
+        final StringBuilder message = new StringBuilder();
+
+        for (final AccessLogComponent component : format) {
+            final boolean addQuote = component.addQuote();
+            try {
+                final Object text = component.getMessage(log);
+                if (text != null) {
+                    if (addQuote) {
+                        escapeAndQuote(message, text.toString());
+                    } else {
+                        message.append(text);
+                    }
+                } else {
+                    appendEmptyField(message, addQuote);
+                }
+            } catch (Throwable e) {
+                logger.debug("Caught an exception while formatting an access log:", e);
+                appendEmptyField(message, addQuote);
+            }
+        }
+        return message.toString();
+    }
+
+    private static void appendEmptyField(StringBuilder message, boolean addQuote) {
+        if (addQuote) {
+            message.append("\"-\"");
+        } else {
+            message.append('-');
+        }
+    }
+
+    @VisibleForTesting
+    static StringBuilder escapeAndQuote(StringBuilder message, String input) {
+        message.append('"');
+        boolean isEscaped = false;
+        for (int i = 0; i < input.length(); i++) {
+            final char c = input.charAt(i);
+            if (c == '\\') {
+                isEscaped = true;
+            } else {
+                if (c == '"' && !isEscaped) {
+                    // We escape only '"' for a log message.
+                    message.append('\\');
+                }
+                isEscaped = false;
+            }
+            message.append(c);
+        }
+        message.append('"');
+        return message;
+    }
+
+    private AccessLogger() {}
+}

--- a/core/src/test/java/com/linecorp/armeria/server/logging/AccessLogFormatsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/logging/AccessLogFormatsTest.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.logging;
+
+import static com.linecorp.armeria.server.logging.AccessLogComponent.CommonComponent.dateTimeFormatter;
+import static com.linecorp.armeria.server.logging.AccessLogComponent.CommonComponent.defaultZoneId;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.function.Function;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.NonWrappingRequestContext;
+import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.logging.DefaultRequestLog;
+import com.linecorp.armeria.common.logging.RequestLog;
+import com.linecorp.armeria.common.logging.RequestLogBuilder;
+import com.linecorp.armeria.common.metric.NoopMeterRegistry;
+import com.linecorp.armeria.server.logging.AccessLogComponent.AttributeComponent;
+import com.linecorp.armeria.server.logging.AccessLogComponent.CommonComponent;
+import com.linecorp.armeria.server.logging.AccessLogComponent.RequestHeaderComponent;
+
+import io.netty.channel.Channel;
+import io.netty.channel.EventLoop;
+import io.netty.util.AttributeKey;
+
+public class AccessLogFormatsTest {
+
+    @Rule
+    public MockitoRule mocks = MockitoJUnit.rule();
+
+    @Mock
+    private Channel channel;
+
+    @Test
+    public void parseSuccess() {
+        List<AccessLogComponent> format;
+        AccessLogComponent entry;
+        RequestHeaderComponent headerEntry;
+        CommonComponent commonComponentEntry;
+
+        assertThat(AccessLogFormats.parseCustom("%h %l"))
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsSequence(AccessLogComponent.ofPredefinedCommon(AccessLogType.REMOTE_HOST),
+                                  AccessLogComponent.ofText(" "),
+                                  AccessLogComponent.ofPredefinedCommon(AccessLogType.RFC931));
+
+        format = AccessLogFormats.parseCustom("%200,302{Referer}i");
+        assertThat(format.size()).isOne();
+        entry = format.get(0);
+        assertThat(entry).isInstanceOf(RequestHeaderComponent.class);
+        headerEntry = (RequestHeaderComponent) entry;
+        assertThat(headerEntry.condition()).isNotNull();
+        assertThat(headerEntry.condition().apply(HttpHeaders.of(HttpStatus.OK))).isTrue();
+        assertThat(headerEntry.condition().apply(HttpHeaders.of(HttpStatus.BAD_REQUEST))).isFalse();
+        assertThat(headerEntry.headerName().toString())
+                .isEqualToIgnoringCase(HttpHeaderNames.REFERER.toString());
+
+        format = AccessLogFormats.parseCustom("%!200,302{User-Agent}i");
+        assertThat(format.size()).isOne();
+        entry = format.get(0);
+        assertThat(entry).isInstanceOf(RequestHeaderComponent.class);
+        headerEntry = (RequestHeaderComponent) entry;
+        assertThat(headerEntry.condition()).isNotNull();
+        assertThat(headerEntry.condition().apply(HttpHeaders.of(HttpStatus.OK))).isFalse();
+        assertThat(headerEntry.condition().apply(HttpHeaders.of(HttpStatus.BAD_REQUEST))).isTrue();
+        assertThat(headerEntry.headerName().toString())
+                .isEqualToIgnoringCase(HttpHeaderNames.USER_AGENT.toString());
+
+        format = AccessLogFormats.parseCustom("%200b");
+        assertThat(format.size()).isOne();
+        entry = format.get(0);
+        assertThat(entry).isInstanceOf(CommonComponent.class);
+        commonComponentEntry = (CommonComponent) entry;
+        assertThat(commonComponentEntry.condition()).isNotNull();
+        assertThat(commonComponentEntry.condition().apply(HttpHeaders.of(HttpStatus.OK))).isTrue();
+        assertThat(commonComponentEntry.condition().apply(HttpHeaders.of(HttpStatus.BAD_REQUEST))).isFalse();
+
+        format = AccessLogFormats.parseCustom("%!200b");
+        assertThat(format.size()).isOne();
+        entry = format.get(0);
+        assertThat(entry).isInstanceOf(CommonComponent.class);
+        commonComponentEntry = (CommonComponent) entry;
+        assertThat(commonComponentEntry.condition()).isNotNull();
+        assertThat(commonComponentEntry.condition().apply(HttpHeaders.of(HttpStatus.OK))).isFalse();
+        assertThat(commonComponentEntry.condition().apply(HttpHeaders.of(HttpStatus.BAD_REQUEST))).isTrue();
+
+        assertThat(AccessLogFormats.parseCustom("").isEmpty()).isTrue();
+
+        format = AccessLogFormats.parseCustom(
+                "%{com.linecorp.armeria.server.logging.AccessLogFormatsTest$Attr#KEY" +
+                ":com.linecorp.armeria.server.logging.AccessLogFormatsTest$AttributeStringfier}j");
+        assertThat(format.size()).isOne();
+        entry = format.get(0);
+        assertThat(entry).isInstanceOf(AttributeComponent.class);
+        AttributeComponent attrEntry = (AttributeComponent) entry;
+        assertThat(attrEntry.key().toString())
+                .isEqualTo("com.linecorp.armeria.server.logging.AccessLogFormatsTest$Attr#KEY");
+
+        // Typo, but successful.
+        assertThat(AccessLogFormats.parseCustom("%h00,300{abc}"))
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsSequence(AccessLogComponent.ofPredefinedCommon(AccessLogType.REMOTE_HOST),
+                                  AccessLogComponent.ofText("00,300{abc}"));
+    }
+
+    @Test
+    public void parseFailure() {
+        assertThatThrownBy(() -> AccessLogFormats.parseCustom("%x"))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> AccessLogFormats.parseCustom("%!{abc}i"))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> AccessLogFormats.parseCustom("%{abci"))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> AccessLogFormats.parseCustom("%{abc}"))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> AccessLogFormats.parseCustom("%200,300{abc}"))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> AccessLogFormats.parseCustom("%200,30x{abc}"))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> AccessLogFormats.parseCustom("%200,300{abc"))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> AccessLogFormats.parseCustom("%x00,300{abc}"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void formatMessage() {
+        final DummyRequestContext ctx = new DummyRequestContext();
+        final DefaultRequestLog log = spy(new DefaultRequestLog(ctx));
+
+        ctx.attr(Attr.ATTR_KEY).set(new Attr("line"));
+
+        log.startRequest(channel, SessionProtocol.H2, "www.example.com");
+        log.requestHeaders(HttpHeaders.of(HttpMethod.GET, "/armeria/log")
+                                      .add(HttpHeaderNames.USER_AGENT, "armeria/x.y.z")
+                                      .add(HttpHeaderNames.REFERER, "http://log.example.com")
+                                      .add(HttpHeaderNames.COOKIE, "a=1;b=2"));
+        log.endRequest();
+        log.responseHeaders(HttpHeaders.of(HttpStatus.OK));
+        log.responseLength(1024);
+        log.endResponse();
+
+        // To generate the same datetime string always.
+        when(log.requestStartTimeMillis()).thenReturn(0L);
+
+        final String timestamp = dateTimeFormatter.format(ZonedDateTime.ofInstant(
+                Instant.ofEpochMilli(0), defaultZoneId));
+
+        String message;
+        List<AccessLogComponent> format;
+
+        message = AccessLogger.format(AccessLogFormats.COMMON, log);
+        assertThat(message).isEqualTo(
+                "- - - " + timestamp + " \"GET /armeria/log h2\" 200 1024");
+
+        message = AccessLogger.format(AccessLogFormats.COMBINED, log);
+        assertThat(message).isEqualTo(
+                "- - - " + timestamp + " \"GET /armeria/log h2\" 200 1024" +
+                " \"http://log.example.com\" \"armeria/x.y.z\" \"a=1;b=2\"");
+
+        // Check conditions with custom formats.
+        format = AccessLogFormats.parseCustom(
+                "%h %l %u %t \"%r\" %s %b \"%200,302{Referer}i\" \"%!200,304{User-Agent}i\"" +
+                " some-text %{Non-Existing-Header}i");
+
+        message = AccessLogger.format(format, log);
+        assertThat(message).isEqualTo(
+                "- - - " + timestamp + " \"GET /armeria/log h2\" 200 1024" +
+                " \"http://log.example.com\" \"-\" some-text -");
+
+        format = AccessLogFormats.parseCustom(
+                "%h %l %u %t \"%r\" %s %b \"%!200,302{Referer}i\" \"%200,304{User-Agent}i\"" +
+                " some-text %{Non-Existing-Header}i");
+        message = AccessLogger.format(format, log);
+        assertThat(message).isEqualTo(
+                "- - - " + timestamp + " \"GET /armeria/log h2\" 200 1024" +
+                " \"-\" \"armeria/x.y.z\" some-text -");
+
+        format = AccessLogFormats.parseCustom(
+                "%{com.linecorp.armeria.server.logging.AccessLogFormatsTest$Attr#KEY" +
+                ":com.linecorp.armeria.server.logging.AccessLogFormatsTest$AttributeStringfier}j");
+        message = AccessLogger.format(format, log);
+        assertThat(message).isEqualTo("(line)");
+
+        format = AccessLogFormats.parseCustom(
+                "%{com.linecorp.armeria.server.logging.AccessLogFormatsTest$Attr#KEY}j");
+        message = AccessLogger.format(format, log);
+        assertThat(message).isEqualTo("LINE");
+    }
+
+    private class DummyRequestContext extends NonWrappingRequestContext {
+        DummyRequestContext() {
+            super(NoopMeterRegistry.get(), SessionProtocol.HTTP,
+                  HttpMethod.GET, "/", null, HttpRequest.of(HttpMethod.GET, "/"));
+        }
+
+        @Override
+        public RequestContext newDerivedContext() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public EventLoop eventLoop() {
+            return channel.eventLoop();
+        }
+
+        @Override
+        protected Channel channel() {
+            return channel;
+        }
+
+        @Override
+        public RequestLog log() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public RequestLogBuilder logBuilder() {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    public static class Attr {
+        static final AttributeKey<Attr> ATTR_KEY = AttributeKey.valueOf(Attr.class, "KEY");
+
+        private final String member;
+
+        Attr(String member) {
+            this.member = member;
+        }
+
+        public String member() {
+            return member;
+        }
+
+        @Override
+        public String toString() {
+            return member().toUpperCase();
+        }
+    }
+
+    public static class AttributeStringfier implements Function<Attr, String> {
+        @Override
+        public String apply(Attr attr) {
+            return '(' + attr.member() + ')';
+        }
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/logging/AccessLoggerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/logging/AccessLoggerTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.logging;
+
+import static com.linecorp.armeria.server.logging.AccessLogger.escapeAndQuote;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class AccessLoggerTest {
+
+    @Test
+    public void testQuote() {
+        assertThat(escapeAndQuote(new StringBuilder(), "a").toString())
+                .isEqualTo("\"a\"");
+        assertThat(escapeAndQuote(new StringBuilder(), "\"a\"").toString())
+                .isEqualTo("\"\\\"a\\\"\"");
+        assertThat(escapeAndQuote(new StringBuilder(), "\\\"a\\\"").toString())
+                .isEqualTo("\"\\\"a\\\"\"");
+        assertThat(escapeAndQuote(new StringBuilder(), "\\\\\"a\\\\\"").toString())
+                .isEqualTo("\"\\\\\"a\\\\\"\"");
+        assertThat(escapeAndQuote(new StringBuilder(), "\"\\\"a\\\"\"").toString())
+                .isEqualTo("\"\\\"\\\"a\\\"\\\"\"");
+    }
+}

--- a/site/src/sphinx/server-access-log.rst
+++ b/site/src/sphinx/server-access-log.rst
@@ -1,0 +1,181 @@
+.. _ServerBuilder: apidocs/index.html?com/linecorp/armeria/server/ServerBuilder.html
+.. _`RequestLog`: apidocs/index.html?com/linecorp/armeria/common/logging/RequestLog.html
+
+.. _server-access-log:
+
+Writing an access log
+=====================
+
+Configuring logging framework
+-----------------------------
+
+To write an access log, you need to configure a logging framework first. The following configurations are
+simple examples of ``logback.xml`` and ``log4j2.xml`` respectively.
+
+logback
+^^^^^^^
+
+.. code-block:: xml
+
+    <configuration>
+      <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+          <pattern>%-4relative [%thread] %-5level %logger{35} - %msg%n</pattern>
+        </encoder>
+      </appender>
+
+      <appender name="ACCESS" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>access.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+          <!-- daily rollover -->
+          <fileNamePattern>access.%d{yyyy-MM-dd}-%i.log</fileNamePattern>
+          <!-- each file should be at most 1GB, keep 30 days worth of history, but at most 30GB -->
+          <maxFileSize>1GB</maxFileSize>
+          <maxHistory>30</maxHistory>
+          <totalSizeCap>30GB</totalSizeCap>
+        </rollingPolicy>
+        <encoder>
+          <pattern>%msg%n</pattern>
+        </encoder>
+      </appender>
+
+      <logger name="com.linecorp.armeria.logging.access" level="INFO" additivity="false">
+        <appender-ref ref="ACCESS"/>
+      </logger>
+
+      <root level="DEBUG">
+        <appender-ref ref="CONSOLE"/>
+      </root>
+    </configuration>
+
+
+log4j2
+^^^^^^
+
+.. code-block:: xml
+
+    <?xml version="1.0" encoding="UTF-8"?>
+    <Configuration status="WARN">
+      <Appenders>
+        <Console name="CONSOLE" target="SYSTEM_OUT">
+          <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </Console>
+        <RollingFile name="ACCESS" fileName="access.log" filePattern="access.%d{MM-dd-yyyy}-%i.log.gz">
+          <PatternLayout>
+            <Pattern>%m%n</Pattern>
+          </PatternLayout>
+
+          <Policies>
+            <!-- daily rollover -->
+            <TimeBasedTriggeringPolicy/>
+            <!-- each file should be at most 1GB -->
+            <SizeBasedTriggeringPolicy size="1GB"/>
+          </Policies>
+          <-- keep 30 archives -->
+          <DefaultRolloverStrategy max="30"/>
+        </RollingFile>
+      </Appenders>
+
+      <Loggers>
+        <Logger name="com.linecorp.armeria.logging.access" level="INFO" additivity="false">
+          <AppenderRef ref="ACCESS"/>
+        </Logger>
+        <Root level="DEBUG">
+          <AppenderRef ref="CONSOLE"/>
+        </Root>
+      </Loggers>
+    </Configuration>
+
+
+
+Customizing a log format
+------------------------
+
+Access logging is disabled by default. If you want to enable it, you need to specify an access log writer
+by `ServerBuilder`_. You may use one of the pre-defined log formats.
+
+.. code-block:: java
+
+    ServerBuilder sb = new ServerBuilder();
+    // Use NCSA common log format.
+    sb.accessLogWriter(AccessLogWriters.common());
+    // Use NCSA combined log format.
+    sb.accessLogWriter(AccessLogWriters.combined());
+    // Use your own log format.
+    sb.accessLogFormat("...log format...");
+    ...
+
+
+Pre-defined log formats are as follows.
+
++---------------+------------------------------------------------------------------------------------+
+| Name          | Format                                                                             |
++===============+====================================================================================+
+| common        | %h %l %u %t "%r" %s %b                                                             |
++---------------+------------------------------------------------------------------------------------+
+| combined      | %h %l %u %t "%r" %s %b "%{Referer}i" "%{User-Agent}i" "%{Cookie}i"                 |
++---------------+------------------------------------------------------------------------------------+
+
+Tokens for the log format are listed in the following table.
+
++---------------------------+-------------------+----------------------------------------------------+
+| Tokens                    | Condition support | Description                                        |
++===========================+===================+====================================================+
+| %h                        | No                | the remote hostname or IP address if DNS           |
+|                           |                   | hostname lookup is not available                   |
++---------------------------+-------------------+----------------------------------------------------+
+| %l                        | No                | the remote logname of the user                     |
+|                           |                   | (not supported yet, always write ``-``)            |
++---------------------------+-------------------+----------------------------------------------------+
+| %u                        | No                | the name of the authenticated remote user          |
+|                           |                   | (not supported yet, always write ``-``)            |
++---------------------------+-------------------+----------------------------------------------------+
+| %t                        | No                | the date, time and time zone that the request      |
+|                           |                   | was received, by default in ``strftime`` format    |
+|                           |                   | %d/%b/%Y:%H:%M:%S %z.                              |
+|                           |                   | (for example, ``10/Oct/2000:13:55:36 -0700``)      |
++---------------------------+-------------------+----------------------------------------------------+
+| %r                        | Yes               | the request line from the client                   |
+|                           |                   | (for example, ``GET /path h2``)                    |
++---------------------------+-------------------+----------------------------------------------------+
+| %s                        | No                | the HTTP status code returned to the client        |
++---------------------------+-------------------+----------------------------------------------------+
+| %b                        | Yes               | the size of the object returned to the client,     |
+|                           |                   | measured in bytes                                  |
++---------------------------+-------------------+----------------------------------------------------+
+| %{HEADER_NAME}i           | Yes               | the value of the specified HTTP request header     |
+|                           |                   | name                                               |
++---------------------------+-------------------+----------------------------------------------------+
+| %{ATTRIBUTE_NAME}j        | Yes               | the value of the specified attribute name          |
++---------------------------+-------------------+----------------------------------------------------+
+
+Some tokens can have a condition of the response status code and the log message can be omitted with
+the condition.
+
++---------------------------------------------------+------------------------------------------------+
+| Example of a condition                            | Description                                    |
++===================================================+================================================+
+| %200b                                             | Write the size of the object returned to the   |
+|                                                   | client only if the response code is ``200``.   |
++---------------------------------------------------+------------------------------------------------+
+| %200,304{User-Agent}i                             | Write ``User-Agent`` header value only if the  |
+|                                                   | response code is ``200`` or ``304``.           |
++---------------------------------------------------+------------------------------------------------+
+| %!200,304{com.example.armeria.Attribute#KEY}j     | Write the value of the specified attribute     |
+|                                                   | only if the response code is neither ``200``   |
+|                                                   | nor ``304``.                                   |
++---------------------------------------------------+------------------------------------------------+
+
+
+Customizing an access log writer
+--------------------------------
+
+You can specify your own log writer which implements Consumer<`RequestLog`_ >.
+
+.. code-block:: java
+
+    ServerBuilder sb = new ServerBuilder();
+    sb.accessLogWriter(requestLog -> {
+        // Write your access log with the given RequestLog instance.
+        ....
+    });

--- a/site/src/sphinx/server.rst
+++ b/site/src/sphinx/server.rst
@@ -14,3 +14,4 @@ Writing a server
     server-rest
     server-http-file
     server-servlet
+    server-access-log


### PR DESCRIPTION
Motivation:
Currently we cannot exactly write an access log for a server because our logging mechanism is based on a decorator and the decorator is only applied when a request is mapped to a service.
So it would be better to provide some access logging mechanism by a server itself, not a based on a decorator.

Modifications:
- Define log format types. Also provide a default log format such as NCSA common log format and NCSA combined log format.
- Add an interface to `ServerBuilder` to specify a log format and a log writer.
- Try to write an access log after a response has been sent.
- Add a site document.

Result:
Closes #817