### PR TITLE
Handle split headers in Http(Request|Response).aggregate()

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/HttpMessageAggregator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpMessageAggregator.java
@@ -21,6 +21,8 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
 
+import javax.annotation.Nullable;
+
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
@@ -31,6 +33,7 @@ abstract class HttpMessageAggregator implements Subscriber<HttpObject>, BiConsum
     private final CompletableFuture<AggregatedHttpMessage> future;
     private final List<HttpData> contentList = new ArrayList<>();
     private int contentLength;
+    @Nullable
     private Subscription subscription;
 
     protected HttpMessageAggregator(CompletableFuture<AggregatedHttpMessage> future) {
@@ -68,7 +71,7 @@ abstract class HttpMessageAggregator implements Subscriber<HttpObject>, BiConsum
 
     protected abstract void onHeaders(HttpHeaders headers);
 
-    private void onData(HttpData data) {
+    protected void onData(HttpData data) {
         boolean added = false;
         try {
             if (future.isDone()) {

--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequestAggregator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequestAggregator.java
@@ -31,7 +31,15 @@ final class HttpRequestAggregator extends HttpMessageAggregator {
 
     @Override
     protected void onHeaders(HttpHeaders headers) {
-        trailingHeaders = headers;
+        if (headers.isEmpty()) {
+            return;
+        }
+
+        if (trailingHeaders.isEmpty()) {
+            trailingHeaders = headers;
+        } else {
+            trailingHeaders.add(headers);
+        }
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponseAggregator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponseAggregator.java
@@ -24,11 +24,22 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
+import javax.annotation.Nullable;
+
 final class HttpResponseAggregator extends HttpMessageAggregator {
 
-    private List<HttpHeaders> informationals;
+    enum State {
+        WAIT_NON_INFORMATIONAL,
+        WAIT_CONTENT,
+        WAIT_TRAILERS
+    }
+
+    @Nullable
+    private List<HttpHeaders> informationals; // needs aggregation as well
+    @Nullable
     private HttpHeaders headers;
     private HttpHeaders trailingHeaders;
+    private State state = State.WAIT_NON_INFORMATIONAL;
 
     HttpResponseAggregator(CompletableFuture<AggregatedHttpMessage> future) {
         super(future);
@@ -36,18 +47,50 @@ final class HttpResponseAggregator extends HttpMessageAggregator {
     }
 
     @Override
+    @SuppressWarnings("checkstyle:FallThrough")
     protected void onHeaders(HttpHeaders headers) {
-        final HttpStatus status = headers.status();
-        if (status != null && status.codeClass() == HttpStatusClass.INFORMATIONAL) {
-            if (informationals == null) {
-                informationals = new ArrayList<>(2);
-            }
-            informationals.add(headers);
-        } else if (this.headers == null) {
-            this.headers = headers;
-        } else {
-            trailingHeaders = headers;
+        switch (state) {
+            case WAIT_NON_INFORMATIONAL:
+                final HttpStatus status = headers.status();
+                if (status != null && status.codeClass() != HttpStatusClass.INFORMATIONAL) {
+                    state = State.WAIT_CONTENT;
+                    // Fall through
+                } else {
+                    if (informationals == null) {
+                        informationals = new ArrayList<>(2);
+                        informationals.add(headers);
+                    } else if (status != null) {
+                        // A new informational headers
+                        informationals.add(headers);
+                    } else {
+                        // Append to the last informational headers
+                        informationals.get(informationals.size() - 1).add(headers);
+                    }
+                    break;
+                }
+            case WAIT_CONTENT:
+                if (this.headers == null) {
+                    this.headers = headers;
+                } else {
+                    this.headers.add(headers);
+                }
+                break;
+            case WAIT_TRAILERS:
+                if (!headers.isEmpty()) {
+                    if (trailingHeaders.isEmpty()) {
+                        trailingHeaders = headers;
+                    } else {
+                        trailingHeaders.add(headers);
+                    }
+                }
+                break;
         }
+    }
+
+    @Override
+    protected void onData(HttpData data) {
+        state = State.WAIT_TRAILERS;
+        super.onData(data);
     }
 
     @Override


### PR DESCRIPTION
Motivation:

Some HTTP/2 implementations can send additional headers after sending a
non-informational HEADERS frame.

HttpRequest.aggregate() and HttpResponse.aggregate() will not merge the
split headers correctly, making AggregatedHttpMessage.informationals()
contain split headers and headers() and trailingHeaders() omit some
headers.

Modifications:

- Merge the split HTTP headers correctly.

Result:

- Fixes #1014 for HttpRequest.aggregate() and HttpResponse.aggregate()