### PR TITLE
Allow specifying no default port when building PropertiesEndpointGroup

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
@@ -16,7 +16,10 @@
 
 package com.linecorp.armeria.client;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
+
+import javax.annotation.Nullable;
 
 import com.google.common.net.HostAndPort;
 
@@ -93,6 +96,7 @@ public final class Endpoint {
     private final String host;
     private final int port;
     private final int weight;
+    @Nullable
     private String authority;
 
     private Endpoint(String groupName) {
@@ -250,9 +254,7 @@ public final class Endpoint {
     }
 
     private static void validatePort(String name, int port) {
-        if (port <= 0 || port > 65535) {
-            throw new IllegalArgumentException(name + ": " + port + " (expected: 1-65535)");
-        }
+        checkArgument(port > 0 && port <= 65535, "%s: %s (expected: 1-65535)", name, port);
     }
 
     private static void validateWeight(int weight) {


### PR DESCRIPTION
Motivation:

A user does not always want to specify the default port number when
building a PropertiesEndpointGroup, especially for HTTP and HTTPS
endpoints that run on their default ports.

Modifications:

- Add two overloaded factory methods that do not require 'defaultPort'
- Fix off-by-one validation bug with 'defaultPort'
- Overall clean-up on Javadoc and exception messages

Result:

- A user can build PropertiesEndpointGroup without defaultPort
- Specifying 0 as defaultPort will trigger an exception at earlier point