### PR TITLE
Closes the request stream message when the HTTP/2 stream is removed f…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/Http2RequestDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http2RequestDecoder.java
@@ -23,6 +23,7 @@ import static io.netty.handler.codec.http2.Http2Exception.streamError;
 
 import java.nio.charset.StandardCharsets;
 
+import com.linecorp.armeria.common.ClosedSessionException;
 import com.linecorp.armeria.common.ContentTooLargeException;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpMethod;
@@ -133,7 +134,11 @@ final class Http2RequestDecoder extends Http2EventAdapter {
 
     @Override
     public void onStreamRemoved(Http2Stream stream) {
-        requests.remove(stream.id());
+        final DecodedHttpRequest req = requests.remove(stream.id());
+        if (req != null) {
+            // Ignored if the stream has already been closed.
+            req.close(ClosedSessionException.get());
+        }
     }
 
     @Override

--- a/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/test.proto
+++ b/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/test.proto
@@ -126,7 +126,7 @@ service UnitTestService {
     rpc CheckRequestContext(stream SimpleRequest) returns (SimpleResponse);
 
     // A streaming RPC where the client cancels without explicitly closing the stream (e.g. socket disconnect).
-    rpc StreamClientCancels(stream SimpleRequest) returns (SimpleResponse);
+    rpc StreamClientCancels(stream SimpleRequest) returns (stream SimpleResponse);
 }
 
 // A simple service NOT implemented at servers so clients can test for

--- a/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/test.proto
+++ b/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/test.proto
@@ -124,6 +124,9 @@ service UnitTestService {
     // A streaming request call that tracks incoming requests in the RequestContext to make sure it is correctly
     // set for callbacks.
     rpc CheckRequestContext(stream SimpleRequest) returns (SimpleResponse);
+
+    // A streaming RPC where the client cancels without explicitly closing the stream (e.g. socket disconnect).
+    rpc StreamClientCancels(stream SimpleRequest) returns (SimpleResponse);
 }
 
 // A simple service NOT implemented at servers so clients can test for


### PR DESCRIPTION
…rom the connection.

In the case of an abrupt HTTP/2 connection close, HTTP/2 streams will be removed from the connection before the client has sent an END_STREAM frame. Without handling this and closing the request stream message, there is no way for server logic to handle this error for e.g., cleanup actions, especially if they disable response timeout because the stream is intended to have infinite length.

Because clients are expected to send END_STREAM in normal circumstances, this case is handled as a ClosedSessionException.

Logic change originally proposed by @tobias-.

Fixes #971