### PR TITLE
More concise port and TLS configuration

### DIFF
--- a/benchmarks/src/jmh/java/com/linecorp/armeria/core/HttpServerBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/core/HttpServerBenchmark.java
@@ -67,7 +67,6 @@ public class HttpServerBenchmark {
     @Setup
     public void startServer() throws Exception {
         server = new ServerBuilder()
-                .port(0, HTTP)
                 .service("/empty", ((ctx, req) -> HttpResponse.of(HttpStatus.OK)))
                 .defaultRequestTimeout(Duration.ZERO)
                 .meterRegistry(NoopMeterRegistry.get())

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/grpc/downstream/DownstreamSimpleBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/grpc/downstream/DownstreamSimpleBenchmark.java
@@ -59,7 +59,6 @@ public class DownstreamSimpleBenchmark extends SimpleBenchmarkBase {
     @Override
     protected void setUp() throws Exception {
         server = new ServerBuilder()
-                .port(0, HTTP)
                 .serviceUnder("/", new GrpcServiceBuilder().addService(new GithubApiService()).build())
                 .build();
         server.start().join();

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/grpc/downstream/LargePayloadBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/grpc/downstream/LargePayloadBenchmark.java
@@ -67,7 +67,6 @@ public class LargePayloadBenchmark {
     @Setup
     public void setUp() {
         server = new ServerBuilder()
-                .port(0, HTTP)
                 .serviceUnder("/", new GrpcServiceBuilder().addService(
                         new BinaryProxyImplBase() {
                             @Override

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/thrift/PooledResponseBufferBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/thrift/PooledResponseBufferBenchmark.java
@@ -141,7 +141,6 @@ public class PooledResponseBufferBenchmark {
     @Setup
     public void startServer() throws Exception {
         ServerBuilder sb = new ServerBuilder()
-                .port(0, HTTP)
                 .service("/a", THttpService.of(
                         (AsyncIface) (name, resultHandler) ->
                                 resultHandler.onComplete(RESPONSE))

--- a/core/src/main/java/com/linecorp/armeria/server/ServerPort.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerPort.java
@@ -25,6 +25,8 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 
+import javax.annotation.Nullable;
+
 import com.linecorp.armeria.common.SessionProtocol;
 
 /**
@@ -36,6 +38,7 @@ public final class ServerPort implements Comparable<ServerPort> {
     private final String localAddressString;
     private final SessionProtocol protocol;
     private int hashCode;
+    @Nullable
     private String strVal;
 
     /**
@@ -136,7 +139,7 @@ public final class ServerPort implements Comparable<ServerPort> {
         return strVal;
     }
 
-    static String toString(Class<?> type, InetSocketAddress localAddress, SessionProtocol protocol) {
+    static String toString(@Nullable Class<?> type, InetSocketAddress localAddress, SessionProtocol protocol) {
         StringBuilder buf = new StringBuilder();
         if (type != null) {
             buf.append(type.getSimpleName());

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientIntegrationTest.java
@@ -16,7 +16,6 @@
 
 package com.linecorp.armeria.client;
 
-import static com.linecorp.armeria.common.SessionProtocol.HTTP;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
@@ -172,8 +171,6 @@ public class HttpClientIntegrationTest {
     public static final ServerRule server = new ServerRule() {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
-            sb.port(0, HTTP);
-
             sb.service("/httptestbody", new AbstractHttpService() {
 
                 @Override

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientSniTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientSniTest.java
@@ -68,16 +68,14 @@ public class HttpClientSniTest {
             sscA = new SelfSignedCertificate("a.com");
             sscB = new SelfSignedCertificate("b.com");
 
-            sb.port(0, HTTPS);
-
             final VirtualHostBuilder a = new VirtualHostBuilder("a.com");
             final VirtualHostBuilder b = new VirtualHostBuilder("b.com");
 
             a.service("/", new SniTestService("a.com"));
             b.service("/", new SniTestService("b.com"));
 
-            a.sslContext(HTTPS, sscA.certificate(), sscA.privateKey());
-            b.sslContext(HTTPS, sscB.certificate(), sscB.privateKey());
+            a.tls(sscA.certificate(), sscA.privateKey());
+            b.tls(sscB.certificate(), sscB.privateKey());
 
             sb.virtualHost(a.build());
             sb.defaultVirtualHost(b.build());

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroupTest.java
@@ -67,9 +67,9 @@ public class HttpHealthCheckedEndpointGroupTest {
 
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
-            sb.port(0, HTTP);
-            sb.port(0, HTTPS);
-            sb.sslContext(HTTPS, certificate.certificateFile(), certificate.privateKeyFile());
+            sb.http(0);
+            sb.https(0);
+            sb.tls(certificate.certificateFile(), certificate.privateKeyFile());
             sb.service(HEALTH_CHECK_PATH, new HttpHealthCheckService());
         }
     }

--- a/core/src/test/java/com/linecorp/armeria/internal/ConnectionLimitingHandlerIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/ConnectionLimitingHandlerIntegrationTest.java
@@ -16,7 +16,6 @@
 
 package com.linecorp.armeria.internal;
 
-import static org.apache.http.HttpVersion.HTTP;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
@@ -43,7 +42,6 @@ public class ConnectionLimitingHandlerIntegrationTest {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
             sb.workerGroup(EventLoopGroups.newEventLoopGroup(1), true);
-            sb.port(0, HTTP);
             sb.maxNumConnections(2);
             sb.serviceUnder("/", new AbstractHttpService() {});
         }

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerPathTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerPathTest.java
@@ -32,7 +32,6 @@ import com.google.common.io.ByteStreams;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
-import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.testing.server.ServerRule;
 
 import io.netty.util.NetUtil;
@@ -43,7 +42,6 @@ public class HttpServerPathTest {
     public static final ServerRule server = new ServerRule() {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
-            sb.port(0, SessionProtocol.HTTP);
             sb.service("/service/foo", new AbstractHttpService() {
                 @Override
                 protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) {

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerTest.java
@@ -20,8 +20,6 @@ import static com.linecorp.armeria.common.SessionProtocol.H1;
 import static com.linecorp.armeria.common.SessionProtocol.H1C;
 import static com.linecorp.armeria.common.SessionProtocol.H2;
 import static com.linecorp.armeria.common.SessionProtocol.H2C;
-import static com.linecorp.armeria.common.SessionProtocol.HTTP;
-import static com.linecorp.armeria.common.SessionProtocol.HTTPS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertNotNull;
@@ -147,11 +145,11 @@ public class HttpServerTest {
         protected void configure(ServerBuilder sb) throws Exception {
 
             sb.workerGroup(workerGroup, true);
-            sb.port(0, HTTP);
-            sb.port(0, HTTPS);
+            sb.http(0);
+            sb.https(0);
 
             SelfSignedCertificate ssc = new SelfSignedCertificate();
-            sb.sslContext(HTTPS, ssc.certificate(), ssc.privateKey());
+            sb.tls(ssc.certificate(), ssc.privateKey());
 
             sb.service("/delay/{delay}", new AbstractHttpService() {
                 @Override

--- a/core/src/test/java/com/linecorp/armeria/server/RedirectServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/RedirectServiceTest.java
@@ -64,7 +64,7 @@ public class RedirectServiceTest {
             try (ServerSocket ss = new ServerSocket(0)) {
                 final int serverRule1Port = ss.getLocalPort();
 
-                sb.port(serverRule1Port, "HTTP");
+                sb.http(serverRule1Port);
                 sb.service("/new0/branch1", SERVICE_BRANCH_1);
                 sb.service("/new0/branch2", SERVICE_BRANCH_2);
 

--- a/core/src/test/java/com/linecorp/armeria/server/SniServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/SniServerTest.java
@@ -16,7 +16,6 @@
 
 package com.linecorp.armeria.server;
 
-import static com.linecorp.armeria.common.SessionProtocol.HTTPS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.security.cert.X509Certificate;
@@ -75,15 +74,13 @@ public class SniServerTest {
             b.service("/", new SniTestService("b.com"));
             c.service("/", new SniTestService("c.com"));
 
-            a.sslContext(HTTPS, sscA.certificateFile(), sscA.privateKeyFile());
-            b.sslContext(HTTPS, sscB.certificateFile(), sscB.privateKeyFile());
-            c.sslContext(HTTPS, sscC.certificateFile(), sscC.privateKeyFile());
+            a.tls(sscA.certificateFile(), sscA.privateKeyFile());
+            b.tls(sscB.certificateFile(), sscB.privateKeyFile());
+            c.tls(sscC.certificateFile(), sscC.privateKeyFile());
 
             sb.virtualHost(a.build());
             sb.virtualHost(b.build());
             sb.defaultVirtualHost(c.build());
-
-            sb.port(0, HTTPS);
         }
     };
 

--- a/core/src/test/java/com/linecorp/armeria/server/healthcheck/HttpHealthCheckServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/healthcheck/HttpHealthCheckServiceTest.java
@@ -16,7 +16,6 @@
 
 package com.linecorp.armeria.server.healthcheck;
 
-import static com.linecorp.armeria.common.SessionProtocol.HTTP;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
@@ -115,7 +114,6 @@ public class HttpHealthCheckServiceTest {
     @Test
     public void testGet() throws Exception {
         final ServerBuilder builder = new ServerBuilder();
-        builder.port(0, HTTP);
         builder.service("/l7check", new HttpHealthCheckService());
         final Server server = builder.build();
         try {
@@ -143,7 +141,6 @@ public class HttpHealthCheckServiceTest {
     @Test
     public void testHead() throws Exception {
         final ServerBuilder builder = new ServerBuilder();
-        builder.port(0, HTTP);
         builder.service("/l7check", new HttpHealthCheckService());
         final Server server = builder.build();
         try {

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientTest.java
@@ -16,7 +16,6 @@
 
 package com.linecorp.armeria.client.grpc;
 
-import static com.linecorp.armeria.common.SessionProtocol.HTTP;
 import static com.linecorp.armeria.grpc.testing.Messages.PayloadType.COMPRESSABLE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
@@ -105,7 +104,6 @@ public class GrpcClientTest {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
             sb.workerGroup(EventLoopGroups.newEventLoopGroup(1), true);
-            sb.port(0, HTTP);
             sb.defaultMaxRequestLength(MAX_MESSAGE_SIZE);
             sb.idleTimeoutMillis(0);
 

--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcMetricsIntegrationTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcMetricsIntegrationTest.java
@@ -44,7 +44,6 @@ import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.SerializationFormat;
-import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
 import com.linecorp.armeria.common.metric.MeterIdPrefix;
 import com.linecorp.armeria.common.metric.MeterIdPrefixFunction;
@@ -95,7 +94,6 @@ public class GrpcMetricsIntegrationTest {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
             sb.meterRegistry(registry);
-            sb.port(0, SessionProtocol.HTTP);
             sb.serviceUnder("/", new GrpcServiceBuilder()
                          .addService(new TestServiceImpl())
                          .enableUnframedRequests(true)

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
@@ -16,7 +16,6 @@
 
 package com.linecorp.armeria.server.grpc;
 
-import static com.linecorp.armeria.common.SessionProtocol.HTTP;
 import static com.linecorp.armeria.internal.grpc.GrpcTestUtil.REQUEST_MESSAGE;
 import static com.linecorp.armeria.internal.grpc.GrpcTestUtil.RESPONSE_MESSAGE;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -262,7 +261,6 @@ public class GrpcServiceServerTest {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
             sb.workerGroup(EventLoopGroups.newEventLoopGroup(1), true);
-            sb.port(0, HTTP);
             sb.defaultMaxRequestLength(0);
 
             sb.serviceUnder("/", new GrpcServiceBuilder()

--- a/it/src/test/java/com/linecorp/armeria/server/grpc/interop/ArmeriaGrpcServerInteropTest.java
+++ b/it/src/test/java/com/linecorp/armeria/server/grpc/interop/ArmeriaGrpcServerInteropTest.java
@@ -31,7 +31,6 @@ import org.slf4j.bridge.SLF4JBridgeHandler;
 import com.google.common.collect.ImmutableList;
 import com.squareup.okhttp.ConnectionSpec;
 
-import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.ServerListenerAdapter;
@@ -94,8 +93,8 @@ public class ArmeriaGrpcServerInteropTest extends AbstractInteropTest {
                 }
             });
 
-            sb.port(new InetSocketAddress("127.0.0.1", 0), SessionProtocol.HTTPS);
-            sb.sslContext(newSslContext());
+            sb.https(new InetSocketAddress("127.0.0.1", 0));
+            sb.tls(newSslContext());
             sb.defaultMaxRequestLength(16 * 1024 * 1024);
             sb.serviceUnder("/", new GrpcServiceBuilder()
                     .addService(ServerInterceptors.intercept(

--- a/jetty/src/test/java/com/linecorp/armeria/server/jetty/JettyServiceTest.java
+++ b/jetty/src/test/java/com/linecorp/armeria/server/jetty/JettyServiceTest.java
@@ -42,7 +42,6 @@ import org.eclipse.jetty.webapp.WebAppContext;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.logging.LoggingService;
 import com.linecorp.armeria.testing.internal.webapp.WebAppContainerTest;
@@ -58,11 +57,10 @@ public class JettyServiceTest extends WebAppContainerTest {
     public static final ServerRule server = new ServerRule() {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
-            sb.port(0, SessionProtocol.HTTP);
-            sb.port(0, SessionProtocol.HTTPS);
-            sb.sslContext(SessionProtocol.HTTPS,
-                          certificate.certificateFile(),
-                          certificate.privateKeyFile());
+            sb.http(0);
+            sb.https(0);
+            sb.tls(certificate.certificateFile(),
+                   certificate.privateKeyFile());
 
             sb.serviceUnder(
                     "/jsp/",

--- a/jetty/src/test/java/com/linecorp/armeria/server/jetty/UnmanagedJettyServiceTest.java
+++ b/jetty/src/test/java/com/linecorp/armeria/server/jetty/UnmanagedJettyServiceTest.java
@@ -20,7 +20,6 @@ import org.eclipse.jetty.server.Server;
 import org.junit.AfterClass;
 import org.junit.ClassRule;
 
-import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.logging.LoggingService;
 import com.linecorp.armeria.testing.internal.webapp.WebAppContainerTest;
@@ -34,11 +33,10 @@ public class UnmanagedJettyServiceTest extends WebAppContainerTest {
     public static final ServerRule server = new ServerRule() {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
-            sb.port(0, SessionProtocol.HTTP);
-            sb.port(0, SessionProtocol.HTTPS);
-            sb.sslContext(SessionProtocol.HTTPS,
-                          certificate.certificateFile(),
-                          certificate.privateKeyFile());
+            sb.http(0);
+            sb.https(0);
+            sb.tls(certificate.certificateFile(),
+                   certificate.privateKeyFile());
 
             jetty = new Server(0);
             jetty.setHandler(JettyServiceTest.newWebAppContext());

--- a/site/src/sphinx/server-basics.rst
+++ b/site/src/sphinx/server-basics.rst
@@ -28,11 +28,9 @@ To serve anything, you need to specify which TCP/IP port you want to bind onto:
 
 .. code-block:: java
 
-    import static com.linecorp.armeria.common.SessionProtocol.HTTP;
-
     ServerBuilder sb = new ServerBuilder();
     // Configure an HTTP port.
-    sb.port(8080, HTTP);
+    sb.http(8080);
     // TODO: Add your services here.
     Server server = sb.build();
     CompletableFuture<Void> future = server.start();
@@ -50,7 +48,6 @@ Even if we opened a port, it's of no use if we didn't bind any services to them.
     import com.linecorp.armeria.common.HttpResponse;
     import com.linecorp.armeria.common.HttpStatus;
     import com.linecorp.armeria.common.MediaType;
-    import com.linecorp.armeria.common.SessionProtocol;
 
     import com.linecorp.armeria.server.AbstractHttpService;
     import com.linecorp.armeria.server.Server;
@@ -65,7 +62,7 @@ Even if we opened a port, it's of no use if we didn't bind any services to them.
     import com.linecorp.armeria.server.logging.LoggingService;
 
     ServerBuilder sb = new ServerBuilder();
-    sb.port(8080, HTTP);
+    sb.http(8080);
 
     // Add a simple 'Hello, world!' service.
     sb.service("/", (ctx, res) -> HttpResponse.of(
@@ -158,11 +155,9 @@ You can also add an HTTPS port with your certificate and its private key files:
 
 .. code-block:: java
 
-    import static com.linecorp.armeria.common.SessionProtocol.HTTPS;
-
     ServerBuilder sb = new ServerBuilder();
-    sb.port(8443, HTTPS)
-      .sslContext(HTTPS, new File("certificate.crt"), new File("private.key"), "myPassphrase");
+    sb.https(8443)
+      .tls(new File("certificate.crt"), new File("private.key"), "myPassphrase");
     ...
 
 Virtual hosts
@@ -179,14 +174,14 @@ Use ``ServerBuilder.withVirtualHost()`` to configure `a name-based virtual host`
     // Configure foo.com.
     sb.withVirtualHost("foo.com")
       .service(...)
-      .sslContext(...)
+      .tls(...)
       .and() // Configure *.bar.com.
       .withVirtualHost("*.bar.com")
       .service(...)
-      .sslContext(...)
+      .tls(...)
       .and() // Configure the default virtual host.
       .service(...)
-      .sslContext(...);
+      .tls(...);
     ...
 
 See also

--- a/site/src/sphinx/server-docservice.rst
+++ b/site/src/sphinx/server-docservice.rst
@@ -19,7 +19,7 @@ First, add DocService_ to the ServerBuilder_:
 .. code-block:: java
 
     ServerBuilder sb = new ServerBuilder();
-    sb.port(8080, "http");
+    sb.http(8080);
     // Add some RPC services.
     sb.service("/hello", THttpService.of(new MyHelloService());
     // Add DocService.

--- a/spring-boot/autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaAutoConfiguration.java
+++ b/spring-boot/autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaAutoConfiguration.java
@@ -57,6 +57,7 @@ import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.server.AbstractHttpService;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.ServerPort;
 import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.docs.DocServiceBuilder;
@@ -233,7 +234,7 @@ public class ArmeriaAutoConfiguration {
 
     private static void configurePorts(ArmeriaSettings armeriaSettings, ServerBuilder server) {
         if (armeriaSettings.getPorts().isEmpty()) {
-            server.port(DEFAULT_PORT.getPort(), DEFAULT_PORT.getProtocol());
+            server.port(new ServerPort(DEFAULT_PORT.getPort(), DEFAULT_PORT.getProtocol()));
             return;
         }
 
@@ -245,12 +246,12 @@ public class ArmeriaAutoConfiguration {
 
             if (ip == null) {
                 if (iface == null) {
-                    server.port(new InetSocketAddress(port), proto);
+                    server.port(new ServerPort(port, proto));
                 } else {
                     try {
                         Enumeration<InetAddress> e = NetworkInterface.getByName(iface).getInetAddresses();
                         while (e.hasMoreElements()) {
-                            server.port(new InetSocketAddress(e.nextElement(), port), proto);
+                            server.port(new ServerPort(new InetSocketAddress(e.nextElement(), port), proto));
                         }
                     } catch (SocketException e) {
                         throw new IllegalStateException("Failed to find an iface: " + iface, e);
@@ -260,7 +261,8 @@ public class ArmeriaAutoConfiguration {
                 if (NetUtil.isValidIpV4Address(ip) || NetUtil.isValidIpV6Address(ip)) {
                     final byte[] bytes = NetUtil.createByteArrayFromIpAddressString(ip);
                     try {
-                        server.port(new InetSocketAddress(InetAddress.getByAddress(bytes), port), proto);
+                        server.port(new ServerPort(new InetSocketAddress(
+                                InetAddress.getByAddress(bytes), port), proto));
                     } catch (UnknownHostException e) {
                         // Should never happen.
                         throw new Error(e);

--- a/thrift/src/test/java/com/linecorp/armeria/client/thrift/ThriftOverHttpClientTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/client/thrift/ThriftOverHttpClientTest.java
@@ -189,11 +189,11 @@ public class ThriftOverHttpClientTest {
         final ServerBuilder sb = new ServerBuilder();
 
         try {
-            sb.port(0, HTTP);
-            sb.port(0, HTTPS);
+            sb.http(0);
+            sb.https(0);
 
             ssc = new SelfSignedCertificate("127.0.0.1");
-            sb.sslContext(HTTPS, ssc.certificate(), ssc.privateKey());
+            sb.tls(ssc.certificate(), ssc.privateKey());
 
             for (Handlers h : Handlers.values()) {
                 for (SerializationFormat defaultSerializationFormat : ThriftSerializationFormats.values()) {

--- a/thrift/src/test/java/com/linecorp/armeria/server/thrift/AbstractThriftOverHttpTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/server/thrift/AbstractThriftOverHttpTest.java
@@ -98,11 +98,11 @@ public abstract class AbstractThriftOverHttpTest {
         final ServerBuilder sb = new ServerBuilder();
 
         try {
-            sb.port(0, HTTP);
-            sb.port(0, HTTPS);
+            sb.http(0);
+            sb.https(0);
 
             ssc = new SelfSignedCertificate("127.0.0.1");
-            sb.sslContext(HTTPS, ssc.certificate(), ssc.privateKey());
+            sb.tls(ssc.certificate(), ssc.privateKey());
 
             sb.service("/hello", THttpService.of(
                     (AsyncIface) (name, resultHandler) -> resultHandler.onComplete("Hello, " + name + '!')));

--- a/tomcat/src/test/java/com/linecorp/armeria/server/tomcat/TomcatServiceTest.java
+++ b/tomcat/src/test/java/com/linecorp/armeria/server/tomcat/TomcatServiceTest.java
@@ -30,7 +30,6 @@ import org.apache.http.impl.client.HttpClients;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.logging.LoggingService;
 import com.linecorp.armeria.testing.internal.webapp.WebAppContainerTest;
@@ -49,11 +48,10 @@ public class TomcatServiceTest extends WebAppContainerTest {
     public static final ServerRule server = new ServerRule() {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
-            sb.port(0, SessionProtocol.HTTP);
-            sb.port(0, SessionProtocol.HTTPS);
-            sb.sslContext(SessionProtocol.HTTPS,
-                          certificate.certificateFile(),
-                          certificate.privateKeyFile());
+            sb.http(0);
+            sb.https(0);
+            sb.tls(certificate.certificateFile(),
+                   certificate.privateKeyFile());
 
             sb.serviceUnder(
                     "/jsp/",

--- a/zookeeper/src/test/java/com/linecorp/armeria/server/zookeeper/ZooKeeperRegistrationTest.java
+++ b/zookeeper/src/test/java/com/linecorp/armeria/server/zookeeper/ZooKeeperRegistrationTest.java
@@ -36,7 +36,6 @@ import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
-import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.util.CompletionActions;
 import com.linecorp.armeria.common.zookeeper.NodeValueCodec;
 import com.linecorp.armeria.server.AbstractHttpService;
@@ -61,7 +60,7 @@ public class ZooKeeperRegistrationTest extends TestBase implements ZooKeeperAsse
         listeners = new ArrayList<>();
 
         for (Endpoint endpoint : sampleEndpoints) {
-            Server server = new ServerBuilder().port(endpoint.port(), SessionProtocol.HTTP)
+            Server server = new ServerBuilder().http(endpoint.port())
                                                .service("/", new EchoService())
                                                .build();
             ZooKeeperUpdatingListener listener;


### PR DESCRIPTION
Motivation:

- A user currently has to specify SessionProtocol when adding a port,
  which increases the chance of specifying incorrect SessionProtocol.
- sslContext() builder methods require SessionProtocol which is
  practically unncessary.
- It would be confusing if Server serves plaintext HTTP when a user
  configured TLS even if he or she did not specify a port. More sensible
  behavior would be serving HTTPS when no port is specified in this case.

Modifications:

- Add http() and https() which supercede most port() methods.
- Add tls() which supercede sslContext() methods.
- Serve HTTPS by default when a user called tls() and no port was
  specified.
- Add log messages that indicates the protocol and local address.
- Deprecate the old methods.
- Update documentation.
- Miscellaneous:
  - Remove redundant `port(0, HTTP)` calls
  - Add `@Nullable` where necessary

Result:

- Fixes #1050
- More user-friendliness
