### PR TITLE
Do not use Class.isAssignableFrom() if not applicable

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/annotation/ByteArrayRequestConverterFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/ByteArrayRequestConverterFunction.java
@@ -41,10 +41,10 @@ public class ByteArrayRequestConverterFunction implements RequestConverterFuncti
             mediaType.is(MediaType.OCTET_STREAM) ||
             mediaType.is(MediaType.APPLICATION_BINARY)) {
 
-            if (expectedResultType.isAssignableFrom(byte[].class)) {
+            if (expectedResultType == byte[].class) {
                 return request.content().array();
             }
-            if (expectedResultType.isAssignableFrom(HttpData.class)) {
+            if (expectedResultType == HttpData.class) {
                 return request.content();
             }
         }

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/StringRequestConverterFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/StringRequestConverterFunction.java
@@ -33,7 +33,8 @@ public class StringRequestConverterFunction implements RequestConverterFunction 
     @Override
     public Object convertRequest(ServiceRequestContext ctx, AggregatedHttpMessage request,
                                  Class<?> expectedResultType) throws Exception {
-        if (expectedResultType.isAssignableFrom(String.class)) {
+        if (expectedResultType == String.class ||
+            expectedResultType == CharSequence.class) {
             final MediaType contentType = request.headers().contentType();
             if (contentType != null && contentType.is(MediaType.ANY_TEXT_TYPE)) {
                 // See https://tools.ietf.org/html/rfc2616#section-3.7.1

--- a/core/src/test/java/com/linecorp/armeria/server/AnnotatedHttpServiceHandlersOrderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/AnnotatedHttpServiceHandlersOrderTest.java
@@ -70,8 +70,8 @@ public class AnnotatedHttpServiceHandlersOrderTest {
 
         @Post("/requestConverterOrder")
         @RequestConverter(MethodLevelRequestConverter.class)
-        public HttpResponse requestConverterOrder(@RequestObject(ParameterLevelRequestConverter.class)
-                                                    JsonNode node) {
+        public HttpResponse requestConverterOrder(
+                @RequestObject(ParameterLevelRequestConverter.class) JsonNode node) {
             assertThat(node).isNotNull();
             return HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, HttpData.ofUtf8(node.toString()));
         }
@@ -99,7 +99,7 @@ public class AnnotatedHttpServiceHandlersOrderTest {
         @Override
         public Object convertRequest(ServiceRequestContext ctx, AggregatedHttpMessage request,
                                      Class<?> expectedResultType) throws Exception {
-            if (expectedResultType.isAssignableFrom(JsonNode.class)) {
+            if (expectedResultType == JsonNode.class) {
                 assertThat(requestCounter.getAndIncrement()).isZero();
             }
             return RequestConverterFunction.fallthrough();
@@ -110,7 +110,7 @@ public class AnnotatedHttpServiceHandlersOrderTest {
         @Override
         public Object convertRequest(ServiceRequestContext ctx, AggregatedHttpMessage request,
                                      Class<?> expectedResultType) throws Exception {
-            if (expectedResultType.isAssignableFrom(JsonNode.class)) {
+            if (expectedResultType == JsonNode.class) {
                 assertThat(requestCounter.getAndIncrement()).isOne();
             }
             return RequestConverterFunction.fallthrough();
@@ -121,7 +121,7 @@ public class AnnotatedHttpServiceHandlersOrderTest {
         @Override
         public Object convertRequest(ServiceRequestContext ctx, AggregatedHttpMessage request,
                                      Class<?> expectedResultType) throws Exception {
-            if (expectedResultType.isAssignableFrom(JsonNode.class)) {
+            if (expectedResultType == JsonNode.class) {
                 assertThat(requestCounter.getAndIncrement()).isEqualTo(2);
             }
             return RequestConverterFunction.fallthrough();
@@ -132,7 +132,7 @@ public class AnnotatedHttpServiceHandlersOrderTest {
         @Override
         public Object convertRequest(ServiceRequestContext ctx, AggregatedHttpMessage request,
                                      Class<?> expectedResultType) throws Exception {
-            if (expectedResultType.isAssignableFrom(JsonNode.class)) {
+            if (expectedResultType == JsonNode.class) {
                 assertThat(requestCounter.getAndIncrement()).isEqualTo(3);
             }
             return RequestConverterFunction.fallthrough();


### PR DESCRIPTION
Motivation:

We are using Class.isAssignableFrom() incorrectly in some places. For
example:

    expectedReturnType.isAssignableFrom(SomeType.class)

will return true even if 'expectedReturnType' is Object.class. We
obviously do not want our RequestConverterFunction implementations to
inject an Object parameter, but only when the parameter type matches in
a more meaningful way.

Similarly, I find this code:

    parameterInfo.type().isAssignableFrom(Optional.class)

which will match even when parameterInfo.type() is Object.class.

Modifictions:

- Use Class.isAssignableFrom() only when necessary

Result:

- More sensible type matching