### PR TITLE
Write pooled objects to the request so pooled-aware subscribers can p…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/Http1RequestDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http1RequestDecoder.java
@@ -23,11 +23,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.linecorp.armeria.common.ContentTooLargeException;
-import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.ProtocolViolationException;
 import com.linecorp.armeria.internal.ArmeriaHttpUtil;
+import com.linecorp.armeria.internal.ByteBufHttpData;
 import com.linecorp.armeria.internal.InboundTrafficController;
 
 import io.netty.buffer.ByteBuf;
@@ -179,7 +179,7 @@ final class Http1RequestDecoder extends ChannelDuplexHandler {
                     }
 
                     if (req.isOpen()) {
-                        req.write(HttpData.of(data));
+                        req.write(new ByteBufHttpData(data.retain(), false));
                     }
                 }
 

--- a/core/src/main/java/com/linecorp/armeria/server/Http2RequestDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http2RequestDecoder.java
@@ -24,12 +24,12 @@ import static io.netty.handler.codec.http2.Http2Exception.streamError;
 import java.nio.charset.StandardCharsets;
 
 import com.linecorp.armeria.common.ContentTooLargeException;
-import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequestWriter;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.internal.ArmeriaHttpUtil;
+import com.linecorp.armeria.internal.ByteBufHttpData;
 import com.linecorp.armeria.internal.InboundTrafficController;
 
 import io.netty.buffer.ByteBuf;
@@ -173,7 +173,7 @@ final class Http2RequestDecoder extends Http2EventAdapter {
             }
         } else if (req.isOpen()) {
             try {
-                req.write(HttpData.of(data));
+                req.write(new ByteBufHttpData(data.retain(), endOfStream));
             } catch (Throwable t) {
                 req.close(t);
                 throw connectionError(INTERNAL_ERROR, t, "failed to consume a DATA frame");


### PR DESCRIPTION
…rocess ByteBuf directly.

Since our stream messages are aware of pooling, it should be ok to write pooled objects to the request for less copying with pooling-aware subscribers.

After
```
Benchmark                         (clientType)   Mode  Cnt    Score    Error  Units
DownstreamSimpleBenchmark.simple        OKHTTP  thrpt   20  490.181 ± 33.306  ops/s
```

Before
```
Benchmark                         (clientType)   Mode  Cnt    Score    Error  Units
DownstreamSimpleBenchmark.simple        OKHTTP  thrpt   20  482.963 ± 30.219  ops/s
```