### PR TITLE
Extract common logic for async benchmarks and allow running HttpServe…

### DIFF
--- a/benchmarks/src/jmh/java/com/linecorp/armeria/shared/AsyncCounters.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/shared/AsyncCounters.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.shared;
+
+import static org.awaitility.Awaitility.await;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.openjdk.jmh.annotations.AuxCounters;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+
+/**
+ * Counters useful for measuring asynchronous requests. It is important for users to call
+ * {@link #incrementCurrentRequests()} and {@link #decrementCurrentRequests()} at beginning and end of a
+ * request to make sure all requests are completed before moving onto the next benchmark iteration.
+ */
+@AuxCounters
+@State(Scope.Thread)
+public class AsyncCounters {
+    private AtomicLong numSuccesses = new AtomicLong();
+    private AtomicLong numFailures = new AtomicLong();
+    private AtomicLong currentRequests = new AtomicLong();
+
+    private volatile boolean waiting;
+
+    public void incrementNumSuccesses() {
+        if (!waiting) {
+            numSuccesses.incrementAndGet();
+        }
+    }
+
+    public void incrementNumFailures() {
+        if (!waiting) {
+            numFailures.incrementAndGet();
+        }
+    }
+
+    public void incrementCurrentRequests() {
+        currentRequests.incrementAndGet();
+    }
+
+    public void decrementCurrentRequests() {
+        currentRequests.decrementAndGet();
+    }
+
+    public long numSuccesses() {
+        return numSuccesses.get();
+    }
+
+    public long numFailures() {
+        return numFailures.get();
+    }
+
+    public long currentRequests() {
+        return currentRequests.get();
+    }
+
+    @Setup(Level.Iteration)
+    public void reset() {
+        waiting = false;
+        numSuccesses.set(0);
+        numFailures.set(0);
+        currentRequests.set(0);
+    }
+
+    @TearDown(Level.Iteration)
+    public void waitForCurrentRequests() {
+        waiting = true;
+        await().forever().until(() -> currentRequests.get() == 0);
+    }
+}


### PR DESCRIPTION
…rBenchmark with H1C too.

Immediately noticed that this level of DoS with an HTTP/1 client immediately causes `Too many open files`. I expected the files to be restricted to the number of event loops, but if not, then there needs to be a cap of some sort. Anyways, investigating that is for another PR wanted to get this cleanup / tweak in so others can try it out.

Disables request timeout and metrics too to better isolate performance.

```
19:52:20.421 [armeria-boss-http-*:35689] WARN  i.n.channel.DefaultChannelPipeline - An exceptionCaught() event was fired, and it reached at the tail of the pipeline. It usually means the last handler in the pipeline did not handle the exception.
io.netty.channel.unix.Errors$NativeIoException: accept(..) failed: Too many open files
        at io.netty.channel.unix.Errors.newIOException(Errors.java:117)
        at io.netty.channel.unix.Socket.accept(Socket.java:314)
        at io.netty.channel.epoll.AbstractEpollServerChannel$EpollServerSocketUnsafe.epollInReady(AbstractEpollServerChannel.java:112)
        at io.netty.channel.epoll.EpollEventLoop.processReady(EpollEventLoop.java:404)
        at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:304)
        at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:858)
        at java.lang.Thread.run(Thread.java:748)
19:52:21.421 [armeria-boss-http-*:35689] WARN  i.n.channel.DefaultChannelPipeline - An exceptionCaught() event was fired, and it reached at the tail of the pipeline. It usually means the last handler in the pipeline did not handle the exception.
io.netty.channel.unix.Errors$NativeIoException: accept(..) failed: Too many open files
        at io.netty.channel.unix.Errors.newIOException(Errors.java:117)
        at io.netty.channel.unix.Socket.accept(Socket.java:314)
        at io.netty.channel.epoll.AbstractEpollServerChannel$EpollServerSocketUnsafe.epollInReady(AbstractEpollServerChannel.java:112)
        at io.netty.channel.epoll.EpollEventLoop.processReady(EpollEventLoop.java:404)
        at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:304)
        at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:858)
        at java.lang.Thread.run(Thread.java:748)
```