### PR TITLE
Update to Brave 4.13.1

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -91,7 +91,10 @@ io.prometheus:
   simpleclient_common: { version: '0.1.0' }
 
 io.zipkin.brave:
-  brave: { version: &BRAVE_VERSION '4.10.0' }
+  brave: { version: &BRAVE_VERSION '4.13.1' }
+
+io.zipkin.java:
+  zipkin: { version: &ZIPKIN_VERSION '2.4.2' }
 
 it.unimi.dsi:
   fastutil: { version: '8.1.1' }

--- a/zipkin/build.gradle
+++ b/zipkin/build.gradle
@@ -5,4 +5,5 @@ dependencies {
 managedDependencies {
     // Zipkin
     compile 'io.zipkin.brave:brave'
+    compile 'io.zipkin.java:zipkin'
 }


### PR DESCRIPTION
Added an explicit dependency on zipkin-java as the transitive dependency seems to have been removed. 

/cc @adriancole