### PR TITLE
Improve the cleanup of streaming responses

### DIFF
--- a/jetty/src/main/java/com/linecorp/armeria/server/jetty/JettyService.java
+++ b/jetty/src/main/java/com/linecorp/armeria/server/jetty/JettyService.java
@@ -282,16 +282,17 @@ public final class JettyService implements HttpService {
             }
 
             final HttpHeaders headers = toResponseHeaders(transport);
-            res.write(headers);
-            for (;;) {
-                final HttpData data = out.poll();
-                if (data == null || !res.tryWrite(data)) {
-                    break;
+            if (res.tryWrite(headers)) {
+                for (;;) {
+                    final HttpData data = out.poll();
+                    if (data == null || !res.tryWrite(data)) {
+                        break;
+                    }
                 }
             }
-            res.close();
         } catch (Throwable t) {
             logger.warn("{} Failed to produce a response:", ctx, t);
+        } finally {
             res.close();
         }
     }

--- a/tomcat/src/main/java/com/linecorp/armeria/server/tomcat/TomcatService.java
+++ b/tomcat/src/main/java/com/linecorp/armeria/server/tomcat/TomcatService.java
@@ -406,16 +406,17 @@ public final class TomcatService implements HttpService {
                     try {
                         coyoteAdapter.service(coyoteReq, coyoteRes);
                         final HttpHeaders headers = convertResponse(coyoteRes);
-                        res.write(headers);
-                        for (;;) {
-                            final HttpData d = data.poll();
-                            if (d == null || !res.tryWrite(d)) {
-                                break;
+                        if (res.tryWrite(headers)) {
+                            for (;;) {
+                                final HttpData d = data.poll();
+                                if (d == null || !res.tryWrite(d)) {
+                                    break;
+                                }
                             }
                         }
-                        res.close();
                     } catch (Throwable t) {
                         logger.warn("{} Failed to produce a response:", ctx, t);
+                    } finally {
                         res.close();
                     }
                 });

--- a/tomcat/src/test/java/com/linecorp/armeria/server/tomcat/TomcatServiceTest.java
+++ b/tomcat/src/test/java/com/linecorp/armeria/server/tomcat/TomcatServiceTest.java
@@ -27,6 +27,7 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -97,6 +98,7 @@ public class TomcatServiceTest extends WebAppContainerTest {
                         .startsWith("application/java");
                 assertThat(res.getFirstHeader(HttpHeaderNames.CONTENT_LENGTH.toString()).getValue())
                         .isEqualTo("1361");
+                EntityUtils.consume(res.getEntity());
             }
         }
     }
@@ -110,6 +112,7 @@ public class TomcatServiceTest extends WebAppContainerTest {
                         .startsWith("application/java");
                 assertThat(res.getFirstHeader(HttpHeaderNames.CONTENT_LENGTH.toString()).getValue())
                         .isEqualTo("1361");
+                EntityUtils.consume(res.getEntity());
             }
         }
     }


### PR DESCRIPTION
Motivation:

A successfully sent response can be logged with AbortedStreamException
or ClosedChannelException due to race conditions.

Modifications:

- Make HttpResponseSubscriber handle AbortedStreamException and
  ClosedChannelException better so that they are not logged
  unnecessarily
- Make HttpServerHandler clean up unfinished HTTP/1 responses a little
  bit later so that they are not aborted too early.
- Miscellaneous:
  - Fix a bug in DeferredStreamMessage where NeverInvokedSubscriber is
    invoked, which happens when a DeferredStreamMessage is delegated to
    another DeferredStreamMessage.

Result:

- Much less chance of redundant AbortedStreamException or
  ClosedChannelException