### PR TITLE
Rename 'armeria.server.numConnections` to `armeria.server.connections`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/Server.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Server.java
@@ -204,7 +204,7 @@ public final class Server implements AutoCloseable {
         final MeterRegistry meterRegistry = config().meterRegistry();
         meterRegistry.gauge("armeria.server.pendingResponses", gracefulShutdownSupport,
                             GracefulShutdownSupport::pendingResponses);
-        meterRegistry.gauge("armeria.server.numConnections", connectionLimitingHandler,
+        meterRegistry.gauge("armeria.server.connections", connectionLimitingHandler,
                             ConnectionLimitingHandler::numConnections);
     }
 


### PR DESCRIPTION
Motivation:

`numConnections` violates the Prometheus naming convention

Modifications:

- Rename 'armeria.server.numConnections` to `armeria.server.connections`

Result:

Consistency