### PR TITLE
Write serialized gRPC message as ByteBufHttpData to avoid unnecessary…

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaClientCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaClientCall.java
@@ -31,7 +31,6 @@ import org.slf4j.LoggerFactory;
 
 import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.client.ClientRequestContext;
-import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpRequestWriter;
@@ -186,17 +185,7 @@ class ArmeriaClientCall<I, O> extends ClientCall<I, O>
     public void sendMessage(I message) {
         try {
             ByteBuf serialized = marshaller.serializeRequest(message);
-            boolean success = false;
-            final HttpData frame;
-            try {
-                frame = messageFramer.writePayload(serialized);
-                success = true;
-            } finally {
-                if (!success) {
-                    serialized.release();
-                }
-            }
-            req.write(frame);
+            req.write(messageFramer.writePayload(serialized));
         } catch (Throwable t) {
             cancel(null, t);
         }


### PR DESCRIPTION
… copy.

Request side was already skipping the copy but not response side.

- Cleans up `ArmeriaClientCall` to reflect that `writePayload` takes ownership.
- Write to a normal buffer instead of composite buffer when framing since it is what's written out to the wire. During profiling / debugging exercises, I found that the buffer written to wire has to be consolidated so there's no reason to use a composite buffer at the final stage.