### PR TITLE
Fix IntelliJ inspection warnings about nullness

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
@@ -18,6 +18,8 @@ package com.linecorp.armeria.client;
 
 import java.time.Duration;
 
+import javax.annotation.Nullable;
+
 import com.linecorp.armeria.common.ContentTooLargeException;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpRequest;
@@ -61,8 +63,9 @@ public interface ClientRequestContext extends RequestContext {
      * Returns the fragment part of the URI of the current {@link Request}, as defined in
      * <a href="https://tools.ietf.org/html/rfc3986#section-3.5">the section 3.5 of RFC3986</a>.
      *
-     * @return the fragment part of the request URI, or an empty string if no fragment was specified
+     * @return the fragment part of the request URI, or {@code null} if no fragment was specified
      */
+    @Nullable
     String fragment();
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/DecodedHttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DecodedHttpResponse.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.client;
 
+import javax.annotation.Nullable;
+
 import com.linecorp.armeria.common.DefaultHttpResponse;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpObject;
@@ -27,6 +29,7 @@ import io.netty.util.concurrent.EventExecutor;
 final class DecodedHttpResponse extends DefaultHttpResponse {
 
     private final EventLoop eventLoop;
+    @Nullable
     private InboundTrafficController inboundTrafficController;
     private long writtenBytes;
 
@@ -52,6 +55,7 @@ final class DecodedHttpResponse extends DefaultHttpResponse {
         final boolean published = super.tryWrite(obj);
         if (published && obj instanceof HttpData) {
             final int length = ((HttpData) obj).length();
+            assert inboundTrafficController != null;
             inboundTrafficController.inc(length);
             writtenBytes += length;
         }
@@ -62,6 +66,7 @@ final class DecodedHttpResponse extends DefaultHttpResponse {
     protected void onRemoval(HttpObject obj) {
         if (obj instanceof HttpData) {
             final int length = ((HttpData) obj).length();
+            assert inboundTrafficController != null;
             inboundTrafficController.dec(length);
         }
     }

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -52,6 +52,7 @@ public class DefaultClientRequestContext extends NonWrappingRequestContext imple
     private final EventLoop eventLoop;
     private final ClientOptions options;
     private final Endpoint endpoint;
+    @Nullable
     private final String fragment;
 
     private final DefaultRequestLog log;
@@ -60,6 +61,7 @@ public class DefaultClientRequestContext extends NonWrappingRequestContext imple
     private long responseTimeoutMillis;
     private long maxResponseLength;
 
+    @Nullable
     private String strVal;
 
     /**
@@ -110,10 +112,10 @@ public class DefaultClientRequestContext extends NonWrappingRequestContext imple
     private DefaultClientRequestContext(DefaultClientRequestContext ctx, Request request) {
         super(ctx.meterRegistry(), ctx.sessionProtocol(), ctx.method(), ctx.path(), ctx.query(), request);
 
-        this.eventLoop = ctx.eventLoop();
-        this.options = ctx.options();
-        this.endpoint = ctx.endpoint();
-        this.fragment = ctx.fragment();
+        eventLoop = ctx.eventLoop();
+        options = ctx.options();
+        endpoint = ctx.endpoint();
+        fragment = ctx.fragment();
 
         log = new DefaultRequestLog(this);
 
@@ -121,7 +123,7 @@ public class DefaultClientRequestContext extends NonWrappingRequestContext imple
         responseTimeoutMillis = ctx.responseTimeoutMillis();
         maxResponseLength = ctx.maxResponseLength();
 
-        for (Iterator<Attribute<?>> i = ctx.attrs(); i.hasNext();) {
+        for (final Iterator<Attribute<?>> i = ctx.attrs(); i.hasNext();) {
             addAttr(i.next());
         }
         runThreadLocalContextCustomizer();
@@ -144,6 +146,7 @@ public class DefaultClientRequestContext extends NonWrappingRequestContext imple
     }
 
     @Override
+    @Nullable
     protected Channel channel() {
         if (log.isAvailable(RequestLogAvailability.REQUEST_START)) {
             return log.channel();

--- a/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
@@ -92,7 +92,9 @@ public final class Endpoint {
         return new Endpoint(host, port, weight);
     }
 
+    @Nullable
     private final String groupName;
+    @Nullable
     private final String host;
     private final int port;
     private final int weight;

--- a/core/src/main/java/com/linecorp/armeria/client/Http1ResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http1ResponseDecoder.java
@@ -66,7 +66,7 @@ final class Http1ResponseDecoder extends HttpResponseDecoder implements ChannelI
 
     @Override
     HttpResponseWrapper addResponse(
-            int id, HttpRequest req, DecodedHttpResponse res, RequestLogBuilder logBuilder,
+            int id, @Nullable HttpRequest req, DecodedHttpResponse res, RequestLogBuilder logBuilder,
             long responseTimeoutMillis, long maxContentLength) {
 
         final HttpResponseWrapper resWrapper =
@@ -177,6 +177,7 @@ final class Http1ResponseDecoder extends HttpResponseDecoder implements ChannelI
                         final ByteBuf data = content.content();
                         final int dataLength = data.readableBytes();
                         if (dataLength > 0) {
+                            assert res != null;
                             final long maxContentLength = res.maxContentLength();
                             if (maxContentLength > 0 && res.writtenBytes() > maxContentLength - dataLength) {
                                 fail(ctx, ContentTooLargeException.get());
@@ -188,6 +189,7 @@ final class Http1ResponseDecoder extends HttpResponseDecoder implements ChannelI
 
                         if (msg instanceof LastHttpContent) {
                             final HttpResponseWrapper res = removeResponse(resId++);
+                            assert res != null;
                             assert this.res == res;
                             this.res = null;
 

--- a/core/src/main/java/com/linecorp/armeria/client/Http2ResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http2ResponseDecoder.java
@@ -20,6 +20,8 @@ import static io.netty.handler.codec.http2.Http2Error.INTERNAL_ERROR;
 import static io.netty.handler.codec.http2.Http2Error.PROTOCOL_ERROR;
 import static io.netty.handler.codec.http2.Http2Exception.connectionError;
 
+import javax.annotation.Nullable;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,7 +62,7 @@ final class Http2ResponseDecoder extends HttpResponseDecoder implements Http2Con
 
     @Override
     HttpResponseWrapper addResponse(
-            int id, HttpRequest req, DecodedHttpResponse res, RequestLogBuilder logBuilder,
+            int id, @Nullable HttpRequest req, DecodedHttpResponse res, RequestLogBuilder logBuilder,
             long responseTimeoutMillis, long maxContentLength) {
 
         final HttpResponseWrapper resWrapper =
@@ -129,7 +131,7 @@ final class Http2ResponseDecoder extends HttpResponseDecoder implements Http2Con
     @Override
     public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers, int padding,
                               boolean endOfStream) throws Http2Exception {
-        HttpResponseWrapper res = getResponse(streamIdToId(streamId), endOfStream);
+        final HttpResponseWrapper res = getResponse(streamIdToId(streamId), endOfStream);
         if (res == null) {
             if (conn.streamMayHaveExisted(streamId)) {
                 if (logger.isDebugEnabled()) {

--- a/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
@@ -65,7 +65,7 @@ abstract class HttpResponseDecoder {
     }
 
     HttpResponseWrapper addResponse(
-            int id, HttpRequest req, DecodedHttpResponse res, RequestLogBuilder logBuilder,
+            int id, @Nullable HttpRequest req, DecodedHttpResponse res, RequestLogBuilder logBuilder,
             long responseTimeoutMillis, long maxContentLength) {
 
         final HttpResponseWrapper newRes =
@@ -116,15 +116,17 @@ abstract class HttpResponseDecoder {
     }
 
     static final class HttpResponseWrapper implements StreamWriter<HttpObject>, Runnable {
+        @Nullable
         private final HttpRequest request;
         private final DecodedHttpResponse delegate;
         private final RequestLogBuilder logBuilder;
         private final long responseTimeoutMillis;
         private final long maxContentLength;
+        @Nullable
         private ScheduledFuture<?> responseTimeoutFuture;
 
-        HttpResponseWrapper(HttpRequest request, DecodedHttpResponse delegate, RequestLogBuilder logBuilder,
-                            long responseTimeoutMillis, long maxContentLength) {
+        HttpResponseWrapper(@Nullable HttpRequest request, DecodedHttpResponse delegate,
+                            RequestLogBuilder logBuilder, long responseTimeoutMillis, long maxContentLength) {
             this.request = request;
             this.delegate = delegate;
             this.logBuilder = logBuilder;

--- a/core/src/main/java/com/linecorp/armeria/client/HttpSession.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpSession.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.client;
 
+import javax.annotation.Nullable;
+
 import com.linecorp.armeria.common.ClosedSessionException;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.SessionProtocol;
@@ -31,6 +33,7 @@ interface HttpSession {
         private final InboundTrafficController inboundTrafficController =
                 new InboundTrafficController(null, 0, 0);
 
+        @Nullable
         @Override
         public SessionProtocol protocol() {
             return null;
@@ -81,6 +84,7 @@ interface HttpSession {
         return INACTIVE;
     }
 
+    @Nullable
     SessionProtocol protocol();
 
     boolean isActive();

--- a/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
@@ -23,6 +23,8 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.concurrent.ScheduledFuture;
 
+import javax.annotation.Nullable;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,9 +73,12 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
     /**
      * The current negotiated {@link SessionProtocol}.
      */
+    @Nullable
     private SessionProtocol protocol;
 
+    @Nullable
     private HttpResponseDecoder responseDecoder;
+    @Nullable
     private HttpObjectEncoder requestEncoder;
 
     /**
@@ -103,11 +108,13 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
 
     @Override
     public InboundTrafficController inboundTrafficController() {
+        assert responseDecoder != null;
         return responseDecoder.inboundTrafficController();
     }
 
     @Override
     public boolean hasUnfinishedResponses() {
+        assert responseDecoder != null;
         return responseDecoder.hasUnfinishedResponses();
     }
 
@@ -127,6 +134,9 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
         final long writeTimeoutMillis = ctx.writeTimeoutMillis();
         final long responseTimeoutMillis = ctx.responseTimeoutMillis();
         final long maxContentLength = ctx.maxResponseLength();
+
+        assert responseDecoder != null;
+        assert requestEncoder != null;
 
         final int numRequestsSent = ++this.numRequestsSent;
         final HttpResponseWrapper wrappedRes =

--- a/core/src/main/java/com/linecorp/armeria/client/SessionProtocolNegotiationException.java
+++ b/core/src/main/java/com/linecorp/armeria/client/SessionProtocolNegotiationException.java
@@ -32,6 +32,7 @@ public final class SessionProtocolNegotiationException extends RuntimeException 
     private static final long serialVersionUID = 5788454584691399858L;
 
     private final SessionProtocol expected;
+    @Nullable
     private final SessionProtocol actual;
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/NonBlockingCircuitBreaker.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/NonBlockingCircuitBreaker.java
@@ -84,7 +84,7 @@ final class NonBlockingCircuitBreaker implements CircuitBreaker {
     }
 
     @Override
-    public void onFailure(Throwable cause) {
+    public void onFailure(@Nullable Throwable cause) {
         try {
             if (cause != null && !config.exceptionFilter().shouldDealWith(cause)) {
                 return;

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroup.java
@@ -44,7 +44,7 @@ public class DynamicEndpointGroup extends AbstractListenable<List<Endpoint>> imp
     protected final void addEndpoint(Endpoint e) {
         endpointsLock.lock();
         try {
-            ImmutableList.Builder<Endpoint> newEndpointsBuilder = ImmutableList.builder();
+            final ImmutableList.Builder<Endpoint> newEndpointsBuilder = ImmutableList.builder();
             newEndpointsBuilder.addAll(endpoints);
             newEndpointsBuilder.add(e);
             endpoints = newEndpointsBuilder.build();

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/EndpointGroupRegistry.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/EndpointGroupRegistry.java
@@ -22,6 +22,8 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 
+import javax.annotation.Nullable;
+
 import com.google.common.base.Ascii;
 
 import com.linecorp.armeria.client.ClientRequestContext;
@@ -83,6 +85,7 @@ public final class EndpointGroupRegistry {
      *
      * @return the {@link EndpointSelector}, or {@code null} if {@code groupName} has not been registered yet.
      */
+    @Nullable
     public static EndpointSelector getNodeSelector(String groupName) {
         groupName = normalizeGroupName(groupName);
         return serverGroups.get(groupName);
@@ -93,9 +96,10 @@ public final class EndpointGroupRegistry {
      *
      * @return the {@link EndpointSelector}, or {@code null} if {@code groupName} has not been registered yet.
      */
+    @Nullable
     public static EndpointGroup get(String groupName) {
         groupName = normalizeGroupName(groupName);
-        EndpointSelector endpointSelector = serverGroups.get(groupName);
+        final EndpointSelector endpointSelector = serverGroups.get(groupName);
         if (endpointSelector == null) {
             return null;
         }
@@ -108,7 +112,7 @@ public final class EndpointGroupRegistry {
      */
     public static Endpoint selectNode(ClientRequestContext ctx, String groupName) {
         groupName = normalizeGroupName(groupName);
-        EndpointSelector endpointSelector = getNodeSelector(groupName);
+        final EndpointSelector endpointSelector = getNodeSelector(groupName);
         if (endpointSelector == null) {
             throw new EndpointGroupException("non-existent EndpointGroup: " + groupName);
         }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/EndpointGroupUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/EndpointGroupUtil.java
@@ -19,14 +19,17 @@ package com.linecorp.armeria.client.endpoint;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import javax.annotation.Nullable;
+
 final class EndpointGroupUtil {
 
     private static final String ENDPOINT_GROUP_MARK = "group:";
     private static final Pattern ENDPOINT_GROUP_PATTERN = Pattern.compile(
             "://(?:[^@]*@)?(" + ENDPOINT_GROUP_MARK + "([^:/]+)(:\\d+)?)");
 
+    @Nullable
     static String getEndpointGroupName(String uri) {
-        Matcher matcher = ENDPOINT_GROUP_PATTERN.matcher(uri);
+        final Matcher matcher = ENDPOINT_GROUP_PATTERN.matcher(uri);
         if (matcher.find()) {
             return matcher.group(2);
         }
@@ -34,7 +37,7 @@ final class EndpointGroupUtil {
     }
 
     static String replaceEndpointGroup(String uri, String endpointUri) {
-        Matcher matcher = ENDPOINT_GROUP_PATTERN.matcher(uri);
+        final Matcher matcher = ENDPOINT_GROUP_PATTERN.matcher(uri);
         if (matcher.find()) {
             return new StringBuilder(uri).replace(matcher.start(1), matcher.end(1), endpointUri).toString();
         }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroup.java
@@ -107,7 +107,7 @@ public final class HttpHealthCheckedEndpointGroup extends HealthCheckedEndpointG
         public CompletableFuture<Boolean> isHealthy(Endpoint endpoint) {
             return httpClient.get(healthCheckPath)
                              .aggregate()
-                             .thenApply(message -> message.status().equals(HttpStatus.OK));
+                             .thenApply(message -> HttpStatus.OK.equals(message.status()));
         }
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/retry/BackoffSpec.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/BackoffSpec.java
@@ -21,6 +21,8 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.List;
 
+import javax.annotation.Nullable;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Ascii;
 import com.google.common.base.MoreObjects;
@@ -59,6 +61,7 @@ final class BackoffSpec {
         random
     }
 
+    @Nullable
     private BaseOption baseOption;
 
     private boolean jitterConfigured;
@@ -148,9 +151,9 @@ final class BackoffSpec {
         checkNegative(key, maxDelayMillis, ORDINALS.get(1));
 
         if (initialDelayMillis > maxDelayMillis) {
-            long temp = initialDelayMillis;
-            this.initialDelayMillis = maxDelayMillis;
-            this.maxDelayMillis = temp;
+            final long temp = initialDelayMillis;
+            initialDelayMillis = maxDelayMillis;
+            maxDelayMillis = temp;
         }
 
         if (values.size() == 3) {
@@ -188,9 +191,9 @@ final class BackoffSpec {
         checkNegative(key, randomMaxDelayMillis, ORDINALS.get(1));
 
         if (randomMinDelayMillis > randomMaxDelayMillis) {
-            long temp = randomMinDelayMillis;
-            this.randomMinDelayMillis = randomMaxDelayMillis;
-            this.randomMaxDelayMillis = temp;
+            final long temp = randomMinDelayMillis;
+            randomMinDelayMillis = randomMaxDelayMillis;
+            randomMaxDelayMillis = temp;
         }
     }
 
@@ -205,7 +208,7 @@ final class BackoffSpec {
                       "the number of values for '%s' should be 1 or 2. input '%s'", key, jitterValues);
 
         if (values.size() == 1) {
-            double jitterRate = parseDouble(key, values.get(0), ORDINALS.get(0));
+            final double jitterRate = parseDouble(key, values.get(0), ORDINALS.get(0));
             checkDoubleBetween(key, jitterRate, 0.0, 1.0, ORDINALS.get(0));
             minJitterRate = jitterRate * -1;
             maxJitterRate = jitterRate;
@@ -215,14 +218,14 @@ final class BackoffSpec {
             maxJitterRate = parseDouble(key, values.get(1), ORDINALS.get(1));
             checkDoubleBetween(key, maxJitterRate, -1.0, 1.0, ORDINALS.get(1));
             if (minJitterRate > maxJitterRate) {
-                double temp = minJitterRate;
+                final double temp = minJitterRate;
                 minJitterRate = maxJitterRate;
                 maxJitterRate = temp;
             }
         }
     }
 
-    private void checkDoubleBetween(String key, double value, double min, double max, String ordinal) {
+    private static void checkDoubleBetween(String key, double value, double min, double max, String ordinal) {
         checkArgument(min <= value && value <= max,
                       "%s parameter for %s must be >= %s and <= %s. input: %s",
                       ordinal, key, min, max, value);

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
@@ -20,6 +20,8 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.concurrent.TimeUnit;
 
+import javax.annotation.Nullable;
+
 import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.ResponseTimeoutException;
@@ -173,6 +175,7 @@ public abstract class RetryingClient<I extends Request, O extends Response>
         private final long responseTimeoutMillis;
         private final long deadlineNanos;
 
+        @Nullable
         private Backoff lastBackoff;
         private int currentAttemptNoWithLastBackoff;
         private int totalAttemptNo;

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingHttpClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingHttpClient.java
@@ -24,6 +24,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
+import javax.annotation.Nullable;
+
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import org.slf4j.Logger;
@@ -143,7 +145,7 @@ public final class RetryingHttpClient extends RetryingClient<HttpRequest, HttpRe
                                                      : -1;
                                resDuplicator.close();
 
-                               long nextDelay;
+                               final long nextDelay;
                                try {
                                    nextDelay = getNextDelay(ctx, backoffOpt.get(), millisAfter);
                                } catch (Exception e) {
@@ -177,7 +179,7 @@ public final class RetryingHttpClient extends RetryingClient<HttpRequest, HttpRe
     private static long getRetryAfterMillis(HttpResponse res) {
         final HttpHeaders headers = getHttpHeaders(res);
         long millisAfter = -1;
-        String value = headers.get(HttpHeaderNames.RETRY_AFTER);
+        final String value = headers.get(HttpHeaderNames.RETRY_AFTER);
         if (value != null) {
             try {
                 millisAfter = Duration.ofSeconds(Integer.parseInt(value)).toMillis();
@@ -217,6 +219,7 @@ public final class RetryingHttpClient extends RetryingClient<HttpRequest, HttpRe
 
         private final int contentPreviewLength;
         private int contentLength;
+        @Nullable
         private Subscription subscription;
 
         ContentPreviewResponse(HttpResponse delegate, int contentPreviewLength) {
@@ -239,6 +242,7 @@ public final class RetryingHttpClient extends RetryingClient<HttpRequest, HttpRe
                 final int dataLength = ((HttpData) obj).length();
                 contentLength += dataLength;
                 if (contentLength >= contentPreviewLength) {
+                    assert subscription != null;
                     subscription.cancel();
                 }
             }

--- a/core/src/main/java/com/linecorp/armeria/common/AggregatedHttpMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AggregatedHttpMessage.java
@@ -27,6 +27,8 @@ import java.util.Formatter;
 import java.util.List;
 import java.util.Locale;
 
+import javax.annotation.Nullable;
+
 import com.google.common.collect.ImmutableList;
 
 /**
@@ -384,6 +386,7 @@ public interface AggregatedHttpMessage {
      *
      * @return the scheme, or {@code null} if there's no such header
      */
+    @Nullable
     default String scheme() {
         return headers().scheme();
     }
@@ -393,6 +396,7 @@ public interface AggregatedHttpMessage {
      *
      * @return the method, or {@code null} if there's no such header
      */
+    @Nullable
     default HttpMethod method() {
         return headers().method();
     }
@@ -402,6 +406,7 @@ public interface AggregatedHttpMessage {
      *
      * @return the path, or {@code null} if there's no such header
      */
+    @Nullable
     default String path() {
         return headers().path();
     }
@@ -412,6 +417,7 @@ public interface AggregatedHttpMessage {
      *
      * @return the authority, or {@code null} if there's no such header
      */
+    @Nullable
     default String authority() {
         return headers().authority();
     }
@@ -421,6 +427,7 @@ public interface AggregatedHttpMessage {
      *
      * @return the status, or {@code null} if there's no such header
      */
+    @Nullable
     default HttpStatus status() {
         return headers().status();
     }

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultHttpHeaders.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultHttpHeaders.java
@@ -20,6 +20,8 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.List;
 
+import javax.annotation.Nullable;
+
 import com.linecorp.armeria.internal.ArmeriaHttpUtil;
 
 import io.netty.handler.codec.DefaultHeaders;
@@ -36,8 +38,11 @@ public final class DefaultHttpHeaders
 
     private final boolean endOfStream;
 
+    @Nullable
     private HttpMethod method;
+    @Nullable
     private HttpStatus status;
+    @Nullable
     private MediaType contentType;
 
     /**
@@ -80,9 +85,10 @@ public final class DefaultHttpHeaders
         this.endOfStream = endOfStream;
     }
 
+    @Nullable
     @Override
     public HttpMethod method() {
-        HttpMethod method = this.method;
+        final HttpMethod method = this.method;
         if (method != null) {
             return method;
         }
@@ -143,9 +149,10 @@ public final class DefaultHttpHeaders
         return this;
     }
 
+    @Nullable
     @Override
     public HttpStatus status() {
-        HttpStatus status = this.status;
+        final HttpStatus status = this.status;
         if (status != null) {
             return status;
         }
@@ -176,6 +183,7 @@ public final class DefaultHttpHeaders
         return this;
     }
 
+    @Nullable
     @Override
     public MediaType contentType() {
         final MediaType contentType = this.contentType;
@@ -192,6 +200,7 @@ public final class DefaultHttpHeaders
             this.contentType = MediaType.parse(contentTypeString);
             return this.contentType;
         } catch (IllegalArgumentException unused) {
+            // Invalid media type
             return null;
         }
     }
@@ -218,7 +227,7 @@ public final class DefaultHttpHeaders
         final StringBuilder buf = new StringBuilder(size() * 16).append('[');
         String separator = "";
         for (AsciiString name : names()) {
-            List<String> values = getAll(name);
+            final List<String> values = getAll(name);
             for (int i = 0; i < values.size(); ++i) {
                 buf.append(separator);
                 buf.append(name).append('=').append(values.get(i));

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultRpcResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultRpcResponse.java
@@ -38,6 +38,7 @@ public class DefaultRpcResponse extends CompletableFuture<Object> implements Rpc
     private static final AtomicReferenceFieldUpdater<DefaultRpcResponse, Throwable> causeUpdater =
             AtomicReferenceFieldUpdater.newUpdater(DefaultRpcResponse.class, Throwable.class, "cause");
 
+    @Nullable
     private volatile Throwable cause;
 
     /**
@@ -64,6 +65,7 @@ public class DefaultRpcResponse extends CompletableFuture<Object> implements Rpc
         completeExceptionally(cause);
     }
 
+    @Nullable
     @Override
     public final Throwable cause() {
         return cause;

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -21,6 +21,7 @@ import java.util.function.IntPredicate;
 import java.util.function.LongPredicate;
 import java.util.function.Predicate;
 
+import javax.annotation.Nullable;
 import javax.net.ssl.SSLEngine;
 
 import org.slf4j.Logger;
@@ -543,6 +544,7 @@ public final class Flags {
         return defaultValue;
     }
 
+    @Nullable
     private static String getLowerCased(String fullName) {
         String value = System.getProperty(fullName);
         if (value != null) {

--- a/core/src/main/java/com/linecorp/armeria/common/HttpHeaders.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpHeaders.java
@@ -121,6 +121,7 @@ public interface HttpHeaders extends HttpObject, Headers<AsciiString, String, Ht
     /**
      * Gets the {@link HttpHeaderNames#METHOD} header or {@code null} if there is no such header.
      */
+    @Nullable
     HttpMethod method();
 
     /**
@@ -131,6 +132,7 @@ public interface HttpHeaders extends HttpObject, Headers<AsciiString, String, Ht
     /**
      * Gets the {@link HttpHeaderNames#SCHEME} header or {@code null} if there is no such header.
      */
+    @Nullable
     String scheme();
 
     /**
@@ -141,6 +143,7 @@ public interface HttpHeaders extends HttpObject, Headers<AsciiString, String, Ht
     /**
      * Gets the {@link HttpHeaderNames#AUTHORITY} header or {@code null} if there is no such header.
      */
+    @Nullable
     String authority();
 
     /**
@@ -151,6 +154,7 @@ public interface HttpHeaders extends HttpObject, Headers<AsciiString, String, Ht
     /**
      * Gets the {@link HttpHeaderNames#PATH} header or {@code null} if there is no such header.
      */
+    @Nullable
     String path();
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/HttpHeadersJsonDeserializer.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpHeadersJsonDeserializer.java
@@ -20,6 +20,8 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.Map.Entry;
 
+import javax.annotation.Nullable;
+
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
@@ -44,6 +46,7 @@ public final class HttpHeadersJsonDeserializer extends StdDeserializer<HttpHeade
         super(HttpHeaders.class);
     }
 
+    @Nullable
     @Override
     public HttpHeaders deserialize(JsonParser p, DeserializationContext ctx)
             throws IOException {
@@ -56,7 +59,7 @@ public final class HttpHeadersJsonDeserializer extends StdDeserializer<HttpHeade
         final ObjectNode obj = (ObjectNode) tree;
         final HttpHeaders headers = HttpHeaders.of();
 
-        for (Iterator<Entry<String, JsonNode>> i = obj.fields(); i.hasNext();) {
+        for (final Iterator<Entry<String, JsonNode>> i = obj.fields(); i.hasNext();) {
             final Entry<String, JsonNode> e = i.next();
             final AsciiString name = HttpHeaderNames.of(e.getKey());
             final JsonNode values = e.getValue();

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponseWriter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponseWriter.java
@@ -16,11 +16,13 @@
 
 package com.linecorp.armeria.common;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.linecorp.armeria.internal.ArmeriaHttpUtil.isContentAlwaysEmpty;
 import static com.linecorp.armeria.internal.ArmeriaHttpUtil.isContentAlwaysEmptyWithValidation;
 import static java.util.Objects.requireNonNull;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Formatter;
 import java.util.Locale;
 
 import com.linecorp.armeria.common.stream.StreamWriter;
@@ -83,7 +85,7 @@ public interface HttpResponseWriter extends HttpResponse, StreamWriter<HttpObjec
      * {@linkplain Locale#ENGLISH English locale}.
      *
      * @param mediaType the {@link MediaType} of the response content
-     * @param format {@linkplain java.util.Formatter the format string} of the response content
+     * @param format {@linkplain Formatter the format string} of the response content
      * @param args the arguments referenced by the format specifiers in the format string
      *
      * @deprecated Use {@link HttpResponse#of(HttpStatus, MediaType, String, Object...)}.
@@ -208,6 +210,8 @@ public interface HttpResponseWriter extends HttpResponse, StreamWriter<HttpObjec
 
         final HttpHeaders headers = res.headers();
         final HttpStatus status = headers.status();
+        checkArgument(status != null, "res does not contain :status.");
+
         final HttpData content = res.content();
         final HttpHeaders trailingHeaders = res.trailingHeaders();
 

--- a/core/src/main/java/com/linecorp/armeria/common/HttpStatus.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpStatus.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.common;
 
+import javax.annotation.Nullable;
+
 import io.netty.util.collection.IntObjectHashMap;
 import io.netty.util.collection.IntObjectMap;
 
@@ -349,7 +351,7 @@ public final class HttpStatus implements Comparable<HttpStatus> {
     /**
      * Creates a new instance with the specified {@code code} and its {@code reasonPhrase}.
      */
-    public HttpStatus(int code, String reasonPhrase) {
+    public HttpStatus(int code, @Nullable String reasonPhrase) {
         if (code < 0) {
             throw new IllegalArgumentException(
                     "code: " + code + " (expected: 0+)");
@@ -360,7 +362,7 @@ public final class HttpStatus implements Comparable<HttpStatus> {
         }
 
         for (int i = 0; i < reasonPhrase.length(); i++) {
-            char c = reasonPhrase.charAt(i);
+            final char c = reasonPhrase.charAt(i);
             // Check prohibited characters.
             switch (c) {
                 case '\n': case '\r':
@@ -430,7 +432,7 @@ public final class HttpStatus implements Comparable<HttpStatus> {
      * for equality.
      */
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (!(o instanceof HttpStatus)) {
             return false;
         }

--- a/core/src/main/java/com/linecorp/armeria/common/MediaTypeJsonDeserializer.java
+++ b/core/src/main/java/com/linecorp/armeria/common/MediaTypeJsonDeserializer.java
@@ -17,6 +17,8 @@ package com.linecorp.armeria.common;
 
 import java.io.IOException;
 
+import javax.annotation.Nullable;
+
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
@@ -37,6 +39,7 @@ public final class MediaTypeJsonDeserializer extends StdDeserializer<MediaType> 
         super(MediaType.class);
     }
 
+    @Nullable
     @Override
     public MediaType deserialize(JsonParser p, DeserializationContext ctx)
             throws IOException {

--- a/core/src/main/java/com/linecorp/armeria/common/NonWrappingRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/common/NonWrappingRequestContext.java
@@ -46,12 +46,16 @@ public abstract class NonWrappingRequestContext extends AbstractRequestContext {
     private final SessionProtocol sessionProtocol;
     private final HttpMethod method;
     private final String path;
+    @Nullable
     private final String query;
     private final Request request;
 
     // Callbacks
+    @Nullable
     private List<Consumer<? super RequestContext>> onEnterCallbacks;
+    @Nullable
     private List<Consumer<? super RequestContext>> onExitCallbacks;
+    @Nullable
     private List<BiConsumer<? super RequestContext, ? super RequestContext>> onChildCallbacks;
 
     /**
@@ -190,7 +194,7 @@ public abstract class NonWrappingRequestContext extends AbstractRequestContext {
         invokeCallbacks(onExitCallbacks);
     }
 
-    private void invokeCallbacks(List<Consumer<? super RequestContext>> callbacks) {
+    private void invokeCallbacks(@Nullable List<Consumer<? super RequestContext>> callbacks) {
         if (callbacks == null) {
             return;
         }

--- a/core/src/main/java/com/linecorp/armeria/common/RequestContextThreadLocal.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestContextThreadLocal.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.common;
 
+import javax.annotation.Nullable;
+
 import io.netty.util.concurrent.FastThreadLocal;
 import io.netty.util.internal.InternalThreadLocalMap;
 
@@ -23,11 +25,13 @@ final class RequestContextThreadLocal {
 
     private static final FastThreadLocal<RequestContext> context = new FastThreadLocal<>();
 
+    @Nullable
     @SuppressWarnings("unchecked")
     static <T extends RequestContext> T get() {
         return (T) context.get();
     }
 
+    @Nullable
     @SuppressWarnings("unchecked")
     static <T extends RequestContext> T getAndSet(RequestContext ctx) {
         final InternalThreadLocalMap map = InternalThreadLocalMap.get();

--- a/core/src/main/java/com/linecorp/armeria/common/RpcResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RpcResponse.java
@@ -95,6 +95,7 @@ public interface RpcResponse extends Response, Future<Object>, CompletionStage<O
      * @return the cause, or
      *         {@code null} if this {@link RpcResponse} completed successfully or did not complete yet.
      */
+    @Nullable
     Throwable cause();
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/Scheme.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Scheme.java
@@ -21,6 +21,8 @@ import static java.util.Objects.requireNonNull;
 import java.util.Map;
 import java.util.Optional;
 
+import javax.annotation.Nullable;
+
 import com.google.common.base.Ascii;
 import com.google.common.collect.ImmutableMap;
 
@@ -72,7 +74,7 @@ public final class Scheme implements Comparable<Scheme> {
      * @return {@link Optional#empty()} if the specified {@link String} could not be parsed or
      *         there is no such {@link Scheme} available
      */
-    public static Optional<Scheme> tryParse(String scheme) {
+    public static Optional<Scheme> tryParse(@Nullable String scheme) {
         if (scheme == null) {
             return Optional.empty();
         }

--- a/core/src/main/java/com/linecorp/armeria/common/SerializationFormat.java
+++ b/core/src/main/java/com/linecorp/armeria/common/SerializationFormat.java
@@ -60,6 +60,7 @@ public final class SerializationFormat implements Comparable<SerializationFormat
      * @deprecated Use {@code ThriftSerializationFormats.BINARY}. Note that the value of this field will be
      *             {@code null} if {@code armeria-thrift} module is not loaded.
      */
+    @Nullable
     @Deprecated
     public static final SerializationFormat THRIFT_BINARY;
 
@@ -69,6 +70,7 @@ public final class SerializationFormat implements Comparable<SerializationFormat
      * @deprecated Use {@code ThriftSerializationFormats.COMPACT}. Note that the value of this field will be
      *             {@code null} if {@code armeria-thrift} module is not loaded.
      */
+    @Nullable
     @Deprecated
     public static final SerializationFormat THRIFT_COMPACT;
 
@@ -78,6 +80,7 @@ public final class SerializationFormat implements Comparable<SerializationFormat
      * @deprecated Use {@code ThriftSerializationFormats.JSON}. Note that the value of this field will be
      *             {@code null} if {@code armeria-thrift} module is not loaded.
      */
+    @Nullable
     @Deprecated
     public static final SerializationFormat THRIFT_JSON;
 
@@ -87,14 +90,17 @@ public final class SerializationFormat implements Comparable<SerializationFormat
      * @deprecated Use {@code ThriftSerializationFormats.TEXT}. Note that the value of this field will be
      *             {@code null} if {@code armeria-thrift} module is not loaded.
      */
+    @Nullable
     @Deprecated
     public static final SerializationFormat THRIFT_TEXT;
 
+    @Nullable
     private static final Set<SerializationFormat> THRIFT_FORMATS;
 
     static {
-        BiMap<String, SerializationFormat> mutableUriTextToFormats = HashBiMap.create();
-        Multimap<MediaType, SerializationFormat> mutableSimplifiedMediaTypeToFormats = HashMultimap.create();
+        final BiMap<String, SerializationFormat> mutableUriTextToFormats = HashBiMap.create();
+        final Multimap<MediaType, SerializationFormat> mutableSimplifiedMediaTypeToFormats =
+                HashMultimap.create();
 
         // Register the core formats first.
         NONE = register(mutableUriTextToFormats, mutableSimplifiedMediaTypeToFormats,

--- a/core/src/main/java/com/linecorp/armeria/common/StringValueConverter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/StringValueConverter.java
@@ -34,6 +34,8 @@ import java.time.Instant;
 import java.util.Calendar;
 import java.util.Date;
 
+import javax.annotation.Nullable;
+
 import io.netty.handler.codec.DateFormatter;
 import io.netty.handler.codec.ValueConverter;
 
@@ -49,8 +51,9 @@ final class StringValueConverter implements ValueConverter<String> {
 
     private StringValueConverter() {}
 
+    @Nullable
     @Override
-    public String convertObject(Object value) {
+    public String convertObject(@Nullable Object value) {
         if (value == null) {
             return null;
         }

--- a/core/src/main/java/com/linecorp/armeria/common/logging/LogLevel.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/LogLevel.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.common.logging;
 
+import javax.annotation.Nullable;
+
 import org.slf4j.Logger;
 
 /**
@@ -118,7 +120,7 @@ public enum LogLevel {
      * Logs a message at this level.
      */
     @SuppressWarnings("MethodParameterNamingConvention")
-    public void log(Logger logger, String format, Object arg1, Object arg2) {
+    public void log(Logger logger, String format, @Nullable Object arg1, @Nullable Object arg2) {
         switch (this) {
             case TRACE:
                 logger.trace(format, arg1, arg2);

--- a/core/src/main/java/com/linecorp/armeria/common/logging/NoopRequestLogBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/NoopRequestLogBuilder.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.common.logging;
 
+import javax.annotation.Nullable;
+
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.SessionProtocol;
@@ -46,7 +48,7 @@ final class NoopRequestLogBuilder implements RequestLogBuilder {
     public void requestHeaders(HttpHeaders requestHeaders) {}
 
     @Override
-    public void requestContent(Object requestContent, Object rawRequestContent) {}
+    public void requestContent(@Nullable Object requestContent, @Nullable Object rawRequestContent) {}
 
     @Override
     public void deferRequestContent() {}
@@ -75,7 +77,7 @@ final class NoopRequestLogBuilder implements RequestLogBuilder {
     public void responseHeaders(HttpHeaders responseHeaders) {}
 
     @Override
-    public void responseContent(Object responseContent, Object rawResponseContent) {}
+    public void responseContent(@Nullable Object responseContent, @Nullable Object rawResponseContent) {}
 
     @Override
     public void deferResponseContent() {}

--- a/core/src/main/java/com/linecorp/armeria/common/metric/NoopMeterRegistry.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/NoopMeterRegistry.java
@@ -20,6 +20,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.ToDoubleFunction;
 import java.util.function.ToLongFunction;
 
+import javax.annotation.Nullable;
+
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.DistributionSummary;
@@ -36,6 +38,7 @@ import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 import io.micrometer.core.instrument.distribution.pause.PauseDetector;
 import io.micrometer.core.instrument.noop.NoopCounter;
+import io.micrometer.core.instrument.noop.NoopDistributionSummary;
 import io.micrometer.core.instrument.noop.NoopFunctionCounter;
 import io.micrometer.core.instrument.noop.NoopFunctionTimer;
 import io.micrometer.core.instrument.noop.NoopGauge;
@@ -63,7 +66,7 @@ public final class NoopMeterRegistry extends MeterRegistry {
     }
 
     @Override
-    protected <T> Gauge newGauge(Id id, T obj, ToDoubleFunction<T> f) {
+    protected <T> Gauge newGauge(Id id, @Nullable T obj, ToDoubleFunction<T> f) {
         return new NoopGauge(id);
     }
 
@@ -85,7 +88,7 @@ public final class NoopMeterRegistry extends MeterRegistry {
     @Override
     protected DistributionSummary newDistributionSummary(Id id, DistributionStatisticConfig distributionConfig,
             double scale) {
-        return null;
+        return new NoopDistributionSummary(id);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessage.java
@@ -21,6 +21,8 @@ import static java.util.Objects.requireNonNull;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 
+import javax.annotation.Nullable;
+
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
@@ -165,7 +167,7 @@ abstract class AbstractStreamMessage<T> implements StreamMessage<T> {
                 }
 
                 @SuppressWarnings("unchecked")
-                T obj = (T) e;
+                final T obj = (T) e;
                 onRemoval(obj);
             } finally {
                 ReferenceCountUtil.safeRelease(e);
@@ -258,9 +260,10 @@ abstract class AbstractStreamMessage<T> implements StreamMessage<T> {
     }
 
     static final class CloseEvent {
+        @Nullable
         private final Throwable cause;
 
-        CloseEvent(Throwable cause) {
+        CloseEvent(@Nullable Throwable cause) {
             this.cause = cause;
         }
 

--- a/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
@@ -21,8 +21,9 @@ import static java.util.Objects.requireNonNull;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
-import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+
+import javax.annotation.Nullable;
 
 import org.jctools.queues.MpscChunkedArrayQueue;
 import org.reactivestreams.Subscriber;
@@ -74,6 +75,7 @@ public class DefaultStreamMessage<T> extends AbstractStreamMessageAndWriter<T> {
 
     private final Queue<Object> queue;
 
+    @Nullable
     @SuppressWarnings("unused")
     private volatile SubscriptionImpl subscription; // set only via subscriptionUpdater
 
@@ -274,10 +276,7 @@ public class DefaultStreamMessage<T> extends AbstractStreamMessageAndWriter<T> {
 
         final SubscriptionImpl subscription = this.subscription;
         if (!invokedOnSubscribe) {
-            Executor executor = subscription.executor();
-            if (executor == null) {
-                executor = ForkJoinPool.commonPool();
-            }
+            final Executor executor = subscription.executor();
 
             // Subscriber.onSubscribe() was not invoked yet.
             // Reschedule the notification so that onSubscribe() is invoked before other events.

--- a/core/src/main/java/com/linecorp/armeria/common/stream/EventLoopStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/EventLoopStreamMessage.java
@@ -69,6 +69,7 @@ public class EventLoopStreamMessage<T> extends AbstractStreamMessageAndWriter<T>
     private final EventLoop eventLoop;
     private final Queue<Object> queue;
 
+    @Nullable
     private SubscriptionImpl subscription;
     private long demand;
     private boolean invokedOnSubscribe;
@@ -126,7 +127,7 @@ public class EventLoopStreamMessage<T> extends AbstractStreamMessageAndWriter<T>
 
     @Override
     void subscribe(SubscriptionImpl subscription) {
-        Subscriber<?> subscriber = subscription.subscriber();
+        final Subscriber<?> subscriber = subscription.subscriber();
         if (!subscribedUpdater.compareAndSet(this, 0, 1)) {
             eventLoop.execute(() -> failLateSubscriber(this.subscription, subscriber));
             return;
@@ -287,7 +288,7 @@ public class EventLoopStreamMessage<T> extends AbstractStreamMessageAndWriter<T>
 
     private void doAddObject(T obj) {
         if (queue.isEmpty() && demand > 0 && !inOnNext) {
-            SubscriptionImpl subscription = this.subscription;
+            final SubscriptionImpl subscription = this.subscription;
             // Nothing in the queue and the subscriber is ready for an object, so send it directly.
             demand--;
             doNotifySubscriberOfObject(subscription, obj);
@@ -372,7 +373,7 @@ public class EventLoopStreamMessage<T> extends AbstractStreamMessageAndWriter<T>
             demand--;
 
             @SuppressWarnings("unchecked")
-            T obj = (T) queue.remove();
+            final T obj = (T) queue.remove();
             doNotifySubscriberOfObject(subscription, obj);
         }
     }
@@ -458,5 +459,7 @@ public class EventLoopStreamMessage<T> extends AbstractStreamMessageAndWriter<T>
      * Indicates an invocation of {@link EventLoopStreamMessage#EventLoopStreamMessage()} with no available
      * event loop, likely causing significant performance issues.
      */
-    private static class UnexpectedEventLoopException extends RuntimeException {}
+    private static class UnexpectedEventLoopException extends RuntimeException {
+        private static final long serialVersionUID = 5610415039321743416L;
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/FilteredStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/FilteredStreamMessage.java
@@ -20,6 +20,8 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.concurrent.CompletableFuture;
 
+import javax.annotation.Nullable;
+
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import org.slf4j.Logger;
@@ -91,6 +93,7 @@ public abstract class FilteredStreamMessage<T, U> implements StreamMessage<U> {
      * subscription. This method may rewrite the {@code cause} and then return a new one so that the new
      * {@link Throwable} would be passed to {@link Subscriber#onError(Throwable)}.
      */
+    @Nullable
     protected Throwable beforeError(Subscriber<? super U> subscriber, Throwable cause) {
         return cause;
     }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/OneElementFixedStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/OneElementFixedStreamMessage.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.common.stream;
 
+import javax.annotation.Nullable;
+
 import io.netty.util.ReferenceCountUtil;
 
 /**
@@ -23,6 +25,7 @@ import io.netty.util.ReferenceCountUtil;
  */
 public class OneElementFixedStreamMessage<T> extends FixedStreamMessage<T> {
 
+    @Nullable
     private T obj;
 
     protected OneElementFixedStreamMessage(T obj) {
@@ -59,7 +62,8 @@ public class OneElementFixedStreamMessage<T> extends FixedStreamMessage<T> {
 
     private void doNotify(SubscriptionImpl subscription) {
         // Only called with correct demand, so no need to even check it.
-        T published = prepareObjectForNotification(subscription, obj);
+        assert obj != null;
+        final T published = prepareObjectForNotification(subscription, obj);
         obj = null;
         // Not possible to have re-entrant onNext with only one item, so no need to keep track of it.
         subscription.subscriber().onNext(published);

--- a/core/src/main/java/com/linecorp/armeria/common/stream/PublisherBasedStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/PublisherBasedStreamMessage.java
@@ -21,6 +21,8 @@ import static java.util.Objects.requireNonNull;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
+import javax.annotation.Nullable;
+
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
@@ -47,6 +49,7 @@ public class PublisherBasedStreamMessage<T> implements StreamMessage<T> {
 
     private final Publisher<? extends T> publisher;
     private final CompletableFuture<Void> completionFuture = new CompletableFuture<>();
+    @Nullable
     @SuppressWarnings("unused") // Updated only via subscriberUpdater.
     private volatile AbortableSubscriber subscriber;
     private volatile boolean publishedAny;
@@ -160,6 +163,7 @@ public class PublisherBasedStreamMessage<T> implements StreamMessage<T> {
         private final EventExecutor executor;
         private Subscriber<Object> subscriber;
         private volatile boolean abortPending;
+        @Nullable
         private volatile Subscription subscription;
 
         @SuppressWarnings("unchecked")

--- a/core/src/main/java/com/linecorp/armeria/common/stream/TwoElementFixedStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/TwoElementFixedStreamMessage.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.common.stream;
 
+import javax.annotation.Nullable;
+
 import io.netty.util.ReferenceCountUtil;
 
 /**
@@ -23,7 +25,9 @@ import io.netty.util.ReferenceCountUtil;
  */
 public class TwoElementFixedStreamMessage<T> extends FixedStreamMessage<T> {
 
+    @Nullable
     private T obj1;
+    @Nullable
     private T obj2;
 
     private boolean inOnNext;
@@ -58,7 +62,7 @@ public class TwoElementFixedStreamMessage<T> extends FixedStreamMessage<T> {
 
     @Override
     final void doRequest(SubscriptionImpl subscription, long n) {
-        int oldDemand = requested();
+        final int oldDemand = requested();
         if (oldDemand >= 2) {
             // Already have demand, so don't need to do anything, the current demand will complete the
             // stream.
@@ -112,7 +116,7 @@ public class TwoElementFixedStreamMessage<T> extends FixedStreamMessage<T> {
     }
 
     private void doNotifyObject(SubscriptionImpl subscription, T obj) {
-        T published = prepareObjectForNotification(subscription, obj);
+        final T published = prepareObjectForNotification(subscription, obj);
         inOnNext = true;
         try {
             subscription.subscriber().onNext(published);

--- a/core/src/main/java/com/linecorp/armeria/common/util/CompletionActions.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/CompletionActions.java
@@ -18,6 +18,8 @@ package com.linecorp.armeria.common.util;
 
 import java.util.concurrent.CompletionStage;
 
+import javax.annotation.Nullable;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,6 +39,7 @@ public final class CompletionActions {
      *
      * @return {@code null}
      */
+    @Nullable
     public static <T> T log(Throwable cause) {
         logger.warn("Unexpected exception from a completion action:", cause);
         return null;

--- a/core/src/main/java/com/linecorp/armeria/common/util/Exceptions.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/Exceptions.java
@@ -28,8 +28,9 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
+import javax.annotation.Nullable;
+
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Throwables;
 
@@ -45,8 +46,6 @@ import io.netty.handler.codec.http2.Http2Exception;
  * Provides methods that are useful for handling exceptions.
  */
 public final class Exceptions {
-
-    private static final Logger logger = LoggerFactory.getLogger(Exceptions.class);
 
     private static final Pattern IGNORABLE_SOCKET_ERROR_MESSAGE = Pattern.compile(
             "(?:connection.*(?:reset|closed|abort|broken)|broken.*pipe)", Pattern.CASE_INSENSITIVE);
@@ -94,7 +93,8 @@ public final class Exceptions {
     /**
      * Logs the specified exception if it is {@linkplain #isExpected(Throwable) unexpected}.
      */
-    public static void logIfUnexpected(Logger logger, Channel ch, SessionProtocol protocol, Throwable cause) {
+    public static void logIfUnexpected(Logger logger, Channel ch,
+                                       @Nullable SessionProtocol protocol, Throwable cause) {
         if (!logger.isWarnEnabled() || isExpected(cause)) {
             return;
         }
@@ -106,7 +106,7 @@ public final class Exceptions {
     /**
      * Logs the specified exception if it is {@linkplain #isExpected(Throwable) unexpected}.
      */
-    public static void logIfUnexpected(Logger logger, Channel ch, SessionProtocol protocol,
+    public static void logIfUnexpected(Logger logger, Channel ch, @Nullable SessionProtocol protocol,
                                        String debugData, Throwable cause) {
 
         if (!logger.isWarnEnabled() || isExpected(cause)) {
@@ -117,7 +117,7 @@ public final class Exceptions {
                     ch, protocolName(protocol), debugData, cause);
     }
 
-    private static String protocolName(SessionProtocol protocol) {
+    private static String protocolName(@Nullable SessionProtocol protocol) {
         return protocol != null ? protocol.uriText() : "<unknown>";
     }
 
@@ -193,7 +193,7 @@ public final class Exceptions {
      */
     public static <T> T throwUnsafely(Throwable cause) {
         doThrowUnsafely(requireNonNull(cause, "cause"));
-        return null;
+        return null; // Never reaches here.
     }
 
     // This black magic causes the Java compiler to believe E is an unchecked exception type.

--- a/core/src/main/java/com/linecorp/armeria/common/util/Version.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/Version.java
@@ -47,6 +47,8 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
+import javax.annotation.Nullable;
+
 import com.google.common.io.Closeables;
 
 /**
@@ -84,18 +86,18 @@ public final class Version {
      *
      * @return A {@link Map} whose keys are Maven artifact IDs and whose values are {@link Version}s
      */
-    public static Map<String, Version> identify(ClassLoader classLoader) {
+    public static Map<String, Version> identify(@Nullable ClassLoader classLoader) {
         if (classLoader == null) {
             classLoader = getContextClassLoader();
         }
 
         // Collect all properties.
-        Properties props = new Properties();
+        final Properties props = new Properties();
         try {
-            Enumeration<URL> resources = classLoader.getResources(PROP_RESOURCE_PATH);
+            final Enumeration<URL> resources = classLoader.getResources(PROP_RESOURCE_PATH);
             while (resources.hasMoreElements()) {
-                URL url = resources.nextElement();
-                InputStream in = url.openStream();
+                final URL url = resources.nextElement();
+                final InputStream in = url.openStream();
                 try {
                     props.load(in);
                 } finally {
@@ -107,16 +109,16 @@ public final class Version {
         }
 
         // Collect all artifactIds.
-        Set<String> artifactIds = new HashSet<>();
+        final Set<String> artifactIds = new HashSet<>();
         for (Object o: props.keySet()) {
-            String k = (String) o;
+            final String k = (String) o;
 
-            int dotIndex = k.indexOf('.');
+            final int dotIndex = k.indexOf('.');
             if (dotIndex <= 0) {
                 continue;
             }
 
-            String artifactId = k.substring(0, dotIndex);
+            final String artifactId = k.substring(0, dotIndex);
 
             // Skip the entries without required information.
             if (!props.containsKey(artifactId + PROP_VERSION) ||
@@ -130,7 +132,7 @@ public final class Version {
             artifactIds.add(artifactId);
         }
 
-        Map<String, Version> versions = new HashMap<>();
+        final Map<String, Version> versions = new HashMap<>();
         for (String artifactId: artifactIds) {
             versions.put(
                     artifactId,

--- a/core/src/main/java/com/linecorp/armeria/internal/AbstractHttp2ConnectionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/AbstractHttp2ConnectionHandler.java
@@ -92,7 +92,7 @@ public abstract class AbstractHttp2ConnectionHandler extends Http2ConnectionHand
         super.onConnectionError(ctx, outbound, cause, http2Ex);
     }
 
-    private static String goAwayDebugData(@Nullable Http2Exception http2Ex, Throwable cause) {
+    private static String goAwayDebugData(@Nullable Http2Exception http2Ex, @Nullable Throwable cause) {
         final StringBuilder buf = new StringBuilder(256);
         final String type;
         final String message;

--- a/core/src/main/java/com/linecorp/armeria/internal/ArmeriaHttpUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/ArmeriaHttpUtil.java
@@ -46,6 +46,8 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.StringJoiner;
 
+import javax.annotation.Nullable;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
 
@@ -161,7 +163,7 @@ public final class ArmeriaHttpUtil {
     /**
      * Concatenates two path strings.
      */
-    public static String concatPaths(String path1, String path2) {
+    public static String concatPaths(@Nullable String path1, @Nullable String path2) {
         path2 = path2 == null ? "" : path2;
 
         if (path1 == null || path1.isEmpty() || EMPTY_REQUEST_PATH.equals(path1)) {
@@ -301,7 +303,7 @@ public final class ArmeriaHttpUtil {
 
         if (!isOriginForm(requestTargetUri) && !isAsteriskForm(requestTargetUri)) {
             // Attempt to take from HOST header before taking from the request-line
-            String host = inHeaders.getAsString(HttpHeaderNames.HOST);
+            final String host = inHeaders.getAsString(HttpHeaderNames.HOST);
             setHttp2Authority(host == null || host.isEmpty() ? requestTargetUri.getAuthority() : host, out);
         }
 
@@ -314,7 +316,7 @@ public final class ArmeriaHttpUtil {
      * Converts the headers of the given Netty HTTP/1.x response into Armeria HTTP/2 headers.
      */
     public static HttpHeaders toArmeria(HttpResponse in) {
-        io.netty.handler.codec.http.HttpHeaders inHeaders = in.headers();
+        final io.netty.handler.codec.http.HttpHeaders inHeaders = in.headers();
         final HttpHeaders out = new DefaultHttpHeaders(true, inHeaders.size());
         out.status(in.status().code());
 
@@ -379,10 +381,10 @@ public final class ArmeriaHttpUtil {
 
     private static CharSequenceMap toLowercaseMap(Iterator<? extends CharSequence> valuesIter,
                                                   int arraySizeHint) {
-        CharSequenceMap result = new CharSequenceMap(arraySizeHint);
+        final CharSequenceMap result = new CharSequenceMap(arraySizeHint);
 
         while (valuesIter.hasNext()) {
-            AsciiString lowerCased = AsciiString.of(valuesIter.next()).toLowerCase();
+            final AsciiString lowerCased = AsciiString.of(valuesIter.next()).toLowerCase();
             try {
                 int index = lowerCased.forEachByte(FIND_COMMA);
                 if (index != -1) {
@@ -420,7 +422,7 @@ public final class ArmeriaHttpUtil {
                 out.add(HttpHeaderNames.TE, HttpHeaderValues.TRAILERS.toString());
             }
         } else {
-            List<CharSequence> teValues = StringUtil.unescapeCsvFields(entry.getValue());
+            final List<CharSequence> teValues = StringUtil.unescapeCsvFields(entry.getValue());
             for (CharSequence teValue : teValues) {
                 if (AsciiString.contentEqualsIgnoreCase(AsciiString.trim(teValue),
                                                         HttpHeaderValues.TRAILERS)) {
@@ -471,7 +473,7 @@ public final class ArmeriaHttpUtil {
     }
 
     @VisibleForTesting
-    static void setHttp2Authority(String authority, HttpHeaders out) {
+    static void setHttp2Authority(@Nullable String authority, HttpHeaders out) {
         // The authority MUST NOT include the deprecated "userinfo" subcomponent
         if (authority != null) {
             final String actualAuthority;
@@ -492,14 +494,14 @@ public final class ArmeriaHttpUtil {
     }
 
     private static void setHttp2Scheme(io.netty.handler.codec.http.HttpHeaders in, URI uri, HttpHeaders out) {
-        String value = uri.getScheme();
+        final String value = uri.getScheme();
         if (value != null) {
             out.scheme(value);
             return;
         }
 
         // Consume the Scheme extension header if present
-        CharSequence cValue = in.get(ExtensionHeaderNames.SCHEME.text());
+        final CharSequence cValue = in.get(ExtensionHeaderNames.SCHEME.text());
         if (cValue != null) {
             out.scheme(cValue.toString());
         } else {
@@ -557,7 +559,7 @@ public final class ArmeriaHttpUtil {
             for (Entry<AsciiString, String> entry : inputHeaders) {
                 final AsciiString name = entry.getKey();
                 final String value = entry.getValue();
-                AsciiString translatedName = translations.get(name);
+                final AsciiString translatedName = translations.get(name);
                 if (translatedName != null) {
                     outputHeaders.add(translatedName, value);
                     continue;

--- a/core/src/main/java/com/linecorp/armeria/internal/Http1ClientCodec.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/Http1ClientCodec.java
@@ -35,6 +35,8 @@ import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.atomic.AtomicLong;
 
+import javax.annotation.Nullable;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
@@ -218,7 +220,7 @@ public class Http1ClientCodec extends CombinedChannelDuplexHandler<HttpResponseD
         protected void decode(
                 ChannelHandlerContext ctx, ByteBuf buffer, List<Object> out) throws Exception {
             if (done) {
-                int readable = actualReadableBytes();
+                final int readable = actualReadableBytes();
                 if (readable == 0) {
                     // if non is readable just return null
                     // https://github.com/netty/netty/issues/1159
@@ -226,10 +228,10 @@ public class Http1ClientCodec extends CombinedChannelDuplexHandler<HttpResponseD
                 }
                 out.add(buffer.readBytes(readable));
             } else {
-                int oldSize = out.size();
+                final int oldSize = out.size();
                 super.decode(ctx, buffer, out);
                 if (failOnMissingResponse) {
-                    int size = out.size();
+                    final int size = out.size();
                     for (int i = oldSize; i < size; i++) {
                         decrement(out.get(i));
                     }
@@ -237,7 +239,7 @@ public class Http1ClientCodec extends CombinedChannelDuplexHandler<HttpResponseD
             }
         }
 
-        private void decrement(Object msg) {
+        private void decrement(@Nullable Object msg) {
             if (msg == null) {
                 return;
             }
@@ -259,9 +261,9 @@ public class Http1ClientCodec extends CombinedChannelDuplexHandler<HttpResponseD
 
             // Get the getMethod of the HTTP request that corresponds to the
             // current response.
-            HttpMethod method = queue.poll();
+            final HttpMethod method = queue.poll();
 
-            char firstChar = method.name().charAt(0);
+            final char firstChar = method.name().charAt(0);
             switch (firstChar) {
                 case 'H':
                     // According to 4.3, RFC2616:
@@ -310,7 +312,7 @@ public class Http1ClientCodec extends CombinedChannelDuplexHandler<HttpResponseD
             super.channelInactive(ctx);
 
             if (failOnMissingResponse) {
-                long missingResponses = requestResponseCounter.get();
+                final long missingResponses = requestResponseCounter.get();
                 if (missingResponses > 0) {
                     ctx.fireExceptionCaught(new PrematureChannelClosureException(
                             "channel gone inactive with " + missingResponses +

--- a/core/src/main/java/com/linecorp/armeria/internal/Http1ObjectEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/Http1ObjectEncoder.java
@@ -229,10 +229,12 @@ public final class Http1ObjectEncoder extends HttpObjectEncoder {
         }
 
         // Convert leading headers.
+        final String path = headers.path();
+        assert path != null;
         final HttpRequest req = new DefaultHttpRequest(
                 HttpVersion.HTTP_1_1,
                 io.netty.handler.codec.http.HttpMethod.valueOf(method.name()),
-                headers.path(), false);
+                path, false);
 
         convert(streamId, headers, req.headers(), false);
 
@@ -370,7 +372,7 @@ public final class Http1ObjectEncoder extends HttpObjectEncoder {
 
     private static ByteBuf dataChunk(HttpData data, int offset, int chunkSize) {
         if (data instanceof ByteBufHolder) {
-            ByteBuf buf = ((ByteBufHolder) data).content();
+            final ByteBuf buf = ((ByteBufHolder) data).content();
             return buf.retainedSlice(offset, chunkSize);
         } else {
             return Unpooled.wrappedBuffer(data.array(), offset, chunkSize);

--- a/core/src/main/java/com/linecorp/armeria/internal/Http2ObjectEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/Http2ObjectEncoder.java
@@ -18,6 +18,8 @@ package com.linecorp.armeria.internal;
 
 import static java.util.Objects.requireNonNull;
 
+import javax.annotation.Nullable;
+
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.stream.ClosedPublisherException;
@@ -73,6 +75,7 @@ public final class Http2ObjectEncoder extends HttpObjectEncoder {
         return encoder.writeRstStream(ctx, streamId, error.code(), ctx.newPromise());
     }
 
+    @Nullable
     private ChannelFuture validateStream(ChannelHandlerContext ctx, int streamId) {
         final Http2Stream stream = encoder.connection().stream(streamId);
         if (stream != null) {

--- a/core/src/main/java/com/linecorp/armeria/internal/HttpHeaderSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/HttpHeaderSubscriber.java
@@ -21,6 +21,8 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
 
+import javax.annotation.Nullable;
+
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
@@ -40,7 +42,9 @@ public final class HttpHeaderSubscriber
         implements Subscriber<HttpObject>, BiConsumer<Void, Throwable> {
 
     private final CompletableFuture<HttpHeaders> future;
+    @Nullable
     private Subscription subscription;
+    @Nullable
     private HttpHeaders headers;
 
     /**
@@ -63,6 +67,7 @@ public final class HttpHeaderSubscriber
             final HttpStatus status = headers.status();
             if (status != null && status.codeClass() != HttpStatusClass.INFORMATIONAL && this.headers == null) {
                 this.headers = headers;
+                assert subscription != null;
                 subscription.cancel();
             }
         }

--- a/core/src/main/java/com/linecorp/armeria/internal/InboundTrafficController.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/InboundTrafficController.java
@@ -35,6 +35,7 @@ public final class InboundTrafficController extends AtomicInteger {
         return numDeferredReads;
     }
 
+    @Nullable
     private final ChannelConfig cfg;
     private final int highWatermark;
     private final int lowWatermark;

--- a/core/src/main/java/com/linecorp/armeria/internal/PathAndQuery.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/PathAndQuery.java
@@ -53,6 +53,7 @@ public final class PathAndQuery {
 
     private static final Pattern CONSECUTIVE_SLASHES_PATTERN = Pattern.compile("/{2,}");
 
+    @Nullable
     private static final Cache<String, PathAndQuery> CACHE =
             Flags.parsedPathCacheSpec().map(PathAndQuery::buildCache).orElse(null);
 
@@ -96,7 +97,7 @@ public final class PathAndQuery {
     @Nullable
     public static PathAndQuery parse(String rawPath) {
         if (CACHE != null) {
-            PathAndQuery parsed = CACHE.getIfPresent(rawPath);
+            final PathAndQuery parsed = CACHE.getIfPresent(rawPath);
             if (parsed != null) {
                 return parsed;
             }
@@ -142,14 +143,14 @@ public final class PathAndQuery {
             return false;
         }
 
-        PathAndQuery that = (PathAndQuery) o;
+        final PathAndQuery that = (PathAndQuery) o;
         return Objects.equals(path, that.path) &&
                Objects.equals(query, that.query);
     }
 
     @Override
     public int hashCode() {
-        return 31 * path.hashCode() + query.hashCode();
+        return Objects.hash(path, query);
     }
 
     @Override
@@ -160,6 +161,7 @@ public final class PathAndQuery {
                 .toString();
     }
 
+    @Nullable
     private static PathAndQuery splitPathAndQuery(final String pathAndQuery) {
         final String path;
         final String query;
@@ -200,7 +202,7 @@ public final class PathAndQuery {
         return new PathAndQuery(CONSECUTIVE_SLASHES_PATTERN.matcher(path).replaceAll("/"), query);
     }
 
-    private static boolean isValidEncoding(String value) {
+    private static boolean isValidEncoding(@Nullable String value) {
         if (value == null) {
             return true;
         }

--- a/core/src/main/java/com/linecorp/armeria/server/AbstractPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AbstractPathMapping.java
@@ -20,6 +20,8 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Optional;
 
+import javax.annotation.Nullable;
+
 /**
  * A skeletal {@link PathMapping} implementation. Implement {@link #doApply(PathMappingContext)}.
  */
@@ -67,7 +69,7 @@ public abstract class AbstractPathMapping implements PathMapping {
         return "__UNKNOWN__";
     }
 
-    static String loggerName(String pathish) {
+    static String loggerName(@Nullable String pathish) {
         if (pathish == null) {
             return "__UNKNOWN__";
         }

--- a/core/src/main/java/com/linecorp/armeria/server/AbstractVirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AbstractVirtualHostBuilder.java
@@ -89,7 +89,7 @@ abstract class AbstractVirtualHostBuilder<B extends AbstractVirtualHostBuilder> 
             final String line = new BufferedReader(new InputStreamReader(process.getInputStream())).readLine();
             if (line == null) {
                 logger.warn("The 'hostname' command returned nothing; " +
-                            "using InetAddress.getLocalHost() instead", line);
+                            "using InetAddress.getLocalHost() instead");
             } else {
                 hostname = normalizeDefaultHostname(line.trim());
                 logger.info("Hostname: {} (via 'hostname' command)", hostname);

--- a/core/src/main/java/com/linecorp/armeria/server/DecodedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DecodedHttpRequest.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.server;
 
+import javax.annotation.Nullable;
+
 import com.linecorp.armeria.common.DefaultHttpRequest;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaders;
@@ -32,6 +34,7 @@ final class DecodedHttpRequest extends DefaultHttpRequest {
     private final boolean keepAlive;
     private final InboundTrafficController inboundTrafficController;
     private final long defaultMaxRequestLength;
+    @Nullable
     private ServiceRequestContext ctx;
     private long transferredBytes;
 

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultPathMapping.java
@@ -27,6 +27,8 @@ import java.util.StringJoiner;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import javax.annotation.Nullable;
+
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
@@ -137,6 +139,7 @@ final class DefaultPathMapping extends AbstractPathMapping {
      *   <li>{@code "baz"} -> {@code null}</li>
      * </ul>
      */
+    @Nullable
     private static String paramName(String token) {
         if (token.startsWith("{") && token.endsWith("}")) {
             return token.substring(1, token.length() - 1);
@@ -203,7 +206,7 @@ final class DefaultPathMapping extends AbstractPathMapping {
             return false;
         }
 
-        DefaultPathMapping that = (DefaultPathMapping) o;
+        final DefaultPathMapping that = (DefaultPathMapping) o;
 
         return skeleton.equals(that.skeleton) &&
                Arrays.equals(paramNameArray, that.paramNameArray);

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultPathMappingContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultPathMappingContext.java
@@ -51,10 +51,14 @@ final class DefaultPathMappingContext implements PathMappingContext {
     private final String hostname;
     private final HttpMethod method;
     private final String path;
+    @Nullable
     private final String query;
+    @Nullable
     private final MediaType consumeType;
+    @Nullable
     private final List<MediaType> produceTypes;
     private final List<Object> summary;
+    @Nullable
     private Throwable delayedCause;
 
     DefaultPathMappingContext(VirtualHost virtualHost, String hostname,
@@ -143,7 +147,6 @@ final class DefaultPathMappingContext implements PathMappingContext {
     /**
      * Returns a new {@link PathMappingContext} instance.
      */
-    @VisibleForTesting
     static PathMappingContext of(VirtualHost virtualHost, String hostname,
                                  String path, @Nullable String query,
                                  HttpHeaders headers, @Nullable MediaTypeSet producibleMediaTypes) {
@@ -153,6 +156,7 @@ final class DefaultPathMappingContext implements PathMappingContext {
                                              consumeType, produceTypes);
     }
 
+    @Nullable
     @VisibleForTesting
     static MediaType resolveConsumeType(HttpHeaders headers) {
         final MediaType contentType = headers.contentType();
@@ -162,8 +166,10 @@ final class DefaultPathMappingContext implements PathMappingContext {
         return null;
     }
 
+    @Nullable
     @VisibleForTesting
-    static List<MediaType> resolveProduceTypes(HttpHeaders headers, MediaTypeSet producibleMediaTypes) {
+    static List<MediaType> resolveProduceTypes(HttpHeaders headers,
+                                               @Nullable MediaTypeSet producibleMediaTypes) {
         if (producibleMediaTypes == null || producibleMediaTypes.isEmpty()) {
             // No media type negotiation supports.
             return null;
@@ -226,14 +232,14 @@ final class DefaultPathMappingContext implements PathMappingContext {
         // 2 : Path
         // 3 : Content-Type
         // 4~: Accept
-        List<Object> summary = new ArrayList<>(8);
+        final List<Object> summary = new ArrayList<>(8);
 
         summary.add(mappingCtx.virtualHost());
         summary.add(mappingCtx.method());
         summary.add(mappingCtx.path());
         summary.add(mappingCtx.consumeType());
 
-        List<MediaType> produceTypes = mappingCtx.produceTypes();
+        final List<MediaType> produceTypes = mappingCtx.produceTypes();
         if (produceTypes != null) {
             summary.addAll(produceTypes);
         }

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
@@ -55,19 +55,23 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
     private final ServiceConfig cfg;
     private final PathMappingContext pathMappingContext;
     private final PathMappingResult pathMappingResult;
+    @Nullable
     private final SSLSession sslSession;
 
     private final DefaultRequestLog log;
     private final Logger logger;
 
+    @Nullable
     private ExecutorService blockingTaskExecutor;
 
     private long requestTimeoutMillis;
     @Nullable
     private Runnable requestTimeoutHandler;
     private long maxRequestLength;
+    @Nullable
     private volatile RequestTimeoutChangeListener requestTimeoutChangeListener;
 
+    @Nullable
     private String strVal;
 
     /**
@@ -124,7 +128,7 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
         final DefaultServiceRequestContext ctx = new DefaultServiceRequestContext(
                 cfg, ch, meterRegistry(), sessionProtocol(), pathMappingContext,
                 pathMappingResult, request, sslSession());
-        for (Iterator<Attribute<?>> i = attrs(); i.hasNext();) {
+        for (final Iterator<Attribute<?>> i = attrs(); i.hasNext();) {
             ctx.addAttr(i.next());
         }
         return ctx;

--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
@@ -20,6 +20,8 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
+import javax.annotation.Nullable;
+
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import org.slf4j.Logger;
@@ -64,7 +66,9 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject>, RequestTim
     private final Consumer<RequestLog> accessLogWriter;
     private final long startTimeNanos;
 
+    @Nullable
     private Subscription subscription;
+    @Nullable
     private ScheduledFuture<?> timeoutFuture;
     private State state = State.NEEDS_HEADERS;
     private boolean isComplete;
@@ -111,7 +115,7 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject>, RequestTim
     private void onTimeout() {
         if (state != State.DONE) {
             reqCtx.setTimedOut();
-            Runnable requestTimeoutHandler = reqCtx.requestTimeoutHandler();
+            final Runnable requestTimeoutHandler = reqCtx.requestTimeoutHandler();
             if (requestTimeoutHandler != null) {
                 requestTimeoutHandler.run();
             } else {

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServer.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServer.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.server;
 
+import javax.annotation.Nullable;
+
 import com.linecorp.armeria.common.SessionProtocol;
 
 import io.netty.channel.Channel;
@@ -25,6 +27,7 @@ import io.netty.channel.ChannelPipeline;
 
 interface HttpServer {
 
+    @Nullable
     static HttpServer get(Channel channel) {
         final ChannelPipeline p = channel.pipeline();
         final ChannelHandler lastHandler = p.last();
@@ -41,6 +44,7 @@ interface HttpServer {
         return null;
     }
 
+    @Nullable
     static HttpServer get(ChannelHandlerContext ctx) {
         return get(ctx.channel());
     }

--- a/core/src/main/java/com/linecorp/armeria/server/PathMappingContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/server/PathMappingContextWrapper.java
@@ -34,6 +34,7 @@ import com.linecorp.armeria.common.MediaType;
 class PathMappingContextWrapper implements PathMappingContext {
 
     private final PathMappingContext delegate;
+    @Nullable
     private List<Object> summary;
 
     PathMappingContextWrapper(PathMappingContext delegate) {

--- a/core/src/main/java/com/linecorp/armeria/server/PathMappingResult.java
+++ b/core/src/main/java/com/linecorp/armeria/server/PathMappingResult.java
@@ -69,11 +69,15 @@ public final class PathMappingResult {
         return new PathMappingResult(path, query, pathParams, score);
     }
 
+    @Nullable
     private final String path;
+    @Nullable
     private final String query;
+    @Nullable
     private final Map<String, String> pathParams;
 
     private int score;
+    @Nullable
     private MediaType negotiatedProduceType;
 
     private PathMappingResult(@Nullable String path, @Nullable String query,

--- a/core/src/main/java/com/linecorp/armeria/server/RouteCache.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RouteCache.java
@@ -21,6 +21,8 @@ import static java.util.Objects.requireNonNull;
 import java.io.OutputStream;
 import java.util.function.Function;
 
+import javax.annotation.Nullable;
+
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.base.MoreObjects;
@@ -39,6 +41,7 @@ import io.micrometer.core.instrument.MeterRegistry;
  */
 final class RouteCache {
 
+    @Nullable
     private static final Cache<PathMappingContext, ServiceConfig> CACHE =
             Flags.routeCacheSpec().map(RouteCache::<ServiceConfig>buildCache)
                  .orElse(null);

--- a/core/src/main/java/com/linecorp/armeria/server/Routers.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Routers.java
@@ -29,6 +29,8 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.function.Function;
 
+import javax.annotation.Nullable;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -150,7 +152,7 @@ public final class Routers {
     /**
      * Finds the most suitable service from the given {@link ServiceConfig} list.
      */
-    private static <V> PathMapped<V> findsBest(PathMappingContext mappingCtx, List<V> values,
+    private static <V> PathMapped<V> findsBest(PathMappingContext mappingCtx, @Nullable List<V> values,
                                                Function<V, PathMapping> pathMappingResolver) {
         PathMapped<V> result = PathMapped.empty();
         if (values != null) {
@@ -244,7 +246,7 @@ public final class Routers {
         @Override
         public void dump(OutputStream output) {
             // Do not close this writer in order to keep output stream open.
-            PrintWriter p = new PrintWriter(new OutputStreamWriter(output, StandardCharsets.UTF_8));
+            final PrintWriter p = new PrintWriter(new OutputStreamWriter(output, StandardCharsets.UTF_8));
             p.printf("Dump of %s:%n", this);
             for (int i = 0; i < values.size(); i++) {
                 p.printf("<%d> %s%n", i, values.get(i));

--- a/core/src/main/java/com/linecorp/armeria/server/Server.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Server.java
@@ -226,7 +226,6 @@ public final class Server implements AutoCloseable {
         }
 
         if (!stateManager.enterStarting(future, this::stop0)) {
-            assert future.isCompletedExceptionally();
             return;
         }
 
@@ -465,6 +464,7 @@ public final class Server implements AutoCloseable {
         static final State STOPPED = new State(StateType.STOPPED, null);
 
         final StateType type;
+        @Nullable
         final CompletableFuture<Void> future;
 
         State(StateType type, @Nullable CompletableFuture<Void> future) {
@@ -534,7 +534,7 @@ public final class Server implements AutoCloseable {
             return future;
         }
 
-        boolean enterStopping(State expect, CompletableFuture<Void> future) {
+        boolean enterStopping(@Nullable State expect, CompletableFuture<Void> future) {
             final State update = new State(StateType.STOPPING, future);
             final State oldState;
             if (expect != null) {

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -33,7 +33,6 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLException;
 
@@ -790,7 +789,8 @@ public final class ServerBuilder {
      * @return {@link VirtualHostBuilder} for build the virtual host
      */
     public ChainedVirtualHostBuilder withVirtualHost(String hostnamePattern) {
-        ChainedVirtualHostBuilder virtualHostBuilder = new ChainedVirtualHostBuilder(hostnamePattern, this);
+        final ChainedVirtualHostBuilder virtualHostBuilder =
+                new ChainedVirtualHostBuilder(hostnamePattern, this);
         virtualHostBuilders.add(virtualHostBuilder);
         return virtualHostBuilder;
     }
@@ -804,7 +804,7 @@ public final class ServerBuilder {
      * @return {@link VirtualHostBuilder} for build the virtual host
      */
     public ChainedVirtualHostBuilder withVirtualHost(String defaultHostname, String hostnamePattern) {
-        ChainedVirtualHostBuilder virtualHostBuilder =
+        final ChainedVirtualHostBuilder virtualHostBuilder =
                 new ChainedVirtualHostBuilder(defaultHostname, hostnamePattern, this);
         virtualHostBuilders.add(virtualHostBuilder);
         return virtualHostBuilder;
@@ -823,7 +823,7 @@ public final class ServerBuilder {
         requireNonNull(decorator, "decorator");
 
         @SuppressWarnings("unchecked")
-        Function<Service<HttpRequest, HttpResponse>, Service<HttpRequest, HttpResponse>> castDecorator =
+        final Function<Service<HttpRequest, HttpResponse>, Service<HttpRequest, HttpResponse>> castDecorator =
                 (Function<Service<HttpRequest, HttpResponse>, Service<HttpRequest, HttpResponse>>) decorator;
 
         if (this.decorator != null) {
@@ -905,7 +905,8 @@ public final class ServerBuilder {
         return server;
     }
 
-    private static VirtualHost normalizeDefaultVirtualHost(VirtualHost h, SslContext defaultSslContext) {
+    private static VirtualHost normalizeDefaultVirtualHost(VirtualHost h,
+                                                           @Nullable SslContext defaultSslContext) {
         final SslContext sslCtx = h.sslContext() != null ? h.sslContext() : defaultSslContext;
         return new VirtualHost(
                 h.defaultHostname(), "*", sslCtx,
@@ -914,7 +915,7 @@ public final class ServerBuilder {
                  .collect(Collectors.toList()), h.producibleMediaTypes());
     }
 
-    @Nonnull
+    @Nullable
     private static SslContext findDefaultSslContext(VirtualHost defaultVirtualHost,
                                                     List<VirtualHost> virtualHosts) {
         SslContext lastSslContext = null;

--- a/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
@@ -28,6 +28,8 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
 
+import javax.annotation.Nullable;
+
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.internal.ConnectionLimitingHandler;
@@ -45,6 +47,7 @@ public final class ServerConfig {
     /**
      * Initialized later by {@link Server} via {@link #setServer(Server)}.
      */
+    @Nullable
     private Server server;
 
     private final List<ServerPort> ports;
@@ -74,6 +77,7 @@ public final class ServerConfig {
 
     private final Consumer<RequestLog> accessLogWriter;
 
+    @Nullable
     private String strVal;
 
     ServerConfig(
@@ -290,7 +294,7 @@ public final class ServerConfig {
                 // Consider the case where the specified service is decorated before being added.
                 final Service<?, ?> s = c.service();
                 @SuppressWarnings("rawtypes")
-                Optional<? extends Service> sOpt = s.as(serviceType);
+                final Optional<? extends Service> sOpt = s.as(serviceType);
                 if (!sOpt.isPresent()) {
                     continue;
                 }
@@ -444,17 +448,17 @@ public final class ServerConfig {
     }
 
     static String toString(
-            Class<?> type,
-            Iterable<ServerPort> ports, VirtualHost defaultVirtualHost, List<VirtualHost> virtualHosts,
+            @Nullable Class<?> type, Iterable<ServerPort> ports,
+            @Nullable VirtualHost defaultVirtualHost, List<VirtualHost> virtualHosts,
             EventLoopGroup workerGroup, boolean shutdownWorkerGroupOnStop,
             int maxNumConnections, long idleTimeoutMillis, long defaultRequestTimeoutMillis,
             long defaultMaxRequestLength, long defaultMaxHttp1InitialLineLength,
             long defaultMaxHttp1HeaderSize, long defaultMaxHttp1ChunkSize,
             Duration gracefulShutdownQuietPeriod, Duration gracefulShutdownTimeout,
-            Executor blockingTaskExecutor, MeterRegistry meterRegistry, String serviceLoggerPrefix,
+            Executor blockingTaskExecutor, @Nullable MeterRegistry meterRegistry, String serviceLoggerPrefix,
             Consumer<RequestLog> accessLogWriter) {
 
-        StringBuilder buf = new StringBuilder();
+        final StringBuilder buf = new StringBuilder();
         if (type != null) {
             buf.append(type.getSimpleName());
         }

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceConfig.java
@@ -41,9 +41,11 @@ public final class ServiceConfig {
     /**
      * Initialized later by {@link VirtualHost} via {@link #build(VirtualHost)}.
      */
+    @Nullable
     private VirtualHost virtualHost;
 
     private final PathMapping pathMapping;
+    @Nullable
     private final String loggerName;
     private final Service<HttpRequest, HttpResponse> service;
 

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
@@ -16,10 +16,12 @@
 
 package com.linecorp.armeria.server;
 
+import java.net.SocketAddress;
 import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import org.slf4j.Logger;
@@ -38,6 +40,20 @@ import com.linecorp.armeria.common.RequestContext;
  * {@link ServiceRequestContext} instance.
  */
 public interface ServiceRequestContext extends RequestContext {
+
+    /**
+     * Returns the remote address of this request.
+     */
+    @Nonnull
+    @Override
+    <A extends SocketAddress> A remoteAddress();
+
+    /**
+     * Returns the local address of this request.
+     */
+    @Nonnull
+    @Override
+    <A extends SocketAddress> A localAddress();
 
     @Override
     ServiceRequestContext newDerivedContext();
@@ -75,6 +91,7 @@ public interface ServiceRequestContext extends RequestContext {
     /**
      * Returns the value of the specified path parameter.
      */
+    @Nullable
     default String pathParam(String name) {
         return pathParams().get(name);
     }

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHost.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHost.java
@@ -61,19 +61,22 @@ public final class VirtualHost {
     /**
      * Initialized later by {@link ServerConfig} via {@link #setServerConfig(ServerConfig)}.
      */
+    @Nullable
     private ServerConfig serverConfig;
 
     private final String defaultHostname;
     private final String hostnamePattern;
+    @Nullable
     private final SslContext sslContext;
     private final List<ServiceConfig> services;
     private final Router<ServiceConfig> router;
     private final MediaTypeSet producibleMediaTypes;
 
+    @Nullable
     private String strVal;
 
     VirtualHost(String defaultHostname, String hostnamePattern,
-                SslContext sslContext, Iterable<ServiceConfig> serviceConfigs,
+                @Nullable SslContext sslContext, Iterable<ServiceConfig> serviceConfigs,
                 MediaTypeSet producibleMediaTypes) {
 
         defaultHostname = normalizeDefaultHostname(defaultHostname);
@@ -155,7 +158,7 @@ public final class VirtualHost {
     private static boolean needsNormalization(String hostnamePattern) {
         final int length = hostnamePattern.length();
         for (int i = 0; i < length; i++) {
-            int c = hostnamePattern.charAt(i);
+            final int c = hostnamePattern.charAt(i);
             if (c > 0x7F) {
                 return true;
             }
@@ -163,7 +166,8 @@ public final class VirtualHost {
         return false;
     }
 
-    static SslContext validateSslContext(SslContext sslContext) {
+    @Nullable
+    static SslContext validateSslContext(@Nullable SslContext sslContext) {
         if (sslContext != null && !sslContext.isServer()) {
             throw new IllegalArgumentException("sslContext: " + sslContext + " (expected: server context)");
         }
@@ -211,6 +215,7 @@ public final class VirtualHost {
     /**
      * Returns the {@link SslContext} of this virtual host.
      */
+    @Nullable
     public SslContext sslContext() {
         return sslContext;
     }
@@ -276,10 +281,10 @@ public final class VirtualHost {
         return strVal;
     }
 
-    static String toString(Class<?> type, String defaultHostname, String hostnamePattern,
-                           SslContext sslContext, List<?> services) {
+    static String toString(@Nullable Class<?> type, String defaultHostname, String hostnamePattern,
+                           @Nullable SslContext sslContext, List<?> services) {
 
-        StringBuilder buf = new StringBuilder();
+        final StringBuilder buf = new StringBuilder();
         if (type != null) {
             buf.append(type.getSimpleName());
         }

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/ResponseConverterFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/ResponseConverterFunction.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.server.annotation;
 
+import javax.annotation.Nullable;
+
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.internal.FallthroughException;
 import com.linecorp.armeria.server.ServiceRequestContext;
@@ -34,7 +36,7 @@ public interface ResponseConverterFunction {
      * Calls {@link ResponseConverterFunction#fallthrough()} or throws a {@link FallthroughException} if
      * this converter cannot convert the {@code result} to the {@link HttpResponse}.
      */
-    HttpResponse convertResponse(ServiceRequestContext ctx, Object result) throws Exception;
+    HttpResponse convertResponse(ServiceRequestContext ctx, @Nullable Object result) throws Exception;
 
     /**
      * Throws a {@link FallthroughException} in order to try to convert {@code result} to

--- a/core/src/main/java/com/linecorp/armeria/server/auth/BasicTokenExtractor.java
+++ b/core/src/main/java/com/linecorp/armeria/server/auth/BasicTokenExtractor.java
@@ -23,6 +23,8 @@ import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import javax.annotation.Nullable;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,36 +44,38 @@ final class BasicTokenExtractor implements Function<HttpHeaders, BasicToken> {
             "\\s*(?i)basic\\s+(?<encoded>\\S+)\\s*");
     private static final Decoder BASE64_DECODER = Base64.getDecoder();
 
+    @Nullable
     @Override
     public BasicToken apply(HttpHeaders headers) {
-        String authorization = headers.get(HttpHeaderNames.AUTHORIZATION);
+        final String authorization = headers.get(HttpHeaderNames.AUTHORIZATION);
         if (Strings.isNullOrEmpty(authorization)) {
             return null;
         }
 
-        Matcher matcher = AUTHORIZATION_HEADER_PATTERN.matcher(authorization);
+        final Matcher matcher = AUTHORIZATION_HEADER_PATTERN.matcher(authorization);
         if (!matcher.matches()) {
             logger.warn("Invalid authorization header: {}", authorization);
             return null;
         }
 
-        String base64 = matcher.group("encoded");
-        byte[] decoded;
+        final String base64 = matcher.group("encoded");
+        final byte[] decoded;
         try {
             decoded = BASE64_DECODER.decode(base64);
         } catch (IllegalArgumentException e) {
+            // No need to log stack trace for this because the reason is so obvious.
             logger.warn("Base64 decoding failed: {}", base64);
             return null;
         }
 
-        String credential = new String(decoded, StandardCharsets.UTF_8);
-        int sep = credential.indexOf(':');
+        final String credential = new String(decoded, StandardCharsets.UTF_8);
+        final int sep = credential.indexOf(':');
         if (sep == -1) {
             logger.warn("Invalid credential: {}", credential);
             return null;
         }
-        String username = credential.substring(0, sep);
-        String password = credential.substring(sep + 1);
+        final String username = credential.substring(0, sep);
+        final String password = credential.substring(sep + 1);
 
         return BasicToken.of(username, password);
     }

--- a/core/src/main/java/com/linecorp/armeria/server/auth/OAuth1aTokenExtractor.java
+++ b/core/src/main/java/com/linecorp/armeria/server/auth/OAuth1aTokenExtractor.java
@@ -20,6 +20,8 @@ import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import javax.annotation.Nullable;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,28 +41,29 @@ final class OAuth1aTokenExtractor implements Function<HttpHeaders, OAuth1aToken>
     private static final Pattern AUTHORIZATION_HEADER_PATTERN = Pattern.compile(
             "\\s*(?i)oauth\\s+(?<parameters>\\S+)\\s*");
 
+    @Nullable
     @Override
     public OAuth1aToken apply(HttpHeaders headers) {
-        String authorization = headers.get(HttpHeaderNames.AUTHORIZATION);
+        final String authorization = headers.get(HttpHeaderNames.AUTHORIZATION);
         if (Strings.isNullOrEmpty(authorization)) {
             return null;
         }
 
-        Matcher matcher = AUTHORIZATION_HEADER_PATTERN.matcher(authorization);
+        final Matcher matcher = AUTHORIZATION_HEADER_PATTERN.matcher(authorization);
         if (!matcher.matches()) {
             logger.warn("Invalid authorization header: " + authorization);
             return null;
         }
 
-        ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+        final ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
         for (String token : matcher.group("parameters").split(",")) {
-            int sep = token.indexOf('=');
+            final int sep = token.indexOf('=');
             if (sep == -1 || token.charAt(sep + 1) != '"' || token.charAt(token.length() - 1) != '"') {
                 logger.warn("Invalid token: " + token);
                 return null;
             }
-            String key = token.substring(0, sep);
-            String value = token.substring(sep + 2, token.length() - 1);
+            final String key = token.substring(0, sep);
+            final String value = token.substring(sep + 2, token.length() - 1);
             builder.put(key, value);
         }
 

--- a/core/src/main/java/com/linecorp/armeria/server/auth/OAuth2TokenExtractor.java
+++ b/core/src/main/java/com/linecorp/armeria/server/auth/OAuth2TokenExtractor.java
@@ -20,6 +20,8 @@ import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import javax.annotation.Nullable;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,14 +39,15 @@ final class OAuth2TokenExtractor implements Function<HttpHeaders, OAuth2Token> {
     private static final Pattern AUTHORIZATION_HEADER_PATTERN = Pattern.compile(
             "\\s*(?i)bearer\\s+(?<accessToken>\\S+)\\s*");
 
+    @Nullable
     @Override
     public OAuth2Token apply(HttpHeaders headers) {
-        String authorization = headers.get(HttpHeaderNames.AUTHORIZATION);
+        final String authorization = headers.get(HttpHeaderNames.AUTHORIZATION);
         if (Strings.isNullOrEmpty(authorization)) {
             return null;
         }
 
-        Matcher matcher = AUTHORIZATION_HEADER_PATTERN.matcher(authorization);
+        final Matcher matcher = AUTHORIZATION_HEADER_PATTERN.matcher(authorization);
         if (!matcher.matches()) {
             logger.warn("Invalid authorization header: " + authorization);
             return null;

--- a/core/src/main/java/com/linecorp/armeria/server/composition/AbstractCompositeService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/composition/AbstractCompositeService.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
+import javax.annotation.Nullable;
+
 import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.common.HttpStatus;
@@ -68,7 +70,9 @@ import io.micrometer.core.instrument.MeterRegistry;
 public abstract class AbstractCompositeService<I extends Request, O extends Response> implements Service<I, O> {
 
     private final List<CompositeServiceEntry<I, O>> services;
+    @Nullable
     private Server server;
+    @Nullable
     private Router<Service<I, O>> router;
 
     /**
@@ -131,6 +135,7 @@ public abstract class AbstractCompositeService<I extends Request, O extends Resp
      *         {@link PathMapped#empty()} if there's no match.
      */
     protected PathMapped<Service<I, O>> findService(PathMappingContext mappingCtx) {
+        assert router != null;
         return router.find(mappingCtx);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsConfig.java
@@ -24,6 +24,8 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.function.Supplier;
 
+import javax.annotation.Nullable;
+
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -50,15 +52,20 @@ public final class CorsConfig {
     public static final CorsConfig DISABLED = new CorsConfig();
 
     private final boolean enabled;
+    @Nullable
     private final Set<String> origins;
     private final boolean anyOriginSupported;
     private final boolean nullOriginAllowed;
     private final boolean credentialsAllowed;
     private final boolean shortCircuit;
     private final long maxAge;
+    @Nullable
     private final Set<AsciiString> exposedHeaders;
+    @Nullable
     private final Set<HttpMethod> allowedRequestMethods;
+    @Nullable
     private final Set<AsciiString> allowedRequestHeaders;
+    @Nullable
     private final Map<AsciiString, Supplier<?>> preflightResponseHeaders;
 
     CorsConfig() {
@@ -325,11 +332,12 @@ public final class CorsConfig {
                         preflightResponseHeaders);
     }
 
-    static String toString(Object obj, boolean enabled, Set<String> origins, boolean anyOriginSupported,
-                           boolean nullOriginAllowed, boolean credentialsAllowed, boolean shortCircuit,
-                           long maxAge, Set<AsciiString> exposedHeaders, Set<HttpMethod> allowedRequestMethods,
-                           Set<AsciiString> allowedRequestHeaders,
-                           Map<AsciiString, Supplier<?>> preflightResponseHeaders) {
+    static String toString(Object obj, boolean enabled, @Nullable Set<String> origins,
+                           boolean anyOriginSupported, boolean nullOriginAllowed, boolean credentialsAllowed,
+                           boolean shortCircuit, long maxAge, @Nullable Set<AsciiString> exposedHeaders,
+                           @Nullable Set<HttpMethod> allowedRequestMethods,
+                           @Nullable Set<AsciiString> allowedRequestHeaders,
+                           @Nullable Map<AsciiString, Supplier<?>> preflightResponseHeaders) {
         if (enabled) {
             return MoreObjects.toStringHelper(obj)
                               .add("origins", origins)

--- a/core/src/main/java/com/linecorp/armeria/server/docs/DocService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/DocService.java
@@ -74,6 +74,7 @@ public class DocService extends AbstractCompositeService<HttpRequest, HttpRespon
     private final Map<String, ListMultimap<String, HttpHeaders>> exampleHttpHeaders;
     private final Map<String, ListMultimap<String, String>> exampleRequests;
 
+    @Nullable
     private Server server;
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/docs/EnumInfo.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/EnumInfo.java
@@ -36,6 +36,7 @@ public final class EnumInfo implements NamedTypeInfo {
 
     private final String name;
     private final List<EnumValueInfo> values;
+    @Nullable
     private final String docString;
 
     /**
@@ -111,8 +112,7 @@ public final class EnumInfo implements NamedTypeInfo {
     }
 
     private static Iterable<EnumValueInfo> toEnumValues(Class<? extends Enum<?>> enumType) {
-        @SuppressWarnings("rawtypes")
-        final Class rawEnumType = requireNonNull(enumType, "enumType");
+        final Class<?> rawEnumType = requireNonNull(enumType, "enumType");
         @SuppressWarnings({ "unchecked", "rawtypes" })
         final Set<Enum> values = EnumSet.allOf((Class<Enum>) rawEnumType);
         return values.stream().map(e -> new EnumValueInfo(e.name()))::iterator;

--- a/core/src/main/java/com/linecorp/armeria/server/docs/EnumValueInfo.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/EnumValueInfo.java
@@ -30,6 +30,7 @@ import com.google.common.base.Strings;
 public final class EnumValueInfo {
 
     private final String name;
+    @Nullable
     private final String docString;
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/docs/ExceptionInfo.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/ExceptionInfo.java
@@ -38,6 +38,7 @@ public final class ExceptionInfo implements NamedTypeInfo {
 
     private final String name;
     private final List<FieldInfo> fields;
+    @Nullable
     private final String docString;
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/docs/FieldInfo.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/FieldInfo.java
@@ -36,6 +36,7 @@ public final class FieldInfo {
     private final String name;
     private final FieldRequirement requirement;
     private final TypeSignature typeSignature;
+    @Nullable
     private final String docString;
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/docs/MethodInfo.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/MethodInfo.java
@@ -52,6 +52,7 @@ public final class MethodInfo {
     private final Set<EndpointInfo> endpoints;
     private final List<HttpHeaders> exampleHttpHeaders;
     private final List<String> exampleRequests;
+    @Nullable
     private final String docString;
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/docs/ServiceInfo.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/ServiceInfo.java
@@ -47,6 +47,7 @@ public final class ServiceInfo {
     private final String name;
     private final Set<MethodInfo> methods;
     private final List<HttpHeaders> exampleHttpHeaders;
+    @Nullable
     private final String docString;
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/docs/StructInfo.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/StructInfo.java
@@ -38,6 +38,7 @@ public final class StructInfo implements NamedTypeInfo {
 
     private final String name;
     private final List<FieldInfo> fields;
+    @Nullable
     private final String docString;
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/docs/TypeSignature.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/TypeSignature.java
@@ -23,6 +23,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
+import javax.annotation.Nullable;
+
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
@@ -205,6 +207,7 @@ public final class TypeSignature {
     }
 
     private final String name;
+    @Nullable
     private final Object namedTypeDescriptor;
     private final List<TypeSignature> typeParameters;
 

--- a/core/src/main/java/com/linecorp/armeria/server/encoding/HttpEncoders.java
+++ b/core/src/main/java/com/linecorp/armeria/server/encoding/HttpEncoders.java
@@ -33,7 +33,7 @@ final class HttpEncoders {
 
     @Nullable
     static HttpEncodingType getWrapperForRequest(HttpRequest request) {
-        String acceptEncoding = request.headers().get(HttpHeaderNames.ACCEPT_ENCODING);
+        final String acceptEncoding = request.headers().get(HttpHeaderNames.ACCEPT_ENCODING);
         if (acceptEncoding == null) {
             return null;
         }
@@ -57,13 +57,14 @@ final class HttpEncoders {
     }
 
     // Copied from netty's HttpContentCompressor.
+    @Nullable
     private static HttpEncodingType determineEncoding(String acceptEncoding) {
         float starQ = -1.0f;
         float gzipQ = -1.0f;
         float deflateQ = -1.0f;
         for (String encoding : acceptEncoding.split(",")) {
             float q = 1.0f;
-            int equalsPos = encoding.indexOf('=');
+            final int equalsPos = encoding.indexOf('=');
             if (equalsPos != -1) {
                 try {
                     q = Float.parseFloat(encoding.substring(equalsPos + 1));

--- a/core/src/main/java/com/linecorp/armeria/server/file/HttpVfs.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/HttpVfs.java
@@ -123,12 +123,13 @@ public interface HttpVfs {
          *
          * @return {@code null} if unknown
          */
+        @Nullable
         MediaType mediaType();
 
         /**
          * The content encoding of the entry. Will be set for precompressed files.
          *
-         * @return {code null} if not compressed
+         * @return {@code null} if not compressed
          */
         @Nullable
         String contentEncoding();
@@ -223,7 +224,7 @@ public interface HttpVfs {
                 return HttpData.EMPTY_DATA;
             }
 
-            byte[] buf = new byte[length];
+            final byte[] buf = new byte[length];
             int endOffset = 0;
 
             for (;;) {

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/HttpHealthCheckService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/HttpHealthCheckService.java
@@ -20,6 +20,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import javax.annotation.Nullable;
+
 import com.linecorp.armeria.common.AggregatedHttpMessage;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpRequest;
@@ -78,6 +80,7 @@ public class HttpHealthCheckService extends AbstractHttpService {
 
     final SettableHealthChecker serverHealth;
 
+    @Nullable
     private Server server;
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/logging/AccessLogComponent.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/AccessLogComponent.java
@@ -97,17 +97,20 @@ interface AccessLogComponent {
      */
     abstract class ResponseHeaderConditional implements AccessLogComponent {
 
+        @Nullable
         private final Function<HttpHeaders, Boolean> condition;
 
         protected ResponseHeaderConditional(@Nullable Function<HttpHeaders, Boolean> condition) {
             this.condition = condition;
         }
 
+        @Nullable
         @VisibleForTesting
         Function<HttpHeaders, Boolean> condition() {
             return condition;
         }
 
+        @Nullable
         @Override
         public final Object getMessage(RequestLog log) {
             if (condition != null &&
@@ -160,6 +163,7 @@ interface AccessLogComponent {
             this.addQuote = addQuote;
         }
 
+        @Nullable
         @Override
         public Object getMessage0(RequestLog log) {
             switch (type) {
@@ -257,6 +261,7 @@ interface AccessLogComponent {
             return key;
         }
 
+        @Nullable
         @Override
         Object getMessage0(RequestLog log) {
             final Attribute<?> value = log.context().attr(key);

--- a/core/src/main/java/com/linecorp/armeria/server/logging/AccessLogFormats.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/AccessLogFormats.java
@@ -201,6 +201,7 @@ final class AccessLogFormats {
         }
 
         if (TextComponent.isSupported(type)) {
+            assert variable != null;
             return ofText(variable);
         }
 
@@ -212,9 +213,11 @@ final class AccessLogFormats {
             return new CommonComponent(type, addQuote, condition);
         }
         if (RequestHeaderComponent.isSupported(type)) {
+            assert variable != null;
             return new RequestHeaderComponent(AsciiString.of(variable), addQuote, condition);
         }
         if (AttributeComponent.isSupported(type)) {
+            assert variable != null;
             final Function<Object, String> stringifier;
             final String[] components = variable.split(":");
             if (components.length == 2) {

--- a/core/src/main/java/com/linecorp/armeria/server/logging/structured/StructuredLoggingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/structured/StructuredLoggingService.java
@@ -18,6 +18,8 @@ package com.linecorp.armeria.server.logging.structured;
 
 import static java.util.Objects.requireNonNull;
 
+import javax.annotation.Nullable;
+
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
 import com.linecorp.armeria.common.logging.RequestLog;
@@ -41,6 +43,7 @@ public abstract class StructuredLoggingService<I extends Request, O extends Resp
         extends SimpleDecoratingService<I, O> {
 
     private final StructuredLogBuilder<L> logBuilder;
+    @Nullable
     private Server associatedServer;
 
     /**
@@ -79,7 +82,7 @@ public abstract class StructuredLoggingService<I extends Request, O extends Resp
     @Override
     public O serve(ServiceRequestContext ctx, I req) throws Exception {
         ctx.log().addListener(log -> {
-            L structuredLog = logBuilder.build(log);
+            final L structuredLog = logBuilder.build(log);
             if (structuredLog != null) {
                 writeLog(log, structuredLog);
             }

--- a/core/src/main/java/com/linecorp/armeria/server/throttling/CircuitBreakerThrottlingStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/server/throttling/CircuitBreakerThrottlingStrategy.java
@@ -19,6 +19,8 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.concurrent.CompletableFuture;
 
+import javax.annotation.Nullable;
+
 import com.linecorp.armeria.client.circuitbreaker.CircuitBreaker;
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.server.ServiceRequestContext;
@@ -41,7 +43,7 @@ public final class CircuitBreakerThrottlingStrategy<T extends Request> extends T
      * Creates a new named {@link ThrottlingStrategy} that determines whether a request should be throttled
      * or not using a given {@code circuitBreaker}.
      */
-    public CircuitBreakerThrottlingStrategy(CircuitBreaker circuitBreaker, String name) {
+    public CircuitBreakerThrottlingStrategy(CircuitBreaker circuitBreaker, @Nullable String name) {
         super(name);
         this.circuitBreaker = requireNonNull(circuitBreaker, "circuitBreaker");
     }

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaChannel.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaChannel.java
@@ -70,6 +70,7 @@ class ArmeriaChannel extends Channel implements ClientBuilderParams {
     private final SessionProtocol sessionProtocol;
     private final Endpoint endpoint;
     private final SerializationFormat serializationFormat;
+    @Nullable
     private final MessageMarshaller jsonMarshaller;
 
     ArmeriaChannel(ClientBuilderParams params,
@@ -91,11 +92,10 @@ class ArmeriaChannel extends Channel implements ClientBuilderParams {
     @Override
     public <I, O> ClientCall<I, O> newCall(
             MethodDescriptor<I, O> method, CallOptions callOptions) {
-        HttpRequestWriter req = HttpRequest.streaming(
-                HttpHeaders
-                        .of(HttpMethod.POST, uri().getPath() + method.getFullMethodName())
-                        .contentType(serializationFormat.mediaType()));
-        ClientRequestContext ctx = newContext(HttpMethod.POST, req);
+        final HttpRequestWriter req = HttpRequest.streaming(
+                HttpHeaders.of(HttpMethod.POST, uri().getPath() + method.getFullMethodName())
+                           .contentType(serializationFormat.mediaType()));
+        final ClientRequestContext ctx = newContext(HttpMethod.POST, req);
         ctx.logBuilder().serializationFormat(serializationFormat);
         ctx.logBuilder().requestContent(GrpcLogUtil.rpcRequest(method), null);
         ctx.logBuilder().deferResponseContent();

--- a/grpc/src/main/java/com/linecorp/armeria/internal/grpc/ArmeriaMessageDeframer.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/grpc/ArmeriaMessageDeframer.java
@@ -132,7 +132,7 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
                 return false;
             }
 
-            ByteBufOrStream that = (ByteBufOrStream) o;
+            final ByteBufOrStream that = (ByteBufOrStream) o;
 
             return Objects.equals(buf, that.buf) && Objects.equals(stream, that.stream);
         }
@@ -175,7 +175,9 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
 
     private boolean compressedFlag;
     private boolean endOfStream;
+    @Nullable
     private CompositeByteBuf nextFrame;
+    @Nullable
     private CompositeByteBuf unprocessed;
     private long pendingDeliveries;
     private boolean deliveryStalled = true;
@@ -327,10 +329,10 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
             * frame and not in unprocessed.  If there is extra data but no pending deliveries, it will
             * be in unprocessed.
             */
-            boolean stalled = !unprocessed.isReadable();
+            final boolean stalled = !unprocessed.isReadable();
 
             if (endOfStream && stalled) {
-                boolean havePartialMessage = nextFrame != null && nextFrame.isReadable();
+                final boolean havePartialMessage = nextFrame != null && nextFrame.isReadable();
                 if (!havePartialMessage) {
                     listener.endOfStream();
                     deliveryStalled = false;
@@ -361,12 +363,12 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
         // Read until the buffer contains all the required bytes.
         int missingBytes;
         while ((missingBytes = requiredLength - nextFrame.readableBytes()) > 0) {
-            int numUnprocessedBytes = unprocessed.readableBytes();
+            final int numUnprocessedBytes = unprocessed.readableBytes();
             if (numUnprocessedBytes == 0) {
                 // No more data is available.
                 return false;
             }
-            int toRead = Math.min(missingBytes, numUnprocessedBytes);
+            final int toRead = Math.min(missingBytes, numUnprocessedBytes);
             if (toRead > 0) {
                 nextFrame.addComponent(true, unprocessed.readBytes(toRead));
                 unprocessed.discardReadComponents();
@@ -380,7 +382,7 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
      * frame length.
      */
     private void processHeader() {
-        int type = nextFrame.readUnsignedByte();
+        final int type = nextFrame.readUnsignedByte();
         if ((type & RESERVED_MASK) != 0) {
             throw Status.INTERNAL.withDescription(
                     DEBUG_STRING + ": Frame header malformed: reserved bits not zero")
@@ -406,7 +408,7 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
      * several gRPC messages within it.
      */
     private void processBody() {
-        ByteBufOrStream msg = compressedFlag ? getCompressedBody() : getUncompressedBody();
+        final ByteBufOrStream msg = compressedFlag ? getCompressedBody() : getUncompressedBody();
         nextFrame = null;
         listener.messageRead(msg);
 
@@ -428,7 +430,7 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
 
         try {
             // Enforce the maxMessageSizeBytes limit on the returned stream.
-            InputStream unlimitedStream =
+            final InputStream unlimitedStream =
                     decompressor.decompress(new ByteBufInputStream(nextFrame, true));
             return new ByteBufOrStream(
                     new SizeEnforcingInputStream(unlimitedStream, maxMessageSizeBytes, DEBUG_STRING));
@@ -456,7 +458,7 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
 
         @Override
         public int read() throws IOException {
-            int result = in.read();
+            final int result = in.read();
             if (result != -1) {
                 count++;
             }
@@ -467,7 +469,7 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
 
         @Override
         public int read(byte[] b, int off, int len) throws IOException {
-            int result = in.read(b, off, len);
+            final int result = in.read(b, off, len);
             if (result != -1) {
                 count += result;
             }
@@ -478,7 +480,7 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
 
         @Override
         public long skip(long n) throws IOException {
-            long result = in.skip(n);
+            final long result = in.skip(n);
             count += result;
             verifySize();
             reportCount();

--- a/jetty/src/main/java/com/linecorp/armeria/server/jetty/ArmeriaConnector.java
+++ b/jetty/src/main/java/com/linecorp/armeria/server/jetty/ArmeriaConnector.java
@@ -22,6 +22,8 @@ import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.jetty.io.ArrayByteBufferPool;
 import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.io.Connection;
@@ -102,11 +104,13 @@ final class ArmeriaConnector extends ContainerLifeCycle implements Connector {
         return byteBufferPool;
     }
 
+    @Nullable
     @Override
     public ConnectionFactory getConnectionFactory(String nextProtocol) {
         return PROTOCOL_NAME.equals(nextProtocol) ? connectionFactory : null;
     }
 
+    @Nullable
     @Override
     @SuppressWarnings("unchecked")
     public <T> T getConnectionFactory(Class<T> factoryType) {

--- a/jetty/src/main/java/com/linecorp/armeria/server/jetty/JettyServiceBuilder.java
+++ b/jetty/src/main/java/com/linecorp/armeria/server/jetty/JettyServiceBuilder.java
@@ -25,6 +25,8 @@ import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.RequestLog;
 import org.eclipse.jetty.server.Server;
@@ -48,12 +50,19 @@ public final class JettyServiceBuilder {
     private final List<LifeCycle.Listener> lifeCycleListeners = new ArrayList<>();
     private final List<Consumer<? super Server>> configurators = new ArrayList<>();
 
+    @Nullable
     private String hostname;
+    @Nullable
     private Boolean dumpAfterStart;
+    @Nullable
     private Boolean dumpBeforeStop;
+    @Nullable
     private Handler handler;
+    @Nullable
     private RequestLog requestLog;
+    @Nullable
     private Function<? super Server, ? extends SessionIdManager> sessionIdManagerFactory;
+    @Nullable
     private Long stopTimeoutMillis;
 
     /**

--- a/jetty/src/main/java/com/linecorp/armeria/server/jetty/JettyServiceConfig.java
+++ b/jetty/src/main/java/com/linecorp/armeria/server/jetty/JettyServiceConfig.java
@@ -25,6 +25,8 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.RequestLog;
 import org.eclipse.jetty.server.Server;
@@ -37,12 +39,19 @@ import com.google.common.base.MoreObjects;
 
 final class JettyServiceConfig {
 
+    @Nullable
     private final String hostname;
+    @Nullable
     private final Boolean dumpAfterStart;
+    @Nullable
     private final Boolean dumpBeforeStop;
+    @Nullable
     private final Long stopTimeoutMillis;
+    @Nullable
     private final Handler handler;
+    @Nullable
     private final RequestLog requestLog;
+    @Nullable
     private final Function<? super Server, ? extends SessionIdManager> sessionIdManagerFactory;
     private final Map<String, Object> attrs;
     private final List<Bean> beans;
@@ -51,10 +60,11 @@ final class JettyServiceConfig {
     private final List<LifeCycle.Listener> lifeCycleListeners;
     private final List<Consumer<? super Server>> configurators;
 
-    JettyServiceConfig(String hostname,
-                       Boolean dumpAfterStart, Boolean dumpBeforeStop, Long stopTimeoutMillis,
-                       Handler handler, RequestLog requestLog,
-                       Function<? super Server, ? extends SessionIdManager> sessionIdManagerFactory,
+    JettyServiceConfig(@Nullable String hostname,
+                       @Nullable Boolean dumpAfterStart, @Nullable Boolean dumpBeforeStop,
+                       @Nullable Long stopTimeoutMillis,
+                       @Nullable Handler handler, @Nullable RequestLog requestLog,
+                       @Nullable Function<? super Server, ? extends SessionIdManager> sessionIdManagerFactory,
                        Map<String, Object> attrs, List<Bean> beans, List<HandlerWrapper> handlerWrappers,
                        List<Listener> eventListeners, List<LifeCycle.Listener> lifeCycleListeners,
                        List<Consumer<? super Server>> configurators) {
@@ -135,9 +145,10 @@ final class JettyServiceConfig {
     }
 
     static String toString(
-            Object holder, String hostname, Boolean dumpAfterStart, Boolean dumpBeforeStop, Long stopTimeout,
-            Handler handler, RequestLog requestLog,
-            Function<? super Server, ? extends SessionIdManager> sessionIdManagerFactory,
+            Object holder, @Nullable String hostname, @Nullable Boolean dumpAfterStart,
+            @Nullable Boolean dumpBeforeStop, @Nullable Long stopTimeout,
+            @Nullable Handler handler, @Nullable RequestLog requestLog,
+            @Nullable Function<? super Server, ? extends SessionIdManager> sessionIdManagerFactory,
             Map<String, Object> attrs, List<Bean> beans, List<HandlerWrapper> handlerWrappers,
             List<Listener> eventListeners, List<LifeCycle.Listener> lifeCycleListeners,
             List<Consumer<? super Server>> configurators) {
@@ -162,9 +173,10 @@ final class JettyServiceConfig {
     static final class Bean {
 
         private final Object bean;
+        @Nullable
         private final Boolean managed;
 
-        Bean(Object bean, Boolean managed) {
+        Bean(Object bean, @Nullable Boolean managed) {
             this.bean = requireNonNull(bean, "bean");
             this.managed = managed;
         }
@@ -173,6 +185,7 @@ final class JettyServiceConfig {
             return bean;
         }
 
+        @Nullable
         Boolean isManaged() {
             return managed;
         }

--- a/kafka/src/main/java/com/linecorp/armeria/server/logging/structured/kafka/KafkaStructuredLoggingService.java
+++ b/kafka/src/main/java/com/linecorp/armeria/server/logging/structured/kafka/KafkaStructuredLoggingService.java
@@ -87,7 +87,7 @@ public class KafkaStructuredLoggingService<I extends Request, O extends Response
     public static <I extends Request, O extends Response, L>
     Function<Service<I, O>, StructuredLoggingService<I, O, L>> newDecorator(
             Producer<byte[], L> producer, String topic,
-            StructuredLogBuilder<L> logBuilder, KeySelector<L> keySelector) {
+            StructuredLogBuilder<L> logBuilder, @Nullable KeySelector<L> keySelector) {
         return service -> new KafkaStructuredLoggingService<>(
                 service, logBuilder, producer, topic, keySelector, false);
     }
@@ -127,8 +127,8 @@ public class KafkaStructuredLoggingService<I extends Request, O extends Response
     public static <I extends Request, O extends Response, L>
     Function<Service<I, O>, StructuredLoggingService<I, O, L>> newDecorator(
             String bootstrapServers, String topic,
-            StructuredLogBuilder<L> logBuilder, KeySelector<L> keySelector) {
-        Producer<byte[], L> producer = new KafkaProducer<>(newDefaultConfig(bootstrapServers));
+            StructuredLogBuilder<L> logBuilder, @Nullable KeySelector<L> keySelector) {
+        final Producer<byte[], L> producer = new KafkaProducer<>(newDefaultConfig(bootstrapServers));
         return service -> new KafkaStructuredLoggingService<>(
                 service, logBuilder, producer, topic, keySelector, true);
     }
@@ -153,7 +153,7 @@ public class KafkaStructuredLoggingService<I extends Request, O extends Response
     }
 
     private static Properties newDefaultConfig(String bootstrapServers) {
-        Properties producerConfig = new Properties();
+        final Properties producerConfig = new Properties();
 
         producerConfig.setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
 
@@ -187,9 +187,9 @@ public class KafkaStructuredLoggingService<I extends Request, O extends Response
 
     @Override
     protected void writeLog(RequestLog log, L structuredLog) {
-        byte[] key = keySelector.selectKey(log, structuredLog);
+        final byte[] key = keySelector.selectKey(log, structuredLog);
 
-        ProducerRecord<byte[], L> producerRecord = new ProducerRecord<>(topic, key, structuredLog);
+        final ProducerRecord<byte[], L> producerRecord = new ProducerRecord<>(topic, key, structuredLog);
         producer.send(producerRecord, (metadata, exception) -> {
             if (exception != null) {
                 logger.warn("failed to send service log to Kafka {}", producerRecord, exception);

--- a/kafka/src/main/java/com/linecorp/armeria/server/logging/structured/kafka/StructuredLogJsonKafkaSerializer.java
+++ b/kafka/src/main/java/com/linecorp/armeria/server/logging/structured/kafka/StructuredLogJsonKafkaSerializer.java
@@ -18,6 +18,8 @@ package com.linecorp.armeria.server.logging.structured.kafka;
 
 import java.util.Map;
 
+import javax.annotation.Nullable;
+
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 
@@ -43,6 +45,7 @@ public class StructuredLogJsonKafkaSerializer<L> implements Serializer<L> {
     @Override
     public void configure(Map<String, ?> map, boolean b) { /* noop */ }
 
+    @Nullable
     @Override
     public byte[] serialize(String topic, L value) {
         if (value == null) {
@@ -50,7 +53,7 @@ public class StructuredLogJsonKafkaSerializer<L> implements Serializer<L> {
         }
 
         try {
-            String json = objectMapper.writeValueAsString(value);
+            final String json = objectMapper.writeValueAsString(value);
             return stringSerializer.serialize(topic, json);
         } catch (JsonProcessingException ex) {
             throw new IllegalArgumentException(ex);

--- a/logback/src/main/java/com/linecorp/armeria/common/logback/RequestContextExportingAppender.java
+++ b/logback/src/main/java/com/linecorp/armeria/common/logback/RequestContextExportingAppender.java
@@ -66,6 +66,7 @@ public class RequestContextExportingAppender extends UnsynchronizedAppenderBase<
     private static final AttributeKey<State> STATE =
             AttributeKey.valueOf(RequestContextExportingAppender.class, "STATE");
 
+    @Nullable
     private RequestContextExporter exporter;
 
     private final AppenderAttachableImpl<ILoggingEvent> aai = new AppenderAttachableImpl<>();
@@ -241,8 +242,8 @@ public class RequestContextExportingAppender extends UnsynchronizedAppenderBase<
         final Attribute<State> attr = ctx.attr(STATE);
         final State state = attr.get();
         if (state == null) {
-            State newState = new State();
-            State oldState = attr.setIfAbsent(newState);
+            final State newState = new State();
+            final State oldState = attr.setIfAbsent(newState);
             if (oldState != null) {
                 return oldState;
             } else {
@@ -257,7 +258,8 @@ public class RequestContextExportingAppender extends UnsynchronizedAppenderBase<
      * to the export list via {@code add*()} calls and {@code <export />} tags. Override this method to export
      * additional properties.
      */
-    protected void export(Map<String, String> out, RequestContext ctx, @Nullable RequestLog log) {
+    protected void export(Map<String, String> out, RequestContext ctx, RequestLog log) {
+        assert exporter != null;
         exporter.export(out, ctx, log);
     }
 
@@ -319,12 +321,14 @@ public class RequestContextExportingAppender extends UnsynchronizedAppenderBase<
     private static final class State extends Object2ObjectOpenHashMap<String, String> {
         private static final long serialVersionUID = -7084248226635055988L;
 
+        @Nullable
         Set<RequestLogAvailability> availabilities;
     }
 
     private static final class LoggingEventWrapper implements ILoggingEvent {
         private final ILoggingEvent event;
         private final Map<String, String> mdcPropertyMap;
+        @Nullable
         private final LoggerContextVO vo;
 
         LoggingEventWrapper(ILoggingEvent event, Map<String, String> mdcPropertyMap) {
@@ -370,6 +374,7 @@ public class RequestContextExportingAppender extends UnsynchronizedAppenderBase<
         }
 
         @Override
+        @Nullable
         public LoggerContextVO getLoggerContextVO() {
             return vo;
         }

--- a/logback/src/main/java/com/linecorp/armeria/common/logback/UnionMap.java
+++ b/logback/src/main/java/com/linecorp/armeria/common/logback/UnionMap.java
@@ -21,6 +21,8 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
+import javax.annotation.Nullable;
+
 import com.google.common.collect.Sets;
 
 final class UnionMap<K, V> extends AbstractMap<K, V> {
@@ -28,6 +30,7 @@ final class UnionMap<K, V> extends AbstractMap<K, V> {
     private final Map<K, V> first;
     private final Map<K, V> second;
     private int size = -1;
+    @Nullable
     private Set<Entry<K, V>> entrySet;
 
     UnionMap(Map<K, V> first, Map<K, V> second) {

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/ArmeriaCallFactory.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/ArmeriaCallFactory.java
@@ -25,6 +25,8 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.BiFunction;
 import java.util.regex.Pattern;
 
+import javax.annotation.Nullable;
+
 import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.ClientOptionsBuilder;
 import com.linecorp.armeria.client.HttpClient;
@@ -103,6 +105,7 @@ final class ArmeriaCallFactory implements Factory {
 
         private final Request request;
 
+        @Nullable
         private volatile HttpResponse httpResponse;
 
         @SuppressWarnings("FieldMayBeFinal")
@@ -114,10 +117,10 @@ final class ArmeriaCallFactory implements Factory {
         }
 
         private static HttpResponse doCall(ArmeriaCallFactory callFactory, Request request) {
-            HttpUrl httpUrl = request.url();
-            URI uri = httpUrl.uri();
-            HttpClient httpClient = callFactory.getHttpClient(uri.getAuthority(), uri.getScheme());
-            StringBuilder uriBuilder = new StringBuilder(httpUrl.encodedPath());
+            final HttpUrl httpUrl = request.url();
+            final URI uri = httpUrl.uri();
+            final HttpClient httpClient = callFactory.getHttpClient(uri.getAuthority(), uri.getScheme());
+            final StringBuilder uriBuilder = new StringBuilder(httpUrl.encodedPath());
             if (uri.getQuery() != null) {
                 uriBuilder.append('?').append(httpUrl.encodedQuery());
             }

--- a/spring-boot/autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaSettings.java
+++ b/spring-boot/autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaSettings.java
@@ -71,6 +71,7 @@ public class ArmeriaSettings {
         /**
          * Returns the IP address {@link Server} uses.
          */
+        @Nullable
         public String getIp() {
             return ip;
         }
@@ -86,6 +87,7 @@ public class ArmeriaSettings {
         /**
          * Returns the network interface {@link Server} use.
          */
+        @Nullable
         public String getIface() {
             return iface;
         }

--- a/testing/src/main/java/com/linecorp/armeria/testing/server/SelfSignedCertificateRule.java
+++ b/testing/src/main/java/com/linecorp/armeria/testing/server/SelfSignedCertificateRule.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.testing.server;
 
+import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
 import java.io.File;
@@ -24,6 +25,8 @@ import java.security.SecureRandom;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import java.util.Date;
+
+import javax.annotation.Nullable;
 
 import org.junit.rules.ExternalResource;
 import org.junit.rules.TestRule;
@@ -35,12 +38,18 @@ import io.netty.handler.ssl.util.SelfSignedCertificate;
  */
 public class SelfSignedCertificateRule extends ExternalResource {
 
+    @Nullable
     private final String fqdn;
+    @Nullable
     private final SecureRandom random;
+    @Nullable
     private final Integer bits;
+    @Nullable
     private final Date notBefore;
+    @Nullable
     private final Date notAfter;
 
+    @Nullable
     private SelfSignedCertificate certificate;
 
     /**
@@ -160,13 +169,16 @@ public class SelfSignedCertificateRule extends ExternalResource {
      */
     @Override
     protected void after() {
-        certificate.delete();
+        if (certificate != null) {
+            certificate.delete();
+        }
     }
 
     /**
      *  Returns the generated {@link X509Certificate}.
      */
     public X509Certificate certificate() {
+        ensureCertificate();
         return certificate.cert();
     }
 
@@ -174,6 +186,7 @@ public class SelfSignedCertificateRule extends ExternalResource {
      * Returns the self-signed certificate file.
      */
     public File certificateFile() {
+        ensureCertificate();
         return certificate.certificate();
     }
 
@@ -181,6 +194,7 @@ public class SelfSignedCertificateRule extends ExternalResource {
      * Returns the {@link PrivateKey} of the self-signed certificate.
      */
     public PrivateKey privateKey() {
+        ensureCertificate();
         return certificate.key();
     }
 
@@ -188,6 +202,11 @@ public class SelfSignedCertificateRule extends ExternalResource {
      * Returns the private key file of the self-signed certificate.
      */
     public File privateKeyFile() {
+        ensureCertificate();
         return certificate.privateKey();
+    }
+
+    private void ensureCertificate() {
+        checkState(certificate != null, "certificate not created");
     }
 }

--- a/testing/src/main/java/com/linecorp/armeria/testing/server/ServerRule.java
+++ b/testing/src/main/java/com/linecorp/armeria/testing/server/ServerRule.java
@@ -24,6 +24,8 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 
+import javax.annotation.Nullable;
+
 import org.junit.rules.ExternalResource;
 import org.junit.rules.TestRule;
 
@@ -134,7 +136,7 @@ public abstract class ServerRule extends ExternalResource {
         return server;
     }
 
-    private static boolean isStopped(Server server) {
+    private static boolean isStopped(@Nullable Server server) {
         return server == null || server.activePorts().isEmpty();
     }
 

--- a/thrift/src/main/java/com/linecorp/armeria/client/thrift/THttpClientDelegate.java
+++ b/thrift/src/main/java/com/linecorp/armeria/client/thrift/THttpClientDelegate.java
@@ -25,6 +25,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import javax.annotation.Nullable;
+
 import org.apache.thrift.TApplicationException;
 import org.apache.thrift.TBase;
 import org.apache.thrift.TException;
@@ -191,7 +193,7 @@ final class THttpClientDelegate implements Client<RpcRequest, RpcResponse> {
             return;
         }
 
-        TBase<?, ?> result = func.newResult();
+        final TBase<?, ?> result = func.newResult();
         result.read(inputProtocol);
         inputProtocol.readMessageEnd();
 
@@ -223,6 +225,7 @@ final class THttpClientDelegate implements Client<RpcRequest, RpcResponse> {
                                           result.getClass().getName() + '.' + successField.getFieldName()));
     }
 
+    @Nullable
     private static TApplicationException readApplicationException(int seqId, ThriftFunction func,
                                                                   TProtocol inputProtocol,
                                                                   TMessage msg) throws TException {
@@ -244,13 +247,13 @@ final class THttpClientDelegate implements Client<RpcRequest, RpcResponse> {
     }
 
     private static void handleSuccess(ClientRequestContext ctx, DefaultRpcResponse reply,
-                                      Object returnValue, ThriftReply rawResponseContent) {
+                                      @Nullable Object returnValue, @Nullable ThriftReply rawResponseContent) {
         reply.complete(returnValue);
         ctx.logBuilder().responseContent(reply, rawResponseContent);
     }
 
     private static void handleException(ClientRequestContext ctx, DefaultRpcResponse reply,
-                                        ThriftReply rawResponseContent, Exception cause) {
+                                        @Nullable ThriftReply rawResponseContent, Exception cause) {
         reply.completeExceptionally(cause);
         ctx.logBuilder().responseContent(reply, rawResponseContent);
     }
@@ -261,7 +264,8 @@ final class THttpClientDelegate implements Client<RpcRequest, RpcResponse> {
                         decodeException(cause, thriftMethod.declaredExceptions()));
     }
 
-    private static Exception decodeException(Throwable cause, Class<?>[] declaredThrowableExceptions) {
+    private static Exception decodeException(Throwable cause,
+                                             @Nullable Class<?>[] declaredThrowableExceptions) {
         if (cause instanceof RuntimeException || cause instanceof TException) {
             return (Exception) cause;
         }

--- a/thrift/src/main/java/com/linecorp/armeria/client/thrift/THttpClientInvocationHandler.java
+++ b/thrift/src/main/java/com/linecorp/armeria/client/thrift/THttpClientInvocationHandler.java
@@ -25,6 +25,8 @@ import java.net.URI;
 import java.util.Arrays;
 import java.util.concurrent.ExecutionException;
 
+import javax.annotation.Nullable;
+
 import org.apache.thrift.async.AsyncMethodCallback;
 
 import com.linecorp.armeria.client.ClientBuilderParams;
@@ -41,10 +43,11 @@ final class THttpClientInvocationHandler implements InvocationHandler, ClientBui
     private final ClientBuilderParams params;
     private final THttpClient thriftClient;
     private final String path;
+    @Nullable
     private final String fragment;
 
     THttpClientInvocationHandler(ClientBuilderParams params,
-                                 THttpClient thriftClient, String path, String fragment) {
+                                 THttpClient thriftClient, String path, @Nullable String fragment) {
         this.params = params;
         this.thriftClient = thriftClient;
         this.path = path;
@@ -71,6 +74,7 @@ final class THttpClientInvocationHandler implements InvocationHandler, ClientBui
         return params.options();
     }
 
+    @Nullable
     @Override
     public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
         final Class<?> declaringClass = method.getDeclaringClass();
@@ -99,7 +103,8 @@ final class THttpClientInvocationHandler implements InvocationHandler, ClientBui
         }
     }
 
-    private Object invokeClientMethod(Method method, Object[] args) throws Throwable {
+    @Nullable
+    private Object invokeClientMethod(Method method, @Nullable Object[] args) throws Throwable {
         final AsyncMethodCallback<Object> callback;
         if (args == null) {
             args = NO_ARGS;

--- a/thrift/src/main/java/com/linecorp/armeria/common/thrift/ThriftCall.java
+++ b/thrift/src/main/java/com/linecorp/armeria/common/thrift/ThriftCall.java
@@ -18,6 +18,8 @@ package com.linecorp.armeria.common.thrift;
 
 import static java.util.Objects.requireNonNull;
 
+import javax.annotation.Nullable;
+
 import org.apache.thrift.TBase;
 import org.apache.thrift.protocol.TMessage;
 import org.apache.thrift.protocol.TMessageType;
@@ -56,7 +58,7 @@ public final class ThriftCall extends ThriftMessage {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) {
             return true;
         }

--- a/thrift/src/main/java/com/linecorp/armeria/common/thrift/ThriftReply.java
+++ b/thrift/src/main/java/com/linecorp/armeria/common/thrift/ThriftReply.java
@@ -20,6 +20,8 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Objects;
 
+import javax.annotation.Nullable;
+
 import org.apache.thrift.TApplicationException;
 import org.apache.thrift.TBase;
 import org.apache.thrift.protocol.TMessage;
@@ -37,7 +39,9 @@ import com.linecorp.armeria.common.logging.RequestLog;
  */
 public final class ThriftReply extends ThriftMessage {
 
+    @Nullable
     private final TBase<?, ?> result;
+    @Nullable
     private final TApplicationException exception;
 
     /**
@@ -100,7 +104,7 @@ public final class ThriftReply extends ThriftMessage {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) {
             return true;
         }

--- a/thrift/src/main/java/com/linecorp/armeria/common/thrift/text/MapContext.java
+++ b/thrift/src/main/java/com/linecorp/armeria/common/thrift/text/MapContext.java
@@ -30,6 +30,8 @@
 // =================================================================================================
 package com.linecorp.armeria.common.thrift.text;
 
+import javax.annotation.Nullable;
+
 import com.fasterxml.jackson.databind.JsonNode;
 
 /**
@@ -42,7 +44,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 class MapContext extends PairContext {
 
     // SUPPRESS CHECKSTYLE JavadocMethod
-    protected MapContext(JsonNode json) {
+    protected MapContext(@Nullable JsonNode json) {
         super(json);
     }
 

--- a/thrift/src/main/java/com/linecorp/armeria/common/thrift/text/PairContext.java
+++ b/thrift/src/main/java/com/linecorp/armeria/common/thrift/text/PairContext.java
@@ -33,6 +33,8 @@ package com.linecorp.armeria.common.thrift.text;
 import java.util.Iterator;
 import java.util.Map;
 
+import javax.annotation.Nullable;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 
@@ -53,14 +55,16 @@ import com.fasterxml.jackson.databind.node.TextNode;
  */
 class PairContext extends BaseContext {
 
+    @Nullable
     private final Iterator<Map.Entry<String, JsonNode>> children;
     private boolean lhs;
+    @Nullable
     private Map.Entry<String, JsonNode> currentChild;
 
     /**
      * Creates an iterator over this object's children.
      */
-    protected PairContext(JsonNode json) {
+    protected PairContext(@Nullable JsonNode json) {
         children = null != json ? json.fields() : null;
     }
 
@@ -75,6 +79,7 @@ class PairContext extends BaseContext {
         // every other time, do a read, since the read gets the name & value
         // at once.
         if (isLhs()) {
+            assert children != null;
             if (!children.hasNext()) {
                 throw new RuntimeException(
                         "Called PairContext.read() too many times!");
@@ -85,6 +90,7 @@ class PairContext extends BaseContext {
 
     @Override
     protected JsonNode getCurrentChild() {
+        assert currentChild != null;
         if (lhs) {
             return new TextNode(currentChild.getKey());
         }
@@ -93,6 +99,7 @@ class PairContext extends BaseContext {
 
     @Override
     protected boolean hasMoreChildren() {
+        assert children != null;
         return children.hasNext();
     }
 

--- a/thrift/src/main/java/com/linecorp/armeria/common/thrift/text/SequenceContext.java
+++ b/thrift/src/main/java/com/linecorp/armeria/common/thrift/text/SequenceContext.java
@@ -32,6 +32,8 @@ package com.linecorp.armeria.common.thrift.text;
 
 import java.util.Iterator;
 
+import javax.annotation.Nullable;
+
 import com.fasterxml.jackson.databind.JsonNode;
 
 /**
@@ -42,19 +44,22 @@ import com.fasterxml.jackson.databind.JsonNode;
  */
 class SequenceContext extends BaseContext {
 
+    @Nullable
     private final Iterator<JsonNode> children;
+    @Nullable
     private JsonNode currentChild;
 
     /**
      * Create an iterator over the children. May be constructed with a null
      * JsonArray if we only use it for writing.
      */
-    protected SequenceContext(JsonNode json) {
+    protected SequenceContext(@Nullable JsonNode json) {
         children = null != json ? json.elements() : null;
     }
 
     @Override
     protected void read() {
+        assert children != null;
         if (!children.hasNext()) {
             throw new RuntimeException(
                     "Called SequenceContext.read() too many times!");
@@ -64,11 +69,13 @@ class SequenceContext extends BaseContext {
 
     @Override
     protected JsonNode getCurrentChild() {
+        assert currentChild != null;
         return currentChild;
     }
 
     @Override
     protected boolean hasMoreChildren() {
+        assert children != null;
         return children.hasNext();
     }
 }

--- a/thrift/src/main/java/com/linecorp/armeria/common/thrift/text/StructContext.java
+++ b/thrift/src/main/java/com/linecorp/armeria/common/thrift/text/StructContext.java
@@ -77,11 +77,11 @@ class StructContext extends PairContext {
     /**
      * Build the name -> TField map.
      */
-    StructContext(JsonNode json) {
+    StructContext(@Nullable JsonNode json) {
         this(json, getCurrentThriftMessageClass());
     }
 
-    StructContext(JsonNode json, Class<?> clazz) {
+    StructContext(@Nullable JsonNode json, Class<?> clazz) {
         super(json);
         classMap = new HashMap<>();
         fieldNameMap = computeFieldNameMap(clazz);
@@ -132,14 +132,14 @@ class StructContext extends PairContext {
      * TProtocol.writeStructBegin(), rather than relying on the stack trace.
      */
     private static Class<?> getCurrentThriftMessageClass() {
-        StackTraceElement[] frames =
+        final StackTraceElement[] frames =
                 Thread.currentThread().getStackTrace();
 
         for (StackTraceElement f : frames) {
-            String className = f.getClassName();
+            final String className = f.getClassName();
 
             try {
-                Class<?> clazz = Class.forName(className);
+                final Class<?> clazz = Class.forName(className);
 
                 // Note, we need to check
                 // if the class is abstract, because abstract class does not have metaDataMap
@@ -180,9 +180,9 @@ class StructContext extends PairContext {
     }
 
     private static boolean hasNoArgConstructor(Class<?> clazz) {
-        Constructor<?>[] allConstructors = clazz.getConstructors();
+        final Constructor<?>[] allConstructors = clazz.getConstructors();
         for (Constructor<?> ctor : allConstructors) {
-            Class<?>[] pType = ctor.getParameterTypes();
+            final Class<?>[] pType = ctor.getParameterTypes();
             if (pType.length == 0) {
                 return true;
             }
@@ -196,12 +196,12 @@ class StructContext extends PairContext {
      * we are parsing.
      */
     private Map<String, TField> computeFieldNameMap(Class<?> clazz) {
-        Map<String, TField> map = new HashMap<>();
+        final Map<String, TField> map = new HashMap<>();
 
         if (isTBase(clazz)) {
             // Get the metaDataMap for this Thrift class
             @SuppressWarnings("unchecked")
-            Map<? extends TFieldIdEnum, FieldMetaData> metaDataMap =
+            final Map<? extends TFieldIdEnum, FieldMetaData> metaDataMap =
                     FieldMetaData.getStructMetaDataMap((Class<? extends TBase<?, ?>>) clazz);
 
             for (Entry<? extends TFieldIdEnum, FieldMetaData> e : metaDataMap.entrySet()) {
@@ -236,8 +236,8 @@ class StructContext extends PairContext {
                 // The thrift generated parsing code requires that, when expecting
                 // a value of enum, we actually parse a value of type int32. The
                 // generated read() method then looks up the enum value in a map.
-                byte type = TType.ENUM == metaData.valueMetaData.type ? TType.I32
-                                                                      : metaData.valueMetaData.type;
+                final byte type = TType.ENUM == metaData.valueMetaData.type ? TType.I32
+                                                                            : metaData.valueMetaData.type;
 
                 map.put(fieldName,
                         new TField(fieldName,

--- a/thrift/src/main/java/com/linecorp/armeria/internal/thrift/ThriftServiceMetadata.java
+++ b/thrift/src/main/java/com/linecorp/armeria/internal/thrift/ThriftServiceMetadata.java
@@ -25,6 +25,8 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import javax.annotation.Nullable;
+
 import org.apache.thrift.AsyncProcessFunction;
 import org.apache.thrift.ProcessFunction;
 import org.apache.thrift.TBaseAsyncProcessor;
@@ -70,7 +72,7 @@ public final class ThriftServiceMetadata {
         return init(implementation, Types.getAllInterfaces(implementation.getClass()));
     }
 
-    private Set<Class<?>> init(Object implementation, Iterable<Class<?>> candidateInterfaces) {
+    private Set<Class<?>> init(@Nullable Object implementation, Iterable<Class<?>> candidateInterfaces) {
 
         // Build the map of method names and their corresponding process functions.
         final Set<String> methodNames = new HashSet<>();
@@ -106,8 +108,9 @@ public final class ThriftServiceMetadata {
         return Collections.unmodifiableSet(interfaces);
     }
 
-    private static Map<String, ProcessFunction<?, ?>> getThriftProcessMap(Object service, Class<?> iface) {
-
+    @Nullable
+    private static Map<String, ProcessFunction<?, ?>> getThriftProcessMap(@Nullable Object service,
+                                                                          Class<?> iface) {
         final String name = iface.getName();
         if (!name.endsWith("$Iface")) {
             return null;
@@ -126,7 +129,7 @@ public final class ThriftServiceMetadata {
             final TBaseProcessor processor = (TBaseProcessor) processorConstructor.newInstance(service);
 
             @SuppressWarnings("unchecked")
-            Map<String, ProcessFunction<?, ?>> processMap =
+            final Map<String, ProcessFunction<?, ?>> processMap =
                     (Map<String, ProcessFunction<?, ?>>) processor.getProcessMapView();
 
             return processMap;
@@ -136,8 +139,9 @@ public final class ThriftServiceMetadata {
         }
     }
 
+    @Nullable
     private static Map<String, AsyncProcessFunction<?, ?, ?>> getThriftAsyncProcessMap(
-            Object service, Class<?> iface) {
+            @Nullable Object service, Class<?> iface) {
 
         final String name = iface.getName();
         if (!name.endsWith("$AsyncIface")) {
@@ -146,7 +150,7 @@ public final class ThriftServiceMetadata {
 
         final String processorName = name.substring(0, name.length() - 10) + "AsyncProcessor";
         try {
-            Class<?> processorClass = Class.forName(processorName, false, iface.getClassLoader());
+            final Class<?> processorClass = Class.forName(processorName, false, iface.getClassLoader());
             if (!TBaseAsyncProcessor.class.isAssignableFrom(processorClass)) {
                 return null;
             }
@@ -158,7 +162,7 @@ public final class ThriftServiceMetadata {
                     (TBaseAsyncProcessor) processorConstructor.newInstance(service);
 
             @SuppressWarnings("unchecked")
-            Map<String, AsyncProcessFunction<?, ?, ?>> processMap =
+            final Map<String, AsyncProcessFunction<?, ?, ?>> processMap =
                     (Map<String, AsyncProcessFunction<?, ?, ?>>) processor.getProcessMapView();
 
             return processMap;
@@ -205,6 +209,7 @@ public final class ThriftServiceMetadata {
      *
      * @return the {@link ThriftFunction}. {@code null} if there's no such function.
      */
+    @Nullable
     public ThriftFunction function(String method) {
         return functions.get(method);
     }

--- a/thrift/src/main/java/com/linecorp/armeria/server/thrift/TByteBufTransport.java
+++ b/thrift/src/main/java/com/linecorp/armeria/server/thrift/TByteBufTransport.java
@@ -16,6 +16,10 @@
 
 package com.linecorp.armeria.server.thrift;
 
+import static java.util.Objects.requireNonNull;
+
+import javax.annotation.Nullable;
+
 import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
 
@@ -26,7 +30,7 @@ final class TByteBufTransport extends TTransport {
     private final ByteBuf buf;
 
     TByteBufTransport(ByteBuf buf) {
-        this.buf = buf;
+        this.buf = requireNonNull(buf, "buf");
     }
 
     @Override
@@ -42,8 +46,8 @@ final class TByteBufTransport extends TTransport {
 
     @Override
     public int read(byte[] buf, int off, int len) {
-        int bytesRemaining = this.buf.readableBytes();
-        int amtToRead = len > bytesRemaining ? bytesRemaining : len;
+        final int bytesRemaining = this.buf.readableBytes();
+        final int amtToRead = len > bytesRemaining ? bytesRemaining : len;
         if (amtToRead > 0) {
             this.buf.readBytes(buf, off, amtToRead);
         }
@@ -52,7 +56,7 @@ final class TByteBufTransport extends TTransport {
 
     @Override
     public int readAll(byte[] buf, int off, int len) throws TTransportException {
-        int bytesRemaining = this.buf.readableBytes();
+        final int bytesRemaining = this.buf.readableBytes();
         if (len > bytesRemaining) {
             throw new TTransportException("unexpected end of frame");
         }
@@ -66,10 +70,11 @@ final class TByteBufTransport extends TTransport {
         this.buf.writeBytes(buf, off, len);
     }
 
+    @Nullable
     @Override
     public byte[] getBuffer() {
-        ByteBuf buf = this.buf;
-        if (buf == null || !buf.hasArray())  {
+        final ByteBuf buf = this.buf;
+        if (!buf.hasArray())  {
             return null;
         } else {
             return buf.array();
@@ -78,8 +83,8 @@ final class TByteBufTransport extends TTransport {
 
     @Override
     public int getBufferPosition() {
-        ByteBuf buf = this.buf;
-        if (buf == null || !buf.hasArray())  {
+        final ByteBuf buf = this.buf;
+        if (!buf.hasArray())  {
             return 0;
         } else {
             return buf.arrayOffset() + buf.readerIndex();
@@ -88,7 +93,7 @@ final class TByteBufTransport extends TTransport {
 
     @Override
     public int getBytesRemainingInBuffer() {
-        ByteBuf buf = this.buf;
+        final ByteBuf buf = this.buf;
         if (buf.hasArray()) {
             return buf.readableBytes();
         } else {

--- a/thrift/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
+++ b/thrift/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
@@ -418,8 +418,8 @@ public final class THttpService extends AbstractHttpService {
                                    MediaType.PLAIN_TEXT_UTF_8, ACCEPT_THRIFT_PROTOCOL_MUST_MATCH_CONTENT_TYPE);
         }
 
-        CompletableFuture<HttpResponse> responseFuture = new CompletableFuture<>();
-        HttpResponse res = HttpResponse.from(responseFuture);
+        final CompletableFuture<HttpResponse> responseFuture = new CompletableFuture<>();
+        final HttpResponse res = HttpResponse.from(responseFuture);
         ctx.logBuilder().serializationFormat(serializationFormat);
         ctx.logBuilder().deferRequestContent();
         req.aggregate().handle(voidFunction((aReq, cause) -> {
@@ -441,7 +441,7 @@ public final class THttpService extends AbstractHttpService {
         final HttpHeaders headers = req.headers();
         final MediaType contentType = headers.contentType();
 
-        SerializationFormat serializationFormat;
+        final SerializationFormat serializationFormat;
         if (contentType != null) {
             serializationFormat = findSerializationFormat(contentType);
             if (serializationFormat == null) {
@@ -453,7 +453,7 @@ public final class THttpService extends AbstractHttpService {
         return serializationFormat;
     }
 
-    private boolean validateAcceptHeaders(HttpRequest req, SerializationFormat serializationFormat) {
+    private static boolean validateAcceptHeaders(HttpRequest req, SerializationFormat serializationFormat) {
         // If accept header is present, make sure it is sane. Currently, we do not support accept
         // headers with a different format than the content type header.
         final List<String> acceptHeaders = req.headers().getAll(HttpHeaderNames.ACCEPT);
@@ -464,6 +464,7 @@ public final class THttpService extends AbstractHttpService {
         return true;
     }
 
+    @Nullable
     private SerializationFormat findSerializationFormat(MediaType contentType) {
 
         for (SerializationFormat format : allowedSerializationFormatArray) {

--- a/thrift/src/main/java/com/linecorp/armeria/server/thrift/ThriftDocServicePlugin.java
+++ b/thrift/src/main/java/com/linecorp/armeria/server/thrift/ThriftDocServicePlugin.java
@@ -242,7 +242,7 @@ public class ThriftDocServicePlugin implements DocServicePlugin {
     }
 
     private static NamedTypeInfo newNamedTypeInfo(TypeSignature typeSignature) {
-        Class<?> type = (Class<?>) typeSignature.namedTypeDescriptor().get();
+        final Class<?> type = (Class<?>) typeSignature.namedTypeDescriptor().get();
         if (type.isEnum()) {
             return newEnumInfo(type);
         }
@@ -491,6 +491,7 @@ public class ThriftDocServicePlugin implements DocServicePlugin {
         }
     }
 
+    @Nullable
     private static TBase<?, ?> asTBase(Object exampleRequest) {
         final TBase<?, ?> exampleTBase = (TBase<?, ?>) exampleRequest;
         final Class<?> type = exampleTBase.getClass();

--- a/thrift/src/main/java/com/linecorp/armeria/server/thrift/ThriftStructuredLog.java
+++ b/thrift/src/main/java/com/linecorp/armeria/server/thrift/ThriftStructuredLog.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.server.thrift;
 
+import javax.annotation.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
 
@@ -33,9 +35,13 @@ import com.linecorp.armeria.server.logging.structured.StructuredLogBuilder;
  */
 public class ThriftStructuredLog extends StructuredLog {
 
+    @Nullable
     private final String thriftServiceName;
+    @Nullable
     private final String thriftMethodName;
+    @Nullable
     private final ThriftCall thriftCall;
+    @Nullable
     private final ThriftReply thriftReply;
 
     ThriftStructuredLog(long timestampMillis,
@@ -60,7 +66,7 @@ public class ThriftStructuredLog extends StructuredLog {
     public ThriftStructuredLog(RequestLog reqLog) {
         super(reqLog);
 
-        Object requestContent = reqLog.rawRequestContent();
+        final Object requestContent = reqLog.rawRequestContent();
         if (requestContent == null) {
             // Request might be responded as error before reading arguments.
             thriftServiceName = null;
@@ -92,6 +98,7 @@ public class ThriftStructuredLog extends StructuredLog {
      *
      * @return fully qualified Thrift service name
      */
+    @Nullable
     @JsonProperty
     public String thriftServiceName() {
         return thriftServiceName;
@@ -102,6 +109,7 @@ public class ThriftStructuredLog extends StructuredLog {
      *
      * @return Thrift method name
      */
+    @Nullable
     @JsonProperty
     public String thriftMethodName() {
         return thriftMethodName;
@@ -112,6 +120,7 @@ public class ThriftStructuredLog extends StructuredLog {
      *
      * @return an instance of {@link ThriftCall} which is associated to the log
      */
+    @Nullable
     @JsonProperty
     public ThriftCall thriftCall() {
         return thriftCall;
@@ -122,6 +131,7 @@ public class ThriftStructuredLog extends StructuredLog {
      *
      * @return an instance of {@link ThriftReply} which is associated to the log
      */
+    @Nullable
     @JsonProperty
     public ThriftReply thriftReply() {
         return thriftReply;

--- a/tomcat/src/main/java/com/linecorp/armeria/server/tomcat/JarSubsetResourceSet.java
+++ b/tomcat/src/main/java/com/linecorp/armeria/server/tomcat/JarSubsetResourceSet.java
@@ -37,6 +37,8 @@ import java.util.HashMap;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
+import javax.annotation.Nullable;
+
 import org.apache.catalina.WebResourceRoot;
 import org.apache.catalina.webresources.JarResourceSet;
 
@@ -56,6 +58,7 @@ final class JarSubsetResourceSet extends JarResourceSet {
         prefix = jarRoot.substring(1) + '/';
     }
 
+    @Nullable
     @Override
     protected HashMap<String,JarEntry> getArchiveEntries(boolean single) {
         synchronized (archiveLock) {
@@ -64,7 +67,7 @@ final class JarSubsetResourceSet extends JarResourceSet {
                 archiveEntries = new HashMap<>();
                 try {
                     jarFile = openJarFile();
-                    Enumeration<JarEntry> entries = jarFile.entries();
+                    final Enumeration<JarEntry> entries = jarFile.entries();
                     while (entries.hasMoreElements()) {
                         final JarEntry entry = entries.nextElement();
                         final String name = entry.getName();

--- a/tomcat/src/main/java/com/linecorp/armeria/server/tomcat/ManagedConnectorFactory.java
+++ b/tomcat/src/main/java/com/linecorp/armeria/server/tomcat/ManagedConnectorFactory.java
@@ -69,6 +69,7 @@ final class ManagedConnectorFactory implements Function<String, Connector> {
         // Retrieve the components configured by newServer(), so we can use it in checkConfiguration().
         final Service service = server.findServices()[0];
         final Engine engine = TomcatUtil.engine(service);
+        assert engine != null;
         final StandardHost host = (StandardHost) engine.findChildren()[0];
         final Context context = (Context) host.findChildren()[0];
 

--- a/tomcat/src/main/java/com/linecorp/armeria/server/tomcat/Tomcat85ProtocolHandler.java
+++ b/tomcat/src/main/java/com/linecorp/armeria/server/tomcat/Tomcat85ProtocolHandler.java
@@ -19,6 +19,8 @@ package com.linecorp.armeria.server.tomcat;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import javax.annotation.Nullable;
+
 import org.apache.catalina.connector.Connector;
 import org.apache.coyote.Adapter;
 import org.apache.coyote.ProtocolHandler;
@@ -34,6 +36,7 @@ public final class Tomcat85ProtocolHandler implements ProtocolHandler {
     private static final AtomicInteger nextId = new AtomicInteger();
 
     private final int id = nextId.getAndIncrement();
+    @Nullable
     private Adapter adapter;
 
     @Override
@@ -41,6 +44,7 @@ public final class Tomcat85ProtocolHandler implements ProtocolHandler {
         this.adapter = adapter;
     }
 
+    @Nullable
     @Override
     public Adapter getAdapter() {
         return adapter;
@@ -53,6 +57,7 @@ public final class Tomcat85ProtocolHandler implements ProtocolHandler {
         return id;
     }
 
+    @Nullable
     @Override
     public Executor getExecutor() {
         // Doesn't seem to be used.

--- a/tomcat/src/main/java/com/linecorp/armeria/server/tomcat/TomcatService.java
+++ b/tomcat/src/main/java/com/linecorp/armeria/server/tomcat/TomcatService.java
@@ -228,7 +228,8 @@ public final class TomcatService implements HttpService {
         buf.append("(serviceName: ");
         buf.append(serviceName);
         if (TomcatVersion.major() >= 8) {
-            buf.append(", catalinaBase: " + server.getCatalinaBase());
+            buf.append(", catalinaBase: ");
+            buf.append(server.getCatalinaBase());
         }
         buf.append(')');
 
@@ -239,18 +240,23 @@ public final class TomcatService implements HttpService {
     private final Consumer<Connector> postStopTask;
     private final ServerListener configurator;
 
+    @Nullable
     private org.apache.catalina.Server server;
+    @Nullable
     private Server armeriaServer;
+    @Nullable
     private String hostname;
+    @Nullable
     private Connector connector;
+    @Nullable
     private String engineName;
     private boolean started;
 
-    private TomcatService(String hostname, Function<String, Connector> connectorFactory) {
+    private TomcatService(@Nullable String hostname, Function<String, Connector> connectorFactory) {
         this(hostname, connectorFactory, unused -> { /* unused */ });
     }
 
-    private TomcatService(String hostname,
+    private TomcatService(@Nullable String hostname,
                           Function<String, Connector> connectorFactory, Consumer<Connector> postStopTask) {
 
         this.hostname = hostname;
@@ -427,13 +433,13 @@ public final class TomcatService implements HttpService {
         coyoteReq.setLocalPort(localAddr.getPort());
 
         final String hostHeader = req.headers().authority();
-        int colonPos = hostHeader.indexOf(':');
+        final int colonPos = hostHeader.indexOf(':');
         if (colonPos < 0) {
             coyoteReq.serverName().setString(hostHeader);
         } else {
             coyoteReq.serverName().setString(hostHeader.substring(0, colonPos));
             try {
-                int port = Integer.parseInt(hostHeader.substring(colonPos + 1));
+                final int port = Integer.parseInt(hostHeader.substring(colonPos + 1));
                 coyoteReq.setServerPort(port);
             } catch (NumberFormatException e) {
                 // Invalid port number
@@ -518,6 +524,7 @@ public final class TomcatService implements HttpService {
         return headers;
     }
 
+    @Nullable
     private static AsciiString toHeaderName(MessageBytes value) {
         switch (value.getType()) {
             case MessageBytes.T_BYTES: {
@@ -535,6 +542,7 @@ public final class TomcatService implements HttpService {
         return null;
     }
 
+    @Nullable
     private static String toHeaderValue(MessageBytes value) {
         switch (value.getType()) {
             case MessageBytes.T_BYTES: {

--- a/tomcat/src/main/java/com/linecorp/armeria/server/tomcat/TomcatServiceBuilder.java
+++ b/tomcat/src/main/java/com/linecorp/armeria/server/tomcat/TomcatServiceBuilder.java
@@ -34,6 +34,8 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.function.Consumer;
 
+import javax.annotation.Nullable;
+
 import org.apache.catalina.Realm;
 import org.apache.catalina.connector.Connector;
 import org.apache.catalina.core.StandardEngine;
@@ -172,16 +174,21 @@ public final class TomcatServiceBuilder {
     }
 
     private final Path docBase;
+    @Nullable
     private final String jarRoot;
     private final List<Consumer<? super StandardServer>> configurators = new ArrayList<>();
 
     private String serviceName = DEFAULT_SERVICE_NAME;
+    @Nullable
     private String engineName;
+    @Nullable
     private Path baseDir;
+    @Nullable
     private Realm realm;
+    @Nullable
     private String hostname;
 
-    private TomcatServiceBuilder(Path docBase, String jarRoot) {
+    private TomcatServiceBuilder(Path docBase, @Nullable String jarRoot) {
         this.docBase = validateDocBase(docBase);
         if (TomcatUtil.isZip(docBase)) {
             this.jarRoot = normalizeJarRoot(jarRoot);
@@ -208,7 +215,7 @@ public final class TomcatServiceBuilder {
         return docBase;
     }
 
-    private static String normalizeJarRoot(String jarRoot) {
+    private static String normalizeJarRoot(@Nullable String jarRoot) {
         if (jarRoot == null || jarRoot.isEmpty() || "/".equals(jarRoot)) {
             return "/";
         }

--- a/tomcat/src/main/java/com/linecorp/armeria/server/tomcat/TomcatServiceConfig.java
+++ b/tomcat/src/main/java/com/linecorp/armeria/server/tomcat/TomcatServiceConfig.java
@@ -21,6 +21,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
 
+import javax.annotation.Nullable;
+
 import org.apache.catalina.Realm;
 import org.apache.catalina.core.StandardEngine;
 import org.apache.catalina.core.StandardServer;
@@ -34,16 +36,19 @@ import com.google.common.base.MoreObjects;
 final class TomcatServiceConfig {
 
     private final String serviceName;
+    @Nullable
     private final String engineName;
     private final Path baseDir;
     private final Realm realm;
+    @Nullable
     private final String hostname;
     private final Path docBase;
+    @Nullable
     private final String jarRoot;
     private final List<Consumer<? super StandardServer>> configurators;
 
-    TomcatServiceConfig(String serviceName, String engineName, Path baseDir, Realm realm,
-                        String hostname, Path docBase, String jarRoot,
+    TomcatServiceConfig(String serviceName, @Nullable String engineName, Path baseDir, Realm realm,
+                        @Nullable String hostname, Path docBase, @Nullable String jarRoot,
                         List<Consumer<? super StandardServer>> configurators) {
 
         this.engineName = engineName;
@@ -121,8 +126,9 @@ final class TomcatServiceConfig {
                         docBase(), jarRoot().orElse(null));
     }
 
-    static String toString(Object holder, String serviceName, String engineName,
-                           Path baseDir, Realm realm, String hostname, Path docBase, String jarRoot) {
+    static String toString(Object holder, String serviceName, @Nullable String engineName,
+                           @Nullable Path baseDir, @Nullable Realm realm, @Nullable String hostname,
+                           Path docBase, @Nullable String jarRoot) {
 
         return holder.getClass().getSimpleName() +
                "(serviceName: " + serviceName +

--- a/tomcat/src/main/java/com/linecorp/armeria/server/tomcat/TomcatUtil.java
+++ b/tomcat/src/main/java/com/linecorp/armeria/server/tomcat/TomcatUtil.java
@@ -25,6 +25,8 @@ import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.zip.ZipFile;
 
+import javax.annotation.Nullable;
+
 import org.apache.catalina.Container;
 import org.apache.catalina.Engine;
 import org.apache.catalina.LifecycleListener;
@@ -75,9 +77,10 @@ final class TomcatUtil {
      * The return type of {@link Service#getContainer()} has been changed from {@link Container} to
      * {@link Engine} since 8.5. Calling it directly will cause {@link NoSuchMethodError}.
      */
+    @Nullable
     static Engine engine(Service service) {
         try {
-            Method m = Service.class.getDeclaredMethod("getContainer");
+            final Method m = Service.class.getDeclaredMethod("getContainer");
             return (Engine) m.invoke(service);
         } catch (Exception e) {
             throw new Error("failed to invoke Service.getContainer()", e);

--- a/tomcat8.0/src/main/java/com/linecorp/armeria/server/tomcat/Tomcat80ProtocolHandler.java
+++ b/tomcat8.0/src/main/java/com/linecorp/armeria/server/tomcat/Tomcat80ProtocolHandler.java
@@ -19,6 +19,8 @@ package com.linecorp.armeria.server.tomcat;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import javax.annotation.Nullable;
+
 import org.apache.catalina.connector.Connector;
 import org.apache.coyote.Adapter;
 import org.apache.coyote.ProtocolHandler;
@@ -32,6 +34,7 @@ public final class Tomcat80ProtocolHandler implements ProtocolHandler {
     private static final AtomicInteger nextId = new AtomicInteger();
 
     private final int id = nextId.getAndIncrement();
+    @Nullable
     private Adapter adapter;
 
     @Override
@@ -39,6 +42,7 @@ public final class Tomcat80ProtocolHandler implements ProtocolHandler {
         this.adapter = adapter;
     }
 
+    @Nullable
     @Override
     public Adapter getAdapter() {
         return adapter;
@@ -52,6 +56,7 @@ public final class Tomcat80ProtocolHandler implements ProtocolHandler {
     }
 
     @Override
+    @Nullable
     public Executor getExecutor() {
         // Doesn't seem to be used.
         return null;

--- a/zipkin/src/main/java/com/linecorp/armeria/internal/tracing/SpanTags.java
+++ b/zipkin/src/main/java/com/linecorp/armeria/internal/tracing/SpanTags.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.internal.tracing;
 
+import java.net.SocketAddress;
+
 import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.logging.RequestLog;
 
@@ -47,15 +49,18 @@ public final class SpanTags {
             .tag(TraceKeys.HTTP_PATH, log.path())
             .tag(TraceKeys.HTTP_URL, uriBuilder.toString())
             .tag(TraceKeys.HTTP_STATUS_CODE, String.valueOf(log.statusCode()));
-        if (log.responseCause() != null) {
-            span.tag(Constants.ERROR, log.responseCause().toString());
+        final Throwable responseCause = log.responseCause();
+        if (responseCause != null) {
+            span.tag(Constants.ERROR, responseCause.toString());
         }
 
-        if (log.context().remoteAddress() != null) {
-            span.tag("address.remote", log.context().remoteAddress().toString());
+        final SocketAddress raddr = log.context().remoteAddress();
+        if (raddr != null) {
+            span.tag("address.remote", raddr.toString());
         }
-        if (log.context().localAddress() != null) {
-            span.tag("address.local", log.context().localAddress().toString());
+        final SocketAddress laddr = log.context().localAddress();
+        if (laddr != null) {
+            span.tag("address.local", laddr.toString());
         }
 
         final Object requestContent = log.requestContent();

--- a/zookeeper/src/main/java/com/linecorp/armeria/client/zookeeper/ZooKeeperEndpointGroup.java
+++ b/zookeeper/src/main/java/com/linecorp/armeria/client/zookeeper/ZooKeeperEndpointGroup.java
@@ -86,12 +86,12 @@ public class ZooKeeperEndpointGroup extends DynamicEndpointGroup {
         return new ZooKeeperListener() {
             @Override
             public void nodeChildChange(Map<String, String> newChildrenValue) {
-                List<Endpoint> newData = newChildrenValue.values().stream()
-                                                         .map(nodeValueCodec::decode)
-                                                         .filter(Objects::nonNull)
-                                                         .collect(toImmutableList());
+                final List<Endpoint> newData = newChildrenValue.values().stream()
+                                                               .map(nodeValueCodec::decode)
+                                                               .filter(Objects::nonNull)
+                                                               .collect(toImmutableList());
                 final List<Endpoint> prevData = endpoints();
-                if (prevData == null || !prevData.equals(newData)) {
+                if (!prevData.equals(newData)) {
                     setEndpoints(newData);
                 }
             }

--- a/zookeeper/src/main/java/com/linecorp/armeria/common/zookeeper/NodeValueCodec.java
+++ b/zookeeper/src/main/java/com/linecorp/armeria/common/zookeeper/NodeValueCodec.java
@@ -20,6 +20,8 @@ import static java.util.Objects.requireNonNull;
 import java.nio.charset.StandardCharsets;
 import java.util.Set;
 
+import javax.annotation.Nullable;
+
 import com.linecorp.armeria.client.Endpoint;
 
 /**
@@ -64,8 +66,9 @@ public interface NodeValueCodec {
     /**
      * Decode a zNode value to a {@link Endpoint}.
      * @param zNodeValue ZooKeeper node value
-     * @return an {@link Endpoint}
+     * @return an {@link Endpoint} or {@code null} if value needs to be skipped
      */
+    @Nullable
     default Endpoint decode(byte[] zNodeValue) {
         requireNonNull(zNodeValue, "zNodeValue");
         return decode(new String(zNodeValue, StandardCharsets.UTF_8));
@@ -74,8 +77,9 @@ public interface NodeValueCodec {
     /**
      * Decode a zNode value to a {@link Endpoint}.
      * @param zNodeValue ZooKeeper node value
-     * @return an {@link Endpoint}
+     * @return an {@link Endpoint} or {@code null} if value needs to be skipped
      */
+    @Nullable
     Endpoint decode(String zNodeValue);
 
     /**

--- a/zookeeper/src/main/java/com/linecorp/armeria/server/zookeeper/ZooKeeperUpdatingListener.java
+++ b/zookeeper/src/main/java/com/linecorp/armeria/server/zookeeper/ZooKeeperUpdatingListener.java
@@ -17,6 +17,8 @@ package com.linecorp.armeria.server.zookeeper;
 
 import static java.util.Objects.requireNonNull;
 
+import javax.annotation.Nullable;
+
 import com.google.common.annotations.VisibleForTesting;
 
 import com.linecorp.armeria.client.Endpoint;
@@ -31,7 +33,9 @@ public class ZooKeeperUpdatingListener extends ServerListenerAdapter {
     private final String zkConnectionStr;
     private final String zNodePath;
     private final int sessionTimeout;
+    @Nullable
     private Endpoint endpoint;
+    @Nullable
     private ZooKeeperRegistration connector;
 
     /**
@@ -79,11 +83,13 @@ public class ZooKeeperUpdatingListener extends ServerListenerAdapter {
         }
     }
 
+    @Nullable
     @VisibleForTesting
     ZooKeeperRegistration getConnector() {
         return connector;
     }
 
+    @Nullable
     @VisibleForTesting
     Endpoint getEndpoint() {
         return endpoint;


### PR DESCRIPTION
- Add missing `@Nullable` annotations. See the following IntelliJ
  inspections for more info:
  - Constant Conditions & Exceptions
  - `@NotNull`/`@Nullable` problems
- Fixed some obvious yet trivial bugs such as:
  - Redundant null check
  - Incorrectly annotated methods
- Also:
  - Add missing `final` to some local variables
  - Add missing `static` to some methods
  - Remove redundant `this.`