### PR TITLE
Precompute mapping of string content types to well known types to imp…

### DIFF
--- a/benchmarks/src/jmh/java/com/linecorp/armeria/common/HttpHeadersBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/common/HttpHeadersBenchmark.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common;
+
+import org.openjdk.jmh.annotations.Benchmark;
+
+/**
+ * Microbenchmarks of {@link DefaultHttpHeaders} construction.
+ */
+public class HttpHeadersBenchmark {
+
+    @Benchmark
+    public MediaType parseKnown() {
+        HttpHeaders headers = new DefaultHttpHeaders()
+                .set(HttpHeaderNames.CONTENT_TYPE, "application/grpc+proto");
+        return headers.contentType();
+    }
+
+    @Benchmark
+    public MediaType parseUnknown() {
+        HttpHeaders headers = new DefaultHttpHeaders()
+                // Single letter change to keep theoretical parsing performance the same.
+                .set(HttpHeaderNames.CONTENT_TYPE, "application/grpc+oroto");
+        return headers.contentType();
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultHttpHeaders.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultHttpHeaders.java
@@ -16,13 +16,9 @@
 package com.linecorp.armeria.common;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Stream;
 
 import com.linecorp.armeria.internal.ArmeriaHttpUtil;
 
@@ -37,15 +33,6 @@ public final class DefaultHttpHeaders
 
     private static final NameValidator<AsciiString> HTTP2_NAME_VALIDATOR =
             name -> checkArgument(name != null && !name.isEmpty(), "empty headers are not allowed: %s", name);
-
-    private static final Map<String, MediaType> KNOWN_CONTENT_TYPES =
-            Stream.concat(
-                    SerializationFormat.values()
-                                       .stream()
-                                       .flatMap(f -> f.mediaTypes().stream()),
-                    MediaType.knownTypes().stream())
-                  .distinct()
-                  .collect(toImmutableMap(MediaType::toString, Function.identity(), (a, b) -> a));
 
     private final boolean endOfStream;
 
@@ -190,7 +177,7 @@ public final class DefaultHttpHeaders
 
     @Override
     public MediaType contentType() {
-        MediaType contentType = this.contentType;
+        final MediaType contentType = this.contentType;
         if (contentType != null) {
             return contentType;
         }
@@ -198,12 +185,6 @@ public final class DefaultHttpHeaders
         final String contentTypeString = get(HttpHeaderNames.CONTENT_TYPE);
         if (contentTypeString == null) {
             return null;
-        }
-
-        contentType = KNOWN_CONTENT_TYPES.get(contentTypeString);
-        if (contentType != null) {
-            this.contentType = contentType;
-            return contentType;
         }
 
         try {

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultHttpHeaders.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultHttpHeaders.java
@@ -202,6 +202,7 @@ public final class DefaultHttpHeaders
 
         contentType = KNOWN_CONTENT_TYPES.get(contentTypeString);
         if (contentType != null) {
+            this.contentType = contentType;
             return contentType;
         }
 

--- a/core/src/main/java/com/linecorp/armeria/common/MediaType.java
+++ b/core/src/main/java/com/linecorp/armeria/common/MediaType.java
@@ -795,7 +795,7 @@ public final class MediaType {
      */
     public static MediaType parse(String input) {
         checkNotNull(input);
-        final MediaType wellKnown = KNOWN_TYPES_BY_STRING.get(input);
+        final MediaType wellKnown = KnownTypesByString.get(input);
         if (wellKnown != null) {
             return wellKnown;
         }
@@ -1005,14 +1005,22 @@ public final class MediaType {
         return false;
     }
 
-    // Contains the well known media types as well as those registered in the server by SerializationFormats
-    // to optimize parsing of these standard types.
-    private static final Map<String, MediaType> KNOWN_TYPES_BY_STRING =
-            Stream.concat(
-                    SerializationFormat.values()
-                                       .stream()
-                                       .flatMap(f -> f.mediaTypes().stream()),
-                    KNOWN_TYPES.keySet().stream())
-                  .distinct()
-                  .collect(toImmutableMap(MediaType::toString, Function.identity(), (a, b) -> a));
+    private static final class KnownTypesByString {
+        // Contains the well known media types as well as those registered in the server by SerializationFormats
+        // to optimize parsing of these standard types.
+        private static final Map<String, MediaType> KNOWN_TYPES_BY_STRING =
+                Stream.concat(
+                        SerializationFormat.values()
+                                           .stream()
+                                           .flatMap(f -> f.mediaTypes().stream()),
+                        KNOWN_TYPES.keySet().stream())
+                      .distinct()
+                      .collect(toImmutableMap(MediaType::toString, Function.identity(), (a, b) -> a));
+
+        static MediaType get(String input) {
+            return KNOWN_TYPES_BY_STRING.get(input);
+        }
+
+        private KnownTypesByString() {}
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/MediaType.java
+++ b/core/src/main/java/com/linecorp/armeria/common/MediaType.java
@@ -43,6 +43,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.Set;
 
 import javax.annotation.Nullable;
 
@@ -478,6 +479,10 @@ public final class MediaType {
      */
     public static final MediaType XRD_UTF_8 = createConstantUtf8(APPLICATION_TYPE, "xrd+xml");
     public static final MediaType ZIP = createConstant(APPLICATION_TYPE, "zip");
+
+    public static Set<MediaType> knownTypes() {
+        return KNOWN_TYPES.keySet();
+    }
 
     private final String type;
     private final String subtype;

--- a/core/src/main/java/com/linecorp/armeria/common/SerializationFormat.java
+++ b/core/src/main/java/com/linecorp/armeria/common/SerializationFormat.java
@@ -188,7 +188,7 @@ public final class SerializationFormat implements Comparable<SerializationFormat
     }
 
     /**
-     * Returns all available {@link SessionProtocol}s.
+     * Returns all available {@link SerializationFormat}s.
      */
     public static Set<SerializationFormat> values() {
         return values;


### PR DESCRIPTION
…rove mediatype parsing when content types are known.

`MediaType.parse` is relatively slow as it supports all the variability of a content type. As servers only deal with a small number of media types in practice, it is wasteful to do this parse for every single request. Conveniently, servers also have a good idea of what media types they will support, so we can just precompute a mapping from `String` to `MediaType`.

A map like this should save memory / minimize garbage as all hits will result in sharing the same `MediaType` instance among requests. `MediaType.parse` itself has an interning cache, but it only recognizes its well known types, while this one also includes our `SerializationFormat`s.

A `LoadingCache` could also be used to be more general, but I feel like it would help a more limited use case (we'd probably want to add it as a layer after the precomputed map either way since it would have some synchronization overhead).

Benchmark
```
Benchmark                           Mode  Cnt         Score         Error  Units
HttpHeadersBenchmark.parseKnown    thrpt   20  13516374.953 ±  758315.535  ops/s
HttpHeadersBenchmark.parseUnknown  thrpt   20    700837.841 ±   38172.512  ops/s
```