### PR TITLE
Allow overriding ':authority' header

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClientOptions.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientOptions.java
@@ -51,7 +51,6 @@ public final class ClientOptions extends AbstractOptions {
     @SuppressWarnings("deprecation")
     private static final Collection<AsciiString> BLACKLISTED_HEADER_NAMES =
             Collections.unmodifiableCollection(Arrays.asList(
-                    HttpHeaderNames.AUTHORITY,
                     HttpHeaderNames.CONNECTION,
                     HttpHeaderNames.HOST,
                     HttpHeaderNames.KEEP_ALIVE,


### PR DESCRIPTION
Motivation:

Some L7 reverse proxies such as Linkerd requires a user to send a
different ':authority' header than the actual host name.

Modification:

- Do not blacklist ':authority' header from ClientOptions.HTTP_HEADERS.

Result:

- Partial fix for #1014

/cc @daveconde