### PR TITLE
[TRIVIAL] ZooKeeperRegistrationTest#{startServers, stopServers} does not throw Exception anymore

### DIFF
--- a/zookeeper/src/main/java/com/linecorp/armeria/server/zookeeper/ZooKeeperUpdatingListener.java
+++ b/zookeeper/src/main/java/com/linecorp/armeria/server/zookeeper/ZooKeeperUpdatingListener.java
@@ -62,7 +62,7 @@ public class ZooKeeperUpdatingListener extends ServerListenerAdapter {
     }
 
     @Override
-    public void serverStarted(Server server) throws Exception {
+    public void serverStarted(Server server) {
         if (endpoint == null) {
             assert server.activePort().isPresent();
             endpoint = Endpoint.of(server.defaultHostname(),
@@ -73,7 +73,7 @@ public class ZooKeeperUpdatingListener extends ServerListenerAdapter {
     }
 
     @Override
-    public void serverStopping(Server server) throws Exception {
+    public void serverStopping(Server server) {
         if (connector != null) {
             connector.close(true);
         }

--- a/zookeeper/src/test/java/com/linecorp/armeria/server/zookeeper/ZooKeeperRegistrationTest.java
+++ b/zookeeper/src/test/java/com/linecorp/armeria/server/zookeeper/ZooKeeperRegistrationTest.java
@@ -55,7 +55,7 @@ public class ZooKeeperRegistrationTest extends TestBase implements ZooKeeperAsse
     private List<ZooKeeperUpdatingListener> listeners;
 
     @Before
-    public void startServers() throws Exception {
+    public void startServers() {
         servers = new ArrayList<>();
         zkConnectors = new ArrayList<>();
         listeners = new ArrayList<>();
@@ -76,7 +76,7 @@ public class ZooKeeperRegistrationTest extends TestBase implements ZooKeeperAsse
     }
 
     @After
-    public void stopServers() throws Exception {
+    public void stopServers() {
         if (servers != null) {
             servers.forEach(s -> s.stop().join());
         }


### PR DESCRIPTION
Found while I was working on `ZooKeeperUpdatingListener`.