### PR TITLE
Update dependencies

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/Http2ResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http2ResponseDecoder.java
@@ -236,10 +236,10 @@ final class Http2ResponseDecoder extends HttpResponseDecoder implements Http2Con
                                boolean exclusive) {}
 
     @Override
-    public void onPingRead(ChannelHandlerContext ctx, ByteBuf data) {}
+    public void onPingRead(ChannelHandlerContext ctx, long data) {}
 
     @Override
-    public void onPingAckRead(ChannelHandlerContext ctx, ByteBuf data) {}
+    public void onPingAckRead(ChannelHandlerContext ctx, long data) {}
 
     @Override
     public void onGoAwayRead(ChannelHandlerContext ctx, int lastStreamId, long errorCode, ByteBuf debugData) {}

--- a/core/src/main/java/com/linecorp/armeria/common/metric/DropwizardMeterRegistries.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/DropwizardMeterRegistries.java
@@ -19,6 +19,8 @@ package com.linecorp.armeria.common.metric;
 import static java.util.Comparator.comparing;
 import static java.util.Objects.requireNonNull;
 
+import javax.annotation.Nullable;
+
 import com.codahale.metrics.MetricRegistry;
 
 import io.micrometer.core.instrument.Clock;
@@ -58,10 +60,11 @@ public final class DropwizardMeterRegistries {
     private static final DropwizardConfig DEFAULT_DROPWIZARD_CONFIG = new DropwizardConfig() {
         @Override
         public String prefix() {
-            return null;
+            return "dropwizard";
         }
 
         @Override
+        @Nullable
         public String get(String k) {
             return null;
         }
@@ -119,7 +122,14 @@ public final class DropwizardMeterRegistries {
                 DEFAULT_DROPWIZARD_CONFIG,
                 requireNonNull(registry, "registry"),
                 requireNonNull(nameMapper, "nameMapper"),
-                requireNonNull(clock, "clock"));
+                requireNonNull(clock, "clock")) {
+
+            @Override
+            protected Double nullGaugeValue() {
+                return 0.0;
+            }
+        };
+
         meterRegistry.config().namingConvention(MoreNamingConventions.dropwizard());
         meterRegistry.config().pauseDetector(new NoPauseDetector());
         return meterRegistry;

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -20,9 +20,9 @@ com.fasterxml.jackson.core:
 
 com.github.ben-manes.caffeine:
   caffeine:
-    version: '2.6.1'
+    version: '2.6.2'
     javadocs:
-    - https://static.javadoc.io/com.github.ben-manes.caffeine/caffeine/2.6.1/
+    - https://static.javadoc.io/com.github.ben-manes.caffeine/caffeine/2.6.2/
     relocations:
     - from: com.github.benmanes.caffeine
       to: com.linecorp.armeria.internal.shaded.caffeine
@@ -88,7 +88,7 @@ io.dropwizard.metrics:
 
 io.grpc:
   grpc-core:
-    version: &GRPC_VERSION '1.9.0'
+    version: &GRPC_VERSION '1.10.0'
     javadocs:
     - https://grpc.io/grpc-java/javadoc/
     - https://developers.google.com/protocol-buffers/docs/reference/java/
@@ -112,23 +112,23 @@ io.grpc:
 
 io.micrometer:
   micrometer-core:
-    version: &MICROMETER_VERSION '1.0.0'
+    version: &MICROMETER_VERSION '1.0.1'
     javadocs:
-    - https://static.javadoc.io/io.micrometer/micrometer-core/1.0.0/
+    - https://static.javadoc.io/io.micrometer/micrometer-core/1.0.1/
   micrometer-registry-prometheus:
     version: *MICROMETER_VERSION
     javadocs:
-    - https://static.javadoc.io/io.micrometer/micrometer-registry-prometheus/1.0.0/
+    - https://static.javadoc.io/io.micrometer/micrometer-registry-prometheus/1.0.1/
   micrometer-spring-legacy:
     version: *MICROMETER_VERSION
     javadocs:
-    - https://static.javadoc.io/io.micrometer/micrometer-spring-legacy/1.0.0/
+    - https://static.javadoc.io/io.micrometer/micrometer-spring-legacy/1.0.1/
     exclusions:
     - org.springframework:spring-web
     - org.springframework:spring-webmvc
 
 io.netty:
-  netty-codec-http2: { version: &NETTY_VERSION '4.1.21.Final' }
+  netty-codec-http2: { version: &NETTY_VERSION '4.1.22.Final' }
   netty-handler: { version: *NETTY_VERSION }
   netty-resolver-dns: { version: *NETTY_VERSION }
   netty-transport:
@@ -141,15 +141,15 @@ io.netty:
 
 io.prometheus:
   simpleclient_common:
-    version: '0.2.0'
+    version: '0.3.0'
     javadocs:
     - http://prometheus.github.io/client_java/
 
 io.zipkin.brave:
-  brave: { version: &BRAVE_VERSION '4.14.3' }
+  brave: { version: &BRAVE_VERSION '4.16.2' }
 
 io.zipkin.java:
-  zipkin: { version: &ZIPKIN_VERSION '2.4.5' }
+  zipkin: { version: &ZIPKIN_VERSION '2.5.0' }
 
 it.unimi.dsi:
   fastutil:
@@ -218,7 +218,7 @@ org.apache.thrift:
 
 org.apache.tomcat.embed:
   tomcat-embed-core:
-    version: &TOMCAT_VERSION '8.5.27'
+    version: &TOMCAT_VERSION '8.5.28'
     javadocs:
     - https://tomcat.apache.org/tomcat-8.5-doc/api/
   tomcat-embed-jasper: { version: *TOMCAT_VERSION }
@@ -233,13 +233,13 @@ org.apache.zookeeper:
     - org.slf4j:slf4j-log4j12
 
 org.assertj:
-  assertj-core: { version: '3.9.0' }
+  assertj-core: { version: '3.9.1' }
 
 org.awaitility:
-  awaitility: { version: '3.0.0' }
+  awaitility: { version: '3.1.0' }
 
 org.checkerframework:
-  checker-compat-qual: { version: '2.3.2' }
+  checker-compat-qual: { version: '2.4.0' }
 
 org.curioswitch.curiostack:
   protobuf-jackson: { version: '0.1.1' }
@@ -281,7 +281,7 @@ org.jctools:
       to: com.linecorp.armeria.internal.shaded.jctools
 
 org.mockito:
-  mockito-core: { version: '2.13.0' }
+  mockito-core: { version: '2.15.0' }
 
 org.mortbay.jetty.alpn:
   jetty-alpn-agent: { version: '2.0.7' }

--- a/tomcat8.0/build.gradle
+++ b/tomcat8.0/build.gradle
@@ -1,6 +1,6 @@
 dependencyManagement {
     dependencies {
-        dependencySet(group: 'org.apache.tomcat.embed', version: '8.0.49') {
+        dependencySet(group: 'org.apache.tomcat.embed', version: '8.0.50') {
             entry 'tomcat-embed-core'
             entry 'tomcat-embed-jasper'
             entry 'tomcat-embed-el'


### PR DESCRIPTION
- Awaitility 3.0.0 -> 3.1.0
- Caffeine 2.6.1 -> 2.6.2
- gRPC 1.9.0 -> 1.10.0
- Micrometer 1.0.0 -> 1.0.1
- Netty 4.1.21 -> 4.1.22
- Prometheus 0.2.0 -> 0.3.0
- Brave 4.14.3 -> 4.16.2
- Zipkin 2.4.5 -> 2.5.0
- Tomcat 8.5.27 -> 8.5.28 and 8.0.49 -> 8.0.50
- AssertJ 3.9.0 -> 3.9.1
- Mockito 2.13.0 -> 2.15.0