### PR TITLE
Add a dangerous option to allow wrapping the incoming ByteBuf when de…

### DIFF
--- a/benchmarks/src/jmh/java/com/linecorp/armeria/grpc/downstream/LargePayloadBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/grpc/downstream/LargePayloadBenchmark.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.grpc.downstream;
+
+import static com.linecorp.armeria.common.SessionProtocol.HTTP;
+
+import java.util.concurrent.CountDownLatch;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.util.Timestamps;
+
+import com.linecorp.armeria.client.Clients;
+import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.common.grpc.GrpcUnsafeBufferUtil;
+import com.linecorp.armeria.grpc.BinaryProxyGrpc.BinaryProxyImplBase;
+import com.linecorp.armeria.grpc.BinaryProxyGrpc.BinaryProxyStub;
+import com.linecorp.armeria.grpc.BinaryProxyOuterClass.BinaryPayload;
+import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.ServerPort;
+import com.linecorp.armeria.server.grpc.GrpcServiceBuilder;
+
+import io.grpc.stub.StreamObserver;
+import joptsimple.internal.Strings;
+
+/**
+ * A {@link Benchmark} to check performance of armeria-grpc with large payloads in the megabytes, which is
+ * a relatively common use case for a binary proxy (metadata + large binary blobs).
+ */
+@State(Scope.Benchmark)
+public class LargePayloadBenchmark {
+
+    // 4MB payload
+    private static final BinaryPayload PAYLOAD =
+            BinaryPayload.newBuilder()
+                         .setTimeReceived(Timestamps.fromMillis(10000000L))
+                         .setPayload(ByteString.copyFromUtf8(Strings.repeat('a', 4_000_000)))
+                         .build();
+
+    private Server server;
+    private BinaryProxyStub binaryProxyClient;
+
+    @Param({ "false", "true" })
+    private boolean wrapBuffer;
+
+    @Setup
+    public void setUp() {
+        server = new ServerBuilder()
+                .port(0, HTTP)
+                .serviceUnder("/", new GrpcServiceBuilder().addService(
+                        new BinaryProxyImplBase() {
+                            @Override
+                            public StreamObserver<BinaryPayload> echo(
+                                    StreamObserver<BinaryPayload> responseObserver) {
+                                return new StreamObserver<BinaryPayload>() {
+                                    @Override
+                                    public void onNext(BinaryPayload value) {
+                                        try {
+                                            responseObserver.onNext(value);
+                                        } finally {
+                                            if (wrapBuffer) {
+                                                GrpcUnsafeBufferUtil.releaseBuffer(value,
+                                                                                   RequestContext.current());
+                                            }
+                                        }
+                                    }
+
+                                    @Override
+                                    public void onError(Throwable t) {
+                                        responseObserver.onError(t);
+                                    }
+
+                                    @Override
+                                    public void onCompleted() {
+                                        responseObserver.onCompleted();
+                                    }
+                                };
+                            }
+                        }).unsafeWrapRequestBuffers(wrapBuffer).build())
+                .build();
+        server.start().join();
+        ServerPort httpPort = server.activePorts().values().stream()
+                                    .filter(p1 -> p1.protocol() == HTTP).findAny()
+                                    .get();
+        final String url = "gproto+http://127.0.0.1:" + httpPort.localAddress().getPort() + "/";
+        binaryProxyClient = Clients.newClient(url, BinaryProxyStub.class);
+    }
+
+    @TearDown
+    public void tearDown() {
+        server.stop().join();
+    }
+
+    @Benchmark
+    public boolean normal() throws Exception {
+        EchoObserver responseObserver = new EchoObserver();
+        StreamObserver<BinaryPayload> requestObserver = binaryProxyClient.echo(responseObserver);
+        requestObserver.onNext(PAYLOAD);
+        requestObserver.onNext(PAYLOAD);
+        // TODO(anuraag): Figure out why 3 requests doesn't work.
+        requestObserver.onCompleted();
+        return responseObserver.finish(2);
+    }
+
+    private static final class EchoObserver implements StreamObserver<BinaryPayload> {
+
+        private final CountDownLatch latch = new CountDownLatch(1);
+
+        private volatile Throwable error;
+        private volatile int num;
+
+        public boolean finish(int expected) throws Exception {
+            latch.await();
+            if (error != null) {
+                throw new RuntimeException(error);
+            }
+            if (num != expected) {
+                throw new IllegalStateException("Unexpected num: " + num);
+            }
+            return true;
+        }
+
+        @Override
+        public void onNext(BinaryPayload value) {
+            num++;
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            error = t;
+            latch.countDown();
+        }
+
+        @Override
+        public void onCompleted() {
+            latch.countDown();
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        LargePayloadBenchmark benchmark = new LargePayloadBenchmark();
+        benchmark.setUp();
+        try {
+            benchmark.normal();
+        } finally {
+            benchmark.tearDown();
+        }
+    }
+}

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/grpc/downstream/LargePayloadBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/grpc/downstream/LargePayloadBenchmark.java
@@ -32,7 +32,6 @@ import com.google.protobuf.util.Timestamps;
 
 import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.common.RequestContext;
-import com.linecorp.armeria.common.grpc.GrpcUnsafeBufferUtil;
 import com.linecorp.armeria.grpc.BinaryProxyGrpc.BinaryProxyImplBase;
 import com.linecorp.armeria.grpc.BinaryProxyGrpc.BinaryProxyStub;
 import com.linecorp.armeria.grpc.BinaryProxyOuterClass.BinaryPayload;
@@ -40,6 +39,7 @@ import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.ServerPort;
 import com.linecorp.armeria.server.grpc.GrpcServiceBuilder;
+import com.linecorp.armeria.unsafe.grpc.GrpcUnsafeBufferUtil;
 
 import io.grpc.stub.StreamObserver;
 import joptsimple.internal.Strings;

--- a/benchmarks/src/jmh/proto/com/linecorp/armeria/grpc/binary-proxy.proto
+++ b/benchmarks/src/jmh/proto/com/linecorp/armeria/grpc/binary-proxy.proto
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+syntax = "proto3";
+
+package armeria;
+
+option java_package = "com.linecorp.armeria.grpc";
+
+import "google/protobuf/timestamp.proto";
+
+message BinaryPayload {
+    google.protobuf.Timestamp time_received = 1;
+
+    bytes payload = 2;
+}
+
+service BinaryProxy {
+    // Echos a payload back. In a normal service, it's more likely the payload would be sent
+    // to another service, but echoing is simpler for a benchmark.
+    rpc Echo (stream BinaryPayload) returns (stream BinaryPayload);
+}

--- a/core/src/main/java/com/linecorp/armeria/server/Http1RequestDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http1RequestDecoder.java
@@ -27,8 +27,8 @@ import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.ProtocolViolationException;
 import com.linecorp.armeria.internal.ArmeriaHttpUtil;
-import com.linecorp.armeria.internal.ByteBufHttpData;
 import com.linecorp.armeria.internal.InboundTrafficController;
+import com.linecorp.armeria.unsafe.ByteBufHttpData;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;

--- a/core/src/main/java/com/linecorp/armeria/server/Http2RequestDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http2RequestDecoder.java
@@ -29,8 +29,8 @@ import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequestWriter;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.internal.ArmeriaHttpUtil;
-import com.linecorp.armeria.internal.ByteBufHttpData;
 import com.linecorp.armeria.internal.InboundTrafficController;
+import com.linecorp.armeria.unsafe.ByteBufHttpData;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;

--- a/core/src/main/java/com/linecorp/armeria/unsafe/ByteBufHttpData.java
+++ b/core/src/main/java/com/linecorp/armeria/unsafe/ByteBufHttpData.java
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-package com.linecorp.armeria.internal;
+package com.linecorp.armeria.unsafe;
 
 import static java.util.Objects.requireNonNull;
 

--- a/core/src/main/java/com/linecorp/armeria/unsafe/package-info.java
+++ b/core/src/main/java/com/linecorp/armeria/unsafe/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Utilities for working with {@link io.netty.buffer.ByteBuf} in an unsafe way. These can improve performance
+ * when dealing with large buffers but require careful memory management or there will be memory leaks. Only use
+ * these methods if you really know what you're doing.
+ */
+package com.linecorp.armeria.unsafe;

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientIntegrationTest.java
@@ -55,7 +55,6 @@ import com.linecorp.armeria.common.HttpResponseWriter;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.util.CompletionActions;
-import com.linecorp.armeria.internal.ByteBufHttpData;
 import com.linecorp.armeria.server.AbstractHttpService;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.Service;
@@ -63,6 +62,7 @@ import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.SimpleDecoratingService;
 import com.linecorp.armeria.server.encoding.HttpEncodingService;
 import com.linecorp.armeria.testing.server.ServerRule;
+import com.linecorp.armeria.unsafe.ByteBufHttpData;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;

--- a/core/src/test/java/com/linecorp/armeria/client/encoding/AbstractStreamDecoderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/encoding/AbstractStreamDecoderTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 
-import com.linecorp.armeria.internal.ByteBufHttpData;
+import com.linecorp.armeria.unsafe.ByteBufHttpData;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;

--- a/core/src/test/java/com/linecorp/armeria/common/stream/AbstractStreamMessageAndWriterTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/AbstractStreamMessageAndWriterTest.java
@@ -32,7 +32,7 @@ import org.reactivestreams.Subscription;
 
 import com.google.common.collect.ImmutableList;
 
-import com.linecorp.armeria.internal.ByteBufHttpData;
+import com.linecorp.armeria.unsafe.ByteBufHttpData;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;

--- a/core/src/test/java/com/linecorp/armeria/common/stream/AbstractStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/AbstractStreamMessageTest.java
@@ -35,7 +35,7 @@ import org.reactivestreams.Subscription;
 import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.common.util.Exceptions;
-import com.linecorp.armeria.internal.ByteBufHttpData;
+import com.linecorp.armeria.unsafe.ByteBufHttpData;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerTest.java
@@ -97,10 +97,10 @@ import com.linecorp.armeria.common.logging.RequestLogAvailability;
 import com.linecorp.armeria.common.stream.StreamWriter;
 import com.linecorp.armeria.common.util.EventLoopGroups;
 import com.linecorp.armeria.common.util.Exceptions;
-import com.linecorp.armeria.internal.ByteBufHttpData;
 import com.linecorp.armeria.internal.InboundTrafficController;
 import com.linecorp.armeria.server.encoding.HttpEncodingService;
 import com.linecorp.armeria.testing.server.ServerRule;
+import com.linecorp.armeria.unsafe.ByteBufHttpData;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;

--- a/core/src/test/java/com/linecorp/armeria/server/encoding/HttpEncodedResponseTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/encoding/HttpEncodedResponseTest.java
@@ -26,7 +26,7 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.stream.NoopSubscriber;
-import com.linecorp.armeria.internal.ByteBufHttpData;
+import com.linecorp.armeria.unsafe.ByteBufHttpData;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaClientCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaClientCall.java
@@ -109,7 +109,10 @@ class ArmeriaClientCall<I, O> extends ClientCall<I, O>
         this.decompressorRegistry = decompressorRegistry;
         this.messageFramer = new ArmeriaMessageFramer(ctx.alloc(), maxOutboundMessageSizeBytes);
         this.marshaller = new GrpcMessageMarshaller<>(
-                ctx.alloc(), serializationFormat, method, jsonMarshaller);
+                ctx.alloc(), serializationFormat, method, jsonMarshaller,
+                // TODO(anuraag): Consider adding a GrpcClientOption for this after checking the server-side
+                // works / makes sense.
+                false);
         responseReader = new HttpStreamReader(
                 decompressorRegistry,
                 new ArmeriaMessageDeframer(this, maxInboundMessageSizeBytes, ctx.alloc()),

--- a/grpc/src/main/java/com/linecorp/armeria/common/grpc/GrpcUnsafeBufferUtil.java
+++ b/grpc/src/main/java/com/linecorp/armeria/common/grpc/GrpcUnsafeBufferUtil.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.grpc;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import java.util.IdentityHashMap;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.protobuf.Message;
+
+import com.linecorp.armeria.common.RequestContext;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.util.AttributeKey;
+
+public final class GrpcUnsafeBufferUtil {
+
+    @VisibleForTesting
+    public static final AttributeKey<IdentityHashMap<Object, ByteBuf>> BUFFERS = AttributeKey.valueOf(
+            GrpcUnsafeBufferUtil.class, "BUFFERS");
+
+    /**
+     * Stores the {@link ByteBuf} backing {@link Message} to be released later using
+     * {@link #releaseBuffer(Object, RequestContext)}.
+     */
+    public static void storeBuffer(ByteBuf buf, Object message, RequestContext ctx) {
+        IdentityHashMap<Object, ByteBuf> buffers = ctx.attr(BUFFERS).get();
+        if (buffers == null) {
+            buffers = new IdentityHashMap<>();
+            ctx.attr(BUFFERS).set(buffers);
+        }
+        buffers.put(message, buf);
+    }
+
+    /**
+     * Releases the {@link ByteBuf} backing the provided {@link Message}.
+     */
+    public static void releaseBuffer(Object message, RequestContext ctx) {
+        IdentityHashMap<Object, ByteBuf> buffers = ctx.attr(BUFFERS).get();
+        checkState(buffers != null,
+                   "Releasing buffer even though storeBuffer has not been called.");
+        ByteBuf removed = buffers.remove(message);
+        if (removed == null) {
+            throw new IllegalArgumentException("The provided message does not have a stored buffer.");
+        }
+        removed.release();
+    }
+
+    private GrpcUnsafeBufferUtil() {}
+}

--- a/grpc/src/main/java/com/linecorp/armeria/internal/grpc/ArmeriaMessageFramer.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/grpc/ArmeriaMessageFramer.java
@@ -52,7 +52,7 @@ import static java.util.Objects.requireNonNull;
 import java.io.IOException;
 import java.io.OutputStream;
 
-import com.linecorp.armeria.internal.ByteBufHttpData;
+import com.linecorp.armeria.unsafe.ByteBufHttpData;
 
 import io.grpc.Codec;
 import io.grpc.Compressor;

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
@@ -47,6 +47,7 @@ import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
+import com.linecorp.armeria.common.grpc.GrpcUnsafeBufferUtil;
 import com.linecorp.armeria.common.util.SafeCloseable;
 import com.linecorp.armeria.internal.ByteBufHttpData;
 import com.linecorp.armeria.internal.grpc.ArmeriaMessageDeframer;
@@ -103,6 +104,7 @@ class ArmeriaServerCall<I, O> extends ServerCall<I, O>
     private final ServiceRequestContext ctx;
     private final SerializationFormat serializationFormat;
     private final GrpcMessageMarshaller<I, O> marshaller;
+    private final boolean unsafeWrapRequestBuffers;
 
     // Only set once.
     private ServerCall.Listener<I> listener;
@@ -130,7 +132,8 @@ class ArmeriaServerCall<I, O> extends ServerCall<I, O>
                       int maxOutboundMessageSizeBytes,
                       ServiceRequestContext ctx,
                       SerializationFormat serializationFormat,
-                      MessageMarshaller jsonMarshaller) {
+                      MessageMarshaller jsonMarshaller,
+                      boolean unsafeWrapRequestBuffers) {
         requireNonNull(clientHeaders, "clientHeaders");
         this.method = requireNonNull(method, "method");
         this.ctx = requireNonNull(ctx, "ctx");
@@ -149,7 +152,9 @@ class ArmeriaServerCall<I, O> extends ServerCall<I, O>
         this.clientAcceptEncoding =
                 Strings.emptyToNull(clientHeaders.get(GrpcHeaderNames.GRPC_ACCEPT_ENCODING));
         this.decompressorRegistry = requireNonNull(decompressorRegistry, "decompressorRegistry");
-        marshaller = new GrpcMessageMarshaller<>(ctx.alloc(), serializationFormat, method, jsonMarshaller);
+        marshaller = new GrpcMessageMarshaller<>(ctx.alloc(), serializationFormat, method, jsonMarshaller,
+                                                 unsafeWrapRequestBuffers);
+        this.unsafeWrapRequestBuffers = unsafeWrapRequestBuffers;
     }
 
     @Override
