### PR TITLE
Only cache non-exact path mappings when opted-in by the service.

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/PathAndQuery.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/PathAndQuery.java
@@ -23,6 +23,7 @@ import javax.annotation.Nullable;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Strings;
 
@@ -90,6 +91,11 @@ public final class PathAndQuery {
         if (CACHE != null) {
             CACHE.put(rawPath, this);
         }
+    }
+
+    @VisibleForTesting
+    public static Cache<String, PathAndQuery> pathCache() {
+        return CACHE;
     }
 
     private final String path;

--- a/core/src/main/java/com/linecorp/armeria/internal/PathAndQuery.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/PathAndQuery.java
@@ -16,7 +16,10 @@
 
 package com.linecorp.armeria.internal;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.Objects;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 import javax.annotation.Nullable;
@@ -64,6 +67,24 @@ public final class PathAndQuery {
     }
 
     /**
+     * Clears the currently cached parsed paths. Only for use in tests.
+     */
+    @VisibleForTesting
+    public static void clearCachedPaths() {
+        requireNonNull(CACHE, "CACHE");
+        CACHE.asMap().clear();
+    }
+
+    /**
+     * Returns paths that have had their parse result cached. Only for use in tests.
+     */
+    @VisibleForTesting
+    public static Set<String> cachedPaths() {
+        requireNonNull(CACHE, "CACHE");
+        return CACHE.asMap().keySet();
+    }
+
+    /**
      * Validates the {@link String} that contains an absolute path and a query, and splits them into
      * the path part and the query part. If the path is usable (e.g., can be served a successful response from
      * the server and doesn't have variable path parameters), {@link PathAndQuery#storeInCache(String)} should
@@ -91,11 +112,6 @@ public final class PathAndQuery {
         if (CACHE != null) {
             CACHE.put(rawPath, this);
         }
-    }
-
-    @VisibleForTesting
-    public static Cache<String, PathAndQuery> pathCache() {
-        return CACHE;
     }
 
     private final String path;

--- a/core/src/main/java/com/linecorp/armeria/server/DecoratingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DecoratingService.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
+import com.linecorp.armeria.internal.PathAndQuery;
 
 /**
  * A {@link Service} that decorates another {@link Service}. Use {@link SimpleDecoratingService} or
@@ -63,6 +64,11 @@ public abstract class DecoratingService<T_I extends Request, T_O extends Respons
     public final <T> Optional<T> as(Class<T> serviceType) {
         final Optional<T> result = Service.super.as(serviceType);
         return result.isPresent() ? result : delegate.as(serviceType);
+    }
+
+    @Override
+    public boolean shouldCachePath(PathAndQuery pathAndQuery, PathMapping pathMapping) {
+        return delegate.shouldCachePath(pathAndQuery, pathMapping);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/DecoratingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DecoratingService.java
@@ -20,9 +20,10 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Optional;
 
+import javax.annotation.Nullable;
+
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
-import com.linecorp.armeria.internal.PathAndQuery;
 
 /**
  * A {@link Service} that decorates another {@link Service}. Use {@link SimpleDecoratingService} or
@@ -67,8 +68,8 @@ public abstract class DecoratingService<T_I extends Request, T_O extends Respons
     }
 
     @Override
-    public boolean shouldCachePath(PathAndQuery pathAndQuery, PathMapping pathMapping) {
-        return delegate.shouldCachePath(pathAndQuery, pathMapping);
+    public boolean shouldCachePath(String path, @Nullable String query, PathMapping pathMapping) {
+        return delegate.shouldCachePath(path, query, pathMapping);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -331,7 +331,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
             gracefulShutdownSupport.inc();
             unfinishedRequests++;
 
-            if (pathAndQuery.query() == null && mapped.mapping().paramNames().isEmpty()) {
+            if (service.shouldCachePath(pathAndQuery, mapped.mapping())) {
                 reqCtx.log().addListener(log -> {
                     HttpStatus status = log.responseHeaders().status();
                     if (status != null && status.code() >= 200 && status.code() < 400) {

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -331,7 +331,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
             gracefulShutdownSupport.inc();
             unfinishedRequests++;
 
-            if (service.shouldCachePath(pathAndQuery, mapped.mapping())) {
+            if (service.shouldCachePath(pathAndQuery.path(), pathAndQuery.query(), mapped.mapping())) {
                 reqCtx.log().addListener(log -> {
                     HttpStatus status = log.responseHeaders().status();
                     if (status != null && status.code() >= 200 && status.code() < 400) {

--- a/core/src/main/java/com/linecorp/armeria/server/Service.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Service.java
@@ -22,13 +22,14 @@ import java.lang.reflect.Constructor;
 import java.util.Optional;
 import java.util.function.Function;
 
+import javax.annotation.Nullable;
+
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
 import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.RpcResponse;
-import com.linecorp.armeria.internal.PathAndQuery;
 
 /**
  * Handles a {@link Request} received by a {@link Server}.
@@ -133,10 +134,10 @@ public interface Service<I extends Request, O extends Response> {
     }
 
     /**
-     * Returns whether the given {@link PathAndQuery} should be cached if the service's result is successful.
-     * By default, exact path mappings with no input query are cached.
+     * Returns whether the given {@code path} and {@code query }should be cached if the service's result is
+     * successful. By default, exact path mappings with no input query are cached.
      */
