### PR TITLE
Remove STATIC_INIT token from EmptyLineSeparator checkstyle rule

### DIFF
--- a/settings/checkstyle/checkstyle.xml
+++ b/settings/checkstyle/checkstyle.xml
@@ -233,7 +233,7 @@
     <module name="EmptyLineSeparator">
       <property name="allowNoEmptyLineBetweenFields" value="true"/>
       <property name="tokens"
-                value="IMPORT, CLASS_DEF, INTERFACE_DEF, ENUM_DEF, STATIC_INIT, INSTANCE_INIT, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
+                value="IMPORT, CLASS_DEF, INTERFACE_DEF, ENUM_DEF, INSTANCE_INIT, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
     </module>
     <module name="GenericWhitespace">
       <message key="ws.followed"


### PR DESCRIPTION
Motivation:

Many static initialization blocks are directly tied to a field. Removing
the empty line between the field declaration and its static
initialization block makes the association clearer:

    private static final String X;
    static {
        X = ...;
    }

Modifications:

- Remove STATIC_INIT token from the EmptyLineSeparator checkstyle rule

Result:

- Fixes #700