### PR TITLE
Cancel subscription after writing the object is complete for better completion signaling

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/HttpRequestSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpRequestSubscriber.java
@@ -247,6 +247,10 @@ final class HttpRequestSubscriber implements Subscriber<HttpObject>, ChannelFutu
         if (flush) {
             ctx.flush();
         }
+
+        if (state == State.DONE) {
+            subscription.cancel();
+        }
     }
 
     private int streamId() {
@@ -256,12 +260,12 @@ final class HttpRequestSubscriber implements Subscriber<HttpObject>, ChannelFutu
     private void fail(Throwable cause) {
         setDone();
         logBuilder.endRequest(cause);
+        subscription.cancel();
     }
 
     private void setDone() {
         cancelTimeout();
         state = State.DONE;
-        subscription.cancel();
     }
 
     private void failAndRespond(Throwable cause) {

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -150,6 +150,20 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
     }
 
     /**
+     * Creates a new HTTP response of the specified headers.
+     */
+    static HttpResponse of(HttpHeaders headers) {
+        return of(headers, HttpData.EMPTY_DATA);
+    }
+
+    /**
+     * Creates a new HTTP response of the specified headers and content.
+     */
+    static HttpResponse of(HttpHeaders headers, HttpData content) {
+        return of(headers, content, HttpHeaders.EMPTY_HEADERS);
+    }
+
+    /**
      * Creates a new HTTP response of the specified objects and closes the stream.
      */
     static HttpResponse of(HttpHeaders headers, HttpData content, HttpHeaders trailingHeaders) {


### PR DESCRIPTION
Currently, the subscription is cancelled as soon as the response subscriber receives an end-of-stream object, before it is actually written. This makes sense from a reactive streams perspective, but we also have the concept of a completion future which is tied into the stream's lifecycle. When the subscription is canceled, the completion future is set to a cancelled state as well - depending on the stream's implementation, this could be synchronous, meaning the completion future is notified before the last write can even happen. If someone is listening for the completion future to do a cleanup type of thing, it might happen even though things were successful. This is the result of a slightly confusing correlation between the stream lifecycle and completion future.

This PR changes the response/request subscriber to only cancel after finishing their write. This allows the completion future to be completed successfully on stream close before the subscriber calls cancel, for cleaner semantics.

Admittedly, I'm not sure why this only seems to repro when the request is HTTP/1.0 (not 1.1), but it seems to be better behavior either way.