### PR TITLE
Fix typo in `logback.xml` example

### DIFF
--- a/site/src/sphinx/server-access-log.rst
+++ b/site/src/sphinx/server-access-log.rst
@@ -27,7 +27,7 @@ logback
 
       <appender name="ACCESS" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>access.log</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
           <!-- daily rollover -->
           <fileNamePattern>access.%d{yyyy-MM-dd}-%i.log</fileNamePattern>
           <!-- each file should be at most 1GB, keep 30 days worth of history, but at most 30GB -->


### PR DESCRIPTION
In the `logback.xml` example, `SizeAndTimeBasedRollingPolicy` must be used because:
- `maxFileSize` element is specified.
- `%i` is used in the `fileNamePattern`.

