### PR TITLE
Make JacksonRequestConverterFunction support +json media type as well

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/MediaType.java
+++ b/core/src/main/java/com/linecorp/armeria/common/MediaType.java
@@ -366,6 +366,12 @@ public final class MediaType {
     public static final MediaType JSON_UTF_8 = createConstantUtf8(APPLICATION_TYPE, "json");
     public static final MediaType JSON = createConstant(APPLICATION_TYPE, "json");
     /**
+     * As described in <a href="https://www.ietf.org/rfc/rfc6902.txt">RFC 6902</a>, this constant
+     * ({@code application/json-patch+json}) is used for expressing a sequence of operations to apply
+     * to a JavaScript Object Notation(JSON) document.
+     */
+    public static final MediaType JSON_PATCH = createConstant(APPLICATION_TYPE, "json-patch+json");
+    /**
      * Media type for the <a href="https://www.w3.org/TR/appmanifest/">Manifest for a web
      * application</a>.
      */

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/JacksonRequestConverterFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/JacksonRequestConverterFunction.java
@@ -41,6 +41,8 @@ public class JacksonRequestConverterFunction implements RequestConverterFunction
 
     private static final Logger logger = LoggerFactory.getLogger(JacksonRequestConverterFunction.class);
 
+    private static final ObjectMapper DEFAULT_MAPPER = new ObjectMapper();
+
     private final ObjectMapper mapper;
     private final ConcurrentMap<Class<?>, ObjectReader> readers = new ConcurrentHashMap<>();
 
@@ -48,7 +50,7 @@ public class JacksonRequestConverterFunction implements RequestConverterFunction
      * Creates an instance with the default {@link ObjectMapper}.
      */
     public JacksonRequestConverterFunction() {
-        this(new ObjectMapper());
+        this(DEFAULT_MAPPER);
     }
 
     /**
@@ -64,7 +66,8 @@ public class JacksonRequestConverterFunction implements RequestConverterFunction
     @Override
     public boolean canConvertRequest(AggregatedHttpMessage request, Class<?> expectedResultType) {
         final MediaType contentType = request.headers().contentType();
-        if (contentType != null && contentType.is(MediaType.JSON)) {
+        if (contentType != null && (contentType.is(MediaType.JSON) ||
+                                    contentType.subtype().contains("+json"))) {
             try {
                 return readers.computeIfAbsent(expectedResultType, mapper::readerFor) != null;
             } catch (Throwable cause) {

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/JacksonRequestConverterFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/JacksonRequestConverterFunction.java
@@ -67,7 +67,7 @@ public class JacksonRequestConverterFunction implements RequestConverterFunction
     public boolean canConvertRequest(AggregatedHttpMessage request, Class<?> expectedResultType) {
         final MediaType contentType = request.headers().contentType();
         if (contentType != null && (contentType.is(MediaType.JSON) ||
-                                    contentType.subtype().contains("+json"))) {
+                                    contentType.subtype().endsWith("+json"))) {
             try {
                 return readers.computeIfAbsent(expectedResultType, mapper::readerFor) != null;
             } catch (Throwable cause) {

--- a/core/src/test/java/com/linecorp/armeria/server/AnnotatedHttpServiceRequestConverterTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/AnnotatedHttpServiceRequestConverterTest.java
@@ -241,8 +241,26 @@ public class AnnotatedHttpServiceRequestConverterTest {
         final RequestObj1 obj1 = new RequestObj1(1, "abc");
         final String content1 = mapper.writeValueAsString(obj1);
 
+        // MediaType.JSON_UTF_8
         response = client.execute(AggregatedHttpMessage.of(HttpMethod.POST, "/2/default/json",
                                                            MediaType.JSON_UTF_8, content1))
+                         .aggregate().join();
+        assertThat(response.headers().status()).isEqualTo(HttpStatus.OK);
+        assertThat(response.content().toStringUtf8()).isEqualTo("abc");
+
+        // MediaType.JSON_PATCH
+        // obj1 is not a json-patch+json format, but just check if it's converted by
+        // DefaultRequestConverter when it is valid JSON format
+        response = client.execute(AggregatedHttpMessage.of(HttpMethod.POST, "/2/default/json",
+                                                           MediaType.JSON_PATCH, content1))
+                         .aggregate().join();
+        assertThat(response.headers().status()).isEqualTo(HttpStatus.OK);
+        assertThat(response.content().toStringUtf8()).isEqualTo("abc");
+
+        // "application/vnd.api+json"
+        response = client.execute(AggregatedHttpMessage.of(HttpMethod.POST, "/2/default/json",
+                                                           MediaType.create("application", "vnd.api+json"),
+                                                           content1))
                          .aggregate().join();
         assertThat(response.headers().status()).isEqualTo(HttpStatus.OK);
         assertThat(response.content().toStringUtf8()).isEqualTo("abc");


### PR DESCRIPTION
Motivation:
Not only `application/json` has JSON content, but also many variants whose subtype
contains `+json` has JSON contents. It is reasonable that `JacksonRequestConveterFunction`
supports converting the requests who have those headers.
I found a similar issue: https://github.com/NativeScript/NativeScript/issues/2593

Modifications:
- make `JacksonRequestConverterFunction` convert requests who have `+json` header
- Add `json-patch+json` media type

Result:
- Robust `JacksonRequestConveterFunction`