### PR TITLE
Always call .join() on Server start futures in examples

### DIFF
--- a/site/src/sphinx/server-basics.rst
+++ b/site/src/sphinx/server-basics.rst
@@ -19,7 +19,9 @@ To start a server, you need to build it first. Use `ServerBuilder`_:
     ServerBuilder sb = new ServerBuilder();
     // TODO: Configure your server here.
     Server server = sb.build();
-    server.start();
+    CompletableFuture<Void> future = server.start();
+    // Wait until the server is ready.
+    future.join();
 
 Ports
 -----


### PR DESCRIPTION
Related: #1042

Motivation:

A user who is not used to asynchronous nature of our API may be confused
when a server fails to start up, because the failure is only notified
via the returned CompletableFuture.

Modifications:

Update all examples that calls Server.start() also call join() against
the returned future.

Result:

- Hopefully less confusing

/cc @kishida