### PR TITLE
Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,18 @@ Visit [the official web site](https://line.github.io/armeria/) for more informat
 
 # Armeria
 
-_Armeria_ is an open-source asynchronous RPC/API client/server library built on top of [Java 8](https://java.oracle.com/), [Netty 4.1](https://netty.io/), [HTTP/2](https://http2.github.io/), and [Thrift](https://thrift.apache.org/). Its primary goal is to help engineers build high-performance asynchronous Thrift microservices that use HTTP/2 as a session layer protocol, although it is designed to be protocol-agnostic and highly extensible (for example, you can serve a directory of static files via HTTP/2 and run Java EE web applications).
+_Armeria_ is an open-source asynchronous RPC/API client/server library built on top of
+[Java 8](https://java.oracle.com/), [Netty 4.1](https://netty.io/), [HTTP/2](https://http2.github.io/),
+[Thrift](https://thrift.apache.org/) and [gRPC](https://grpc.io/). Its primary goal is to help engineers build
+high-performance asynchronous microservices that use HTTP/2 as a session layer protocol.
 
-It is open-sourced and licensed under [Apache License 2.0](https://tldrlegal.com/license/apache-license-2.0-(apache-2.0)) by [LINE Corporation](https://linecorp.com/en/), who uses it in production.
+It is open-sourced and licensed under [Apache License 2.0](https://tldrlegal.com/license/apache-license-2.0-(apache-2.0))
+by [LINE Corporation](https://linecorp.com/en/), who uses it in production.
 
 ## How to build
 
-We use [Gradle](https://gradle.org/) to build Armeria. The following command will compile Armeria and generate JARs and web site:
+We use [Gradle](https://gradle.org/) to build Armeria. The following command will compile Armeria and generate
+JARs and web site:
 
 ```bash
 $ ./gradlew build
@@ -16,7 +21,8 @@ $ ./gradlew build
 
 ## How to ask a question
 
-Just [create a new issue](https://github.com/line/armeria/issues/new) to ask a question, and browse [the list of previously answered questions](https://github.com/line/armeria/issues?q=label%3Aquestion-answered).
+Just [create a new issue](https://github.com/line/armeria/issues/new) to ask a question, and browse
+[the list of previously answered questions](https://github.com/line/armeria/issues?q=label%3Aquestion-answered).
 
 We also have [a Slack workspace](https://line-slacknow.herokuapp.com/line-armeria/).
 

--- a/site/src/sphinx/client-grpc.rst
+++ b/site/src/sphinx/client-grpc.rst
@@ -60,7 +60,9 @@ looked like the following:
 
     import com.google.common.util.concurrent.Futures;
     import com.google.common.util.concurrent.ListenableFuture;
+    import com.google.common.util.concurrent.MoreExecutors;
     import com.linecorp.armeria.client.Clients;
+    import java.util.concurrent.ForkJoinPool;
 
     HelloServiceFutureStub helloService = Clients.newClient(
             "gproto+http://127.0.0.1:8080/",
@@ -79,7 +81,10 @@ looked like the following:
         public void onFailure(Throwable t) {
             t.printStackTrace();
         }
-    });
+    }, MoreExecutors.directExecutor());
+
+    // You can also wait until the call is finished.
+    HelloReply reply = future.get();
 
 The asynchronous stub uses Guava's ListenableFuture_ and can be operated on using methods on Futures_. The
 futures-extra_ library is very convenient for working with ListenableFuture_ in Java 8, including the ability
@@ -98,12 +103,14 @@ you can use the streaming stub to send and receive multiple responses, in a full
 .. code-block:: java
 
     import com.linecorp.armeria.client.Clients;
+    import java.util.concurrent.CountDownLatch;
 
     HelloServiceStub helloService = Clients.newClient(
             "gproto+http://127.0.0.1:8080/",
             HelloServiceStub.class);
 
-    HelloRequest request = HelloRequest.newBuilder().setName("Armerian World").build();
+    // Prepare the observer that will receive the request stream.
+    CountDownLatch latch = new CountDownLatch(1);
     StreamObserver<HelloReply> replyStream = new StreamObserver<>() {
         @Override
         public void onNext(HelloReply reply) {
@@ -113,17 +120,25 @@ you can use the streaming stub to send and receive multiple responses, in a full
         @Override
         public void onError(Throwable t) {
             t.printStackTrace();
+            latch.countDown();
         }
 
         @Override
         public void onCompleted() {
             System.out.println("We're done!");
+            latch.countDown();
         }
     };
-    StreamObserver<HelloRequest> requestStream = helloService.manyHellos(responseStream);
+
+    // Send the request stream.
+    StreamObserver<HelloRequest> requestStream = helloService.manyHellos(replyStream);
+    HelloRequest request = HelloRequest.newBuilder().setName("Armerian World").build();
     requestStream.onNext(request);
     requestStream.onNext(request);
     requestStream.onCompleted();
+
+    // You may want to wait until the call is finished.
+    latch.await();
 
 You can also use the builder pattern for client construction:
 

--- a/site/src/sphinx/client-retrofit.rst
+++ b/site/src/sphinx/client-retrofit.rst
@@ -17,8 +17,6 @@ Armeria provides a class called `ArmeriaRetrofit`_ that replaces the networking 
 `OkHttp`_ to Armeria. By doing so, you get the following benefits:
 
 - Better performance, thanks to `Netty`_ and its JNI-based I/O and TLS implementation
-- Less context switches when building `an API gateway`_, because Armeria will assign the same event loop thread
-  for the incoming request and the outgoing request
 - Leverage other advanced features of Armeria, such as client-side load-balancing and service discovery
 - Cleartext HTTP/2 support, as known as ``h2c``
 

--- a/site/src/sphinx/server-grpc.rst
+++ b/site/src/sphinx/server-grpc.rst
@@ -4,8 +4,10 @@
 .. _GrpcSerializationFormats: https://github.com/line/armeria/blob/master/grpc/src/main/java/com/linecorp/armeria/common/grpc/GrpcSerializationFormats.java
 .. _GrpcService: apidocs/index.html?com/linecorp/armeria/server/grpc/GrpcService.html
 .. _GrpcServiceBuilder: apidocs/index.html?com/linecorp/armeria/server/grpc/GrpcServiceBuilder.html
+.. _protobuf-gradle-plugin: https://github.com/google/protobuf-gradle-plugin
 .. _Protobuf-JSON: https://developers.google.com/protocol-buffers/docs/proto3#json
 .. _ServerBuilder: apidocs/index.html?com/linecorp/armeria/server/ServerBuilder.html
+.. _the gRPC-Java README: https://github.com/grpc/grpc-java/blob/master/README.md#download
 
 .. _server-grpc:
 
@@ -64,6 +66,11 @@ Our implementation would look like the following:
             responseObserver.onCompleted();
         }
     }
+
+.. note::
+
+    It is recommended to use the build plugin as explained in `the gRPC-Java README`_ rather than
+    running ``protoc`` manually.
 
 ``GrpcService``
 ---------------

--- a/site/src/sphinx/setup-common.rst
+++ b/site/src/sphinx/setup-common.rst
@@ -1,6 +1,8 @@
+.. _`Caffeine`: https://github.com/ben-manes/caffeine
 .. _`completable-futures`: https://github.com/spotify/completable-futures
 .. _`fastutil`: http://fastutil.di.unimi.it/
 .. _`Guava`: https://github.com/google/guava
+.. _`JCTools`: https://jctools.github.io/JCTools/
 .. _`Reflections`: https://github.com/ronmamo/reflections
 
 You may not need all Armeria modules depending on your use case. Please remove unused ones.
@@ -8,9 +10,11 @@ You may not need all Armeria modules depending on your use case. Please remove u
 Armeria also provides its artifacts as a shaded JAR so that it can coexist with other components
 better. The following is the list of the shaded dependencies:
 
+- `Caffeine`_
 - `completable-futures`_
 - `fastutil`_
 - `Guava`_
+- `JCTools`_
 - `Reflections`_
 
 Please append the ``-shaded`` suffix to the artifact ID to use the shaded dependencies.


### PR DESCRIPTION
- README.md
  - Update the project summary
  - Wrap at 112 column
- 'Calling a gRPC service'
  - Do not use the deprecated Futures.addCallback()
  - Make all examples wait until the call is finished so that the JVM
    does not exit too early, because the default event loop threads are
    daemon.
  - responseStream -> replyStream
- 'Running a gRPC service'
  - Add a note about how to configure the build
- 'Retrofit integration'
  - Remove the benefit item that's not true anymore
- Update the list of shaded dependencies