### PR TITLE
Expose netty configuration using NettyServerCustomizer and NettyClien…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/NettyServerCustomizer.java
+++ b/core/src/main/java/com/linecorp/armeria/common/NettyServerCustomizer.java
@@ -15,19 +15,15 @@
  */
 package com.linecorp.armeria.common;
 
+import java.util.function.Consumer;
+
 import io.netty.bootstrap.ServerBootstrap;
 
-public interface NettyServerCustomizer {
+public interface NettyServerCustomizer extends Consumer<ServerBootstrap>{
     NettyServerCustomizer DEFAULT = new NettyServerCustomizer() {
         @Override
-        public void afterBootstrapInitialized(ServerBootstrap bootstrap) {
-            //noop
+        public void accept(ServerBootstrap serverBootstrap) {
+            // noop
         }
     };
-
-    /**
-     * TBD
-     * @param bootstrap
-     */
-    void afterBootstrapInitialized(ServerBootstrap bootstrap);
 }

--- a/core/src/main/java/com/linecorp/armeria/common/NettyServerCustomizer.java
+++ b/core/src/main/java/com/linecorp/armeria/common/NettyServerCustomizer.java
@@ -1,0 +1,33 @@
+/*
+ *  Copyright 2017 LINE Corporation
+ *
+ *  LINE Corporation licenses this file to you under the Apache License,
+ *  version 2.0 (the "License"); you may not use this file except in compliance
+ *  with the License. You may obtain a copy of the License at:
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations
+ *  under the License.
+ */
+package com.linecorp.armeria.common;
+
+import io.netty.bootstrap.ServerBootstrap;
+
+public interface NettyServerCustomizer {
+    NettyServerCustomizer DEFAULT = new NettyServerCustomizer() {
+        @Override
+        public void afterBootstrapInitialized(ServerBootstrap bootstrap) {
+            //noop
+        }
+    };
+
+    /**
+     * TBD
+     * @param bootstrap
+     */
+    void afterBootstrapInitialized(ServerBootstrap bootstrap);
+}

--- a/core/src/main/java/com/linecorp/armeria/server/Server.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Server.java
@@ -44,6 +44,7 @@ import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableSet;
 
@@ -81,6 +82,7 @@ public final class Server implements AutoCloseable {
 
     private final ServerConfig config;
     private final DomainNameMapping<SslContext> sslContexts;
+    private ServerBootstrap serverBootstrap;
 
     private final StateManager stateManager = new StateManager();
     private final Set<Channel> serverChannels = Collections.newSetFromMap(new ConcurrentHashMap<>());
@@ -274,7 +276,9 @@ public final class Server implements AutoCloseable {
 
     private ChannelFuture start(ServerPort port) {
         final ServerBootstrap b = new ServerBootstrap();
+        serverBootstrap = b;
 
+        config.nettyCustomizer().afterBootstrapInitialized(b);
         b.group(EventLoopGroups.newEventLoopGroup(1, r -> {
             final FastThreadLocalThread thread = new FastThreadLocalThread(r, bossThreadName(port));
             thread.setDaemon(false);
@@ -344,6 +348,9 @@ public final class Server implements AutoCloseable {
     public EventLoop nextEventLoop() {
         return config().workerGroup().next();
     }
+
+    @VisibleForTesting
+    ServerBootstrap bootstrap() { return serverBootstrap; }
 
     private void stop0(CompletableFuture<Void> future) {
         assert future != null;

--- a/core/src/main/java/com/linecorp/armeria/server/Server.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Server.java
@@ -278,7 +278,7 @@ public final class Server implements AutoCloseable {
         final ServerBootstrap b = new ServerBootstrap();
         serverBootstrap = b;
 
-        config.nettyCustomizer().afterBootstrapInitialized(b);
+        config.nettyCustomizer().accept(b);
         b.group(EventLoopGroups.newEventLoopGroup(1, r -> {
             final FastThreadLocalThread thread = new FastThreadLocalThread(r, bossThreadName(port));
             thread.setDaemon(false);

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -41,6 +41,7 @@ import com.linecorp.armeria.common.CommonPools;
 import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.NettyServerCustomizer;
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.logging.RequestLog;
@@ -110,6 +111,7 @@ public final class ServerBuilder {
     private long defaultRequestTimeoutMillis = Flags.defaultRequestTimeoutMillis();
     private long defaultMaxRequestLength = Flags.defaultMaxRequestLength();
     private int maxHttp1InitialLineLength = Flags.defaultMaxHttp1InitialLineLength();
+    private NettyServerCustomizer nettyCustomizer = NettyServerCustomizer.DEFAULT;
     private int maxHttp1HeaderSize = Flags.defaultMaxHttp1HeaderSize();
     private int maxHttp1ChunkSize = Flags.defaultMaxHttp1ChunkSize();
     private Duration gracefulShutdownQuietPeriod = DEFAULT_GRACEFUL_SHUTDOWN_QUIET_PERIOD;
@@ -174,6 +176,14 @@ public final class ServerBuilder {
      */
     public ServerBuilder virtualHost(VirtualHost virtualHost) {
         virtualHosts.add(requireNonNull(virtualHost, "virtualHost"));
+        return this;
+    }
+
+    /**
+     * TBD
+     */
+    public ServerBuilder nettyCustomizer(NettyServerCustomizer nettyCustomizer) {
+        this.nettyCustomizer = requireNonNull(nettyCustomizer, "nettyCustomizer") ;
         return this;
     }
 
@@ -730,7 +740,7 @@ public final class ServerBuilder {
                 maxNumConnections, idleTimeoutMillis, defaultRequestTimeoutMillis, defaultMaxRequestLength,
                 maxHttp1InitialLineLength, maxHttp1HeaderSize, maxHttp1ChunkSize,
                 gracefulShutdownQuietPeriod, gracefulShutdownTimeout, blockingTaskExecutor,
-                meterRegistry, serviceLoggerPrefix, accessLogWriter));
+                meterRegistry, serviceLoggerPrefix, accessLogWriter, nettyCustomizer));
         serverListeners.forEach(server::addListener);
         return server;
     }

--- a/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
@@ -29,6 +29,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
+import com.linecorp.armeria.common.NettyServerCustomizer;
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.internal.ConnectionLimitingHandler;
@@ -64,6 +65,7 @@ public final class ServerConfig {
     private final int defaultMaxHttp1InitialLineLength;
     private final int defaultMaxHttp1HeaderSize;
     private final int defaultMaxHttp1ChunkSize;
+    private final NettyServerCustomizer nettyCustomizer;
 
     private final Duration gracefulShutdownQuietPeriod;
     private final Duration gracefulShutdownTimeout;
@@ -87,13 +89,14 @@ public final class ServerConfig {
             int defaultMaxHttp1InitialLineLength, int defaultMaxHttp1HeaderSize, int defaultMaxHttp1ChunkSize,
             Duration gracefulShutdownQuietPeriod, Duration gracefulShutdownTimeout,
             Executor blockingTaskExecutor, MeterRegistry meterRegistry, String serviceLoggerPrefix,
-            Consumer<RequestLog> accessLogWriter) {
+            Consumer<RequestLog> accessLogWriter, NettyServerCustomizer nettyCustomizer) {
 
         requireNonNull(ports, "ports");
         requireNonNull(defaultVirtualHost, "defaultVirtualHost");
         requireNonNull(virtualHosts, "virtualHosts");
 
         // Set the primitive properties.
+        this.nettyCustomizer = nettyCustomizer;
         this.workerGroup = requireNonNull(workerGroup, "workerGroup");
         this.shutdownWorkerGroupOnStop = shutdownWorkerGroupOnStop;
         this.maxNumConnections = validateMaxNumConnections(maxNumConnections);
@@ -272,6 +275,10 @@ public final class ServerConfig {
      */
     public VirtualHost defaultVirtualHost() {
         return defaultVirtualHost;
+    }
+
+    public NettyServerCustomizer nettyCustomizer() {
+        return nettyCustomizer;
     }
 
     /**

--- a/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
@@ -136,12 +136,7 @@ public class ServerTest {
             sb.decorator(decorator);
 
             sb.idleTimeoutMillis(idleTimeoutMillis);
-            sb.nettyCustomizer(new NettyServerCustomizer() {
-                @Override
-                public void afterBootstrapInitialized(ServerBootstrap bootstrap) {
-                    bootstrap.option(ChannelOption.SO_BACKLOG, 1024);
-                }
-            });
+            sb.nettyCustomizer(b -> b.option(ChannelOption.SO_BACKLOG, 1024));
         }
     };
 

--- a/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
@@ -16,6 +16,7 @@
 package com.linecorp.armeria.server;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import java.io.BufferedReader;
@@ -46,6 +47,7 @@ import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.NettyServerCustomizer;
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.metric.MeterIdPrefix;
 import com.linecorp.armeria.common.metric.PrometheusMeterRegistries;
@@ -57,6 +59,8 @@ import com.linecorp.armeria.testing.internal.AnticipatedException;
 import com.linecorp.armeria.testing.server.ServerRule;
 
 import io.micrometer.core.instrument.MeterRegistry;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.ChannelOption;
 import io.netty.handler.codec.http.HttpStatusClass;
 import io.netty.util.concurrent.DefaultEventExecutorGroup;
 import io.netty.util.concurrent.EventExecutorGroup;
@@ -132,6 +136,12 @@ public class ServerTest {
             sb.decorator(decorator);
 
             sb.idleTimeoutMillis(idleTimeoutMillis);
+            sb.nettyCustomizer(new NettyServerCustomizer() {
+                @Override
+                public void afterBootstrapInitialized(ServerBootstrap bootstrap) {
+                    bootstrap.option(ChannelOption.SO_BACKLOG, 1024);
+                }
+            });
         }
     };
 
@@ -164,6 +174,12 @@ public class ServerTest {
     @Test
     public void testInvocation() throws Exception {
         testInvocation0("/");
+    }
+
+    @Test
+    public void testNettyCustomizer() throws Exception {
+        final Server server = ServerTest.server.server();
+        assertEquals(1024, server.bootstrap().config().options().get(ChannelOption.SO_BACKLOG));
     }
 
     @Test


### PR DESCRIPTION
…tCustomizer

Solve https://github.com/line/armeria/issues/1009
just POC first to discuss. Wil add NettyClientCustomizer later.

Some concern:
- As @trustin said, it may make it hard to shade netty later, I'm not sure but is that user still use shaded Netty's ChannelOption to config, and the only disadvantage is that they could not share common config only?
- Added method to expose `ServerBootstrap` for testing , seems not beautiful but I could not find any other way.