### PR TITLE
[TRIVIAL] EndpointGroupTest#[disconnectZk, setNodeChild] does not throw Throwable anymore

### DIFF
--- a/zookeeper/src/test/java/com/linecorp/armeria/client/zookeeper/EndpointGroupTest.java
+++ b/zookeeper/src/test/java/com/linecorp/armeria/client/zookeeper/EndpointGroupTest.java
@@ -62,7 +62,7 @@ public class EndpointGroupTest extends TestBase implements ZooKeeperAssert, Opti
     }
 
     @After
-    public void disconnectZk() throws Throwable {
+    public void disconnectZk() {
         try {
             endpointGroup.close();
             //clear node data
@@ -157,7 +157,7 @@ public class EndpointGroupTest extends TestBase implements ZooKeeperAssert, Opti
         assertExists(zNode);
     }
 
-    private void setNodeChild(Set<Endpoint> children) throws Throwable {
+    private void setNodeChild(Set<Endpoint> children) {
         try (CloseableZooKeeper closeableZooKeeper = connection()) {
             //if the parent node dose not exist, create it
             try {


### PR DESCRIPTION
I found these [while working on #1007](https://github.com/dongjinleekr/armeria/tree/feature/issue-1007).