### PR TITLE
Update dependencies

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -7,9 +7,17 @@ dependencies {
         compile "com.fasterxml.jackson.core:$it"
     }
 
-    // Micrometer
+    // Micrometer and other metric-related stuff
     compile 'io.micrometer:micrometer-core'
-    compile 'io.micrometer:micrometer-registry-prometheus'
+    compile('io.micrometer:micrometer-registry-prometheus') {
+        ext.optional = true
+    }
+    compile('io.dropwizard.metrics:metrics-core') {
+        ext.optional = true
+    }
+    compile('io.prometheus:simpleclient_common') {
+        ext.optional = true
+    }
 
     // Netty
     [ 'netty-transport', 'netty-codec-http2', 'netty-resolver-dns' ].each {
@@ -19,9 +27,6 @@ dependencies {
     compile "io.netty:netty-transport-native-epoll:${managedVersions['io.netty:netty-transport-native-epoll']}:linux-x86_64"
     compile 'io.netty:netty-tcnative-boringssl-static'
     runtime 'org.javassist:javassist'
-
-    // Prometheus
-    compile 'io.prometheus:simpleclient_common'
 
     // Reactive Streams
     compile 'org.reactivestreams:reactive-streams'

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/MetricCollectingCircuitBreakerListener.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/MetricCollectingCircuitBreakerListener.java
@@ -23,7 +23,6 @@ import com.linecorp.armeria.internal.metric.MicrometerUtil;
 
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Tags;
 
 /**
  * A {@link CircuitBreakerListener} which exports the status of {@link CircuitBreaker}s to
@@ -92,7 +91,7 @@ public final class MetricCollectingCircuitBreakerListener implements CircuitBrea
     }
 
     private CircuitBreakerMetrics metricsOf(CircuitBreaker circuitBreaker) {
-        final MeterIdPrefix idPrefix = new MeterIdPrefix(name, Tags.zip("name", circuitBreaker.name()));
+        final MeterIdPrefix idPrefix = new MeterIdPrefix(name, "name", circuitBreaker.name());
         return MicrometerUtil.register(registry, idPrefix,
                                        CircuitBreakerMetrics.class,
                                        CircuitBreakerMetrics::new);

--- a/core/src/main/java/com/linecorp/armeria/common/metric/DropwizardMeterRegistries.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/DropwizardMeterRegistries.java
@@ -19,6 +19,8 @@ package com.linecorp.armeria.common.metric;
 import static java.util.Comparator.comparing;
 import static java.util.Objects.requireNonNull;
 
+import com.codahale.metrics.MetricRegistry;
+
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.config.NamingConvention;
@@ -70,7 +72,15 @@ public final class DropwizardMeterRegistries {
      * {@link HierarchicalNameMapper}.
      */
     public static DropwizardMeterRegistry newRegistry() {
-        return newRegistry(DEFAULT_NAME_MAPPER);
+        return newRegistry(new MetricRegistry(), DEFAULT_NAME_MAPPER);
+    }
+
+    /**
+     * Returns a newly-created {@link DropwizardMeterRegistry} instance with the specified
+     * {@link MetricRegistry} and the default {@link HierarchicalNameMapper}.
+     */
+    public static DropwizardMeterRegistry newRegistry(MetricRegistry registry) {
+        return newRegistry(registry, DEFAULT_NAME_MAPPER);
     }
 
     /**
@@ -78,7 +88,16 @@ public final class DropwizardMeterRegistries {
      * {@link HierarchicalNameMapper}.
      */
     public static DropwizardMeterRegistry newRegistry(HierarchicalNameMapper nameMapper) {
-        return newRegistry(nameMapper, Clock.SYSTEM);
+        return newRegistry(new MetricRegistry(), nameMapper, Clock.SYSTEM);
+    }
+
+    /**
+     * Returns a newly-created {@link DropwizardMeterRegistry} instance with the specified
+     * {@link MetricRegistry} and {@link HierarchicalNameMapper}.
+     */
+    public static DropwizardMeterRegistry newRegistry(MetricRegistry registry,
+                                                      HierarchicalNameMapper nameMapper) {
+        return newRegistry(registry, nameMapper, Clock.SYSTEM);
     }
 
     /**
@@ -86,18 +105,21 @@ public final class DropwizardMeterRegistries {
      * {@link HierarchicalNameMapper} and {@link Clock}.
      */
     public static DropwizardMeterRegistry newRegistry(HierarchicalNameMapper nameMapper, Clock clock) {
-        return newRegistry(DEFAULT_DROPWIZARD_CONFIG, nameMapper, clock);
+        return newRegistry(new MetricRegistry(), nameMapper, clock);
     }
 
     /**
      * Returns a newly-created {@link DropwizardMeterRegistry} instance with the specified
-     * {@link DropwizardConfig}, {@link HierarchicalNameMapper} and {@link Clock}.
+     * {@link MetricRegistry}, {@link HierarchicalNameMapper} and {@link Clock}.
      */
-    public static DropwizardMeterRegistry newRegistry(DropwizardConfig dropwizardConfig,
-                                                      HierarchicalNameMapper nameMapper, Clock clock) {
+    public static DropwizardMeterRegistry newRegistry(MetricRegistry registry,
+                                                      HierarchicalNameMapper nameMapper,
+                                                      Clock clock) {
         final DropwizardMeterRegistry meterRegistry = new DropwizardMeterRegistry(
-                requireNonNull(dropwizardConfig, "dropwizardConfig"),
-                requireNonNull(nameMapper, "nameMapper"), requireNonNull(clock, "clock"));
+                DEFAULT_DROPWIZARD_CONFIG,
+                requireNonNull(registry, "registry"),
+                requireNonNull(nameMapper, "nameMapper"),
+                requireNonNull(clock, "clock"));
         meterRegistry.config().namingConvention(MoreNamingConventions.dropwizard());
         meterRegistry.config().pauseDetector(new NoPauseDetector());
         return meterRegistry;

--- a/core/src/main/java/com/linecorp/armeria/common/metric/MeterIdPrefixFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/MeterIdPrefixFunction.java
@@ -96,7 +96,7 @@ public interface MeterIdPrefixFunction {
      */
     default MeterIdPrefixFunction withTags(String... keyValues) {
         requireNonNull(keyValues, "keyValues");
-        return withTags(Tags.zip(keyValues));
+        return withTags(Tags.of(keyValues));
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/metric/MoreMeters.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/MoreMeters.java
@@ -21,7 +21,6 @@ import static java.util.Objects.requireNonNull;
 import java.util.Iterator;
 import java.util.Map;
 
-import com.google.common.base.CaseFormat;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Streams;
 
@@ -98,7 +97,7 @@ public final class MoreMeters {
 
         // Append statistic.
         buf.append('#');
-        buf.append(CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_CAMEL, measurement.getStatistic().name()));
+        buf.append(measurement.getStatistic().getTagValueRepresentation());
 
         // Append tags if there are any.
         final Iterator<Tag> tagsIterator = id.getTags().iterator();

--- a/core/src/main/java/com/linecorp/armeria/common/metric/MoreNamingConventions.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/MoreNamingConventions.java
@@ -18,6 +18,8 @@ package com.linecorp.armeria.common.metric;
 
 import java.util.regex.Pattern;
 
+import javax.annotation.Nullable;
+
 import com.google.common.base.CaseFormat;
 import com.google.common.base.Splitter;
 
@@ -78,7 +80,7 @@ public final class MoreNamingConventions {
         private static final BetterPrometheusNamingConvention INSTANCE = new BetterPrometheusNamingConvention();
 
         @Override
-        public String name(String name, Type type, String baseUnit) {
+        public String name(String name, Type type, @Nullable String baseUnit) {
             final StringBuilder buf = new StringBuilder();
             for (String n : NAME_SPLITTER.split(name)) {
                 if (ALPHANUM_ONLY_PATTERN.matcher(n).matches()) {
@@ -90,7 +92,7 @@ public final class MoreNamingConventions {
             }
             buf.setLength(buf.length() - 1);
 
-            if (type == Type.Timer) {
+            if (type == Type.TIMER) {
                 baseUnit = SUFFIX_SECONDS;
             }
 
@@ -100,7 +102,7 @@ public final class MoreNamingConventions {
                 buf.append('_').append(baseUnit);
             }
 
-            if (type == Type.Counter) {
+            if (type == Type.COUNTER) {
                 if (buf.length() < SUFFIX_TOTAL.length() ||
                     !buf.substring(buf.length() - SUFFIX_TOTAL.length()).equalsIgnoreCase(SUFFIX_TOTAL)) {
                     buf.append('_').append(SUFFIX_TOTAL);

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -83,7 +83,7 @@ io.dropwizard.metrics:
   metrics-core:
     version: &DROPWIZARD_VERSION '4.0.2'
     javadocs:
-    - http://metrics.dropwizard.io/3.2.3/apidocs/
+    - http://metrics.dropwizard.io/4.0.0/apidocs/
   metrics-json: { version: *DROPWIZARD_VERSION }
 
 io.grpc:
@@ -112,17 +112,17 @@ io.grpc:
 
 io.micrometer:
   micrometer-core:
-    version: &MICROMETER_VERSION '1.0.0-rc.7'
+    version: &MICROMETER_VERSION '1.0.0-rc.9'
     javadocs:
-    - https://static.javadoc.io/io.micrometer/micrometer-core/1.0.0-rc.7/
+    - https://static.javadoc.io/io.micrometer/micrometer-core/1.0.0-rc.9/
   micrometer-registry-prometheus:
     version: *MICROMETER_VERSION
     javadocs:
-    - https://static.javadoc.io/io.micrometer/micrometer-registry-prometheus/1.0.0-rc.7/
+    - https://static.javadoc.io/io.micrometer/micrometer-registry-prometheus/1.0.0-rc.9/
   micrometer-spring-legacy:
     version: *MICROMETER_VERSION
     javadocs:
-    - https://static.javadoc.io/io.micrometer/micrometer-spring-legacy/1.0.0-rc.7/
+    - https://static.javadoc.io/io.micrometer/micrometer-spring-legacy/1.0.0-rc.9/
     exclusions:
     - org.springframework:spring-web
     - org.springframework:spring-webmvc
@@ -146,7 +146,7 @@ io.prometheus:
     - http://prometheus.github.io/client_java/
 
 io.zipkin.brave:
-  brave: { version: &BRAVE_VERSION '4.14.1' }
+  brave: { version: &BRAVE_VERSION '4.14.3' }
 
 io.zipkin.java:
   zipkin: { version: &ZIPKIN_VERSION '2.4.5' }
@@ -180,7 +180,7 @@ me.champeau.gradle:
   jmh-gradle-plugin: { version: '0.4.5' }
 
 net.javacrumbs.json-unit:
-  json-unit: { version: &JSON_UNIT_VERSION '1.28.1' }
+  json-unit: { version: &JSON_UNIT_VERSION '1.28.2' }
   json-unit-fluent: { version: *JSON_UNIT_VERSION }
 
 net.sf.proguard:
@@ -318,7 +318,7 @@ org.slf4j:
 
 org.springframework.boot:
   spring-boot-starter:
-    version: &SPRING_BOOT_VERSION '1.5.9.RELEASE'
+    version: &SPRING_BOOT_VERSION '1.5.10.RELEASE'
     javadocs:
     - https://docs.spring.io/spring/docs/current/javadoc-api/
   spring-boot-starter-test: { version: *SPRING_BOOT_VERSION }

--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcMetricsIntegrationTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcMetricsIntegrationTest.java
@@ -16,9 +16,12 @@
 
 package com.linecorp.armeria.it.grpc;
 
+import static io.micrometer.core.instrument.Statistic.COUNT;
+import static io.micrometer.core.instrument.Statistic.TOTAL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.given;
 
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.AfterClass;
@@ -39,7 +42,9 @@ import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
+import com.linecorp.armeria.common.metric.MeterIdPrefix;
 import com.linecorp.armeria.common.metric.MeterIdPrefixFunction;
+import com.linecorp.armeria.common.metric.MoreMeters;
 import com.linecorp.armeria.common.metric.PrometheusMeterRegistries;
 import com.linecorp.armeria.grpc.testing.Messages.Payload;
 import com.linecorp.armeria.grpc.testing.Messages.SimpleRequest;
@@ -53,7 +58,6 @@ import com.linecorp.armeria.testing.server.ServerRule;
 
 import io.grpc.stub.StreamObserver;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.MeterRegistry.Search;
 import io.micrometer.core.instrument.Statistic;
 
 public class GrpcMetricsIntegrationTest {
@@ -110,47 +114,42 @@ public class GrpcMetricsIntegrationTest {
 
         // Chance that get() returns NPE before the metric is first added, so ignore exceptions.
         given().ignoreExceptions().untilAsserted(() -> assertThat(
-                findServerMeter("UnaryCall", "requests", "result", "success")
-                        .value(Statistic.Count, 4).meter()).isPresent());
+                findServerMeter("UnaryCall", "requests", COUNT, "result", "success")).contains(4.0));
         given().ignoreExceptions().untilAsserted(() -> assertThat(
-                findServerMeter("UnaryCall", "requests", "result", "failure")
-                        .value(Statistic.Count, 3).meter()).isPresent());
+                findServerMeter("UnaryCall", "requests", COUNT, "result", "failure")).contains(3.0));
         given().ignoreExceptions().untilAsserted(() -> assertThat(
-                findClientMeter("UnaryCall", "requests", "result", "success")
-                        .value(Statistic.Count, 4).meter()).isPresent());
+                findClientMeter("UnaryCall", "requests", COUNT, "result", "success")).contains(4.0));
         given().ignoreExceptions().untilAsserted(() -> assertThat(
-                findClientMeter("UnaryCall", "requests", "result", "failure")
-                        .value(Statistic.Count, 3).meter()).isPresent());
+                findClientMeter("UnaryCall", "requests", COUNT, "result", "failure")).contains(3.0));
 
-        assertThat(findServerMeter("UnaryCall", "requestLength")
-                           .value(Statistic.Count, 7).meter()).isPresent();
-        assertThat(findServerMeter("UnaryCall", "requestLength")
-                           .value(Statistic.Total, 7 * 14).meter()).isPresent();
-        assertThat(findClientMeter("UnaryCall", "requestLength")
-                           .value(Statistic.Count, 7).meter()).isPresent();
-        assertThat(findClientMeter("UnaryCall", "requestLength")
-                           .value(Statistic.Total, 7 * 14).meter()).isPresent();
-        assertThat(findServerMeter("UnaryCall", "responseLength")
-                           .value(Statistic.Count, 7).meter()).isPresent();
-        assertThat(findServerMeter("UnaryCall", "responseLength")
-                           .value(Statistic.Total, 4 * 5 /* + 3 * 0 */).meter()).isPresent();
-        assertThat(findClientMeter("UnaryCall", "responseLength")
-                           .value(Statistic.Count, 7).meter()).isPresent();
-        assertThat(findClientMeter("UnaryCall", "responseLength")
-                           .value(Statistic.Total, 4 * 5 /* + 3 * 0 */).meter()).isPresent();
+        assertThat(findServerMeter("UnaryCall", "requestLength", COUNT)).contains(7.0);
+        assertThat(findServerMeter("UnaryCall", "requestLength", TOTAL)).contains(7.0 * 14);
+        assertThat(findClientMeter("UnaryCall", "requestLength", COUNT)).contains(7.0);
+        assertThat(findClientMeter("UnaryCall", "requestLength", TOTAL)).contains(7.0 * 14);
+        assertThat(findServerMeter("UnaryCall", "responseLength", COUNT)).contains(7.0);
+        assertThat(findServerMeter("UnaryCall", "responseLength", TOTAL)).contains(4.0 * 5 /* + 3 * 0 */);
+        assertThat(findClientMeter("UnaryCall", "responseLength", COUNT)).contains(7.0);
+        assertThat(findClientMeter("UnaryCall", "responseLength", TOTAL)).contains(4.0 * 5 /* + 3 * 0 */);
     }
 
-    private static Search findServerMeter(String method, String suffix, String... keyValues) {
-        return registry.find("server." + suffix)
-                       .tags("method", "armeria.grpc.testing.TestService/" + method,
-                             "pathMapping", "catch-all")
-                       .tags(keyValues);
+    private static Optional<Double> findServerMeter(
+            String method, String suffix, Statistic type, String... keyValues) {
+        final MeterIdPrefix prefix = new MeterIdPrefix(
+                "server." + suffix + '#' + type.getTagValueRepresentation(),
+                "method", "armeria.grpc.testing.TestService/" + method,
+                "hostnamePattern", "*",
+                "pathMapping", "catch-all");
+        final String meterIdStr = prefix.withTags(keyValues).toString();
+        return Optional.ofNullable(MoreMeters.measureAll(registry).get(meterIdStr));
     }
 
-    private static Search findClientMeter(String method, String suffix, String... keyValues) {
-        return registry.find("client." + suffix)
-                       .tags("method", "armeria.grpc.testing.TestService/" + method)
-                       .tags(keyValues);
+    private static Optional<Double> findClientMeter(
+            String method, String suffix, Statistic type, String... keyValues) {
+        final MeterIdPrefix prefix = new MeterIdPrefix(
+                "client." + suffix + '#' + type.getTagValueRepresentation(),
+                "method", "armeria.grpc.testing.TestService/" + method);
+        final String meterIdStr = prefix.withTags(keyValues).toString();
+        return Optional.ofNullable(MoreMeters.measureAll(registry).get(meterIdStr));
     }
 
     private static void makeRequest(String name) throws Exception {

--- a/spring-boot/autoconfigure/build.gradle
+++ b/spring-boot/autoconfigure/build.gradle
@@ -5,6 +5,7 @@ dependencies {
     compile project(':logback')
 
     compile 'io.micrometer:micrometer-spring-legacy'
+    compile 'io.micrometer:micrometer-registry-prometheus'
     compile 'io.dropwizard.metrics:metrics-json'
     compile 'javax.inject:javax.inject'
     compile 'javax.validation:validation-api'


### PR DESCRIPTION
- Prometheus and Dropwizard related dependencies are all optional now
- Micrometer 1.0.0-rc.7 -> 1.0.0-rc.9
  - Tags.zip() has been removed
  - Search.value() has been removed
  - Enum values of Statistic have been renamed
- Brave 4.14.1 -> 4.14.3
- JSON-unit 1.28.1 -> 1.28.2
- Spring Boot 1.5.9 -> 1.5.10