### PR TITLE
Fix to retry for HttpStatusBasedRetryStrategy when it gets exceptions…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryStrategy.java
@@ -17,9 +17,10 @@ package com.linecorp.armeria.client.retry;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Function;
+import java.util.function.BiFunction;
+
+import javax.annotation.Nullable;
 
 import com.linecorp.armeria.client.ResponseTimeoutException;
 import com.linecorp.armeria.common.Flags;
@@ -44,17 +45,12 @@ public interface RetryStrategy<I extends Request, O extends Response> {
      * A {@link RetryStrategy} that defines a retry should not be performed.
      */
     static <I extends Request, O extends Response> RetryStrategy<I, O> never() {
-        return new RetryStrategy<I, O>() {
-            @Override
-            public CompletableFuture<Optional<Backoff>> shouldRetry(I request, O response) {
-                return CompletableFuture.completedFuture(Optional.empty());
-            }
-        };
+        return (request, response) -> CompletableFuture.completedFuture(null);
     }
 
     /**
      * Returns the {@link RetryStrategy} that retries the request with the {@link #defaultBackoff}
-     * when the response matches {@link HttpStatusClass#SERVER_ERROR}.
+     * when the response matches {@link HttpStatusClass#SERVER_ERROR} or an {@link Exception} is raised.
      */
     static RetryStrategy<HttpRequest, HttpResponse> onServerErrorStatus() {
         return onServerErrorStatus(defaultBackoff);
@@ -62,33 +58,40 @@ public interface RetryStrategy<I extends Request, O extends Response> {
 
     /**
      * Returns the {@link RetryStrategy} that retries the request with the specified {@code backoff}
-     * when the response matches {@link HttpStatusClass#SERVER_ERROR}.
+     * when the response matches {@link HttpStatusClass#SERVER_ERROR} or an {@link Exception} is raised.
      */
     static RetryStrategy<HttpRequest, HttpResponse> onServerErrorStatus(Backoff backoff) {
         requireNonNull(backoff, "backoff");
-        return onStatus(status -> status.codeClass() == HttpStatusClass.SERVER_ERROR ? Optional.of(backoff)
-                                                                                     : Optional.empty());
+        return onStatus((status, thrown) -> {
+            if (thrown != null || (status != null && status.codeClass() == HttpStatusClass.SERVER_ERROR)) {
+                return backoff;
+            }
+            return null;
+        });
     }
 
     /**
-     * Returns the {@link RetryStrategy} that decides to retry the request using
-     * {@code statusBasedBackoffFunction}.
+     * Returns the {@link RetryStrategy} that decides to retry the request using the specified
+     * {@code backoffFunction}.
      *
-     * @param statusBasedBackoffFunction the {@link Function} that returns {@code Optional<Backoff>} according
-     *                                   to the {@link HttpStatus}
+     * @param backoffFunction the {@link BiFunction} that returns the {@link Backoff} or {@code null}
+     *                        according to the {@link HttpStatus} and {@link Throwable}
      */
     static RetryStrategy<HttpRequest, HttpResponse> onStatus(
-            Function<HttpStatus, Optional<Backoff>> statusBasedBackoffFunction) {
-        return new HttpStatusBasedRetryStrategy(statusBasedBackoffFunction);
+            BiFunction<HttpStatus, Throwable, Backoff> backoffFunction) {
+        return new HttpStatusBasedRetryStrategy(backoffFunction);
     }
 
     /**
-     * Returns {@link CompletableFuture} with {@link Optional} that contains {@link Backoff} which will be
-     * used for retry. If the condition does not match, this needs to return {@link Optional#empty()}
-     * to stop retry attempt. Note that {@link ResponseTimeoutException} is not retriable for
-     * the whole retry, but each attempt.
+     * Returns a {@link CompletableFuture} that contains {@link Backoff} which will be used for retry.
+     * If the condition does not match, this will return {@code null} to stop retry attempt.
+     * Note that {@link ResponseTimeoutException} is not retriable for the whole retry, but each attempt.
      *
      * @see RetryingClientBuilder#responseTimeoutMillisForEachAttempt(long)
+     *
+     * @see <a href="https://line.github.io/armeria/advanced-retry.html#per-attempt-timeout">Per-attempt
+     *      timeout</a>
      */
-    CompletableFuture<Optional<Backoff>> shouldRetry(I request, O response);
+    @Nullable
+    CompletableFuture<Backoff> shouldRetry(I request, O response);
 }

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClientBuilder.java
@@ -78,6 +78,9 @@ public abstract class RetryingClientBuilder<
      * dose not specify.
      *
      * @return {@link T} to support method chaining.
+     *
+     * @see <a href="https://line.github.io/armeria/advanced-retry.html#per-attempt-timeout">Per-attempt
+     *      timeout</a>
      */
     public T responseTimeoutMillisForEachAttempt(long responseTimeoutMillisForEachAttempt) {
         checkArgument(responseTimeoutMillisForEachAttempt >= 0,
@@ -92,6 +95,9 @@ public abstract class RetryingClientBuilder<
      * corresponding responses are timed out by this value. {@code 0} disables the timeout.
      *
      * @return {@link T} to support method chaining.
+     *
+     * @see <a href="https://line.github.io/armeria/advanced-retry.html#per-attempt-timeout">Per-attempt
+     *      timeout</a>
      */
     public T responseTimeoutForEachAttempt(Duration responseTimeoutForEachAttempt) {
         checkArgument(

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingHttpClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingHttpClientBuilder.java
@@ -30,7 +30,7 @@ import com.linecorp.armeria.common.HttpResponse;
 public class RetryingHttpClientBuilder extends RetryingClientBuilder<
         RetryingHttpClientBuilder, RetryingHttpClient, HttpRequest, HttpResponse> {
 
-    private static final int DEFAULT_CONTENT_PREVIEW_LENGTH = 1024 * 1024; // 1 MiB
+    private static final int DEFAULT_CONTENT_PREVIEW_LENGTH = 0; // no preview (0 byte)
 
     private boolean useRetryAfter;
 
@@ -61,7 +61,9 @@ public class RetryingHttpClientBuilder extends RetryingClientBuilder<
     /**
      * Sets the length of content to look up whether retry or not. If the total length of content exceeds
      * this and there's no retry condition matched, it will hand over the stream to the client.
-     * @param contentPreviewLength the content length to preview. {@code 0} disables the length limit
+     * @param contentPreviewLength the content length to preview. Unlike other length related arguments,
+     *                             {@code 0} does not disable the length limit. It means that it will not
+     *                             look up the content
      * @return {@link RetryingHttpClientBuilder} to support method chaining
      */
     public RetryingHttpClientBuilder contentPreviewLength(int contentPreviewLength) {

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClient.java
@@ -96,11 +96,11 @@ public final class RetryingRpcClient extends RetryingClient<RpcRequest, RpcRespo
 
         final RpcResponse response = getResponse(ctx, req);
 
-        retryStrategy().shouldRetry(req, response).handle(voidFunction((backoffOpt, unused) -> {
-            if (backoffOpt.isPresent()) {
+        retryStrategy().shouldRetry(req, response).handle(voidFunction((backoff, unused) -> {
+            if (backoff != null) {
                 long nextDelay;
                 try {
-                    nextDelay = getNextDelay(ctx, backoffOpt.get());
+                    nextDelay = getNextDelay(ctx, backoff);
                 } catch (Exception e) {
                     completeOnException(ctx, responseFuture, e);
                     return;

--- a/core/src/main/java/com/linecorp/armeria/internal/HttpHeaderSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/HttpHeaderSubscriber.java
@@ -26,17 +26,18 @@ import javax.annotation.Nullable;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
-import com.linecorp.armeria.common.AggregatedHttpMessage;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpObject;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.HttpStatusClass;
+import com.linecorp.armeria.common.stream.AbortedStreamException;
+import com.linecorp.armeria.common.stream.CancelledSubscriptionException;
 
 /**
- * A {@link Subscriber} that subscribes until it receives {@link HttpHeaders} and then returns a
- * {@link CompletableFuture} that contains {@link AggregatedHttpMessage}. The message contains
- * {@link HttpHeaders} and {@code informationalHeaders}. If this class can not subscribe the
- * {@link HttpHeaders}, it will return {@link AggregatedHttpMessage} with {@link HttpHeaders#EMPTY_HEADERS}.
+ * A {@link Subscriber} that completes the {@link CompletableFuture} which has taken as the argument in the
+ * constructor with {@link HttpHeaders}. The {@link HttpHeaders} contains a status that is not informational.
+ * If subscription is finished before subscribing a status, this will complete the future with
+ * the {@link HttpHeaders#EMPTY_HEADERS}.
  */
 public final class HttpHeaderSubscriber
         implements Subscriber<HttpObject>, BiConsumer<Void, Throwable> {
@@ -80,7 +81,12 @@ public final class HttpHeaderSubscriber
     public void onComplete() {}
 
     @Override
-    public void accept(Void aVoid, Throwable throwable) {
-        future.complete(firstNonNull(headers, HttpHeaders.EMPTY_HEADERS));
+    public void accept(Void aVoid, Throwable thrown) {
+        if (thrown != null && !(thrown instanceof CancelledSubscriptionException) &&
+            !(thrown instanceof AbortedStreamException)) {
+            future.completeExceptionally(thrown);
+        } else {
+            future.complete(firstNonNull(headers, HttpHeaders.EMPTY_HEADERS));
+        }
     }
 }

--- a/thrift/src/test/java/com/linecorp/armeria/it/client/retry/RetryingRpcClientTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/client/retry/RetryingRpcClientTest.java
@@ -27,7 +27,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import org.junit.Rule;
@@ -50,21 +49,21 @@ import com.linecorp.armeria.testing.server.ServerRule;
 public class RetryingRpcClientTest {
     private static final RetryStrategy<RpcRequest, RpcResponse> ALWAYS =
             (request, response) -> {
-                final CompletableFuture<Optional<Backoff>> future = new CompletableFuture<>();
+                final CompletableFuture<Backoff> future = new CompletableFuture<>();
                 response.handle(voidFunction((unused1, unused2) -> {
-                    future.complete(Optional.of(Backoff.withoutDelay()));
+                    future.complete(Backoff.withoutDelay());
                 }));
                 return future;
             };
 
     private static final RetryStrategy<RpcRequest, RpcResponse> ONLY_HANDLES_EXCEPTION =
         (request, response) -> {
-            final CompletableFuture<Optional<Backoff>> future = new CompletableFuture<>();
+            final CompletableFuture<Backoff> future = new CompletableFuture<>();
             response.handle(voidFunction((unused1, cause) -> {
                 if (cause != null) {
-                    future.complete(Optional.of(Backoff.withoutDelay()));
+                    future.complete(Backoff.withoutDelay());
                 } else {
-                    future.complete(Optional.empty());
+                    future.complete(null);
                 }
             }));
             return future;


### PR DESCRIPTION
… while processing response

Motivation:
Currently, `HttpStatusBasedRetryStrategy` ignores exceptions in the result.
It is common to have exceptions like `ClosedSessionException`, which should be retried
since they can be random socket closures, so it seems like a bad default to ignore
the exceptions.

Modifications:
- Change to retry on any `Exception`
- Change not to look up the response contents to retry by default
- Return `Backoff` instead of `Optional<Backoff>` in`RetryStrategy.shouldRetry()` 

Result:
- Retry on any exception

To-do:
- Provide knobs for the RetryStrategy