### PR TITLE
Micrometer 1.0.0-rc.7 / Increase metrics integration test timeout

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -70,7 +70,7 @@ io.grpc:
   grpc-testing: { version: *GRPC_VERSION }
 
 io.micrometer:
-  micrometer-core: { version: &MICROMETER_VERSION '1.0.0-rc.6' }
+  micrometer-core: { version: &MICROMETER_VERSION '1.0.0-rc.7' }
   micrometer-registry-prometheus: { version: *MICROMETER_VERSION }
   micrometer-spring-legacy:
     version: *MICROMETER_VERSION

--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcMetricsIntegrationTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcMetricsIntegrationTest.java
@@ -96,7 +96,7 @@ public class GrpcMetricsIntegrationTest {
     }
 
     @Rule
-    public TestRule globalTimeout = new DisableOnDebug(new Timeout(20, TimeUnit.SECONDS));
+    public final TestRule globalTimeout = new DisableOnDebug(new Timeout(30, TimeUnit.SECONDS));
 
     @Test
     public void normal() throws Exception {

--- a/thrift/src/test/java/com/linecorp/armeria/it/metric/DropwizardMetricsIntegrationTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/metric/DropwizardMetricsIntegrationTest.java
@@ -21,10 +21,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.AfterClass;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.DisableOnDebug;
+import org.junit.rules.TestRule;
+import org.junit.rules.Timeout;
 
 import com.codahale.metrics.Counting;
 import com.codahale.metrics.MetricRegistry;
@@ -81,7 +86,10 @@ public class DropwizardMetricsIntegrationTest {
         clientFactory.close();
     }
 
-    @Test(timeout = 10000L)
+    @Rule
+    public final TestRule globalTimeout = new DisableOnDebug(new Timeout(30, TimeUnit.SECONDS));
+
+    @Test
     public void normal() throws Exception {
         latch = new CountDownLatch(14);
 

--- a/thrift/src/test/java/com/linecorp/armeria/it/metric/PrometheusMetricsIntegrationTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/metric/PrometheusMetricsIntegrationTest.java
@@ -22,13 +22,18 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
 import org.apache.thrift.TApplicationException;
 import org.apache.thrift.TException;
 import org.junit.AfterClass;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.DisableOnDebug;
+import org.junit.rules.TestRule;
+import org.junit.rules.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -98,6 +103,9 @@ public class PrometheusMetricsIntegrationTest {
     public static void closeClientFactory() {
         clientFactory.close();
     }
+
+    @Rule
+    public final TestRule globalTimeout = new DisableOnDebug(new Timeout(30, TimeUnit.SECONDS));
 
     @Test
     public void hello_first_second_endpoint() throws Exception {


### PR DESCRIPTION
- Update Micrometer to 1.0.0-rc.7
- Increase metrics integration test timeout to 30 seconds so that the
  build doesn't fail on slow CI machines