### PR TITLE
Add ServerBuilder.tlsSelfSigned()

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/AbstractVirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AbstractVirtualHostBuilder.java
@@ -200,7 +200,7 @@ abstract class AbstractVirtualHostBuilder<B extends AbstractVirtualHostBuilder> 
 
     /**
      * Configures SSL or TLS of this {@link VirtualHost} with an auto-generated self-signed certificate.
-     * Note: You should never use this in production but only for a testing purpose.
+     * <strong>Note:</strong> You should never use this in production but only for a testing purpose.
      *
      * @throws CertificateException if failed to generate a self-signed certificate
      */

--- a/core/src/main/java/com/linecorp/armeria/server/AbstractVirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AbstractVirtualHostBuilder.java
@@ -25,6 +25,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.InputStreamReader;
 import java.net.InetAddress;
+import java.security.cert.CertificateException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
@@ -57,6 +58,7 @@ import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslProvider;
 import io.netty.handler.ssl.SupportedCipherSuiteFilter;
+import io.netty.handler.ssl.util.SelfSignedCertificate;
 
 /**
  * Contains information for the build of the virtual host.
@@ -194,6 +196,17 @@ abstract class AbstractVirtualHostBuilder<B extends AbstractVirtualHostBuilder> 
 
         tls(builder.build());
         return self();
+    }
+
+    /**
+     * Configures SSL or TLS of this {@link VirtualHost} with an auto-generated self-signed certificate.
+     * Note: You should never use this in production but only for a testing purpose.
+     *
+     * @throws CertificateException if failed to generate a self-signed certificate
+     */
+    public B tlsSelfSigned() throws SSLException, CertificateException {
+        final SelfSignedCertificate ssc = new SelfSignedCertificate(defaultHostname);
+        return tls(ssc.certificate(), ssc.privateKey());
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -25,6 +25,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.io.File;
 import java.net.InetSocketAddress;
+import java.security.cert.CertificateException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -462,8 +463,8 @@ public final class ServerBuilder {
     }
 
     /**
-     * Sets the {@link SslContext} of the default {@link VirtualHost} from the specified
-     * {@code keyCertChainFile} and cleartext {@code keyFile}.
+     * Configures SSL or TLS of  the default {@link VirtualHost} from the specified {@code keyCertChainFile}
+     * and cleartext {@code keyFile}.
      *
      * @throws IllegalStateException if the default {@link VirtualHost} has been set via
      *                               {@link #defaultVirtualHost(VirtualHost)} already
@@ -475,8 +476,8 @@ public final class ServerBuilder {
     }
 
     /**
-     * Sets the {@link SslContext} of the default {@link VirtualHost} from the specified
-     * {@code keyCertChainFile}, {@code keyFile} and {@code keyPassword}.
+     * Configures SSL or TLS of the default {@link VirtualHost} from the specified {@code keyCertChainFile},
+     * {@code keyFile} and {@code keyPassword}.
      *
      * @throws IllegalStateException if the default {@link VirtualHost} has been set via
      *                               {@link #defaultVirtualHost(VirtualHost)} already
@@ -486,6 +487,20 @@ public final class ServerBuilder {
 
         defaultVirtualHostBuilderUpdated();
         defaultVirtualHostBuilder.tls(keyCertChainFile, keyFile, keyPassword);
+        return this;
+    }
+
+    /**
+     * Configures SSL or TLS of the default {@link VirtualHost} with an auto-generated self-signed
+     * certificate. Note: You should never use this in production but only for a testing purpose.
+     *
+     * @throws IllegalStateException if the default {@link VirtualHost} has been set via
+     *                               {@link #defaultVirtualHost(VirtualHost)} already
+     * @throws CertificateException if failed to generate a self-signed certificate
+     */
+    public ServerBuilder tlsSelfSigned() throws SSLException, CertificateException {
+        defaultVirtualHostBuilderUpdated();
+        defaultVirtualHostBuilder.tlsSelfSigned();
         return this;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -463,7 +463,7 @@ public final class ServerBuilder {
     }
 
     /**
-     * Configures SSL or TLS of  the default {@link VirtualHost} from the specified {@code keyCertChainFile}
+     * Configures SSL or TLS of the default {@link VirtualHost} from the specified {@code keyCertChainFile}
      * and cleartext {@code keyFile}.
      *
      * @throws IllegalStateException if the default {@link VirtualHost} has been set via
@@ -492,7 +492,8 @@ public final class ServerBuilder {
 
     /**
      * Configures SSL or TLS of the default {@link VirtualHost} with an auto-generated self-signed
-     * certificate. Note: You should never use this in production but only for a testing purpose.
+     * certificate. <strong>Note:</strong> You should never use this in production but only for a testing
+     * purpose.
      *
      * @throws IllegalStateException if the default {@link VirtualHost} has been set via
      *                               {@link #defaultVirtualHost(VirtualHost)} already

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroupTest.java
@@ -40,7 +40,6 @@ import com.linecorp.armeria.common.metric.MoreMeters;
 import com.linecorp.armeria.common.metric.PrometheusMeterRegistries;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.healthcheck.HttpHealthCheckService;
-import com.linecorp.armeria.testing.server.SelfSignedCertificateRule;
 import com.linecorp.armeria.testing.server.ServerRule;
 
 import io.micrometer.core.instrument.MeterRegistry;
@@ -56,10 +55,7 @@ public class HttpHealthCheckedEndpointGroupTest {
         return ImmutableList.of(HTTP, HTTPS);
     }
 
-    @Rule
-    public final SelfSignedCertificateRule certificate = new SelfSignedCertificateRule();
-
-    private class HealthCheckServerRule extends ServerRule {
+    private static class HealthCheckServerRule extends ServerRule {
 
         protected HealthCheckServerRule() {
             super(false); // Disable auto-start.
@@ -69,7 +65,7 @@ public class HttpHealthCheckedEndpointGroupTest {
         protected void configure(ServerBuilder sb) throws Exception {
             sb.http(0);
             sb.https(0);
-            sb.tls(certificate.certificateFile(), certificate.privateKeyFile());
+            sb.tlsSelfSigned();
             sb.service(HEALTH_CHECK_PATH, new HttpHealthCheckService());
         }
     }

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerTest.java
@@ -100,7 +100,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.channel.EventLoopGroup;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
-import io.netty.handler.ssl.util.SelfSignedCertificate;
 import io.netty.util.AsciiString;
 import io.netty.util.NetUtil;
 import io.netty.util.ResourceLeakDetector;
@@ -147,9 +146,7 @@ public class HttpServerTest {
             sb.workerGroup(workerGroup, true);
             sb.http(0);
             sb.https(0);
-
-            SelfSignedCertificate ssc = new SelfSignedCertificate();
-            sb.tls(ssc.certificate(), ssc.privateKey());
+            sb.tlsSelfSigned();
 
             sb.service("/delay/{delay}", new AbstractHttpService() {
                 @Override

--- a/jetty/src/test/java/com/linecorp/armeria/server/jetty/JettyServiceTest.java
+++ b/jetty/src/test/java/com/linecorp/armeria/server/jetty/JettyServiceTest.java
@@ -59,8 +59,7 @@ public class JettyServiceTest extends WebAppContainerTest {
         protected void configure(ServerBuilder sb) throws Exception {
             sb.http(0);
             sb.https(0);
-            sb.tls(certificate.certificateFile(),
-                   certificate.privateKeyFile());
+            sb.tlsSelfSigned();
 
             sb.serviceUnder(
                     "/jsp/",

--- a/jetty/src/test/java/com/linecorp/armeria/server/jetty/UnmanagedJettyServiceTest.java
+++ b/jetty/src/test/java/com/linecorp/armeria/server/jetty/UnmanagedJettyServiceTest.java
@@ -35,8 +35,7 @@ public class UnmanagedJettyServiceTest extends WebAppContainerTest {
         protected void configure(ServerBuilder sb) throws Exception {
             sb.http(0);
             sb.https(0);
-            sb.tls(certificate.certificateFile(),
-                   certificate.privateKeyFile());
+            sb.tlsSelfSigned();
 
             jetty = new Server(0);
             jetty.setHandler(JettyServiceTest.newWebAppContext());

--- a/testing-internal/src/main/java/com/linecorp/armeria/testing/internal/webapp/WebAppContainerTest.java
+++ b/testing-internal/src/main/java/com/linecorp/armeria/testing/internal/webapp/WebAppContainerTest.java
@@ -37,7 +37,6 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
-import org.junit.ClassRule;
 import org.junit.Test;
 
 import com.linecorp.armeria.client.ClientFactory;
@@ -46,7 +45,6 @@ import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.common.AggregatedHttpMessage;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.Service;
-import com.linecorp.armeria.testing.server.SelfSignedCertificateRule;
 import com.linecorp.armeria.testing.server.ServerRule;
 
 import io.netty.handler.codec.http.HttpHeaderNames;
@@ -58,12 +56,6 @@ import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 public abstract class WebAppContainerTest {
 
     private static final Pattern CR_OR_LF = Pattern.compile("[\\r\\n]");
-
-    /**
-     * The self-signed certificate that is used for testing a TLS connection.
-     */
-    @ClassRule
-    public static final SelfSignedCertificateRule certificate = new SelfSignedCertificateRule();
 
     /**
      * Returns the doc-base directory of the test web application.

--- a/thrift/src/test/java/com/linecorp/armeria/client/thrift/ThriftOverHttpClientTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/client/thrift/ThriftOverHttpClientTest.java
@@ -82,7 +82,6 @@ import com.linecorp.armeria.service.test.thrift.main.TimeService;
 
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
-import io.netty.handler.ssl.util.SelfSignedCertificate;
 import io.netty.util.AsciiString;
 
 @SuppressWarnings("unchecked")
@@ -185,15 +184,12 @@ public class ThriftOverHttpClientTest {
     }
 
     static {
-        final SelfSignedCertificate ssc;
         final ServerBuilder sb = new ServerBuilder();
 
         try {
             sb.http(0);
             sb.https(0);
-
-            ssc = new SelfSignedCertificate("127.0.0.1");
-            sb.tls(ssc.certificate(), ssc.privateKey());
+            sb.tlsSelfSigned();
 
             for (Handlers h : Handlers.values()) {
                 for (SerializationFormat defaultSerializationFormat : ThriftSerializationFormats.values()) {

--- a/thrift/src/test/java/com/linecorp/armeria/server/thrift/AbstractThriftOverHttpTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/server/thrift/AbstractThriftOverHttpTest.java
@@ -61,8 +61,6 @@ import com.linecorp.armeria.service.test.thrift.main.HelloService.AsyncIface;
 import com.linecorp.armeria.service.test.thrift.main.SleepService;
 import com.linecorp.armeria.testing.internal.AnticipatedException;
 
-import io.netty.handler.ssl.util.SelfSignedCertificate;
-
 public abstract class AbstractThriftOverHttpTest {
 
     private static final String LARGER_THAN_TLS = Strings.repeat("A", 16384);
@@ -94,15 +92,12 @@ public abstract class AbstractThriftOverHttpTest {
     }
 
     static {
-        final SelfSignedCertificate ssc;
         final ServerBuilder sb = new ServerBuilder();
 
         try {
             sb.http(0);
             sb.https(0);
-
-            ssc = new SelfSignedCertificate("127.0.0.1");
-            sb.tls(ssc.certificate(), ssc.privateKey());
+            sb.tlsSelfSigned();
 
             sb.service("/hello", THttpService.of(
                     (AsyncIface) (name, resultHandler) -> resultHandler.onComplete("Hello, " + name + '!')));

--- a/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftOverHttp1Test.java
+++ b/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftOverHttp1Test.java
@@ -58,6 +58,7 @@ public class ThriftOverHttp1Test extends AbstractThriftOverHttpTest {
 
         final THttpClient client = new THttpClient(
                 uri, HttpClientBuilder.create()
+                                      .setSSLHostnameVerifier((hostname, session) -> true)
                                       .setSSLContext(sslContext)
                                       .build());
         client.setCustomHeaders(

--- a/tomcat/src/test/java/com/linecorp/armeria/server/tomcat/TomcatServiceTest.java
+++ b/tomcat/src/test/java/com/linecorp/armeria/server/tomcat/TomcatServiceTest.java
@@ -50,8 +50,7 @@ public class TomcatServiceTest extends WebAppContainerTest {
         protected void configure(ServerBuilder sb) throws Exception {
             sb.http(0);
             sb.https(0);
-            sb.tls(certificate.certificateFile(),
-                   certificate.privateKeyFile());
+            sb.tlsSelfSigned();
 
             sb.serviceUnder(
                     "/jsp/",


### PR DESCRIPTION
Motivation:

It is a common pattern to create a self-signed certificate to test a
server and we could simplify that.

Modifications:

- Add ServerBuilder.tlsSelfSigned() which generates a self-signed
  certificate automatically.
- Remove some code that uses `SelfSignedCertificateGenerator` directly.

Result:

- Brevity