### PR TITLE
Close the requests associated with killed stream

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/Http2RequestDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http2RequestDecoder.java
@@ -133,7 +133,10 @@ final class Http2RequestDecoder extends Http2EventAdapter {
 
     @Override
     public void onStreamRemoved(Http2Stream stream) {
-        requests.remove(stream.id());
+        DecodedHttpRequest req = requests.remove(stream.id());
+        if (req != null) {
+            req.close();
+        }
     }
 
     @Override


### PR DESCRIPTION
When a socket is closed, make sure that the outstanding requests
(unfinishedRequests) are closed/terminated as well by closing
the stream when removing it.

This closes line/armeria#971.
My modifications are placed under CC0 1.0 (https://creativecommons.org/publicdomain/zero/1.0/)