### PR TITLE
Close in-progress responses when channel is closed.

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/DecodedHttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DecodedHttpResponse.java
@@ -48,8 +48,8 @@ final class DecodedHttpResponse extends DefaultHttpResponse {
     }
 
     @Override
-    public boolean write(HttpObject obj) {
-        final boolean published = super.write(obj);
+    public boolean tryWrite(HttpObject obj) {
+        final boolean published = super.tryWrite(obj);
         if (published && obj instanceof HttpData) {
             final int length = ((HttpData) obj).length();
             inboundTrafficController.inc(length);

--- a/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
@@ -184,7 +184,7 @@ abstract class HttpResponseDecoder {
         }
 
         @Override
-        public boolean write(HttpObject o) {
+        public boolean tryWrite(HttpObject o) {
             if (o instanceof HttpHeaders) {
                 // NB: It's safe to call logBuilder.start() multiple times.
                 //     See AbstractMessageLog.start() for more information.
@@ -197,12 +197,12 @@ abstract class HttpResponseDecoder {
             } else if (o instanceof HttpData) {
                 logBuilder.increaseResponseLength(((HttpData) o).length());
             }
-            return delegate.write(o);
+            return delegate.tryWrite(o);
         }
 
         @Override
-        public boolean write(Supplier<? extends HttpObject> o) {
-            return delegate.write(o);
+        public boolean tryWrite(Supplier<? extends HttpObject> o) {
+            return delegate.tryWrite(o);
         }
 
         @Override

--- a/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessageAndWriter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessageAndWriter.java
@@ -54,7 +54,7 @@ abstract class AbstractStreamMessageAndWriter<T> extends AbstractStreamMessage<T
     }
 
     @Override
-    public boolean write(T obj) {
+    public boolean tryWrite(T obj) {
         requireNonNull(obj, "obj");
         if (obj instanceof ReferenceCounted) {
             ((ReferenceCounted) obj).touch();

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamWriter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamWriter.java
@@ -37,12 +37,37 @@ public interface StreamWriter<T> {
      * Writes the specified object to the {@link StreamMessage}. The written object will be transferred to the
      * {@link Subscriber}.
      *
+     * @throws AbortedStreamException if the stream was already closed
+     * @throws IllegalArgumentException if the publication of the specified object has been rejected
+     */
+    default void write(T o) {
+        if (!tryWrite(o)) {
+            throw AbortedStreamException.get();
+        }
+    }
+
+    /**
+     * Writes the specified object {@link Supplier} to the {@link StreamMessage}. The object provided by the
+     * {@link Supplier} will be transferred to the {@link Subscriber}.
+     *
+     * @throws AbortedStreamException if the stream was already closed.
+     */
+    default void write(Supplier<? extends T> o) {
+        if (!tryWrite(o)) {
+            throw AbortedStreamException.get();
+        }
+    }
+
+    /**
+     * Writes the specified object to the {@link StreamMessage}. The written object will be transferred to the
+     * {@link Subscriber}.
+     *
      * @return {@code true} if the specified object has been scheduled for publication. {@code false} if the
      *         stream has been closed already.
      *
      * @throws IllegalArgumentException if the publication of the specified object has been rejected
      */
-    boolean write(T o);
+    boolean tryWrite(T o);
 
     /**
      * Writes the specified object {@link Supplier} to the {@link StreamMessage}. The object provided by the
@@ -51,8 +76,8 @@ public interface StreamWriter<T> {
      * @return {@code true} if the specified object has been scheduled for publication. {@code false} if the
      *         stream has been closed already.
      */
-    default boolean write(Supplier<? extends T> o) {
-        return write(o.get());
+    default boolean tryWrite(Supplier<? extends T> o) {
+        return tryWrite(o.get());
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamWriter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamWriter.java
@@ -19,6 +19,8 @@ package com.linecorp.armeria.common.stream;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
+import javax.annotation.CheckReturnValue;
+
 import org.reactivestreams.Subscriber;
 
 /**
@@ -67,6 +69,7 @@ public interface StreamWriter<T> {
      *
      * @throws IllegalArgumentException if the publication of the specified object has been rejected
      */
+    @CheckReturnValue
     boolean tryWrite(T o);
 
     /**
@@ -76,6 +79,7 @@ public interface StreamWriter<T> {
      * @return {@code true} if the specified object has been scheduled for publication. {@code false} if the
      *         stream has been closed already.
      */
+    @CheckReturnValue
     default boolean tryWrite(Supplier<? extends T> o) {
         return tryWrite(o.get());
     }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamWriter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamWriter.java
@@ -44,7 +44,7 @@ public interface StreamWriter<T> {
      */
     default void write(T o) {
         if (!tryWrite(o)) {
-            throw AbortedStreamException.get();
+            throw new IllegalStateException("stream closed");
         }
     }
 
@@ -56,7 +56,7 @@ public interface StreamWriter<T> {
      */
     default void write(Supplier<? extends T> o) {
         if (!tryWrite(o)) {
-            throw AbortedStreamException.get();
+            throw new IllegalStateException("stream closed");
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamWriter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamWriter.java
@@ -39,8 +39,8 @@ public interface StreamWriter<T> {
      * Writes the specified object to the {@link StreamMessage}. The written object will be transferred to the
      * {@link Subscriber}.
      *
-     * @throws AbortedStreamException if the stream was already closed
-     * @throws IllegalArgumentException if the publication of the specified object has been rejected
+     * @throws IllegalArgumentException if the stream was already closed or the publication of the specified
+     *         object has been rejected
      */
     default void write(T o) {
         if (!tryWrite(o)) {
@@ -52,7 +52,8 @@ public interface StreamWriter<T> {
      * Writes the specified object {@link Supplier} to the {@link StreamMessage}. The object provided by the
      * {@link Supplier} will be transferred to the {@link Subscriber}.
      *
-     * @throws AbortedStreamException if the stream was already closed.
+     * @throws IllegalArgumentException if the stream was already closed or the publication of the specified
+     *         object has been rejected
      */
     default void write(Supplier<? extends T> o) {
         if (!tryWrite(o)) {

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamWriter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamWriter.java
@@ -39,8 +39,8 @@ public interface StreamWriter<T> {
      * Writes the specified object to the {@link StreamMessage}. The written object will be transferred to the
      * {@link Subscriber}.
      *
-     * @throws IllegalArgumentException if the stream was already closed or the publication of the specified
-     *         object has been rejected
+     * @throws IllegalStateException if the stream was already closed
+     * @throws IllegalArgumentException if the publication of the specified object has been rejected
      */
     default void write(T o) {
         if (!tryWrite(o)) {
@@ -52,8 +52,7 @@ public interface StreamWriter<T> {
      * Writes the specified object {@link Supplier} to the {@link StreamMessage}. The object provided by the
      * {@link Supplier} will be transferred to the {@link Subscriber}.
      *
-     * @throws IllegalArgumentException if the stream was already closed or the publication of the specified
-     *         object has been rejected
+     * @throws IllegalStateException if the stream was already closed.
      */
     default void write(Supplier<? extends T> o) {
         if (!tryWrite(o)) {

--- a/core/src/main/java/com/linecorp/armeria/server/DecodedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DecodedHttpRequest.java
@@ -90,8 +90,8 @@ final class DecodedHttpRequest extends DefaultHttpRequest {
     }
 
     @Override
-    public boolean write(HttpObject obj) {
-        final boolean published = super.write(obj);
+    public boolean tryWrite(HttpObject obj) {
+        final boolean published = super.tryWrite(obj);
         if (published && obj instanceof HttpData) {
             final int length = ((HttpData) obj).length();
             inboundTrafficController.inc(length);

--- a/core/src/test/java/com/linecorp/armeria/common/stream/AbstractStreamMessageAndWriterTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/AbstractStreamMessageAndWriterTest.java
@@ -111,7 +111,7 @@ public abstract class AbstractStreamMessageAndWriterTest extends AbstractStreamM
         stream.close();
 
         await().untilAsserted(() -> assertThat(stream.tryWrite(buf)).isFalse());
-        assertThatThrownBy(() -> stream.write(buf)).isInstanceOf(AbortedStreamException.class);
+        assertThatThrownBy(() -> stream.write(buf)).isInstanceOf(IllegalStateException.class);
         assertThat(buf.refCnt()).isZero();
     }
 
@@ -122,7 +122,7 @@ public abstract class AbstractStreamMessageAndWriterTest extends AbstractStreamM
         stream.close();
 
         await().untilAsserted(() -> assertThat(stream.tryWrite(data)).isFalse());
-        assertThatThrownBy(() -> stream.write(data)).isInstanceOf(AbortedStreamException.class);
+        assertThatThrownBy(() -> stream.write(data)).isInstanceOf(IllegalStateException.class);
         assertThat(data.refCnt()).isZero();
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/common/stream/AbstractStreamMessageAndWriterTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/AbstractStreamMessageAndWriterTest.java
@@ -22,7 +22,6 @@ import static org.awaitility.Awaitility.await;
 
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.Executor;
 import java.util.concurrent.LinkedTransferQueue;
 import java.util.concurrent.TimeUnit;
 
@@ -39,6 +38,7 @@ import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.channel.EventLoop;
 import io.netty.util.AbstractReferenceCounted;
 import io.netty.util.ReferenceCounted;
+import io.netty.util.concurrent.EventExecutor;
 
 public abstract class AbstractStreamMessageAndWriterTest extends AbstractStreamMessageTest {
 
@@ -52,7 +52,7 @@ public abstract class AbstractStreamMessageAndWriterTest extends AbstractStreamM
     /**
      * Makes sure {@link Subscriber#onComplete()} is always invoked after
      * {@link Subscriber#onSubscribe(Subscription)} even if
-     * {@link StreamMessage#subscribe(Subscriber, Executor)}  is called from non-{@link EventLoop}.
+     * {@link StreamMessage#subscribe(Subscriber, EventExecutor)} is called from non-{@link EventLoop}.
      */
     @Test
     public void onSubscribeBeforeOnComplete() throws Exception {
@@ -110,7 +110,8 @@ public abstract class AbstractStreamMessageAndWriterTest extends AbstractStreamM
         final ByteBuf buf = PooledByteBufAllocator.DEFAULT.buffer();
         stream.close();
 
-        await().untilAsserted(() -> assertThat(stream.write(buf)).isFalse());
+        await().untilAsserted(() -> assertThat(stream.tryWrite(buf)).isFalse());
+        assertThatThrownBy(() -> stream.write(buf)).isInstanceOf(AbortedStreamException.class);
         assertThat(buf.refCnt()).isZero();
     }
 
@@ -120,7 +121,8 @@ public abstract class AbstractStreamMessageAndWriterTest extends AbstractStreamM
         final ByteBufHttpData data = new ByteBufHttpData(newPooledBuffer(), true);
         stream.close();
 
-        await().untilAsserted(() -> assertThat(stream.write(data)).isFalse());
+        await().untilAsserted(() -> assertThat(stream.tryWrite(data)).isFalse());
+        assertThatThrownBy(() -> stream.write(data)).isInstanceOf(AbortedStreamException.class);
         assertThat(data.refCnt()).isZero();
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/common/stream/AbstractStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/AbstractStreamMessageTest.java
@@ -184,7 +184,7 @@ public abstract class AbstractStreamMessageTest {
         StreamMessage<ByteBuf> stream = newStream(ImmutableList.of(buf));
 
         if (stream instanceof StreamWriter) {
-            assertThat(((StreamWriter<ByteBuf>) stream).write(buf)).isTrue();
+            ((StreamWriter<ByteBuf>) stream).write(buf);
             ((StreamWriter<?>) stream).close();
         }
         assertThat(buf.refCnt()).isEqualTo(1);
@@ -222,7 +222,7 @@ public abstract class AbstractStreamMessageTest {
         StreamMessage<ByteBufHolder> stream = newStream(ImmutableList.of(data));
 
         if (stream instanceof StreamWriter) {
-            assertThat(((StreamWriter<ByteBufHolder>) stream).write(data)).isTrue();
+            ((StreamWriter<ByteBufHolder>) stream).write(data);
             ((StreamWriter<?>) stream).close();
         }
         assertThat(data.refCnt()).isEqualTo(1);

--- a/core/src/test/java/com/linecorp/armeria/common/stream/DefaultStreamMessageVerification.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/DefaultStreamMessageVerification.java
@@ -48,7 +48,7 @@ public class DefaultStreamMessageVerification extends StreamMessageVerification<
         stream.onDemand(() -> {
             for (;;) {
                 final long r = remaining.decrementAndGet();
-                final boolean written = stream.write(elements - r);
+                final boolean written = stream.tryWrite(elements - r);
                 if (r == 0) {
                     if (abort) {
                         stream.abort();

--- a/core/src/test/java/com/linecorp/armeria/common/stream/DeferredStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/DeferredStreamMessageTest.java
@@ -65,7 +65,9 @@ public class DeferredStreamMessageTest {
     @Test
     public void testEarlyAbortWithSubscriber() throws Exception {
         final DeferredStreamMessage<Object> m = new DeferredStreamMessage<>();
-        m.subscribe(mock(Subscriber.class), ImmediateEventExecutor.INSTANCE);
+        @SuppressWarnings("unchecked")
+        Subscriber<Object> subscriber = mock(Subscriber.class);
+        m.subscribe(subscriber, ImmediateEventExecutor.INSTANCE);
         m.abort();
         assertAborted(m);
 

--- a/core/src/test/java/com/linecorp/armeria/common/stream/EventLoopStreamMessageVerification.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/EventLoopStreamMessageVerification.java
@@ -65,7 +65,7 @@ public class EventLoopStreamMessageVerification extends StreamMessageVerificatio
         stream.onDemand(() -> {
             for (;;) {
                 final long r = remaining.decrementAndGet();
-                final boolean written = stream.write(elements - r);
+                final boolean written = stream.tryWrite(elements - r);
                 if (r == 0) {
                     if (abort) {
                         stream.abort();

--- a/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageDuplicatorTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageDuplicatorTest.java
@@ -313,7 +313,7 @@ public class StreamMessageDuplicatorTest {
         for (int i = 0; i < 30; i++) {
             final ByteBuf buf = newUnpooledBuffer();
             bufs[i] = buf;
-            assertThat(publisher.write(buf)).isTrue();  // Removing internal caches happens when i = 25
+            publisher.write(buf);
             assertThat(buf.refCnt()).isOne();
         }
 

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerTest.java
@@ -943,7 +943,7 @@ public class HttpServerTest {
     }
 
     private static void stream(StreamWriter<HttpObject> writer, long size, int chunkSize) {
-        if (!writer.write(HttpData.of(new byte[chunkSize]))) {
+        if (!writer.tryWrite(HttpData.of(new byte[chunkSize]))) {
             return;
         }
 

--- a/core/src/test/java/com/linecorp/armeria/server/healthcheck/ManagedHttpHealthCheckServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/healthcheck/ManagedHttpHealthCheckServiceTest.java
@@ -45,39 +45,35 @@ public class ManagedHttpHealthCheckServiceTest {
     @Rule
     public MockitoRule rule = MockitoJUnit.rule();
 
-    private static final HttpRequestWriter HC_REQ = HttpRequest.streaming(HttpMethod.HEAD, "/");
-
-    private static final HttpRequestWriter HC_TURN_OFF_REQ = HttpRequest.streaming(HttpMethod.PUT, "/");
-    private static final HttpRequestWriter HC_TURN_ON_REQ = HttpRequest.streaming(HttpMethod.PUT, "/");
-
     @Mock
     private ServiceRequestContext context;
 
     private final ManagedHttpHealthCheckService service = new ManagedHttpHealthCheckService();
 
+    private final HttpRequest hcReq = HttpRequest.of(HttpMethod.HEAD, "/");
+
+    private final HttpRequest hcTurnOffReq =
+            HttpRequest.of(HttpMethod.PUT, "/", MediaType.PLAIN_TEXT_UTF_8, "off");
+    private final HttpRequest hcTurnOnReq =
+            HttpRequest.of(HttpMethod.PUT, "/", MediaType.PLAIN_TEXT_UTF_8, "on");
+
     @Before
     public void setUp() {
         when(context.logBuilder()).thenReturn(new DefaultRequestLog(context));
-
-        HC_TURN_OFF_REQ.write(HttpData.ofAscii("off"));
-        HC_TURN_OFF_REQ.close();
-
-        HC_TURN_ON_REQ.write(HttpData.ofAscii("on"));
-        HC_TURN_ON_REQ.close();
     }
 
     @Test
     public void turnOff() throws Exception {
         service.serverHealth.setHealthy(true);
 
-        AggregatedHttpMessage res = service.serve(context, HC_TURN_OFF_REQ).aggregate().get();
+        AggregatedHttpMessage res = service.serve(context, hcTurnOffReq).aggregate().get();
 
         assertThat(res.status(), is(HttpStatus.OK));
         assertThat(res.headers().get(AsciiString.of(HttpHeaders.CONTENT_TYPE)),
                    is(MediaType.PLAIN_TEXT_UTF_8.toString()));
         assertThat(res.content().toStringUtf8(), is("Set unhealthy."));
 
-        res = service.serve(context, HC_REQ).aggregate().get();
+        res = service.serve(context, hcReq).aggregate().get();
 
         assertThat(res.status(), is(HttpStatus.SERVICE_UNAVAILABLE));
         assertThat(res.headers().get(AsciiString.of(HttpHeaders.CONTENT_TYPE)),
@@ -86,14 +82,14 @@ public class ManagedHttpHealthCheckServiceTest {
 
     @Test
     public void turnOn() throws Exception {
-        AggregatedHttpMessage res = service.serve(context, HC_TURN_ON_REQ).aggregate().get();
+        AggregatedHttpMessage res = service.serve(context, hcTurnOnReq).aggregate().get();
 
         assertThat(res.status(), is(HttpStatus.OK));
         assertThat(res.headers().get(AsciiString.of(HttpHeaders.CONTENT_TYPE)),
                    is(MediaType.PLAIN_TEXT_UTF_8.toString()));
         assertThat(res.content().toStringUtf8(), is("Set healthy."));
 
-        res = service.serve(context, HC_REQ).aggregate().get();
+        res = service.serve(context, hcReq).aggregate().get();
 
         assertThat(res.status(), is(HttpStatus.OK));
         assertThat(res.headers().get(AsciiString.of(HttpHeaders.CONTENT_TYPE)),

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
@@ -57,7 +57,6 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
-import com.linecorp.armeria.common.stream.AbortedStreamException;
 import com.linecorp.armeria.common.util.EventLoopGroups;
 import com.linecorp.armeria.grpc.testing.Messages.EchoStatus;
 import com.linecorp.armeria.grpc.testing.Messages.Payload;
@@ -243,7 +242,7 @@ public class GrpcServiceServerTest {
                 await().until(CLIENT_CLOSED::get);
                 try {
                     responseObserver.onNext(SimpleResponse.getDefaultInstance());
-                } catch (AbortedStreamException e) {
+                } catch (IllegalStateException e) {
                     COMPLETED.set(true);
                 }
             });

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
@@ -43,6 +43,8 @@ import com.google.common.primitives.Ints;
 import com.google.protobuf.ByteString;
 
 import com.linecorp.armeria.client.ClientBuilder;
+import com.linecorp.armeria.client.ClientFactory;
+import com.linecorp.armeria.client.ClientFactoryBuilder;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.client.SimpleDecoratingClient;
@@ -55,6 +57,7 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
+import com.linecorp.armeria.common.stream.AbortedStreamException;
 import com.linecorp.armeria.common.util.EventLoopGroups;
 import com.linecorp.armeria.grpc.testing.Messages.EchoStatus;
 import com.linecorp.armeria.grpc.testing.Messages.Payload;
@@ -70,6 +73,7 @@ import com.linecorp.armeria.internal.grpc.GrpcHeaderNames;
 import com.linecorp.armeria.internal.grpc.GrpcTestUtil;
 import com.linecorp.armeria.internal.grpc.StreamRecorder;
 import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.testing.server.ServerRule;
 
 import io.grpc.Codec;
@@ -93,6 +97,10 @@ public class GrpcServiceServerTest {
 
     // Used to communicate completion to a test when it is not possible to return to the client.
     private static final AtomicReference<Boolean> COMPLETED = new AtomicReference<>();
+
+    // Used to communicate that the client has closed to allow the server to continue executing logic when
+    // required.
+    private static final AtomicReference<Boolean> CLIENT_CLOSED = new AtomicReference<>();
 
     private static class UnitTestServiceImpl extends UnitTestServiceImplBase {
 
@@ -222,9 +230,23 @@ public class GrpcServiceServerTest {
                 }
 
                 @Override
-                public void onCompleted() {
-                }
+                public void onCompleted() {}
             };
+        }
+
+        @Override
+        public void streamClientCancelsBeforeResponseClosed(SimpleRequest request,
+                                                            StreamObserver<SimpleResponse> responseObserver) {
+            responseObserver.onNext(SimpleResponse.getDefaultInstance());
+            ServiceRequestContext ctx = RequestContext.current();
+            ctx.blockingTaskExecutor().execute(() -> {
+                await().until(CLIENT_CLOSED::get);
+                try {
+                    responseObserver.onNext(SimpleResponse.getDefaultInstance());
+                } catch (AbortedStreamException e) {
+                    COMPLETED.set(true);
+                }
+            });
         }
     }
 
@@ -268,6 +290,7 @@ public class GrpcServiceServerTest {
     @Before
     public void setUp() {
         COMPLETED.set(false);
+        CLIENT_CLOSED.set(false);
         blockingClient = UnitTestServiceGrpc.newBlockingStub(channel);
         streamingClient = UnitTestServiceGrpc.newStub(channel);
 
@@ -408,13 +431,22 @@ public class GrpcServiceServerTest {
                 .isEqualTo(RESPONSE_MESSAGE);
     }
 
-    // TODO(anuraaga): Add HTTP1 version as well after https://github.com/line/armeria/issues/972
     @Test
-    public void clientSocketClosedHttp2() throws Exception {
-        ManagedChannel channel = ManagedChannelBuilder.forAddress("127.0.0.1", server.httpPort())
-                                                      .usePlaintext(true)
-                                                      .build();
-        UnitTestServiceStub stub = UnitTestServiceGrpc.newStub(channel);
+    public void clientSocketClosedBeforeHalfCloseHttp2() throws Exception {
+        clientSocketClosedBeforeHalfClose("h2c");
+    }
+
+    @Test
+    public void clientSocketClosedBeforeHalfCloseHttp1() throws Exception {
+        clientSocketClosedBeforeHalfClose("h1c");
+    }
+
+    private void clientSocketClosedBeforeHalfClose(String protocol) {
+        ClientFactory factory = new ClientFactoryBuilder().build();
+        UnitTestServiceStub stub =
+                new ClientBuilder("gproto+" + protocol + "://127.0.0.1:" + server.httpPort() + "/")
+                        .factory(factory)
+                        .build(UnitTestServiceStub.class);
         AtomicReference<SimpleResponse> response = new AtomicReference<>();
         StreamObserver<SimpleRequest> stream = stub.streamClientCancels(new StreamObserver<SimpleResponse>() {
             @Override
@@ -432,7 +464,46 @@ public class GrpcServiceServerTest {
         });
         stream.onNext(SimpleRequest.getDefaultInstance());
         await().untilAsserted(() -> assertThat(response).hasValue(SimpleResponse.getDefaultInstance()));
-        channel.shutdownNow().awaitTermination(10, TimeUnit.SECONDS);
+        factory.close();
+        await().untilAsserted(() -> assertThat(COMPLETED).hasValue(true));
+    }
+
+    @Test
+    public void clientSocketClosedAfterHalfCloseBeforeCloseHttp2() throws Exception {
+        clientSocketClosedAfterHalfCloseBeforeClose("h2c");
+    }
+
+    @Test
+    public void clientSocketClosedAfterHalfCloseBeforeCloseHttp1() throws Exception {
+        clientSocketClosedAfterHalfCloseBeforeClose("h1c");
+    }
+
+    private void clientSocketClosedAfterHalfCloseBeforeClose(String protocol) {
+        ClientFactory factory = new ClientFactoryBuilder().build();
+        UnitTestServiceStub stub =
+                new ClientBuilder("gproto+" + protocol + "://127.0.0.1:" + server.httpPort() + "/")
+                        .factory(factory)
+                        .build(UnitTestServiceStub.class);
+        AtomicReference<SimpleResponse> response = new AtomicReference<>();
+        stub.streamClientCancelsBeforeResponseClosed(
+                SimpleRequest.getDefaultInstance(),
+                new StreamObserver<SimpleResponse>() {
+                    @Override
+                    public void onNext(SimpleResponse value) {
+                        response.set(value);
+                    }
+
+                    @Override
+                    public void onError(Throwable t) {
+                    }
+
+                    @Override
+                    public void onCompleted() {
+                    }
+                });
+        await().untilAsserted(() -> assertThat(response).hasValue(SimpleResponse.getDefaultInstance()));
+        factory.close();
+        CLIENT_CLOSED.set(true);
         await().untilAsserted(() -> assertThat(COMPLETED).hasValue(true));
     }
 

--- a/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/test.proto
+++ b/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/test.proto
@@ -127,6 +127,10 @@ service UnitTestService {
 
     // A streaming RPC where the client cancels without explicitly closing the stream (e.g. socket disconnect).
     rpc StreamClientCancels(stream SimpleRequest) returns (stream SimpleResponse);
+
+    // A streaming RPC where the client half-closes but cancels without explicitly closing the stream
+    // before receiving the full response (e.g. socket disconnect).
+    rpc StreamClientCancelsBeforeResponseClosed(SimpleRequest) returns (stream SimpleResponse);
 }
 
 // A simple service NOT implemented at servers so clients can test for

--- a/jetty/src/main/java/com/linecorp/armeria/server/jetty/JettyService.java
+++ b/jetty/src/main/java/com/linecorp/armeria/server/jetty/JettyService.java
@@ -282,7 +282,7 @@ public final class JettyService implements HttpService {
             res.write(headers);
             for (;;) {
                 final HttpData data = out.poll();
-                if (data == null || !res.write(data)) {
+                if (data == null || !res.tryWrite(data)) {
                     break;
                 }
             }

--- a/tomcat/src/main/java/com/linecorp/armeria/server/tomcat/TomcatService.java
+++ b/tomcat/src/main/java/com/linecorp/armeria/server/tomcat/TomcatService.java
@@ -388,7 +388,7 @@ public final class TomcatService implements HttpService {
                         res.write(headers);
                         for (;;) {
                             final HttpData d = data.poll();
-                            if (d == null || !res.write(d)) {
+                            if (d == null || !res.tryWrite(d)) {
                                 break;
                             }
                         }


### PR DESCRIPTION
This ended up being more complicated than I expected. Please check that my understanding makes sense :)

Currently, there is no notification to response streams if the client disconnects. If the client disconnects before finishing a request, server logic will be notified in the request stream, but if it disconnects after finshing a request but before finishing a response, the server logic has no way of knowing to abort processing.

- Now, any in-progress response streams are aborted when channel is closed
- Default behavior of `StreamMessage.write` changed to throw an exception when stream is closed, which is more natural. `tryWrite` can be used when this is not desired.
- Also fix that a client close on HTTP/1 request did not notify the request stream of closure
- Fixes a test which kept a stream in a static variable and writing consecutively to it

Fixes #1028