### PR TITLE
Disables http1 pipelining by default

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -132,7 +132,7 @@ public final class Flags {
                    value -> value >= 0);
 
     private static final boolean DEFAULT_USE_HTTP2_PREFACE = getBoolean("defaultUseHttp2Preface", false);
-    private static final boolean DEFAULT_USE_HTTP1_PIPELINING = getBoolean("defaultUseHttp1Pipelining", true);
+    private static final boolean DEFAULT_USE_HTTP1_PIPELINING = getBoolean("defaultUseHttp1Pipelining", false);
 
     private static final String DEFAULT_DEFAULT_BACKOFF_SPEC =
             "exponential=200:10000,jitter=0.2,maxAttempts=10";
@@ -373,7 +373,7 @@ public final class Flags {
      * Returns the default value of the {@link ClientFactoryBuilder#useHttp1Pipelining(boolean)} option.
      * Note that this value has effect only if a user did not specify it.
      *
-     * <p>This flag is enabled by default. Specify the
+     * <p>This flag is disabled by default. Specify the
      * {@code -Dcom.linecorp.armeria.defaultUseHttp1Pipelining=false} JVM option to disable it.
      */
     public static boolean defaultUseHttp1Pipelining() {

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -374,7 +374,7 @@ public final class Flags {
      * Note that this value has effect only if a user did not specify it.
      *
      * <p>This flag is disabled by default. Specify the
-     * {@code -Dcom.linecorp.armeria.defaultUseHttp1Pipelining=false} JVM option to disable it.
+     * {@code -Dcom.linecorp.armeria.defaultUseHttp1Pipelining=true} JVM option to enable it.
      */
     public static boolean defaultUseHttp1Pipelining() {
         return DEFAULT_USE_HTTP1_PIPELINING;


### PR DESCRIPTION
Most http clients including modern http browser does not enable
http1 pipelining by default because many http servers are still
do not works well with it. For this reason, disabling http1 pipelining
by default.

Related to #897 
