### PR TITLE
Allow to serve HTTP and HTTPS on a single port

### DIFF
--- a/benchmarks/src/jmh/java/com/linecorp/armeria/core/HttpServerBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/core/HttpServerBenchmark.java
@@ -16,8 +16,6 @@
 
 package com.linecorp.armeria.core;
 
-import static com.linecorp.armeria.common.SessionProtocol.HTTP;
-
 import java.time.Duration;
 
 import org.openjdk.jmh.annotations.Benchmark;
@@ -73,7 +71,7 @@ public class HttpServerBenchmark {
                 .build();
         server.start().join();
         ServerPort httpPort = server.activePorts().values().stream()
-                                    .filter(p1 -> p1.protocol() == HTTP).findAny()
+                                    .filter(ServerPort::hasHttp).findAny()
                                     .get();
         httpClient = Clients.newClient("none+" + protocol.uriText() + "://127.0.0.1:" +
                                        httpPort.localAddress().getPort() + "/",

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/grpc/downstream/DownstreamSimpleBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/grpc/downstream/DownstreamSimpleBenchmark.java
@@ -16,8 +16,6 @@
 
 package com.linecorp.armeria.grpc.downstream;
 
-import static com.linecorp.armeria.common.SessionProtocol.HTTP;
-
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 
@@ -41,7 +39,7 @@ public class DownstreamSimpleBenchmark extends SimpleBenchmarkBase {
     @Override
     protected int port() {
         ServerPort httpPort = server.activePorts().values().stream()
-                                    .filter(p1 -> p1.protocol() == HTTP).findAny()
+                                    .filter(ServerPort::hasHttp).findAny()
                                     .get();
         return httpPort.localAddress().getPort();
     }

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/grpc/downstream/LargePayloadBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/grpc/downstream/LargePayloadBenchmark.java
@@ -16,8 +16,6 @@
 
 package com.linecorp.armeria.grpc.downstream;
 
-import static com.linecorp.armeria.common.SessionProtocol.HTTP;
-
 import java.util.concurrent.CountDownLatch;
 
 import org.openjdk.jmh.annotations.Benchmark;
@@ -100,7 +98,7 @@ public class LargePayloadBenchmark {
                 .build();
         server.start().join();
         ServerPort httpPort = server.activePorts().values().stream()
-                                    .filter(p1 -> p1.protocol() == HTTP).findAny()
+                                    .filter(ServerPort::hasHttp).findAny()
                                     .get();
         final String url = "gproto+http://127.0.0.1:" + httpPort.localAddress().getPort() + "/";
         binaryProxyClient = Clients.newClient(url, BinaryProxyStub.class);

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/thrift/PooledResponseBufferBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/thrift/PooledResponseBufferBenchmark.java
@@ -16,8 +16,6 @@
 
 package com.linecorp.armeria.thrift;
 
-import static com.linecorp.armeria.common.SessionProtocol.HTTP;
-
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
@@ -144,16 +142,16 @@ public class PooledResponseBufferBenchmark {
                 .service("/a", THttpService.of(
                         (AsyncIface) (name, resultHandler) ->
                                 resultHandler.onComplete(RESPONSE))
-                                                  .decorate(PooledDecoratingService::new))
+                                           .decorate(PooledDecoratingService::new))
                 .service("/b", THttpService.of(
                         (AsyncIface) (name, resultHandler) ->
                                 resultHandler.onComplete(RESPONSE))
-                                             .decorate(UnpooledDecoratingService::new));
+                                           .decorate(UnpooledDecoratingService::new));
         server = sb.build();
         server.start().join();
 
         ServerPort httpPort = server.activePorts().values().stream()
-                                    .filter(p1 -> p1.protocol() == HTTP).findAny()
+                                    .filter(ServerPort::hasHttp).findAny()
                                     .get();
         pooledClient = Clients.newClient(
                 "tbinary+http://127.0.0.1:" + httpPort.localAddress().getPort() + "/a",

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     }
 
     // Netty
-    [ 'netty-transport', 'netty-codec-http2', 'netty-resolver-dns' ].each {
+    [ 'netty-transport', 'netty-codec-http2', 'netty-codec-haproxy', 'netty-resolver-dns' ].each {
         compile "io.netty:$it"
     }
     compile "io.netty:netty-transport-native-unix-common:${managedVersions['io.netty:netty-transport-native-unix-common']}:linux-x86_64"

--- a/core/src/main/java/com/linecorp/armeria/common/SessionProtocol.java
+++ b/core/src/main/java/com/linecorp/armeria/common/SessionProtocol.java
@@ -52,7 +52,11 @@ public enum SessionProtocol {
     /**
      * HTTP/2 - cleartext.
      */
-    H2C("h2c", false, true, 80);
+    H2C("h2c", false, true, 80),
+    /**
+     * PROXY - cleartext.
+     */
+    PROXY("proxy", false, false, 0);
 
     private static final Map<String, SessionProtocol> uriTextToProtocols;
 

--- a/core/src/main/java/com/linecorp/armeria/server/AbstractVirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AbstractVirtualHostBuilder.java
@@ -345,7 +345,8 @@ abstract class AbstractVirtualHostBuilder<B extends AbstractVirtualHostBuilder> 
      */
     public B annotatedService(Object service, Object... exceptionHandlersAndConverters) {
         return annotatedService("/", service, Function.identity(),
-                                ImmutableList.copyOf(exceptionHandlersAndConverters));
+                                ImmutableList.copyOf(requireNonNull(exceptionHandlersAndConverters,
+                                                                    "exceptionHandlersAndConverters")));
     }
 
     /**
@@ -359,7 +360,9 @@ abstract class AbstractVirtualHostBuilder<B extends AbstractVirtualHostBuilder> 
                               Function<Service<HttpRequest, HttpResponse>,
                                       ? extends Service<HttpRequest, HttpResponse>> decorator,
                               Object... exceptionHandlersAndConverters) {
-        return annotatedService("/", service, decorator, exceptionHandlersAndConverters);
+        return annotatedService("/", service, decorator,
+                                requireNonNull(exceptionHandlersAndConverters,
+                                               "exceptionHandlersAndConverters"));
     }
 
     /**
@@ -379,7 +382,8 @@ abstract class AbstractVirtualHostBuilder<B extends AbstractVirtualHostBuilder> 
     public B annotatedService(String pathPrefix, Object service,
                               Object... exceptionHandlersAndConverters) {
         return annotatedService(pathPrefix, service, Function.identity(),
-                                ImmutableList.copyOf(exceptionHandlersAndConverters));
+                                ImmutableList.copyOf(requireNonNull(exceptionHandlersAndConverters,
+                                                                    "exceptionHandlersAndConverters")));
     }
 
     /**
@@ -394,7 +398,8 @@ abstract class AbstractVirtualHostBuilder<B extends AbstractVirtualHostBuilder> 
                                       ? extends Service<HttpRequest, HttpResponse>> decorator,
                               Object... exceptionHandlersAndConverters) {
         return annotatedService(pathPrefix, service, decorator,
-                                ImmutableList.copyOf(exceptionHandlersAndConverters));
+                                ImmutableList.copyOf(requireNonNull(exceptionHandlersAndConverters,
+                                                                    "exceptionHandlersAndConverters")));
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
@@ -58,6 +58,9 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
     @Nullable
     private final SSLSession sslSession;
 
+    @Nullable
+    private final ProxiedAddresses proxiedAddresses;
+
     private final DefaultRequestLog log;
     private final Logger logger;
 
@@ -86,7 +89,7 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
     public DefaultServiceRequestContext(
             ServiceConfig cfg, Channel ch, MeterRegistry meterRegistry, SessionProtocol sessionProtocol,
             PathMappingContext pathMappingContext, PathMappingResult pathMappingResult, Request request,
-            @Nullable SSLSession sslSession) {
+            @Nullable SSLSession sslSession, @Nullable ProxiedAddresses proxiedAddresses) {
 
         super(meterRegistry, sessionProtocol,
               requireNonNull(pathMappingContext, "pathMappingContext").method(), pathMappingContext.path(),
@@ -98,6 +101,7 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
         this.pathMappingContext = pathMappingContext;
         this.pathMappingResult = pathMappingResult;
         this.sslSession = sslSession;
+        this.proxiedAddresses = proxiedAddresses;
 
         log = new DefaultRequestLog(this);
         log.startRequest(ch, sessionProtocol, cfg.virtualHost().defaultHostname());
@@ -127,8 +131,8 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
     public ServiceRequestContext newDerivedContext(Request request) {
         final DefaultServiceRequestContext ctx = new DefaultServiceRequestContext(
                 cfg, ch, meterRegistry(), sessionProtocol(), pathMappingContext,
-                pathMappingResult, request, sslSession());
-        for (final Iterator<Attribute<?>> i = attrs(); i.hasNext();) {
+                pathMappingResult, request, sslSession(), proxiedAddresses());
+        for (final Iterator<Attribute<?>> i = attrs(); i.hasNext();/* noop */) {
             ctx.addAttr(i.next());
         }
         return ctx;
@@ -262,6 +266,12 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
                     "maxRequestLength: " + maxRequestLength + " (expected: >= 0)");
         }
         this.maxRequestLength = maxRequestLength;
+    }
+
+    @Nullable
+    @Override
+    public ProxiedAddresses proxiedAddresses() {
+        return proxiedAddresses;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/InetProxiedAddress.java
+++ b/core/src/main/java/com/linecorp/armeria/server/InetProxiedAddress.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static java.util.Objects.requireNonNull;
+
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+
+import com.google.common.base.MoreObjects;
+
+/**
+ * A concrete class to provide source and destination addresses delivered from PROXY protocol.
+ */
+final class InetProxiedAddress implements ProxiedAddresses {
+
+    private final InetSocketAddress sourceAddress;
+    private final InetSocketAddress destinationAddress;
+
+    InetProxiedAddress(InetSocketAddress sourceAddress,
+                       InetSocketAddress destinationAddress) {
+        this.sourceAddress = requireNonNull(sourceAddress, "sourceAddress");
+        this.destinationAddress = requireNonNull(destinationAddress, "destinationAddress");
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <A extends SocketAddress> A sourceAddress() {
+        return (A) sourceAddress;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <A extends SocketAddress> A destinationAddress() {
+        return (A) destinationAddress;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("sourceAddress", sourceAddress)
+                          .add("destinationAddress", destinationAddress)
+                          .toString();
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/ProxiedAddresses.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ProxiedAddresses.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+
+/**
+ * An interface to provide source and destination addresses delivered from a proxy server.
+ */
+public interface ProxiedAddresses {
+
+    /**
+     * Creates an {@link InetProxiedAddress} instance.
+     */
+    static InetProxiedAddress of(String sourceAddress, int sourcePort,
+                                 String destinationAddress, int destinationPort) {
+        return new InetProxiedAddress(
+                InetSocketAddress.createUnresolved(sourceAddress, sourcePort),
+                InetSocketAddress.createUnresolved(destinationAddress, destinationPort));
+    }
+
+    /**
+     * Creates an {@link InetProxiedAddress} instance.
+     */
+    static InetProxiedAddress of(InetSocketAddress sourceAddress,
+                                 InetSocketAddress destinationAddress) {
+        return new InetProxiedAddress(sourceAddress, destinationAddress);
+    }
+
+    /**
+     * Returns the source address of the proxied request.
+     */
+    <A extends SocketAddress> A sourceAddress();
+
+    /**
+     * Returns the destination address of the proxied request.
+     */
+    <A extends SocketAddress> A destinationAddress();
+}

--- a/core/src/main/java/com/linecorp/armeria/server/Server.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Server.java
@@ -249,7 +249,7 @@ public final class Server implements AutoCloseable {
                                                        config().blockingTaskExecutor());
             }
 
-            for (ServerPort p: ports) {
+            for (final ServerPort p: ports) {
                 start(p).addListener(new ServerPortStartListener(remainingPorts, future, p));
             }
         } catch (Throwable t) {
@@ -627,7 +627,7 @@ public final class Server implements AutoCloseable {
                   .addListener((ChannelFutureListener) future -> serverChannels.remove(future.channel()));
 
                 final InetSocketAddress localAddress = (InetSocketAddress) ch.localAddress();
-                final ServerPort actualPort = new ServerPort(localAddress, port.protocol());
+                final ServerPort actualPort = new ServerPort(localAddress, port.protocols());
 
                 // Update the boss thread so its name contains the actual port.
                 Thread.currentThread().setName(bossThreadName(actualPort));
@@ -643,10 +643,10 @@ public final class Server implements AutoCloseable {
                 if (localAddress.getAddress().isAnyLocalAddress() ||
                     localAddress.getAddress().isLoopbackAddress()) {
                     logger.info("Serving {} at {} - {}://127.0.0.1:{}/",
-                                port.protocol().name(), localAddress,
-                                port.protocol().uriText(), localAddress.getPort());
+                                port.protocolNames(), localAddress,
+                                port.protocolNames(), localAddress.getPort());
                 } else {
-                    logger.info("Serving {} at {}", port.protocol().name(), localAddress);
+                    logger.info("Serving {} at {}", port.protocolNames(), localAddress);
                 }
 
                 if (remainingPorts.decrementAndGet() == 0) {
@@ -665,7 +665,7 @@ public final class Server implements AutoCloseable {
 
         // e.g. 'armeria-boss-http-*:8080'
         //      'armeria-boss-http-127.0.0.1:8443'
-        return "armeria-boss-" + port.protocol().uriText() + '-' + localHostName + ':' + localAddr.getPort();
+        return "armeria-boss-" + port.protocolNames() + '-' + localHostName + ':' + localAddr.getPort();
     }
 
     private static void completeFuture(CompletableFuture<Void> future) {

--- a/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
@@ -77,6 +77,8 @@ public final class ServerConfig {
 
     private final Consumer<RequestLog> accessLogWriter;
 
+    private final int proxyProtocolMaxTlvSize;
+
     @Nullable
     private String strVal;
 
@@ -89,7 +91,7 @@ public final class ServerConfig {
             int defaultMaxHttp1InitialLineLength, int defaultMaxHttp1HeaderSize, int defaultMaxHttp1ChunkSize,
             Duration gracefulShutdownQuietPeriod, Duration gracefulShutdownTimeout,
             Executor blockingTaskExecutor, MeterRegistry meterRegistry, String serviceLoggerPrefix,
-            Consumer<RequestLog> accessLogWriter) {
+            Consumer<RequestLog> accessLogWriter, int proxyProtocolMaxTlvSize) {
 
         requireNonNull(ports, "ports");
         requireNonNull(defaultVirtualHost, "defaultVirtualHost");
@@ -140,6 +142,12 @@ public final class ServerConfig {
         }
 
         this.ports = Collections.unmodifiableList(portsCopy);
+
+        if (this.ports.stream().anyMatch(ServerPort::hasProxy)) {
+            this.proxyProtocolMaxTlvSize = proxyProtocolMaxTlvSize;
+        } else {
+            this.proxyProtocolMaxTlvSize = 0;
+        }
 
         // Set virtual host definitions and initialize their domain name mapping.
         final DomainNameMappingBuilder<VirtualHost> mappingBuilder =
@@ -430,6 +438,14 @@ public final class ServerConfig {
         return accessLogWriter;
     }
 
+    /**
+     * Returns the maximum size of additional data (TLV, Tag-Length-Value). It is only used when
+     * PROXY protocol is enabled on the server port.
+     */
+    public int proxyProtocolMaxTlvSize() {
+        return proxyProtocolMaxTlvSize;
+    }
+
     @Override
     public String toString() {
         String strVal = this.strVal;
@@ -441,7 +457,8 @@ public final class ServerConfig {
                     defaultRequestTimeoutMillis(), defaultMaxRequestLength(),
                     defaultMaxHttp1InitialLineLength(), defaultMaxHttp1HeaderSize(), defaultMaxHttp1ChunkSize(),
                     gracefulShutdownQuietPeriod(), gracefulShutdownTimeout(),
-                    blockingTaskExecutor(), meterRegistry(), serviceLoggerPrefix(), accessLogWriter());
+                    blockingTaskExecutor(), meterRegistry(), serviceLoggerPrefix(), accessLogWriter(),
+                    proxyProtocolMaxTlvSize());
         }
 
         return strVal;
@@ -456,7 +473,7 @@ public final class ServerConfig {
             long defaultMaxHttp1HeaderSize, long defaultMaxHttp1ChunkSize,
             Duration gracefulShutdownQuietPeriod, Duration gracefulShutdownTimeout,
             Executor blockingTaskExecutor, @Nullable MeterRegistry meterRegistry, String serviceLoggerPrefix,
-            Consumer<RequestLog> accessLogWriter) {
+            Consumer<RequestLog> accessLogWriter, int proxyProtocolMaxTlvSize) {
 
         final StringBuilder buf = new StringBuilder();
         if (type != null) {
@@ -466,8 +483,8 @@ public final class ServerConfig {
         buf.append("(ports: [");
 
         boolean hasPorts = false;
-        for (ServerPort p : ports) {
-            buf.append(ServerPort.toString(null, p.localAddress(), p.protocol()));
+        for (final ServerPort p : ports) {
+            buf.append(ServerPort.toString(null, p.localAddress(), p.protocols()));
             buf.append(", ");
             hasPorts = true;
         }
@@ -532,6 +549,8 @@ public final class ServerConfig {
         buf.append(serviceLoggerPrefix);
         buf.append(", accessLogWriter: ");
         buf.append(accessLogWriter);
+        buf.append(", proxyProtocolMaxTlvSize: ");
+        buf.append(proxyProtocolMaxTlvSize);
         buf.append(')');
 
         return buf.toString();

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
@@ -185,4 +185,10 @@ public interface ServiceRequestContext extends RequestContext {
      * @see ContentTooLargeException
      */
     void setMaxRequestLength(long maxRequestLength);
+
+    /**
+     * Returns the proxied addresses if the current {@link Request} is received through a proxy.
+     */
+    @Nullable
+    ProxiedAddresses proxiedAddresses();
 }

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
@@ -133,4 +133,10 @@ public class ServiceRequestContextWrapper
     public void setMaxRequestLength(long maxRequestLength) {
         delegate().setMaxRequestLength(maxRequestLength);
     }
+
+    @Nullable
+    @Override
+    public ProxiedAddresses proxiedAddresses() {
+        return delegate().proxiedAddresses();
+    }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientSniTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientSniTest.java
@@ -16,7 +16,6 @@
 
 package com.linecorp.armeria.client;
 
-import static com.linecorp.armeria.common.SessionProtocol.HTTPS;
 import static org.junit.Assert.assertEquals;
 
 import java.net.InetAddress;
@@ -40,6 +39,7 @@ import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.server.AbstractHttpService;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.ServerPort;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.VirtualHostBuilder;
 
@@ -89,7 +89,7 @@ public class HttpClientSniTest {
     public static void init() throws Exception {
         server.start().get();
         httpsPort = server.activePorts().values().stream()
-                          .filter(p -> p.protocol() == HTTPS).findAny().get().localAddress()
+                          .filter(ServerPort::hasHttps).findAny().get().localAddress()
                           .getPort();
         clientFactory = new ClientFactoryBuilder()
                 .sslContextCustomizer(b -> b.trustManager(InsecureTrustManagerFactory.INSTANCE))

--- a/core/src/test/java/com/linecorp/armeria/server/DefaultServiceRequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/DefaultServiceRequestContextTest.java
@@ -47,7 +47,8 @@ public class DefaultServiceRequestContextTest {
         final ServiceRequestContext originalCtx = new DefaultServiceRequestContext(
                 virtualHost.serviceConfigs().get(0), mock(Channel.class), NoopMeterRegistry.get(),
                 SessionProtocol.H2,
-                mappingCtx, PathMappingResult.of("/foo", null, ImmutableMap.of()), mock(Request.class), null);
+                mappingCtx, PathMappingResult.of("/foo", null, ImmutableMap.of()),
+                mock(Request.class), null, null);
 
         final AttributeKey<String> foo = AttributeKey.valueOf(DefaultServiceRequestContextTest.class, "foo");
         originalCtx.attr(foo).set("foo");

--- a/core/src/test/java/com/linecorp/armeria/server/PortUnificationServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/PortUnificationServerTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collection;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.client.ClientFactory;
+import com.linecorp.armeria.client.ClientFactoryBuilder;
+import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.testing.server.ServerRule;
+
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+
+@RunWith(Parameterized.class)
+public class PortUnificationServerTest {
+
+    private static ClientFactory clientFactory =
+            new ClientFactoryBuilder().sslContextCustomizer(
+                    b -> b.trustManager(InsecureTrustManagerFactory.INSTANCE)).build();
+
+    @ClassRule
+    public static final ServerRule server = new ServerRule() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.http(0).https(0).haproxy(0);
+            sb.tlsSelfSigned();
+            sb.service("/", new AbstractHttpService() {
+                @Override
+                protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) {
+                    return HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8,
+                                           ctx.sessionProtocol().name());
+                }
+            });
+        }
+    };
+
+    @Parameters(name = "{index}: scheme={0}")
+    public static Collection<String> schemes() {
+        return ImmutableList.of("h1c", "h2c", "h1", "h2");
+    }
+
+    private final String scheme;
+
+    public PortUnificationServerTest(String scheme) {
+        this.scheme = scheme;
+    }
+
+    @Test
+    public void test() throws Exception {
+        final HttpClient client = HttpClient.of(clientFactory,
+                                                scheme + "://127.0.0.1:" + server.httpsPort() + '/');
+        final AggregatedHttpMessage response = client.execute(HttpRequest.of(HttpMethod.GET, "/"))
+                                                     .aggregate().join();
+        assertThat(response.content().toStringUtf8()).isEqualToIgnoringCase(scheme);
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/ProxyProtocolEnabledServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ProxyProtocolEnabledServerTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.server.annotation.Get;
+import com.linecorp.armeria.testing.server.ServerRule;
+
+public class ProxyProtocolEnabledServerTest {
+
+    private static final TrustManager[] trustAllCerts = {
+            new X509TrustManager() {
+                public X509Certificate[] getAcceptedIssuers() {
+                    return new X509Certificate[0];
+                }
+
+                public void checkClientTrusted(X509Certificate[] certs, String authType) {}
+
+                public void checkServerTrusted(X509Certificate[] certs, String authType) {}
+            }
+    };
+
+    @ClassRule
+    public static final ServerRule server = new ServerRule() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.http(0).https(0).haproxy(0);
+            sb.tlsSelfSigned();
+            sb.service("/", new AbstractHttpService() {
+                @Override
+                protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) {
+                    final InetSocketAddress src = ctx.proxiedAddresses().sourceAddress();
+                    final InetSocketAddress dst = ctx.proxiedAddresses().destinationAddress();
+                    return HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8,
+                                           String.format("%s:%d -> %s:%d\n",
+                                                         src.getHostString(), src.getPort(),
+                                                         dst.getHostString(), dst.getPort()));
+                }
+            });
+        }
+    };
+
+    @Test
+    public void http() throws Exception {
+        try (Socket sock = new Socket("127.0.0.1", server.httpsPort())) {
+            final PrintWriter writer = new PrintWriter(sock.getOutputStream());
+            writer.print("PROXY TCP4 192.168.0.1 192.168.0.11 56324 443\r\n");
+            writer.print("GET / HTTP/1.1\r\n\r\n");
+            writer.flush();
+
+            final BufferedReader reader = new BufferedReader(new InputStreamReader(sock.getInputStream()));
+            checkResponse(reader);
+
+            writer.print("GET / HTTP/1.1\r\n\r\n");
+            writer.flush();
+
+            checkResponse(reader);
+        }
+    }
+
+    @Test
+    public void https() throws Exception {
+        try (Socket sock = new Socket("127.0.0.1", server.httpsPort())) {
+            final PrintWriter writer = new PrintWriter(sock.getOutputStream());
+            writer.print("PROXY TCP4 192.168.0.1 192.168.0.11 56324 443\r\n");
+            writer.flush();
+
+            final SSLContext sc = SSLContext.getInstance("SSL");
+            sc.init(null, trustAllCerts, new SecureRandom());
+            final Socket sslSock =
+                    sc.getSocketFactory().createSocket(sock, "127.0.0.1", server.httpsPort(), false);
+            final PrintWriter sslWriter = new PrintWriter(sslSock.getOutputStream());
+            sslWriter.print("GET / HTTP/1.1\r\n\r\n");
+            sslWriter.flush();
+
+            final BufferedReader reader = new BufferedReader(new InputStreamReader(sslSock.getInputStream()));
+            checkResponse(reader);
+
+            sslWriter.print("GET / HTTP/1.1\r\n\r\n");
+            sslWriter.flush();
+
+            checkResponse(reader);
+        }
+    }
+
+    @Test
+    public void builder() throws Exception {
+        final Object service = new Object() {
+            @Get("/")
+            public String get() {
+                return "";
+            }
+        };
+        assertThat(new ServerBuilder().tlsSelfSigned().https(0).http(0).haproxy(0)
+                                      .annotatedService(service).build()).isNotNull();
+        assertThat(new ServerBuilder().tlsSelfSigned().https(0).haproxy(0)
+                                      .annotatedService(service).build()).isNotNull();
+        assertThat(new ServerBuilder().http(0).haproxy(0)
+                                      .annotatedService(service).build()).isNotNull();
+        assertThatThrownBy(() -> new ServerBuilder().haproxy(0).annotatedService(service).build())
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private static void checkResponse(BufferedReader reader) throws IOException {
+        assertThat(reader.readLine()).isEqualToIgnoringCase("HTTP/1.1 200 Ok");
+
+        // Content-Length header, Content-Type header, an empty line
+        reader.readLine();
+        reader.readLine();
+        reader.readLine();
+
+        assertThat(reader.readLine()).isEqualToIgnoringCase("192.168.0.1:56324 -> 192.168.0.11:443");
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/file/HttpFileServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/file/HttpFileServiceTest.java
@@ -15,7 +15,6 @@
  */
 package com.linecorp.armeria.server.file;
 
-import static com.linecorp.armeria.common.SessionProtocol.HTTP;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
@@ -50,6 +49,7 @@ import com.google.common.io.Resources;
 import com.linecorp.armeria.internal.PathAndQuery;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.ServerPort;
 import com.linecorp.armeria.server.logging.LoggingService;
 
 import io.netty.handler.codec.DateFormatter;
@@ -100,7 +100,7 @@ public class HttpFileServiceTest {
         server.start().get();
 
         httpPort = server.activePorts().values().stream()
-                         .filter(p -> p.protocol() == HTTP).findAny().get().localAddress().getPort();
+                         .filter(ServerPort::hasHttp).findAny().get().localAddress().getPort();
     }
 
     @AfterClass
@@ -147,7 +147,7 @@ public class HttpFileServiceTest {
 
             // Confirm file service paths are cached when cache is enabled.
             assertThat(PathAndQuery.cachedPaths())
-                                           .contains("/foo.txt");
+                    .contains("/foo.txt");
         }
     }
 
@@ -197,7 +197,7 @@ public class HttpFileServiceTest {
 
                 // Confirm path not cached when cache disabled.
                 assertThat(PathAndQuery.cachedPaths())
-                                               .doesNotContain("/compressed/foo.txt");
+                        .doesNotContain("/compressed/foo.txt");
             }
         }
     }
@@ -327,7 +327,7 @@ public class HttpFileServiceTest {
         if (expectedContentType != null) {
             assertThat(res.containsHeader(HttpHeaders.CONTENT_TYPE)).isTrue();
             assertThat(res.getFirstHeader(HttpHeaders.CONTENT_TYPE).getValue())
-                      .startsWith(expectedContentType);
+                    .startsWith(expectedContentType);
         } else {
             assertThat(res.containsHeader(HttpHeaders.CONTENT_TYPE)).isFalse();
         }

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -129,6 +129,7 @@ io.micrometer:
 
 io.netty:
   netty-codec-http2: { version: &NETTY_VERSION '4.1.22.Final' }
+  netty-codec-haproxy: { version: *NETTY_VERSION }
   netty-handler: { version: *NETTY_VERSION }
   netty-resolver-dns: { version: *NETTY_VERSION }
   netty-transport:

--- a/logback/src/test/java/com/linecorp/armeria/common/logback/RequestContextExportingAppenderTest.java
+++ b/logback/src/test/java/com/linecorp/armeria/common/logback/RequestContextExportingAppenderTest.java
@@ -424,7 +424,7 @@ public class RequestContextExportingAppenderTest {
 
         final ServiceRequestContext ctx = new DefaultServiceRequestContext(
                 serviceConfig, ch, NoopMeterRegistry.get(), SessionProtocol.H2, mappingCtx,
-                PathMappingResult.of(path, query, ImmutableMap.of()), req, newSslSession());
+                PathMappingResult.of(path, query, ImmutableMap.of()), req, newSslSession(), null);
 
         ctx.attr(MY_ATTR).set(new CustomValue("some-attr"));
         return ctx;

--- a/spring-boot/autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaAutoConfigurationTest.java
+++ b/spring-boot/autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaAutoConfigurationTest.java
@@ -40,7 +40,6 @@ import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
-import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.server.AbstractHttpService;
 import com.linecorp.armeria.server.PathMapping;
 import com.linecorp.armeria.server.Server;
@@ -162,8 +161,9 @@ public class ArmeriaAutoConfigurationTest {
     @Test
     public void testPortConfiguration() throws Exception {
         final Collection<ServerPort> ports = server.activePorts().values();
-        assertThat(ports.stream().filter(p -> p.protocol() == SessionProtocol.HTTP)).hasSize(3);
-        assertThat(ports.stream().filter(p -> p.localAddress().getAddress().isAnyLocalAddress())).hasSize(2);
+        // IP address 127.0.0.1 and 0.0.0.0 would be merged into a single port.
+        assertThat(ports.stream().filter(ServerPort::hasHttp)).hasSize(2);
+        assertThat(ports.stream().filter(p -> p.localAddress().getAddress().isAnyLocalAddress())).hasSize(1);
         assertThat(ports.stream().filter(p -> p.localAddress().getAddress().isLoopbackAddress())).hasSize(1);
     }
 

--- a/testing/src/main/java/com/linecorp/armeria/testing/server/ServerRule.java
+++ b/testing/src/main/java/com/linecorp/armeria/testing/server/ServerRule.java
@@ -166,7 +166,7 @@ public abstract class ServerRule extends ExternalResource {
      */
     public int port(SessionProtocol protocol) {
         return server().activePorts().values().stream()
-                       .filter(p1 -> p1.protocol() == protocol).findAny()
+                       .filter(p1 -> p1.hasProtocol(protocol)).findAny()
                        .flatMap(p -> Optional.of(p.localAddress().getPort()))
                        .orElseThrow(() -> new IllegalStateException(protocol + " port not open"));
     }
@@ -189,7 +189,7 @@ public abstract class ServerRule extends ExternalResource {
         final Server server = this.server.get();
         return server != null &&
                server.activePorts().values().stream()
-                     .anyMatch(port -> port.protocol() == protocol);
+                     .anyMatch(port -> port.hasProtocol(protocol));
     }
 
     /**

--- a/thrift/src/test/java/com/linecorp/armeria/client/thrift/ThriftOverHttpClientTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/client/thrift/ThriftOverHttpClientTest.java
@@ -16,8 +16,6 @@
 
 package com.linecorp.armeria.client.thrift;
 
-import static com.linecorp.armeria.common.SessionProtocol.HTTP;
-import static com.linecorp.armeria.common.SessionProtocol.HTTPS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -68,6 +66,7 @@ import com.linecorp.armeria.common.thrift.ThriftSerializationFormats;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.ServerPort;
 import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.logging.LoggingService;
 import com.linecorp.armeria.server.thrift.THttpService;
@@ -211,15 +210,15 @@ public class ThriftOverHttpClientTest {
     public static Collection<Object[]> parameters() throws Exception {
         List<Object[]> parameters = new ArrayList<>();
         for (SerializationFormat serializationFormat : ThriftSerializationFormats.values()) {
-            parameters.add(new Object[] { serializationFormat, "http",  false, true });
-            parameters.add(new Object[] { serializationFormat, "http",  false, false });
-            parameters.add(new Object[] { serializationFormat, "https", true,  false });
-            parameters.add(new Object[] { serializationFormat, "h1",    true,  false }); // HTTP/1 over TLS
-            parameters.add(new Object[] { serializationFormat, "h1c",   false, true  }); // HTTP/1 cleartext
-            parameters.add(new Object[] { serializationFormat, "h1c",   false, false });
-            parameters.add(new Object[] { serializationFormat, "h2",    true,  false }); // HTTP/2 over TLS
-            parameters.add(new Object[] { serializationFormat, "h2c",   false, true  }); // HTTP/2 cleartext
-            parameters.add(new Object[] { serializationFormat, "h2c",   false, false });
+            parameters.add(new Object[] { serializationFormat, "http", false, true });
+            parameters.add(new Object[] { serializationFormat, "http", false, false });
+            parameters.add(new Object[] { serializationFormat, "https", true, false });
+            parameters.add(new Object[] { serializationFormat, "h1", true, false }); // HTTP/1 over TLS
+            parameters.add(new Object[] { serializationFormat, "h1c", false, true }); // HTTP/1 cleartext
+            parameters.add(new Object[] { serializationFormat, "h1c", false, false });
+            parameters.add(new Object[] { serializationFormat, "h2", true, false }); // HTTP/2 over TLS
+            parameters.add(new Object[] { serializationFormat, "h2c", false, true }); // HTTP/2 cleartext
+            parameters.add(new Object[] { serializationFormat, "h2c", false, false });
         }
         return parameters;
     }
@@ -245,10 +244,10 @@ public class ThriftOverHttpClientTest {
         server.start().get();
 
         httpPort = server.activePorts().values().stream()
-                         .filter(p -> p.protocol() == HTTP).findAny().get().localAddress()
+                         .filter(ServerPort::hasHttp).findAny().get().localAddress()
                          .getPort();
         httpsPort = server.activePorts().values().stream()
-                          .filter(p -> p.protocol() == HTTPS).findAny().get().localAddress()
+                          .filter(ServerPort::hasHttps).findAny().get().localAddress()
                           .getPort();
 
         final Consumer<SslContextBuilder> sslContextCustomizer =

--- a/thrift/src/test/java/com/linecorp/armeria/server/thrift/AbstractThriftOverHttpTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/server/thrift/AbstractThriftOverHttpTest.java
@@ -15,8 +15,6 @@
  */
 package com.linecorp.armeria.server.thrift;
 
-import static com.linecorp.armeria.common.SessionProtocol.HTTP;
-import static com.linecorp.armeria.common.SessionProtocol.HTTPS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -52,6 +50,7 @@ import com.linecorp.armeria.common.thrift.ThriftProtocolFactories;
 import com.linecorp.armeria.common.thrift.ThriftReply;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.ServerPort;
 import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.SimpleDecoratingService;
@@ -123,7 +122,7 @@ public abstract class AbstractThriftOverHttpTest {
             sb.decorator(LoggingService.newDecorator());
 
             final Function<Service<HttpRequest, HttpResponse>,
-                           Service<HttpRequest, HttpResponse>> logCollectingDecorator =
+                    Service<HttpRequest, HttpResponse>> logCollectingDecorator =
                     s -> new SimpleDecoratingService<HttpRequest, HttpResponse>(s) {
                         @Override
                         public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
@@ -147,10 +146,10 @@ public abstract class AbstractThriftOverHttpTest {
         server.start().get();
 
         httpPort = server.activePorts().values().stream()
-                         .filter(p -> p.protocol() == HTTP).findAny().get()
+                         .filter(ServerPort::hasHttp).findAny().get()
                          .localAddress().getPort();
         httpsPort = server.activePorts().values().stream()
-                          .filter(p -> p.protocol() == HTTPS).findAny().get()
+                          .filter(ServerPort::hasHttps).findAny().get()
                           .localAddress().getPort();
     }
 
@@ -364,10 +363,10 @@ public abstract class AbstractThriftOverHttpTest {
 
     protected static String newUri(String scheme, String path) {
         switch (scheme) {
-        case "http":
-            return scheme + "://127.0.0.1:" + httpPort + path;
-        case "https":
-            return scheme + "://127.0.0.1:" + httpsPort + path;
+            case "http":
+                return scheme + "://127.0.0.1:" + httpPort + path;
+            case "https":
+                return scheme + "://127.0.0.1:" + httpsPort + path;
         }
 
         throw new Error();


### PR DESCRIPTION
Motivation:
In some environment, a user may need to serve HTTP and HTTPS on a single port, but Armeria has not allowed it.

Modifications:
- Make `ServerPort` have a list of `SessionProtocol` enum values in order to allow to serve HTTP and HTTPS on a single port.
- Add an option for enabling PROXY protocol in order to interoperate with HAProxy well.
- Expose source and destination addresses delivered from PROXY protocol as `ProxiedAddresses` class.

Result:
Closes #1099