### PR TITLE
Prioritize rpc response error over end response error.

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
@@ -616,9 +616,14 @@ public class DefaultRequestLog implements RequestLog, RequestLogBuilder {
             return;
         }
 
-        if (responseContent instanceof RpcResponse &&
-            !((RpcResponse) responseContent).isDone()) {
-            throw new IllegalArgumentException("responseContent must be complete: " + responseContent);
+        if (responseContent instanceof RpcResponse) {
+            RpcResponse rpcResponse = (RpcResponse) responseContent;
+            if (!rpcResponse.isDone()) {
+                throw new IllegalArgumentException("responseContent must be complete: " + responseContent);
+            }
+            if (rpcResponse.cause() != null) {
+                this.responseCause = rpcResponse.cause();
+            }
         }
 
         this.responseContent = responseContent;
@@ -671,7 +676,9 @@ public class DefaultRequestLog implements RequestLog, RequestLogBuilder {
         startResponse0(responseEndTimeNanos, System.currentTimeMillis(), false);
 
         this.responseEndTimeNanos = responseEndTimeNanos;
-        this.responseCause = responseCause;
+        if (this.responseCause == null) {
+            this.responseCause = responseCause;
+        }
         updateAvailability(flags);
     }
 

--- a/core/src/test/java/com/linecorp/armeria/common/logging/DefaultRequestLogTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/logging/DefaultRequestLogTest.java
@@ -93,7 +93,7 @@ public class DefaultRequestLogTest {
         log.responseContent(RpcResponse.ofFailure(error), null);
         log.endResponse(error2);
         assertThat(log.responseDurationNanos()).isZero();
-        assertThat(log.responseCause()).isSameAs(error2);
+        assertThat(log.responseCause()).isSameAs(error);
     }
 
     @Test


### PR DESCRIPTION
I think I had originally written it this way, but thought I could simplify the logic. I realized though, that the response cause pretty much always ends up being `AbortedStreamException` since we call `req.abort()` when finishing a request in `HttpServerHandler`. I guess if an RPC failure has been specified, it will always be more relevant than an `endResponse` exception, so it makes sense to prioritize it, but let me know what you think.