### PR TITLE
Make sure RPC information is set to metrics for unframed requests.

### DIFF
--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcDocServicePluginTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcDocServicePluginTest.java
@@ -170,7 +170,7 @@ public class GrpcDocServicePluginTest {
                 .methods()
                 .stream()
                 .collect(toImmutableMap(MethodInfo::name, Function.identity()));
-        assertThat(functions).hasSize(7);
+        assertThat(functions).hasSize(8);
         MethodInfo emptyCall = functions.get("EmptyCall");
         assertThat(emptyCall.name()).isEqualTo("EmptyCall");
         assertThat(emptyCall.parameters())
@@ -185,6 +185,7 @@ public class GrpcDocServicePluginTest {
         // Just sanity check that all methods are present, function conversion is more thoroughly tested in
         // newMethodInfo()
         assertThat(functions.get("UnaryCall").name()).isEqualTo("UnaryCall");
+        assertThat(functions.get("UnaryCall2").name()).isEqualTo("UnaryCall2");
         assertThat(functions.get("StreamingOutputCall").name()).isEqualTo("StreamingOutputCall");
         assertThat(functions.get("StreamingInputCall").name()).isEqualTo("StreamingInputCall");
         assertThat(functions.get("FullDuplexCall").name()).isEqualTo("FullDuplexCall");

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceTest.java
@@ -121,6 +121,7 @@ public class GrpcServiceTest {
                 .containsExactlyInAnyOrder(
                         PathMapping.ofExact("/armeria.grpc.testing.TestService/EmptyCall"),
                         PathMapping.ofExact("/armeria.grpc.testing.TestService/UnaryCall"),
+                        PathMapping.ofExact("/armeria.grpc.testing.TestService/UnaryCall2"),
                         PathMapping.ofExact("/armeria.grpc.testing.TestService/StreamingOutputCall"),
                         PathMapping.ofExact("/armeria.grpc.testing.TestService/StreamingInputCall"),
                         PathMapping.ofExact("/armeria.grpc.testing.TestService/FullDuplexCall"),

--- a/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/test.proto
+++ b/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/test.proto
@@ -61,6 +61,9 @@ service TestService {
   // One request followed by one response.
   rpc UnaryCall(SimpleRequest) returns (SimpleResponse);
 
+  // Another method with one request followed by one response.
+  rpc UnaryCall2(SimpleRequest) returns (SimpleResponse);
+
   // One request followed by a sequence of responses (streamed download).
   // The server returns the payload with client desired type and sizes.
   rpc StreamingOutputCall(StreamingOutputCallRequest)


### PR DESCRIPTION
This seems a bit hacky, but couldn't think of a cleaner approach.

Fixes #1000 