-    default boolean shouldCachePath(PathAndQuery pathAndQuery, PathMapping pathMapping) {
-        return pathMapping.exactPath().isPresent() && pathAndQuery.query() == null;
+    default boolean shouldCachePath(String path, @Nullable String query, PathMapping pathMapping) {
+        return pathMapping.exactPath().isPresent() && query == null;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/Service.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Service.java
@@ -28,6 +28,7 @@ import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
 import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.RpcResponse;
+import com.linecorp.armeria.internal.PathAndQuery;
 
 /**
  * Handles a {@link Request} received by a {@link Server}.
@@ -129,5 +130,13 @@ public interface Service<I extends Request, O extends Response> {
      */
     default Service<I, O> decorate(DecoratingServiceFunction<I, O> function) {
         return new FunctionalDecoratingService<>(this, function);
+    }
+
+    /**
+     * Returns whether the given {@link PathAndQuery} should be cached if the service's result is successful.
+     * By default, exact path mappings with no input query are cached.
+     */
+    default boolean shouldCachePath(PathAndQuery pathAndQuery, PathMapping pathMapping) {
+        return pathMapping.exactPath().isPresent() && pathAndQuery.query() == null;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/Service.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Service.java
@@ -134,7 +134,7 @@ public interface Service<I extends Request, O extends Response> {
     }
 
     /**
-     * Returns whether the given {@code path} and {@code query }should be cached if the service's result is
+     * Returns whether the given {@code path} and {@code query} should be cached if the service's result is
      * successful. By default, exact path mappings with no input query are cached.
      */
     default boolean shouldCachePath(String path, @Nullable String query, PathMapping pathMapping) {

--- a/core/src/main/java/com/linecorp/armeria/server/file/HttpFileService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/HttpFileService.java
@@ -42,7 +42,6 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.metric.MeterIdPrefix;
-import com.linecorp.armeria.internal.PathAndQuery;
 import com.linecorp.armeria.internal.metric.CaffeineMetricSupport;
 import com.linecorp.armeria.server.AbstractHttpService;
 import com.linecorp.armeria.server.HttpService;
@@ -134,7 +133,7 @@ public final class HttpFileService extends AbstractHttpService {
     }
 
     @Override
-    public boolean shouldCachePath(PathAndQuery pathAndQuery, PathMapping pathMapping) {
+    public boolean shouldCachePath(String path, @Nullable String query, PathMapping pathMapping) {
         // We assume that if a file cache is enabled, the number of paths is also finite.
         return cache != null;
     }
@@ -367,11 +366,11 @@ public final class HttpFileService extends AbstractHttpService {
         }
 
         @Override
-        public boolean shouldCachePath(PathAndQuery pathAndQuery, PathMapping pathMapping) {
+        public boolean shouldCachePath(String path, @Nullable String query, PathMapping pathMapping) {
             // No good way of propagating the first vs second decision to the cache decision, so just make a
             // best effort, it should work for most cases.
-            return first.shouldCachePath(pathAndQuery, pathMapping) &&
-                   second.shouldCachePath(pathAndQuery, pathMapping);
+            return first.shouldCachePath(path, query, pathMapping) &&
+                   second.shouldCachePath(path, query, pathMapping);
         }
     }
 

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerTest.java
@@ -56,6 +56,8 @@ import java.util.function.Function;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.InflaterInputStream;
 
+import javax.annotation.Nullable;
+
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -430,7 +432,7 @@ public class HttpServerTest {
                 }
 
                 @Override
-                public boolean shouldCachePath(PathAndQuery pathAndQuery, PathMapping pathMapping) {
+                public boolean shouldCachePath(String path, @Nullable String query, PathMapping pathMapping) {
                     return true;
                 }
             });
@@ -479,7 +481,7 @@ public class HttpServerTest {
         serverMaxRequestLength = MAX_CONTENT_LENGTH;
         clientMaxResponseLength = MAX_CONTENT_LENGTH;
 
-        PathAndQuery.pathCache().asMap().clear();
+        PathAndQuery.clearCachedPaths();
     }
 
     @After
@@ -918,8 +920,8 @@ public class HttpServerTest {
         org.assertj.core.api.Assertions.assertThat(client().get("/cached-exact-path")
                                                            .aggregate().get().status())
                                        .isEqualTo(HttpStatus.OK);
-        org.assertj.core.api.Assertions.assertThat(PathAndQuery.pathCache().asMap())
-                                       .containsKeys("/cached-exact-path");
+        org.assertj.core.api.Assertions.assertThat(PathAndQuery.cachedPaths())
+                                       .contains("/cached-exact-path");
     }
 
     @Test(timeout = 10000)
@@ -927,8 +929,8 @@ public class HttpServerTest {
         org.assertj.core.api.Assertions.assertThat(client().get("/not-cached-paths/hoge")
                                                            .aggregate().get().status())
                                        .isEqualTo(HttpStatus.OK);
-        org.assertj.core.api.Assertions.assertThat(PathAndQuery.pathCache().asMap())
-                                       .doesNotContainKeys("/not-cached-paths/hoge");
+        org.assertj.core.api.Assertions.assertThat(PathAndQuery.cachedPaths())
+                                       .doesNotContain("/not-cached-paths/hoge");
     }
 
     @Test(timeout = 10000)
@@ -936,8 +938,8 @@ public class HttpServerTest {
         org.assertj.core.api.Assertions.assertThat(client().get("/cached-paths/hoge")
                                                            .aggregate().get().status())
                                        .isEqualTo(HttpStatus.OK);
-        org.assertj.core.api.Assertions.assertThat(PathAndQuery.pathCache().asMap())
-                                       .containsKeys("/cached-paths/hoge");
+        org.assertj.core.api.Assertions.assertThat(PathAndQuery.cachedPaths())
+                                       .contains("/cached-paths/hoge");
     }
 
     private static void stream(StreamWriter<HttpObject> writer, long size, int chunkSize) {

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerTest.java
@@ -98,6 +98,7 @@ import com.linecorp.armeria.common.stream.StreamWriter;
 import com.linecorp.armeria.common.util.EventLoopGroups;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.internal.InboundTrafficController;
+import com.linecorp.armeria.internal.PathAndQuery;
 import com.linecorp.armeria.server.encoding.HttpEncodingService;
 import com.linecorp.armeria.testing.server.ServerRule;
 import com.linecorp.armeria.unsafe.ByteBufHttpData;
@@ -420,6 +421,22 @@ public class HttpServerTest {
 
             sb.service("/head-headers-only", ((ctx, req) -> HttpResponse.of(HttpHeaders.of(HttpStatus.OK))));
 
+            sb.serviceUnder("/not-cached-paths", (ctx, req) -> HttpResponse.of(HttpStatus.OK));
+
+            sb.serviceUnder("/cached-paths", new Service<HttpRequest, HttpResponse>() {
+                @Override
+                public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+                    return HttpResponse.of(HttpStatus.OK);
+                }
+
+                @Override
+                public boolean shouldCachePath(PathAndQuery pathAndQuery, PathMapping pathMapping) {
+                    return true;
+                }
+            });
+
+            sb.service("/cached-exact-path", (ctx, req) -> HttpResponse.of(HttpStatus.OK));
+
             final Function<Service<HttpRequest, HttpResponse>, Service<HttpRequest, HttpResponse>> decorator =
                     s -> new SimpleDecoratingService<HttpRequest, HttpResponse>(s) {
                         @Override
@@ -461,6 +478,8 @@ public class HttpServerTest {
 
         serverMaxRequestLength = MAX_CONTENT_LENGTH;
         clientMaxResponseLength = MAX_CONTENT_LENGTH;
+
+        PathAndQuery.pathCache().asMap().clear();
     }
 
     @After
@@ -892,6 +911,33 @@ public class HttpServerTest {
 
         final AggregatedHttpMessage res = f.get();
         assertThat(res.trailingHeaders().get(AsciiString.of("foo")), is("bar"));
+    }
+
+    @Test(timeout = 10000)
+    public void testExactPathCached() throws Exception {
+        org.assertj.core.api.Assertions.assertThat(client().get("/cached-exact-path")
+                                                           .aggregate().get().status())
+                                       .isEqualTo(HttpStatus.OK);
+        org.assertj.core.api.Assertions.assertThat(PathAndQuery.pathCache().asMap())
+                                       .containsKeys("/cached-exact-path");
+    }
+
+    @Test(timeout = 10000)
+    public void testPrefixPathNotCached() throws Exception {
+        org.assertj.core.api.Assertions.assertThat(client().get("/not-cached-paths/hoge")
+                                                           .aggregate().get().status())
+                                       .isEqualTo(HttpStatus.OK);
+        org.assertj.core.api.Assertions.assertThat(PathAndQuery.pathCache().asMap())
+                                       .doesNotContainKeys("/not-cached-paths/hoge");
+    }
+
+    @Test(timeout = 10000)
+    public void testPrefixPath_cacheForced() throws Exception {
+        org.assertj.core.api.Assertions.assertThat(client().get("/cached-paths/hoge")
+                                                           .aggregate().get().status())
+                                       .isEqualTo(HttpStatus.OK);
+        org.assertj.core.api.Assertions.assertThat(PathAndQuery.pathCache().asMap())
+                                       .containsKeys("/cached-paths/hoge");
     }
 
     private static void stream(StreamWriter<HttpObject> writer, long size, int chunkSize) {

--- a/core/src/test/java/com/linecorp/armeria/server/file/HttpFileServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/file/HttpFileServiceTest.java
@@ -42,12 +42,14 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.google.common.io.ByteStreams;
 import com.google.common.io.Resources;
 
+import com.linecorp.armeria.internal.PathAndQuery;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.logging.LoggingService;
@@ -81,6 +83,7 @@ public class HttpFileServiceTest {
                     "/compressed/",
                     HttpFileServiceBuilder.forClassPath(baseResourceDir + "foo")
                                           .serveCompressedFiles(true)
+                                          .maxCacheEntries(0)
                                           .build());
 
             sb.serviceUnder(
@@ -122,6 +125,11 @@ public class HttpFileServiceTest {
         });
     }
 
+    @Before
+    public void setUp() {
+        PathAndQuery.pathCache().asMap().clear();
+    }
+
     @Test
     public void testClassPathGet() throws Exception {
         try (CloseableHttpClient hc = HttpClients.createMinimal()) {
@@ -138,6 +146,10 @@ public class HttpFileServiceTest {
             try (CloseableHttpResponse res = hc.execute(req)) {
                 assert304NotModified(res, lastModified);
             }
+
+            // Confirm file service paths are cached when cache is enabled.
+            org.assertj.core.api.Assertions.assertThat(PathAndQuery.pathCache().asMap())
+                                           .containsKeys("/foo.txt");
         }
     }
 
@@ -183,6 +195,10 @@ public class HttpFileServiceTest {
                 assertThat(res.getFirstHeader("Content-Type").getValue(), is("text/plain; charset=utf-8"));
                 final byte[] content = ByteStreams.toByteArray(res.getEntity().getContent());
                 assertThat(new String(content, StandardCharsets.UTF_8), is("foo"));
+
+                // Confirm path not cached when cache disabled.
+                org.assertj.core.api.Assertions.assertThat(PathAndQuery.pathCache().asMap())
+                                               .doesNotContainKeys("/compressed/foo.txt");
             }
         }
     }

--- a/core/src/test/java/com/linecorp/armeria/server/file/HttpFileServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/file/HttpFileServiceTest.java
@@ -127,7 +127,7 @@ public class HttpFileServiceTest {
 
     @Before
     public void setUp() {
-        PathAndQuery.pathCache().asMap().clear();
+        PathAndQuery.clearCachedPaths();
     }
 
     @Test
@@ -148,8 +148,8 @@ public class HttpFileServiceTest {
             }
 
             // Confirm file service paths are cached when cache is enabled.
-            org.assertj.core.api.Assertions.assertThat(PathAndQuery.pathCache().asMap())
-                                           .containsKeys("/foo.txt");
+            org.assertj.core.api.Assertions.assertThat(PathAndQuery.cachedPaths())
+                                           .contains("/foo.txt");
         }
     }
 
@@ -197,8 +197,8 @@ public class HttpFileServiceTest {
                 assertThat(new String(content, StandardCharsets.UTF_8), is("foo"));
 
                 // Confirm path not cached when cache disabled.
-                org.assertj.core.api.Assertions.assertThat(PathAndQuery.pathCache().asMap())
-                                               .doesNotContainKeys("/compressed/foo.txt");
+                org.assertj.core.api.Assertions.assertThat(PathAndQuery.cachedPaths())
+                                               .doesNotContain("/compressed/foo.txt");
             }
         }
     }

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
@@ -38,6 +38,7 @@ import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.util.SafeCloseable;
+import com.linecorp.armeria.internal.PathAndQuery;
 import com.linecorp.armeria.internal.grpc.GrpcHeaderNames;
 import com.linecorp.armeria.internal.grpc.GrpcJsonUtil;
 import com.linecorp.armeria.internal.grpc.GrpcLogUtil;
@@ -210,6 +211,12 @@ public final class GrpcService extends AbstractHttpService
         if (maxInboundMessageSizeBytes == NO_MAX_INBOUND_MESSAGE_SIZE) {
             maxInboundMessageSizeBytes = (int) cfg.server().config().defaultMaxRequestLength();
         }
+    }
+
+    @Override
+    public boolean shouldCachePath(PathAndQuery pathAndQuery, PathMapping pathMapping) {
+        // gRPC services always have a single path per method that is safe to cache.
+        return true;
     }
 
     List<ServerServiceDefinition> services() {

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
@@ -38,7 +38,6 @@ import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.util.SafeCloseable;
-import com.linecorp.armeria.internal.PathAndQuery;
 import com.linecorp.armeria.internal.grpc.GrpcHeaderNames;
 import com.linecorp.armeria.internal.grpc.GrpcJsonUtil;
 import com.linecorp.armeria.internal.grpc.GrpcLogUtil;
@@ -214,7 +213,7 @@ public final class GrpcService extends AbstractHttpService
     }
 
     @Override
-    public boolean shouldCachePath(PathAndQuery pathAndQuery, PathMapping pathMapping) {
+    public boolean shouldCachePath(String path, @Nullable String query, PathMapping pathMapping) {
         // gRPC services always have a single path per method that is safe to cache.
         return true;
     }

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
@@ -271,7 +271,7 @@ public class GrpcServiceServerTest {
         blockingClient = UnitTestServiceGrpc.newBlockingStub(channel);
         streamingClient = UnitTestServiceGrpc.newStub(channel);
 
-        PathAndQuery.pathCache().asMap().clear();
+        PathAndQuery.clearCachedPaths();
     }
 
     @Test
@@ -279,8 +279,8 @@ public class GrpcServiceServerTest {
         assertThat(blockingClient.staticUnaryCall(REQUEST_MESSAGE)).isEqualTo(RESPONSE_MESSAGE);
 
         // Confirm gRPC paths are cached despite using serviceUnder
-        assertThat(PathAndQuery.pathCache().asMap())
-                .containsKeys("/armeria.grpc.testing.UnitTestService/StaticUnaryCall");
+        assertThat(PathAndQuery.cachedPaths())
+                .contains("/armeria.grpc.testing.UnitTestService/StaticUnaryCall");
     }
 
     @Test

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
@@ -65,6 +65,7 @@ import com.linecorp.armeria.grpc.testing.UnitTestServiceGrpc;
 import com.linecorp.armeria.grpc.testing.UnitTestServiceGrpc.UnitTestServiceBlockingStub;
 import com.linecorp.armeria.grpc.testing.UnitTestServiceGrpc.UnitTestServiceImplBase;
 import com.linecorp.armeria.grpc.testing.UnitTestServiceGrpc.UnitTestServiceStub;
+import com.linecorp.armeria.internal.PathAndQuery;
 import com.linecorp.armeria.internal.grpc.GrpcHeaderNames;
 import com.linecorp.armeria.internal.grpc.GrpcTestUtil;
 import com.linecorp.armeria.internal.grpc.StreamRecorder;
@@ -269,11 +270,17 @@ public class GrpcServiceServerTest {
         COMPLETED.set(false);
         blockingClient = UnitTestServiceGrpc.newBlockingStub(channel);
         streamingClient = UnitTestServiceGrpc.newStub(channel);
+
+        PathAndQuery.pathCache().asMap().clear();
     }
 
     @Test
     public void unary_normal() throws Exception {
         assertThat(blockingClient.staticUnaryCall(REQUEST_MESSAGE)).isEqualTo(RESPONSE_MESSAGE);
+
+        // Confirm gRPC paths are cached despite using serviceUnder
+        assertThat(PathAndQuery.pathCache().asMap())
+                .containsKeys("/armeria.grpc.testing.UnitTestService/StaticUnaryCall");
     }
 
     @Test


### PR DESCRIPTION
Currently, prefix mappings used with an infinite number of URLs (common for a frontend proxy) will cause cache-thrashing. While it can be disabled for these situations, defaulting to exact paths + our common services should be good for most cases either way.

Fixes #967