### PR TITLE
Catch the Exception while converting RequestObject using JacksonRequestConverterFunction

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -35,6 +35,7 @@ import com.linecorp.armeria.client.ClientFactoryBuilder;
 import com.linecorp.armeria.client.retry.Backoff;
 import com.linecorp.armeria.client.retry.RetryingHttpClient;
 import com.linecorp.armeria.client.retry.RetryingRpcClient;
+import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.server.PathMappingContext;
 import com.linecorp.armeria.server.ServiceConfig;
 
@@ -169,14 +170,14 @@ public final class Flags {
 
     static {
         if (!Epoll.isAvailable()) {
-            final Throwable cause = filterCause(Epoll.unavailabilityCause());
+            final Throwable cause = Exceptions.peel(Epoll.unavailabilityCause());
             logger.info("/dev/epoll not available: {}", cause.toString());
         } else if (USE_EPOLL) {
             logger.info("Using /dev/epoll");
         }
 
         if (!OpenSsl.isAvailable()) {
-            final Throwable cause = filterCause(OpenSsl.unavailabilityCause());
+            final Throwable cause = Exceptions.peel(OpenSsl.unavailabilityCause());
             logger.info("OpenSSL not available: {}", cause.toString());
         } else if (USE_OPENSSL) {
             logger.info("Using OpenSSL: {}, 0x{}",
@@ -548,14 +549,6 @@ public final class Flags {
             value = Ascii.toLowerCase(value);
         }
         return value;
-    }
-
-    private static Throwable filterCause(Throwable cause) {
-        if (cause instanceof ExceptionInInitializerError) {
-            return cause.getCause();
-        }
-
-        return cause;
     }
 
     private Flags() {}

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -29,12 +29,11 @@ import java.util.concurrent.CompletionStage;
 
 import org.reactivestreams.Publisher;
 
-import com.google.common.base.Throwables;
-
 import com.linecorp.armeria.common.FixedHttpResponse.OneElementFixedHttpResponse;
 import com.linecorp.armeria.common.FixedHttpResponse.RegularFixedHttpResponse;
 import com.linecorp.armeria.common.FixedHttpResponse.TwoElementFixedHttpResponse;
 import com.linecorp.armeria.common.stream.StreamMessage;
+import com.linecorp.armeria.common.util.Exceptions;
 
 import io.netty.util.concurrent.EventExecutor;
 
@@ -64,7 +63,7 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
         final DeferredHttpResponse res = new DeferredHttpResponse();
         stage.whenComplete((delegate, thrown) -> {
             if (thrown != null) {
-                res.close(Throwables.getRootCause(thrown));
+                res.close(Exceptions.peel(thrown));
             } else if (delegate == null) {
                 res.close(new NullPointerException("delegate stage produced a null response: " + stage));
             } else {

--- a/core/src/main/java/com/linecorp/armeria/server/AnnotatedHttpServiceMethod.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AnnotatedHttpServiceMethod.java
@@ -37,7 +37,6 @@ import org.reactivestreams.Subscriber;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.common.AggregatedHttpMessage;
@@ -222,10 +221,10 @@ final class AnnotatedHttpServiceMethod {
      */
     private HttpResponse convertException(ServiceRequestContext ctx, HttpRequest req,
                                           Throwable cause) {
-        final Throwable rootCause = Throwables.getRootCause(cause);
+        final Throwable peeledCause = Exceptions.peel(cause);
         for (final ExceptionHandlerFunction func : exceptionHandlers) {
             try {
-                return func.handleException(ctx, req, rootCause);
+                return func.handleException(ctx, req, peeledCause);
             } catch (FallthroughException ignore) {
                 // Do nothing.
             } catch (Exception e) {
@@ -233,7 +232,7 @@ final class AnnotatedHttpServiceMethod {
                             func.getClass().getName(), e);
             }
         }
-        return ExceptionHandlerFunction.DEFAULT.handleException(ctx, req, rootCause);
+        return ExceptionHandlerFunction.DEFAULT.handleException(ctx, req, peeledCause);
     }
 
     /**

--- a/core/src/test/java/com/linecorp/armeria/common/util/ExceptionsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/util/ExceptionsTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+
+import org.junit.Test;
+
+public class ExceptionsTest {
+
+    @Test
+    public void peelTest() {
+        final IllegalArgumentException originalException = new IllegalArgumentException();
+
+        // There's nothing to peel.
+        assertThat(Exceptions.peel(originalException)).isSameAs(originalException);
+
+        // Wrap the exception with a CompletionException.
+        final CompletionException completionException = new CompletionException(originalException);
+        assertThat(Exceptions.peel(completionException)).isSameAs(originalException);
+
+        // Wrap the CompletionException with the same ExecutionException.
+        final CompletionException wrappedTwice = new CompletionException(completionException);
+        assertThat(Exceptions.peel(wrappedTwice)).isSameAs(originalException);
+
+        // Wrap the CompletionException with a ExecutionException.
+        final ExecutionException executionException = new ExecutionException(completionException);
+        assertThat(Exceptions.peel(executionException)).isSameAs(originalException);
+
+        // Wrap the CompletionException with a InvocationTargetException.
+        final InvocationTargetException invocationTargetException = new InvocationTargetException(
+                executionException);
+        assertThat(Exceptions.peel(invocationTargetException)).isSameAs(originalException);
+
+        // Wrap the CompletionException with a ExceptionInInitializerError.
+        final ExceptionInInitializerError exceptionInInitializerError = new ExceptionInInitializerError(
+                executionException);
+        assertThat(Exceptions.peel(exceptionInInitializerError)).isSameAs(originalException);
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerTest.java
@@ -96,6 +96,7 @@ import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.logging.RequestLogAvailability;
 import com.linecorp.armeria.common.stream.StreamWriter;
 import com.linecorp.armeria.common.util.EventLoopGroups;
+import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.internal.ByteBufHttpData;
 import com.linecorp.armeria.internal.InboundTrafficController;
 import com.linecorp.armeria.server.encoding.HttpEncodingService;
@@ -561,7 +562,7 @@ public class HttpServerTest {
             f.get();
             fail();
         } catch (ExecutionException e) {
-            assertThat(e.getCause(), is(instanceOf(ClosedSessionException.class)));
+            assertThat(Exceptions.peel(e), is(instanceOf(ClosedSessionException.class)));
         }
     }
 
@@ -580,7 +581,7 @@ public class HttpServerTest {
             f.get();
             fail();
         } catch (ExecutionException e) {
-            assertThat(e.getCause(), is(instanceOf(ClosedSessionException.class)));
+            assertThat(Exceptions.peel(e), is(instanceOf(ClosedSessionException.class)));
         }
     }
 

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/ArmeriaCallFactory.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/ArmeriaCallFactory.java
@@ -32,6 +32,7 @@ import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.util.Exceptions;
 
 import okhttp3.Call;
 import okhttp3.Call.Factory;
@@ -190,7 +191,7 @@ final class ArmeriaCallFactory implements Factory {
             } catch (CancellationException e) {
                 throw new IOException(e);
             } catch (CompletionException e) {
-                throw new IOException(e.getCause());
+                throw new IOException(Exceptions.peel(e));
             }
         }
 

--- a/thrift/src/main/java/com/linecorp/armeria/client/thrift/THttpClientDelegate.java
+++ b/thrift/src/main/java/com/linecorp/armeria/client/thrift/THttpClientDelegate.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.thrift.TApplicationException;
@@ -59,6 +58,7 @@ import com.linecorp.armeria.common.thrift.ThriftCall;
 import com.linecorp.armeria.common.thrift.ThriftProtocolFactories;
 import com.linecorp.armeria.common.thrift.ThriftReply;
 import com.linecorp.armeria.common.util.CompletionActions;
+import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.internal.thrift.TApplicationExceptions;
 import com.linecorp.armeria.internal.thrift.ThriftFieldAccess;
 import com.linecorp.armeria.internal.thrift.ThriftFunction;
@@ -127,8 +127,7 @@ final class THttpClientDelegate implements Client<RpcRequest, RpcResponse> {
 
             future.handle(voidFunction((res, cause) -> {
                 if (cause != null) {
-                    handlePreDecodeException(ctx, reply, func,
-                                             cause instanceof ExecutionException ? cause.getCause() : cause);
+                    handlePreDecodeException(ctx, reply, func, Exceptions.peel(cause));
                     return;
                 }
 

--- a/thrift/src/main/java/com/linecorp/armeria/client/thrift/THttpClientInvocationHandler.java
+++ b/thrift/src/main/java/com/linecorp/armeria/client/thrift/THttpClientInvocationHandler.java
@@ -32,6 +32,7 @@ import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.ClientOptions;
 import com.linecorp.armeria.common.RpcResponse;
 import com.linecorp.armeria.common.util.CompletionActions;
+import com.linecorp.armeria.common.util.Exceptions;
 
 final class THttpClientInvocationHandler implements InvocationHandler, ClientBuilderParams {
 
@@ -138,7 +139,7 @@ final class THttpClientInvocationHandler implements InvocationHandler, ClientBui
                 try {
                     return reply.get();
                 } catch (ExecutionException e) {
-                    throw e.getCause();
+                    throw Exceptions.peel(e);
                 }
             }
         } catch (Throwable cause) {

--- a/thrift/src/test/java/com/linecorp/armeria/client/thrift/THttpClientBadSeqIdTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/client/thrift/THttpClientBadSeqIdTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 
 import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.common.RpcResponse;
+import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.service.test.thrift.main.HelloService;
 
 public class THttpClientBadSeqIdTest {
@@ -81,7 +82,7 @@ public class THttpClientBadSeqIdTest {
             assertThatThrownBy(res::get)
                     .isInstanceOf(ExecutionException.class)
                     .hasCauseInstanceOf(TApplicationException.class)
-                    .satisfies(cause -> assertThat(((TApplicationException) cause.getCause()).getType())
+                    .satisfies(cause -> assertThat(((TApplicationException) Exceptions.peel(cause)).getType())
                             .isEqualTo(TApplicationException.BAD_SEQUENCE_ID));
         }
     }


### PR DESCRIPTION
Motivation:
If the client request with invalid JSON, `JacksonRequestConvertFunction` currently, throw
a converting excpeiton and there's no place to catch the exception. Therefore, the client
get `500` error which is not right.

Modification:
- Catch the exception and throw new `IllegalArgumentException` so that `DefaultExceptinHandler` handles it

Result:
- Respond with proper status to clients