### PR TITLE
Add Endpoint.ipAddr

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientDelegate.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientDelegate.java
@@ -59,13 +59,14 @@ final class HttpClientDelegate implements Client<HttpRequest, HttpResponse> {
         }
 
         final EventLoop eventLoop = ctx.eventLoop();
-        final PoolKey poolKey = new PoolKey(endpoint.host(), endpoint.port(), ctx.sessionProtocol());
+        final PoolKey poolKey = new PoolKey(endpoint.host(), endpoint.ipAddr(),
+                                            endpoint.port(), ctx.sessionProtocol());
         final Future<Channel> channelFuture = factory.pool(eventLoop).acquire(poolKey);
         final DecodedHttpResponse res = new DecodedHttpResponse(eventLoop);
 
         if (channelFuture.isDone()) {
             if (channelFuture.isSuccess()) {
-                Channel ch = channelFuture.getNow();
+                final Channel ch = channelFuture.getNow();
                 invoke0(ch, ctx, req, res, poolKey);
             } else {
                 res.close(channelFuture.cause());
@@ -73,7 +74,7 @@ final class HttpClientDelegate implements Client<HttpRequest, HttpResponse> {
         } else {
             channelFuture.addListener((Future<Channel> future) -> {
                 if (future.isSuccess()) {
-                    Channel ch = future.getNow();
+                    final Channel ch = future.getNow();
                     invoke0(ch, ctx, req, res, poolKey);
                 } else {
                     res.close(channelFuture.cause());
@@ -115,7 +116,7 @@ final class HttpClientDelegate implements Client<HttpRequest, HttpResponse> {
         // Add the headers specified in ClientOptions, if not overridden by request.
         if (!clientOptionHeaders.isEmpty()) {
             clientOptionHeaders.forEach(entry -> {
-                AsciiString name = entry.getKey();
+                final AsciiString name = entry.getKey();
                 if (!headers.contains(name)) {
                     headers.set(name, entry.getValue());
                 }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsServiceEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsServiceEndpointGroup.java
@@ -231,6 +231,6 @@ public class DnsServiceEndpointGroup extends DynamicEndpointGroup {
         String target = DefaultDnsRecordDecoder.decodeName(recordContent);
         // Last character always a '.'
         target = target.substring(0, target.length() - 1);
-        return Endpoint.of(target, port, weight);
+        return Endpoint.of(target, port).withWeight(weight);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/EndpointTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/EndpointTest.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.Test;
+
+public class EndpointTest {
+
+    @Test
+    public void parse() {
+        final Endpoint foo = Endpoint.parse("foo");
+        assertThat(foo).isEqualTo(Endpoint.of("foo"));
+        assertThatThrownBy(foo::port).isInstanceOf(IllegalStateException.class);
+        assertThat(foo.weight()).isEqualTo(1000);
+        assertThat(foo.ipAddr()).isNull();
+
+        final Endpoint bar = Endpoint.parse("bar:80");
+        assertThat(bar).isEqualTo(Endpoint.of("bar", 80));
+        assertThat(bar.port()).isEqualTo(80);
+        assertThat(foo.weight()).isEqualTo(1000);
+        assertThat(foo.ipAddr()).isNull();
+
+        assertThat(Endpoint.parse("group:foo")).isEqualTo(Endpoint.ofGroup("foo"));
+    }
+
+    @Test
+    public void group() {
+        final Endpoint foo = Endpoint.ofGroup("foo");
+        assertThat(foo.isGroup()).isTrue();
+        assertThat(foo.groupName()).isEqualTo("foo");
+        assertThat(foo.authority()).isEqualTo("group:foo");
+
+        assertThatThrownBy(foo::host).isInstanceOf(IllegalStateException.class);
+        assertThatThrownBy(foo::ipAddr).isInstanceOf(IllegalStateException.class);
+        assertThatThrownBy(foo::port).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void hostWithoutPort() {
+        final Endpoint foo = Endpoint.of("foo.com");
+        assertThat(foo.isGroup()).isFalse();
+        assertThat(foo.host()).isEqualTo("foo.com");
+        assertThat(foo.ipAddr()).isNull();
+        assertThat(foo.port(42)).isEqualTo(42);
+        assertThat(foo.withDefaultPort(42).port()).isEqualTo(42);
+        assertThat(foo.weight()).isEqualTo(1000);
+        assertThat(foo.authority()).isEqualTo("foo.com");
+        assertThat(foo.withIpAddr(null)).isSameAs(foo);
+
+        assertThatThrownBy(foo::port).isInstanceOf(IllegalStateException.class);
+        assertThatThrownBy(foo::groupName).isInstanceOf(IllegalStateException.class);
+        assertThatThrownBy(() -> foo.withDefaultPort(-1)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void hostWithPort() {
+        final Endpoint foo = Endpoint.of("foo.com", 80);
+        assertThat(foo.isGroup()).isFalse();
+        assertThat(foo.host()).isEqualTo("foo.com");
+        assertThat(foo.ipAddr()).isNull();
+        assertThat(foo.port()).isEqualTo(80);
+        assertThat(foo.port(42)).isEqualTo(80);
+        assertThat(foo.withDefaultPort(42)).isSameAs(foo);
+        assertThat(foo.weight()).isEqualTo(1000);
+        assertThat(foo.authority()).isEqualTo("foo.com:80");
+
+        assertThatThrownBy(foo::groupName).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void hostWithWeight() {
+        final Endpoint foo = Endpoint.of("foo.com", 80).withWeight(500);
+        assertThat(foo.weight()).isEqualTo(500);
+        assertThat(foo.withWeight(750).weight()).isEqualTo(750);
+        assertThat(foo.withWeight(500)).isSameAs(foo);
+
+        assertThatThrownBy(() -> foo.withWeight(-1)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void hostWithIpAddr() {
+        final Endpoint foo = Endpoint.of("foo.com").withIpAddr("192.168.0.1");
+        assertThat(foo.authority()).isEqualTo("foo.com");
+        assertThat(foo.ipAddr()).isEqualTo("192.168.0.1");
+        assertThat(foo.withIpAddr(null).ipAddr()).isNull();
+        assertThat(foo.withIpAddr("::1").authority()).isEqualTo("foo.com");
+        assertThat(foo.withIpAddr("::1").ipAddr()).isEqualTo("::1");
+        assertThat(foo.withIpAddr("192.168.0.1")).isSameAs(foo);
+        assertThat(foo.withIpAddr("192.168.0.2").authority()).isEqualTo("foo.com");
+        assertThat(foo.withIpAddr("192.168.0.2").ipAddr()).isEqualTo("192.168.0.2");
+
+        assertThatThrownBy(() -> foo.withIpAddr("no-ip")).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void badHost() {
+        // Should not accept the host name followed by a port.
+        assertThatThrownBy(() -> Endpoint.of("foo:80")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> Endpoint.of("127.0.0.1:80")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> Endpoint.of("[::1]:80")).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void ipV4() {
+        final Endpoint a = Endpoint.of("192.168.0.1");
+        assertThat(a.host()).isEqualTo("192.168.0.1");
+        assertThat(a.ipAddr()).isEqualTo("192.168.0.1");
+        assertThat(a.authority()).isEqualTo("192.168.0.1");
+        assertThatThrownBy(() -> a.withIpAddr(null)).isInstanceOf(IllegalStateException.class);
+        assertThat(a.withIpAddr("192.168.0.1")).isSameAs(a);
+        assertThat(a.withIpAddr("192.168.0.2")).isEqualTo(Endpoint.of("192.168.0.2"));
+
+        assertThat(Endpoint.of("192.168.0.1", 80).authority()).isEqualTo("192.168.0.1:80");
+    }
+
+    @Test
+    public void ipV4Parse() {
+        final Endpoint a = Endpoint.parse("192.168.0.1:80");
+        assertThat(a.host()).isEqualTo("192.168.0.1");
+        assertThat(a.ipAddr()).isEqualTo("192.168.0.1");
+        assertThat(a.port()).isEqualTo(80);
+        assertThat(a.authority()).isEqualTo("192.168.0.1:80");
+    }
+
+    @Test
+    public void ipV6() {
+        final Endpoint a = Endpoint.of("::1");
+        assertThat(a.host()).isEqualTo("::1");
+        assertThat(a.ipAddr()).isEqualTo("::1");
+        assertThat(a.authority()).isEqualTo("[::1]");
+        assertThatThrownBy(() -> a.withIpAddr(null)).isInstanceOf(IllegalStateException.class);
+        assertThat(a.withIpAddr("::1")).isSameAs(a);
+        assertThat(a.withIpAddr("::2")).isEqualTo(Endpoint.of("::2"));
+        assertThat(a.withIpAddr("[::1]")).isSameAs(a);
+        assertThat(a.withIpAddr("[::2]")).isEqualTo(Endpoint.of("::2"));
+
+        final Endpoint b = Endpoint.of("::1", 80);
+        assertThat(b.host()).isEqualTo("::1");
+        assertThat(b.ipAddr()).isEqualTo("::1");
+        assertThat(b.authority()).isEqualTo("[::1]:80");
+
+        // Surrounding '[' and ']' should be handled correctly.
+        final Endpoint c = Endpoint.of("[::1]");
+        assertThat(c.host()).isEqualTo("::1");
+        assertThat(c.ipAddr()).isEqualTo("::1");
+        assertThat(c.authority()).isEqualTo("[::1]");
+
+        final Endpoint d = Endpoint.of("[::1]", 80);
+        assertThat(d.host()).isEqualTo("::1");
+        assertThat(d.ipAddr()).isEqualTo("::1");
+        assertThat(d.authority()).isEqualTo("[::1]:80");
+
+        // withIpAddr() should handle surrounding '[' and ']' correctly.
+        final Endpoint e = Endpoint.of("foo").withIpAddr("[::1]");
+        assertThat(e.host()).isEqualTo("foo");
+        assertThat(e.ipAddr()).isEqualTo("::1");
+    }
+
+    @Test
+    public void ipV6Parse() {
+        final Endpoint a = Endpoint.parse("[::1]:80");
+        assertThat(a.host()).isEqualTo("::1");
+        assertThat(a.ipAddr()).isEqualTo("::1");
+        assertThat(a.port()).isEqualTo(80);
+        assertThat(a.authority()).isEqualTo("[::1]:80");
+    }
+
+    @Test
+    public void authorityCache() {
+        final Endpoint foo = Endpoint.of("foo.com", 80);
+        final String authority1 = foo.authority();
+        final String authority2 = foo.authority();
+        assertThat(authority1).isSameAs(authority2);
+    }
+
+    @Test
+    public void equals() {
+        final Endpoint a1 = Endpoint.of("a");
+        final Endpoint a2 = Endpoint.of("a");
+        final Endpoint groupA1 = Endpoint.ofGroup("a");
+        final Endpoint groupA2 = Endpoint.ofGroup("a");
+
+        assertThat(a1).isNotEqualTo(new Object());
+        assertThat(a1).isNotEqualTo(groupA1);
+        assertThat(groupA1).isNotEqualTo(a1);
+        assertThat(a1).isEqualTo(a1);
+        assertThat(a1).isEqualTo(a2);
+        assertThat(groupA1).isEqualTo(groupA1);
+        assertThat(groupA1).isEqualTo(groupA2);
+    }
+
+    @Test
+    public void portEquals() {
+        final Endpoint a = Endpoint.of("a");
+        final Endpoint b = Endpoint.of("a", 80);
+        final Endpoint c = Endpoint.of("a", 80);
+        final Endpoint d = Endpoint.of("a", 81);
+        final Endpoint e = Endpoint.of("a", 80).withIpAddr("::1");
+        final Endpoint f = Endpoint.of("a", 80).withWeight(500); // Weight not part of comparison
+        final Endpoint g = Endpoint.of("g", 80);
+        assertThat(a).isNotEqualTo(b);
+        assertThat(b).isEqualTo(c);
+        assertThat(b).isNotEqualTo(d);
+        assertThat(b).isNotEqualTo(e);
+        assertThat(b).isEqualTo(f);
+        assertThat(b).isNotEqualTo(g);
+    }
+
+    @Test
+    public void ipAddrEquals() {
+        final Endpoint a = Endpoint.of("a");
+        final Endpoint b = Endpoint.of("a").withIpAddr("::1");
+        final Endpoint c = Endpoint.of("a").withIpAddr("::1");
+        final Endpoint d = Endpoint.of("a").withIpAddr("::2");
+        final Endpoint e = Endpoint.of("a", 80).withIpAddr("::1");
+        final Endpoint f = Endpoint.of("a").withIpAddr("::1").withWeight(500); // Weight not part of comparison
+        final Endpoint g = Endpoint.of("g").withIpAddr("::1");
+        assertThat(a).isNotEqualTo(b);
+        assertThat(b).isEqualTo(c);
+        assertThat(b).isNotEqualTo(d);
+        assertThat(b).isNotEqualTo(e);
+        assertThat(b).isEqualTo(f);
+        assertThat(b).isNotEqualTo(g);
+    }
+
+    @Test
+    public void testHashCode() {
+        assertThat(Endpoint.of("a").hashCode()).isNotZero();
+        assertThat(Endpoint.of("a", 80).hashCode()).isNotZero();
+        assertThat(Endpoint.of("a").withIpAddr("::1").hashCode()).isNotZero();
+        assertThat(Endpoint.of("a", 80).withIpAddr("::1").hashCode()).isNotZero();
+        assertThat(Endpoint.ofGroup("a").hashCode()).isNotZero();
+
+        // Weight not part of comparison
+        final int hash = Endpoint.of("a", 80).withWeight(500).hashCode();
+        assertThat(Endpoint.of("a", 80).withWeight(750).hashCode()).isEqualTo(hash);
+    }
+
+    @Test
+    public void testToString() {
+        assertThat(Endpoint.of("a").toString()).isNotNull();
+        assertThat(Endpoint.of("a", 80).toString()).isNotNull();
+        assertThat(Endpoint.of("a").withIpAddr("::1").toString()).isNotNull();
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/PropertiesEndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/PropertiesEndpointGroupTest.java
@@ -41,9 +41,9 @@ public class PropertiesEndpointGroupTest {
     public void propertiesWithoutDefaultPort() {
         PropertiesEndpointGroup endpointGroup = PropertiesEndpointGroup.of(PROPS, "serverA.hosts");
 
-        assertThat(endpointGroup.endpoints()).containsOnly(Endpoint.of("127.0.0.1:8080"),
-                                                           Endpoint.of("127.0.0.1:8081"),
-                                                           Endpoint.of("127.0.0.1"));
+        assertThat(endpointGroup.endpoints()).containsExactlyInAnyOrder(Endpoint.parse("127.0.0.1:8080"),
+                                                                        Endpoint.parse("127.0.0.1:8081"),
+                                                                        Endpoint.parse("127.0.0.1"));
     }
 
     @Test
@@ -51,11 +51,11 @@ public class PropertiesEndpointGroupTest {
         PropertiesEndpointGroup endpointGroupA = PropertiesEndpointGroup.of(PROPS, "serverA.hosts", 80);
         PropertiesEndpointGroup endpointGroupB = PropertiesEndpointGroup.of(PROPS, "serverB.hosts", 8080);
 
-        assertThat(endpointGroupA.endpoints()).containsOnly(Endpoint.of("127.0.0.1:8080"),
-                                                            Endpoint.of("127.0.0.1:8081"),
-                                                            Endpoint.of("127.0.0.1:80"));
-        assertThat(endpointGroupB.endpoints()).containsOnly(Endpoint.of("127.0.0.1:8082"),
-                                                            Endpoint.of("127.0.0.1:8083"));
+        assertThat(endpointGroupA.endpoints()).containsExactlyInAnyOrder(Endpoint.parse("127.0.0.1:8080"),
+                                                                         Endpoint.parse("127.0.0.1:8081"),
+                                                                         Endpoint.parse("127.0.0.1:80"));
+        assertThat(endpointGroupB.endpoints()).containsExactlyInAnyOrder(Endpoint.parse("127.0.0.1:8082"),
+                                                                         Endpoint.parse("127.0.0.1:8083"));
     }
 
     @Test
@@ -63,9 +63,9 @@ public class PropertiesEndpointGroupTest {
         PropertiesEndpointGroup endpointGroup = PropertiesEndpointGroup.of(
                 getClass().getClassLoader(), "server-list.properties", "serverA.hosts");
 
-        assertThat(endpointGroup.endpoints()).containsOnly(Endpoint.of("127.0.0.1:8080"),
-                                                           Endpoint.of("127.0.0.1:8081"),
-                                                           Endpoint.of("127.0.0.1"));
+        assertThat(endpointGroup.endpoints()).containsExactlyInAnyOrder(Endpoint.parse("127.0.0.1:8080"),
+                                                                        Endpoint.parse("127.0.0.1:8081"),
+                                                                        Endpoint.parse("127.0.0.1"));
     }
 
     @Test
@@ -75,11 +75,11 @@ public class PropertiesEndpointGroupTest {
         PropertiesEndpointGroup endpointGroupB = PropertiesEndpointGroup.of(
                 getClass().getClassLoader(), "server-list.properties", "serverB.hosts", 8080);
 
-        assertThat(endpointGroupA.endpoints()).containsOnly(Endpoint.of("127.0.0.1:8080"),
-                                                            Endpoint.of("127.0.0.1:8081"),
-                                                            Endpoint.of("127.0.0.1:80"));
-        assertThat(endpointGroupB.endpoints()).containsOnly(Endpoint.of("127.0.0.1:8082"),
-                                                            Endpoint.of("127.0.0.1:8083"));
+        assertThat(endpointGroupA.endpoints()).containsExactlyInAnyOrder(Endpoint.parse("127.0.0.1:8080"),
+                                                                         Endpoint.parse("127.0.0.1:8081"),
+                                                                         Endpoint.parse("127.0.0.1:80"));
+        assertThat(endpointGroupB.endpoints()).containsExactlyInAnyOrder(Endpoint.parse("127.0.0.1:8082"),
+                                                                         Endpoint.parse("127.0.0.1:8083"));
     }
 
     @Test
@@ -87,9 +87,9 @@ public class PropertiesEndpointGroupTest {
         PropertiesEndpointGroup endpointGroup = PropertiesEndpointGroup.of(
                 getClass().getClassLoader(), "server-list.properties", "serverA.hosts.");
 
-        assertThat(endpointGroup.endpoints()).containsOnly(Endpoint.of("127.0.0.1:8080"),
-                                                           Endpoint.of("127.0.0.1:8081"),
-                                                           Endpoint.of("127.0.0.1"));
+        assertThat(endpointGroup.endpoints()).containsExactlyInAnyOrder(Endpoint.parse("127.0.0.1:8080"),
+                                                                        Endpoint.parse("127.0.0.1:8081"),
+                                                                        Endpoint.parse("127.0.0.1"));
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/RoundRobinStrategyTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/RoundRobinStrategyTest.java
@@ -30,8 +30,10 @@ import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
 
 public class RoundRobinStrategyTest {
-    private static final EndpointGroup ENDPOINT_GROUP = new StaticEndpointGroup(Endpoint.of("localhost:1234"),
-                                                                                Endpoint.of("localhost:2345"));
+    private static final EndpointGroup ENDPOINT_GROUP =
+            new StaticEndpointGroup(Endpoint.parse("localhost:1234"),
+                                    Endpoint.parse("localhost:2345"));
+
     private static final EndpointGroup EMPTY_ENDPOINT_GROUP = new StaticEndpointGroup();
 
     private final RoundRobinStrategy strategy = new RoundRobinStrategy();

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/StickyEndpointSelectionStrategyTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/StickyEndpointSelectionStrategyTest.java
@@ -46,13 +46,13 @@ public class StickyEndpointSelectionStrategyTest {
     final StickyEndpointSelectionStrategy strategy = new StickyEndpointSelectionStrategy(hasher);
 
     private static final EndpointGroup STATIC_ENDPOINT_GROUP = new StaticEndpointGroup(
-            Endpoint.of("localhost:1234"),
-            Endpoint.of("localhost:2345"),
-            Endpoint.of("localhost:3333"),
-            Endpoint.of("localhost:5555"),
-            Endpoint.of("localhost:3444"),
-            Endpoint.of("localhost:9999"),
-            Endpoint.of("localhost:1111")
+            Endpoint.parse("localhost:1234"),
+            Endpoint.parse("localhost:2345"),
+            Endpoint.parse("localhost:3333"),
+            Endpoint.parse("localhost:5555"),
+            Endpoint.parse("localhost:3444"),
+            Endpoint.parse("localhost:9999"),
+            Endpoint.parse("localhost:1111")
     );
 
     private static final DynamicEndpointGroup DYNAMIC_ENDPOINT_GROUP = new DynamicEndpointGroup();
@@ -86,7 +86,7 @@ public class StickyEndpointSelectionStrategyTest {
         }
 
         //confirm rebuild tree of dynamic
-        Endpoint ep4 = Endpoint.of("localhost:9494");
+        Endpoint ep4 = Endpoint.parse("localhost:9494");
         DYNAMIC_ENDPOINT_GROUP.addEndpoint(ep4);
         assertThat(EndpointGroupRegistry.selectNode(
                 contextWithHeader(STICKY_HEADER_NAME, "armeria1"), "dynamic")).isEqualTo(ep4);

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/WeightedRoundRobinStrategyTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/WeightedRoundRobinStrategyTest.java
@@ -35,8 +35,10 @@ import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
 
 public class WeightedRoundRobinStrategyTest {
-    private static final EndpointGroup ENDPOINT_GROUP = new StaticEndpointGroup(Endpoint.of("localhost:1234"),
-                                                                                Endpoint.of("localhost:2345"));
+    private static final EndpointGroup ENDPOINT_GROUP =
+            new StaticEndpointGroup(Endpoint.parse("localhost:1234"),
+                                    Endpoint.parse("localhost:2345"));
+
     private static final EndpointGroup EMPTY_ENDPOINT_GROUP = new StaticEndpointGroup();
 
     private final WeightedRoundRobinStrategy strategy = new WeightedRoundRobinStrategy();
@@ -83,9 +85,9 @@ public class WeightedRoundRobinStrategyTest {
     public void testWeightedRoundRobinSelect() {
         //weight 1,2,3
         EndpointGroup endpointGroup = new StaticEndpointGroup(
-                Endpoint.of("127.0.0.1", 1234, 1),
-                Endpoint.of("127.0.0.1", 2345, 2),
-                Endpoint.of("127.0.0.1", 3456, 3));
+                Endpoint.of("127.0.0.1", 1234).withWeight(1),
+                Endpoint.of("127.0.0.1", 2345).withWeight(2),
+                Endpoint.of("127.0.0.1", 3456).withWeight(3));
         String groupName = "weighted";
 
         EndpointGroupRegistry.register(groupName, endpointGroup, WEIGHTED_ROUND_ROBIN);
@@ -106,9 +108,9 @@ public class WeightedRoundRobinStrategyTest {
 
         //weight 3,2,2
         EndpointGroup endpointGroup2 = new StaticEndpointGroup(
-                Endpoint.of("127.0.0.1", 1234, 3),
-                Endpoint.of("127.0.0.1", 2345, 2),
-                Endpoint.of("127.0.0.1", 3456, 2));
+                Endpoint.of("127.0.0.1", 1234).withWeight(3),
+                Endpoint.of("127.0.0.1", 2345).withWeight(2),
+                Endpoint.of("127.0.0.1", 3456).withWeight(2));
         EndpointGroupRegistry.register(groupName, endpointGroup2, WEIGHTED_ROUND_ROBIN);
 
         assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:1234");
@@ -129,9 +131,9 @@ public class WeightedRoundRobinStrategyTest {
 
         //weight 4,4,4
         EndpointGroup endpointGroup3 = new StaticEndpointGroup(
-                Endpoint.of("127.0.0.1", 1234, 4),
-                Endpoint.of("127.0.0.1", 2345, 4),
-                Endpoint.of("127.0.0.1", 3456, 4));
+                Endpoint.of("127.0.0.1", 1234).withWeight(4),
+                Endpoint.of("127.0.0.1", 2345).withWeight(4),
+                Endpoint.of("127.0.0.1", 3456).withWeight(4));
         EndpointGroupRegistry.register(groupName, endpointGroup3, WEIGHTED_ROUND_ROBIN);
 
         assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:1234");
@@ -143,9 +145,9 @@ public class WeightedRoundRobinStrategyTest {
 
         //weight 2,4,6
         EndpointGroup endpointGroup4 = new StaticEndpointGroup(
-                Endpoint.of("127.0.0.1", 1234, 2),
-                Endpoint.of("127.0.0.1", 2345, 4),
-                Endpoint.of("127.0.0.1", 3456, 6));
+                Endpoint.of("127.0.0.1", 1234).withWeight(2),
+                Endpoint.of("127.0.0.1", 2345).withWeight(4),
+                Endpoint.of("127.0.0.1", 3456).withWeight(6));
         EndpointGroupRegistry.register(groupName, endpointGroup4, WEIGHTED_ROUND_ROBIN);
 
         assertThat(EndpointGroupRegistry.selectNode(ctx, groupName).authority()).isEqualTo("127.0.0.1:1234");
@@ -184,15 +186,15 @@ public class WeightedRoundRobinStrategyTest {
         EndpointSelector selector = EndpointGroupRegistry.getNodeSelector("dynamic");
         assertThat(selector.select(ctx)).isEqualTo(Endpoint.of("127.0.0.1", 1000));
 
-        endpointGroup.updateEndpoints(ImmutableList.of(Endpoint.of("127.0.0.1", 1111, 1),
-                                                       Endpoint.of("127.0.0.1", 2222, 2)));
+        endpointGroup.updateEndpoints(ImmutableList.of(Endpoint.of("127.0.0.1", 1111).withWeight(1),
+                                                       Endpoint.of("127.0.0.1", 2222).withWeight(2)));
 
-        assertThat(selector.select(ctx)).isEqualTo(Endpoint.of("127.0.0.1", 2222, 2));
-        assertThat(selector.select(ctx)).isEqualTo(Endpoint.of("127.0.0.1", 2222, 2));
-        assertThat(selector.select(ctx)).isEqualTo(Endpoint.of("127.0.0.1", 1111, 1));
-        assertThat(selector.select(ctx)).isEqualTo(Endpoint.of("127.0.0.1", 2222, 2));
-        assertThat(selector.select(ctx)).isEqualTo(Endpoint.of("127.0.0.1", 2222, 2));
-        assertThat(selector.select(ctx)).isEqualTo(Endpoint.of("127.0.0.1", 1111, 1));
+        assertThat(selector.select(ctx)).isEqualTo(Endpoint.of("127.0.0.1", 2222).withWeight(2));
+        assertThat(selector.select(ctx)).isEqualTo(Endpoint.of("127.0.0.1", 2222).withWeight(2));
+        assertThat(selector.select(ctx)).isEqualTo(Endpoint.of("127.0.0.1", 1111).withWeight(1));
+        assertThat(selector.select(ctx)).isEqualTo(Endpoint.of("127.0.0.1", 2222).withWeight(2));
+        assertThat(selector.select(ctx)).isEqualTo(Endpoint.of("127.0.0.1", 2222).withWeight(2));
+        assertThat(selector.select(ctx)).isEqualTo(Endpoint.of("127.0.0.1", 1111).withWeight(1));
     }
 
     private static final class TestDynamicEndpointGroup extends DynamicEndpointGroup {

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/dns/DnsServiceEndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/dns/DnsServiceEndpointGroupTest.java
@@ -66,9 +66,9 @@ public class DnsServiceEndpointGroupTest {
 
     private static final List<Endpoint> ENDPOINTS =
             ImmutableList.of(
-                    Endpoint.of("1.armeria.com", 443, 1),
-                    Endpoint.of("2.armeria.com", 8080, 1),
-                    Endpoint.of("3.armeria.com", 9000, 5));
+                    Endpoint.of("1.armeria.com", 443).withWeight(1),
+                    Endpoint.of("2.armeria.com", 8080).withWeight(1),
+                    Endpoint.of("3.armeria.com", 9000).withWeight(5));
 
     private static EventLoop EVENT_LOOP;
 

--- a/thrift/src/test/java/com/linecorp/armeria/it/client/endpoint/StaticEndpointGroupIntegrationTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/client/endpoint/StaticEndpointGroupIntegrationTest.java
@@ -68,9 +68,9 @@ public class StaticEndpointGroupIntegrationTest {
         assertThat(ipService.hello("ip")).isEqualTo("host:127.0.0.1:" + serverThree.httpPort());
 
         StaticEndpointGroup serverGroup2 = new StaticEndpointGroup(
-                Endpoint.of("127.0.0.1", serverOne.httpPort(), 2),
-                Endpoint.of("127.0.0.1", serverTwo.httpPort(), 4),
-                Endpoint.of("127.0.0.1", serverThree.httpPort(), 2));
+                Endpoint.of("127.0.0.1", serverOne.httpPort()).withWeight(2),
+                Endpoint.of("127.0.0.1", serverTwo.httpPort()).withWeight(4),
+                Endpoint.of("127.0.0.1", serverThree.httpPort()).withWeight(2));
 
         EndpointGroupRegistry.register(groupName, serverGroup2, WEIGHTED_ROUND_ROBIN);
 

--- a/zookeeper/src/main/java/com/linecorp/armeria/common/zookeeper/DefaultNodeValueCodec.java
+++ b/zookeeper/src/main/java/com/linecorp/armeria/common/zookeeper/DefaultNodeValueCodec.java
@@ -56,7 +56,7 @@ final class DefaultNodeValueCodec implements NodeValueCodec {
                 if (port == 0) {
                     endpoint = Endpoint.of(host).withWeight(weight);
                 } else {
-                    endpoint = Endpoint.of(host, port, weight);
+                    endpoint = Endpoint.of(host, port).withWeight(weight);
                 }
                 break;
             }

--- a/zookeeper/src/test/java/com/linecorp/armeria/client/zookeeper/EndpointGroupTest.java
+++ b/zookeeper/src/test/java/com/linecorp/armeria/client/zookeeper/EndpointGroupTest.java
@@ -81,8 +81,8 @@ public class EndpointGroupTest extends TestBase implements ZooKeeperAssert, Opti
 
     @Test
     public void testUpdateEndpointGroup() throws Throwable {
-        Set<Endpoint> expected = ImmutableSet.of(Endpoint.of("127.0.0.1", 8001, 2),
-                                                 Endpoint.of("127.0.0.1", 8002, 3));
+        Set<Endpoint> expected = ImmutableSet.of(Endpoint.of("127.0.0.1", 8001).withWeight(2),
+                                                 Endpoint.of("127.0.0.1", 8002).withWeight(3));
         //add two more node
         setNodeChild(expected);
         //construct the final expected node list

--- a/zookeeper/src/test/java/com/linecorp/armeria/client/zookeeper/TestBase.java
+++ b/zookeeper/src/test/java/com/linecorp/armeria/client/zookeeper/TestBase.java
@@ -50,9 +50,9 @@ public class TestBase {
 
     static {
         final int[] ports = unusedPorts(3);
-        sampleEndpoints = ImmutableSet.of(Endpoint.of("127.0.0.1", ports[0], 2),
-                                          Endpoint.of("127.0.0.1", ports[1], 4),
-                                          Endpoint.of("127.0.0.1", ports[2], 2));
+        sampleEndpoints = ImmutableSet.of(Endpoint.of("127.0.0.1", ports[0]).withWeight(2),
+                                          Endpoint.of("127.0.0.1", ports[1]).withWeight(4),
+                                          Endpoint.of("127.0.0.1", ports[2]).withWeight(2));
     }
 
     private static final Duration duration = Duration.ofSeconds(10);

--- a/zookeeper/src/test/java/com/linecorp/armeria/common/zookeeper/NodeValueCodecTest.java
+++ b/zookeeper/src/test/java/com/linecorp/armeria/common/zookeeper/NodeValueCodecTest.java
@@ -31,7 +31,7 @@ public class NodeValueCodecTest {
                 .containsExactlyInAnyOrder(Endpoint.of("foo.com"),
                                            Endpoint.of("bar.com", 8080),
                                            Endpoint.of("10.0.2.15").withWeight(500),
-                                           Endpoint.of("192.168.1.2", 8443, 700));
+                                           Endpoint.of("192.168.1.2", 8443).withWeight(700));
         assertThatThrownBy(() -> NodeValueCodec.DEFAULT
                 .decodeAll("http://foo.com:8001, bar.com:8002"))
                 .isInstanceOf(EndpointGroupException.class);


### PR DESCRIPTION
Motivation:

Currently, `Endpoint.host()` is used as a hostname or an IP address of
an endpoint. This does not work well for the `Endpoint`s whose IP
addresses are known already. For example, let's say we want to use
`DnsServiceEndpointGroup` with the following SRV records:

    _https._tcp.foo.com. 3600 IN SRV 10 100 443 one.foo.com.
    _https._tcp.foo.com. 3600 IN SRV 10 100 443 two.foo.com.
    _https._tcp.foo.com. 3600 IN SRV 10 100 443 three.foo.com.

Because the client will have to create a TLS connection with proper SNI
settings, the `Endpoint` should provide `foo.com` as the host name and
provide `<the IP address of {one,two,three}.foo.com>` as the IP address
of `foo.com`, which is not possible with our current API.

Modifications:

- Add a new property `ipAddr` to `Endpoint`
- Add `Endpoint.withIpAddr()`
- Handle the case where a host name in an `Endpoint` is an IP address
- Add test cases
- Compare authority, IP address and port only
  - Take `port` and `ipAddr` into account when comparing.
  - Do *not* take `weight` into account when comparing.
- Add host name validation using Guava InternetDomainName
- Fix incorrect uses of `Endpoint.of()` in some test cases
- Deprecate `Endpoint.of(host, port, weight)` in favor of
  `Endpoint.of(host, port).withWeight(weight)`


Result:

- Fixes #1087
- A user can create an `Endpoint` with an IP address.
- `Endpoint.equals()` makes more sense.