### PR TITLE
Don't notify the server listener of client closure if it will be noti…

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
@@ -336,6 +336,13 @@ class ArmeriaServerCall<I, O> extends ServerCall<I, O>
 
     @Override
     public void transportReportStatus(Status status) {
+        if (closeCalled) {
+            // We've already called close on the server-side and will close the listener with the server-side
+            // status, so we ignore client transport status's at this point (it's usually the RST_STREAM
+            // corresponding to a successful stream ending in practice, but even if it was an actual transport
+            // failure there's no need to notify the server listener of it).
+            return;
+        }
         closeListener(status);
     }
 


### PR DESCRIPTION
…fied of server closure.

Currently, in a gRPC stream where the server closes the stream before the client, the client's following `RST_STREAM` is logged as an error, even though this is a successful case. Instead, it is appropriate to ignore client events after the server has closed the stream.

Example stack trace that currently happens in this situation but shouldn't.
```
io.grpc.StatusException: CANCELLED at io.grpc.Status.asException(Status.java:534) ~[grpc-core-1.9.0.jar:1.9.0] at 
com.linecorp.armeria.server.grpc.ArmeriaServerCall.closeListener(ArmeriaServerCall.java:373) [armeria-grpc-0.58.0.jar:?] at 
com.linecorp.armeria.server.grpc.ArmeriaServerCall.transportReportStatus(ArmeriaServerCall.java:339) [armeria-grpc-0.58.0.jar:?] at 
com.linecorp.armeria.internal.grpc.HttpStreamReader.onError(HttpStreamReader.java:146) [armeria-grpc-0.58.0.jar:?] at 
com.linecorp.armeria.common.stream.AbstractStreamMessage$CloseEvent.notifySubscriber(AbstractStreamMessage.java:288) [armeria-0.58.0.jar:?] at 
com.linecorp.armeria.common.stream.DefaultStreamMessage.notifySubscriberOfCloseEvent(DefaultStreamMessage.java:191) [armeria-0.58.0.jar:?] at 
com.linecorp.armeria.common.stream.DefaultStreamMessage.handleCloseEvent(DefaultStreamMessage.java:363) [armeria-0.58.0.jar:?] at 
com.linecorp.armeria.common.stream.DefaultStreamMessage.notifySubscriber0(DefaultStreamMessage.java:306) [armeria-0.58.0.jar:?] at 
com.linecorp.armeria.common.stream.DefaultStreamMessage.notifySubscriber(DefaultStreamMessage.java:250) [armeria-0.58.0.jar:?] at 
com.linecorp.armeria.common.stream.DefaultStreamMessage.addObjectOrEvent(DefaultStreamMessage.java:236) [armeria-0.58.0.jar:?] at 
com.linecorp.armeria.common.stream.DefaultStreamMessage.close(DefaultStreamMessage.java:381) [armeria-0.58.0.jar:?] at 
com.linecorp.armeria.server.Http2RequestDecoder.onRstStreamRead(Http2RequestDecoder.java:229) [armeria-0.58.0.jar:?] at 
io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder$FrameReadListener.onRstStreamRead(DefaultHttp2ConnectionDecoder.java:354) [netty-codec-http2-4.1.21.Final.jar:4.1.21.Final] at 
io.netty.handler.codec.http2.DefaultHttp2FrameReader.readRstStreamFrame(DefaultHttp2FrameReader.java:516) [netty-codec-http2-4.1.21.Final.jar:4.1.21.Final] at 
io.netty.handler.codec.http2.DefaultHttp2FrameReader.processPayloadState(DefaultHttp2FrameReader.java:260) [netty-codec-http2-4.1.21.Final.jar:4.1.21.Final] at 
io.netty.handler.codec.http2.DefaultHttp2FrameReader.readFrame(DefaultHttp2FrameReader.java:160) [netty-codec-http2-4.1.21.Final.jar:4.1.21.Final] at 
io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder.decodeFrame(DefaultHttp2ConnectionDecoder.java:118) [netty-codec-http2-4.1.21.Final.jar:4.1.21.Final] at
 
```