### PR TITLE
[Trivial] ArmeriaMessageFramer#writeUncompressed does not throw IOException anymore

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/internal/grpc/ArmeriaMessageFramer.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/grpc/ArmeriaMessageFramer.java
@@ -160,7 +160,7 @@ public class ArmeriaMessageFramer implements AutoCloseable {
         return compressed;
     }
 
-    private ByteBuf writeUncompressed(ByteBuf message) throws IOException {
+    private ByteBuf writeUncompressed(ByteBuf message) {
         int messageLength = message.readableBytes();
         if (maxOutboundMessageSize >= 0 && messageLength > maxOutboundMessageSize) {
             throw Status.RESOURCE_EXHAUSTED


### PR DESCRIPTION
Long time no see. I found this when I was analyzing `UnframedGrpcService`. 😃 