### PR TITLE
[TRIVIAL] Fix Typos

### DIFF
--- a/site/src/sphinx/advanced-structured-logging.rst
+++ b/site/src/sphinx/advanced-structured-logging.rst
@@ -131,7 +131,7 @@ automatically for you:
     import com.linecorp.armeria.common.thrift.ThriftSerializationFormats;
     import com.linecorp.armeria.server.AbstractHttpService;
 
-    public class MyService extenda AbstractHttpService {
+    public class MyService extends AbstractHttpService {
         @Override
         public void doGet(ServiceRequestContext ctx, HttpRequest req, HttpResponseWriter res) {
             // serializationFormat and requestContent will be set to NONE and null

--- a/zookeeper/src/main/java/com/linecorp/armeria/server/zookeeper/ZooKeeperUpdatingListener.java
+++ b/zookeeper/src/main/java/com/linecorp/armeria/server/zookeeper/ZooKeeperUpdatingListener.java
@@ -24,7 +24,7 @@ import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerListenerAdapter;
 
 /**
- * A ZooKeeper Server Listener.When you add this listener, server will be automatically registered
+ * A ZooKeeper Server Listener. When you add this listener, server will be automatically registered
  * into the ZooKeeper.
  */
 public class ZooKeeperUpdatingListener extends ServerListenerAdapter {


### PR DESCRIPTION
1. Fix Typo: extenda -> extends.
2. Fix spacing: `ZooKeeperUpdatingListener`.