### PR TITLE
Keep track of created channels to close them if the connection pool i…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/pool/DefaultKeyedChannelPool.java
+++ b/core/src/main/java/com/linecorp/armeria/client/pool/DefaultKeyedChannelPool.java
@@ -292,6 +292,7 @@ public class DefaultKeyedChannelPool<K> implements KeyedChannelPool<K> {
                 ch.close().syncUninterruptibly();
             }
         }
+        createdChannels.clear();
         for (Iterator<Deque<Channel>> i = pool.values().iterator(); i.hasNext();) {
             final Deque<Channel> queue = i.next();
             i.remove();

--- a/core/src/main/java/com/linecorp/armeria/client/pool/DefaultKeyedChannelPool.java
+++ b/core/src/main/java/com/linecorp/armeria/client/pool/DefaultKeyedChannelPool.java
@@ -25,7 +25,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -82,7 +81,7 @@ public class DefaultKeyedChannelPool<K> implements KeyedChannelPool<K> {
                                                                                    "channelPoolHandler"));
         this.healthCheckOnRelease = healthCheckOnRelease;
 
-        pool = new ConcurrentHashMap<>();
+        pool = new HashMap<>();
         pendingConnections = new HashMap<>();
         allChannels = new HashSet<>();
     }
@@ -318,7 +317,11 @@ public class DefaultKeyedChannelPool<K> implements KeyedChannelPool<K> {
     private void doClose(boolean blocking) {
         closed = true;
 
-        List<ChannelFuture> closeFutures = new ArrayList<>();
+        if (allChannels.isEmpty()) {
+            return;
+        }
+
+        final List<ChannelFuture> closeFutures = new ArrayList<>(allChannels.size());
 
         for (Channel ch : allChannels) {
             if (ch.isOpen()) {

--- a/core/src/main/java/com/linecorp/armeria/server/Http2RequestDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http2RequestDecoder.java
@@ -23,6 +23,7 @@ import static io.netty.handler.codec.http2.Http2Exception.streamError;
 
 import java.nio.charset.StandardCharsets;
 
+import com.linecorp.armeria.common.ClosedSessionException;
 import com.linecorp.armeria.common.ContentTooLargeException;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpMethod;
@@ -133,7 +134,11 @@ final class Http2RequestDecoder extends Http2EventAdapter {
 
     @Override
     public void onStreamRemoved(Http2Stream stream) {
-        requests.remove(stream.id());
+        final DecodedHttpRequest req = requests.remove(stream.id());
+        if (req != null) {
+            // Ignored if the stream has already been closed.
+            req.close(ClosedSessionException.get());
+        }
     }
 
     @Override


### PR DESCRIPTION
…s closed.

Also changes the behavior to wait for channel close, as it seems like it's intended to block (similar to how the factory blocks on worker group shutdown when closed).

Fixes #972