### PR TITLE
[TRIVIAL] Remove unused 'throws Exception's from DeferredStreamMessageTest

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/common/stream/DeferredStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/DeferredStreamMessageTest.java
@@ -38,7 +38,7 @@ import io.netty.util.concurrent.ImmediateEventExecutor;
 public class DeferredStreamMessageTest {
 
     @Test
-    public void testInitialState() throws Exception {
+    public void testInitialState() {
         final DeferredStreamMessage<Object> m = new DeferredStreamMessage<>();
         assertThat(m.isOpen()).isTrue();
         assertThat(m.isEmpty()).isFalse();
@@ -46,7 +46,7 @@ public class DeferredStreamMessageTest {
     }
 
     @Test
-    public void testSetDelegate() throws Exception {
+    public void testSetDelegate() {
         final DeferredStreamMessage<Object> m = new DeferredStreamMessage<>();
         m.delegate(new DefaultStreamMessage<>());
         assertThatThrownBy(() -> m.delegate(new DefaultStreamMessage<>()))
@@ -55,7 +55,7 @@ public class DeferredStreamMessageTest {
     }
 
     @Test
-    public void testEarlyAbort() throws Exception {
+    public void testEarlyAbort() {
         final DeferredStreamMessage<Object> m = new DeferredStreamMessage<>();
         m.abort();
         assertAborted(m);
@@ -63,7 +63,7 @@ public class DeferredStreamMessageTest {
     }
 
     @Test
-    public void testEarlyAbortWithSubscriber() throws Exception {
+    public void testEarlyAbortWithSubscriber() {
         final DeferredStreamMessage<Object> m = new DeferredStreamMessage<>();
         m.subscribe(mock(Subscriber.class), ImmediateEventExecutor.INSTANCE);
         m.abort();
@@ -75,7 +75,7 @@ public class DeferredStreamMessageTest {
     }
 
     @Test
-    public void testLateAbort() throws Exception {
+    public void testLateAbort() {
         final DeferredStreamMessage<Object> m = new DeferredStreamMessage<>();
         final DefaultStreamMessage<Object> d = new DefaultStreamMessage<>();
 
@@ -87,7 +87,7 @@ public class DeferredStreamMessageTest {
     }
 
     @Test
-    public void testLateAbortWithSubscriber() throws Exception {
+    public void testLateAbortWithSubscriber() {
         final DeferredStreamMessage<Object> m = new DeferredStreamMessage<>();
         final DefaultStreamMessage<Object> d = new DefaultStreamMessage<>();
         @SuppressWarnings("unchecked")
@@ -105,7 +105,7 @@ public class DeferredStreamMessageTest {
     }
 
     @Test
-    public void testEarlySubscription() throws Exception {
+    public void testEarlySubscription() {
         final DeferredStreamMessage<Object> m = new DeferredStreamMessage<>();
         final DefaultStreamMessage<Object> d = new DefaultStreamMessage<>();
         @SuppressWarnings("unchecked")
@@ -119,7 +119,7 @@ public class DeferredStreamMessageTest {
     }
 
     @Test
-    public void testLateSubscription() throws Exception {
+    public void testLateSubscription() {
         final DeferredStreamMessage<Object> m = new DeferredStreamMessage<>();
         final DefaultStreamMessage<Object> d = new DefaultStreamMessage<>();
 
@@ -150,7 +150,7 @@ public class DeferredStreamMessageTest {
     }
 
     @Test
-    public void testStreaming() throws Exception {
+    public void testStreaming() {
         final DeferredStreamMessage<Object> m = new DeferredStreamMessage<>();
         final DefaultStreamMessage<Object> d = new DefaultStreamMessage<>();
         m.delegate(d);


### PR DESCRIPTION
Found while working on #1003.