### PR TITLE
Better document / test reference counting of stream duplication.

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessageDuplicator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessageDuplicator.java
@@ -821,6 +821,7 @@ public abstract class AbstractStreamMessageDuplicator<T, U extends StreamMessage
             elements = new Object[16];
         }
 
+        // Steals a reference to o.
         int addAndRemoveIfRequested(Object o) {
             requireNonNull(o);
             int removedLength = 0;
@@ -836,6 +837,7 @@ public abstract class AbstractStreamMessageDuplicator<T, U extends StreamMessage
             return removedLength;
         }
 
+        // Releases references to removed elements.
         private int removeElements() {
             final int removalRequestedOffset = lastRemovalRequestedOffset;
             final int numElementsToBeRemoved = removalRequestedOffset - headOffset;
@@ -883,6 +885,7 @@ public abstract class AbstractStreamMessageDuplicator<T, U extends StreamMessage
             this.elements = a;
         }
 
+        // Steals a reference to the object.
         Object get(int offset) {
             final int head = this.head;
             final int tail = this.tail;
@@ -917,6 +920,7 @@ public abstract class AbstractStreamMessageDuplicator<T, U extends StreamMessage
             return size;
         }
 
+        // Removes references to all objects.
         void clear() {
             Object[] oldElements = elements;
             if (oldElements == null) {

--- a/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageDuplicatorTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageDuplicatorTest.java
@@ -309,6 +309,7 @@ public class StreamMessageDuplicatorTest {
         // duplicateStream() is not allowed anymore.
         assertThatThrownBy(duplicator::duplicateStream).isInstanceOf(IllegalStateException.class);
 
+        // Only used to read refCnt, not an actual reference.
         final ByteBuf[] bufs = new ByteBuf[30];
         for (int i = 0; i < 30; i++) {
             final ByteBuf buf = newUnpooledBuffer();
@@ -322,8 +323,8 @@ public class StreamMessageDuplicatorTest {
         }
         for (int i = 25; i < 30; i++) {  // rest of them are still in the queue.
             assertThat(bufs[i].refCnt()).isOne();
-            bufs[i].release();
         }
+        duplicator.close();
     }
 
     private static ByteBuf newUnpooledBuffer() {


### PR DESCRIPTION
While the queue releases references fine, it doesn't retain the first one, so it will not be able to do signal the object a second time as it has likely already been released. The unit test forgot about the reference the test itself holds to the buffers.