### PR TITLE
Remove HttpRequest.isKeepAlive()

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/DefaultHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultHttpRequest.java
@@ -25,20 +25,18 @@ import com.linecorp.armeria.common.stream.DefaultStreamMessage;
 /**
  * Default {@link HttpRequest} implementation.
  *
- * @deprecated Use {@link HttpRequest#streaming()}.
+ * @deprecated Use {@link HttpRequest#streaming(HttpHeaders)}.
  */
 @Deprecated
 public class DefaultHttpRequest extends DefaultStreamMessage<HttpObject> implements HttpRequestWriter {
 
     private final HttpHeaders headers;
-    private final boolean keepAlive;
 
     /**
      * Creates a new instance with the specified headers.
      */
-    public DefaultHttpRequest(HttpHeaders headers, boolean keepAlive) {
+    public DefaultHttpRequest(HttpHeaders headers) {
         this.headers = requireNonNull(headers, "headers");
-        this.keepAlive = keepAlive;
     }
 
     @Override
@@ -47,14 +45,8 @@ public class DefaultHttpRequest extends DefaultStreamMessage<HttpObject> impleme
     }
 
     @Override
-    public boolean isKeepAlive() {
-        return keepAlive;
-    }
-
-    @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
-                          .add("keepAlive", isKeepAlive())
-                          .add("headers", headers()).toString();
+                          .addValue(headers()).toString();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/FixedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/FixedHttpRequest.java
@@ -31,21 +31,14 @@ final class FixedHttpRequest {
             extends EmptyFixedStreamMessage<HttpObject> implements HttpRequest {
 
         private final HttpHeaders headers;
-        private final boolean keepAlive;
 
-        EmptyFixedHttpRequest(HttpHeaders headers, boolean keepAlive) {
+        EmptyFixedHttpRequest(HttpHeaders headers) {
             this.headers = headers;
-            this.keepAlive = keepAlive;
         }
 
         @Override
         public HttpHeaders headers() {
             return headers;
-        }
-
-        @Override
-        public boolean isKeepAlive() {
-            return keepAlive;
         }
     }
 
@@ -53,22 +46,15 @@ final class FixedHttpRequest {
             extends OneElementFixedStreamMessage<HttpObject> implements HttpRequest {
 
         private final HttpHeaders headers;
-        private final boolean keepAlive;
 
-        OneElementFixedHttpRequest(HttpHeaders headers, boolean keepAlive, HttpObject obj) {
+        OneElementFixedHttpRequest(HttpHeaders headers, HttpObject obj) {
             super(obj);
             this.headers = headers;
-            this.keepAlive = keepAlive;
         }
 
         @Override
         public HttpHeaders headers() {
             return headers;
-        }
-
-        @Override
-        public boolean isKeepAlive() {
-            return keepAlive;
         }
     }
 
@@ -76,23 +62,16 @@ final class FixedHttpRequest {
             extends TwoElementFixedStreamMessage<HttpObject> implements HttpRequest {
 
         private final HttpHeaders headers;
-        private final boolean keepAlive;
 
         TwoElementFixedHttpRequest(
-                HttpHeaders headers, boolean keepAlive, HttpObject obj1, HttpObject obj2) {
+                HttpHeaders headers, HttpObject obj1, HttpObject obj2) {
             super(obj1, obj2);
             this.headers = headers;
-            this.keepAlive = keepAlive;
         }
 
         @Override
         public HttpHeaders headers() {
             return headers;
-        }
-
-        @Override
-        public boolean isKeepAlive() {
-            return keepAlive;
         }
     }
 
@@ -100,22 +79,15 @@ final class FixedHttpRequest {
             extends RegularFixedStreamMessage<HttpObject> implements HttpRequest {
 
         private final HttpHeaders headers;
-        private final boolean keepAlive;
 
-        RegularFixedHttpRequest(HttpHeaders headers, boolean keepAlive, HttpObject... objs) {
+        RegularFixedHttpRequest(HttpHeaders headers, HttpObject... objs) {
             super(objs);
             this.headers = headers;
-            this.keepAlive = keepAlive;
         }
 
         @Override
         public HttpHeaders headers() {
             return headers;
-        }
-
-        @Override
-        public boolean isKeepAlive() {
-            return keepAlive;
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequestDuplicator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequestDuplicator.java
@@ -53,8 +53,6 @@ public class HttpRequestDuplicator extends AbstractStreamMessageDuplicator<HttpO
 
     private final HttpHeaders headers;
 
-    private final boolean keepAlive;
-
     /**
      * Creates a new instance wrapping a {@link HttpRequest} and publishing to multiple subscribers.
      * The length of request is limited by default with the server-side parameter which is
@@ -90,7 +88,6 @@ public class HttpRequestDuplicator extends AbstractStreamMessageDuplicator<HttpO
             return 0;
         }, executor, maxSignalLength);
         headers = req.headers();
-        keepAlive = req.isKeepAlive();
     }
 
     @Override
@@ -111,15 +108,9 @@ public class HttpRequestDuplicator extends AbstractStreamMessageDuplicator<HttpO
         }
 
         @Override
-        public boolean isKeepAlive() {
-            return keepAlive;
-        }
-
-        @Override
         public String toString() {
             return MoreObjects.toStringHelper(this)
-                              .add("keepAlive", isKeepAlive())
-                              .add("headers", headers()).toString();
+                              .addValue(headers()).toString();
         }
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequestWriter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequestWriter.java
@@ -19,8 +19,8 @@ package com.linecorp.armeria.common;
 import com.linecorp.armeria.common.stream.StreamWriter;
 
 /**
- * An {@link HttpRequest} that can have {@link HttpObject}s written to it. Use {@link HttpRequest#streaming()}
- * to construct.
+ * An {@link HttpRequest} that can have {@link HttpObject}s written to it.
+ * Use {@link HttpRequest#streaming(HttpHeaders)} to construct.
  */
 public interface HttpRequestWriter extends HttpRequest, StreamWriter<HttpObject> {
 }

--- a/core/src/main/java/com/linecorp/armeria/common/PublisherBasedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/PublisherBasedHttpRequest.java
@@ -23,22 +23,14 @@ import com.linecorp.armeria.common.stream.PublisherBasedStreamMessage;
 final class PublisherBasedHttpRequest extends PublisherBasedStreamMessage<HttpObject> implements HttpRequest {
 
     private final HttpHeaders headers;
-    private final boolean keepAlive;
 
-    PublisherBasedHttpRequest(HttpHeaders headers, boolean keepAlive,
-                              Publisher<? extends HttpObject> publisher) {
+    PublisherBasedHttpRequest(HttpHeaders headers, Publisher<? extends HttpObject> publisher) {
         super(publisher);
         this.headers = headers;
-        this.keepAlive = keepAlive;
     }
 
     @Override
     public HttpHeaders headers() {
         return headers;
-    }
-
-    @Override
-    public boolean isKeepAlive() {
-        return keepAlive;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/DecodedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DecodedHttpRequest.java
@@ -29,6 +29,7 @@ final class DecodedHttpRequest extends DefaultHttpRequest {
     private final EventLoop eventLoop;
     private final int id;
     private final int streamId;
+    private final boolean keepAlive;
     private final InboundTrafficController inboundTrafficController;
     private final long defaultMaxRequestLength;
     private ServiceRequestContext ctx;
@@ -37,11 +38,12 @@ final class DecodedHttpRequest extends DefaultHttpRequest {
     DecodedHttpRequest(EventLoop eventLoop, int id, int streamId, HttpHeaders headers, boolean keepAlive,
                        InboundTrafficController inboundTrafficController, long defaultMaxRequestLength) {
 
-        super(headers, keepAlive);
+        super(headers);
 
         this.eventLoop = eventLoop;
         this.id = id;
         this.streamId = streamId;
+        this.keepAlive = keepAlive;
         this.inboundTrafficController = inboundTrafficController;
         this.defaultMaxRequestLength = defaultMaxRequestLength;
     }
@@ -57,6 +59,13 @@ final class DecodedHttpRequest extends DefaultHttpRequest {
 
     int streamId() {
         return streamId;
+    }
+
+    /**
+     * Returns whether to keep the connection alive after this request is handled.
+     */
+    boolean isKeepAlive() {
+        return keepAlive;
     }
 
     long maxRequestLength() {

--- a/core/src/test/java/com/linecorp/armeria/common/RequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/RequestContextTest.java
@@ -408,7 +408,7 @@ public class RequestContextTest {
     private class DummyRequestContext extends NonWrappingRequestContext {
         DummyRequestContext() {
             super(NoopMeterRegistry.get(), SessionProtocol.HTTP,
-                  HttpMethod.GET, "/", null, HttpRequest.streaming());
+                  HttpMethod.GET, "/", null, HttpRequest.streaming(HttpMethod.GET, "/"));
         }
 
         @Override

--- a/core/src/test/java/com/linecorp/armeria/internal/DefaultHttpRequestTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/DefaultHttpRequestTest.java
@@ -65,7 +65,7 @@ public class DefaultHttpRequestTest {
     @Test
     public void abortedAggregation() {
         final Thread mainThread = Thread.currentThread();
-        final DefaultHttpRequest req = new DefaultHttpRequest(HttpHeaders.of(HttpMethod.GET, "/foo"), true);
+        final DefaultHttpRequest req = new DefaultHttpRequest(HttpHeaders.of(HttpMethod.GET, "/foo"));
         final CompletableFuture<AggregatedHttpMessage> future;
 
         // Practically same execution, but we need to test the both case due to code duplication.

--- a/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftServiceTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftServiceTest.java
@@ -639,7 +639,7 @@ public class ThriftServiceTest {
         doNothing().when(ctx).invokeOnEnterCallbacks();
         doNothing().when(ctx).invokeOnExitCallbacks();
 
-        final HttpRequestWriter req = HttpRequest.streaming(HttpHeaders.of(HttpMethod.POST, "/"), false);
+        final HttpRequestWriter req = HttpRequest.streaming(HttpHeaders.of(HttpMethod.POST, "/"));
 
         req.write(content);
         req.close();


### PR DESCRIPTION
Motivation:

HttpRequest.isKeepAlive() was originally meant to be server-side only
transport-level detail, which means:

- It has no use on the client side. Creating a request with the false
  keepAlive property has no effect at all.
- There's no notion of keep-alive in HTTP/2.

Modification:

- Move HttpRequest.keepAlive down to DecodedHttpRequest so that it's
  kept only for the server-side decoder-level
- Remove HttpRequest.streaming() which creates an invalid request.

Result:

- Less noise in the public API
- A user does not have a way anymore to know if the current request will
  keep the connection alive or not. It was transport-layer detail anyway.