### PR TITLE
Add addChild method to RequestLogBuilder

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/Http1ResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http1ResponseDecoder.java
@@ -74,12 +74,18 @@ final class Http1ResponseDecoder extends HttpResponseDecoder implements ChannelI
                 super.addResponse(id, req, res, logBuilder, responseTimeoutMillis, maxContentLength);
 
         resWrapper.completionFuture().whenComplete((unused, cause) -> {
-            // Ensure that the scheduled timeout is not executed.
-            resWrapper.cancelTimeout();
             if (cause != null) {
+                // Ensure that the resWrapper is closed.
+                // This is needed in case the response is aborted by the client.
+                resWrapper.close(cause);
+
                 // Disconnect when the response has been closed with an exception because there's no way
                 // to recover from it in HTTP/1.
                 channel().close();
+            } else {
+                // Ensure that the resWrapper is closed.
+                // This is needed in case the response is aborted by the client.
+                resWrapper.close();
             }
         });
 

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
@@ -82,9 +82,17 @@ public abstract class RetryingClient<I extends Request, O extends Response>
      */
     protected final O executeDelegate(ClientRequestContext ctx, I req) throws Exception {
         final ClientRequestContext derivedContext = ctx.newDerivedContext();
+        ctx.logBuilder().addChild(derivedContext.log());
         try (SafeCloseable ignore = RequestContext.push(derivedContext, false)) {
             return delegate().execute(derivedContext, req);
         }
+    }
+
+    /**
+     * This should be called when retrying is finished.
+     */
+    protected static void onRetryingComplete(ClientRequestContext ctx) {
+        ctx.logBuilder().endResponseWithLastChild();
     }
 
     protected RetryStrategy<I, O> retryStrategy() {

--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.common.logging;
 
+import static com.google.common.base.Preconditions.checkState;
 import static com.linecorp.armeria.common.logging.RequestLogAvailability.COMPLETE;
 import static com.linecorp.armeria.common.logging.RequestLogAvailability.REQUEST_CONTENT;
 import static com.linecorp.armeria.common.logging.RequestLogAvailability.REQUEST_END;
@@ -64,6 +65,9 @@ public class DefaultRequestLog implements RequestLog, RequestLogBuilder {
 
     private final RequestContext ctx;
 
+    private List<RequestLog> children;
+    private boolean hasLastChild;
+
     /**
      * Updated by {@link #flagsUpdater}.
      */
@@ -107,6 +111,121 @@ public class DefaultRequestLog implements RequestLog, RequestLogBuilder {
      */
     public DefaultRequestLog(RequestContext ctx) {
         this.ctx = requireNonNull(ctx, "ctx");
+    }
+
+    @Override
+    public void addChild(RequestLog child) {
+        checkState(!hasLastChild, "last child is already added");
+        requireNonNull(child, "child");
+        if (children == null) {
+            // first child's all request-side logging events are propagated immediately to the parent
+            children = new ArrayList<>();
+            propagateRequestSideLog(child);
+        }
+        children.add(child);
+    }
+
+    private void propagateRequestSideLog(RequestLog child) {
+        child.addListener(log -> {
+            final long requestStartTimeNanos;
+            final long requestStartTimeMillis;
+            if (log instanceof DefaultRequestLog) {
+                requestStartTimeNanos = ((DefaultRequestLog) log).requestStartTimeNanos;
+                requestStartTimeMillis = log.requestStartTimeMillis();
+            } else {
+                requestStartTimeNanos = System.nanoTime();
+                requestStartTimeMillis = System.currentTimeMillis();
+            }
+            startRequest0(requestStartTimeNanos, requestStartTimeMillis, log.channel(),
+                          log.sessionProtocol(), log.host(), true);
+        }, REQUEST_START);
+        child.addListener(log -> serializationFormat(log.serializationFormat()), SCHEME);
+        child.addListener(log -> requestHeaders(log.requestHeaders()), REQUEST_HEADERS);
+        child.addListener(log -> requestContent(log.requestContent(), log.rawRequestContent()),
+                          REQUEST_CONTENT);
+        child.addListener(log -> {
+            final long requestEndTimeNanos;
+            if (log instanceof DefaultRequestLog) {
+                requestEndTimeNanos = ((DefaultRequestLog) log).requestEndTimeNanos;
+            } else {
+                requestEndTimeNanos = System.nanoTime();
+            }
+
+            if (log.requestCause() != null) {
+                endRequest0(requestEndTimeNanos, log.requestCause());
+            } else {
+                endRequest0(requestEndTimeNanos, null);
+            }
+        }, REQUEST_END);
+    }
+
+    @Override
+    public void endResponseWithLastChild() {
+        checkState(!hasLastChild, "last child is already added");
+        checkState(!children.isEmpty(), "at least one child should be already added");
+        hasLastChild = true;
+        final RequestLog lastChild = children.get(children.size() - 1);
+        propagateResponseSideLog(lastChild);
+    }
+
+    private void propagateResponseSideLog(RequestLog lastChild) {
+        // update the available logs if the lastChild already has them
+        if (lastChild.isAvailable(RequestLogAvailability.RESPONSE_START)) {
+            startResponseFrom(lastChild);
+        }
+
+        if (lastChild.isAvailable(RequestLogAvailability.RESPONSE_HEADERS)) {
+            responseHeadersFrom(lastChild);
+        }
+
+        if (lastChild.isAvailable(RequestLogAvailability.RESPONSE_CONTENT)) {
+            responseContentFrom(lastChild);
+        }
+
+        if (lastChild.isAvailable(RequestLogAvailability.RESPONSE_END)) {
+            endResponseFrom(lastChild);
+        }
+
+        lastChild.addListener(this::startResponseFrom, RESPONSE_START);
+        lastChild.addListener(this::responseHeadersFrom, RESPONSE_HEADERS);
+        lastChild.addListener(this::responseContentFrom, RESPONSE_CONTENT);
+        lastChild.addListener(this::endResponseFrom, RESPONSE_END);
+    }
+
+    private void startResponseFrom(RequestLog log) {
+        if (log instanceof DefaultRequestLog) {
+            startResponse0(((DefaultRequestLog) log).responseStartTimeNanos,
+                           log.responseStartTimeMillis(), true);
+        } else {
+            startResponse();
+        }
+    }
+
+    private void responseHeadersFrom(RequestLog log) {
+        if (log.responseHeaders() != HttpHeaders.EMPTY_HEADERS) {
+            responseHeaders(log.responseHeaders());
+        }
+    }
+
+    private void responseContentFrom(RequestLog log) {
+        if (log.responseContent() != null) {
+            responseContent(log.responseContent(), log.rawResponseContent());
+        }
+    }
+
+    private void endResponseFrom(RequestLog log) {
+        final long responseEndTimeNanos;
+        if (log instanceof DefaultRequestLog) {
+            responseEndTimeNanos = ((DefaultRequestLog) log).responseEndTimeNanos;
+        } else {
+            responseEndTimeNanos = System.nanoTime();
+        }
+
+        if (log.responseCause() != null) {
+            endResponse0(responseEndTimeNanos, log.responseCause());
+        } else {
+            endResponse0(responseEndTimeNanos, null);
+        }
     }
 
     @Override
@@ -214,13 +333,18 @@ public class DefaultRequestLog implements RequestLog, RequestLogBuilder {
 
     private void startRequest0(Channel channel, SessionProtocol sessionProtocol,
                                String host, boolean updateAvailability) {
+        startRequest0(System.nanoTime(), System.currentTimeMillis(), channel, sessionProtocol, host,
+                      updateAvailability);
+    }
 
+    private void startRequest0(long requestStartTimeNanos, long requestStartTimeMillis, Channel channel,
+                               SessionProtocol sessionProtocol, String host, boolean updateAvailability) {
         if (isAvailabilityAlreadyUpdated(REQUEST_START)) {
             return;
         }
 
-        requestStartTimeNanos = System.nanoTime();
-        requestStartTimeMillis = System.currentTimeMillis();
+        this.requestStartTimeNanos = requestStartTimeNanos;
+        this.requestStartTimeMillis = requestStartTimeMillis;
         this.channel = channel;
         this.sessionProtocol = sessionProtocol;
         this.host = host;
@@ -383,14 +507,22 @@ public class DefaultRequestLog implements RequestLog, RequestLogBuilder {
     }
 
     private void endRequest0(Throwable requestCause) {
+        endRequest0(System.nanoTime(), requestCause);
+    }
+
+    private void endRequest0(long requestEndTimeNanos, Throwable requestCause) {
         final int flags = requestCause == null && requestContentDeferred ? FLAGS_REQUEST_END_WITHOUT_CONTENT
                                                                          : REQUEST_END.setterFlags();
         if (isAvailable(flags)) {
             return;
         }
 
-        startRequest0(null, context().sessionProtocol(), null, false);
-        requestEndTimeNanos = System.nanoTime();
+        // if the request is not started yet, call startRequest() with requestEndTimeNanos so that
+        // totalRequestDuration will be 0
+        startRequest0(requestEndTimeNanos, System.currentTimeMillis(), null,
+                      context().sessionProtocol(), null, false);
+
+        this.requestEndTimeNanos = requestEndTimeNanos;
         this.requestCause = requestCause;
         updateAvailability(flags);
     }
@@ -401,12 +533,17 @@ public class DefaultRequestLog implements RequestLog, RequestLogBuilder {
     }
 
     private void startResponse0(boolean updateAvailability) {
+        startResponse0(System.nanoTime(), System.currentTimeMillis(), updateAvailability);
+    }
+
+    private void startResponse0(long responseStartTimeNanos, long responseStartTimeMillis,
+                                boolean updateAvailability) {
         if (isAvailabilityAlreadyUpdated(RESPONSE_START)) {
             return;
         }
 
-        responseStartTimeNanos = System.nanoTime();
-        responseStartTimeMillis = System.currentTimeMillis();
+        this.responseStartTimeNanos = responseStartTimeNanos;
+        this.responseStartTimeMillis = responseStartTimeMillis;
         if (updateAvailability) {
             updateAvailability(RESPONSE_START);
         }
@@ -530,14 +667,21 @@ public class DefaultRequestLog implements RequestLog, RequestLogBuilder {
     }
 
     private void endResponse0(Throwable responseCause) {
+        endResponse0(System.nanoTime(), responseCause);
+    }
+
+    private void endResponse0(long responseEndTimeNanos, Throwable responseCause) {
         final int flags = responseCause == null && responseContentDeferred ? FLAGS_RESPONSE_END_WITHOUT_CONTENT
                                                                            : RESPONSE_END.setterFlags();
         if (isAvailable(flags)) {
             return;
         }
 
-        startResponse0(false);
-        responseEndTimeNanos = System.nanoTime();
+        // if the response is not started yet, call startResponse() with responseEndTimeNanos so that
+        // totalResponseDuration will be 0
+        startResponse0(responseEndTimeNanos, System.currentTimeMillis(), false);
+
+        this.responseEndTimeNanos = responseEndTimeNanos;
         this.responseCause = responseCause;
         updateAvailability(flags);
     }
@@ -612,13 +756,28 @@ public class DefaultRequestLog implements RequestLog, RequestLogBuilder {
     public String toString() {
         final String req = toStringRequestOnly();
         final String res = toStringResponseOnly();
+
+        // Create a StringBuilder with the initial capacity not considering the children's log length.
+        // The children will be empty in most of the cases, so it is OK.
         final StringBuilder buf = new StringBuilder(5 + req.length() + 6 + res.length() + 1);
-        return buf.append("{req=")  // 5 chars
-                  .append(req)
-                  .append(", res=") // 6 chars
-                  .append(res)
-                  .append('}')      // 1 char
-                  .toString();
+        buf.append("{req=")  // 5 chars
+           .append(req)
+           .append(", res=") // 6 chars
+           .append(res)
+           .append('}');      // 1 char
+        if (children != null && children.size() > 1) {
+            buf.append(", {totalAttempts=");
+            buf.append(children.size());
+            buf.append("}[");
+            for (int i = 0; i < children.size(); i++) {
+                buf.append(children.get(i));
+                if (i != children.size() - 1) {
+                    buf.append(", ");
+                }
+            }
+            buf.append(']');
+        }
+        return buf.toString();
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/logging/NoopRequestLogBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/NoopRequestLogBuilder.java
@@ -25,6 +25,12 @@ import io.netty.channel.Channel;
 final class NoopRequestLogBuilder implements RequestLogBuilder {
 
     @Override
+    public void addChild(RequestLog child) {}
+
+    @Override
+    public void endResponseWithLastChild() {}
+
+    @Override
     public void startRequest(Channel ch, SessionProtocol sessionProtocol, String host) {}
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestLog.java
@@ -180,6 +180,22 @@ public interface RequestLog {
     long requestStartTimeMillis();
 
     /**
+     * Returns the time when the processing of the request started, in nanoseconds. This value can only be
+     * used to measure elapsed time and is not related to any other notion of system or wall-clock time.
+     *
+     * @throws RequestLogAvailabilityException if this property is not available yet
+     */
+    long requestStartTimeNanos();
+
+    /**
+     * Returns the time when the processing of the request finished, in nanoseconds. This value can only be
+     * used to measure elapsed time and is not related to any other notion of system or wall-clock time.
+     *
+     * @throws RequestLogAvailabilityException if this property is not available yet
+     */
+    long requestEndTimeNanos();
+
+    /**
      * Returns the duration that was taken to consume or produce the request completely, in nanoseconds.
      *
      * @throws RequestLogAvailabilityException if this property is not available yet
@@ -208,6 +224,22 @@ public interface RequestLog {
      * @throws RequestLogAvailabilityException if this property is not available yet
      */
     long responseStartTimeMillis();
+
+    /**
+     * Returns the time when the processing of the response started, in nanoseconds. This value can only be
+     * used to measure elapsed time and is not related to any other notion of system or wall-clock time.
+     *
+     * @throws RequestLogAvailabilityException if this property is not available yet
+     */
+    long responseStartTimeNanos();
+
+    /**
+     * Returns the time when the processing of the response finished, in nanoseconds. This value can only be
+     * used to measure elapsed time and is not related to any other notion of system or wall-clock time.
+     *
+     * @throws RequestLogAvailabilityException if this property is not available yet
+     */
+    long responseEndTimeNanos();
 
     /**
      * Returns the duration that was taken to consume or produce the response completely, in nanoseconds.

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogBuilder.java
@@ -36,6 +36,19 @@ public interface RequestLogBuilder {
      */
     RequestLogBuilder NOOP = new NoopRequestLogBuilder();
 
+    /**
+     * Adds the specified {@link RequestLog} so that the logs are propagated from the {@code child}.
+     * Note that only the request-side logs of the first added child will be propagated. To fill the
+     * response-side logs you need to call {@link #endResponseWithLastChild()}.
+     */
+    void addChild(RequestLog child);
+
+    /**
+     * Fills the response-side logs from the last added child. Note that already fulfilled
+     * {@link RequestLogAvailability}s in the child log will be propagated immediately.
+     */
+    void endResponseWithLastChild();
+
     // Methods related with a request:
 
     /**

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientWithLoggingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientWithLoggingTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.retry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.linecorp.armeria.client.Client;
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.client.HttpClientBuilder;
+import com.linecorp.armeria.client.SimpleDecoratingClient;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpResponseWriter;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.logging.RequestLog;
+import com.linecorp.armeria.common.logging.RequestLogAvailability;
+import com.linecorp.armeria.common.logging.RequestLogAvailabilityException;
+import com.linecorp.armeria.common.logging.RequestLogListener;
+import com.linecorp.armeria.server.AbstractHttpService;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.testing.server.ServerRule;
+
+public class RetryingClientWithLoggingTest {
+
+    @Rule
+    public final ServerRule server = new ServerRule() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.service("/hello", new AbstractHttpService() {
+                final AtomicInteger reqCount = new AtomicInteger();
+
+                @Override
+                protected void doGet(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res)
+                        throws Exception {
+                    if (reqCount.getAndIncrement() < 2) {
+                        res.respond(HttpStatus.INTERNAL_SERVER_ERROR);
+                    } else {
+                        res.respond(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "hello");
+                    }
+                }
+            });
+        }
+    };
+
+    private final RequestLogListener listener = new RequestLogListener() {
+        @Override
+        public void onRequestLog(RequestLog log) throws Exception {
+            logResult.add(log);
+            final int index = logIndex.getAndIncrement();
+            if (index % 2 == 0) {
+                assertRequestSideLog(log);
+            } else {
+                assertResponseSideLog(log, index == successLogIndex);
+            }
+        }
+    };
+
+    private final AtomicInteger logIndex = new AtomicInteger();
+    private int successLogIndex;
+    private final List<RequestLog> logResult = new ArrayList<>();
+
+    @Before
+    public void init() {
+        logIndex.set(0);
+        logResult.clear();
+    }
+
+    // HttpClient -> RetryingClient -> LoggingClient -> HttpClientDelegate
+    // In this case, all of the requests and responses are logged.
+    @Test
+    public void retryingThenLogging() {
+        successLogIndex = 5;
+        final HttpClient client = new HttpClientBuilder(server.uri("/"))
+                .decorator(loggingDecorator())
+                .decorator(RetryingHttpClient.newDecorator(RetryStrategy.onServerErrorStatus()))
+                .build();
+        assertThat(client.get("/hello").aggregate().join().content().toStringUtf8()).isEqualTo("hello");
+
+        // wait until 6 logs(3 requests and 3 responses) are called back
+        await().untilAsserted(() -> assertThat(logResult.size()).isEqualTo(successLogIndex + 1));
+    }
+
+    // HttpClient -> LoggingClient -> RetryingClient -> HttpClientDelegate
+    // In this case, only the first request and the last response are logged.
+    @Test
+    public void loggingThenRetrying() throws Exception {
+        successLogIndex = 1;
+        final HttpClient client = new HttpClientBuilder(server.uri("/"))
+                .decorator(RetryingHttpClient.newDecorator(RetryStrategy.onServerErrorStatus()))
+                .decorator(loggingDecorator())
+                .build();
+        assertThat(client.get("/hello").aggregate().join().content().toStringUtf8()).isEqualTo("hello");
+
+        // wait until 2 logs are called back
+        await().untilAsserted(() -> assertThat(logResult.size()).isEqualTo(successLogIndex + 1));
+
+        // toStringRequestOnly() is same in the request log and the response log
+        assertThat(logResult.get(0).toStringRequestOnly()).isEqualTo(logResult.get(1).toStringRequestOnly());
+    }
+
+    private Function<Client<HttpRequest, HttpResponse>, Client<HttpRequest, HttpResponse>>
+    loggingDecorator() {
+        return delegate -> new SimpleDecoratingClient<HttpRequest, HttpResponse>(delegate) {
+            @Override
+            public HttpResponse execute(ClientRequestContext ctx, HttpRequest req) throws Exception {
+                ctx.log().addListener(listener, RequestLogAvailability.REQUEST_END);
+                ctx.log().addListener(listener, RequestLogAvailability.COMPLETE);
+                return delegate().execute(ctx, req);
+            }
+        };
+    }
+
+    private static void assertRequestSideLog(RequestLog log) {
+        assertThat(log.requestHeaders()).isNotNull();
+        assertThat(log.requestHeaders().path()).isEqualTo("/hello");
+
+        assertThat(log.toStringResponseOnly()).isEqualTo("{}"); // empty response
+        assertThatThrownBy(log::responseStartTimeMillis).isInstanceOf(RequestLogAvailabilityException.class);
+    }
+
+    private static void assertResponseSideLog(RequestLog log, boolean success) {
+        assertThat(log.requestHeaders()).isNotNull();
+        assertThat(log.responseHeaders()).isNotNull();
+
+        assertThat(log.responseHeaders().status()).isEqualTo(success ? HttpStatus.OK
+                                                                     : HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/common/logging/DefaultRequestLogTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/logging/DefaultRequestLogTest.java
@@ -101,7 +101,6 @@ public class DefaultRequestLogTest {
         final DefaultRequestLog child = new DefaultRequestLog(ctx);
         log.addChild(child);
         child.startRequest(channel, SessionProtocol.H2C, "/example.com");
-        final long childStartTime = child.requestStartTimeMillis();
         assertThat(log.requestStartTimeMillis()).isEqualTo(child.requestStartTimeMillis());
         assertThat(log.channel()).isSameAs(channel);
         assertThat(log.sessionProtocol()).isSameAs(SessionProtocol.H2C);

--- a/core/src/test/java/com/linecorp/armeria/common/logging/DefaultRequestLogTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/logging/DefaultRequestLogTest.java
@@ -17,6 +17,7 @@
 package com.linecorp.armeria.common.logging;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -25,8 +26,15 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
+import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.RpcResponse;
+import com.linecorp.armeria.common.SerializationFormat;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.testing.internal.AnticipatedException;
+
+import io.netty.channel.Channel;
+import io.netty.util.AsciiString;
 
 public class DefaultRequestLogTest {
 
@@ -36,6 +44,9 @@ public class DefaultRequestLogTest {
     @Mock
     private RequestContext ctx;
 
+    @Mock
+    private Channel channel;
+
     private DefaultRequestLog log;
 
     @Before
@@ -44,8 +55,16 @@ public class DefaultRequestLogTest {
     }
 
     @Test
+    public void endRequestSuccess() {
+        log.endRequest();
+        assertThat(log.requestDurationNanos()).isZero();
+        assertThat(log.requestCause()).isNull();
+    }
+
+    @Test
     public void endResponseSuccess() {
         log.endResponse();
+        assertThat(log.responseDurationNanos()).isZero();
         assertThat(log.responseCause()).isNull();
     }
 
@@ -53,6 +72,7 @@ public class DefaultRequestLogTest {
     public void endResponseFailure() {
         Throwable error = new Throwable("response failed");
         log.endResponse(error);
+        assertThat(log.responseDurationNanos()).isZero();
         assertThat(log.responseCause()).isSameAs(error);
     }
 
@@ -62,6 +82,7 @@ public class DefaultRequestLogTest {
         log.responseContent(RpcResponse.ofFailure(error), null);
         // If user code doesn't call endResponse, the framework automatically does with no cause.
         log.endResponse();
+        assertThat(log.responseDurationNanos()).isZero();
         assertThat(log.responseCause()).isSameAs(error);
     }
 
@@ -71,6 +92,60 @@ public class DefaultRequestLogTest {
         Throwable error2 = new Throwable("response failed a different way?");
         log.responseContent(RpcResponse.ofFailure(error), null);
         log.endResponse(error2);
+        assertThat(log.responseDurationNanos()).isZero();
         assertThat(log.responseCause()).isSameAs(error2);
+    }
+
+    @Test
+    public void addChild() {
+        final DefaultRequestLog child = new DefaultRequestLog(ctx);
+        log.addChild(child);
+        child.startRequest(channel, SessionProtocol.H2C, "/example.com");
+        final long childStartTime = child.requestStartTimeMillis();
+        assertThat(log.requestStartTimeMillis()).isEqualTo(child.requestStartTimeMillis());
+        assertThat(log.channel()).isSameAs(channel);
+        assertThat(log.sessionProtocol()).isSameAs(SessionProtocol.H2C);
+        assertThat(log.host()).isEqualTo("/example.com");
+
+        child.serializationFormat(SerializationFormat.NONE);
+        assertThat(log.serializationFormat()).isSameAs(SerializationFormat.NONE);
+
+        final HttpHeaders foo = HttpHeaders.of(AsciiString.of("foo"), "foo");
+        child.requestHeaders(foo);
+        assertThat(log.requestHeaders()).isSameAs(foo);
+
+        final String requestContent = "baz";
+        final String rawRequestContent = "bax";
+
+        child.requestContent(requestContent, rawRequestContent);
+        assertThat(log.requestContent()).isSameAs(requestContent);
+        assertThat(log.rawRequestContent()).isSameAs(rawRequestContent);
+
+        child.endRequest();
+        assertThat(log.requestDurationNanos()).isEqualTo(child.requestDurationNanos());
+
+        // response-side log are propagated when RequestLogBuilder.endResponseWithLastChild() is invoked
+        child.startResponse();
+        assertThatThrownBy(() -> log.responseStartTimeMillis())
+                .isExactlyInstanceOf(RequestLogAvailabilityException.class);
+
+        final HttpHeaders bar = HttpHeaders.of(AsciiString.of("bar"), "bar");
+        child.responseHeaders(bar);
+        assertThatThrownBy(() -> log.responseHeaders())
+                .isExactlyInstanceOf(RequestLogAvailabilityException.class);
+
+        log.endResponseWithLastChild();
+        assertThat(log.responseStartTimeMillis()).isEqualTo(child.responseStartTimeMillis());
+        assertThat(log.responseHeaders()).isSameAs(bar);
+
+        final String responseContent = "baz1";
+        final String rawResponseContent = "bax1";
+        child.responseContent(responseContent, rawResponseContent);
+        assertThat(log.responseContent()).isSameAs(responseContent);
+        assertThat(log.rawResponseContent()).isSameAs(rawResponseContent);
+
+        child.endResponse(new AnticipatedException("Oops!"));
+        assertThat(log.responseDurationNanos()).isEqualTo(child.responseDurationNanos());
+        assertThat(log.totalDurationNanos()).isEqualTo(child.totalDurationNanos());
     }
 }


### PR DESCRIPTION
Motivation:
`RetryingClient` could not record the logs properly.

Modifications:
- Add `addChild` to `RequestLogBuilder` to propagate the logs from child

Result:
- Close #869