### PR TITLE
Make sure stub code handlers run on the event loop.

### DIFF
--- a/grpc/src/test/java/com/linecorp/armeria/internal/grpc/GrpcTestUtil.java
+++ b/grpc/src/test/java/com/linecorp/armeria/internal/grpc/GrpcTestUtil.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.internal.grpc;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.zip.GZIPOutputStream;
 
 import com.google.common.io.ByteStreams;
@@ -46,22 +48,24 @@ public final class GrpcTestUtil {
                                              .setBody(ByteString.copyFromUtf8("grpc and armeria")))
                           .build();
 
-    public static byte[] uncompressedResponseBytes() throws Exception {
+    public static byte[] uncompressedResponseBytes() {
         return uncompressedFrame(protoByteBuf(RESPONSE_MESSAGE));
     }
 
-    public static byte[] compressedResponseBytes() throws Exception {
+    public static byte[] compressedResponseBytes() {
         return compressedFrame(protoByteBuf(RESPONSE_MESSAGE));
     }
 
-    public static ByteBuf requestByteBuf() throws Exception {
+    public static ByteBuf requestByteBuf() {
         return protoByteBuf(REQUEST_MESSAGE);
     }
 
-    public static ByteBuf protoByteBuf(MessageLite msg) throws Exception {
+    public static ByteBuf protoByteBuf(MessageLite msg) {
         ByteBuf buf = Unpooled.buffer();
         try (ByteBufOutputStream os = new ByteBufOutputStream(buf)) {
             msg.writeTo(os);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
         }
         return buf;
     }
@@ -77,11 +81,13 @@ public final class GrpcTestUtil {
         return result;
     }
 
-    public static byte[] compressedFrame(ByteBuf uncompressed) throws Exception {
+    public static byte[] compressedFrame(ByteBuf uncompressed) {
         ByteBuf compressed = Unpooled.buffer();
         try (ByteBufInputStream is = new ByteBufInputStream(uncompressed, true);
              GZIPOutputStream os = new GZIPOutputStream(new ByteBufOutputStream(compressed))) {
             ByteStreams.copy(is, os);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
         }
         ByteBuf buf = Unpooled.buffer();
         buf.writeByte(1);

--- a/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/test.proto
+++ b/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/test.proto
@@ -133,10 +133,6 @@ service UnitTestService {
 
     // A streaming RPC where the client half-closes but cancels without explicitly closing the stream
     // before receiving the full response (e.g. socket disconnect).
-    rpc StreamClientCancelsBeforeResponseClosed(SimpleRequest) returns (stream SimpleResponse);
-
-    // A streaming RPC where the client half-closes but cancels without explicitly closing the stream
-    // before receiving the full response (e.g. socket disconnect).
     rpc StreamClientCancelsBeforeResponseClosedCancels(SimpleRequest) returns (stream SimpleResponse);
 }
 


### PR DESCRIPTION
Currently, methods called from gRPC stub code do not enforce event loop safety as they should. This has a reasonable chance of causing issues for the client in particular since it's common for stubs to be called from a server event loop, and especially true for unit tests.

Now, business logic is always run on the event loop. The few methods that are only for setting up state via experimental APIs before issuing any calls use synchronized instead to force a memory fence.

A test was removed which relied on the previous broken behavior of a write error being synchronously reported to the caller even when on a different thread.