### PR TITLE
Change AbstractHttpService API to always return HttpResponse instead …

### DIFF
--- a/benchmarks/src/jmh/java/com/linecorp/armeria/thrift/PooledResponseBufferBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/thrift/PooledResponseBufferBenchmark.java
@@ -28,10 +28,10 @@ import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
 import com.linecorp.armeria.client.Clients;
-import com.linecorp.armeria.common.DefaultHttpResponse;
 import com.linecorp.armeria.common.HttpObject;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpResponseWriter;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.ServerPort;
@@ -72,7 +72,7 @@ public class PooledResponseBufferBenchmark {
         @Override
         public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
             HttpResponse res = delegate().serve(ctx, req);
-            DefaultHttpResponse decorated = new DefaultHttpResponse();
+            HttpResponseWriter decorated = HttpResponse.streaming();
             res.subscribe(new Subscriber<HttpObject>() {
                 @Override
                 public void onSubscribe(Subscription s) {
@@ -108,7 +108,7 @@ public class PooledResponseBufferBenchmark {
         @Override
         public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
             HttpResponse res = delegate().serve(ctx, req);
-            DefaultHttpResponse decorated = new DefaultHttpResponse();
+            HttpResponseWriter decorated = HttpResponse.streaming();
             res.subscribe(new Subscriber<HttpObject>() {
                 @Override
                 public void onSubscribe(Subscription s) {

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultHttpClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultHttpClient.java
@@ -21,9 +21,9 @@ import static com.linecorp.armeria.internal.ArmeriaHttpUtil.concatPaths;
 import javax.annotation.Nullable;
 
 import com.linecorp.armeria.common.AggregatedHttpMessage;
-import com.linecorp.armeria.common.DefaultHttpResponse;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpResponseWriter;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.internal.PathAndQuery;
 
@@ -53,7 +53,7 @@ final class DefaultHttpClient extends UserClient<HttpRequest, HttpResponse> impl
         }
 
         return execute(eventLoop, req.method(), pathAndQuery.path(), pathAndQuery.query(), null, req, cause -> {
-            final DefaultHttpResponse res = new DefaultHttpResponse();
+            final HttpResponseWriter res = HttpResponse.streaming();
             res.close(cause);
             return res;
         });

--- a/core/src/main/java/com/linecorp/armeria/client/Http1ResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http1ResponseDecoder.java
@@ -25,7 +25,6 @@ import com.linecorp.armeria.common.ClosedSessionException;
 import com.linecorp.armeria.common.ContentTooLargeException;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpRequest;
-import com.linecorp.armeria.common.HttpResponseWriter;
 import com.linecorp.armeria.common.ProtocolViolationException;
 import com.linecorp.armeria.common.logging.RequestLogBuilder;
 import com.linecorp.armeria.internal.ArmeriaHttpUtil;
@@ -188,7 +187,7 @@ final class Http1ResponseDecoder extends HttpResponseDecoder implements ChannelI
                         }
 
                         if (msg instanceof LastHttpContent) {
-                            final HttpResponseWriter res = removeResponse(resId++);
+                            final HttpResponseWrapper res = removeResponse(resId++);
                             assert this.res == res;
                             this.res = null;
 
@@ -225,7 +224,7 @@ final class Http1ResponseDecoder extends HttpResponseDecoder implements ChannelI
     private void fail(ChannelHandlerContext ctx, Throwable cause) {
         state = State.DISCARD;
 
-        final HttpResponseWriter res = this.res;
+        final HttpResponseWrapper res = this.res;
         this.res = null;
 
         if (res != null) {

--- a/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
@@ -29,11 +29,10 @@ import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpObject;
 import com.linecorp.armeria.common.HttpRequest;
-import com.linecorp.armeria.common.HttpResponseWriter;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.HttpStatusClass;
-import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.logging.RequestLogBuilder;
+import com.linecorp.armeria.common.stream.StreamWriter;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.internal.InboundTrafficController;
 
@@ -71,7 +70,7 @@ abstract class HttpResponseDecoder {
 
         final HttpResponseWrapper newRes =
                 new HttpResponseWrapper(req, res, logBuilder, responseTimeoutMillis, maxContentLength);
-        final HttpResponseWriter oldRes = responses.put(id, newRes);
+        final HttpResponseWrapper oldRes = responses.put(id, newRes);
 
         assert oldRes == null : "addResponse(" + id + ", " + res + ", " + responseTimeoutMillis + "): " +
                                 oldRes;
@@ -116,7 +115,7 @@ abstract class HttpResponseDecoder {
         return disconnectWhenFinished && !hasUnfinishedResponses();
     }
 
-    static final class HttpResponseWrapper implements HttpResponseWriter, Runnable {
+    static final class HttpResponseWrapper implements StreamWriter<HttpObject>, Runnable {
         private final HttpRequest request;
         private final DecodedHttpResponse delegate;
         private final RequestLogBuilder logBuilder;
@@ -237,35 +236,6 @@ abstract class HttpResponseDecoder {
             if (request != null) {
                 request.abort();
             }
-        }
-
-        @Override
-        public void respond(HttpStatus status) {
-            delegate.respond(status);
-        }
-
-        @Override
-        public void respond(HttpStatus status,
-                            MediaType mediaType, String content) {
-            delegate.respond(status, mediaType, content);
-        }
-
-        @Override
-        public void respond(HttpStatus status,
-                            MediaType mediaType, String format, Object... args) {
-            delegate.respond(status, mediaType, format, args);
-        }
-
-        @Override
-        public void respond(HttpStatus status,
-                            MediaType mediaType, byte[] content) {
-            delegate.respond(status, mediaType, content);
-        }
-
-        @Override
-        public void respond(HttpStatus status,
-                            MediaType mediaType, byte[] content, int offset, int length) {
-            delegate.respond(status, mediaType, content, offset, length);
         }
 
         @Override

--- a/core/src/main/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingHttpClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingHttpClient.java
@@ -16,12 +16,12 @@
 
 package com.linecorp.armeria.client.limit;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
 import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.client.ClientRequestContext;
-import com.linecorp.armeria.common.DeferredHttpResponse;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 
@@ -68,7 +68,8 @@ public final class ConcurrencyLimitingHttpClient extends ConcurrencyLimitingClie
     @Override
     protected Deferred<HttpResponse> defer(ClientRequestContext ctx, HttpRequest req) throws Exception {
         return new Deferred<HttpResponse>() {
-            private final DeferredHttpResponse res = new DeferredHttpResponse();
+            private final CompletableFuture<HttpResponse> responseFuture = new CompletableFuture<>();
+            private final HttpResponse res = HttpResponse.from(responseFuture);
 
             @Override
             public HttpResponse response() {
@@ -77,12 +78,12 @@ public final class ConcurrencyLimitingHttpClient extends ConcurrencyLimitingClie
 
             @Override
             public void delegate(HttpResponse response) {
-                res.delegate(response);
+                responseFuture.complete(response);
             }
 
             @Override
             public void close(Throwable cause) {
-                res.close(cause);
+                responseFuture.completeExceptionally(cause);
             }
         };
     }

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultHttpRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 LINE Corporation
+ * Copyright 2017 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -24,38 +24,17 @@ import com.linecorp.armeria.common.stream.DefaultStreamMessage;
 
 /**
  * Default {@link HttpRequest} implementation.
+ *
+ * @deprecated Use {@link HttpRequest#streaming()}.
  */
-public class DefaultHttpRequest
-        extends DefaultStreamMessage<HttpObject> implements HttpRequest, HttpRequestWriter {
+@Deprecated
+public class DefaultHttpRequest extends DefaultStreamMessage<HttpObject> implements HttpRequestWriter {
 
     private final HttpHeaders headers;
     private final boolean keepAlive;
 
     /**
-     * Creates a new instance with empty headers.
-     */
-    public DefaultHttpRequest() {
-        this(new DefaultHttpHeaders());
-    }
-
-    /**
      * Creates a new instance with the specified headers.
-     */
-    public DefaultHttpRequest(HttpHeaders headers) {
-        this(headers, true);
-    }
-
-    /**
-     * Creates a new instance with the specified {@link HttpMethod} and path.
-     */
-    public DefaultHttpRequest(HttpMethod method, String path) {
-        this(HttpHeaders.of(method, path));
-    }
-
-    /**
-     * Creates a new instance with the specified headers.
-     *
-     * @param keepAlive whether to keep the connection alive after this request is handled
      */
     public DefaultHttpRequest(HttpHeaders headers, boolean keepAlive) {
         this.headers = requireNonNull(headers, "headers");

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultHttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultHttpResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 LINE Corporation
+ * Copyright 2017 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -22,9 +22,12 @@ import com.linecorp.armeria.common.stream.DefaultStreamMessage;
 
 /**
  * Default {@link HttpResponse} instance.
+ *
+ * @deprecated Use {@link HttpResponse#streaming()}.
  */
+@Deprecated
 public class DefaultHttpResponse
-        extends DefaultStreamMessage<HttpObject> implements HttpResponse, HttpResponseWriter {
+        extends DefaultStreamMessage<HttpObject> implements HttpResponseWriter {
 
     @Override
     public String toString() {

--- a/core/src/main/java/com/linecorp/armeria/common/DeferredHttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DeferredHttpResponse.java
@@ -38,9 +38,4 @@ public class DeferredHttpResponse extends DeferredStreamMessage<HttpObject> impl
     public void delegate(HttpResponse delegate) {
         super.delegate(delegate);
     }
-
-    @Override
-    public boolean isDeferred() {
-        return true;
-    }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/DeferredHttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DeferredHttpResponse.java
@@ -16,29 +16,19 @@
 
 package com.linecorp.armeria.common;
 
+import java.util.concurrent.CompletionStage;
+
 import com.linecorp.armeria.common.stream.DeferredStreamMessage;
 
 /**
- * An {@link HttpResponse} whose stream is published later by another {@link HttpResponse}. It is useful when
- * your {@link HttpResponse} will not be instantiated early. For example:
- * <pre>{@code
- * public class DelayService extends DecoratingService<HttpRequest, HttpResponse> {
- *     public DelayService(Service<HttpRequest, HttpResponse> delegate) {
- *         super(delegate);
- *     }
+ * An {@link HttpResponse} whose stream is published later by another {@link HttpResponse}. It is used when
+ * an {@link HttpResponse} will not be instantiated early.
  *
- *     public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) {
- *         // Delay all requests by 3 seconds.
- *         DeferredHttpResponse res = new DeferredHttpResponse();
- *         ctx.eventLoop().schedule(() -> {
- *             res.delegate(delegate().serve(ctx, req));
- *         }, 3, TimeUnit.SECONDS);
- *         return res;
- *     }
- * }
- * }</pre>
+ * @deprecated Use {@link HttpResponse#from(CompletionStage)}.
  */
+@Deprecated
 public class DeferredHttpResponse extends DeferredStreamMessage<HttpObject> implements HttpResponse {
+
     /**
      * Sets the delegate {@link HttpResponse} which will publish the stream actually.
      *
@@ -47,5 +37,10 @@ public class DeferredHttpResponse extends DeferredStreamMessage<HttpObject> impl
      */
     public void delegate(HttpResponse delegate) {
         super.delegate(delegate);
+    }
+
+    @Override
+    public boolean isDeferred() {
+        return true;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
@@ -48,6 +48,57 @@ public interface HttpRequest extends Request, StreamMessage<HttpObject> {
     //       AggregatedHttpMessage for consistency.
 
     /**
+     * Creates a new HTTP request that can be used to stream an arbitrary number of {@link HttpObject} to a
+     * server with empty headers and keep-alive enabled.
+     */
+    static HttpRequestWriter streaming() {
+        return streaming(true);
+    }
+
+    /**
+     * Creates a new HTTP request that can be used to stream an arbitrary number of {@link HttpObject} to a
+     * server with empty headers and specified {@code keepAlive}.
+     */
+    static HttpRequestWriter streaming(boolean keepAlive) {
+        return streaming(HttpHeaders.EMPTY_HEADERS, keepAlive);
+    }
+
+    /**
+     * Creates a new HTTP request that can be used to stream an arbitrary number of {@link HttpObject} to a
+     * server with the specified {@link HttpMethod} and {@code path} with keep-alive enabled.
+     */
+    static HttpRequestWriter streaming(HttpMethod method, String path) {
+        return streaming(method, path, true);
+    }
+
+    /**
+     * Creates a new HTTP request that can be used to stream an arbitrary number of {@link HttpObject} to a
+     * server with the specified {@link HttpMethod}, {@code path}, and {@code keepAlive}.
+     */
+    static HttpRequestWriter streaming(HttpMethod method, String path, boolean keepAlive) {
+        requireNonNull(method, "method");
+        requireNonNull(path, "path");
+        return streaming(HttpHeaders.of(method, path), keepAlive);
+    }
+
+    /**
+     * Creates a new HTTP request that can be used to stream an arbitrary number of {@link HttpObject} to a
+     * server with the specified headers and keep-alive enabled.
+     */
+    static HttpRequestWriter streaming(HttpHeaders headers) {
+        return streaming(headers, true);
+    }
+
+    /**
+     * Creates a new HTTP request that can be used to stream an arbitrary number of {@link HttpObject} to a
+     * server with the specified headers and {@code keepAlive}.
+     */
+    static HttpRequestWriter streaming(HttpHeaders headers, boolean keepAlive) {
+        requireNonNull(headers, "headers");
+        return new DefaultHttpRequest(headers, keepAlive);
+    }
+
+    /**
      * Creates a new HTTP request with empty content and closes the stream.
      *
      * @param method the HTTP method of the request

--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequestWriter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequestWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 LINE Corporation
+ * Copyright 2017 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -19,8 +19,8 @@ package com.linecorp.armeria.common;
 import com.linecorp.armeria.common.stream.StreamWriter;
 
 /**
- * A {@link StreamWriter} of an {@link HttpRequest}.
+ * An {@link HttpRequest} that can have {@link HttpObject}s written to it. Use {@link HttpRequest#streaming()}
+ * to construct.
  */
-public interface HttpRequestWriter extends StreamWriter<HttpObject> {
-    // TODO(trustin): Add lots of convenience methods for easier response construction.
+public interface HttpRequestWriter extends HttpRequest, StreamWriter<HttpObject> {
 }

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -328,11 +328,4 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
         subscribe(aggregator, executor);
         return future;
     }
-
-    /**
-     * Whether this is a deferred {@link HttpResponse}, created by {@link #from(CompletionStage)}.
-     */
-    default boolean isDeferred() {
-        return false;
-    }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponseWriter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponseWriter.java
@@ -21,24 +21,22 @@ import static com.linecorp.armeria.internal.ArmeriaHttpUtil.isContentAlwaysEmpty
 import static java.util.Objects.requireNonNull;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Formatter;
 import java.util.Locale;
 
 import com.linecorp.armeria.common.stream.StreamWriter;
 
 /**
- * A {@link StreamWriter} of an {@link HttpResponse}.
+ * An {@link HttpResponse} that can have {@link HttpObject}s written to it.
  */
-public interface HttpResponseWriter extends StreamWriter<HttpObject> {
-    // TODO(trustin): Add lots of convenience methods for easier response construction.
-
-    // Note: Ensure we provide the same set of `respond()` methods with the `of()` methods of
-    //       HttpResponse and AggregatedHttpMessage for consistency.
+public interface HttpResponseWriter extends HttpResponse, StreamWriter<HttpObject> {
 
     /**
      * Writes the HTTP response of the specified {@code statusCode} and closes the stream if the
      * {@link HttpStatusClass} is not {@linkplain HttpStatusClass#INFORMATIONAL informational} (1xx).
+     *
+     * @deprecated Use {@link HttpResponse#of(int)}.
      */
+    @Deprecated
     default void respond(int statusCode) {
         respond(HttpStatus.valueOf(statusCode));
     }
@@ -46,7 +44,10 @@ public interface HttpResponseWriter extends StreamWriter<HttpObject> {
     /**
      * Writes the HTTP response of the specified {@link HttpStatus} and closes the stream if the
      * {@link HttpStatusClass} is not {@linkplain HttpStatusClass#INFORMATIONAL informational} (1xx).
+     *
+     * @deprecated Use {@link HttpResponse#of(HttpStatus)}.
      */
+    @Deprecated
     default void respond(HttpStatus status) {
         requireNonNull(status, "status");
         if (status.codeClass() == HttpStatusClass.INFORMATIONAL) {
@@ -64,7 +65,10 @@ public interface HttpResponseWriter extends StreamWriter<HttpObject> {
      *
      * @param mediaType the {@link MediaType} of the response content
      * @param content the content of the response
+     *
+     * @deprecated Use {@link HttpResponse#of(HttpStatus, MediaType, String)}.
      */
+    @Deprecated
     default void respond(HttpStatus status, MediaType mediaType, String content) {
         requireNonNull(status, "status");
         requireNonNull(mediaType, "mediaType");
@@ -79,9 +83,12 @@ public interface HttpResponseWriter extends StreamWriter<HttpObject> {
      * {@linkplain Locale#ENGLISH English locale}.
      *
      * @param mediaType the {@link MediaType} of the response content
-     * @param format {@linkplain Formatter the format string} of the response content
+     * @param format {@linkplain java.util.Formatter the format string} of the response content
      * @param args the arguments referenced by the format specifiers in the format string
+     *
+     * @deprecated Use {@link HttpResponse#of(HttpStatus, MediaType, String, Object...)}.
      */
+    @Deprecated
     default void respond(HttpStatus status, MediaType mediaType, String format, Object... args) {
         requireNonNull(status, "status");
         requireNonNull(mediaType, "mediaType");
@@ -98,7 +105,10 @@ public interface HttpResponseWriter extends StreamWriter<HttpObject> {
      *
      * @param mediaType the {@link MediaType} of the response content
      * @param content the content of the response
+     *
+     * @deprecated Use {@link HttpResponse#of(HttpStatus, MediaType, byte[])}.
      */
+    @Deprecated
     default void respond(HttpStatus status, MediaType mediaType, byte[] content) {
         requireNonNull(status, "status");
         requireNonNull(mediaType, "mediaType");
@@ -113,7 +123,10 @@ public interface HttpResponseWriter extends StreamWriter<HttpObject> {
      * @param content the content of the response
      * @param offset the start offset of {@code content}
      * @param length the length of {@code content}
+     *
+     * @deprecated Use {@link HttpResponse#of(HttpStatus, MediaType, byte[], int, int)}.
      */
+    @Deprecated
     default void respond(HttpStatus status, MediaType mediaType, byte[] content, int offset, int length) {
         requireNonNull(status, "status");
         requireNonNull(mediaType, "mediaType");
@@ -126,7 +139,10 @@ public interface HttpResponseWriter extends StreamWriter<HttpObject> {
      *
      * @param mediaType the {@link MediaType} of the response content
      * @param content the content of the response
+     *
+     * @deprecated Use {@link HttpResponse#of(HttpStatus, MediaType, HttpData)}.
      */
+    @Deprecated
     default void respond(HttpStatus status, MediaType mediaType, HttpData content) {
         requireNonNull(status, "status");
         requireNonNull(mediaType, "mediaType");
@@ -140,7 +156,10 @@ public interface HttpResponseWriter extends StreamWriter<HttpObject> {
      * @param mediaType the {@link MediaType} of the response content
      * @param content the content of the response
      * @param trailingHeaders the trailing HTTP headers
+     *
+     * @deprecated Use {@link HttpResponse#of(HttpStatus, MediaType, HttpData, HttpHeaders)}.
      */
+    @Deprecated
     default void respond(HttpStatus status, MediaType mediaType, HttpData content,
                          HttpHeaders trailingHeaders) {
         requireNonNull(status, "status");
@@ -173,7 +192,10 @@ public interface HttpResponseWriter extends StreamWriter<HttpObject> {
 
     /**
      * Writes the specified HTTP response and closes the stream.
+     *
+     * @deprecated Use {@link HttpResponse#of(AggregatedHttpMessage)}.
      */
+    @Deprecated
     default void respond(AggregatedHttpMessage res) {
         requireNonNull(res, "res");
 
@@ -197,6 +219,14 @@ public interface HttpResponseWriter extends StreamWriter<HttpObject> {
             write(trailingHeaders);
         }
 
+        close();
+    }
+
+    /**
+     * Write the given {@link HttpObject} and close the stream.
+     */
+    default void respond(HttpObject obj) {
+        write(obj);
         close();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponseWriter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponseWriter.java
@@ -192,10 +192,7 @@ public interface HttpResponseWriter extends HttpResponse, StreamWriter<HttpObjec
 
     /**
      * Writes the specified HTTP response and closes the stream.
-     *
-     * @deprecated Use {@link HttpResponse#of(AggregatedHttpMessage)}.
      */
-    @Deprecated
     default void respond(AggregatedHttpMessage res) {
         requireNonNull(res, "res");
 
@@ -219,14 +216,6 @@ public interface HttpResponseWriter extends HttpResponse, StreamWriter<HttpObjec
             write(trailingHeaders);
         }
 
-        close();
-    }
-
-    /**
-     * Write the given {@link HttpObject} and close the stream.
-     */
-    default void respond(HttpObject obj) {
-        write(obj);
         close();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponseWriter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponseWriter.java
@@ -192,8 +192,18 @@ public interface HttpResponseWriter extends HttpResponse, StreamWriter<HttpObjec
 
     /**
      * Writes the specified HTTP response and closes the stream.
+     *
+     * @deprecated Use {@link #close(AggregatedHttpMessage)}.
      */
+    @Deprecated
     default void respond(AggregatedHttpMessage res) {
+        close(res);
+    }
+
+    /**
+     * Writes the specified HTTP response and closes the stream.
+     */
+    default void close(AggregatedHttpMessage res) {
         requireNonNull(res, "res");
 
         final HttpHeaders headers = res.headers();

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamWriter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamWriter.java
@@ -74,4 +74,12 @@ public interface StreamWriter<T> {
      * signal that the {@link Subscriber} did not consume the stream completely.
      */
     void close(Throwable cause);
+
+    /**
+     * Writes the given object and closes the stream successfully.
+     */
+    default void close(T obj) {
+        write(obj);
+        close();
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/AbstractHttpService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AbstractHttpService.java
@@ -16,7 +16,6 @@
 
 package com.linecorp.armeria.server;
 
-import com.linecorp.armeria.common.DefaultHttpResponse;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
@@ -29,17 +28,17 @@ import com.linecorp.armeria.common.logging.RequestLogBuilder;
  * A skeletal {@link HttpService} for easier HTTP service implementation.
  *
  * <p>This class provides the methods that handles the HTTP requests of the methods their names signify.
- * For example, {@link #doGet(ServiceRequestContext, HttpRequest, HttpResponseWriter) doGet()} method handles a
+ * For example, {@link #doGet(ServiceRequestContext, HttpRequest) doGet()} method handles a
  * {@code GET} request.
  * <ul>
- *   <li>{@link #doOptions(ServiceRequestContext, HttpRequest, HttpResponseWriter)}</li>
- *   <li>{@link #doGet(ServiceRequestContext, HttpRequest, HttpResponseWriter)}</li>
- *   <li>{@link #doHead(ServiceRequestContext, HttpRequest, HttpResponseWriter)}</li>
- *   <li>{@link #doPost(ServiceRequestContext, HttpRequest, HttpResponseWriter)}</li>
- *   <li>{@link #doPut(ServiceRequestContext, HttpRequest, HttpResponseWriter)}</li>
- *   <li>{@link #doPatch(ServiceRequestContext, HttpRequest, HttpResponseWriter)}</li>
- *   <li>{@link #doDelete(ServiceRequestContext, HttpRequest, HttpResponseWriter)}</li>
- *   <li>{@link #doTrace(ServiceRequestContext, HttpRequest, HttpResponseWriter)}</li>
+ *   <li>{@link #doOptions(ServiceRequestContext, HttpRequest)}</li>
+ *   <li>{@link #doGet(ServiceRequestContext, HttpRequest)}</li>
+ *   <li>{@link #doHead(ServiceRequestContext, HttpRequest)}</li>
+ *   <li>{@link #doPost(ServiceRequestContext, HttpRequest)}</li>
+ *   <li>{@link #doPut(ServiceRequestContext, HttpRequest)}</li>
+ *   <li>{@link #doPatch(ServiceRequestContext, HttpRequest)}</li>
+ *   <li>{@link #doDelete(ServiceRequestContext, HttpRequest)}</li>
+ *   <li>{@link #doTrace(ServiceRequestContext, HttpRequest)}</li>
  * </ul>
  * These methods reject requests with a {@link HttpStatus#METHOD_NOT_ALLOWED 405 Method Not Allowed} response
  * by default. Override one of them to handle requests properly.
@@ -66,37 +65,26 @@ public abstract class AbstractHttpService implements HttpService {
     @Override
     public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
         try {
-            final DefaultHttpResponse res = new DefaultHttpResponse();
             switch (req.method()) {
                 case OPTIONS:
-                    doOptions(ctx, req, res);
-                    break;
+                    return doOptions(ctx, req);
                 case GET:
-                    doGet(ctx, req, res);
-                    break;
+                    return doGet(ctx, req);
                 case HEAD:
-                    doHead(ctx, req, res);
-                    break;
+                    return doHead(ctx, req);
                 case POST:
-                    doPost(ctx, req, res);
-                    break;
+                    return doPost(ctx, req);
                 case PUT:
-                    doPut(ctx, req, res);
-                    break;
+                    return doPut(ctx, req);
                 case PATCH:
-                    doPatch(ctx, req, res);
-                    break;
+                    return doPatch(ctx, req);
                 case DELETE:
-                    doDelete(ctx, req, res);
-                    break;
+                    return doDelete(ctx, req);
                 case TRACE:
-                    doTrace(ctx, req, res);
-                    break;
+                    return doTrace(ctx, req);
                 default:
-                    res.respond(HttpStatus.METHOD_NOT_ALLOWED);
+                    return HttpResponse.of(HttpStatus.METHOD_NOT_ALLOWED);
             }
-
-            return res;
         } finally {
             final RequestLogBuilder logBuilder = ctx.logBuilder();
             if (!logBuilder.isRequestContentDeferred()) {
@@ -115,8 +103,21 @@ public abstract class AbstractHttpService implements HttpService {
      * Handles an {@link HttpMethod#OPTIONS OPTIONS} request.
      * This method sends a {@link HttpStatus#METHOD_NOT_ALLOWED 405 Method Not Allowed} response by default.
      */
-    protected void doOptions(ServiceRequestContext ctx,
-                             HttpRequest req, HttpResponseWriter res) throws Exception {
+    protected HttpResponse doOptions(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+        HttpResponseWriter res = HttpResponse.streaming();
+        doOptions(ctx, req, res);
+        return res;
+    }
+
+    /**
+     * Handles an {@link HttpMethod#OPTIONS OPTIONS} request.
+     * This method sends a {@link HttpStatus#METHOD_NOT_ALLOWED 405 Method Not Allowed} response by default.
+     *
+     * @deprecated Use {@link #doOptions(ServiceRequestContext, HttpRequest)}.
+     */
+    @Deprecated
+    protected void doOptions(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res)
+            throws Exception {
         res.respond(HttpStatus.METHOD_NOT_ALLOWED);
     }
 
@@ -124,8 +125,21 @@ public abstract class AbstractHttpService implements HttpService {
      * Handles a {@link HttpMethod#GET GET} request.
      * This method sends a {@link HttpStatus#METHOD_NOT_ALLOWED 405 Method Not Allowed} response by default.
      */
-    protected void doGet(ServiceRequestContext ctx,
-                         HttpRequest req, HttpResponseWriter res) throws Exception {
+    protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+        HttpResponseWriter res = HttpResponse.streaming();
+        doGet(ctx, req, res);
+        return res;
+    }
+
+    /**
+     * Handles an {@link HttpMethod#GET GET} request.
+     * This method sends a {@link HttpStatus#METHOD_NOT_ALLOWED 405 Method Not Allowed} response by default.
+     *
+     * @deprecated Use {@link #doGet(ServiceRequestContext, HttpRequest)}.
+     */
+    @Deprecated
+    protected void doGet(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res)
+            throws Exception {
         res.respond(HttpStatus.METHOD_NOT_ALLOWED);
     }
 
@@ -133,8 +147,21 @@ public abstract class AbstractHttpService implements HttpService {
      * Handles a {@link HttpMethod#HEAD HEAD} request.
      * This method sends a {@link HttpStatus#METHOD_NOT_ALLOWED 405 Method Not Allowed} response by default.
      */
-    protected void doHead(ServiceRequestContext ctx,
-                          HttpRequest req, HttpResponseWriter res) throws Exception {
+    protected HttpResponse doHead(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+        HttpResponseWriter res = HttpResponse.streaming();
+        doHead(ctx, req, res);
+        return res;
+    }
+
+    /**
+     * Handles an {@link HttpMethod#HEAD HEAD} request.
+     * This method sends a {@link HttpStatus#METHOD_NOT_ALLOWED 405 Method Not Allowed} response by default.
+     *
+     * @deprecated Use {@link #doHead(ServiceRequestContext, HttpRequest)}.
+     */
+    @Deprecated
+    protected void doHead(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res)
+            throws Exception {
         res.respond(HttpStatus.METHOD_NOT_ALLOWED);
     }
 
@@ -142,8 +169,21 @@ public abstract class AbstractHttpService implements HttpService {
      * Handles a {@link HttpMethod#POST POST} request.
      * This method sends a {@link HttpStatus#METHOD_NOT_ALLOWED 405 Method Not Allowed} response by default.
      */
-    protected void doPost(ServiceRequestContext ctx,
-                          HttpRequest req, HttpResponseWriter res) throws Exception {
+    protected HttpResponse doPost(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+        HttpResponseWriter res = HttpResponse.streaming();
+        doPost(ctx, req, res);
+        return res;
+    }
+
+    /**
+     * Handles an {@link HttpMethod#POST POST} request.
+     * This method sends a {@link HttpStatus#METHOD_NOT_ALLOWED 405 Method Not Allowed} response by default.
+     *
+     * @deprecated Use {@link #doPost(ServiceRequestContext, HttpRequest)}.
+     */
+    @Deprecated
+    protected void doPost(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res)
+            throws Exception {
         res.respond(HttpStatus.METHOD_NOT_ALLOWED);
     }
 
@@ -151,8 +191,21 @@ public abstract class AbstractHttpService implements HttpService {
      * Handles a {@link HttpMethod#PUT PUT} request.
      * This method sends a {@link HttpStatus#METHOD_NOT_ALLOWED 405 Method Not Allowed} response by default.
      */
-    protected void doPut(ServiceRequestContext ctx,
-                         HttpRequest req, HttpResponseWriter res) throws Exception {
+    protected HttpResponse doPut(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+        HttpResponseWriter res = HttpResponse.streaming();
+        doPut(ctx, req, res);
+        return res;
+    }
+
+    /**
+     * Handles an {@link HttpMethod#PUT PUT} request.
+     * This method sends a {@link HttpStatus#METHOD_NOT_ALLOWED 405 Method Not Allowed} response by default.
+     *
+     * @deprecated Use {@link #doPut(ServiceRequestContext, HttpRequest)}.
+     */
+    @Deprecated
+    protected void doPut(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res)
+            throws Exception {
         res.respond(HttpStatus.METHOD_NOT_ALLOWED);
     }
 
@@ -160,8 +213,21 @@ public abstract class AbstractHttpService implements HttpService {
      * Handles a {@link HttpMethod#PATCH PATCH} request.
      * This method sends a {@link HttpStatus#METHOD_NOT_ALLOWED 405 Method Not Allowed} response by default.
      */
-    protected void doPatch(ServiceRequestContext ctx,
-                           HttpRequest req, HttpResponseWriter res) throws Exception {
+    protected HttpResponse doPatch(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+        HttpResponseWriter res = HttpResponse.streaming();
+        doPatch(ctx, req, res);
+        return res;
+    }
+
+    /**
+     * Handles an {@link HttpMethod#PATCH PATCH} request.
+     * This method sends a {@link HttpStatus#METHOD_NOT_ALLOWED 405 Method Not Allowed} response by default.
+     *
+     * @deprecated Use {@link #doPatch(ServiceRequestContext, HttpRequest)}.
+     */
+    @Deprecated
+    protected void doPatch(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res)
+            throws Exception {
         res.respond(HttpStatus.METHOD_NOT_ALLOWED);
     }
 
@@ -169,8 +235,21 @@ public abstract class AbstractHttpService implements HttpService {
      * Handles a {@link HttpMethod#DELETE DELETE} request.
      * This method sends a {@link HttpStatus#METHOD_NOT_ALLOWED 405 Method Not Allowed} response by default.
      */
-    protected void doDelete(ServiceRequestContext ctx,
-                            HttpRequest req, HttpResponseWriter res) throws Exception {
+    protected HttpResponse doDelete(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+        HttpResponseWriter res = HttpResponse.streaming();
+        doDelete(ctx, req, res);
+        return res;
+    }
+
+    /**
+     * Handles an {@link HttpMethod#DELETE DELETE} request.
+     * This method sends a {@link HttpStatus#METHOD_NOT_ALLOWED 405 Method Not Allowed} response by default.
+     *
+     * @deprecated Use {@link #doDelete(ServiceRequestContext, HttpRequest)}.
+     */
+    @Deprecated
+    protected void doDelete(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res)
+            throws Exception {
         res.respond(HttpStatus.METHOD_NOT_ALLOWED);
     }
 
@@ -178,8 +257,21 @@ public abstract class AbstractHttpService implements HttpService {
      * Handles a {@link HttpMethod#TRACE TRACE} request.
      * This method sends a {@link HttpStatus#METHOD_NOT_ALLOWED 405 Method Not Allowed} response by default.
      */
-    protected void doTrace(ServiceRequestContext ctx,
-                           HttpRequest req, HttpResponseWriter res) throws Exception {
+    protected HttpResponse doTrace(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+        HttpResponseWriter res = HttpResponse.streaming();
+        doTrace(ctx, req, res);
+        return res;
+    }
+
+    /**
+     * Handles an {@link HttpMethod#TRACE TRACE} request.
+     * This method sends a {@link HttpStatus#METHOD_NOT_ALLOWED 405 Method Not Allowed} response by default.
+     *
+     * @deprecated Use {@link #doTrace(ServiceRequestContext, HttpRequest)}.
+     */
+    @Deprecated
+    protected void doTrace(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res)
+            throws Exception {
         res.respond(HttpStatus.METHOD_NOT_ALLOWED);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/Http2RequestDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http2RequestDecoder.java
@@ -24,10 +24,10 @@ import static io.netty.handler.codec.http2.Http2Exception.streamError;
 import java.nio.charset.StandardCharsets;
 
 import com.linecorp.armeria.common.ContentTooLargeException;
-import com.linecorp.armeria.common.DefaultHttpRequest;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequestWriter;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.internal.ArmeriaHttpUtil;
 import com.linecorp.armeria.internal.InboundTrafficController;
@@ -215,7 +215,7 @@ final class Http2RequestDecoder extends Http2EventAdapter {
 
     @Override
     public void onRstStreamRead(ChannelHandlerContext ctx, int streamId, long errorCode) throws Http2Exception {
-        final DefaultHttpRequest req = requests.get(streamId);
+        final HttpRequestWriter req = requests.get(streamId);
         if (req == null) {
             throw connectionError(PROTOCOL_ERROR,
                                   "received a RST_STREAM frame for an unknown stream: %d", streamId);

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
@@ -133,14 +133,15 @@ public interface ServiceRequestContext extends RequestContext {
 
     /**
      * Sets a handler to run when the request times out. {@code requestTimeoutHandler} must close the response,
-     * e.g., by calling {@link HttpResponseWriter#respond(int)}. If not set, the response will be closed with
+     * e.g., by calling {@link HttpResponseWriter#close()}. If not set, the response will be closed with
      * {@link HttpStatus#SERVICE_UNAVAILABLE}.
      *
      * <p>For example,
      * <pre>{@code
-     *   DefaultHttpResponse res = new DefaultHttpResponse();
+     *   HttpResponseWriter res = HttpResponse.streaming();
      *   ctx.setRequestTimeoutHandler(() -> {
-     *      res.respond(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "Request timed out.");
+     *      res.write(HttpHeaders.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "Request timed out."));
+     *      res.close();
      *   });
      *   ...
      * }</pre>

--- a/core/src/main/java/com/linecorp/armeria/server/auth/HttpAuthService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/auth/HttpAuthService.java
@@ -28,7 +28,6 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableList;
 
-import com.linecorp.armeria.common.DefaultHttpResponse;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
@@ -99,9 +98,7 @@ public abstract class HttpAuthService extends SimpleDecoratingService<HttpReques
         if (cause != null) {
             logger.warn("Unexpected exception during authorization.", cause);
         }
-        final DefaultHttpResponse res = new DefaultHttpResponse();
-        res.respond(HttpStatus.UNAUTHORIZED);
-        return res;
+        return HttpResponse.of(HttpStatus.UNAUTHORIZED);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsService.java
@@ -28,7 +28,6 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Ascii;
 
-import com.linecorp.armeria.common.DefaultHttpResponse;
 import com.linecorp.armeria.common.FilteredHttpResponse;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
@@ -126,7 +125,6 @@ public final class CorsService extends SimpleDecoratingService<HttpRequest, Http
      * @param req the decoded HTTP request
      */
     private HttpResponse handleCorsPreflight(HttpRequest req) {
-        DefaultHttpResponse res = new DefaultHttpResponse();
         HttpHeaders headers = HttpHeaders.of(HttpStatus.OK);
         if (setCorsOrigin(req, headers)) {
             setCorsAllowMethods(headers);
@@ -136,9 +134,7 @@ public final class CorsService extends SimpleDecoratingService<HttpRequest, Http
             setPreflightHeaders(headers);
         }
 
-        res.write(headers);
-        res.close();
-        return res;
+        return HttpResponse.of(headers);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/HttpHealthCheckService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/HttpHealthCheckService.java
@@ -23,7 +23,7 @@ import java.util.List;
 import com.linecorp.armeria.common.AggregatedHttpMessage;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpRequest;
-import com.linecorp.armeria.common.HttpResponseWriter;
+import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.server.AbstractHttpService;
@@ -126,14 +126,13 @@ public class HttpHealthCheckService extends AbstractHttpService {
     }
 
     @Override
-    protected void doHead(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) throws Exception {
-        res.write(newResponse(ctx).headers()); // Send without the content.
-        res.close();
+    protected HttpResponse doHead(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+        return HttpResponse.of(newResponse(ctx).headers()); // Send without the content.
     }
 
     @Override
-    protected void doGet(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) {
-        res.respond(newResponse(ctx));
+    protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) {
+        return HttpResponse.of(newResponse(ctx));
     }
 
     private AggregatedHttpMessage newResponse(ServiceRequestContext ctx) {

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/ManagedHttpHealthCheckService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/ManagedHttpHealthCheckService.java
@@ -24,10 +24,9 @@ import com.google.common.base.Ascii;
 import com.linecorp.armeria.common.AggregatedHttpMessage;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpRequest;
-import com.linecorp.armeria.common.HttpResponseWriter;
+import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
-import com.linecorp.armeria.common.util.Functions;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
 /**
@@ -58,9 +57,10 @@ public class ManagedHttpHealthCheckService extends HttpHealthCheckService {
             .of(HttpStatus.BAD_REQUEST, MediaType.PLAIN_TEXT_UTF_8, HttpData.ofUtf8("Not supported."));
 
     @Override
-    protected void doPut(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) throws Exception {
-        updateHealthStatus(ctx, req).thenAccept(res::respond)
-                                    .exceptionally(Functions.voidFunction(res::close));
+    protected HttpResponse doPut(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+        return HttpResponse.from(
+                updateHealthStatus(ctx, req).thenApply(HttpResponse::of)
+                                            .exceptionally(HttpResponse::ofFailure));
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/metric/PrometheusExpositionService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/metric/PrometheusExpositionService.java
@@ -22,7 +22,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.OutputStreamWriter;
 
 import com.linecorp.armeria.common.HttpRequest;
-import com.linecorp.armeria.common.HttpResponseWriter;
+import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.server.AbstractHttpService;
@@ -52,18 +52,16 @@ public class PrometheusExpositionService extends AbstractHttpService {
     }
 
     @Override
-    protected void doGet(ServiceRequestContext ctx, HttpRequest req,
-                         HttpResponseWriter res) throws Exception {
+    protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) throws Exception {
         ByteArrayOutputStream stream = new ByteArrayOutputStream();
         try (OutputStreamWriter writer = new OutputStreamWriter(stream)) {
             TextFormat.write004(writer, collectorRegistry.metricFamilySamples());
         }
-        res.respond(HttpStatus.OK, CONTENT_TYPE_004, stream.toByteArray());
+        return HttpResponse.of(HttpStatus.OK, CONTENT_TYPE_004, stream.toByteArray());
     }
 
     @Override
-    protected void doPost(ServiceRequestContext ctx, HttpRequest req,
-                          HttpResponseWriter res) throws Exception {
-        doGet(ctx, req, res);
+    protected HttpResponse doPost(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+        return doGet(ctx, req);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/throttling/ThrottlingHttpService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/throttling/ThrottlingHttpService.java
@@ -21,7 +21,6 @@ import java.util.function.Function;
 
 import javax.annotation.Nullable;
 
-import com.linecorp.armeria.common.DefaultHttpResponse;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
@@ -58,8 +57,6 @@ public class ThrottlingHttpService extends ThrottlingService<HttpRequest, HttpRe
     @Override
     protected HttpResponse onFailure(ServiceRequestContext ctx, HttpRequest req, @Nullable Throwable cause)
             throws Exception {
-        final DefaultHttpResponse res = new DefaultHttpResponse();
-        res.respond(HttpStatus.SERVICE_UNAVAILABLE);
-        return res;
+        return HttpResponse.of(HttpStatus.SERVICE_UNAVAILABLE);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/ClientDecorationBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientDecorationBuilderTest.java
@@ -21,12 +21,12 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.Test;
 
-import com.linecorp.armeria.common.DefaultHttpRequest;
-import com.linecorp.armeria.common.DefaultHttpResponse;
 import com.linecorp.armeria.common.DefaultRpcRequest;
 import com.linecorp.armeria.common.DefaultRpcResponse;
 import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpRequestWriter;
 import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpResponseWriter;
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
 import com.linecorp.armeria.common.RpcRequest;
@@ -47,7 +47,7 @@ public class ClientDecorationBuilderTest {
                 .isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(() -> cdb.add(RpcRequest.class, HttpResponse.class, identity()))
                 .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> cdb.add(DefaultHttpRequest.class, DefaultHttpResponse.class, identity()))
+        assertThatThrownBy(() -> cdb.add(HttpRequestWriter.class, HttpResponseWriter.class, identity()))
                 .isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(() -> cdb.add(DefaultRpcRequest.class, DefaultRpcResponse.class, identity()))
                 .isInstanceOf(IllegalArgumentException.class);

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientIntegrationTest.java
@@ -17,7 +17,6 @@
 package com.linecorp.armeria.client;
 
 import static com.linecorp.armeria.common.SessionProtocol.HTTP;
-import static com.linecorp.armeria.common.util.Functions.voidFunction;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
@@ -29,7 +28,6 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketTimeoutException;
 import java.nio.charset.StandardCharsets;
-import java.util.Locale;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.IntFunction;
 
@@ -46,7 +44,6 @@ import com.google.common.io.Closeables;
 import com.linecorp.armeria.client.encoding.DeflateStreamDecoderFactory;
 import com.linecorp.armeria.client.encoding.HttpDecodingClient;
 import com.linecorp.armeria.common.AggregatedHttpMessage;
-import com.linecorp.armeria.common.DefaultHttpResponse;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
@@ -86,7 +83,7 @@ public class HttpClientIntegrationTest {
         @Override
         public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
             HttpResponse res = delegate().serve(ctx, req);
-            DefaultHttpResponse decorated = new DefaultHttpResponse();
+            HttpResponseWriter decorated = HttpResponse.streaming();
             res.subscribe(new Subscriber<HttpObject>() {
                 @Override
                 public void onSubscribe(Subscription s) {
@@ -121,7 +118,7 @@ public class HttpClientIntegrationTest {
         @Override
         public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
             HttpResponse res = delegate().serve(ctx, req);
-            DefaultHttpResponse decorated = new DefaultHttpResponse();
+            HttpResponseWriter decorated = HttpResponse.streaming();
             res.subscribe(new Subscriber<HttpObject>() {
                 @Override
                 public void onSubscribe(Subscription s) {
@@ -158,12 +155,12 @@ public class HttpClientIntegrationTest {
     private static class PooledContentService extends AbstractHttpService {
 
         @Override
-        protected void doGet(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res)
+        protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req)
                 throws Exception {
             ByteBuf buf = ctx.alloc().buffer();
             buf.writeCharSequence("pooled content", StandardCharsets.UTF_8);
             releasedByteBuf.set(buf);
-            res.respond(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, new ByteBufHttpData(buf, false));
+            return HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, new ByteBufHttpData(buf, false));
         }
     }
 
@@ -176,19 +173,17 @@ public class HttpClientIntegrationTest {
             sb.service("/httptestbody", new AbstractHttpService() {
 
                 @Override
-                protected void doGet(ServiceRequestContext ctx, HttpRequest req,
-                                     HttpResponseWriter res) {
-                    doGetOrPost(req, res);
+                protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) {
+                    return doGetOrPost(req);
                 }
 
                 @Override
-                protected void doPost(ServiceRequestContext ctx, HttpRequest req,
-                                      HttpResponseWriter res) {
-                    doGetOrPost(req, res);
+                protected HttpResponse doPost(ServiceRequestContext ctx, HttpRequest req) {
+                    return doGetOrPost(req);
                 }
 
-                private void doGetOrPost(HttpRequest req, HttpResponseWriter res) {
-                    final MediaType contentType = req.headers().contentType();
+                private HttpResponse doGetOrPost(HttpRequest req) {
+                        final MediaType contentType = req.headers().contentType();
                     if (contentType != null) {
                         throw new IllegalArgumentException(
                                 "Serialization format is none, so content type should not be set: " +
@@ -202,64 +197,62 @@ public class HttpClientIntegrationTest {
                                 accept);
                     }
 
-                    req.aggregate().handle(voidFunction((aReq, cause) -> {
+                    return HttpResponse.from(req.aggregate().handle((aReq, cause) -> {
                         if (cause != null) {
-                            res.respond(HttpStatus.INTERNAL_SERVER_ERROR,
-                                        MediaType.PLAIN_TEXT_UTF_8, Throwables.getStackTraceAsString(cause));
-                            return;
+                            return HttpResponse.of(
+                                    HttpStatus.INTERNAL_SERVER_ERROR,
+                                    MediaType.PLAIN_TEXT_UTF_8, Throwables.getStackTraceAsString(cause));
                         }
 
-                        res.write(HttpHeaders.of(HttpStatus.OK)
-                                             .set(HttpHeaderNames.CACHE_CONTROL, "alwayscache"));
-                        res.write(HttpData.ofUtf8(String.format(
-                                Locale.ENGLISH,
-                                "METHOD: %s|ACCEPT: %s|BODY: %s",
-                                req.method().name(), accept,
-                                aReq.content().toString(StandardCharsets.UTF_8))));
-                        res.close();
-                    })).exceptionally(CompletionActions::log);
+                        return HttpResponse.of(
+                                HttpHeaders.of(HttpStatus.OK)
+                                           .set(HttpHeaderNames.CACHE_CONTROL, "alwayscache"),
+                                HttpData.ofUtf8(
+                                        "METHOD: %s|ACCEPT: %s|BODY: %s",
+                                        req.method().name(), accept,
+                                        aReq.content().toString(StandardCharsets.UTF_8)));
+                    }).exceptionally(CompletionActions::log));
                 }
             });
 
             sb.service("/not200", new AbstractHttpService() {
                 @Override
-                protected void doGet(ServiceRequestContext ctx, HttpRequest req,
-                                     HttpResponseWriter res) {
-                    res.respond(HttpStatus.NOT_FOUND);
+                protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) {
+                    return HttpResponse.of(HttpStatus.NOT_FOUND);
                 }
             });
 
             sb.service("/useragent", new AbstractHttpService() {
                 @Override
-                protected void doGet(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) {
+                protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) {
                     String ua = req.headers().get(HttpHeaderNames.USER_AGENT, "undefined");
-                    res.respond(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, ua);
+                    return HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, ua);
                 }
             });
 
             sb.service("/hello/world", new AbstractHttpService() {
                 @Override
-                protected void doGet(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) {
-                    res.respond(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "success");
+                protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) {
+                    return HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "success");
                 }
             });
 
             sb.service("/encoding", new AbstractHttpService() {
                 @Override
-                protected void doGet(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res)
+                protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req)
                         throws Exception {
-                    res.write(HttpHeaders.of(HttpStatus.OK));
-                    res.write(HttpData.ofUtf8("some content to compress "));
-                    res.write(HttpData.ofUtf8("more content to compress"));
-                    res.close();
+                    return HttpResponse.of(
+                            HttpHeaders.of(HttpStatus.OK),
+                            HttpData.ofUtf8("some content to compress "),
+                            HttpData.ofUtf8("more content to compress"));
                 }
             }.decorate(HttpEncodingService.class));
 
             sb.service("/encoding-toosmall", new AbstractHttpService() {
                 @Override
-                protected void doGet(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res)
+                protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req)
                         throws Exception {
-                    res.respond(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "small content");
+                    return HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "small content");
                 }
             }.decorate(HttpEncodingService.class));
 

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientSniTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientSniTest.java
@@ -34,7 +34,7 @@ import org.junit.Test;
 
 import com.linecorp.armeria.common.AggregatedHttpMessage;
 import com.linecorp.armeria.common.HttpRequest;
-import com.linecorp.armeria.common.HttpResponseWriter;
+import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.server.AbstractHttpService;
@@ -176,11 +176,10 @@ public class HttpClientSniTest {
         }
 
         @Override
-        protected void doGet(ServiceRequestContext ctx, HttpRequest req,
-                             HttpResponseWriter res) {
+        protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) {
             final X509Certificate c = (X509Certificate) ctx.sslSession().getLocalCertificates()[0];
             final String name = c.getSubjectX500Principal().getName();
-            res.respond(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, domainName + ": " + name);
+            return HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, domainName + ": " + name);
         }
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/StickyEndpointSelectionStrategyTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/StickyEndpointSelectionStrategyTest.java
@@ -28,7 +28,8 @@ import org.junit.Test;
 
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
-import com.linecorp.armeria.common.DefaultHttpRequest;
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 
 import io.netty.util.AsciiString;
@@ -99,9 +100,8 @@ public class StickyEndpointSelectionStrategyTest {
 
     private static ClientRequestContext contextWithHeader(String k, String v) {
         ClientRequestContext ctx = mock(ClientRequestContext.class);
-        HttpRequest testReq = new DefaultHttpRequest();
-        testReq.headers().set(AsciiString.of(k), v);
-        when(ctx.request()).thenReturn(testReq);
+        when(ctx.request()).thenReturn(HttpRequest.of(HttpHeaders.of(HttpMethod.GET, "/")
+                                                                 .set(AsciiString.of(k), v)));
         return ctx;
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingHttpClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingHttpClientTest.java
@@ -68,7 +68,6 @@ public class ConcurrencyLimitingHttpClientTest {
         assertThat(client.numActiveRequests()).isZero();
 
         final HttpResponse res = client.execute(ctx, req);
-        assertThat(res.isDeferred()).isTrue();
         assertThat(res.isOpen()).isTrue();
         assertThat(client.numActiveRequests()).isEqualTo(1);
 
@@ -101,13 +100,11 @@ public class ConcurrencyLimitingHttpClientTest {
         // The first request should be delegated immediately.
         final HttpResponse res1 = client.execute(ctx1, req1);
         verify(delegate).execute(ctx1, req1);
-        assertThat(res1.isDeferred()).isTrue();
         assertThat(res1.isOpen()).isTrue();
 
         // The second request should never be delegated until the first response is closed.
         final HttpResponse res2 = client.execute(ctx2, req2);
         verify(delegate, never()).execute(ctx2, req2);
-        assertThat(res2.isDeferred()).isTrue();
         assertThat(res2.isOpen()).isTrue();
         assertThat(client.numActiveRequests()).isEqualTo(1); // Only req1 is active.
 
@@ -185,7 +182,6 @@ public class ConcurrencyLimitingHttpClientTest {
         // Consume everything from the returned response so its close future is completed.
         res.subscribe(NoopSubscriber.get());
 
-        assertThat(res.isDeferred()).isTrue();
         assertThat(res.isOpen()).isFalse();
         assertThatThrownBy(() -> res.completionFuture().get()).hasCauseInstanceOf(Exception.class);
         await().untilAsserted(() -> assertThat(client.numActiveRequests()).isZero());
@@ -207,7 +203,6 @@ public class ConcurrencyLimitingHttpClientTest {
         // A request should be delegated immediately, creating no deferred response.
         final HttpResponse res = client.execute(ctx, req);
         verify(delegate).execute(ctx, req);
-        assertThat(res.isDeferred()).isFalse();
         assertThat(res.isOpen()).isTrue();
         assertThat(client.numActiveRequests()).isEqualTo(1);
 

--- a/core/src/test/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingHttpClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingHttpClientTest.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.client.limit;
 
+import static com.linecorp.armeria.client.limit.ConcurrencyLimitingHttpClient.newDecorator;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
@@ -32,10 +33,9 @@ import org.junit.Test;
 import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.ResponseTimeoutException;
-import com.linecorp.armeria.common.DefaultHttpResponse;
-import com.linecorp.armeria.common.DeferredHttpResponse;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpResponseWriter;
 import com.linecorp.armeria.common.stream.NoopSubscriber;
 
 import io.netty.channel.DefaultEventLoop;
@@ -57,18 +57,18 @@ public class ConcurrencyLimitingHttpClientTest {
     public void testOrdinaryRequest() throws Exception {
         final ClientRequestContext ctx = newContext();
         final HttpRequest req = mock(HttpRequest.class);
-        final DefaultHttpResponse actualRes = new DefaultHttpResponse();
+        final HttpResponseWriter actualRes = HttpResponse.streaming();
 
         @SuppressWarnings("unchecked")
         final Client<HttpRequest, HttpResponse> delegate = mock(Client.class);
         when(delegate.execute(ctx, req)).thenReturn(actualRes);
 
         final ConcurrencyLimitingHttpClient client =
-                ConcurrencyLimitingHttpClient.newDecorator(1).apply(delegate);
+                newDecorator(1).apply(delegate);
         assertThat(client.numActiveRequests()).isZero();
 
         final HttpResponse res = client.execute(ctx, req);
-        assertThat(res).isInstanceOf(DeferredHttpResponse.class);
+        assertThat(res.isDeferred()).isTrue();
         assertThat(res.isOpen()).isTrue();
         assertThat(client.numActiveRequests()).isEqualTo(1);
 
@@ -87,8 +87,8 @@ public class ConcurrencyLimitingHttpClientTest {
         final ClientRequestContext ctx2 = newContext();
         final HttpRequest req1 = mock(HttpRequest.class);
         final HttpRequest req2 = mock(HttpRequest.class);
-        final DefaultHttpResponse actualRes1 = new DefaultHttpResponse();
-        final DefaultHttpResponse actualRes2 = new DefaultHttpResponse();
+        final HttpResponseWriter actualRes1 = HttpResponse.streaming();
+        final HttpResponseWriter actualRes2 = HttpResponse.streaming();
 
         @SuppressWarnings("unchecked")
         final Client<HttpRequest, HttpResponse> delegate = mock(Client.class);
@@ -96,18 +96,18 @@ public class ConcurrencyLimitingHttpClientTest {
         when(delegate.execute(ctx2, req2)).thenReturn(actualRes2);
 
         final ConcurrencyLimitingHttpClient client =
-                ConcurrencyLimitingHttpClient.newDecorator(1).apply(delegate);
+                newDecorator(1).apply(delegate);
 
         // The first request should be delegated immediately.
         final HttpResponse res1 = client.execute(ctx1, req1);
         verify(delegate).execute(ctx1, req1);
-        assertThat(res1).isInstanceOf(DeferredHttpResponse.class);
+        assertThat(res1.isDeferred()).isTrue();
         assertThat(res1.isOpen()).isTrue();
 
         // The second request should never be delegated until the first response is closed.
         final HttpResponse res2 = client.execute(ctx2, req2);
         verify(delegate, never()).execute(ctx2, req2);
-        assertThat(res2).isInstanceOf(DeferredHttpResponse.class);
+        assertThat(res2.isDeferred()).isTrue();
         assertThat(res2.isOpen()).isTrue();
         assertThat(client.numActiveRequests()).isEqualTo(1); // Only req1 is active.
 
@@ -132,8 +132,8 @@ public class ConcurrencyLimitingHttpClientTest {
         final ClientRequestContext ctx2 = newContext();
         final HttpRequest req1 = mock(HttpRequest.class);
         final HttpRequest req2 = mock(HttpRequest.class);
-        final DefaultHttpResponse actualRes1 = new DefaultHttpResponse();
-        final DefaultHttpResponse actualRes2 = new DefaultHttpResponse();
+        final HttpResponseWriter actualRes1 = HttpResponse.streaming();
+        final HttpResponseWriter actualRes2 = HttpResponse.streaming();
 
         @SuppressWarnings("unchecked")
         final Client<HttpRequest, HttpResponse> delegate = mock(Client.class);
@@ -141,7 +141,7 @@ public class ConcurrencyLimitingHttpClientTest {
         when(delegate.execute(ctx2, req2)).thenReturn(actualRes2);
 
         final ConcurrencyLimitingHttpClient client =
-                ConcurrencyLimitingHttpClient.newDecorator(1, 500, TimeUnit.MILLISECONDS).apply(delegate);
+                newDecorator(1, 500, TimeUnit.MILLISECONDS).apply(delegate);
 
         // Send two requests, where only the first one is delegated.
         final HttpResponse res1 = client.execute(ctx1, req1);
@@ -185,7 +185,7 @@ public class ConcurrencyLimitingHttpClientTest {
         // Consume everything from the returned response so its close future is completed.
         res.subscribe(NoopSubscriber.get());
 
-        assertThat(res).isInstanceOf(DeferredHttpResponse.class);
+        assertThat(res.isDeferred()).isTrue();
         assertThat(res.isOpen()).isFalse();
         assertThatThrownBy(() -> res.completionFuture().get()).hasCauseInstanceOf(Exception.class);
         await().untilAsserted(() -> assertThat(client.numActiveRequests()).isZero());
@@ -195,19 +195,19 @@ public class ConcurrencyLimitingHttpClientTest {
     public void testUnlimitedRequest() throws Exception {
         final ClientRequestContext ctx = newContext();
         final HttpRequest req = mock(HttpRequest.class);
-        final DefaultHttpResponse actualRes = new DefaultHttpResponse();
+        final HttpResponseWriter actualRes = HttpResponse.streaming();
 
         @SuppressWarnings("unchecked")
         final Client<HttpRequest, HttpResponse> delegate = mock(Client.class);
         when(delegate.execute(ctx, req)).thenReturn(actualRes);
 
         final ConcurrencyLimitingHttpClient client =
-                ConcurrencyLimitingHttpClient.newDecorator(0).apply(delegate);
+                newDecorator(0).apply(delegate);
 
         // A request should be delegated immediately, creating no deferred response.
         final HttpResponse res = client.execute(ctx, req);
         verify(delegate).execute(ctx, req);
-        assertThat(res).isNotInstanceOf(DeferredHttpResponse.class);
+        assertThat(res.isDeferred()).isFalse();
         assertThat(res.isOpen()).isTrue();
         assertThat(client.numActiveRequests()).isEqualTo(1);
 
@@ -246,7 +246,7 @@ public class ConcurrencyLimitingHttpClientTest {
      * Closes the response returned by the delegate and consumes everything from it, so that its close future
      * is completed.
      */
-    private static void closeAndDrain(DefaultHttpResponse actualRes, HttpResponse deferredRes) {
+    private static void closeAndDrain(HttpResponseWriter actualRes, HttpResponse deferredRes) {
         actualRes.close();
         deferredRes.subscribe(NoopSubscriber.get());
         deferredRes.completionFuture().join();

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientWithLoggingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientWithLoggingTest.java
@@ -36,7 +36,6 @@ import com.linecorp.armeria.client.HttpClientBuilder;
 import com.linecorp.armeria.client.SimpleDecoratingClient;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.common.HttpResponseWriter;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.logging.RequestLog;
@@ -58,12 +57,12 @@ public class RetryingClientWithLoggingTest {
                 final AtomicInteger reqCount = new AtomicInteger();
 
                 @Override
-                protected void doGet(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res)
+                protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req)
                         throws Exception {
                     if (reqCount.getAndIncrement() < 2) {
-                        res.respond(HttpStatus.INTERNAL_SERVER_ERROR);
+                        return HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR);
                     } else {
-                        res.respond(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "hello");
+                        return HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "hello");
                     }
                 }
             });

--- a/core/src/test/java/com/linecorp/armeria/common/HttpResponseDuplicatorTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/HttpResponseDuplicatorTest.java
@@ -25,7 +25,7 @@ public class HttpResponseDuplicatorTest {
 
     @Test
     public void aggregateTwice() {
-        final DefaultHttpResponse publisher = new DefaultHttpResponse();
+        final HttpResponseWriter publisher = HttpResponse.streaming();
         final HttpResponseDuplicator resDuplicator = new HttpResponseDuplicator(publisher);
 
         publisher.write(HttpHeaders.of(HttpStatus.OK).contentType(MediaType.PLAIN_TEXT_UTF_8));

--- a/core/src/test/java/com/linecorp/armeria/common/RequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/RequestContextTest.java
@@ -408,7 +408,7 @@ public class RequestContextTest {
     private class DummyRequestContext extends NonWrappingRequestContext {
         DummyRequestContext() {
             super(NoopMeterRegistry.get(), SessionProtocol.HTTP,
-                  HttpMethod.GET, "/", null, new DefaultHttpRequest());
+                  HttpMethod.GET, "/", null, HttpRequest.streaming());
         }
 
         @Override

--- a/core/src/test/java/com/linecorp/armeria/internal/DefaultHttpRequestTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/DefaultHttpRequestTest.java
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-package com.linecorp.armeria.common;
+package com.linecorp.armeria.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -35,6 +35,11 @@ import org.junit.runners.Parameterized.Parameters;
 
 import com.google.common.collect.ImmutableList;
 
+import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.CommonPools;
+import com.linecorp.armeria.common.DefaultHttpRequest;
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.stream.AbortedStreamException;
 
 @RunWith(Parameterized.class)
@@ -60,7 +65,7 @@ public class DefaultHttpRequestTest {
     @Test
     public void abortedAggregation() {
         final Thread mainThread = Thread.currentThread();
-        final DefaultHttpRequest req = new DefaultHttpRequest(HttpHeaders.of(HttpMethod.GET, "/foo"));
+        final DefaultHttpRequest req = new DefaultHttpRequest(HttpHeaders.of(HttpMethod.GET, "/foo"), true);
         final CompletableFuture<AggregatedHttpMessage> future;
 
         // Practically same execution, but we need to test the both case due to code duplication.

--- a/core/src/test/java/com/linecorp/armeria/internal/DefaultHttpResponseTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/DefaultHttpResponseTest.java
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-package com.linecorp.armeria.common;
+package com.linecorp.armeria.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -35,6 +35,10 @@ import org.junit.runners.Parameterized.Parameters;
 
 import com.google.common.collect.ImmutableList;
 
+import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.CommonPools;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpResponseWriter;
 import com.linecorp.armeria.common.stream.AbortedStreamException;
 
 @RunWith(Parameterized.class)
@@ -60,7 +64,7 @@ public class DefaultHttpResponseTest {
     @Test
     public void abortedAggregation() {
         final Thread mainThread = Thread.currentThread();
-        final DefaultHttpResponse res = new DefaultHttpResponse();
+        final HttpResponseWriter res = HttpResponse.streaming();
         final CompletableFuture<AggregatedHttpMessage> future;
 
         // Practically same execution, but we need to test the both case due to code duplication.

--- a/core/src/test/java/com/linecorp/armeria/server/AnnotatedHttpServiceExceptionHandlerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/AnnotatedHttpServiceExceptionHandlerTest.java
@@ -28,11 +28,11 @@ import org.junit.Test;
 
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.common.AggregatedHttpMessage;
-import com.linecorp.armeria.common.DefaultHttpResponse;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpResponseWriter;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.RequestContext;
@@ -198,7 +198,7 @@ public class AnnotatedHttpServiceExceptionHandlerTest {
     static class BadExceptionHandler1 implements ExceptionHandlerFunction {
         @Override
         public HttpResponse handle(RequestContext ctx, HttpRequest req, Throwable cause) {
-            final DefaultHttpResponse response = new DefaultHttpResponse();
+            final HttpResponseWriter response = HttpResponse.streaming();
             response.write(HttpHeaders.of(HttpStatus.OK));
             // Timeout may occur before responding.
             ctx.eventLoop().schedule((Runnable) response::close, 10, TimeUnit.SECONDS);
@@ -209,7 +209,7 @@ public class AnnotatedHttpServiceExceptionHandlerTest {
     static class BadExceptionHandler2 implements ExceptionHandlerFunction {
         @Override
         public HttpResponse handle(RequestContext ctx, HttpRequest req, Throwable cause) {
-            final DefaultHttpResponse response = new DefaultHttpResponse();
+            final HttpResponseWriter response = HttpResponse.streaming();
             // Make invalid response.
             response.write(HttpStatus.OK.toHttpData());
             response.close();

--- a/core/src/test/java/com/linecorp/armeria/server/AnnotatedHttpServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/AnnotatedHttpServiceTest.java
@@ -50,12 +50,12 @@ import org.junit.runner.Description;
 import com.google.common.collect.ImmutableMap;
 
 import com.linecorp.armeria.common.AggregatedHttpMessage;
-import com.linecorp.armeria.common.DefaultHttpResponse;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpParameters;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpResponseWriter;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.Request;
@@ -312,7 +312,7 @@ public class AnnotatedHttpServiceTest {
         @Path("/a/string-async2")
         public HttpResponse postStringAsync2(AggregatedHttpMessage message, RequestContext ctx) {
             validateContext(ctx);
-            DefaultHttpResponse response = new DefaultHttpResponse();
+            HttpResponseWriter response = HttpResponse.streaming();
             response.write(HttpHeaders.of(HttpStatus.OK));
             response.write(message.content());
             response.close();

--- a/core/src/test/java/com/linecorp/armeria/server/HttpResponseExceptionTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpResponseExceptionTest.java
@@ -20,15 +20,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.Test;
 
 import com.linecorp.armeria.common.AggregatedHttpMessage;
-import com.linecorp.armeria.common.DefaultHttpResponse;
 import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpResponseWriter;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 
 public class HttpResponseExceptionTest {
     @Test
     public void testHttpResponse() throws Exception {
-        final DefaultHttpResponse response = new DefaultHttpResponse();
+        final HttpResponseWriter response = HttpResponse.streaming();
         final HttpResponseException exception = HttpResponseException.of(response);
         response.write(HttpHeaders.of(HttpStatus.INTERNAL_SERVER_ERROR)
                                   .contentType(MediaType.PLAIN_TEXT_UTF_8));

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerPathTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerPathTest.java
@@ -30,7 +30,7 @@ import org.junit.Test;
 import com.google.common.io.ByteStreams;
 
 import com.linecorp.armeria.common.HttpRequest;
-import com.linecorp.armeria.common.HttpResponseWriter;
+import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.testing.server.ServerRule;
@@ -46,15 +46,15 @@ public class HttpServerPathTest {
             sb.port(0, SessionProtocol.HTTP);
             sb.service("/service/foo", new AbstractHttpService() {
                 @Override
-                protected void doGet(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) {
-                    res.respond(HttpStatus.OK);
+                protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) {
+                    return HttpResponse.of(HttpStatus.OK);
                 }
             });
 
             sb.serviceUnder("/", new AbstractHttpService() {
                 @Override
-                protected void doGet(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) {
-                    res.respond(HttpStatus.OK);
+                protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) {
+                    return HttpResponse.of(HttpStatus.OK);
                 }
             });
         }

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServiceTest.java
@@ -32,7 +32,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 
 import com.linecorp.armeria.common.HttpRequest;
-import com.linecorp.armeria.common.HttpResponseWriter;
+import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.server.logging.LoggingService;
@@ -48,11 +48,10 @@ public class HttpServiceTest {
                     "/hello/{name}",
                     new AbstractHttpService() {
                         @Override
-                        protected void doGet(
-                                ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) {
-
+                        protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) {
                             final String name = ctx.pathParam("name");
-                            res.respond(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "Hello, %s!", name);
+                            return HttpResponse.of(
+                                    HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "Hello, %s!", name);
                         }
                     }.decorate(LoggingService.newDecorator()));
 
@@ -60,17 +59,13 @@ public class HttpServiceTest {
                     "/200",
                     new AbstractHttpService() {
                         @Override
-                        protected void doHead(
-                                ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) {
-
-                            res.respond(HttpStatus.OK);
+                        protected HttpResponse doHead(ServiceRequestContext ctx, HttpRequest req) {
+                            return HttpResponse.of(HttpStatus.OK);
                         }
 
                         @Override
-                        protected void doGet(
-                                ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) {
-
-                            res.respond(HttpStatus.OK);
+                        protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) {
+                            return HttpResponse.of(HttpStatus.OK);
                         }
                     }.decorate(LoggingService.newDecorator()));
 
@@ -78,10 +73,8 @@ public class HttpServiceTest {
                     "/204",
                     new AbstractHttpService() {
                         @Override
-                        protected void doGet(
-                                ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) {
-
-                            res.respond(HttpStatus.NO_CONTENT);
+                        protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) {
+                            return HttpResponse.of(HttpStatus.NO_CONTENT);
                         }
                     }.decorate(LoggingService.newDecorator()));
         }

--- a/core/src/test/java/com/linecorp/armeria/server/SniServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/SniServerTest.java
@@ -36,7 +36,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 
 import com.linecorp.armeria.common.HttpRequest;
-import com.linecorp.armeria.common.HttpResponseWriter;
+import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.testing.server.SelfSignedCertificateRule;
@@ -143,11 +143,10 @@ public class SniServerTest {
         }
 
         @Override
-        protected void doGet(ServiceRequestContext ctx, HttpRequest req,
-                             HttpResponseWriter res) {
+        protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) {
             final X509Certificate c = (X509Certificate) ctx.sslSession().getLocalCertificates()[0];
             final String name = c.getSubjectX500Principal().getName();
-            res.respond(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, domainName + ": " + name);
+            return HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, domainName + ": " + name);
         }
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/TestConverters.java
+++ b/core/src/test/java/com/linecorp/armeria/server/TestConverters.java
@@ -16,11 +16,11 @@
 
 package com.linecorp.armeria.server;
 
-import com.linecorp.armeria.common.DefaultHttpResponse;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpResponseWriter;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.RequestContext;
@@ -83,7 +83,7 @@ final class TestConverters {
 
     private static HttpResponse httpResponse(HttpData data) {
         assert RequestContext.current() != null;
-        final DefaultHttpResponse res = new DefaultHttpResponse();
+        final HttpResponseWriter res = HttpResponse.streaming();
         final long current = System.currentTimeMillis();
         HttpHeaders headers = HttpHeaders.of(HttpStatus.OK)
                                          .setInt(HttpHeaderNames.CONTENT_LENGTH,

--- a/core/src/test/java/com/linecorp/armeria/server/auth/HttpAuthServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/auth/HttpAuthServiceTest.java
@@ -42,7 +42,6 @@ import com.google.common.collect.ImmutableMap;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.common.HttpResponseWriter;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.server.AbstractHttpService;
 import com.linecorp.armeria.server.HttpService;
@@ -62,9 +61,8 @@ public class HttpAuthServiceTest {
         protected void configure(ServerBuilder sb) throws Exception {
             final HttpService ok = new AbstractHttpService() {
                 @Override
-                protected void doGet(
-                        ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) {
-                    res.respond(HttpStatus.OK);
+                protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) {
+                    return HttpResponse.of(HttpStatus.OK);
                 }
             };
 

--- a/core/src/test/java/com/linecorp/armeria/server/composition/CompositeServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/composition/CompositeServiceTest.java
@@ -30,7 +30,6 @@ import org.junit.Test;
 
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.common.HttpResponseWriter;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.metric.MeterIdPrefix;
@@ -145,9 +144,9 @@ public class CompositeServiceTest {
         }
 
         @Override
-        protected void doGet(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) {
-            res.respond(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8,
-                        "%s:%s:%s", name, ctx.path(), ctx.mappedPath());
+        protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) {
+            return HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8,
+                                   "%s:%s:%s", name, ctx.path(), ctx.mappedPath());
         }
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/cors/HttpServerCorsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/cors/HttpServerCorsTest.java
@@ -28,7 +28,7 @@ import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
-import com.linecorp.armeria.common.HttpResponseWriter;
+import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.server.AbstractHttpService;
 import com.linecorp.armeria.server.ServerBuilder;
@@ -47,23 +47,23 @@ public class HttpServerCorsTest {
         protected void configure(ServerBuilder sb) throws Exception {
             sb.service("/cors", new AbstractHttpService() {
                 @Override
-                protected void doGet(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) {
-                    res.respond(HttpStatus.OK);
+                protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) {
+                    return HttpResponse.of(HttpStatus.OK);
                 }
 
                 @Override
-                protected void doPost(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) {
-                    res.respond(HttpStatus.OK);
+                protected HttpResponse doPost(ServiceRequestContext ctx, HttpRequest req) {
+                    return HttpResponse.of(HttpStatus.OK);
                 }
 
                 @Override
-                protected void doHead(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) {
-                    res.respond(HttpStatus.OK);
+                protected HttpResponse doHead(ServiceRequestContext ctx, HttpRequest req) {
+                    return HttpResponse.of(HttpStatus.OK);
                 }
 
                 @Override
-                protected void doOptions(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) {
-                    res.respond(HttpStatus.OK);
+                protected HttpResponse doOptions(ServiceRequestContext ctx, HttpRequest req) {
+                    return HttpResponse.of(HttpStatus.OK);
                 }
             }.decorate(CorsServiceBuilder.forOrigin("http://example.com")
                                          .allowRequestMethods(HttpMethod.POST)

--- a/core/src/test/java/com/linecorp/armeria/server/healthcheck/ManagedHttpHealthCheckServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/healthcheck/ManagedHttpHealthCheckServiceTest.java
@@ -29,9 +29,10 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
 import com.linecorp.armeria.common.AggregatedHttpMessage;
-import com.linecorp.armeria.common.DefaultHttpRequest;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpRequestWriter;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.logging.DefaultRequestLog;
@@ -44,10 +45,10 @@ public class ManagedHttpHealthCheckServiceTest {
     @Rule
     public MockitoRule rule = MockitoJUnit.rule();
 
-    private static final DefaultHttpRequest HC_REQ = new DefaultHttpRequest(HttpMethod.HEAD, "/");
+    private static final HttpRequestWriter HC_REQ = HttpRequest.streaming(HttpMethod.HEAD, "/");
 
-    private static final DefaultHttpRequest HC_TURN_OFF_REQ = new DefaultHttpRequest(HttpMethod.PUT, "/");
-    private static final DefaultHttpRequest HC_TURN_ON_REQ = new DefaultHttpRequest(HttpMethod.PUT, "/");
+    private static final HttpRequestWriter HC_TURN_OFF_REQ = HttpRequest.streaming(HttpMethod.PUT, "/");
+    private static final HttpRequestWriter HC_TURN_ON_REQ = HttpRequest.streaming(HttpMethod.PUT, "/");
 
     @Mock
     private ServiceRequestContext context;
@@ -101,7 +102,7 @@ public class ManagedHttpHealthCheckServiceTest {
 
     @Test
     public void notSupported() throws Exception {
-        DefaultHttpRequest noopRequest = new DefaultHttpRequest(HttpMethod.PUT, "/");
+        HttpRequestWriter noopRequest = HttpRequest.streaming(HttpMethod.PUT, "/");
         noopRequest.write(() -> HttpData.ofAscii("noop"));
         noopRequest.close();
 
@@ -114,7 +115,7 @@ public class ManagedHttpHealthCheckServiceTest {
 
         service.serverHealth.setHealthy(true);
 
-        noopRequest = new DefaultHttpRequest(HttpMethod.PUT, "/");
+        noopRequest = HttpRequest.streaming(HttpMethod.PUT, "/");
         noopRequest.write(() -> HttpData.ofAscii("noop"));
         noopRequest.close();
 

--- a/core/src/test/java/com/linecorp/armeria/server/throttling/ThrottlingServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/throttling/ThrottlingServiceTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
 
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.common.HttpRequest;
-import com.linecorp.armeria.common.HttpResponseWriter;
+import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.server.AbstractHttpService;
 import com.linecorp.armeria.server.HttpService;
@@ -36,9 +36,9 @@ public class ThrottlingServiceTest {
 
     static final HttpService SERVICE = new AbstractHttpService() {
         @Override
-        protected void doGet(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res)
+        protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req)
                 throws Exception {
-            res.respond(HttpStatus.OK);
+            return HttpResponse.of(HttpStatus.OK);
         }
     };
 

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaChannel.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaChannel.java
@@ -30,10 +30,10 @@ import com.linecorp.armeria.client.ClientOptions;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.DefaultClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
-import com.linecorp.armeria.common.DefaultHttpRequest;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpRequestWriter;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.SessionProtocol;
@@ -91,7 +91,7 @@ class ArmeriaChannel extends Channel implements ClientBuilderParams {
     @Override
     public <I, O> ClientCall<I, O> newCall(
             MethodDescriptor<I, O> method, CallOptions callOptions) {
-        DefaultHttpRequest req = new DefaultHttpRequest(
+        HttpRequestWriter req = HttpRequest.streaming(
                 HttpHeaders
                         .of(HttpMethod.POST, uri().getPath() + method.getFullMethodName())
                         .contentType(serializationFormat.mediaType()));

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaClientCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaClientCall.java
@@ -31,10 +31,10 @@ import org.slf4j.LoggerFactory;
 
 import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.client.ClientRequestContext;
-import com.linecorp.armeria.common.DefaultHttpRequest;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpRequestWriter;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.SerializationFormat;
@@ -75,7 +75,7 @@ class ArmeriaClientCall<I, O> extends ClientCall<I, O>
 
     private final ClientRequestContext ctx;
     private final Client<HttpRequest, HttpResponse> httpClient;
-    private final DefaultHttpRequest req;
+    private final HttpRequestWriter req;
     private final CallOptions callOptions;
     private final ArmeriaMessageFramer messageFramer;
     private final GrpcMessageMarshaller<I, O> marshaller;
@@ -93,7 +93,7 @@ class ArmeriaClientCall<I, O> extends ClientCall<I, O>
     ArmeriaClientCall(
             ClientRequestContext ctx,
             Client<HttpRequest, HttpResponse> httpClient,
-            DefaultHttpRequest req,
+            HttpRequestWriter req,
             MethodDescriptor<I, O> method,
             int maxOutboundMessageSizeBytes,
             int maxInboundMessageSizeBytes,

--- a/jetty/src/main/java/com/linecorp/armeria/server/jetty/JettyService.java
+++ b/jetty/src/main/java/com/linecorp/armeria/server/jetty/JettyService.java
@@ -237,7 +237,7 @@ public final class JettyService implements HttpService {
         req.aggregate().handle(voidFunction((aReq, cause) -> {
             if (cause != null) {
                 logger.warn("{} Failed to aggregate a request:", ctx, cause);
-                res.respond(HttpHeaders.of(HttpStatus.INTERNAL_SERVER_ERROR));
+                res.close(HttpHeaders.of(HttpStatus.INTERNAL_SERVER_ERROR));
                 return;
             }
 

--- a/jetty/src/main/java/com/linecorp/armeria/server/jetty/JettyService.java
+++ b/jetty/src/main/java/com/linecorp/armeria/server/jetty/JettyService.java
@@ -51,7 +51,6 @@ import org.slf4j.LoggerFactory;
 import com.google.common.base.Splitter;
 
 import com.linecorp.armeria.common.AggregatedHttpMessage;
-import com.linecorp.armeria.common.DefaultHttpResponse;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
@@ -233,12 +232,12 @@ public final class JettyService implements HttpService {
     public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
         final ArmeriaConnector connector = this.connector;
 
-        final DefaultHttpResponse res = new DefaultHttpResponse();
+        final HttpResponseWriter res = HttpResponse.streaming();
 
         req.aggregate().handle(voidFunction((aReq, cause) -> {
             if (cause != null) {
                 logger.warn("{} Failed to aggregate a request:", ctx, cause);
-                res.respond(HttpStatus.INTERNAL_SERVER_ERROR);
+                res.respond(HttpHeaders.of(HttpStatus.INTERNAL_SERVER_ERROR));
                 return;
             }
 

--- a/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/ArmeriaCallFactoryTest.java
+++ b/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/ArmeriaCallFactoryTest.java
@@ -16,7 +16,6 @@
 package com.linecorp.armeria.client.retrofit2;
 
 import static com.linecorp.armeria.client.endpoint.EndpointSelectionStrategy.ROUND_ROBIN;
-import static com.linecorp.armeria.common.util.Functions.voidFunction;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
@@ -41,7 +40,6 @@ import com.linecorp.armeria.client.endpoint.EndpointGroupRegistry;
 import com.linecorp.armeria.client.endpoint.StaticEndpointGroup;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.common.HttpResponseWriter;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.internal.PathAndQuery;
@@ -163,120 +161,108 @@ public class ArmeriaCallFactoryTest {
         protected void configure(ServerBuilder sb) throws Exception {
             sb.service("/pojo", new AbstractHttpService() {
                 @Override
-                protected void doGet(ServiceRequestContext ctx,
-                                     HttpRequest req, HttpResponseWriter res) throws Exception {
-                    res.respond(HttpStatus.OK, MediaType.JSON_UTF_8,
+                protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+                    return HttpResponse.of(HttpStatus.OK, MediaType.JSON_UTF_8,
                                 "{\"name\":\"Cony\", \"age\":26}");
                 }
             })
               .serviceUnder("/pathWithName", new AbstractHttpService() {
 
                   @Override
-                  protected void doGet(ServiceRequestContext ctx,
-                                       HttpRequest req, HttpResponseWriter res) throws Exception {
-                      req.aggregate().handle(voidFunction((aReq, cause) -> {
+                  protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+                      return HttpResponse.from(req.aggregate().handle(((aReq, cause) -> {
                           Map<String, List<String>> params = new QueryStringDecoder(aReq.path())
                                   .parameters();
                           String fullPath = PathAndQuery.parse(req.path()).path();
-                          res.respond(HttpStatus.OK, MediaType.JSON_UTF_8,
+                          return HttpResponse.of(HttpStatus.OK, MediaType.JSON_UTF_8,
                                       "{\"name\":\"" + fullPath.replace("/pathWithName/", "") + "\", " +
                                       "\"age\":" + params.get("age").get(0) + '}');
-                      }));
+                      })));
                   }
               })
               .service("/nest/pojo", new AbstractHttpService() {
                   @Override
-                  protected void doGet(ServiceRequestContext ctx,
-                                       HttpRequest req, HttpResponseWriter res) throws Exception {
-                      res.respond(HttpStatus.OK, MediaType.JSON_UTF_8,
+                  protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+                      return HttpResponse.of(HttpStatus.OK, MediaType.JSON_UTF_8,
                                   "{\"name\":\"Leonard\", \"age\":21}");
                   }
               })
               .service("/pojos", new AbstractHttpService() {
                   @Override
-                  protected void doGet(ServiceRequestContext ctx,
-                                       HttpRequest req, HttpResponseWriter res) throws Exception {
-                      res.respond(HttpStatus.OK, MediaType.JSON_UTF_8,
+                  protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+                      return HttpResponse.of(HttpStatus.OK, MediaType.JSON_UTF_8,
                                   "[{\"name\":\"Cony\", \"age\":26}," +
                                   "{\"name\":\"Leonard\", \"age\":21}]");
                   }
               })
               .service("/queryString", new AbstractHttpService() {
                   @Override
-                  protected void doGet(ServiceRequestContext ctx,
-                                       HttpRequest req, HttpResponseWriter res) throws Exception {
-                      req.aggregate().handle(voidFunction((aReq, cause) -> {
+                  protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+                      return HttpResponse.from(req.aggregate().handle(((aReq, cause) -> {
                           Map<String, List<String>> params = new QueryStringDecoder(aReq.path())
                                   .parameters();
-                          res.respond(HttpStatus.OK, MediaType.JSON_UTF_8,
+                          return HttpResponse.of(HttpStatus.OK, MediaType.JSON_UTF_8,
                                       "{\"name\":\"" + params.get("name").get(0) + "\", " +
                                       "\"age\":" + params.get("age").get(0) + '}');
-                      }));
+                      })));
                   }
               })
               .service("/post", new AbstractHttpService() {
                   @Override
-                  protected void doPost(ServiceRequestContext ctx,
-                                        HttpRequest req, HttpResponseWriter res) throws Exception {
-                      req.aggregate().handle(voidFunction((aReq, cause) -> {
+                  protected HttpResponse doPost(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+                      return HttpResponse.from(req.aggregate().handle(((aReq, cause) -> {
                           if (cause != null) {
-                              res.respond(HttpStatus.INTERNAL_SERVER_ERROR,
+                              return HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR,
                                           MediaType.PLAIN_TEXT_UTF_8,
                                           Throwables.getStackTraceAsString(cause));
-                              return;
                           }
                           String text = aReq.content().toStringUtf8();
                           final Pojo request;
                           try {
                               request = OBJECT_MAPPER.readValue(text, Pojo.class);
                           } catch (IOException e) {
-                              res.respond(HttpStatus.INTERNAL_SERVER_ERROR,
+                              return HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR,
                                           MediaType.PLAIN_TEXT_UTF_8,
                                           Throwables.getStackTraceAsString(e));
-                              return;
                           }
                           assertThat(request).isEqualTo(new Pojo("Cony", 26));
-                          res.respond(HttpStatus.OK);
-                      }));
+                          return HttpResponse.of(HttpStatus.OK);
+                      })));
                   }
               })
               .service("/postForm", new AbstractHttpService() {
                   @Override
-                  protected void doPost(ServiceRequestContext ctx,
-                                        HttpRequest req, HttpResponseWriter res) throws Exception {
-                      req.aggregate().handle(voidFunction((aReq, cause) -> {
+                  protected HttpResponse doPost(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+                      return HttpResponse.from(req.aggregate().handle(((aReq, cause) -> {
                           if (cause != null) {
-                              res.respond(HttpStatus.INTERNAL_SERVER_ERROR,
+                              return HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR,
                                           MediaType.PLAIN_TEXT_UTF_8,
                                           Throwables.getStackTraceAsString(cause));
-                              return;
                           }
                           Map<String, List<String>> params = new QueryStringDecoder(
                                   aReq.content().toStringUtf8(), false)
                                   .parameters();
-                          res.respond(HttpStatus.OK, MediaType.JSON_UTF_8,
+                          return HttpResponse.of(HttpStatus.OK, MediaType.JSON_UTF_8,
                                       "{\"name\":\"" + params.get("name").get(0) + "\", " +
                                       "\"age\":" + params.get("age").get(0) + '}');
-                      }));
+                      })));
                   }
               })
               .service("/postCustomContentType", new AbstractHttpService() {
                   @Override
-                  protected void doPost(ServiceRequestContext ctx,
-                                        HttpRequest req, HttpResponseWriter res) throws Exception {
-                      req.aggregate().handle(voidFunction((aReq, cause) -> {
+                  protected HttpResponse doPost(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+                      return HttpResponse.from(req.aggregate().handle(((aReq, cause) -> {
                           if (cause != null) {
-                              res.respond(HttpStatus.INTERNAL_SERVER_ERROR,
+                              return HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR,
                                           MediaType.PLAIN_TEXT_UTF_8,
                                           Throwables.getStackTraceAsString(cause));
-                              return;
                           }
                           Map<String, List<String>> params = new QueryStringDecoder(
                                   aReq.content().toStringUtf8(), false)
                                   .parameters();
                           assertThat(params).isEmpty();
-                          res.respond(HttpStatus.OK);
-                      }));
+                          return HttpResponse.of(HttpStatus.OK);
+                      })));
                   }
               });
         }

--- a/spring-boot/autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaAutoConfiguration.java
+++ b/spring-boot/autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaAutoConfiguration.java
@@ -51,7 +51,6 @@ import com.google.common.base.Strings;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.common.HttpResponseWriter;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.SessionProtocol;
@@ -204,10 +203,10 @@ public class ArmeriaAutoConfiguration {
                         armeriaSettings.getMetricsPath(),
                         new AbstractHttpService() {
                             @Override
-                            protected void doGet(ServiceRequestContext ctx, HttpRequest req,
-                                                 HttpResponseWriter res) throws Exception {
-                                res.respond(HttpStatus.OK, MediaType.JSON_UTF_8,
-                                            objectMapper.writeValueAsBytes(dropwizardRegistry));
+                            protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req)
+                                    throws Exception {
+                                return HttpResponse.of(HttpStatus.OK, MediaType.JSON_UTF_8,
+                                                       objectMapper.writeValueAsBytes(dropwizardRegistry));
                             }
                         });
             }

--- a/spring-boot/autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaAutoConfigurationTest.java
+++ b/spring-boot/autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaAutoConfigurationTest.java
@@ -40,7 +40,6 @@ import com.linecorp.armeria.common.AggregatedHttpMessage;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.common.HttpResponseWriter;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.SessionProtocol;
@@ -104,9 +103,8 @@ public class ArmeriaAutoConfigurationTest {
 
     public static class OkService extends AbstractHttpService {
         @Override
-        protected void doGet(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res)
-                throws Exception {
-            res.respond(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "ok");
+        protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+            return HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "ok");
         }
     }
 

--- a/spring-boot/autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaAutoConfigurationWithoutMeterTest.java
+++ b/spring-boot/autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaAutoConfigurationWithoutMeterTest.java
@@ -31,7 +31,6 @@ import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.common.AggregatedHttpMessage;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.common.HttpResponseWriter;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.server.AbstractHttpService;
@@ -58,9 +57,9 @@ public class ArmeriaAutoConfigurationWithoutMeterTest {
                     .setServiceName("okService")
                     .setService(new AbstractHttpService() {
                         @Override
-                        protected void doGet(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res)
+                        protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req)
                                 throws Exception {
-                            res.respond(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "ok");
+                            return HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "ok");
                         }
                     })
                     .setPathMapping(PathMapping.ofExact("/ok"))

--- a/spring-boot/autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaMeterBindersConfigurationTest.java
+++ b/spring-boot/autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaMeterBindersConfigurationTest.java
@@ -29,7 +29,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import com.linecorp.armeria.common.HttpRequest;
-import com.linecorp.armeria.common.HttpResponseWriter;
+import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.metric.MoreMeters;
@@ -56,9 +56,8 @@ public class ArmeriaMeterBindersConfigurationTest {
                     .setServiceName("okService")
                     .setService(new AbstractHttpService() {
                         @Override
-                        protected void doGet(ServiceRequestContext ctx, HttpRequest req,
-                                             HttpResponseWriter res) throws Exception {
-                            res.respond(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "ok");
+                        protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) {
+                            return HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "ok");
                         }
                     })
                     .setPathMapping(PathMapping.ofExact("/ok"))

--- a/thrift/src/main/java/com/linecorp/armeria/client/thrift/THttpClientDelegate.java
+++ b/thrift/src/main/java/com/linecorp/armeria/client/thrift/THttpClientDelegate.java
@@ -44,7 +44,6 @@ import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.InvalidResponseException;
 import com.linecorp.armeria.common.AggregatedHttpMessage;
-import com.linecorp.armeria.common.DefaultHttpRequest;
 import com.linecorp.armeria.common.DefaultRpcResponse;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaders;
@@ -116,11 +115,10 @@ final class THttpClientDelegate implements Client<RpcRequest, RpcResponse> {
 
             ctx.logBuilder().requestContent(call, new ThriftCall(header, tArgs));
 
-            final DefaultHttpRequest httpReq = new DefaultHttpRequest(
+            final HttpRequest httpReq = HttpRequest.of(
                     HttpHeaders.of(HttpMethod.POST, ctx.path())
-                               .contentType(mediaType), true);
-            httpReq.write(HttpData.of(outTransport.getArray(), 0, outTransport.length()));
-            httpReq.close();
+                               .contentType(mediaType),
+                    HttpData.of(outTransport.getArray(), 0, outTransport.length()));
 
             ctx.logBuilder().deferResponseContent();
 

--- a/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftServiceTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftServiceTest.java
@@ -50,10 +50,11 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
-import com.linecorp.armeria.common.DefaultHttpRequest;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpRequestWriter;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.logging.DefaultRequestLog;
@@ -638,8 +639,7 @@ public class ThriftServiceTest {
         doNothing().when(ctx).invokeOnEnterCallbacks();
         doNothing().when(ctx).invokeOnExitCallbacks();
 
-        final DefaultHttpRequest req = new DefaultHttpRequest(
-                HttpHeaders.of(HttpMethod.POST, "/"), false);
+        final HttpRequestWriter req = HttpRequest.streaming(HttpHeaders.of(HttpMethod.POST, "/"), false);
 
         req.write(content);
         req.close();

--- a/tomcat/src/main/java/com/linecorp/armeria/server/tomcat/TomcatService.java
+++ b/tomcat/src/main/java/com/linecorp/armeria/server/tomcat/TomcatService.java
@@ -51,13 +51,13 @@ import org.slf4j.LoggerFactory;
 import com.google.common.collect.Sets;
 
 import com.linecorp.armeria.common.AggregatedHttpMessage;
-import com.linecorp.armeria.common.DefaultHttpResponse;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpResponseWriter;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.util.CompletionActions;
 import com.linecorp.armeria.server.HttpService;
@@ -356,18 +356,18 @@ public final class TomcatService implements HttpService {
             throw HttpStatusException.of(HttpStatus.SERVICE_UNAVAILABLE);
         }
 
-        final DefaultHttpResponse res = new DefaultHttpResponse();
+        final HttpResponseWriter res = HttpResponse.streaming();
         req.aggregate().handle(voidFunction((aReq, cause) -> {
             if (cause != null) {
                 logger.warn("{} Failed to aggregate a request:", ctx, cause);
-                res.respond(HttpStatus.INTERNAL_SERVER_ERROR);
+                res.respond(HttpHeaders.of(HttpStatus.INTERNAL_SERVER_ERROR));
                 return;
             }
 
             try {
                 final Request coyoteReq = convertRequest(ctx, aReq);
                 if (coyoteReq == null) {
-                    res.respond(HttpStatus.BAD_REQUEST);
+                    res.respond(HttpHeaders.of(HttpStatus.BAD_REQUEST));
                     return;
                 }
                 final Response coyoteRes = new Response();

--- a/tomcat/src/main/java/com/linecorp/armeria/server/tomcat/TomcatService.java
+++ b/tomcat/src/main/java/com/linecorp/armeria/server/tomcat/TomcatService.java
@@ -360,14 +360,14 @@ public final class TomcatService implements HttpService {
         req.aggregate().handle(voidFunction((aReq, cause) -> {
             if (cause != null) {
                 logger.warn("{} Failed to aggregate a request:", ctx, cause);
-                res.respond(HttpHeaders.of(HttpStatus.INTERNAL_SERVER_ERROR));
+                res.close(HttpHeaders.of(HttpStatus.INTERNAL_SERVER_ERROR));
                 return;
             }
 
             try {
                 final Request coyoteReq = convertRequest(ctx, aReq);
                 if (coyoteReq == null) {
-                    res.respond(HttpHeaders.of(HttpStatus.BAD_REQUEST));
+                    res.close(HttpHeaders.of(HttpStatus.BAD_REQUEST));
                     return;
                 }
                 final Response coyoteRes = new Response();

--- a/zookeeper/src/test/java/com/linecorp/armeria/server/zookeeper/ZooKeeperRegistrationTest.java
+++ b/zookeeper/src/test/java/com/linecorp/armeria/server/zookeeper/ZooKeeperRegistrationTest.java
@@ -34,7 +34,7 @@ import com.linecorp.armeria.client.zookeeper.TestBase;
 import com.linecorp.armeria.common.AggregatedHttpMessage;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpRequest;
-import com.linecorp.armeria.common.HttpResponseWriter;
+import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.util.CompletionActions;
@@ -179,16 +179,16 @@ public class ZooKeeperRegistrationTest extends TestBase implements ZooKeeperAsse
 
     private static class EchoService extends AbstractHttpService {
         @Override
-        protected final void doPost(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) {
-            req.aggregate()
-               .thenAccept(aReq -> echo(aReq, res))
-               .exceptionally(CompletionActions::log);
+        protected final HttpResponse doPost(ServiceRequestContext ctx, HttpRequest req) {
+            return HttpResponse.from(req.aggregate()
+               .thenApply(this::echo)
+               .exceptionally(CompletionActions::log));
         }
 
-        protected void echo(AggregatedHttpMessage aReq, HttpResponseWriter res) {
-            res.write(HttpHeaders.of(HttpStatus.OK));
-            res.write(aReq.content());
-            res.close();
+        protected HttpResponse echo(AggregatedHttpMessage aReq) {
+            return HttpResponse.of(
+                    HttpHeaders.of(HttpStatus.OK),
+                    aReq.content());
         }
     }
 }


### PR DESCRIPTION
…of passing in DefaultHttpResponse.

Discussion in #850 - this change allows service implementations to choose an `HttpResponse` that is appropriate for a given codepath, with little to no loss in writability.

`HttpRequest` and `HttpResponse` are the entrypoints for creating request and response objects now - `DefaultHttpRequest` and `DefaultHttpResponse` and `DeferredHttpResponse` are also planned to be made private (`HttpResponse.from(CompletableFuture)` seems like a more easy-to-use and natural API for users than `DeferredHttpResponse.delegate` so I think we can consolidate on it).

Most `respond` methods from `HttpResponseWriter` have been deprecated as it should now be more common to use `HttpResponse.of` or `HttpResponse.from` for its use cases. One easy to maintain one is left for advanced use cases.

Result is less exposure of implementation classes for more flexibility, less API duplication, reducing of "two ways of doing something" (I noticed that all of `HttpResponse.of` methods are accessible as `DefaultHttpResponse.of` as well, I guess interfaces with static methods should not have public implementations to prevent this sort of confusion), less object allocations / memory usage for many cases like `HttpFileService`, and probably thrift too.

This is a highly deprecating change, but no explicit breaks. Templates for helping in conversion towards when we actually do remove the APIs below.

Some IntelliJ templates
##### Converting service implementations

Search template:
```java
protected void doGet(ServiceRequestContext $CtxVar$, HttpRequest $ReqVar$, HttpResponseWriter $ResVar$) {
  $MethodBody$;
}
```

Replacement template:
```java
protected HttpResponse doGet(ServiceRequestContext $CtxVar$, HttpRequest $ReqVar$) {
  HttpResponseWriter $ResVar$ = HttpResponse.streaming();
  $MethodBody$;
  return $ResVar$;
}
```

##### Converting manual initializations

Search:
```java
DefaultHttpResponse $Var$ = new DefaultHttpResponse();
```

Replace:
```java
HttpResponseWriter $Var$ = HttpResponse.streaming();
```


Search:
```java
DefaultHttpRequest $Var$ = new DefaultHttpRequest();
```

Replace:
```java
HttpRequestWriter $Var$ = HttpRequest.streaming();
```