### PR TITLE
Replace HttpVfs.toString() with HttpVfs.meterTag()

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/docs/DocService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/DocService.java
@@ -50,8 +50,8 @@ import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceConfig;
 import com.linecorp.armeria.server.VirtualHost;
 import com.linecorp.armeria.server.composition.AbstractCompositeService;
+import com.linecorp.armeria.server.file.AbstractHttpVfs;
 import com.linecorp.armeria.server.file.HttpFileService;
-import com.linecorp.armeria.server.file.HttpVfs;
 
 /**
  * An {@link HttpService} that provides information about the {@link Service}s running in a
@@ -296,13 +296,18 @@ public class DocService extends AbstractCompositeService<HttpRequest, HttpRespon
         return supportedServiceTypes.stream().anyMatch(type -> serviceCfg.service().as(type).isPresent());
     }
 
-    static final class DocServiceVfs implements HttpVfs {
+    static final class DocServiceVfs extends AbstractHttpVfs {
 
         private volatile Entry entry = Entry.NONE;
 
         @Override
         public Entry get(String path, @Nullable String contentEncoding) {
             return entry;
+        }
+
+        @Override
+        public String meterTag() {
+            return DocService.class.getSimpleName();
         }
 
         void setSpecification(byte[] content) {

--- a/core/src/main/java/com/linecorp/armeria/server/file/AbstractHttpVfs.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/AbstractHttpVfs.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.file;
+
+/**
+ * A skeletal {@link HttpVfs} implementation.
+ */
+public abstract class AbstractHttpVfs implements HttpVfs {
+
+    /**
+     * Returns the {@link #meterTag()} of this {@link HttpVfs}.
+     */
+    @Override
+    public String toString() {
+        return meterTag();
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/file/ClassPathHttpVfs.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/ClassPathHttpVfs.java
@@ -28,7 +28,7 @@ import javax.annotation.Nullable;
 
 import com.linecorp.armeria.common.HttpData;
 
-final class ClassPathHttpVfs implements HttpVfs {
+final class ClassPathHttpVfs extends AbstractHttpVfs {
 
     private final ClassLoader classLoader;
     private final String rootDir;
@@ -78,7 +78,7 @@ final class ClassPathHttpVfs implements HttpVfs {
     }
 
     @Override
-    public String toString() {
+    public String meterTag() {
         return "classpath:" + rootDir;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/file/FileSystemHttpVfs.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/FileSystemHttpVfs.java
@@ -29,7 +29,7 @@ import javax.annotation.Nullable;
 
 import com.linecorp.armeria.common.HttpData;
 
-final class FileSystemHttpVfs implements HttpVfs {
+final class FileSystemHttpVfs extends AbstractHttpVfs {
 
     private static final boolean FILE_SEPARATOR_IS_NOT_SLASH = File.separatorChar != '/';
 
@@ -58,7 +58,7 @@ final class FileSystemHttpVfs implements HttpVfs {
     }
 
     @Override
-    public String toString() {
+    public String meterTag() {
         return "file:" + rootDir;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/file/HttpFileService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/HttpFileService.java
@@ -127,7 +127,7 @@ public final class HttpFileService extends AbstractHttpService {
                     new MeterIdPrefix("armeria.server.file.vfsCache",
                                       "hostnamePattern", cfg.virtualHost().hostnamePattern(),
                                       "pathMapping", cfg.pathMapping().meterTag(),
-                                      "rootDir", config.vfs().toString()),
+                                      "vfs", config.vfs().meterTag()),
                     cache);
         }
     }

--- a/core/src/main/java/com/linecorp/armeria/server/file/HttpVfs.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/HttpVfs.java
@@ -30,10 +30,12 @@ import javax.annotation.Nullable;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.MediaType;
 
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Tag;
+
 /**
  * A virtual file system that provides the files requested by {@link HttpFileService}.
  */
-@FunctionalInterface
 public interface HttpVfs {
 
     /**
@@ -75,6 +77,11 @@ public interface HttpVfs {
      *         {@link Entry#NONE} if not found.
      */
     Entry get(String path, @Nullable String contentEncoding);
+
+    /**
+     * Returns the value of the {@code "vfs"} {@link Tag} in a {@link Meter}.
+     */
+    String meterTag();
 
     /**
      * A file entry in an {@link HttpVfs}.


### PR DESCRIPTION
Motivation:

Using toString() as a way to get the specific information is not a good
idea in general since toString() always has the default implementation.

Modifications:

- Add HttpVfs.meterTag()
  - HttpVfs is not a functional interface anymore.
- Add AbstractHttpVfs which overrides toString()
- Rename the 'rootDir' tag to 'vfs'

Result:

- Fixes #893
- HttpVfs is not a functional interface anymore due to the addition of
  meterTag()
- Tag name has been changed from 'rootDir' to 'vfs'.