### PR TITLE
Support enum as a type of @Param annotated parameter(#935)

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/AnnotatedHttpServiceMethod.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AnnotatedHttpServiceMethod.java
@@ -17,6 +17,7 @@
 package com.linecorp.armeria.server;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.linecorp.armeria.common.HttpParameters.EMPTY_PARAMETERS;
 import static com.linecorp.armeria.internal.DefaultValues.getSpecifiedValue;
@@ -24,12 +25,14 @@ import static java.util.Objects.requireNonNull;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
 
 import javax.annotation.Nullable;
 
@@ -37,6 +40,7 @@ import org.reactivestreams.Subscriber;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Ascii;
 import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.common.AggregatedHttpMessage;
@@ -346,7 +350,7 @@ final class AnnotatedHttpServiceMethod {
                 case PATH_PARAM:
                     value = ctx.pathParam(entry.name());
                     assert value != null;
-                    values[i] = stringToType(value, entry.type());
+                    values[i] = convertParameter(value, entry);
                     break;
                 case PARAM:
                     if (httpParameters == null) {
@@ -484,7 +488,12 @@ final class AnnotatedHttpServiceMethod {
     }
 
     private static Object convertParameter(String value, Parameter entry) {
-        final Object converted = value != null ? stringToType(value, entry.type()) : null;
+        Object converted = null;
+        if (value != null) {
+            converted = entry.isEnum() ? entry.getEnumElement(value)
+                                       : stringToType(value, entry.type());
+        }
+
         return entry.isOptionalWrapped() ? Optional.ofNullable(converted) : converted;
     }
 
@@ -561,6 +570,9 @@ final class AnnotatedHttpServiceMethod {
         if (clazz == Double.TYPE || clazz == Double.class) {
             return Double.TYPE;
         }
+        if (clazz.isEnum()) {
+            return clazz;
+        }
         if (clazz == String.class) {
             return String.class;
         }
@@ -626,6 +638,8 @@ final class AnnotatedHttpServiceMethod {
         private final String name;
         private final String defaultValue;
         private final RequestConverterFunction requestConverterFunction;
+        private final boolean isCaseSensitiveEnum;
+        private final Map<String, ? extends Enum<?>> enumMap;
 
         Parameter(ParameterType parameterType,
                   boolean isRequired, boolean isOptionalWrapped, Class<?> type,
@@ -638,6 +652,39 @@ final class AnnotatedHttpServiceMethod {
             this.name = name;
             this.defaultValue = defaultValue;
             this.requestConverterFunction = requestConverterFunction;
+
+            if (type.isEnum()) {
+                final Set<? extends Enum<?>> enumInstances = EnumSet.allOf(type.asSubclass(Enum.class));
+                Map<String, ? extends Enum<?>> lowerCaseEnumMap = enumInstances.stream().collect(
+                        toImmutableMap(e -> Ascii.toLowerCase(e.name()), Function.identity(), (e1, e2) -> e1));
+                if (enumInstances.size() != lowerCaseEnumMap.size()) {
+                    enumMap = enumInstances.stream().collect(toImmutableMap(Enum::name, Function.identity()));
+                    isCaseSensitiveEnum = true;
+                } else {
+                    enumMap = lowerCaseEnumMap;
+                    isCaseSensitiveEnum = false;
+                }
+            } else {
+                enumMap = null;
+                isCaseSensitiveEnum = false;
+            }
+        }
+
+        <T> T getEnumElement(String str) {
+            final Object o = enumMap.get(isCaseSensitiveEnum ? str : Ascii.toLowerCase(str));
+
+            if (o == null) {
+                throw new IllegalArgumentException("unknown enum value: " + str + " (expected: " +
+                                                   enumMap.values() + ')');
+            }
+
+            @SuppressWarnings("unchecked")
+            final T result = (T) o;
+            return result;
+        }
+
+        boolean isEnum() {
+            return type.isEnum();
         }
 
         ParameterType parameterType() {


### PR DESCRIPTION
Motivation:

Users may want to use enumeration type for requesting parameter

Modifications:

- Add converting logic from the enumeration type to string in ‘AnnotatedHttpServiceMethod'
- Add unit test for supporting enumeration type

Results:

- Users are now able to use requesting parameter