### PR TITLE
Fix NoSuchElementException in ZooKeeperUpdatingListener

### DIFF
--- a/zookeeper/src/main/java/com/linecorp/armeria/server/zookeeper/ZooKeeperUpdatingListener.java
+++ b/zookeeper/src/main/java/com/linecorp/armeria/server/zookeeper/ZooKeeperUpdatingListener.java
@@ -62,7 +62,7 @@ public class ZooKeeperUpdatingListener extends ServerListenerAdapter {
     }
 
     @Override
-    public void serverStarting(Server server) throws Exception {
+    public void serverStarted(Server server) throws Exception {
         if (endpoint == null) {
             assert server.activePort().isPresent();
             endpoint = Endpoint.of(server.defaultHostname(),


### PR DESCRIPTION
Motivation:

ZooKeeperUpdatingListener attempts to access `Server.activePort()` in
`serverStarting()`. `Server.activePort()` is supposed to be available in
`serverStarted()`.

Modifications:

Use `serverStarted()` rather than `serverStarting()`.

Result:

- Fixes #933