### PR TITLE
Allow aggregating pooled objects.

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
@@ -34,6 +34,7 @@ import com.linecorp.armeria.common.FixedHttpRequest.RegularFixedHttpRequest;
 import com.linecorp.armeria.common.FixedHttpRequest.TwoElementFixedHttpRequest;
 import com.linecorp.armeria.common.stream.StreamMessage;
 
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.util.concurrent.EventExecutor;
 
 /**
@@ -344,7 +345,7 @@ public interface HttpRequest extends Request, StreamMessage<HttpObject> {
      */
     default CompletableFuture<AggregatedHttpMessage> aggregate() {
         final CompletableFuture<AggregatedHttpMessage> future = new CompletableFuture<>();
-        final HttpRequestAggregator aggregator = new HttpRequestAggregator(this, future);
+        final HttpRequestAggregator aggregator = new HttpRequestAggregator(this, future, null);
         completionFuture().whenComplete(aggregator);
         subscribe(aggregator);
         return future;
@@ -355,10 +356,54 @@ public interface HttpRequest extends Request, StreamMessage<HttpObject> {
      * the trailing headers of the request is received fully.
      */
     default CompletableFuture<AggregatedHttpMessage> aggregate(EventExecutor executor) {
+        requireNonNull(executor, "executor");
         final CompletableFuture<AggregatedHttpMessage> future = new CompletableFuture<>();
-        final HttpRequestAggregator aggregator = new HttpRequestAggregator(this, future);
+        final HttpRequestAggregator aggregator = new HttpRequestAggregator(this, future, null);
         completionFuture().whenCompleteAsync(aggregator, executor);
         subscribe(aggregator, executor);
+        return future;
+    }
+
+    /**
+     * Aggregates this request. The returned {@link CompletableFuture} will be notified when the content and
+     * the trailing headers of the request is received fully. {@link AggregatedHttpMessage#content()} will
+     * return a pooled object, and the caller must ensure to release it. If you don't know what this means,
+     * use {@link HttpResponse#aggregate()}.
+     */
+    default CompletableFuture<AggregatedHttpMessage> aggregateWithPooledObjects(ByteBufAllocator alloc) {
+        requireNonNull(alloc, "alloc");
+        final CompletableFuture<AggregatedHttpMessage> future = new CompletableFuture<>();
+        final HttpRequestAggregator aggregator = new HttpRequestAggregator(this, future, alloc);
+        completionFuture().whenComplete(aggregator);
+        subscribe(aggregator, true);
+        return future;
+    }
+
+    /**
+     * Aggregates this request. The returned {@link CompletableFuture} will be notified when the content and
+     * the trailing headers of the request is received fully. {@link AggregatedHttpMessage#content()} will
+     * return a pooled object, and the caller must ensure to release it. If you don't know what this means,
+     * use {@link HttpResponse#aggregate()}.
+     */
+    default CompletableFuture<AggregatedHttpMessage> aggregateWithPooledObjects(RequestContext ctx) {
+        requireNonNull(ctx, "ctx");
+        return aggregateWithPooledObjects(ctx.eventLoop(), ctx.alloc());
+    }
+
+    /**
+     * Aggregates this request. The returned {@link CompletableFuture} will be notified when the content and
+     * the trailing headers of the request is received fully. {@link AggregatedHttpMessage#content()} will
+     * return a pooled object, and the caller must ensure to release it. If you don't know what this means,
+     * use {@link HttpResponse#aggregate()}.
+     */
+    default CompletableFuture<AggregatedHttpMessage> aggregateWithPooledObjects(
+            EventExecutor executor, ByteBufAllocator alloc) {
+        requireNonNull(executor, "executor");
+        requireNonNull(alloc, "alloc");
+        final CompletableFuture<AggregatedHttpMessage> future = new CompletableFuture<>();
+        final HttpRequestAggregator aggregator = new HttpRequestAggregator(this, future, alloc);
+        completionFuture().whenCompleteAsync(aggregator, executor);
+        subscribe(aggregator, executor, true);
         return future;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
@@ -385,17 +385,6 @@ public interface HttpRequest extends Request, StreamMessage<HttpObject> {
      * return a pooled object, and the caller must ensure to release it. If you don't know what this means,
      * use {@link HttpResponse#aggregate()}.
      */
-    default CompletableFuture<AggregatedHttpMessage> aggregateWithPooledObjects(RequestContext ctx) {
-        requireNonNull(ctx, "ctx");
-        return aggregateWithPooledObjects(ctx.eventLoop(), ctx.alloc());
-    }
-
-    /**
-     * Aggregates this request. The returned {@link CompletableFuture} will be notified when the content and
-     * the trailing headers of the request is received fully. {@link AggregatedHttpMessage#content()} will
-     * return a pooled object, and the caller must ensure to release it. If you don't know what this means,
-     * use {@link HttpResponse#aggregate()}.
-     */
     default CompletableFuture<AggregatedHttpMessage> aggregateWithPooledObjects(
             EventExecutor executor, ByteBufAllocator alloc) {
         requireNonNull(executor, "executor");

--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequestAggregator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequestAggregator.java
@@ -18,13 +18,18 @@ package com.linecorp.armeria.common;
 
 import java.util.concurrent.CompletableFuture;
 
+import javax.annotation.Nullable;
+
+import io.netty.buffer.ByteBufAllocator;
+
 final class HttpRequestAggregator extends HttpMessageAggregator {
 
     private final HttpRequest request;
     private HttpHeaders trailingHeaders;
 
-    HttpRequestAggregator(HttpRequest request, CompletableFuture<AggregatedHttpMessage> future) {
-        super(future);
+    HttpRequestAggregator(HttpRequest request, CompletableFuture<AggregatedHttpMessage> future,
+                          @Nullable ByteBufAllocator alloc) {
+        super(future, alloc);
         this.request = request;
         trailingHeaders = HttpHeaders.EMPTY_HEADERS;
     }

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -348,17 +348,6 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
 
     /**
      * Aggregates this response. The returned {@link CompletableFuture} will be notified when the content and
-     * the trailing headers of the response are received fully. {@link AggregatedHttpMessage#content()} will
-     * return a pooled object, and the caller must ensure to release it. If you don't know what this means,
-     * use {@link HttpResponse#aggregate()}.
-     */
-    default CompletableFuture<AggregatedHttpMessage> aggregateWithPooledObjects(RequestContext ctx) {
-        requireNonNull(ctx, "ctx");
-        return aggregateWithPooledObjects(ctx.eventLoop(), ctx.alloc());
-    }
-
-    /**
-     * Aggregates this response. The returned {@link CompletableFuture} will be notified when the content and
      * the trailing headers of the request is received fully. {@link AggregatedHttpMessage#content()} will
      * return a pooled object, and the caller must ensure to release it. If you don't know what this means,
      * use {@link HttpResponse#aggregate()}.

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -35,6 +35,7 @@ import com.linecorp.armeria.common.FixedHttpResponse.TwoElementFixedHttpResponse
 import com.linecorp.armeria.common.stream.StreamMessage;
 import com.linecorp.armeria.common.util.Exceptions;
 
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.EventExecutor;
 
@@ -312,7 +313,7 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
      */
     default CompletableFuture<AggregatedHttpMessage> aggregate() {
         final CompletableFuture<AggregatedHttpMessage> future = new CompletableFuture<>();
-        final HttpResponseAggregator aggregator = new HttpResponseAggregator(future);
+        final HttpResponseAggregator aggregator = new HttpResponseAggregator(future, null);
         completionFuture().whenComplete(aggregator);
         subscribe(aggregator);
         return future;
@@ -324,9 +325,52 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
      */
     default CompletableFuture<AggregatedHttpMessage> aggregate(EventExecutor executor) {
         final CompletableFuture<AggregatedHttpMessage> future = new CompletableFuture<>();
-        final HttpResponseAggregator aggregator = new HttpResponseAggregator(future);
+        final HttpResponseAggregator aggregator = new HttpResponseAggregator(future, null);
         completionFuture().whenCompleteAsync(aggregator, executor);
         subscribe(aggregator, executor);
+        return future;
+    }
+
+    /**
+     * Aggregates this response. The returned {@link CompletableFuture} will be notified when the content and
+     * the trailing headers of the response are received fully. {@link AggregatedHttpMessage#content()} will
+     * return a pooled object, and the caller must ensure to release it. If you don't know what this means,
+     * use {@link HttpResponse#aggregate()}.
+     */
+    default CompletableFuture<AggregatedHttpMessage> aggregateWithPooledObjects(ByteBufAllocator alloc) {
+        requireNonNull(alloc, "alloc");
+        final CompletableFuture<AggregatedHttpMessage> future = new CompletableFuture<>();
+        final HttpResponseAggregator aggregator = new HttpResponseAggregator(future, alloc);
+        completionFuture().whenComplete(aggregator);
+        subscribe(aggregator, true);
+        return future;
+    }
+
+    /**
+     * Aggregates this response. The returned {@link CompletableFuture} will be notified when the content and
+     * the trailing headers of the response are received fully. {@link AggregatedHttpMessage#content()} will
+     * return a pooled object, and the caller must ensure to release it. If you don't know what this means,
+     * use {@link HttpResponse#aggregate()}.
+     */
+    default CompletableFuture<AggregatedHttpMessage> aggregateWithPooledObjects(RequestContext ctx) {
+        requireNonNull(ctx, "ctx");
+        return aggregateWithPooledObjects(ctx.eventLoop(), ctx.alloc());
+    }
+
+    /**
+     * Aggregates this response. The returned {@link CompletableFuture} will be notified when the content and
+     * the trailing headers of the request is received fully. {@link AggregatedHttpMessage#content()} will
+     * return a pooled object, and the caller must ensure to release it. If you don't know what this means,
+     * use {@link HttpResponse#aggregate()}.
+     */
+    default CompletableFuture<AggregatedHttpMessage> aggregateWithPooledObjects(
+            EventExecutor executor, ByteBufAllocator alloc) {
+        requireNonNull(executor, "executor");
+        requireNonNull(alloc, "alloc");
+        final CompletableFuture<AggregatedHttpMessage> future = new CompletableFuture<>();
+        final HttpResponseAggregator aggregator = new HttpResponseAggregator(future, alloc);
+        completionFuture().whenCompleteAsync(aggregator, executor);
+        subscribe(aggregator, executor, true);
         return future;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponseAggregator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponseAggregator.java
@@ -26,6 +26,8 @@ import java.util.concurrent.CompletableFuture;
 
 import javax.annotation.Nullable;
 
+import io.netty.buffer.ByteBufAllocator;
+
 final class HttpResponseAggregator extends HttpMessageAggregator {
 
     enum State {
@@ -41,8 +43,9 @@ final class HttpResponseAggregator extends HttpMessageAggregator {
     private HttpHeaders trailingHeaders;
     private State state = State.WAIT_NON_INFORMATIONAL;
 
-    HttpResponseAggregator(CompletableFuture<AggregatedHttpMessage> future) {
-        super(future);
+    HttpResponseAggregator(CompletableFuture<AggregatedHttpMessage> future,
+                           @Nullable ByteBufAllocator alloc) {
+        super(future, alloc);
         trailingHeaders = HttpHeaders.EMPTY_HEADERS;
     }
 

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcService.java
@@ -52,6 +52,7 @@ import io.grpc.MethodDescriptor.MethodType;
 import io.grpc.ServerMethodDefinition;
 import io.grpc.Status;
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufHolder;
 
 /**
  * A {@link SimpleDecoratingService} which allows {@link GrpcService} to serve requests without the framing
@@ -151,17 +152,15 @@ class UnframedGrpcService extends SimpleDecoratingService<HttpRequest, HttpRespo
         ctx.logBuilder().requestContent(GrpcLogUtil.rpcRequest(method), null);
 
         final CompletableFuture<HttpResponse> responseFuture = new CompletableFuture<>();
-        final HttpResponse res = HttpResponse.from(responseFuture);
-        req.aggregate().whenCompleteAsync(
+        req.aggregateWithPooledObjects(ctx).whenComplete(
                 (clientRequest, t) -> {
                     if (t != null) {
                         responseFuture.completeExceptionally(t);
                     } else {
                         frameAndServe(ctx, grpcHeaders, clientRequest, responseFuture);
                     }
-                },
-                ctx.eventLoop());
-        return res;
+                });
+        return HttpResponse.from(responseFuture);
     }
 
     private void frameAndServe(
@@ -173,11 +172,16 @@ class UnframedGrpcService extends SimpleDecoratingService<HttpRequest, HttpRespo
         try (ArmeriaMessageFramer framer = new ArmeriaMessageFramer(
                 ctx.alloc(), ArmeriaMessageFramer.NO_MAX_OUTBOUND_MESSAGE_SIZE)) {
             final HttpData content = clientRequest.content();
-            final ByteBuf message = ctx.alloc().buffer(content.length());
+            final ByteBuf message;
+            if (content instanceof ByteBufHolder) {
+                message = ((ByteBufHolder) content).content();
+            } else {
+                message = ctx.alloc().buffer(content.length());
+                message.writeBytes(content.array(), content.offset(), content.length());
+            }
             final HttpData frame;
             boolean success = false;
             try {
-                message.writeBytes(content.array(), content.offset(), content.length());
                 frame = framer.writePayload(message);
                 success = true;
             } finally {

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcService.java
@@ -152,7 +152,7 @@ class UnframedGrpcService extends SimpleDecoratingService<HttpRequest, HttpRespo
         ctx.logBuilder().requestContent(GrpcLogUtil.rpcRequest(method), null);
 
         final CompletableFuture<HttpResponse> responseFuture = new CompletableFuture<>();
-        req.aggregateWithPooledObjects(ctx).whenComplete(
+        req.aggregateWithPooledObjects(ctx.eventLoop(), ctx.alloc()).whenComplete(
                 (clientRequest, t) -> {
                     if (t != null) {
                         responseFuture.completeExceptionally(t);

--- a/thrift/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
+++ b/thrift/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
@@ -417,7 +417,7 @@ public final class THttpService extends AbstractHttpService {
         final HttpResponse res = HttpResponse.from(responseFuture);
         ctx.logBuilder().serializationFormat(serializationFormat);
         ctx.logBuilder().deferRequestContent();
-        req.aggregateWithPooledObjects(ctx).handle(voidFunction((aReq, cause) -> {
+        req.aggregateWithPooledObjects(ctx.eventLoop(), ctx.alloc()).handle(voidFunction((aReq, cause) -> {
             if (cause != null) {
                 responseFuture.complete(
                         HttpResponse.of(

--- a/thrift/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
+++ b/thrift/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
@@ -16,7 +16,6 @@
 
 package com.linecorp.armeria.server.thrift;
 
-import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.linecorp.armeria.common.util.Functions.voidFunction;
 import static java.util.Objects.requireNonNull;
 
@@ -39,8 +38,6 @@ import org.apache.thrift.meta_data.FieldMetaData;
 import org.apache.thrift.protocol.TMessage;
 import org.apache.thrift.protocol.TMessageType;
 import org.apache.thrift.protocol.TProtocol;
-import org.apache.thrift.protocol.TProtocolFactory;
-import org.apache.thrift.transport.TMemoryInputTransport;
 import org.apache.thrift.transport.TTransport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -76,6 +73,7 @@ import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.unsafe.ByteBufHttpData;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufHolder;
 
 /**
  * A {@link Service} that handles a Thrift call.
@@ -91,9 +89,6 @@ public final class THttpService extends AbstractHttpService {
     private static final String ACCEPT_THRIFT_PROTOCOL_MUST_MATCH_CONTENT_TYPE =
             "Thrift protocol specified in Accept header must match " +
             "the one specified in the content-type header";
-
-    private static final Map<SerializationFormat, ThreadLocalTProtocol> FORMAT_TO_THREAD_LOCAL_INPUT_PROTOCOL =
-            createFormatToThreadLocalTProtocolMap();
 
     /**
      * Creates a new {@link THttpService} with the specified service implementation, supporting all thrift
@@ -422,7 +417,7 @@ public final class THttpService extends AbstractHttpService {
         final HttpResponse res = HttpResponse.from(responseFuture);
         ctx.logBuilder().serializationFormat(serializationFormat);
         ctx.logBuilder().deferRequestContent();
-        req.aggregate().handle(voidFunction((aReq, cause) -> {
+        req.aggregateWithPooledObjects(ctx).handle(voidFunction((aReq, cause) -> {
             if (cause != null) {
                 responseFuture.complete(
                         HttpResponse.of(
@@ -479,12 +474,17 @@ public final class THttpService extends AbstractHttpService {
     private void decodeAndInvoke(
             ServiceRequestContext ctx, AggregatedHttpMessage req,
             SerializationFormat serializationFormat, CompletableFuture<HttpResponse> httpRes) {
-
-        final TProtocol inProto = FORMAT_TO_THREAD_LOCAL_INPUT_PROTOCOL.get(serializationFormat).get();
-        inProto.reset();
-        final TMemoryInputTransport inTransport = (TMemoryInputTransport) inProto.getTransport();
         final HttpData content = req.content();
-        inTransport.reset(content.array(), content.offset(), content.length());
+        final ByteBuf buf;
+        if (content instanceof ByteBufHolder) {
+            buf = ((ByteBufHolder) content).content();
+        } else {
+            buf = ctx.alloc().buffer(content.length());
+            buf.writeBytes(content.array(), content.offset(), content.length());
+        }
+
+        final TByteBufTransport inTransport = new TByteBufTransport(buf);
+        final TProtocol inProto = ThriftProtocolFactories.get(serializationFormat).getProtocol(inTransport);
 
         final int seqId;
         final ThriftFunction f;
@@ -560,7 +560,7 @@ public final class THttpService extends AbstractHttpService {
                 return;
             }
         } finally {
-            inTransport.clear();
+            buf.release();
             ctx.logBuilder().requestContent(null, null);
         }
 
@@ -756,26 +756,6 @@ public final class THttpService extends AbstractHttpService {
             if (!success) {
                 buf.release();
             }
-        }
-    }
-
-    private static Map<SerializationFormat, ThreadLocalTProtocol> createFormatToThreadLocalTProtocolMap() {
-        return ThriftSerializationFormats.values().stream().collect(
-                toImmutableMap(Function.identity(),
-                               f -> new ThreadLocalTProtocol(ThriftProtocolFactories.get(f))));
-    }
-
-    private static final class ThreadLocalTProtocol extends ThreadLocal<TProtocol> {
-
-        private final TProtocolFactory protoFactory;
-
-        private ThreadLocalTProtocol(TProtocolFactory protoFactory) {
-            this.protoFactory = protoFactory;
-        }
-
-        @Override
-        protected TProtocol initialValue() {
-            return protoFactory.getProtocol(new TMemoryInputTransport());
         }
     }
 }

--- a/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftServiceTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftServiceTest.java
@@ -140,7 +140,7 @@ public class ThriftServiceTest {
 
     @AfterClass
     public static void closeLoop() {
-        eventLoop.shutdownGracefully().syncUninterruptibly();
+        eventLoop.shutdownGracefully();
     }
 
     @Before

--- a/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftServiceTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftServiceTest.java
@@ -32,6 +32,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
 
 import javax.annotation.Nonnull;
@@ -40,7 +41,9 @@ import org.apache.thrift.TApplicationException;
 import org.apache.thrift.protocol.TProtocol;
 import org.apache.thrift.transport.TMemoryBuffer;
 import org.apache.thrift.transport.TMemoryInputTransport;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -70,6 +73,8 @@ import com.linecorp.armeria.service.test.thrift.main.NameSortService;
 import com.linecorp.armeria.service.test.thrift.main.OnewayHelloService;
 
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.DefaultEventLoop;
+import io.netty.channel.EventLoop;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 
 /**
@@ -107,6 +112,8 @@ public class ThriftServiceTest {
     private static final String BAR = "bar";
     private static final String BAZ = "baz";
 
+    private static EventLoop eventLoop;
+
     @Parameters(name = "{0}")
     public static Collection<SerializationFormat> parameters() throws Exception {
         return ThriftSerializationFormats.values();
@@ -124,6 +131,16 @@ public class ThriftServiceTest {
 
     public ThriftServiceTest(SerializationFormat defaultSerializationFormat) {
         this.defaultSerializationFormat = defaultSerializationFormat;
+    }
+
+    @BeforeClass
+    public static void setupLoop() {
+        eventLoop = new DefaultEventLoop(Executors.newSingleThreadExecutor());
+    }
+
+    @AfterClass
+    public static void closeLoop() {
+        eventLoop.shutdownGracefully().syncUninterruptibly();
     }
 
     @Before
@@ -627,6 +644,7 @@ public class ThriftServiceTest {
 
         final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
         when(ctx.alloc()).thenReturn(ByteBufAllocator.DEFAULT);
+        when(ctx.eventLoop()).thenReturn(eventLoop);
         final DefaultRequestLog reqLogBuilder = new DefaultRequestLog(ctx);
 
         when(ctx.blockingTaskExecutor()).thenReturn(ImmediateEventExecutor.INSTANCE);


### PR DESCRIPTION
For advanced use cases, including inside armeria itself, it is nice to have the option to aggregate without copying into heap buffers. 

Also removed the thread-local thrift protocol factories since it seemed like saving a couple of objects isn't worth the thread-local overhead of the read and very complex code - let me know if you'd like me to restore it though.