### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# https://help.github.com/articles/about-codeowners/
+
+* @hyangtack @minwoox @trustin
+
+/grpc/ @hyangtack @minwoox @trustin @anuraaga


### PR DESCRIPTION
Currently, contributors have to search through a longish list of reviewers for the three main maintainers when requesting reviews. With a CODEOWNERS file, the maintainers will be automatically added to PRs as reviewers.

It is also possible to add directory-specific owners, which I went ahead and did for gRPC.