### PR TITLE
Expose prefix-mapped THttpServices in DocService

### DIFF
--- a/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftDocServiceTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftDocServiceTest.java
@@ -95,6 +95,8 @@ public class ThriftDocServiceTest {
 
             sb.service("/", helloAndSleepService);
             sb.service("/foo", fooService);
+            // Add a service with serviceUnder() to test whether prefix mapping is detected.
+            sb.serviceUnder("/foo", fooService);
             sb.service("/cassandra", cassandraService);
             sb.service("/cassandra/debug", cassandraServiceDebug);
             sb.service("/hbase", hbaseService);
@@ -124,6 +126,7 @@ public class ThriftDocServiceTest {
                         .build(),
                 new EntryBuilder(FooService.class)
                         .endpoint(new EndpointInfo("*", "/foo", "", COMPACT, ImmutableSet.of(COMPACT)))
+                        .endpoint(new EndpointInfo("*", "/foo/", "", COMPACT, ImmutableSet.of(COMPACT)))
                         .build(),
                 new EntryBuilder(Cassandra.class)
                         .endpoint(new EndpointInfo("*", "/cassandra", "", BINARY, ImmutableSet.of(BINARY)))


### PR DESCRIPTION
Motivation:

Although it's strongly recommended to use exact path mapping when a user
binds a THttpService, a user may want to or mistakenly bind his or her
service with a prefix path mapping.

When a THttpService is bound with a prefix path mapping, a user cannot
use a debug form because ThriftDocServicePlugin expects an exact path
mapping.

Modifications:

- Make ThriftDocServicePlugin also accept a prefix path mapping.

Result:

- Less surprising