### PR TITLE
Fix flaky test: CaffeineMetricSupportTest.aggregationAfterGC()

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/metric/CaffeineMetricSupport.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/metric/CaffeineMetricSupport.java
@@ -58,6 +58,7 @@ public final class CaffeineMetricSupport {
     }
 
     public static void setup(MeterRegistry registry, MeterIdPrefix idPrefix, Cache<?, ?> cache, Ticker ticker) {
+        requireNonNull(cache, "cache");
         if (!cache.policy().isRecordingStats()) {
             return;
         }


### PR DESCRIPTION
Motivation:

The offending test case keeps the MockLoadingCache in a WeakReference
from its beginning of life. As a result, CaffeineMetricSupport.setup()
sometimes throws a NullPointerException because `WeakReference<MockLoadingCache>.get()`
can return null even before our System.gc() call.

Modifications:

- Keep the strong reference until System.gc()
- More friendly NPE message

Result:

- Build stability