### PR TITLE
Fix potential buffer leaks due to empty ByteBufHttpData

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -35,6 +35,7 @@ import com.linecorp.armeria.common.FixedHttpResponse.TwoElementFixedHttpResponse
 import com.linecorp.armeria.common.stream.StreamMessage;
 import com.linecorp.armeria.common.util.Exceptions;
 
+import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.EventExecutor;
 
 /**
@@ -209,6 +210,7 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
         }
 
         if (isContentAlwaysEmptyWithValidation(status, content, trailingHeaders)) {
+            ReferenceCountUtil.safeRelease(content);
             return new OneElementFixedHttpResponse(headers);
         } else if (!content.isEmpty()) {
             if (trailingHeaders.isEmpty()) {

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponseWriter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponseWriter.java
@@ -27,6 +27,8 @@ import java.util.Locale;
 
 import com.linecorp.armeria.common.stream.StreamWriter;
 
+import io.netty.util.ReferenceCountUtil;
+
 /**
  * An {@link HttpResponse} that can have {@link HttpObject}s written to it.
  */
@@ -175,6 +177,7 @@ public interface HttpResponseWriter extends HttpResponse, StreamWriter<HttpObjec
                            .setInt(HttpHeaderNames.CONTENT_LENGTH, content.length());
 
         if (isContentAlwaysEmptyWithValidation(status, content, trailingHeaders)) {
+            ReferenceCountUtil.safeRelease(content);
             write(headers);
         } else {
             write(headers);
@@ -216,6 +219,7 @@ public interface HttpResponseWriter extends HttpResponse, StreamWriter<HttpObjec
         final HttpHeaders trailingHeaders = res.trailingHeaders();
 
         if (isContentAlwaysEmptyWithValidation(status, content, trailingHeaders)) {
+            ReferenceCountUtil.safeRelease(content);
             write(headers);
         } else {
             write(headers);

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamWriter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamWriter.java
@@ -23,8 +23,31 @@ import javax.annotation.CheckReturnValue;
 
 import org.reactivestreams.Subscriber;
 
+import com.linecorp.armeria.unsafe.ByteBufHttpData;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.util.ReferenceCounted;
+
 /**
  * Produces the objects to be published by a {@link StreamMessage}.
+ *
+ * <h3 id="reference-counted">Life cycle of reference-counted objects</h3>
+ *
+ * <p>When the following methods are given with a {@link ReferenceCounted} object, such as {@link ByteBuf} and
+ * {@link ByteBufHttpData}, or the {@link Supplier} that provides such an object:
+ *
+ * <ul>
+ *   <li>{@link #tryWrite(Object)}</li>
+ *   <li>{@link #tryWrite(Supplier)}</li>
+ *   <li>{@link #write(Object)}</li>
+ *   <li>{@link #write(Supplier)}</li>
+ * </ul>
+ * the object will be released automatically by the stream when it's no longer in use, such as when:
+ * <ul>
+ *   <li>The method returns {@code false} or raises an exception.</li>
+ *   <li>The {@link Subscriber} of the stream consumes it.</li>
+ *   <li>The stream is cancelled, aborted or failed.</li>
+ * </ul>
  *
  * @param <T> the type of the stream element
  */
@@ -41,6 +64,7 @@ public interface StreamWriter<T> {
      *
      * @throws IllegalStateException if the stream was already closed
      * @throws IllegalArgumentException if the publication of the specified object has been rejected
+     * @see <a href="#reference-counted">Life cycle of reference-counted objects</a>
      */
     default void write(T o) {
         if (!tryWrite(o)) {
@@ -53,6 +77,7 @@ public interface StreamWriter<T> {
      * {@link Supplier} will be transferred to the {@link Subscriber}.
      *
      * @throws IllegalStateException if the stream was already closed.
+     * @see <a href="#reference-counted">Life cycle of reference-counted objects</a>
      */
     default void write(Supplier<? extends T> o) {
         if (!tryWrite(o)) {
@@ -68,6 +93,7 @@ public interface StreamWriter<T> {
      *         stream has been closed already.
      *
      * @throws IllegalArgumentException if the publication of the specified object has been rejected
+     * @see <a href="#reference-counted">Life cycle of reference-counted objects</a>
      */
     @CheckReturnValue
     boolean tryWrite(T o);
@@ -78,6 +104,7 @@ public interface StreamWriter<T> {
      *
      * @return {@code true} if the specified object has been scheduled for publication. {@code false} if the
      *         stream has been closed already.
+     * @see <a href="#reference-counted">Life cycle of reference-counted objects</a>
      */
     @CheckReturnValue
     default boolean tryWrite(Supplier<? extends T> o) {

--- a/core/src/test/java/com/linecorp/armeria/common/stream/AbstractStreamMessageAndWriterTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/AbstractStreamMessageAndWriterTest.java
@@ -107,10 +107,12 @@ public abstract class AbstractStreamMessageAndWriterTest extends AbstractStreamM
     @Test
     public void releaseWhenWritingToClosedStream_ByteBuf() {
         StreamMessageAndWriter<Object> stream = newStreamWriter(ImmutableList.of());
-        final ByteBuf buf = PooledByteBufAllocator.DEFAULT.buffer();
+        final ByteBuf buf = PooledByteBufAllocator.DEFAULT.buffer().retain();
         stream.close();
 
-        await().untilAsserted(() -> assertThat(stream.tryWrite(buf)).isFalse());
+        await().untilAsserted(() -> assertThat(stream.isOpen()).isFalse());
+        assertThat(stream.tryWrite(buf)).isFalse();
+        assertThat(buf.refCnt()).isOne();
         assertThatThrownBy(() -> stream.write(buf)).isInstanceOf(IllegalStateException.class);
         assertThat(buf.refCnt()).isZero();
     }
@@ -118,10 +120,12 @@ public abstract class AbstractStreamMessageAndWriterTest extends AbstractStreamM
     @Test
     public void releaseWhenWritingToClosedStream_HttpData() {
         StreamMessageAndWriter<Object> stream = newStreamWriter(ImmutableList.of());
-        final ByteBufHttpData data = new ByteBufHttpData(newPooledBuffer(), true);
+        final ByteBufHttpData data = new ByteBufHttpData(newPooledBuffer(), true).retain();
         stream.close();
 
-        await().untilAsserted(() -> assertThat(stream.tryWrite(data)).isFalse());
+        await().untilAsserted(() -> assertThat(stream.isOpen()).isFalse());
+        assertThat(stream.tryWrite(data)).isFalse();
+        assertThat(data.refCnt()).isOne();
         assertThatThrownBy(() -> stream.write(data)).isInstanceOf(IllegalStateException.class);
         assertThat(data.refCnt()).isZero();
     }

--- a/grpc/src/test/java/com/linecorp/armeria/internal/grpc/GrpcMessageMarshallerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/internal/grpc/GrpcMessageMarshallerTest.java
@@ -86,6 +86,7 @@ public class GrpcMessageMarshallerTest {
         SimpleRequest request = marshaller.deserializeRequest(new ByteBufOrStream(buf));
         assertThat(request).isEqualTo(GrpcTestUtil.REQUEST_MESSAGE);
         assertThat(buf.refCnt()).isEqualTo(1);
+        buf.release();
     }
 
     @Test
@@ -130,6 +131,7 @@ public class GrpcMessageMarshallerTest {
         SimpleResponse response = marshaller.deserializeResponse(new ByteBufOrStream(buf));
         assertThat(response).isEqualTo(GrpcTestUtil.RESPONSE_MESSAGE);
         assertThat(buf.refCnt()).isEqualTo(1);
+        buf.release();
     }
 
     @Test


### PR DESCRIPTION
Motivation:

We have many places where drops an empty HttpData silently. This can
lead to the leak of empty ByteBufHttpData.

Modifications:

- Use Unpooled.EMPTY_BUFFER for an empty buffer when creating a new
  ByteBufHttpData
- Release ByteBufHttpData explicitly when we drop it even if it's not
  empty
- Fix the incorrect reference count tests in AbstractStreamMessageAndWriterTest
- Update the Javadoc of StreamWriter about the life cycle of
  reference-counted objects

Result:

- Less buffer leak