### PR TITLE
Implement flow control of gRPC stream writes.

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaClientCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaClientCall.java
@@ -22,6 +22,7 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
 import javax.annotation.Nullable;
 
@@ -72,6 +73,10 @@ class ArmeriaClientCall<I, O> extends ClientCall<I, O>
 
     private static final Logger logger = LoggerFactory.getLogger(ArmeriaClientCall.class);
 
+    @SuppressWarnings("rawtypes")
+    private static final AtomicIntegerFieldUpdater<ArmeriaClientCall> pendingMessagesUpdater =
+            AtomicIntegerFieldUpdater.newUpdater(ArmeriaClientCall.class, "pendingMessages");
+
     private final ClientRequestContext ctx;
     private final Client<HttpRequest, HttpResponse> httpClient;
     private final HttpRequestWriter req;
@@ -90,7 +95,7 @@ class ArmeriaClientCall<I, O> extends ClientCall<I, O>
 
     private boolean cancelCalled;
 
-    private volatile boolean ready = true;
+    private volatile int pendingMessages;
 
     ArmeriaClientCall(
             ClientRequestContext ctx,
@@ -201,17 +206,7 @@ class ArmeriaClientCall<I, O> extends ClientCall<I, O>
 
     @Override
     public void sendMessage(I message) {
-        if (ready) {
-            ready = false;
-            req.onDemand(() -> {
-                ready = true;
-                try {
-                    listener.onReady();
-                } catch (Throwable t) {
-                    close(Status.fromThrowable(t));
-                }
-            });
-        }
+        pendingMessagesUpdater.incrementAndGet(this);
         if (ctx.eventLoop().inEventLoop()) {
             doSendMessage(message);
         } else {
@@ -221,13 +216,22 @@ class ArmeriaClientCall<I, O> extends ClientCall<I, O>
 
     @Override
     public boolean isReady() {
-        return ready;
+        return pendingMessages == 0;
     }
 
     private void doSendMessage(I message) {
         try {
             final ByteBuf serialized = marshaller.serializeRequest(message);
             req.write(messageFramer.writePayload(serialized));
+            req.onDemand(() -> {
+                if (pendingMessagesUpdater.decrementAndGet(this) == 0) {
+                    try {
+                        listener.onReady();
+                    } catch (Throwable t) {
+                        close(Status.fromThrowable(t));
+                    }
+                }
+            });
         } catch (Throwable t) {
             cancel(null, t);
         }

--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcFlowControlTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcFlowControlTest.java
@@ -25,6 +25,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.DisableOnDebug;
@@ -51,6 +52,9 @@ import io.grpc.stub.ClientResponseObserver;
 import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
 
+// This test depends on the rate of flow of bytes in the connection. It should be run manually to verify
+// flow control where it is known the rate of flow will be reasonably fast.
+@Ignore
 public class GrpcFlowControlTest {
 
     private static final int TOTAL_NUM_MESSAGES = 10;

--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcFlowControlTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcFlowControlTest.java
@@ -25,7 +25,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Before;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.DisableOnDebug;
@@ -52,9 +51,6 @@ import io.grpc.stub.ClientResponseObserver;
 import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
 
-// This test depends on the rate of flow of bytes in the connection. It should be run manually to verify
-// flow control where it is known the rate of flow will be reasonably fast.
-@Ignore
 public class GrpcFlowControlTest {
 
     private static final int TOTAL_NUM_MESSAGES = 10;

--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcFlowControlTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcFlowControlTest.java
@@ -1,0 +1,324 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.it.grpc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.DisableOnDebug;
+import org.junit.rules.TestRule;
+import org.junit.rules.Timeout;
+
+import com.google.common.base.Strings;
+import com.google.protobuf.ByteString;
+
+import com.linecorp.armeria.client.ClientBuilder;
+import com.linecorp.armeria.client.grpc.GrpcClientOptions;
+import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
+import com.linecorp.armeria.grpc.testing.FlowControlTestServiceGrpc.FlowControlTestServiceImplBase;
+import com.linecorp.armeria.grpc.testing.FlowControlTestServiceGrpc.FlowControlTestServiceStub;
+import com.linecorp.armeria.grpc.testing.Messages.Payload;
+import com.linecorp.armeria.grpc.testing.Messages.SimpleRequest;
+import com.linecorp.armeria.grpc.testing.Messages.SimpleResponse;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.grpc.GrpcServiceBuilder;
+import com.linecorp.armeria.testing.server.ServerRule;
+
+import io.grpc.stub.ClientCallStreamObserver;
+import io.grpc.stub.ClientResponseObserver;
+import io.grpc.stub.ServerCallStreamObserver;
+import io.grpc.stub.StreamObserver;
+
+public class GrpcFlowControlTest {
+
+    private static final int TOTAL_NUM_MESSAGES = 10;
+    private static final int CAPPED_NUM_MESSAGES = 3;
+
+    // Large enough payload to trigger flow control.
+    private static final Payload PAYLOAD =
+            Payload.newBuilder()
+                   .setBody(ByteString.copyFromUtf8(Strings.repeat("a", 5 * 1024 * 1024)))
+                   .build();
+
+    private static final SimpleRequest REQUEST =
+            SimpleRequest.newBuilder()
+                         .setPayload(PAYLOAD)
+                         .build();
+
+    private static final SimpleResponse RESPONSE =
+            SimpleResponse.newBuilder()
+                          .setPayload(PAYLOAD)
+                          .build();
+
+    static class FlowControlService extends FlowControlTestServiceImplBase {
+        @Override
+        public StreamObserver<SimpleRequest> noBackPressure(StreamObserver<SimpleResponse> responseObserver) {
+            AtomicInteger numRequests = new AtomicInteger();
+            return new StreamObserver<SimpleRequest>() {
+                @Override
+                public void onNext(SimpleRequest value) {
+                    numRequests.incrementAndGet();
+                }
+
+                @Override
+                public void onError(Throwable t) {
+                }
+
+                @Override
+                public void onCompleted() {
+                    assertThat(numRequests).hasValue(TOTAL_NUM_MESSAGES);
+                    for (int i = 0; i < TOTAL_NUM_MESSAGES; i++) {
+                        responseObserver.onNext(SimpleResponse.getDefaultInstance());
+                    }
+                    responseObserver.onCompleted();
+                }
+            };
+        }
+
+        @Override
+        public StreamObserver<SimpleRequest> serverBackPressure(
+                StreamObserver<SimpleResponse> rawResponseObserver) {
+            ServerCallStreamObserver<SimpleResponse> responseObserver =
+                    (ServerCallStreamObserver<SimpleResponse>) rawResponseObserver;
+            responseObserver.disableAutoInboundFlowControl();
+            AtomicInteger numRequests = new AtomicInteger();
+            responseObserver.request(1);
+            return new StreamObserver<SimpleRequest>() {
+                @Override
+                public void onNext(SimpleRequest value) {
+                    if (numRequests.incrementAndGet() < CAPPED_NUM_MESSAGES) {
+                        responseObserver.request(1);
+                    } else {
+                        for (int i = 0; i < TOTAL_NUM_MESSAGES; i++) {
+                            responseObserver.onNext(SimpleResponse.getDefaultInstance());
+                        }
+                        responseObserver.onCompleted();
+                    }
+                }
+
+                @Override
+                public void onError(Throwable t) {
+                }
+
+                @Override
+                public void onCompleted() {
+                }
+            };
+        }
+
+        @Override
+        public StreamObserver<SimpleRequest> clientBackPressure(
+                StreamObserver<SimpleResponse> rawResponseObserver) {
+            AtomicInteger numRequests = new AtomicInteger();
+            AtomicInteger numResponses = new AtomicInteger();
+            AtomicBoolean done = new AtomicBoolean();
+            ServerCallStreamObserver<SimpleResponse> responseObserver =
+                    (ServerCallStreamObserver<SimpleResponse>) rawResponseObserver;
+            responseObserver.setOnReadyHandler(() -> {
+                if (numResponses.get() < TOTAL_NUM_MESSAGES && !done.get()) {
+                    numResponses.incrementAndGet();
+                    responseObserver.onNext(RESPONSE);
+                }
+            });
+            for (int i = 0; i < TOTAL_NUM_MESSAGES; i++) {
+                if (responseObserver.isReady()) {
+                    numResponses.incrementAndGet();
+                    responseObserver.onNext(RESPONSE);
+                } else {
+                    break;
+                }
+            }
+            return new StreamObserver<SimpleRequest>() {
+                @Override
+                public void onNext(SimpleRequest value) {
+                    numRequests.incrementAndGet();
+                }
+
+                @Override
+                public void onError(Throwable t) {
+                }
+
+                @Override
+                public void onCompleted() {
+                    done.set(true);
+                    assertThat(numRequests).hasValue(TOTAL_NUM_MESSAGES);
+                    assertThat(numResponses).hasValueBetween(CAPPED_NUM_MESSAGES, CAPPED_NUM_MESSAGES + 2);
+                    responseObserver.onCompleted();
+                }
+            };
+        }
+    }
+
+    @ClassRule
+    public static ServerRule server = new ServerRule() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.defaultMaxRequestLength(0);
+            sb.defaultRequestTimeoutMillis(0);
+
+            sb.serviceUnder("/", new GrpcServiceBuilder()
+                    .addService(new FlowControlService())
+                    .setMaxInboundMessageSizeBytes(Integer.MAX_VALUE)
+                    .build());
+        }
+    };
+
+    @Rule
+    public TestRule globalTimeout = new DisableOnDebug(new Timeout(15, TimeUnit.SECONDS));
+
+    private FlowControlTestServiceStub client;
+
+    @Before
+    public void setUp() {
+        client = new ClientBuilder(server.uri(GrpcSerializationFormats.PROTO, "/"))
+                .defaultMaxResponseLength(0)
+                .defaultResponseTimeoutMillis(0)
+                .option(GrpcClientOptions.MAX_INBOUND_MESSAGE_SIZE_BYTES.newValue(Integer.MAX_VALUE))
+                .build(FlowControlTestServiceStub.class);
+    }
+
+    @Test
+    public void noBackPressure() {
+        AtomicInteger numResponses = new AtomicInteger();
+        AtomicBoolean done = new AtomicBoolean();
+        StreamObserver<SimpleRequest> req = client.noBackPressure(new StreamObserver<SimpleResponse>() {
+            @Override
+            public void onNext(SimpleResponse value) {
+                numResponses.incrementAndGet();
+            }
+
+            @Override
+            public void onError(Throwable t) {
+            }
+
+            @Override
+            public void onCompleted() {
+                done.set(true);
+            }
+        });
+        for (int i = 0; i < TOTAL_NUM_MESSAGES; i++) {
+            req.onNext(SimpleRequest.getDefaultInstance());
+        }
+        req.onCompleted();
+        await().untilAsserted(() -> assertThat(done).isTrue());
+        assertThat(numResponses).hasValue(TOTAL_NUM_MESSAGES);
+    }
+
+    @Test
+    public void serverBackPressure() {
+        AtomicInteger numRequests = new AtomicInteger();
+        AtomicInteger numResponses = new AtomicInteger();
+        AtomicBoolean done = new AtomicBoolean();
+        ClientCallStreamObserver<SimpleRequest> req =
+                (ClientCallStreamObserver<SimpleRequest>) client.serverBackPressure(
+                        new ClientResponseObserver<SimpleRequest, SimpleResponse>() {
+                            @Override
+                            public void onNext(SimpleResponse value) {
+                                numResponses.incrementAndGet();
+                            }
+
+                            @Override
+                            public void onError(Throwable t) {
+                            }
+
+                            @Override
+                            public void onCompleted() {
+                                done.set(true);
+                            }
+
+                            @Override
+                            public void beforeStart(ClientCallStreamObserver<SimpleRequest> requestStream) {
+                                requestStream.setOnReadyHandler(() -> {
+                                    if (numRequests.get() < TOTAL_NUM_MESSAGES) {
+                                        numRequests.incrementAndGet();
+                                        requestStream.onNext(REQUEST);
+                                    }
+                                });
+                            }
+                        });
+        for (int i = 0; i < TOTAL_NUM_MESSAGES; i++) {
+            if (req.isReady()) {
+                numRequests.incrementAndGet();
+                req.onNext(REQUEST);
+            } else {
+                break;
+            }
+        }
+        await().untilAsserted(() -> assertThat(done).isTrue());
+        // Flow control happens on the second request, and an extra message is often sent after the last
+        // requested one since there will still be some space in the last flow control window, which results
+        // in two more than our expected cap.
+        assertThat(numRequests).hasValueBetween(CAPPED_NUM_MESSAGES, CAPPED_NUM_MESSAGES + 2);
+        assertThat(numResponses).hasValue(TOTAL_NUM_MESSAGES);
+    }
+
+    @Test
+    public void clientBackPressure() {
+        AtomicInteger numResponses = new AtomicInteger();
+        AtomicBoolean done = new AtomicBoolean();
+        AtomicBoolean clientClosed = new AtomicBoolean();
+        client.clientBackPressure(
+                        new ClientResponseObserver<SimpleRequest, SimpleResponse>() {
+                            private ClientCallStreamObserver<SimpleRequest> requestStream;
+
+                            @Override
+                            public void onNext(SimpleResponse value) {
+                                if (numResponses.incrementAndGet() < CAPPED_NUM_MESSAGES) {
+                                    requestStream.request(1);
+                                } else {
+                                    if (!clientClosed.get()) {
+                                        for (int i = 0; i < TOTAL_NUM_MESSAGES; i++) {
+                                            requestStream.onNext(SimpleRequest.getDefaultInstance());
+                                        }
+                                        requestStream.onCompleted();
+                                        clientClosed.set(true);
+                                    }
+                                    requestStream.request(1);
+                                }
+                            }
+
+                            @Override
+                            public void onError(Throwable t) {
+                            }
+
+                            @Override
+                            public void onCompleted() {
+                                done.set(true);
+                            }
+
+                            @Override
+                            public void beforeStart(ClientCallStreamObserver<SimpleRequest> requestStream) {
+                                this.requestStream = requestStream;
+                                requestStream.disableAutoInboundFlowControl();
+                            }
+                        });
+
+        await().untilAsserted(() -> assertThat(done).isTrue());
+        // Flow control happens on the second request, and an extra message is often sent after the last
+        // requested one since there will still be some space in the last flow control window, which results
+        // in two more than our expected cap.
+        assertThat(numResponses).hasValueBetween(CAPPED_NUM_MESSAGES, CAPPED_NUM_MESSAGES + 2);
+    }
+}

--- a/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/flow.proto
+++ b/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/flow.proto
@@ -1,0 +1,37 @@
+// Copyright 2018 LINE Corporation
+//
+// LINE Corporation licenses this file to you under the Apache License,
+// version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at:
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+// Tests for flow-control of gRPC services and clients. Some tests will overlap with business logic
+// unit tests, but since flow-control is hard to get right we separate them out here.
+
+syntax = "proto3";
+
+package armeria.grpc.testing;
+
+option java_package = "com.linecorp.armeria.grpc.testing";
+
+import "com/linecorp/armeria/grpc/testing/messages.proto";
+
+service FlowControlTestService {
+    // Neither server nor control exert backpressure.
+    rpc NoBackPressure(stream SimpleRequest) returns (stream SimpleResponse);
+
+    // Server exerts back presure to client. Client must not produce
+    // more messages than the server requests.
+    rpc ServerBackPressure(stream SimpleRequest) returns (stream SimpleResponse);
+
+    // Client exerts back pressure to server. Server must not produce
+    // more messages than the client requests.
+    rpc ClientBackPressure(stream SimpleRequest) returns (stream SimpleResponse);
+}


### PR DESCRIPTION
Currently, reads from the stream are correctly handled by propagating `request` through the stub, but writes are not since `isReady` is not properly implemented. When I first implemented the streams, I didn't understand `StreamWriter` properly, but now I do and realize we can use `onDemand` for this :)

With the change, the stream is only considered ready for writes when there is a request for them. I sort of want to optimize the non-backpressure case by only doing this if `isReady` is called, as that's a heuristic that should generally show the caller is implementing backpressure, but it's a bit weird and for unary calls the one call to `onDemand` doesn't seem like a big deal.

Fixes #1037 