### PR TITLE
Added contentType() to HttpHeaders

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/AggregatedHttpMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AggregatedHttpMessage.java
@@ -17,7 +17,6 @@
 package com.linecorp.armeria.common;
 
 import static com.linecorp.armeria.common.HttpHeaderNames.CONTENT_LENGTH;
-import static com.linecorp.armeria.common.HttpHeaderNames.CONTENT_TYPE;
 import static com.linecorp.armeria.internal.ArmeriaHttpUtil.isContentAlwaysEmpty;
 import static com.linecorp.armeria.internal.ArmeriaHttpUtil.isContentAlwaysEmptyWithValidation;
 import static java.util.Objects.requireNonNull;
@@ -160,7 +159,7 @@ public interface AggregatedHttpMessage {
         requireNonNull(mediaType, "mediaType");
         requireNonNull(content, "content");
         requireNonNull(trailingHeaders, "trailingHeaders");
-        return of(HttpHeaders.of(method, path).setObject(CONTENT_TYPE, mediaType), content, trailingHeaders);
+        return of(HttpHeaders.of(method, path).contentType(mediaType), content, trailingHeaders);
     }
 
     // Note: Ensure we provide the same set of `of()` methods with the `of()` and `respond()` methods of
@@ -281,7 +280,7 @@ public interface AggregatedHttpMessage {
 
         final HttpHeaders headers =
                 HttpHeaders.of(status)
-                           .setObject(CONTENT_TYPE, mediaType)
+                           .contentType(mediaType)
                            .setInt(CONTENT_LENGTH, content.length());
 
         return of(headers, content, trailingHeaders);

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultHttpHeaders.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultHttpHeaders.java
@@ -38,6 +38,7 @@ public final class DefaultHttpHeaders
 
     private HttpMethod method;
     private HttpStatus status;
+    private MediaType contentType;
 
     /**
      * Creates a new instance.
@@ -172,6 +173,33 @@ public final class DefaultHttpHeaders
     public HttpHeaders status(HttpStatus status) {
         requireNonNull(status, "status");
         return status(status.code());
+    }
+
+    @Override
+    public MediaType contentType() {
+        final MediaType contentType = this.contentType;
+        if (contentType != null) {
+            return contentType;
+        }
+
+        final String contentTypeString = get(HttpHeaderNames.CONTENT_TYPE);
+        if (contentTypeString == null) {
+            return null;
+        }
+
+        try {
+            this.contentType = MediaType.parse(contentTypeString);
+            return this.contentType;
+        } catch (IllegalArgumentException unused) {
+            return null;
+        }
+    }
+
+    @Override
+    public HttpHeaders contentType(MediaType contentType) {
+        requireNonNull(contentType, "contentType");
+        this.contentType = contentType;
+        return set(HttpHeaderNames.CONTENT_TYPE, contentType.toString());
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/HttpHeaders.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpHeaders.java
@@ -175,6 +175,18 @@ public interface HttpHeaders extends HttpObject, Headers<AsciiString, String, Ht
     HttpHeaders status(HttpStatus status);
 
     /**
+     * Returns the value of the {@code 'content-type'} header.
+     * @return the valid header value if present. {@code null} otherwise.
+     */
+    @Nullable
+    MediaType contentType();
+
+    /**
+     * Sets the {@link HttpHeaderNames#CONTENT_TYPE} header.
+     */
+    HttpHeaders contentType(MediaType mediaType);
+
+    /**
      * Returns the immutable view of this headers.
      */
     default HttpHeaders asImmutable() {

--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
@@ -17,7 +17,6 @@
 package com.linecorp.armeria.common;
 
 import static com.linecorp.armeria.common.HttpHeaderNames.CONTENT_LENGTH;
-import static com.linecorp.armeria.common.HttpHeaderNames.CONTENT_TYPE;
 import static java.util.Objects.requireNonNull;
 
 import java.nio.charset.StandardCharsets;
@@ -150,7 +149,7 @@ public interface HttpRequest extends Request, StreamMessage<HttpObject> {
         requireNonNull(method, "method");
         requireNonNull(path, "path");
         requireNonNull(mediaType, "mediaType");
-        return of(HttpHeaders.of(method, path).setObject(CONTENT_TYPE, mediaType), content, trailingHeaders);
+        return of(HttpHeaders.of(method, path).contentType(mediaType), content, trailingHeaders);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -144,7 +144,7 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
 
         final HttpHeaders headers =
                 HttpHeaders.of(status)
-                           .setObject(HttpHeaderNames.CONTENT_TYPE, mediaType)
+                           .contentType(mediaType)
                            .setInt(HttpHeaderNames.CONTENT_LENGTH, content.length());
         return of(headers, content, trailingHeaders);
     }

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponseWriter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponseWriter.java
@@ -150,7 +150,7 @@ public interface HttpResponseWriter extends StreamWriter<HttpObject> {
 
         final HttpHeaders headers =
                 HttpHeaders.of(status)
-                           .setObject(HttpHeaderNames.CONTENT_TYPE, mediaType)
+                           .contentType(mediaType)
                            .setInt(HttpHeaderNames.CONTENT_LENGTH, content.length());
 
         if (isContentAlwaysEmptyWithValidation(status, content, trailingHeaders)) {

--- a/core/src/main/java/com/linecorp/armeria/common/ImmutableHttpHeaders.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ImmutableHttpHeaders.java
@@ -90,6 +90,16 @@ final class ImmutableHttpHeaders implements HttpHeaders {
     }
 
     @Override
+    public MediaType contentType() {
+        return delegate.contentType();
+    }
+
+    @Override
+    public HttpHeaders contentType(MediaType mediaType) {
+        return delegate.contentType(mediaType);
+    }
+
+    @Override
     public boolean isEndOfStream() {
         return delegate.isEndOfStream();
     }

--- a/core/src/main/java/com/linecorp/armeria/common/ImmutableHttpHeaders.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ImmutableHttpHeaders.java
@@ -96,7 +96,7 @@ final class ImmutableHttpHeaders implements HttpHeaders {
 
     @Override
     public HttpHeaders contentType(MediaType mediaType) {
-        return delegate.contentType(mediaType);
+        return unsupported();
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/AnnotatedHttpServiceMethod.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AnnotatedHttpServiceMethod.java
@@ -42,7 +42,6 @@ import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.common.AggregatedHttpMessage;
 import com.linecorp.armeria.common.FilteredHttpResponse;
-import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpObject;
 import com.linecorp.armeria.common.HttpParameters;
 import com.linecorp.armeria.common.HttpRequest;
@@ -61,7 +60,6 @@ import com.linecorp.armeria.server.annotation.RequestObject;
 import com.linecorp.armeria.server.annotation.ResponseConverter;
 
 import io.netty.handler.codec.http.HttpConstants;
-import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.QueryStringDecoder;
 import io.netty.util.AsciiString;
 
@@ -708,10 +706,9 @@ final class AnnotatedHttpServiceMethod implements BiFunction<ServiceRequestConte
          * Whether the request is available to be aggregated.
          */
         static boolean aggregationAvailable(HttpRequest req) {
-            final String contentType = req.headers().get(HttpHeaderNames.CONTENT_TYPE);
+            final MediaType contentType = req.headers().contentType();
             // We aggregate request stream messages for the media type of form data currently.
-            return contentType != null &&
-                   MediaType.FORM_DATA.toString().equals(HttpUtil.getMimeType(contentType));
+            return contentType != null && MediaType.FORM_DATA.type().equals(contentType.type());
         }
 
         /**

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultPathMappingContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultPathMappingContext.java
@@ -155,13 +155,9 @@ final class DefaultPathMappingContext implements PathMappingContext {
 
     @VisibleForTesting
     static MediaType resolveConsumeType(HttpHeaders headers) {
-        final String contentType = headers.get(HttpHeaderNames.CONTENT_TYPE);
+        final MediaType contentType = headers.contentType();
         if (contentType != null) {
-            try {
-                return MediaType.parse(contentType);
-            } catch (IllegalArgumentException e) {
-                logger.debug("Failed to parse the 'content-type' header: {}", contentType, e);
-            }
+            return contentType;
         }
         return null;
     }

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -75,7 +75,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
 
     private static final Logger logger = LoggerFactory.getLogger(HttpServerHandler.class);
 
-    private static final String ERROR_CONTENT_TYPE = MediaType.PLAIN_TEXT_UTF_8.toString();
+    private static final MediaType ERROR_CONTENT_TYPE = MediaType.PLAIN_TEXT_UTF_8;
 
     private static final Set<HttpMethod> ALLOWED_METHODS =
             Sets.immutableEnumSet(HttpMethod.DELETE, HttpMethod.GET, HttpMethod.HEAD, HttpMethod.OPTIONS,
@@ -418,7 +418,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
         respond(ctx, req,
                 AggregatedHttpMessage.of(
                         HttpHeaders.of(status)
-                                   .set(HttpHeaderNames.CONTENT_TYPE, ERROR_CONTENT_TYPE),
+                                   .contentType(ERROR_CONTENT_TYPE),
                         content));
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/ByteArrayRequestConverterFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/ByteArrayRequestConverterFunction.java
@@ -18,7 +18,6 @@ package com.linecorp.armeria.server.annotation;
 
 import com.linecorp.armeria.common.AggregatedHttpMessage;
 import com.linecorp.armeria.common.HttpData;
-import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.MediaType;
 
 /**
@@ -40,13 +39,9 @@ public class ByteArrayRequestConverterFunction implements RequestConverterFuncti
             return false;
         }
 
-        final String contentType = request.headers().get(HttpHeaderNames.CONTENT_TYPE);
-        if (contentType == null) {
-            return true;
-        }
-
-        final MediaType mediaType = MediaType.parse(contentType);
-        return mediaType.is(MediaType.OCTET_STREAM) ||
+        final MediaType mediaType = request.headers().contentType();
+        return mediaType == null ||
+               mediaType.is(MediaType.OCTET_STREAM) ||
                mediaType.is(MediaType.APPLICATION_BINARY);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/JacksonRequestConverterFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/JacksonRequestConverterFunction.java
@@ -63,10 +63,9 @@ public class JacksonRequestConverterFunction implements RequestConverterFunction
      */
     @Override
     public boolean accept(AggregatedHttpMessage request, Class<?> expectedResultType) {
-        final String contentType = request.headers().get(HttpHeaderNames.CONTENT_TYPE);
+        final MediaType contentType = request.headers().contentType();
         // TODO(hyangtack) Do benchmark tests to decide whether we add a cache to MediaType#parse.
-        if (contentType != null &&
-            MediaType.parse(contentType).is(MediaType.JSON)) {
+        if (contentType != null && contentType.is(MediaType.JSON)) {
             try {
                 return readers.computeIfAbsent(expectedResultType, mapper::readerFor) != null;
             } catch (Throwable cause) {

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/StringRequestConverterFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/StringRequestConverterFunction.java
@@ -20,7 +20,6 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
 import com.linecorp.armeria.common.AggregatedHttpMessage;
-import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.MediaType;
 
 /**
@@ -38,12 +37,8 @@ public class StringRequestConverterFunction implements RequestConverterFunction 
             return false;
         }
 
-        final String contentType = request.headers().get(HttpHeaderNames.CONTENT_TYPE);
-        if (contentType == null) {
-            return false;
-        }
-
-        return MediaType.parse(contentType).is(MediaType.ANY_TEXT_TYPE);
+        final MediaType contentType = request.headers().contentType();
+        return contentType != null && contentType.is(MediaType.ANY_TEXT_TYPE);
     }
 
     /**
@@ -53,11 +48,11 @@ public class StringRequestConverterFunction implements RequestConverterFunction 
     public Object convert(AggregatedHttpMessage request, Class<?> expectedResultType) throws Exception {
         assert expectedResultType.isAssignableFrom(String.class);
 
-        final String contentType = request.headers().get(HttpHeaderNames.CONTENT_TYPE);
+        final MediaType contentType = request.headers().contentType();
         assert contentType != null;
         // See https://tools.ietf.org/html/rfc2616#section-3.7.1
-        final Charset charset = MediaType.parse(contentType).charset()
-                                         .orElse(StandardCharsets.ISO_8859_1);
+        final Charset charset = contentType.charset()
+                                           .orElse(StandardCharsets.ISO_8859_1);
         return request.content().toString(charset);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/encoding/HttpEncodedResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/server/encoding/HttpEncodedResponse.java
@@ -155,10 +155,10 @@ class HttpEncodedResponse extends FilteredHttpResponse {
             // Content-Encoding.
             return false;
         }
-        if (headers.contains(HttpHeaderNames.CONTENT_TYPE)) {
+        if (headers.contentType() != null) {
             // Make sure the content type is worth encoding.
             try {
-                MediaType contentType = MediaType.parse(headers.get(HttpHeaderNames.CONTENT_TYPE));
+                MediaType contentType = headers.contentType();
                 if (!encodableContentTypePredicate.test(contentType)) {
                     return false;
                 }

--- a/core/src/main/java/com/linecorp/armeria/server/file/HttpFileService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/HttpFileService.java
@@ -193,7 +193,7 @@ public final class HttpFileService extends AbstractHttpService {
                                          .setTimeMillis(HttpHeaderNames.DATE, config().clock().millis())
                                          .setTimeMillis(HttpHeaderNames.LAST_MODIFIED, lastModifiedMillis);
         if (entry.mediaType() != null) {
-            headers.set(HttpHeaderNames.CONTENT_TYPE, entry.mediaType().toString());
+            headers.contentType(entry.mediaType());
         }
         if (entry.contentEncoding() != null) {
             headers.set(HttpHeaderNames.CONTENT_ENCODING, entry.contentEncoding());

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientIntegrationTest.java
@@ -188,7 +188,7 @@ public class HttpClientIntegrationTest {
                 }
 
                 private void doGetOrPost(HttpRequest req, HttpResponseWriter res) {
-                    final CharSequence contentType = req.headers().get(HttpHeaderNames.CONTENT_TYPE);
+                    final MediaType contentType = req.headers().contentType();
                     if (contentType != null) {
                         throw new IllegalArgumentException(
                                 "Serialization format is none, so content type should not be set: " +

--- a/core/src/test/java/com/linecorp/armeria/common/DefaultAggregatedHttpMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/DefaultAggregatedHttpMessageTest.java
@@ -18,7 +18,6 @@ package com.linecorp.armeria.common;
 
 import static com.linecorp.armeria.common.HttpHeaderNames.CONTENT_LENGTH;
 import static com.linecorp.armeria.common.HttpHeaderNames.CONTENT_MD5;
-import static com.linecorp.armeria.common.HttpHeaderNames.CONTENT_TYPE;
 import static com.linecorp.armeria.common.MediaType.PLAIN_TEXT_UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -46,7 +45,7 @@ public class DefaultAggregatedHttpMessageTest {
         final List<HttpObject> unaggregated = unaggregate(req);
 
         assertThat(req.headers()).isEqualTo(HttpHeaders.of(HttpMethod.POST, "/foo")
-                                                       .setObject(CONTENT_TYPE, PLAIN_TEXT_UTF_8)
+                                                       .contentType(PLAIN_TEXT_UTF_8)
                                                        .setInt(CONTENT_LENGTH, 3));
         assertThat(unaggregated).containsExactly(HttpData.of(StandardCharsets.UTF_8, "bar"));
     }
@@ -70,7 +69,7 @@ public class DefaultAggregatedHttpMessageTest {
         final List<HttpObject> unaggregated = unaggregate(req);
 
         assertThat(req.headers()).isEqualTo(HttpHeaders.of(HttpMethod.PUT, "/baz")
-                                                       .setObject(CONTENT_TYPE, PLAIN_TEXT_UTF_8)
+                                                       .contentType(PLAIN_TEXT_UTF_8)
                                                        .setInt(CONTENT_LENGTH, 3));
         assertThat(unaggregated).containsExactly(
                 HttpData.of(StandardCharsets.UTF_8, "bar"),
@@ -105,7 +104,7 @@ public class DefaultAggregatedHttpMessageTest {
 
         assertThat(unaggregated).containsExactly(
                 HttpHeaders.of(HttpStatus.OK)
-                           .setObject(CONTENT_TYPE, PLAIN_TEXT_UTF_8)
+                           .contentType(PLAIN_TEXT_UTF_8)
                            .setInt(CONTENT_LENGTH, 5),
                 HttpData.of(StandardCharsets.UTF_8, "alice"));
     }
@@ -119,7 +118,7 @@ public class DefaultAggregatedHttpMessageTest {
 
         assertThat(unaggregated).containsExactly(
                 HttpHeaders.of(HttpStatus.OK)
-                           .setObject(CONTENT_TYPE, PLAIN_TEXT_UTF_8)
+                           .contentType(PLAIN_TEXT_UTF_8)
                            .setInt(CONTENT_LENGTH, 0));
     }
 
@@ -133,7 +132,7 @@ public class DefaultAggregatedHttpMessageTest {
 
         assertThat(unaggregated).containsExactly(
                 HttpHeaders.of(HttpStatus.OK)
-                           .setObject(CONTENT_TYPE, PLAIN_TEXT_UTF_8)
+                           .contentType(PLAIN_TEXT_UTF_8)
                            .setInt(CONTENT_LENGTH, 3),
                 HttpData.of(StandardCharsets.UTF_8, "bob"),
                 HttpHeaders.of(CONTENT_MD5, "9f9d51bc70ef21ca5c14f307980a29d8"));

--- a/core/src/test/java/com/linecorp/armeria/common/HttpRequestDuplicatorTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/HttpRequestDuplicatorTest.java
@@ -18,7 +18,6 @@ package com.linecorp.armeria.common;
 
 import static com.linecorp.armeria.common.HttpHeaderNames.CONTENT_LENGTH;
 import static com.linecorp.armeria.common.HttpHeaderNames.CONTENT_MD5;
-import static com.linecorp.armeria.common.HttpHeaderNames.CONTENT_TYPE;
 import static com.linecorp.armeria.common.MediaType.PLAIN_TEXT_UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -42,7 +41,7 @@ public class HttpRequestDuplicatorTest {
 
         assertThat(req1.headers()).isEqualTo(
                 HttpHeaders.of(HttpMethod.PUT, "/foo")
-                           .setObject(CONTENT_TYPE, PLAIN_TEXT_UTF_8)
+                           .contentType(PLAIN_TEXT_UTF_8)
                            .setInt(CONTENT_LENGTH, 3));
         assertThat(req1.content()).isEqualTo(HttpData.of(StandardCharsets.UTF_8, "bar"));
         assertThat(req1.trailingHeaders()).isEqualTo(
@@ -50,7 +49,7 @@ public class HttpRequestDuplicatorTest {
 
         assertThat(req2.headers()).isEqualTo(
                 HttpHeaders.of(HttpMethod.PUT, "/foo")
-                           .setObject(CONTENT_TYPE, PLAIN_TEXT_UTF_8)
+                           .contentType(PLAIN_TEXT_UTF_8)
                            .setInt(CONTENT_LENGTH, 3));
         assertThat(req2.content()).isEqualTo(HttpData.of(StandardCharsets.UTF_8, "bar"));
         assertThat(req2.trailingHeaders()).isEqualTo(

--- a/core/src/test/java/com/linecorp/armeria/common/HttpResponseDuplicatorTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/HttpResponseDuplicatorTest.java
@@ -16,7 +16,6 @@
 
 package com.linecorp.armeria.common;
 
-import static com.linecorp.armeria.common.HttpHeaderNames.CONTENT_TYPE;
 import static com.linecorp.armeria.common.HttpHeaderNames.VARY;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -29,7 +28,7 @@ public class HttpResponseDuplicatorTest {
         final DefaultHttpResponse publisher = new DefaultHttpResponse();
         final HttpResponseDuplicator resDuplicator = new HttpResponseDuplicator(publisher);
 
-        publisher.write(HttpHeaders.of(HttpStatus.OK).set(CONTENT_TYPE, "text/plain"));
+        publisher.write(HttpHeaders.of(HttpStatus.OK).contentType(MediaType.PLAIN_TEXT_UTF_8));
         publisher.write(HttpData.ofUtf8("Armeria "));
         publisher.write(HttpData.ofUtf8("is "));
         publisher.write(HttpData.ofUtf8("awesome!"));
@@ -39,12 +38,12 @@ public class HttpResponseDuplicatorTest {
         final AggregatedHttpMessage res2 = resDuplicator.duplicateStream().aggregate().join();
 
         assertThat(res1.status()).isEqualTo(HttpStatus.OK);
-        assertThat(res1.headers().get(CONTENT_TYPE)).isEqualTo("text/plain");
+        assertThat(res1.headers().contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
         assertThat(res1.headers().get(VARY)).isNull();
         assertThat(res1.content().toStringUtf8()).isEqualTo("Armeria is awesome!");
 
         assertThat(res2.status()).isEqualTo(HttpStatus.OK);
-        assertThat(res2.headers().get(CONTENT_TYPE)).isEqualTo("text/plain");
+        assertThat(res2.headers().contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
         assertThat(res2.headers().get(VARY)).isNull();
         assertThat(res2.content().toStringUtf8()).isEqualTo("Armeria is awesome!");
         resDuplicator.close();

--- a/core/src/test/java/com/linecorp/armeria/server/AnnotatedHttpServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/AnnotatedHttpServiceTest.java
@@ -843,7 +843,7 @@ public class AnnotatedHttpServiceTest {
 
         final org.apache.http.Header header = res.getFirstHeader(org.apache.http.HttpHeaders.CONTENT_TYPE);
         if (contentType != null) {
-            assertThat(header.getValue(), is(contentType));
+            assertThat(MediaType.parse(header.getValue()), is(MediaType.parse(contentType)));
         } else if (statusCode >= 400) {
             assertThat(header.getValue(), is(MediaType.PLAIN_TEXT_UTF_8.toString()));
         } else {

--- a/core/src/test/java/com/linecorp/armeria/server/HttpHeaderPathMappingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpHeaderPathMappingTest.java
@@ -141,13 +141,13 @@ public class HttpHeaderPathMappingTest {
     }
 
     private static PathMappingContext method(HttpMethod method) {
-        return DefaultPathMappingContext.of(virtualHost(),"example.com",
+        return DefaultPathMappingContext.of(virtualHost(), "example.com",
                                             PATH, null, HttpHeaders.of(method, PATH), null);
     }
 
     private static PathMappingContext consumeType(HttpMethod method, MediaType contentType) {
         HttpHeaders headers = HttpHeaders.of(method, PATH);
-        headers.add(HttpHeaderNames.CONTENT_TYPE, contentType.toString());
+        headers.contentType(contentType);
         return DefaultPathMappingContext.of(virtualHost(), "example.com",
                                             PATH, null, headers, null);
     }

--- a/core/src/test/java/com/linecorp/armeria/server/HttpResponseExceptionTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpResponseExceptionTest.java
@@ -21,7 +21,6 @@ import org.junit.Test;
 
 import com.linecorp.armeria.common.AggregatedHttpMessage;
 import com.linecorp.armeria.common.DefaultHttpResponse;
-import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
@@ -32,13 +31,11 @@ public class HttpResponseExceptionTest {
         final DefaultHttpResponse response = new DefaultHttpResponse();
         final HttpResponseException exception = HttpResponseException.of(response);
         response.write(HttpHeaders.of(HttpStatus.INTERNAL_SERVER_ERROR)
-                                  .add(HttpHeaderNames.CONTENT_TYPE,
-                                       MediaType.PLAIN_TEXT_UTF_8.toString()));
+                                  .contentType(MediaType.PLAIN_TEXT_UTF_8));
         response.close();
 
         final AggregatedHttpMessage message = exception.httpResponse().aggregate().join();
         assertThat(message.status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
-        assertThat(message.headers().get(HttpHeaderNames.CONTENT_TYPE))
-                .isEqualTo(MediaType.PLAIN_TEXT_UTF_8.toString());
+        assertThat(message.headers().contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerTest.java
@@ -324,7 +324,7 @@ public class HttpServerTest {
             sb.service("/strings", new AbstractHttpService() {
                 @Override
                 protected void doGet(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) {
-                    res.write(HttpHeaders.of(HttpStatus.OK).set(HttpHeaderNames.CONTENT_TYPE, "text/plain"));
+                    res.write(HttpHeaders.of(HttpStatus.OK).contentType(MediaType.PLAIN_TEXT_UTF_8));
 
                     res.write(HttpData.ofUtf8("Armeria "));
                     res.write(HttpData.ofUtf8("is "));
@@ -336,7 +336,7 @@ public class HttpServerTest {
             sb.service("/images", new AbstractHttpService() {
                 @Override
                 protected void doGet(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) {
-                    res.write(HttpHeaders.of(HttpStatus.OK).set(HttpHeaderNames.CONTENT_TYPE, "image/png"));
+                    res.write(HttpHeaders.of(HttpStatus.OK).contentType(MediaType.PNG));
 
                     res.write(HttpData.ofUtf8("Armeria "));
                     res.write(HttpData.ofUtf8("is "));
@@ -350,7 +350,7 @@ public class HttpServerTest {
                 protected void doGet(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) {
                     String response = Strings.repeat("a", 1023);
                     res.write(HttpHeaders.of(HttpStatus.OK)
-                                         .set(HttpHeaderNames.CONTENT_TYPE, "text/plain")
+                                         .contentType(MediaType.PLAIN_TEXT_UTF_8)
                                          .setInt(HttpHeaderNames.CONTENT_LENGTH, response.length()));
                     res.write(HttpData.ofUtf8(response));
                     res.close();
@@ -362,7 +362,7 @@ public class HttpServerTest {
                 protected void doGet(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) {
                     String response = Strings.repeat("a", 1024);
                     res.write(HttpHeaders.of(HttpStatus.OK)
-                                         .set(HttpHeaderNames.CONTENT_TYPE, "text/plain")
+                                         .contentType(MediaType.PLAIN_TEXT_UTF_8)
                                          .setInt(HttpHeaderNames.CONTENT_LENGTH, response.length()));
                     res.write(HttpData.ofUtf8(response));
                     res.close();
@@ -384,7 +384,7 @@ public class HttpServerTest {
             sb.service("/headers", new AbstractHttpService() {
                 @Override
                 protected void doGet(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) {
-                    res.write(HttpHeaders.of(HttpStatus.OK).set(HttpHeaderNames.CONTENT_TYPE, "text/plain")
+                    res.write(HttpHeaders.of(HttpStatus.OK).contentType(MediaType.PLAIN_TEXT_UTF_8)
                                          .add(AsciiString.of("x-custom-header1"), "custom1")
                                          .add(AsciiString.of("X-Custom-Header2"), "custom2"));
 
@@ -486,7 +486,7 @@ public class HttpServerTest {
         serverRequestTimeoutMillis = 100L;
         final AggregatedHttpMessage res = client().get("/delay/2000").aggregate().get();
         assertThat(res.headers().status(), is(HttpStatus.SERVICE_UNAVAILABLE));
-        assertThat(res.headers().get(HttpHeaderNames.CONTENT_TYPE), is(MediaType.PLAIN_TEXT_UTF_8.toString()));
+        assertThat(res.headers().contentType(), is(MediaType.PLAIN_TEXT_UTF_8));
         assertThat(res.content().toStringUtf8(), is("503 Service Unavailable"));
         assertThat(requestLogs.take().statusCode(), is(503));
     }
@@ -496,7 +496,7 @@ public class HttpServerTest {
         serverRequestTimeoutMillis = 100L;
         final AggregatedHttpMessage res = client().get("/delay-deferred/2000").aggregate().get();
         assertThat(res.headers().status(), is(HttpStatus.SERVICE_UNAVAILABLE));
-        assertThat(res.headers().get(HttpHeaderNames.CONTENT_TYPE), is(MediaType.PLAIN_TEXT_UTF_8.toString()));
+        assertThat(res.headers().contentType(), is(MediaType.PLAIN_TEXT_UTF_8));
         assertThat(res.content().toStringUtf8(), is("503 Service Unavailable"));
         assertThat(requestLogs.take().statusCode(), is(503));
     }
@@ -506,7 +506,7 @@ public class HttpServerTest {
         serverRequestTimeoutMillis = 100L;
         final AggregatedHttpMessage res = client().get("/delay-custom/2000").aggregate().get();
         assertThat(res.headers().status(), is(HttpStatus.OK));
-        assertThat(res.headers().get(HttpHeaderNames.CONTENT_TYPE), is(MediaType.PLAIN_TEXT_UTF_8.toString()));
+        assertThat(res.headers().contentType(), is(MediaType.PLAIN_TEXT_UTF_8));
         assertThat(res.content().toStringUtf8(), is("timed out"));
         assertThat(requestLogs.take().statusCode(), is(200));
     }
@@ -516,7 +516,7 @@ public class HttpServerTest {
         serverRequestTimeoutMillis = 100L;
         final AggregatedHttpMessage res = client().get("/delay-custom-deferred/2000").aggregate().get();
         assertThat(res.headers().status(), is(HttpStatus.OK));
-        assertThat(res.headers().get(HttpHeaderNames.CONTENT_TYPE), is(MediaType.PLAIN_TEXT_UTF_8.toString()));
+        assertThat(res.headers().contentType(), is(MediaType.PLAIN_TEXT_UTF_8));
         assertThat(res.content().toStringUtf8(), is("timed out"));
         assertThat(requestLogs.take().statusCode(), is(200));
     }
@@ -532,7 +532,7 @@ public class HttpServerTest {
         });
 
         assertThat(res.headers().status(), is(HttpStatus.SERVICE_UNAVAILABLE));
-        assertThat(res.headers().get(HttpHeaderNames.CONTENT_TYPE), is(MediaType.PLAIN_TEXT_UTF_8.toString()));
+        assertThat(res.headers().contentType(), is(MediaType.PLAIN_TEXT_UTF_8));
         assertThat(res.content().toStringUtf8(), is("503 Service Unavailable"));
         assertThat(requestLogs.take().statusCode(), is(503));
     }
@@ -582,7 +582,7 @@ public class HttpServerTest {
         final AggregatedHttpMessage res = f.get();
 
         assertThat(res.status(), is(HttpStatus.REQUEST_ENTITY_TOO_LARGE));
-        assertThat(res.headers().get(HttpHeaderNames.CONTENT_TYPE), is(MediaType.PLAIN_TEXT_UTF_8.toString()));
+        assertThat(res.headers().contentType(), is(MediaType.PLAIN_TEXT_UTF_8));
         assertThat(res.content().toStringUtf8(), is("413 Request Entity Too Large"));
     }
 
@@ -769,8 +769,7 @@ public class HttpServerTest {
             final AggregatedHttpMessage res = f.get();
 
             assertThat(res.status(), is(HttpStatus.OK));
-            assertThat(res.headers().get(HttpHeaderNames.CONTENT_TYPE),
-                       is(MediaType.PLAIN_TEXT_UTF_8.toString()));
+            assertThat(res.headers().contentType(), is(MediaType.PLAIN_TEXT_UTF_8));
             assertThat(res.content().toStringUtf8(), is(String.valueOf(expectedContentLength)));
         } finally {
             // Make sure the stream is closed even when this test fails due to timeout.

--- a/core/src/test/java/com/linecorp/armeria/server/TestConverters.java
+++ b/core/src/test/java/com/linecorp/armeria/server/TestConverters.java
@@ -93,7 +93,7 @@ final class TestConverters {
         final MediaType contentType =
                 ((ServiceRequestContext) RequestContext.current()).negotiatedProduceType();
         if (contentType != null) {
-            headers.set(HttpHeaderNames.CONTENT_TYPE, contentType.toString());
+            headers.contentType(contentType);
         }
 
         res.write(headers);

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaChannel.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaChannel.java
@@ -31,7 +31,6 @@ import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.DefaultClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.common.DefaultHttpRequest;
-import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
@@ -95,7 +94,7 @@ class ArmeriaChannel extends Channel implements ClientBuilderParams {
         DefaultHttpRequest req = new DefaultHttpRequest(
                 HttpHeaders
                         .of(HttpMethod.POST, uri().getPath() + method.getFullMethodName())
-                        .set(HttpHeaderNames.CONTENT_TYPE, serializationFormat.mediaType().toString()));
+                        .contentType(serializationFormat.mediaType()));
         ClientRequestContext ctx = newContext(HttpMethod.POST, req);
         ctx.logBuilder().serializationFormat(serializationFormat);
         ctx.logBuilder().requestContent(GrpcLogUtil.rpcRequest(method), null);

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
@@ -107,7 +107,8 @@ class ArmeriaServerCall<I, O> extends ServerCall<I, O>
     // Only set once.
     private ServerCall.Listener<I> listener;
 
-    @Nullable private final String clientAcceptEncoding;
+    @Nullable
+    private final String clientAcceptEncoding;
 
     private Compressor compressor;
     private boolean messageCompression;
@@ -167,7 +168,7 @@ class ArmeriaServerCall<I, O> extends ServerCall<I, O>
 
         HttpHeaders headers = HttpHeaders.of(HttpStatus.OK);
 
-        headers.setObject(HttpHeaderNames.CONTENT_TYPE, serializationFormat.mediaType());
+        headers.contentType(serializationFormat.mediaType());
 
         if (compressor == null || !messageCompression || clientAcceptEncoding == null) {
             compressor = Codec.Identity.NONE;
@@ -264,7 +265,7 @@ class ArmeriaServerCall<I, O> extends ServerCall<I, O>
     @Override
     public void setCompression(String compressorName) {
         checkState(!sendHeadersCalled, "sendHeaders has been called");
-        compressor =  compressorRegistry.lookupCompressor(compressorName);
+        compressor = compressorRegistry.lookupCompressor(compressorName);
         checkArgument(compressor != null, "Unable to find compressor by name %s", compressorName);
         messageFramer.setCompressor(compressor);
     }

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceTest.java
@@ -35,6 +35,7 @@ import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.logging.DefaultRequestLog;
 import com.linecorp.armeria.grpc.testing.TestServiceGrpc.TestServiceImplBase;
 import com.linecorp.armeria.server.PathMapping;
@@ -72,7 +73,7 @@ public class GrpcServiceTest {
                 response);
         assertThat(response.aggregate().get()).isEqualTo(AggregatedHttpMessage.of(
                 HttpHeaders.of(HttpStatus.UNSUPPORTED_MEDIA_TYPE)
-                           .set(HttpHeaderNames.CONTENT_TYPE, "text/plain; charset=utf-8"),
+                           .contentType(MediaType.PLAIN_TEXT_UTF_8),
                 HttpData.ofUtf8("Missing or invalid Content-Type header.")));
     }
 
@@ -81,11 +82,11 @@ public class GrpcServiceTest {
         grpcService.doPost(
                 ctx,
                 HttpRequest.of(HttpHeaders.of(HttpMethod.POST, "/grpc.testing.TestService.UnaryCall")
-                                          .set(HttpHeaderNames.CONTENT_TYPE, "application/json")),
+                                          .contentType(MediaType.JSON_UTF_8)),
                 response);
         assertThat(response.aggregate().get()).isEqualTo(AggregatedHttpMessage.of(
                 HttpHeaders.of(HttpStatus.UNSUPPORTED_MEDIA_TYPE)
-                           .set(HttpHeaderNames.CONTENT_TYPE, "text/plain; charset=utf-8"),
+                           .contentType(MediaType.PLAIN_TEXT_UTF_8),
                 HttpData.ofUtf8("Missing or invalid Content-Type header.")));
     }
 
@@ -99,7 +100,7 @@ public class GrpcServiceTest {
                 response);
         assertThat(response.aggregate().get()).isEqualTo(AggregatedHttpMessage.of(
                 HttpHeaders.of(HttpStatus.BAD_REQUEST)
-                           .set(HttpHeaderNames.CONTENT_TYPE, "text/plain; charset=utf-8"),
+                           .contentType(MediaType.PLAIN_TEXT_UTF_8),
                 HttpData.ofUtf8("Invalid path.")));
     }
 

--- a/thrift/src/main/java/com/linecorp/armeria/client/thrift/THttpClientDelegate.java
+++ b/thrift/src/main/java/com/linecorp/armeria/client/thrift/THttpClientDelegate.java
@@ -47,12 +47,12 @@ import com.linecorp.armeria.common.AggregatedHttpMessage;
 import com.linecorp.armeria.common.DefaultHttpRequest;
 import com.linecorp.armeria.common.DefaultRpcResponse;
 import com.linecorp.armeria.common.HttpData;
-import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.RpcResponse;
 import com.linecorp.armeria.common.SerializationFormat;
@@ -72,7 +72,7 @@ final class THttpClientDelegate implements Client<RpcRequest, RpcResponse> {
     private final Client<HttpRequest, HttpResponse> httpClient;
     private final SerializationFormat serializationFormat;
     private final TProtocolFactory protocolFactory;
-    private final String mediaType;
+    private final MediaType mediaType;
     private final Map<Class<?>, ThriftServiceMetadata> metadataMap = new ConcurrentHashMap<>();
 
     THttpClientDelegate(Client<HttpRequest, HttpResponse> httpClient,
@@ -80,7 +80,7 @@ final class THttpClientDelegate implements Client<RpcRequest, RpcResponse> {
         this.httpClient = httpClient;
         this.serializationFormat = serializationFormat;
         protocolFactory = ThriftProtocolFactories.get(serializationFormat);
-        mediaType = serializationFormat.mediaType().toString();
+        mediaType = serializationFormat.mediaType();
     }
 
     @Override
@@ -118,7 +118,7 @@ final class THttpClientDelegate implements Client<RpcRequest, RpcResponse> {
 
             final DefaultHttpRequest httpReq = new DefaultHttpRequest(
                     HttpHeaders.of(HttpMethod.POST, ctx.path())
-                               .set(HttpHeaderNames.CONTENT_TYPE, mediaType), true);
+                               .contentType(mediaType), true);
             httpReq.write(HttpData.of(outTransport.getArray(), 0, outTransport.length()));
             httpReq.close();
 

--- a/thrift/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
+++ b/thrift/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
@@ -428,7 +428,7 @@ public final class THttpService extends AbstractHttpService {
             HttpRequest req, HttpResponseWriter res) {
 
         final HttpHeaders headers = req.headers();
-        final String contentType = headers.get(HttpHeaderNames.CONTENT_TYPE);
+        final MediaType contentType = headers.contentType();
 
         SerializationFormat serializationFormat;
         if (contentType != null) {
@@ -455,17 +455,10 @@ public final class THttpService extends AbstractHttpService {
         return serializationFormat;
     }
 
-    private SerializationFormat findSerializationFormat(String contentType) {
-        final MediaType mediaType;
-        try {
-            mediaType = MediaType.parse(contentType);
-        } catch (IllegalArgumentException e) {
-            logger.debug("Failed to parse the 'content-type' header: {}", contentType, e);
-            return null;
-        }
+    private SerializationFormat findSerializationFormat(MediaType contentType) {
 
         for (SerializationFormat format : allowedSerializationFormatArray) {
-            if (format.isAccepted(mediaType)) {
+            if (format.isAccepted(contentType)) {
                 return format;
             }
         }


### PR DESCRIPTION
When making HttpHeaders for testing it would be more convenient to
have a method for content-type