### PR TITLE
Subscribe to pooled objects for client requests.

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/HttpRequestSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpRequestSubscriber.java
@@ -44,6 +44,7 @@ import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.EventLoop;
 import io.netty.handler.codec.http2.Http2Error;
+import io.netty.util.ReferenceCountUtil;
 
 final class HttpRequestSubscriber implements Subscriber<HttpObject>, ChannelFutureListener {
 
@@ -177,6 +178,7 @@ final class HttpRequestSubscriber implements Subscriber<HttpObject>, ChannelFutu
                 break;
             }
             case DONE:
+                ReferenceCountUtil.safeRelease(o);
                 return;
         }
 

--- a/core/src/main/java/com/linecorp/armeria/client/HttpRequestSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpRequestSubscriber.java
@@ -203,12 +203,14 @@ final class HttpRequestSubscriber implements Subscriber<HttpObject>, ChannelFutu
 
     private void write(HttpObject o, boolean endOfStream, boolean flush) {
         if (state == State.DONE) {
+            ReferenceCountUtil.safeRelease(o);
             throw newIllegalStateException(
                     "a request publisher published an HttpObject after a trailing HttpHeaders: " + o);
         }
 
         final Channel ch = ctx.channel();
         if (!ch.isActive()) {
+            ReferenceCountUtil.safeRelease(o);
             fail(ClosedSessionException.get());
             return;
         }

--- a/core/src/main/java/com/linecorp/armeria/client/HttpRequestSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpRequestSubscriber.java
@@ -202,12 +202,6 @@ final class HttpRequestSubscriber implements Subscriber<HttpObject>, ChannelFutu
     }
 
     private void write(HttpObject o, boolean endOfStream, boolean flush) {
-        if (state == State.DONE) {
-            ReferenceCountUtil.safeRelease(o);
-            throw newIllegalStateException(
-                    "a request publisher published an HttpObject after a trailing HttpHeaders: " + o);
-        }
-
         final Channel ch = ctx.channel();
         if (!ch.isActive()) {
             ReferenceCountUtil.safeRelease(o);

--- a/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
@@ -136,7 +136,8 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
                 new HttpRequestSubscriber(channel, requestEncoder,
                                           numRequestsSent, req, wrappedRes, ctx,
                                           writeTimeoutMillis),
-                channel.eventLoop());
+                channel.eventLoop(),
+                true);
 
         if (numRequestsSent >= MAX_NUM_REQUESTS_SENT) {
             responseDecoder.disconnectWhenFinished();

--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
@@ -256,6 +256,7 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject>, RequestTim
 
     private void write(HttpObject o, boolean endOfStream, boolean flush) {
         if (state == State.DONE) {
+            ReferenceCountUtil.safeRelease(o);
             throw newIllegalStateException(
                     "a response publisher published an HttpObject after a trailing HttpHeaders: " + o);
         }

--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
@@ -255,12 +255,6 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject>, RequestTim
     }
 
     private void write(HttpObject o, boolean endOfStream, boolean flush) {
-        if (state == State.DONE) {
-            ReferenceCountUtil.safeRelease(o);
-            throw newIllegalStateException(
-                    "a response publisher published an HttpObject after a trailing HttpHeaders: " + o);
-        }
-
         final Channel ch = ctx.channel();
         if (endOfStream) {
             setDone();


### PR DESCRIPTION
I had originally done this for responses, but not for requests, probably assuming that requests tend to be small compared to responses. Now I'm writing an object storage client where requests are orders of magnitude larger than responses...