### PR TITLE
Annotate all public packages with NonNullByDefault

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,8 +59,7 @@ configure(projectsWithFlags('java')) {
         compile 'com.google.guava:guava'
 
         // JSR305
-        compileOnly 'com.google.code.findbugs:jsr305'
-        testCompile 'com.google.code.findbugs:jsr305'
+        compile 'com.google.code.findbugs:jsr305'
 
         // JCTools
         compile 'org.jctools:jctools-core'

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/package-info.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/package-info.java
@@ -126,4 +126,7 @@
  * <h2>{@code exceptionFilter}</h2>
  * A filter that decides whether a circuit breaker should deal with a given error.
  */
+@NonNullByDefault
 package com.linecorp.armeria.client.circuitbreaker;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/core/src/main/java/com/linecorp/armeria/client/encoding/package-info.java
+++ b/core/src/main/java/com/linecorp/armeria/client/encoding/package-info.java
@@ -17,4 +17,7 @@
 /**
  * HTTP content decoding client.
  */
+@NonNullByDefault
 package com.linecorp.armeria.client.encoding;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/package-info.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/package-info.java
@@ -17,4 +17,7 @@
 /**
  * DNS-based {@link com.linecorp.armeria.client.endpoint.EndpointGroup} implementation.
  */
+@NonNullByDefault
 package com.linecorp.armeria.client.endpoint.dns;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/package-info.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/package-info.java
@@ -17,4 +17,7 @@
 /**
  * {@link com.linecorp.armeria.client.endpoint.healthcheck.HealthCheckedEndpointGroup} groups.
  */
+@NonNullByDefault
 package com.linecorp.armeria.client.endpoint.healthcheck;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/package-info.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/package-info.java
@@ -23,4 +23,7 @@
  *   <li>{@link com.linecorp.armeria.client.endpoint.StaticEndpointGroup}</li>
  * </ul>
  */
+@NonNullByDefault
 package com.linecorp.armeria.client.endpoint;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/core/src/main/java/com/linecorp/armeria/client/limit/package-info.java
+++ b/core/src/main/java/com/linecorp/armeria/client/limit/package-info.java
@@ -16,4 +16,7 @@
 /**
  * Limits the number of executed {@link com.linecorp.armeria.common.Request}s.
  */
+@NonNullByDefault
 package com.linecorp.armeria.client.limit;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/core/src/main/java/com/linecorp/armeria/client/logging/package-info.java
+++ b/core/src/main/java/com/linecorp/armeria/client/logging/package-info.java
@@ -17,4 +17,7 @@
 /**
  * Logging client decorators.
  */
+@NonNullByDefault
 package com.linecorp.armeria.client.logging;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/core/src/main/java/com/linecorp/armeria/client/metric/package-info.java
+++ b/core/src/main/java/com/linecorp/armeria/client/metric/package-info.java
@@ -17,4 +17,7 @@
 /**
  * Metric-collecting client decorators.
  */
+@NonNullByDefault
 package com.linecorp.armeria.client.metric;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/core/src/main/java/com/linecorp/armeria/client/package-info.java
+++ b/core/src/main/java/com/linecorp/armeria/client/package-info.java
@@ -23,4 +23,7 @@
  *   <li>{@link com.linecorp.armeria.client.ClientBuilder}</li>
  * </ul>
  */
+@NonNullByDefault
 package com.linecorp.armeria.client;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/core/src/main/java/com/linecorp/armeria/client/pool/package-info.java
+++ b/core/src/main/java/com/linecorp/armeria/client/pool/package-info.java
@@ -17,4 +17,7 @@
 /**
  * Asynchronous {@link io.netty.channel.Channel} pool.
  */
+@NonNullByDefault
 package com.linecorp.armeria.client.pool;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/core/src/main/java/com/linecorp/armeria/client/retry/package-info.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/package-info.java
@@ -17,4 +17,7 @@
 /**
  * A {@link com.linecorp.armeria.client.Client} decorator that handles failures and retries requests.
  */
+@NonNullByDefault
 package com.linecorp.armeria.client.retry;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/core/src/main/java/com/linecorp/armeria/common/logging/package-info.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/package-info.java
@@ -24,4 +24,7 @@
  *   <li>{@link com.linecorp.armeria.common.logging.RequestLogBuilder}</li>
  * </ul>
  */
+@NonNullByDefault
 package com.linecorp.armeria.common.logging;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/core/src/main/java/com/linecorp/armeria/common/metric/package-info.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/package-info.java
@@ -17,4 +17,7 @@
 /**
  * Common metric collection utilities.
  */
+@NonNullByDefault
 package com.linecorp.armeria.common.metric;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/core/src/main/java/com/linecorp/armeria/common/package-info.java
+++ b/core/src/main/java/com/linecorp/armeria/common/package-info.java
@@ -22,4 +22,7 @@
  *   <li>{@link com.linecorp.armeria.common.RequestContext}</li>
  * </ul>
  */
+@NonNullByDefault
 package com.linecorp.armeria.common;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/core/src/main/java/com/linecorp/armeria/common/stream/package-info.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/package-info.java
@@ -23,4 +23,7 @@
  *   <li>{@link com.linecorp.armeria.common.stream.StreamWriter}</li>
  * </ul>
  */
+@NonNullByDefault
 package com.linecorp.armeria.common.stream;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/core/src/main/java/com/linecorp/armeria/common/util/NonNullByDefault.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/NonNullByDefault.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 LINE Corporation
+ * Copyright 2018 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/core/src/main/java/com/linecorp/armeria/common/util/NonNullByDefault.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/NonNullByDefault.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2015 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common.util;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.meta.TypeQualifierDefault;
+
+/**
+ * An annotation that signifies the return values, parameters and fields are non-nullable by default
+ * leveraging the JSR-305 {@link Nonnull} annotation. Annotate a package with this annotation and
+ * annotate nullable return values, parameters and fields with {@link Nullable}.
+ */
+@Nonnull
+@Documented
+@Target(ElementType.PACKAGE)
+@Retention(RetentionPolicy.RUNTIME)
+@TypeQualifierDefault({ ElementType.METHOD, ElementType.PARAMETER, ElementType.FIELD })
+public @interface NonNullByDefault {
+}

--- a/core/src/main/java/com/linecorp/armeria/common/util/package-info.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/package-info.java
@@ -17,4 +17,5 @@
 /**
  * Generic utility classes.
  */
+@NonNullByDefault
 package com.linecorp.armeria.common.util;

--- a/core/src/main/java/com/linecorp/armeria/internal/metric/package-info.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/metric/package-info.java
@@ -18,4 +18,7 @@
  * Various metrics related classes used internally.
  * Anything in this package can be changed or removed at any time.
  */
+@NonNullByDefault
 package com.linecorp.armeria.internal.metric;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/core/src/main/java/com/linecorp/armeria/internal/package-info.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/package-info.java
@@ -17,4 +17,7 @@
 /**
  * Various classes used internally. Anything in this package can be changed or removed at any time.
  */
+@NonNullByDefault
 package com.linecorp.armeria.internal;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/package-info.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/package-info.java
@@ -17,4 +17,7 @@
 /**
  * Annotations for building a RESTful service.
  */
+@NonNullByDefault
 package com.linecorp.armeria.server.annotation;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/core/src/main/java/com/linecorp/armeria/server/auth/package-info.java
+++ b/core/src/main/java/com/linecorp/armeria/server/auth/package-info.java
@@ -17,4 +17,7 @@
 /**
  * HTTP authorization service.
  */
+@NonNullByDefault
 package com.linecorp.armeria.server.auth;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/core/src/main/java/com/linecorp/armeria/server/composition/package-info.java
+++ b/core/src/main/java/com/linecorp/armeria/server/composition/package-info.java
@@ -17,4 +17,7 @@
 /**
  * Service composition.
  */
+@NonNullByDefault
 package com.linecorp.armeria.server.composition;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/core/src/main/java/com/linecorp/armeria/server/cors/package-info.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/package-info.java
@@ -18,4 +18,7 @@
  * <a href="https://en.wikipedia.org/wiki/Cross-origin_resource_sharing">Cross-Origin Resource Sharing
  * (CORS)</a> support.
  */
+@NonNullByDefault
 package com.linecorp.armeria.server.cors;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/core/src/main/java/com/linecorp/armeria/server/docs/package-info.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/package-info.java
@@ -17,4 +17,7 @@
 /**
  * Documentation service.
  */
+@NonNullByDefault
 package com.linecorp.armeria.server.docs;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/core/src/main/java/com/linecorp/armeria/server/encoding/package-info.java
+++ b/core/src/main/java/com/linecorp/armeria/server/encoding/package-info.java
@@ -17,4 +17,7 @@
 /**
  * HTTP content encoding service.
  */
+@NonNullByDefault
 package com.linecorp.armeria.server.encoding;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/core/src/main/java/com/linecorp/armeria/server/file/package-info.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/package-info.java
@@ -17,4 +17,7 @@
 /**
  * HTTP static file service.
  */
+@NonNullByDefault
 package com.linecorp.armeria.server.file;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/package-info.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/package-info.java
@@ -17,4 +17,7 @@
 /**
  * HTTP health check service for load balancers.
  */
+@NonNullByDefault
 package com.linecorp.armeria.server.healthcheck;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/core/src/main/java/com/linecorp/armeria/server/logging/package-info.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/package-info.java
@@ -17,4 +17,7 @@
 /**
  * Logging and metric-collecting service decorators.
  */
+@NonNullByDefault
 package com.linecorp.armeria.server.logging;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/core/src/main/java/com/linecorp/armeria/server/logging/structured/package-info.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/structured/package-info.java
@@ -17,4 +17,7 @@
 /**
  * Structured logging support for full request and response.
  */
+@NonNullByDefault
 package com.linecorp.armeria.server.logging.structured;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/core/src/main/java/com/linecorp/armeria/server/metric/package-info.java
+++ b/core/src/main/java/com/linecorp/armeria/server/metric/package-info.java
@@ -17,4 +17,7 @@
 /**
  * Metric-collecting service decorators and exporters.
  */
+@NonNullByDefault
 package com.linecorp.armeria.server.metric;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/core/src/main/java/com/linecorp/armeria/server/package-info.java
+++ b/core/src/main/java/com/linecorp/armeria/server/package-info.java
@@ -24,4 +24,7 @@
  *   <li>{@link com.linecorp.armeria.server.Service}</li>
  * </ul>
  */
+@NonNullByDefault
 package com.linecorp.armeria.server;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/core/src/main/java/com/linecorp/armeria/server/throttling/package-info.java
+++ b/core/src/main/java/com/linecorp/armeria/server/throttling/package-info.java
@@ -17,4 +17,7 @@
 /**
  * Request throttling service decorators and strategies.
  */
+@NonNullByDefault
 package com.linecorp.armeria.server.throttling;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/core/src/main/java/com/linecorp/armeria/unsafe/package-info.java
+++ b/core/src/main/java/com/linecorp/armeria/unsafe/package-info.java
@@ -19,4 +19,8 @@
  * when dealing with large buffers but require careful memory management or there will be memory leaks. Only use
  * these methods if you really know what you're doing.
  */
+
+@NonNullByDefault
 package com.linecorp.armeria.unsafe;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -37,7 +37,6 @@ com.google.guava:
   guava:
     version: &GUAVA_VERSION '23.6-jre'
     exclusions:
-    - com.google.code.findbugs:jsr305
     - com.google.errorprone:error_prone_annotations
     - com.google.j2objc:j2objc-annotations
     - org.codehaus.mojo:animal-sniffer-annotations
@@ -49,7 +48,6 @@ com.google.guava:
   guava-testlib:
     version: *GUAVA_VERSION
     exclusions:
-    - com.google.code.findbugs:jsr305
     - com.google.errorprone:error_prone_annotations
     - com.google.j2objc:j2objc-annotations
     relocations:
@@ -95,7 +93,6 @@ io.grpc:
     - https://grpc.io/grpc-java/javadoc/
     - https://developers.google.com/protocol-buffers/docs/reference/java/
     exclusions:
-    - com.google.code.findbugs:jsr305
     - com.google.errorprone:error_prone_annotations
   grpc-interop-testing:
     version: *GRPC_VERSION

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/package-info.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/package-info.java
@@ -17,4 +17,7 @@
 /**
  * An armeria client that uses the gRPC wire protocol.
  */
+@NonNullByDefault
 package com.linecorp.armeria.client.grpc;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/grpc/src/main/java/com/linecorp/armeria/common/grpc/package-info.java
+++ b/grpc/src/main/java/com/linecorp/armeria/common/grpc/package-info.java
@@ -17,4 +17,7 @@
 /**
  * gRPC-related common classes.
  */
+@NonNullByDefault
 package com.linecorp.armeria.common.grpc;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/grpc/src/main/java/com/linecorp/armeria/internal/grpc/package-info.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/grpc/package-info.java
@@ -17,4 +17,7 @@
 /**
  * Various classes used internally. Anything in this package can be changed or removed at any time.
  */
+@NonNullByDefault
 package com.linecorp.armeria.internal.grpc;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/package-info.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/package-info.java
@@ -17,4 +17,7 @@
 /**
  * Allows an Armeria server to host a gRPC API using the gRPC wire protocol.
  */
+@NonNullByDefault
 package com.linecorp.armeria.server.grpc;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/grpc/src/main/java/com/linecorp/armeria/unsafe/grpc/package-info.java
+++ b/grpc/src/main/java/com/linecorp/armeria/unsafe/grpc/package-info.java
@@ -19,4 +19,7 @@
  * when dealing with large buffers but require careful memory management or there will be memory leaks. Only use
  * these methods if you really know what you're doing.
  */
+@NonNullByDefault
 package com.linecorp.armeria.unsafe.grpc;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/jetty/src/main/java/com/linecorp/armeria/server/jetty/package-info.java
+++ b/jetty/src/main/java/com/linecorp/armeria/server/jetty/package-info.java
@@ -17,4 +17,7 @@
 /**
  * Embedded <a href="https://www.eclipse.org/jetty/">Jetty</a> service.
  */
+@NonNullByDefault
 package com.linecorp.armeria.server.jetty;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/kafka/src/main/java/com/linecorp/armeria/server/logging/structured/kafka/package-info.java
+++ b/kafka/src/main/java/com/linecorp/armeria/server/logging/structured/kafka/package-info.java
@@ -17,4 +17,7 @@
 /**
  * Kafka backend integration support for structured request/response logging.
  */
+@NonNullByDefault
 package com.linecorp.armeria.server.logging.structured.kafka;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/logback/src/main/java/com/linecorp/armeria/common/logback/package-info.java
+++ b/logback/src/main/java/com/linecorp/armeria/common/logback/package-info.java
@@ -20,4 +20,7 @@
  * <p>Read '<a href="https://line.github.io/armeria/server-basics.html">Logging contextual information</a>'
  * for more information.
  */
+@NonNullByDefault
 package com.linecorp.armeria.common.logback;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/package-info.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/package-info.java
@@ -17,4 +17,7 @@
 /**
  * <a href="https://square.github.io/retrofit/">Retrofit2</a> adapter for Armeria.
  */
+@NonNullByDefault
 package com.linecorp.armeria.client.retrofit2;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/settings/checkstyle/checkstyle-suppressions.xml
+++ b/settings/checkstyle/checkstyle-suppressions.xml
@@ -1,8 +1,4 @@
 <?xml version="1.0"?>
-<!--
-  ~ Copyright (c) 2015 LINE Corporation. All rights reserved.
-  ~ LINE Corporation PROPRIETARY/CONFIDENTIAL. Use is subject to license terms.
-  -->
 <!DOCTYPE suppressions PUBLIC
   "-//Puppy Crawl//DTD Suppressions 1.1//EN"
   "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
@@ -17,4 +13,6 @@
   <suppress checks=".*" files="[\\/]gen-src[\\/]" />
   <!-- Suppress checks in large forks to make diffing against upstream easier -->
   <suppress checks=".*" files="[\\/]grpc[\\/]ServerCallImpl.java$" />
+  <!-- Enable 'NonNullByDefaultAnnotation' for package-info.java only -->
+  <suppress id="NonNullByDefaultAnnotation" files="(?&lt;![\\/]package-info\.java)$" />
 </suppressions>

--- a/settings/checkstyle/checkstyle.xml
+++ b/settings/checkstyle/checkstyle.xml
@@ -30,6 +30,14 @@
     <property name="maximum" value="1"/>
     <property name="message" value="missing copyright header"/>
   </module>
+  <!-- All packages must be annotated with @NonNullByDefault -->
+  <module name="RegexpSingleline">
+    <property name="id" value="NonNullByDefaultAnnotation"/>
+    <property name="format" value="^\s*@(?:com\.linecorp\.armeria\.common\.util\.)?NonNullByDefault"/>
+    <property name="minimum" value="1"/>
+    <property name="maximum" value="1"/>
+    <property name="message" value="A package must be annotated with @NonNullByDefault."/>
+  </module>
   <!-- Unmaintainable Javadoc tags -->
   <module name="RegexpSingleline">
     <property name="format" value="(?:@version|\(non-Javadoc\))"/>

--- a/spring-boot/autoconfigure/src/main/java/com/linecorp/armeria/spring/package-info.java
+++ b/spring-boot/autoconfigure/src/main/java/com/linecorp/armeria/spring/package-info.java
@@ -17,4 +17,7 @@
 /**
  * <a href="https://projects.spring.io/spring-boot/">Spring Boot</a> integration.
  */
+@NonNullByDefault
 package com.linecorp.armeria.spring;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/testing-internal/src/main/java/com/linecorp/armeria/testing/internal/package-info.java
+++ b/testing-internal/src/main/java/com/linecorp/armeria/testing/internal/package-info.java
@@ -17,4 +17,7 @@
 /**
  * Common testing utilities.
  */
+@NonNullByDefault
 package com.linecorp.armeria.testing.internal;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/testing-internal/src/main/java/com/linecorp/armeria/testing/internal/webapp/package-info.java
+++ b/testing-internal/src/main/java/com/linecorp/armeria/testing/internal/webapp/package-info.java
@@ -17,4 +17,7 @@
 /**
  * Web application service testing utilities.
  */
+@NonNullByDefault
 package com.linecorp.armeria.testing.internal.webapp;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/testing/src/main/java/com/linecorp/armeria/testing/server/package-info.java
+++ b/testing/src/main/java/com/linecorp/armeria/testing/server/package-info.java
@@ -17,4 +17,7 @@
 /**
  * Server-side testing utilities.
  */
+@NonNullByDefault
 package com.linecorp.armeria.testing.server;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/thrift/src/main/java/com/linecorp/armeria/client/thrift/package-info.java
+++ b/thrift/src/main/java/com/linecorp/armeria/client/thrift/package-info.java
@@ -17,4 +17,7 @@
 /**
  * Thrift client.
  */
+@NonNullByDefault
 package com.linecorp.armeria.client.thrift;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/thrift/src/main/java/com/linecorp/armeria/common/thrift/package-info.java
+++ b/thrift/src/main/java/com/linecorp/armeria/common/thrift/package-info.java
@@ -17,4 +17,7 @@
 /**
  * Thrift-related common classes.
  */
+@NonNullByDefault
 package com.linecorp.armeria.common.thrift;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/thrift/src/main/java/com/linecorp/armeria/common/thrift/text/package-info.java
+++ b/thrift/src/main/java/com/linecorp/armeria/common/thrift/text/package-info.java
@@ -44,4 +44,7 @@
  *     <li>Miscellaneous style cleanups</li>
  * </ul>
  */
+@NonNullByDefault
 package com.linecorp.armeria.common.thrift.text;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/thrift/src/main/java/com/linecorp/armeria/internal/thrift/package-info.java
+++ b/thrift/src/main/java/com/linecorp/armeria/internal/thrift/package-info.java
@@ -17,4 +17,7 @@
 /**
  * Various classes used internally. Anything in this package can be changed or removed at any time.
  */
+@NonNullByDefault
 package com.linecorp.armeria.internal.thrift;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/thrift/src/main/java/com/linecorp/armeria/server/thrift/package-info.java
+++ b/thrift/src/main/java/com/linecorp/armeria/server/thrift/package-info.java
@@ -17,4 +17,7 @@
 /**
  * Thrift service.
  */
+@NonNullByDefault
 package com.linecorp.armeria.server.thrift;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/tomcat/src/main/java/com/linecorp/armeria/server/tomcat/package-info.java
+++ b/tomcat/src/main/java/com/linecorp/armeria/server/tomcat/package-info.java
@@ -17,4 +17,7 @@
 /**
  * Embedded <a href="https://tomcat.apache.org/">Tomcat</a> service.
  */
+@NonNullByDefault
 package com.linecorp.armeria.server.tomcat;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/zipkin/src/main/java/com/linecorp/armeria/client/tracing/package-info.java
+++ b/zipkin/src/main/java/com/linecorp/armeria/client/tracing/package-info.java
@@ -18,4 +18,7 @@
  * Distributed tracing clients based on <a href="https://github.com/openzipkin/brave">Brave</a>,
  * a Java tracing library compatible with <a href="http://zipkin.io/">Zipkin</a>.
  */
+@NonNullByDefault
 package com.linecorp.armeria.client.tracing;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/zipkin/src/main/java/com/linecorp/armeria/internal/tracing/package-info.java
+++ b/zipkin/src/main/java/com/linecorp/armeria/internal/tracing/package-info.java
@@ -17,4 +17,7 @@
 /**
  * Various classes used internally. Anything in this package can be changed or removed at any time.
  */
+@NonNullByDefault
 package com.linecorp.armeria.internal.tracing;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/zipkin/src/main/java/com/linecorp/armeria/server/tracing/package-info.java
+++ b/zipkin/src/main/java/com/linecorp/armeria/server/tracing/package-info.java
@@ -18,4 +18,7 @@
  * Distributed tracing services based on <a href="https://github.com/openzipkin/brave">Brave</a>,
  * a Java tracing library compatible with <a href="http://zipkin.io/">Zipkin</a>.
  */
+@NonNullByDefault
 package com.linecorp.armeria.server.tracing;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/zookeeper/src/main/java/com/linecorp/armeria/client/zookeeper/package-info.java
+++ b/zookeeper/src/main/java/com/linecorp/armeria/client/zookeeper/package-info.java
@@ -16,4 +16,7 @@
 /**
  * ZooKeeper-based {@link com.linecorp.armeria.client.endpoint.EndpointGroup} implementation.
  */
+@NonNullByDefault
 package com.linecorp.armeria.client.zookeeper;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/zookeeper/src/main/java/com/linecorp/armeria/common/zookeeper/package-info.java
+++ b/zookeeper/src/main/java/com/linecorp/armeria/common/zookeeper/package-info.java
@@ -16,4 +16,7 @@
 /**
  * Common classes will be used by Server and Client implementations.
  */
+@NonNullByDefault
 package com.linecorp.armeria.common.zookeeper;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/zookeeper/src/main/java/com/linecorp/armeria/server/zookeeper/package-info.java
+++ b/zookeeper/src/main/java/com/linecorp/armeria/server/zookeeper/package-info.java
@@ -23,4 +23,7 @@
  * servers.
  *
  */
+@NonNullByDefault
 package com.linecorp.armeria.server.zookeeper;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;


### PR DESCRIPTION
Motivation:

Some languages such as Kotlin assumes all Java API are nullable unless
annotated with `@Nonnull`. Our API assumes non-null unless annotated
with `@Nullable`.  As a result, Kotlin complains about Armeria usage.

Modifications:

- Add a new annotation `@NonNullByDefault` to tell Kotlin that all
  return values, parameters and fields are non-null by default
- Annotate all packages with `@NonNullByDefault`
- Include `jsr305` as a dependency so that Kotlin compiler enables
  JSR-305 support

Result:

- Fixes #943

/cc @tobias- @anuraaga @kojilin 