### PR TITLE
Reduce the amount of static memory required for testing :grpc

### DIFF
--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcFlowControlTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcFlowControlTest.java
@@ -23,7 +23,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -57,20 +59,30 @@ public class GrpcFlowControlTest {
     private static final int CAPPED_NUM_MESSAGES = 3;
 
     // Large enough payload to trigger flow control.
-    private static final Payload PAYLOAD =
-            Payload.newBuilder()
-                   .setBody(ByteString.copyFromUtf8(Strings.repeat("a", 5 * 1024 * 1024)))
-                   .build();
+    private static Payload PAYLOAD;
+    private static SimpleRequest REQUEST;
+    private static SimpleResponse RESPONSE;
 
-    private static final SimpleRequest REQUEST =
-            SimpleRequest.newBuilder()
-                         .setPayload(PAYLOAD)
+    @BeforeClass
+    public static void createMessages() {
+        PAYLOAD = Payload.newBuilder()
+                         .setBody(ByteString.copyFromUtf8(Strings.repeat("a", 5 * 1024 * 1024)))
                          .build();
+        REQUEST = SimpleRequest.newBuilder()
+                               .setPayload(PAYLOAD)
+                               .build();
+        RESPONSE = SimpleResponse.newBuilder()
+                                 .setPayload(PAYLOAD)
+                                 .build();
+    }
 
-    private static final SimpleResponse RESPONSE =
-            SimpleResponse.newBuilder()
-                          .setPayload(PAYLOAD)
-                          .build();
+    @AfterClass
+    public static void destroyMessages() {
+        // Dereference to reduce the memory pressure on the VM.
+        PAYLOAD = null;
+        REQUEST = null;
+        RESPONSE = null;
+    }
 
     static class FlowControlService extends FlowControlTestServiceImplBase {
         @Override

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/ArmeriaServerCallTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/ArmeriaServerCallTest.java
@@ -43,7 +43,6 @@ import org.reactivestreams.Subscription;
 import com.linecorp.armeria.common.ClosedSessionException;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpResponseWriter;
-import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
 import com.linecorp.armeria.common.logging.DefaultRequestLog;
 import com.linecorp.armeria.grpc.testing.Messages.SimpleRequest;
@@ -64,7 +63,6 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.ByteBufInputStream;
 import io.netty.channel.DefaultEventLoop;
 import io.netty.channel.EventLoop;
-import io.netty.util.AsciiString;
 import io.netty.util.Attribute;
 
 // TODO(anuraag): Currently only grpc-protobuf has been published so we only test proto here.
@@ -73,14 +71,6 @@ import io.netty.util.Attribute;
 public class ArmeriaServerCallTest {
 
     private static final int MAX_MESSAGE_BYTES = 1024;
-
-    private static final HttpHeaders DEFAULT_RESPONSE_HEADERS =
-            HttpHeaders.of(HttpStatus.OK)
-                       .set(AsciiString.of("content-type"), "application/grpc+proto")
-                       .set(AsciiString.of("grpc-encoding"), "identity")
-                       .set(AsciiString.of("grpc-accept-encoding"),
-                            DecompressorRegistry.getDefaultInstance().getAdvertisedMessageEncodings())
-                       .asImmutable();
 
     private static EventLoop eventLoop;
 

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
@@ -91,7 +91,18 @@ public class GrpcServiceServerTest {
 
     private static final int MAX_MESSAGE_SIZE = 16 * 1024 * 1024;
 
-    private static final AsciiString LARGE_PAYLOAD = AsciiString.of(Strings.repeat("a", MAX_MESSAGE_SIZE + 1));
+    private static AsciiString LARGE_PAYLOAD;
+
+    @BeforeClass
+    public static void createLargePayload() {
+        LARGE_PAYLOAD = AsciiString.of(Strings.repeat("a", MAX_MESSAGE_SIZE + 1));
+    }
+
+    @AfterClass
+    public static void destroyLargePayload() {
+        // Dereference to reduce the memory pressure on the VM.
+        LARGE_PAYLOAD = null;
+    }
 
     // Used to communicate completion to a test when it is not possible to return to the client.
     private static final AtomicReference<Boolean> COMPLETED = new AtomicReference<>();


### PR DESCRIPTION
Motivation:

:grpc:test sometimes fails due to OutOfMemoryError.

Modifications:

- Dereference multi-megabyte strings when the relevant tests are
  finished

Result:

- Less chance of OOME in an environment with memory constraint