### PR TITLE
Add newDerivedContext(Request) to RequestContext

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
@@ -37,6 +37,9 @@ public interface ClientRequestContext extends RequestContext {
     @Override
     ClientRequestContext newDerivedContext();
 
+    @Override
+    ClientRequestContext newDerivedContext(Request request);
+
     /**
      * The {@link AttributeKey} of the {@link HttpHeaders} to include when a {@link Client} sends an
      * {@link HttpRequest}. This {@link Attribute} is initially populated from

--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextWrapper.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.client;
 
 import java.time.Duration;
 
+import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.RequestContextWrapper;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
@@ -37,6 +38,11 @@ public class ClientRequestContextWrapper
     @Override
     public ClientRequestContext newDerivedContext() {
         return delegate().newDerivedContext();
+    }
+
+    @Override
+    public ClientRequestContext newDerivedContext(Request request) {
+        return delegate().newDerivedContext(request);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -28,6 +28,7 @@ import com.linecorp.armeria.common.DefaultHttpHeaders;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.NonWrappingRequestContext;
+import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.logging.DefaultRequestLog;
 import com.linecorp.armeria.common.logging.RequestLog;
@@ -71,7 +72,7 @@ public class DefaultClientRequestContext extends NonWrappingRequestContext imple
             EventLoop eventLoop, MeterRegistry meterRegistry,
             SessionProtocol sessionProtocol, Endpoint endpoint,
             HttpMethod method, String path, @Nullable String query, @Nullable String fragment,
-            ClientOptions options, Object request) {
+            ClientOptions options, Request request) {
 
         super(meterRegistry, sessionProtocol, method, path, query, request);
 
@@ -103,8 +104,11 @@ public class DefaultClientRequestContext extends NonWrappingRequestContext imple
     }
 
     private DefaultClientRequestContext(DefaultClientRequestContext ctx) {
-        super(ctx.meterRegistry(), ctx.sessionProtocol(),
-              ctx.method(), ctx.path(), ctx.query(), ctx.request());
+        this(ctx, ctx.request());
+    }
+
+    private DefaultClientRequestContext(DefaultClientRequestContext ctx, Request request) {
+        super(ctx.meterRegistry(), ctx.sessionProtocol(), ctx.method(), ctx.path(), ctx.query(), request);
 
         this.eventLoop = ctx.eventLoop();
         this.options = ctx.options();
@@ -132,6 +136,11 @@ public class DefaultClientRequestContext extends NonWrappingRequestContext imple
     @Override
     public ClientRequestContext newDerivedContext() {
         return new DefaultClientRequestContext(this);
+    }
+
+    @Override
+    public ClientRequestContext newDerivedContext(Request request) {
+        return new DefaultClientRequestContext(this, request);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
@@ -81,7 +81,7 @@ public abstract class RetryingClient<I extends Request, O extends Response>
      * Executes the delegate with a new derived {@link ClientRequestContext}.
      */
     protected final O executeDelegate(ClientRequestContext ctx, I req) throws Exception {
-        final ClientRequestContext derivedContext = ctx.newDerivedContext();
+        final ClientRequestContext derivedContext = ctx.newDerivedContext(req);
         ctx.logBuilder().addChild(derivedContext.log());
         try (SafeCloseable ignore = RequestContext.push(derivedContext, false)) {
             return delegate().execute(derivedContext, req);

--- a/core/src/main/java/com/linecorp/armeria/common/NonWrappingRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/common/NonWrappingRequestContext.java
@@ -47,7 +47,7 @@ public abstract class NonWrappingRequestContext extends AbstractRequestContext {
     private final HttpMethod method;
     private final String path;
     private final String query;
-    private final Object request;
+    private final Request request;
 
     // Callbacks
     private List<Consumer<? super RequestContext>> onEnterCallbacks;
@@ -62,7 +62,7 @@ public abstract class NonWrappingRequestContext extends AbstractRequestContext {
      */
     protected NonWrappingRequestContext(
             MeterRegistry meterRegistry, SessionProtocol sessionProtocol,
-            HttpMethod method, String path, @Nullable String query, Object request) {
+            HttpMethod method, String path, @Nullable String query, Request request) {
 
         this.meterRegistry = requireNonNull(meterRegistry, "meterRegistry");
         this.sessionProtocol = requireNonNull(sessionProtocol, "sessionProtocol");
@@ -129,7 +129,7 @@ public abstract class NonWrappingRequestContext extends AbstractRequestContext {
 
     @Override
     @SuppressWarnings("unchecked")
-    public final <T> T request() {
+    public final <T extends Request> T request() {
         return (T) request;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/RequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestContext.java
@@ -72,6 +72,13 @@ public interface RequestContext extends AttributeMap {
     RequestContext newDerivedContext();
 
     /**
+     * Creates a new derived {@link RequestContext} with the specified {@link Request} which the
+     * {@link RequestLog} is different from the deriving context.
+     * Note that the references of {@link Attribute}s in the {@link #attrs()} are copied as well.
+     */
+    RequestContext newDerivedContext(Request request);
+
+    /**
      * Returns the context of the {@link Request} that is being handled in the current thread.
      *
      * @throws IllegalStateException if the context is unavailable in the current thread
@@ -219,7 +226,7 @@ public interface RequestContext extends AttributeMap {
     /**
      * Returns the {@link Request} associated with this context.
      */
-    <T> T request();
+    <T extends Request> T request();
 
     /**
      * Returns the {@link RequestLog} that contains the information about the current {@link Request}.

--- a/core/src/main/java/com/linecorp/armeria/common/RequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestContextWrapper.java
@@ -97,7 +97,7 @@ public abstract class RequestContextWrapper<T extends RequestContext> extends Ab
     }
 
     @Override
-    public <T> T request() {
+    public <E extends Request> E request() {
         return delegate().request();
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
@@ -34,6 +34,7 @@ import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.NonWrappingRequestContext;
+import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.logging.DefaultRequestLog;
 import com.linecorp.armeria.common.logging.RequestLog;
@@ -80,7 +81,7 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
      */
     public DefaultServiceRequestContext(
             ServiceConfig cfg, Channel ch, MeterRegistry meterRegistry, SessionProtocol sessionProtocol,
-            PathMappingContext pathMappingContext, PathMappingResult pathMappingResult, Object request,
+            PathMappingContext pathMappingContext, PathMappingResult pathMappingResult, Request request,
             @Nullable SSLSession sslSession) {
 
         super(meterRegistry, sessionProtocol,
@@ -115,10 +116,14 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
 
     @Override
     public ServiceRequestContext newDerivedContext() {
+        return newDerivedContext(request());
+    }
+
+    @Override
+    public ServiceRequestContext newDerivedContext(Request request) {
         final DefaultServiceRequestContext ctx = new DefaultServiceRequestContext(
-                this.cfg, this.ch, this.meterRegistry(), this.sessionProtocol(),
-                this.pathMappingContext, this.pathMappingResult, this.request(),
-                this.sslSession());
+                cfg, ch, meterRegistry(), sessionProtocol(), pathMappingContext,
+                pathMappingResult, request, sslSession());
         for (Iterator<Attribute<?>> i = attrs(); i.hasNext();) {
             ctx.addAttr(i.next());
         }

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -47,6 +47,7 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.NonWrappingRequestContext;
+import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.logging.DefaultRequestLog;
@@ -598,7 +599,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
 
         EarlyRespondingRequestContext(Channel channel, MeterRegistry meterRegistry,
                                       SessionProtocol sessionProtocol, HttpMethod method, String path,
-                                      @Nullable String query, Object request) {
+                                      @Nullable String query, Request request) {
             super(meterRegistry, sessionProtocol, method, path, query, request);
             this.channel = requireNonNull(channel, "channel");
             requestLog = new DefaultRequestLog(this);
@@ -606,9 +607,14 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
 
         @Override
         public RequestContext newDerivedContext() {
+            return newDerivedContext(request());
+        }
+
+        @Override
+        public RequestContext newDerivedContext(Request request) {
             // There are no attributes which should be copied to a new instance.
             return new EarlyRespondingRequestContext(channel(), meterRegistry(), sessionProtocol(),
-                                                     method(), path(), query(), request());
+                                                     method(), path(), query(), request);
         }
 
         @Nullable

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
@@ -42,6 +42,9 @@ public interface ServiceRequestContext extends RequestContext {
     @Override
     ServiceRequestContext newDerivedContext();
 
+    @Override
+    ServiceRequestContext newDerivedContext(Request request);
+
     /**
      * Returns the {@link Server} that is handling the current {@link Request}.
      */

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
@@ -27,6 +27,7 @@ import org.slf4j.Logger;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.RequestContextWrapper;
 
 /**
@@ -45,6 +46,11 @@ public class ServiceRequestContextWrapper
     @Override
     public ServiceRequestContext newDerivedContext() {
         return delegate().newDerivedContext();
+    }
+
+    @Override
+    public ServiceRequestContext newDerivedContext(Request request) {
+        return delegate().newDerivedContext(request);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/composition/AbstractCompositeService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/composition/AbstractCompositeService.java
@@ -171,7 +171,15 @@ public abstract class AbstractCompositeService<I extends Request, O extends Resp
 
         @Override
         public ServiceRequestContext newDerivedContext() {
-            final ServiceRequestContext derivedCtx = super.newDerivedContext();
+            return newDerivedContext(super.newDerivedContext());
+        }
+
+        @Override
+        public ServiceRequestContext newDerivedContext(Request request) {
+            return newDerivedContext(super.newDerivedContext(request));
+        }
+
+        private ServiceRequestContext newDerivedContext(ServiceRequestContext derivedCtx) {
             return new CompositeServiceRequestContext(derivedCtx, pathMapping, mappedPath);
         }
 

--- a/core/src/test/java/com/linecorp/armeria/client/DefaultClientRequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/DefaultClientRequestContextTest.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.mock;
 import org.junit.Test;
 
 import com.linecorp.armeria.common.HttpMethod;
-import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.metric.NoopMeterRegistry;
 
@@ -36,16 +36,18 @@ public class DefaultClientRequestContextTest {
         final DefaultClientRequestContext originalCtx = new DefaultClientRequestContext(
                 mock(EventLoop.class), NoopMeterRegistry.get(), SessionProtocol.H2C,
                 Endpoint.of("example.com", 8080), HttpMethod.POST, "/foo", null, null,
-                ClientOptions.DEFAULT, HttpRequest.of(HttpMethod.POST, "/foo"));
+                ClientOptions.DEFAULT, mock(Request.class));
+
         final AttributeKey<String> foo = AttributeKey.valueOf(DefaultClientRequestContextTest.class, "foo");
         originalCtx.attr(foo).set("foo");
 
-        final ClientRequestContext derivedCtx = originalCtx.newDerivedContext();
+        Request newRequest = mock(Request.class);
+        final ClientRequestContext derivedCtx = originalCtx.newDerivedContext(newRequest);
         assertThat(derivedCtx.endpoint()).isSameAs(originalCtx.endpoint());
         assertThat(derivedCtx.sessionProtocol()).isSameAs(originalCtx.sessionProtocol());
         assertThat(derivedCtx.method()).isSameAs(originalCtx.method());
         assertThat(derivedCtx.options()).isSameAs(originalCtx.options());
-        assertThat(derivedCtx.<Object>request()).isSameAs(originalCtx.request());
+        assertThat(derivedCtx.<Request>request()).isSameAs(newRequest);
 
         assertThat(derivedCtx.path()).isEqualTo(originalCtx.path());
         assertThat(derivedCtx.maxResponseLength()).isEqualTo(originalCtx.maxResponseLength());

--- a/core/src/test/java/com/linecorp/armeria/common/RequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/RequestContextTest.java
@@ -417,6 +417,11 @@ public class RequestContextTest {
         }
 
         @Override
+        public RequestContext newDerivedContext(Request request) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
         public EventLoop eventLoop() {
             return channel.eventLoop();
         }

--- a/core/src/test/java/com/linecorp/armeria/server/DefaultServiceRequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/DefaultServiceRequestContextTest.java
@@ -28,6 +28,7 @@ import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.metric.NoopMeterRegistry;
 
@@ -46,18 +47,18 @@ public class DefaultServiceRequestContextTest {
         final ServiceRequestContext originalCtx = new DefaultServiceRequestContext(
                 virtualHost.serviceConfigs().get(0), mock(Channel.class), NoopMeterRegistry.get(),
                 SessionProtocol.H2,
-                mappingCtx, PathMappingResult.of("/foo", null, ImmutableMap.of()),
-                HttpRequest.of(HttpMethod.POST, "/foo"), null);
+                mappingCtx, PathMappingResult.of("/foo", null, ImmutableMap.of()), mock(Request.class), null);
 
         final AttributeKey<String> foo = AttributeKey.valueOf(DefaultServiceRequestContextTest.class, "foo");
         originalCtx.attr(foo).set("foo");
 
-        final ServiceRequestContext derivedCtx = originalCtx.newDerivedContext();
+        Request newRequest = mock(Request.class);
+        final ServiceRequestContext derivedCtx = originalCtx.newDerivedContext(newRequest);
         assertThat(derivedCtx.server()).isSameAs(originalCtx.server());
         assertThat(derivedCtx.sessionProtocol()).isSameAs(originalCtx.sessionProtocol());
         assertThat(derivedCtx.<Service<HttpRequest, HttpResponse>>service()).isSameAs(originalCtx.service());
         assertThat(derivedCtx.pathMapping()).isSameAs(originalCtx.pathMapping());
-        assertThat(derivedCtx.<Object>request()).isSameAs(originalCtx.request());
+        assertThat(derivedCtx.<Request>request()).isSameAs(newRequest);
 
         assertThat(derivedCtx.path()).isEqualTo(originalCtx.path());
         assertThat(derivedCtx.maxRequestLength()).isEqualTo(originalCtx.maxRequestLength());

--- a/core/src/test/java/com/linecorp/armeria/server/logging/AccessLogFormatsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/logging/AccessLogFormatsTest.java
@@ -40,6 +40,7 @@ import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.NonWrappingRequestContext;
+import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.logging.DefaultRequestLog;
@@ -227,6 +228,11 @@ public class AccessLogFormatsTest {
 
         @Override
         public RequestContext newDerivedContext() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public RequestContext newDerivedContext(Request request) {
             throw new UnsupportedOperationException();
         }
 


### PR DESCRIPTION
So, a user can derive a context with the specified `Request`.
Also, I changed to store the `request` field as `Request` instead of `Object`
inside `NonWrappingRequestContext`.