### PR TITLE
Set previously health-checked endpoints that don't exist anymore to f…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupMetrics.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupMetrics.java
@@ -78,9 +78,7 @@ class HealthCheckedEndpointGroupMetrics implements MeterBinder {
             healthMap.entrySet().forEach(e -> {
                 final String authority = e.getKey();
                 final Boolean healthy = endpointsToUpdate.remove(authority);
-                if (healthy != null) {
-                    e.setValue(healthy);
-                }
+                e.setValue(Boolean.TRUE.equals(healthy));
             });
 
             // Process the newly appeared endpoints.


### PR DESCRIPTION
…alse instead of remaining true.

While it might be possible to encode an enum, like `-1` indicates removed, I don't know if it's worth it. But showing a removed endpoint as healthy seems like a confusing default.