@@ -305,6 +310,11 @@ class ArmeriaServerCall<I, O> extends ServerCall<I, O>
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+
+        if (unsafeWrapRequestBuffers && message.buf() != null) {
+            GrpcUnsafeBufferUtil.storeBuffer(message.buf(), request, ctx);
+        }
+
         try (SafeCloseable ignored = RequestContext.push(ctx)) {
             listener.onMessage(request);
         } catch (Throwable t) {

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
@@ -47,9 +47,7 @@ import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
-import com.linecorp.armeria.common.grpc.GrpcUnsafeBufferUtil;
 import com.linecorp.armeria.common.util.SafeCloseable;
-import com.linecorp.armeria.internal.ByteBufHttpData;
 import com.linecorp.armeria.internal.grpc.ArmeriaMessageDeframer;
 import com.linecorp.armeria.internal.grpc.ArmeriaMessageDeframer.ByteBufOrStream;
 import com.linecorp.armeria.internal.grpc.ArmeriaMessageFramer;
@@ -60,6 +58,8 @@ import com.linecorp.armeria.internal.grpc.HttpStreamReader;
 import com.linecorp.armeria.internal.grpc.StatusMessageEscaper;
 import com.linecorp.armeria.internal.grpc.TransportStatusListener;
 import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.unsafe.ByteBufHttpData;
+import com.linecorp.armeria.unsafe.grpc.GrpcUnsafeBufferUtil;
 
 import io.grpc.Codec;
 import io.grpc.Codec.Identity;

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
@@ -90,6 +90,7 @@ public final class GrpcService extends AbstractHttpService
     private final Set<SerializationFormat> supportedSerializationFormats;
     private final MessageMarshaller jsonMarshaller;
     private final int maxOutboundMessageSizeBytes;
+    private final boolean unsafeWrapRequestBuffers;
 
     private int maxInboundMessageSizeBytes;
 
@@ -99,6 +100,7 @@ public final class GrpcService extends AbstractHttpService
                 CompressorRegistry compressorRegistry,
                 Set<SerializationFormat> supportedSerializationFormats,
                 int maxOutboundMessageSizeBytes,
+                boolean unsafeWrapRequestBuffers,
                 int maxInboundMessageSizeBytes) {
         this.registry = requireNonNull(registry, "registry");
         this.pathMappings = requireNonNull(pathMappings, "pathMappings");
@@ -107,6 +109,7 @@ public final class GrpcService extends AbstractHttpService
         this.supportedSerializationFormats = supportedSerializationFormats;
         jsonMarshaller = jsonMarshaller(registry);
         this.maxOutboundMessageSizeBytes = maxOutboundMessageSizeBytes;
+        this.unsafeWrapRequestBuffers = unsafeWrapRequestBuffers;
         this.maxInboundMessageSizeBytes = maxInboundMessageSizeBytes;
     }
 
