### PR TITLE
Fix a bug where resources are not cleaned up after calling duplicator.close()

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessageDuplicator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessageDuplicator.java
@@ -390,7 +390,7 @@ public abstract class AbstractStreamMessageDuplicator<T, U extends StreamMessage
         }
 
         void doClose() {
-            if (state == State.DUPLICABLE) {
+            if (state != State.CLOSED) {
                 state = State.CLOSED;
                 upstream.abort();
                 doCleanup();
@@ -401,6 +401,7 @@ public abstract class AbstractStreamMessageDuplicator<T, U extends StreamMessage
             final List<CompletableFuture<Void>> completionFutures =
                     new ArrayList<>(downstreamSubscriptions.size());
             downstreamSubscriptions.forEach(s -> {
+                s.abort();
                 final CompletableFuture<Void> future = s.completionFuture();
                 completionFutures.add(future);
             });

--- a/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageDuplicatorTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageDuplicatorTest.java
@@ -326,6 +326,10 @@ public class StreamMessageDuplicatorTest {
             assertThat(bufs[i].refCnt()).isOne();
         }
         duplicator.close();
+
+        for (int i = 25; i < 30; i++) {  // rest of them are cleared after calling duplicator.close()
+            assertThat(bufs[i].refCnt()).isZero();
+        }
     }
 
     @Test


### PR DESCRIPTION
Result:
- Close #1092