### PR TITLE
Have DeferredStreamMessage manage the stream instead of just forwarding.

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/stream/DeferredStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/DeferredStreamMessage.java
@@ -18,15 +18,17 @@ package com.linecorp.armeria.common.stream;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
 import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
 
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.util.CompletionActions;
 
 import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.concurrent.ImmediateEventExecutor;
 
 /**
  * A {@link StreamMessage} whose stream is published later by another {@link StreamMessage}. It is useful when
@@ -34,28 +36,34 @@ import io.netty.util.concurrent.EventExecutor;
  *
  * @param <T> the type of element signaled
  */
-public class DeferredStreamMessage<T> implements StreamMessage<T> {
+public class DeferredStreamMessage<T> extends AbstractStreamMessage<T> {
 
-    private static final PendingSubscription<Object> NO_OP_ALREADY_SUBSCRIBED =
-            new PendingSubscription<>(null, null, false);
+    @SuppressWarnings("rawtypes")
+    private static final AtomicReferenceFieldUpdater<DeferredStreamMessage, SubscriptionImpl>
+            subscriptionUpdater = AtomicReferenceFieldUpdater.newUpdater(
+            DeferredStreamMessage.class, SubscriptionImpl.class, "subscription");
 
     @SuppressWarnings({ "AtomicFieldUpdaterIssues", "rawtypes" })
     private static final AtomicReferenceFieldUpdater<DeferredStreamMessage, StreamMessage> delegateUpdater =
             AtomicReferenceFieldUpdater.newUpdater(
                     DeferredStreamMessage.class, StreamMessage.class, "delegate");
 
-    @SuppressWarnings({ "AtomicFieldUpdaterIssues", "rawtypes" })
-    private static final AtomicReferenceFieldUpdater<DeferredStreamMessage, PendingSubscription>
-            pendingSubscriptionUpdater = AtomicReferenceFieldUpdater.newUpdater(
-            DeferredStreamMessage.class, PendingSubscription.class, "pendingSubscription");
-
-    private final CompletableFuture<Void> completionFuture = new CompletableFuture<>();
-
     @SuppressWarnings("unused") // Updated only via delegateUpdater
     private volatile StreamMessage<T> delegate;
-    @SuppressWarnings("unused") // Updated only via pendingSubscriptionUpdater
-    private volatile PendingSubscription<? super T> pendingSubscription;
+
+    // Only accessed from subscription's executor.
+    private Subscription delegateSubscription;
+
+    @SuppressWarnings("unused") // Updated only via subscriptionUpdater
+    private volatile SubscriptionImpl subscription;
+
+    // Only accessed from subscription's executor.
+    private long pendingDemand;
+
     private volatile boolean abortPending;
+
+    // Only accessed from subscription's executor.
+    private boolean cancelPending;
 
     /**
      * Sets the delegate {@link HttpResponse} which will publish the stream actually.
@@ -74,12 +82,12 @@ public class DeferredStreamMessage<T> implements StreamMessage<T> {
             delegate.abort();
         }
 
-        if (!completionFuture.isDone()) {
+        if (!completionFuture().isDone()) {
             delegate.completionFuture().handle((unused, cause) -> {
                 if (cause == null) {
-                    completionFuture.complete(null);
+                    completionFuture().complete(null);
                 } else {
-                    completionFuture.completeExceptionally(cause);
+                    completionFuture().completeExceptionally(cause);
                 }
                 return null;
             }).exceptionally(CompletionActions::log);
@@ -120,7 +128,7 @@ public class DeferredStreamMessage<T> implements StreamMessage<T> {
             return delegate.isOpen();
         }
 
-        return !completionFuture.isDone();
+        return !completionFuture().isDone();
     }
 
     @Override
@@ -134,125 +142,125 @@ public class DeferredStreamMessage<T> implements StreamMessage<T> {
     }
 
     @Override
-    public CompletableFuture<Void> completionFuture() {
-        return completionFuture;
+    long demand() {
+        return pendingDemand;
     }
 
     @Override
-    public void subscribe(Subscriber<? super T> subscriber) {
-        requireNonNull(subscriber, "subscriber");
-        subscribe0(subscriber, null, false);
-    }
-
-    @Override
-    public void subscribe(Subscriber<? super T> subscriber, boolean withPooledObjects) {
-        requireNonNull(subscriber, "subscriber");
-        subscribe0(subscriber, null, withPooledObjects);
-    }
-
-    @Override
-    public void subscribe(Subscriber<? super T> subscriber, EventExecutor executor) {
-        requireNonNull(subscriber, "subscriber");
-        requireNonNull(executor, "executor");
-        subscribe0(subscriber, executor, false);
-    }
-
-    @Override
-    public void subscribe(Subscriber<? super T> subscriber, EventExecutor executor,
-                          boolean withPooledObjects) {
-        requireNonNull(subscriber, "subscriber");
-        requireNonNull(executor, "executor");
-        subscribe0(subscriber, executor, withPooledObjects);
-    }
-
-    private void subscribe0(Subscriber<? super T> subscriber, EventExecutor executor,
-                            boolean withPooledObjects) {
-        if (abortPending) {
-            failLateSubscriber(subscriber, executor, AbortedStreamException.get());
-            return;
+    void request(long n) {
+        Subscription subscription = delegateSubscription;
+        if (subscription != null) {
+            subscription.request(n);
+        } else {
+            pendingDemand += n;
         }
-
-        final PendingSubscription<? super T> newPendingSubscription =
-                new PendingSubscription<>(subscriber, executor, withPooledObjects);
-
-        if (!pendingSubscriptionUpdater.compareAndSet(this, null, newPendingSubscription)) {
-            failLateSubscriber(subscriber, executor,
-                               new IllegalStateException("subscribed by other subscriber already"));
-            return;
-        }
-
-        safeOnSubscribeToDelegate();
     }
 
-    private void failLateSubscriber(Subscriber<? super T> subscriber, EventExecutor executor, Throwable cause) {
-        if (executor == null) {
+    @Override
+    void cancel() {
+        Subscription delegateSubscription = this.delegateSubscription;
+        if (delegateSubscription != null) {
             try {
-                subscriber.onSubscribe(NoopSubscription.INSTANCE);
+                delegateSubscription.cancel();
             } finally {
-                subscriber.onError(cause);
+                this.subscription.clearSubscriber();
             }
         } else {
+            cancelPending = true;
+        }
+    }
+
+    @Override
+    void notifySubscriberOfCloseEvent(SubscriptionImpl subscription, CloseEvent event) {
+        // Delegate will notify, don't need to do anything special here.
+    }
+
+    @Override
+    void subscribe(SubscriptionImpl subscription) {
+        final Subscriber<Object> subscriber = subscription.subscriber();
+        final Executor executor = subscription.executor();
+
+        if (!subscriptionUpdater.compareAndSet(this, null, subscription)) {
+            failLateSubscriber(this.subscription, subscriber);
+            return;
+        }
+
+        if (subscription.needsDirectInvocation()) {
+            subscriber.onSubscribe(subscription);
+            safeOnSubscribeToDelegate();
+        } else {
             executor.execute(() -> {
-                try {
-                    subscriber.onSubscribe(NoopSubscription.INSTANCE);
-                } finally {
-                    subscriber.onError(cause);
-                }
+                subscriber.onSubscribe(subscription);
+                safeOnSubscribeToDelegate();
             });
         }
     }
 
     private void safeOnSubscribeToDelegate() {
-
-        if (delegate == null) {
+        if (delegate == null || subscription == null) {
             return;
         }
 
-        final PendingSubscription<? super T> subscription = pendingSubscription;
+        final EventExecutor executor = subscription.executor();
+        final boolean withPooledObjects = subscription.withPooledObjects();
 
-        if (subscription == null || subscription == NO_OP_ALREADY_SUBSCRIBED) {
-            return;
-        }
+        final Subscriber<T> delegateSubscriber = new ForwardingSubscriber();
 
-        if (!pendingSubscriptionUpdater.compareAndSet(this,
-                                                      subscription,
-                                                      NO_OP_ALREADY_SUBSCRIBED)) {
-            return;
-        }
-
-        final Subscriber<? super T> subscriber = subscription.subscriber;
-        final EventExecutor executor = subscription.executor;
-        final boolean withPooledObjects = subscription.withPooledObjects;
         if (executor == null) {
-            delegate.subscribe(subscriber, withPooledObjects);
+            delegate.subscribe(delegateSubscriber, withPooledObjects);
         } else {
-            delegate.subscribe(subscriber, executor, withPooledObjects);
+            delegate.subscribe(delegateSubscriber, executor, withPooledObjects);
         }
     }
 
     @Override
     public void abort() {
         abortPending = true;
+
+        final SubscriptionImpl newSubscription = new SubscriptionImpl(
+                this, AbortingSubscriber.get(), ImmediateEventExecutor.INSTANCE, false);
+        subscriptionUpdater.compareAndSet(this, null, newSubscription);
+
         final StreamMessage<T> delegate = this.delegate;
         if (delegate != null) {
             delegate.abort();
         } else {
-            completionFuture.completeExceptionally(AbortedStreamException.get());
+            if (subscription.needsDirectInvocation()) {
+                ABORTED_CLOSE.notifySubscriber(subscription, completionFuture());
+            } else {
+                subscription.executor().execute(
+                        () -> ABORTED_CLOSE.notifySubscriber(subscription, completionFuture()));
+            }
         }
     }
 
-    /**
-     * {@link Subscriber} and {@link EventExecutor}.
-     */
-    private static final class PendingSubscription<T> {
-        final Subscriber<T> subscriber;
-        final EventExecutor executor;
-        final boolean withPooledObjects;
+    private final class ForwardingSubscriber implements Subscriber<T> {
 
-        PendingSubscription(Subscriber<T> subscriber, EventExecutor executor, boolean withPooledObjects) {
-            this.subscriber = subscriber;
-            this.executor = executor;
-            this.withPooledObjects = withPooledObjects;
+        @Override
+        public void onSubscribe(Subscription subscription) {
+            delegateSubscription = subscription;
+
+            if (cancelPending) {
+                delegateSubscription.cancel();
+            } else if (pendingDemand > 0) {
+                delegateSubscription.request(pendingDemand);
+                pendingDemand = 0;
+            }
+        }
+
+        @Override
+        public void onNext(T t) {
+            subscription.subscriber().onNext(t);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            subscription.subscriber().onError(t);
+        }
+
+        @Override
+        public void onComplete() {
+            subscription.subscriber().onComplete();
         }
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/DeferredStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/DeferredStreamMessage.java
@@ -279,8 +279,9 @@ public class DeferredStreamMessage<T> extends AbstractStreamMessage<T> {
             if (cancelPending) {
                 delegateSubscription.cancel();
             } else if (pendingDemand > 0) {
-                delegateSubscription.request(pendingDemand);
+                long demand = pendingDemand;
                 pendingDemand = 0;
+                delegateSubscription.request(demand);
             }
         }
 

--- a/core/src/main/java/com/linecorp/armeria/common/stream/DeferredStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/DeferredStreamMessage.java
@@ -170,7 +170,6 @@ public class DeferredStreamMessage<T> extends AbstractStreamMessage<T> {
     private void doRequest(long n) {
         final Subscription delegateSubscription = this.delegateSubscription;
         if (delegateSubscription != null) {
-            assert pendingDemand == 0;
             delegateSubscription.request(n);
         } else {
             pendingDemand += n;
@@ -279,9 +278,8 @@ public class DeferredStreamMessage<T> extends AbstractStreamMessage<T> {
             if (cancelPending) {
                 delegateSubscription.cancel();
             } else if (pendingDemand > 0) {
-                long demand = pendingDemand;
+                delegateSubscription.request(pendingDemand);
                 pendingDemand = 0;
-                delegateSubscription.request(demand);
             }
         }
 

--- a/core/src/test/java/com/linecorp/armeria/common/stream/DeferredStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/DeferredStreamMessageTest.java
@@ -65,7 +65,7 @@ public class DeferredStreamMessageTest {
     @Test
     public void testEarlyAbortWithSubscriber() throws Exception {
         final DeferredStreamMessage<Object> m = new DeferredStreamMessage<>();
-        m.subscribe(mock(Subscriber.class));
+        m.subscribe(mock(Subscriber.class), ImmediateEventExecutor.INSTANCE);
         m.abort();
         assertAborted(m);
 

--- a/core/src/test/java/com/linecorp/armeria/common/stream/DeferredStreamMessageVerification.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/DeferredStreamMessageVerification.java
@@ -21,6 +21,8 @@ import static com.linecorp.armeria.common.stream.DefaultStreamMessageVerificatio
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
+import io.netty.util.concurrent.EventExecutor;
+
 public class DeferredStreamMessageVerification extends StreamMessageVerification<Long> {
 
     @Override
@@ -48,7 +50,8 @@ public class DeferredStreamMessageVerification extends StreamMessageVerification
 
         stream.delegate(new StreamMessageWrapper<Long>(createStreamMessage(elements + 1, false)) {
             @Override
-            public void subscribe(Subscriber<? super Long> subscriber, boolean withPooledObjects) {
+            public void subscribe(
+                    Subscriber<? super Long> subscriber, EventExecutor executor, boolean withPooledObjects) {
                 super.subscribe(new Subscriber<Long>() {
                     @Override
                     public void onSubscribe(Subscription s) {
@@ -72,7 +75,7 @@ public class DeferredStreamMessageVerification extends StreamMessageVerification
                     public void onComplete() {
                         subscriber.onComplete();
                     }
-                }, withPooledObjects);
+                }, executor, withPooledObjects);
             }
         });
 


### PR DESCRIPTION
Currently request timeout doesn't work correctly with deferred responses - the timeout is set after `onSubscribe` is called, which only happens after `delegate` at some point possibly well in the future. And in general, stream lifecycle events should happen before `delegate` has been called. This means it's not enough for a `DefferedStreamMessage` to simply forward all stream events to the delegate - it needs to handle them and only start forwarding after `delegate` has been called.

This change adds keeping track of demand and cancellation to `DeferredStreamMessage` - even before `delegate` has been called, `onSubscribe` is called on the subscriber to make sure logic that should run as soon as subscription (e.g., setting a request timeout) can happen, and since this will immediately trigger demand, the demand is kept safe until delegation starts. If the stream is aborted, the subscriber is notified immediately as it should. If the Subscriber cancels the stream, the delegate will also be cancelled after delegation happens.