@@ -179,7 +182,8 @@ public final class GrpcService extends AbstractHttpService
                 maxOutboundMessageSizeBytes,
                 ctx,
                 serializationFormat,
-                jsonMarshaller);
+                jsonMarshaller,
+                unsafeWrapRequestBuffers);
         final ServerCall.Listener<I> listener;
         try (SafeCloseable ignored = RequestContext.push(ctx)) {
             listener = methodDef.getServerCallHandler().startCall(call, EMPTY_METADATA);

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
@@ -31,12 +31,12 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
-import com.linecorp.armeria.common.grpc.GrpcUnsafeBufferUtil;
 import com.linecorp.armeria.internal.grpc.ArmeriaMessageFramer;
 import com.linecorp.armeria.server.PathMapping;
 import com.linecorp.armeria.server.ServerConfig;
 import com.linecorp.armeria.server.ServiceWithPathMappings;
 import com.linecorp.armeria.server.encoding.HttpEncodingService;
+import com.linecorp.armeria.unsafe.grpc.GrpcUnsafeBufferUtil;
 
 import io.grpc.BindableService;
 import io.grpc.CompressorRegistry;

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
@@ -28,8 +28,10 @@ import com.google.common.collect.ImmutableSet;
 
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
+import com.linecorp.armeria.common.grpc.GrpcUnsafeBufferUtil;
 import com.linecorp.armeria.internal.grpc.ArmeriaMessageFramer;
 import com.linecorp.armeria.server.PathMapping;
 import com.linecorp.armeria.server.ServerConfig;
@@ -64,6 +66,8 @@ public final class GrpcServiceBuilder {
     private int maxOutboundMessageSizeBytes = ArmeriaMessageFramer.NO_MAX_OUTBOUND_MESSAGE_SIZE;
 
     private boolean enableUnframedRequests;
+
+    private boolean unsafeRetainRequestBuffers;
 
     /**
      * Adds a gRPC {@link ServerServiceDefinition} to this {@link GrpcServiceBuilder}, such as
@@ -172,6 +176,29 @@ public final class GrpcServiceBuilder {
     }
 
     /**
+     * Enables unsafe retention of request buffers. Can improve performance when working with very large
+     * (i.e., several megabytes) payloads.
+     *
+     * <p><strong>DISCLAIMER:</strong> Do not use this if you don't know what you are doing. It is very easy to
+     * introduce memory leaks when using this method. You will probably spend much time debugging memory leaks
+     * during development if this is enabled. You will probably spend much time debugging memory leaks in
+     * production if this is enabled. You probably don't want to do this and should turn back now.
+     *
+     * <p>When enabled, the reference-counted buffer received from the client will be stored into
+     * {@link RequestContext} instead of being released. All {@link com.google.protobuf.ByteString} in a
+     * protobuf message will reference sections of this buffer instead of having their own copies. When done
+     * with a request message, call {@link GrpcUnsafeBufferUtil#releaseBuffer(Object, RequestContext)}
+     * with the message and the request's context to release the buffer. The message must be the same
+     * reference as what was passed to the service stub - a message with the same contents will not
+     * work. If {@link GrpcUnsafeBufferUtil#releaseBuffer(Object, RequestContext)} is not called, the memory
+     * will be leaked.
+     */
+    public GrpcServiceBuilder unsafeWrapRequestBuffers(boolean unsafeRetainRequestBuffers) {
+        this.unsafeRetainRequestBuffers = unsafeRetainRequestBuffers;
+        return this;
+    }
+
+    /**
      * Constructs a new {@link GrpcService} that can be bound to
      * {@link com.linecorp.armeria.server.ServerBuilder}. It is recommended to bind the service to a server
      * using {@link com.linecorp.armeria.server.ServerBuilder#service(ServiceWithPathMappings)} to mount all
@@ -189,7 +216,9 @@ public final class GrpcServiceBuilder {
                       .collect(ImmutableSet.toImmutableSet()),
                 firstNonNull(decompressorRegistry, DecompressorRegistry.getDefaultInstance()),
                 firstNonNull(compressorRegistry, CompressorRegistry.getDefaultInstance()),
-                supportedSerializationFormats, maxOutboundMessageSizeBytes,
+                supportedSerializationFormats,
+                maxOutboundMessageSizeBytes,
+                unsafeRetainRequestBuffers,
                 maxInboundMessageSizeBytes);
         return enableUnframedRequests ? grpcService.decorate(UnframedGrpcService::new) : grpcService;
     }

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcService.java
@@ -33,7 +33,6 @@ import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
-import com.linecorp.armeria.internal.ByteBufHttpData;
 import com.linecorp.armeria.internal.grpc.ArmeriaMessageDeframer;
 import com.linecorp.armeria.internal.grpc.ArmeriaMessageDeframer.ByteBufOrStream;
 import com.linecorp.armeria.internal.grpc.ArmeriaMessageDeframer.Listener;
@@ -45,6 +44,7 @@ import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.ServiceWithPathMappings;
 import com.linecorp.armeria.server.SimpleDecoratingService;
 import com.linecorp.armeria.server.encoding.HttpEncodingService;
+import com.linecorp.armeria.unsafe.ByteBufHttpData;
 
 import io.grpc.MethodDescriptor;
 import io.grpc.MethodDescriptor.MethodType;

--- a/grpc/src/main/java/com/linecorp/armeria/unsafe/grpc/GrpcUnsafeBufferUtil.java
+++ b/grpc/src/main/java/com/linecorp/armeria/unsafe/grpc/GrpcUnsafeBufferUtil.java
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-package com.linecorp.armeria.common.grpc;
+package com.linecorp.armeria.unsafe.grpc;
 
 import static com.google.common.base.Preconditions.checkState;
 

--- a/grpc/src/main/java/com/linecorp/armeria/unsafe/grpc/package-info.java
+++ b/grpc/src/main/java/com/linecorp/armeria/unsafe/grpc/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Utilities for working with {@link io.netty.buffer.ByteBuf} in an unsafe way. These can improve performance
+ * when dealing with large buffers but require careful memory management or there will be memory leaks. Only use
+ * these methods if you really know what you're doing.
+ */
+package com.linecorp.armeria.unsafe.grpc;

--- a/grpc/src/test/java/com/linecorp/armeria/internal/grpc/ArmeriaMessageFramerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/internal/grpc/ArmeriaMessageFramerTest.java
@@ -30,7 +30,7 @@ import com.google.protobuf.ByteString;
 
 import com.linecorp.armeria.grpc.testing.Messages.Payload;
 import com.linecorp.armeria.grpc.testing.Messages.SimpleRequest;
-import com.linecorp.armeria.internal.ByteBufHttpData;
+import com.linecorp.armeria.unsafe.ByteBufHttpData;
 
 import io.grpc.Codec.Gzip;
 import io.grpc.StatusRuntimeException;

--- a/grpc/src/test/java/com/linecorp/armeria/internal/grpc/GrpcMessageMarshallerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/internal/grpc/GrpcMessageMarshallerTest.java
@@ -33,7 +33,6 @@ import com.linecorp.armeria.internal.grpc.ArmeriaMessageDeframer.ByteBufOrStream
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.ByteBufUtil;
-import io.netty.buffer.Unpooled;
 
 public class GrpcMessageMarshallerTest {
 
@@ -48,7 +47,8 @@ public class GrpcMessageMarshallerTest {
                 MessageMarshaller.builder()
                                  .register(SimpleRequest.getDefaultInstance())
                                  .register(SimpleResponse.getDefaultInstance())
-                                 .build());
+                                 .build(),
+                false);
     }
 
     @Test
@@ -61,9 +61,31 @@ public class GrpcMessageMarshallerTest {
 
     @Test
     public void deserializeRequest_byteBuf() throws Exception {
-        SimpleRequest request = marshaller.deserializeRequest(
-                new ByteBufOrStream(Unpooled.wrappedBuffer(GrpcTestUtil.REQUEST_MESSAGE.toByteArray())));
+        ByteBuf buf = ByteBufAllocator.DEFAULT.buffer(GrpcTestUtil.REQUEST_MESSAGE.getSerializedSize());
+        assertThat(buf.refCnt()).isEqualTo(1);
+        buf.writeBytes(GrpcTestUtil.REQUEST_MESSAGE.toByteArray());
+        SimpleRequest request = marshaller.deserializeRequest(new ByteBufOrStream(buf));
         assertThat(request).isEqualTo(GrpcTestUtil.REQUEST_MESSAGE);
+        assertThat(buf.refCnt()).isEqualTo(0);
+    }
+
+    @Test
+    public void deserializeRequest_wrappedByteBuf() throws Exception {
+        marshaller = new GrpcMessageMarshaller<>(
+                ByteBufAllocator.DEFAULT,
+                GrpcSerializationFormats.PROTO,
+                TestServiceGrpc.METHOD_UNARY_CALL,
+                MessageMarshaller.builder()
+                                 .register(SimpleRequest.getDefaultInstance())
+                                 .register(SimpleResponse.getDefaultInstance())
+                                 .build(),
+                true);
+        ByteBuf buf = ByteBufAllocator.DEFAULT.buffer(GrpcTestUtil.REQUEST_MESSAGE.getSerializedSize());
+        assertThat(buf.refCnt()).isEqualTo(1);
+        buf.writeBytes(GrpcTestUtil.REQUEST_MESSAGE.toByteArray());
+        SimpleRequest request = marshaller.deserializeRequest(new ByteBufOrStream(buf));
+        assertThat(request).isEqualTo(GrpcTestUtil.REQUEST_MESSAGE);
+        assertThat(buf.refCnt()).isEqualTo(1);
     }
 
     @Test
@@ -83,9 +105,31 @@ public class GrpcMessageMarshallerTest {
 
     @Test
     public void deserializeResponse_bytebuf() throws Exception {
-        SimpleResponse response = marshaller.deserializeResponse(
-                new ByteBufOrStream(Unpooled.wrappedBuffer(GrpcTestUtil.RESPONSE_MESSAGE.toByteArray())));
+        ByteBuf buf = ByteBufAllocator.DEFAULT.buffer(GrpcTestUtil.RESPONSE_MESSAGE.getSerializedSize());
+        assertThat(buf.refCnt()).isEqualTo(1);
+        buf.writeBytes(GrpcTestUtil.RESPONSE_MESSAGE.toByteArray());
+        SimpleResponse response = marshaller.deserializeResponse(new ByteBufOrStream(buf));
         assertThat(response).isEqualTo(GrpcTestUtil.RESPONSE_MESSAGE);
+        assertThat(buf.refCnt()).isEqualTo(0);
+    }
+
+    @Test
+    public void deserializeResponse_wrappedByteBuf() throws Exception {
+        marshaller = new GrpcMessageMarshaller<>(
+                ByteBufAllocator.DEFAULT,
+                GrpcSerializationFormats.PROTO,
+                TestServiceGrpc.METHOD_UNARY_CALL,
+                MessageMarshaller.builder()
+                                 .register(SimpleRequest.getDefaultInstance())
+                                 .register(SimpleResponse.getDefaultInstance())
+                                 .build(),
+                true);
+        ByteBuf buf = ByteBufAllocator.DEFAULT.buffer(GrpcTestUtil.RESPONSE_MESSAGE.getSerializedSize());
+        assertThat(buf.refCnt()).isEqualTo(1);
+        buf.writeBytes(GrpcTestUtil.RESPONSE_MESSAGE.toByteArray());
+        SimpleResponse response = marshaller.deserializeResponse(new ByteBufOrStream(buf));
+        assertThat(response).isEqualTo(GrpcTestUtil.RESPONSE_MESSAGE);
+        assertThat(buf.refCnt()).isEqualTo(1);
     }
 
     @Test

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/ArmeriaServerCallTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/ArmeriaServerCallTest.java
@@ -39,7 +39,6 @@ import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpResponseWriter;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
-import com.linecorp.armeria.common.grpc.GrpcUnsafeBufferUtil;
 import com.linecorp.armeria.common.logging.DefaultRequestLog;
 import com.linecorp.armeria.grpc.testing.Messages.SimpleRequest;
 import com.linecorp.armeria.grpc.testing.Messages.SimpleResponse;
@@ -47,6 +46,7 @@ import com.linecorp.armeria.grpc.testing.TestServiceGrpc;
 import com.linecorp.armeria.internal.grpc.ArmeriaMessageDeframer.ByteBufOrStream;
 import com.linecorp.armeria.internal.grpc.GrpcTestUtil;
 import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.unsafe.grpc.GrpcUnsafeBufferUtil;
 
 import io.grpc.CompressorRegistry;
 import io.grpc.DecompressorRegistry;

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/ArmeriaServerCallTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/ArmeriaServerCallTest.java
@@ -18,9 +18,13 @@ package com.linecorp.armeria.server.grpc;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
+
+import java.util.IdentityHashMap;
 
 import org.curioswitch.common.protobuf.json.MessageMarshaller;
 import org.junit.Before;
@@ -35,6 +39,7 @@ import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpResponseWriter;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
+import com.linecorp.armeria.common.grpc.GrpcUnsafeBufferUtil;
 import com.linecorp.armeria.common.logging.DefaultRequestLog;
 import com.linecorp.armeria.grpc.testing.Messages.SimpleRequest;
 import com.linecorp.armeria.grpc.testing.Messages.SimpleResponse;
@@ -48,9 +53,11 @@ import io.grpc.DecompressorRegistry;
 import io.grpc.Metadata;
 import io.grpc.ServerCall;
 import io.grpc.Status;
+import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.ByteBufInputStream;
 import io.netty.util.AsciiString;
+import io.netty.util.Attribute;
 
 // TODO(anuraag): Currently only grpc-protobuf has been published so we only test proto here.
 // Once grpc-thrift is published, add tests for thrift stubs which will not go through the
@@ -82,6 +89,9 @@ public class ArmeriaServerCallTest {
     @Mock
     private ServiceRequestContext ctx;
 
+    @Mock
+    private Attribute<IdentityHashMap<Object, ByteBuf>> buffersAttr;
+
     private ArmeriaServerCall<SimpleRequest, SimpleResponse> call;
 
     @Before
@@ -97,11 +107,13 @@ public class ArmeriaServerCallTest {
                 MAX_MESSAGE_BYTES,
                 ctx,
                 GrpcSerializationFormats.PROTO,
-                MessageMarshaller.builder().build());
+                MessageMarshaller.builder().build(),
+                false);
         call.setListener(listener);
         call.messageReader().onSubscribe(subscription);
         when(ctx.logBuilder()).thenReturn(new DefaultRequestLog(ctx));
         when(ctx.alloc()).thenReturn(ByteBufAllocator.DEFAULT);
+        when(ctx.attr(GrpcUnsafeBufferUtil.BUFFERS)).thenReturn(buffersAttr);
     }
 
     @Test
@@ -111,6 +123,35 @@ public class ArmeriaServerCallTest {
         call.messageRead(new ByteBufOrStream(GrpcTestUtil.requestByteBuf()));
 
         verify(listener, never()).onMessage(any());
+    }
+
+    @Test
+    public void messageRead_notWrappedByteBuf() throws Exception {
+        ByteBuf buf = GrpcTestUtil.requestByteBuf();
+        call.messageRead(new ByteBufOrStream(buf));
+
+        verifyZeroInteractions(buffersAttr);
+    }
+
+    @Test
+    public void messageRead_wrappedByteBuf() throws Exception {
+        call = new ArmeriaServerCall<>(
+                HttpHeaders.of(),
+                TestServiceGrpc.METHOD_UNARY_CALL,
+                CompressorRegistry.getDefaultInstance(),
+                DecompressorRegistry.getDefaultInstance(),
+                res,
+                MAX_MESSAGE_BYTES,
+                MAX_MESSAGE_BYTES,
+                ctx,
+                GrpcSerializationFormats.PROTO,
+                MessageMarshaller.builder().build(),
+                true);
+
+        ByteBuf buf = GrpcTestUtil.requestByteBuf();
+        call.messageRead(new ByteBufOrStream(buf));
+
+        verify(buffersAttr).set(argThat(map -> map.containsValue(buf)));
     }
 
     @Test

--- a/thrift/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
+++ b/thrift/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
@@ -68,12 +68,12 @@ import com.linecorp.armeria.common.thrift.ThriftReply;
 import com.linecorp.armeria.common.thrift.ThriftSerializationFormats;
 import com.linecorp.armeria.common.util.CompletionActions;
 import com.linecorp.armeria.common.util.SafeCloseable;
-import com.linecorp.armeria.internal.ByteBufHttpData;
 import com.linecorp.armeria.internal.thrift.ThriftFieldAccess;
 import com.linecorp.armeria.internal.thrift.ThriftFunction;
 import com.linecorp.armeria.server.AbstractHttpService;
 import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.unsafe.ByteBufHttpData;
 
 import io.netty.buffer.ByteBuf;
 


### PR DESCRIPTION
…serializing a proto for advanced use cases with very large payloads.

Allows @anuraaga to shoot himself in the foot when writing a server that proxies to an object store (i.e. 10 MB/s payloads per connection). Feel free to close if this is too weird.

Benchmark:
```
Benchmark                     (wrapBuffer)   Mode  Cnt   Score   Error  Units
LargePayloadBenchmark.normal         false  thrpt  200  27.387 ± 0.441  ops/s
LargePayloadBenchmark.normal          true  thrpt  200  33.693 ± 0.492  ops/s
```