### PR TITLE
Allow caching header values to avoid creating new Strings for the sam…

### DIFF
--- a/benchmarks/src/jmh/java/com/linecorp/armeria/grpc/downstream/DownstreamSimpleBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/grpc/downstream/DownstreamSimpleBenchmark.java
@@ -23,7 +23,6 @@ import org.openjdk.jmh.annotations.State;
 import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.grpc.GithubServiceGrpc.GithubServiceBlockingStub;
 import com.linecorp.armeria.grpc.GithubServiceGrpc.GithubServiceFutureStub;
-import com.linecorp.armeria.grpc.shared.ClientType;
 import com.linecorp.armeria.grpc.shared.GithubApiService;
 import com.linecorp.armeria.grpc.shared.SimpleBenchmarkBase;
 import com.linecorp.armeria.server.Server;
@@ -74,13 +73,12 @@ public class DownstreamSimpleBenchmark extends SimpleBenchmarkBase {
         server.stop().join();
     }
 
-//    public static void main(String[] args) throws Exception {
-//         DownstreamSimpleBenchmark benchmark = new DownstreamSimpleBenchmark();
-//         benchmark.clientType = ClientType.NORMAL;
-//         benchmark.start();
-//         for (long i = 0; i < Long.MAX_VALUE; i++) {
-//             benchmark.empty();
-//         }
-//         benchmark.stop();
-//     }
+    // public static void main(String[] args) throws Exception {
+    //      DownstreamSimpleBenchmark benchmark = new DownstreamSimpleBenchmark();
+    //      benchmark.start();
+    //      for (long i = 0; i < Long.MAX_VALUE; i++) {
+    //          benchmark.empty();
+    //      }
+    //      benchmark.stop();
+    // }
 }

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/grpc/downstream/DownstreamSimpleBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/grpc/downstream/DownstreamSimpleBenchmark.java
@@ -16,12 +16,14 @@
 
 package com.linecorp.armeria.grpc.downstream;
 
+import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 
 import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.grpc.GithubServiceGrpc.GithubServiceBlockingStub;
 import com.linecorp.armeria.grpc.GithubServiceGrpc.GithubServiceFutureStub;
+import com.linecorp.armeria.grpc.shared.ClientType;
 import com.linecorp.armeria.grpc.shared.GithubApiService;
 import com.linecorp.armeria.grpc.shared.SimpleBenchmarkBase;
 import com.linecorp.armeria.server.Server;
@@ -30,6 +32,8 @@ import com.linecorp.armeria.server.ServerPort;
 import com.linecorp.armeria.server.grpc.GrpcServiceBuilder;
 
 @State(Scope.Benchmark)
+@Fork(jvmArgsAppend = { "-Dcom.linecorp.armeria.cachedHeaders=:authority,:scheme,:method,accept-encoding," +
+                        "content-type,:path,user-agent,grpc-accept-encoding,te"})
 public class DownstreamSimpleBenchmark extends SimpleBenchmarkBase {
 
     private Server server;
@@ -70,11 +74,13 @@ public class DownstreamSimpleBenchmark extends SimpleBenchmarkBase {
         server.stop().join();
     }
 
-    // public static void main(String[] args) throws Exception {
-    //     DownstreamSimpleBenchmark benchmark = new DownstreamSimpleBenchmark();
-    //     benchmark.start();
-    //     System.out.println(benchmark.simple());
-    //     System.out.println(benchmark.empty());
-    //     benchmark.stop();
-    // }
+//    public static void main(String[] args) throws Exception {
+//         DownstreamSimpleBenchmark benchmark = new DownstreamSimpleBenchmark();
+//         benchmark.clientType = ClientType.NORMAL;
+//         benchmark.start();
+//         for (long i = 0; i < Long.MAX_VALUE; i++) {
+//             benchmark.empty();
+//         }
+//         benchmark.stop();
+//     }
 }

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/grpc/shared/SimpleBenchmarkBase.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/grpc/shared/SimpleBenchmarkBase.java
@@ -78,7 +78,7 @@ public abstract class SimpleBenchmarkBase {
     private GithubServiceFutureStub githubApiOkhttpFutureClient;
 
     @Param
-    private ClientType clientType;
+    protected ClientType clientType;
 
     @Setup
     public void start() throws Exception {

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/grpc/shared/SimpleBenchmarkBase.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/grpc/shared/SimpleBenchmarkBase.java
@@ -78,7 +78,7 @@ public abstract class SimpleBenchmarkBase {
     private GithubServiceFutureStub githubApiOkhttpFutureClient;
 
     @Param
-    protected ClientType clientType;
+    private ClientType clientType;
 
     @Setup
     public void start() throws Exception {


### PR DESCRIPTION
…e value.

Currently, header values are copied from `AsciiString` to `String` all the time, which results in a copy of the underlying storage. As header values tend to be fairly constant, this is quite wasteful as it results in a lot of garbage on the heap with similar content. With a cache of `String` instances for commonly low-variance cache values, we can avoid this extra allocation.

For #1112