### PR TITLE
Cancel gRPC stream when client cancels.

### DIFF
--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
@@ -56,6 +56,7 @@ import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
 import com.linecorp.armeria.common.util.EventLoopGroups;
 import com.linecorp.armeria.grpc.testing.Messages.EchoStatus;
@@ -476,18 +477,18 @@ public class GrpcServiceServerTest {
 
     @Test
     public void clientSocketClosedAfterHalfCloseBeforeCloseHttp2() throws Exception {
-        clientSocketClosedAfterHalfCloseBeforeClose("h2c");
+        clientSocketClosedAfterHalfCloseBeforeClose(SessionProtocol.H2C);
     }
 
     @Test
     public void clientSocketClosedAfterHalfCloseBeforeCloseHttp1() throws Exception {
-        clientSocketClosedAfterHalfCloseBeforeClose("h1c");
+        clientSocketClosedAfterHalfCloseBeforeClose(SessionProtocol.H1C);
     }
 
-    private void clientSocketClosedAfterHalfCloseBeforeClose(String protocol) {
+    private void clientSocketClosedAfterHalfCloseBeforeClose(SessionProtocol protocol) {
         ClientFactory factory = new ClientFactoryBuilder().build();
         UnitTestServiceStub stub =
-                new ClientBuilder("gproto+" + protocol + "://127.0.0.1:" + server.httpPort() + "/")
+                new ClientBuilder(server.uri(protocol, GrpcSerializationFormats.PROTO, "/"))
                         .factory(factory)
                         .build(UnitTestServiceStub.class);
         AtomicReference<SimpleResponse> response = new AtomicReference<>();
@@ -515,18 +516,18 @@ public class GrpcServiceServerTest {
 
     @Test
     public void clientSocketClosedAfterHalfCloseBeforeCloseCancelsHttp2() throws Exception {
-        clientSocketClosedAfterHalfCloseBeforeCloseCancels("h2c");
+        clientSocketClosedAfterHalfCloseBeforeCloseCancels(SessionProtocol.H2C);
     }
 
     @Test
     public void clientSocketClosedAfterHalfCloseBeforeCloseCancelsHttp1() throws Exception {
-        clientSocketClosedAfterHalfCloseBeforeCloseCancels("h1c");
+        clientSocketClosedAfterHalfCloseBeforeCloseCancels(SessionProtocol.H1C);
     }
 
-    private void clientSocketClosedAfterHalfCloseBeforeCloseCancels(String protocol) {
+    private void clientSocketClosedAfterHalfCloseBeforeCloseCancels(SessionProtocol protocol) {
         ClientFactory factory = new ClientFactoryBuilder().build();
         UnitTestServiceStub stub =
-                new ClientBuilder("gproto+" + protocol + "://127.0.0.1:" + server.httpPort() + "/")
+                new ClientBuilder(server.uri(protocol, GrpcSerializationFormats.PROTO, "/"))
                         .factory(factory)
                         .build(UnitTestServiceStub.class);
         AtomicReference<SimpleResponse> response = new AtomicReference<>();

--- a/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/test.proto
+++ b/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/test.proto
@@ -134,6 +134,10 @@ service UnitTestService {
     // A streaming RPC where the client half-closes but cancels without explicitly closing the stream
     // before receiving the full response (e.g. socket disconnect).
     rpc StreamClientCancelsBeforeResponseClosed(SimpleRequest) returns (stream SimpleResponse);
+
+    // A streaming RPC where the client half-closes but cancels without explicitly closing the stream
+    // before receiving the full response (e.g. socket disconnect).
+    rpc StreamClientCancelsBeforeResponseClosedCancels(SimpleRequest) returns (stream SimpleResponse);
 }
 
 // A simple service NOT implemented at servers so clients can test for

--- a/testing/src/main/java/com/linecorp/armeria/testing/server/ServerRule.java
+++ b/testing/src/main/java/com/linecorp/armeria/testing/server/ServerRule.java
@@ -212,6 +212,28 @@ public abstract class ServerRule extends ExternalResource {
     }
 
     /**
+     * Returns the URI for the {@link Server} of the specified protocol and format.
+     *
+     * @throws IllegalStateException if the {@link Server} is not started or
+     *                               it did not open a port of the protocol.
+     */
+    public String uri(SessionProtocol protocol, SerializationFormat format, String path) {
+        // This will ensure that the server has started.
+        server();
+
+        final int port;
+        if (!protocol.isTls() && hasHttp()) {
+            port = httpPort();
+        } else if (protocol.isTls() && hasHttps()) {
+            port = httpsPort();
+        } else {
+            throw new IllegalStateException("can't find the specified port");
+        }
+
+        return format.uriText() + '+' + protocol.uriText() + "://127.0.0.1:" + port + path;
+    }
+
+    /**
      * Returns the HTTP or HTTPS URI for the {@link Server}.
      *
      * @throws IllegalStateException if the {@link Server} is not started or

--- a/testing/src/main/java/com/linecorp/armeria/testing/server/ServerRule.java
+++ b/testing/src/main/java/com/linecorp/armeria/testing/server/ServerRule.java
@@ -218,6 +218,10 @@ public abstract class ServerRule extends ExternalResource {
      *                               it did not open a port of the protocol.
      */
     public String uri(SessionProtocol protocol, SerializationFormat format, String path) {
+        requireNonNull(protocol, "protocol");
+        requireNonNull(format, "format");
+        requireNonNull(path, "path");
+
         // This will ensure that the server has started.
         server();
 


### PR DESCRIPTION
Currently, a server would know the client cancelled when they attempt to write to the closed stream. Now, they can listen for the cancellation itself.