### PR TITLE
Throw ClosedPublisherException when StreamWriter.write() fails

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamWriter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamWriter.java
@@ -62,13 +62,13 @@ public interface StreamWriter<T> {
      * Writes the specified object to the {@link StreamMessage}. The written object will be transferred to the
      * {@link Subscriber}.
      *
-     * @throws IllegalStateException if the stream was already closed
+     * @throws ClosedPublisherException if the stream was already closed
      * @throws IllegalArgumentException if the publication of the specified object has been rejected
      * @see <a href="#reference-counted">Life cycle of reference-counted objects</a>
      */
     default void write(T o) {
         if (!tryWrite(o)) {
-            throw new IllegalStateException("stream closed");
+            throw ClosedPublisherException.get();
         }
     }
 
@@ -76,12 +76,12 @@ public interface StreamWriter<T> {
      * Writes the specified object {@link Supplier} to the {@link StreamMessage}. The object provided by the
      * {@link Supplier} will be transferred to the {@link Subscriber}.
      *
-     * @throws IllegalStateException if the stream was already closed.
+     * @throws ClosedPublisherException if the stream was already closed.
      * @see <a href="#reference-counted">Life cycle of reference-counted objects</a>
      */
     default void write(Supplier<? extends T> o) {
         if (!tryWrite(o)) {
-            throw new IllegalStateException("stream closed");
+            throw ClosedPublisherException.get();
         }
     }
 

--- a/core/src/test/java/com/linecorp/armeria/common/stream/AbstractStreamMessageAndWriterTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/AbstractStreamMessageAndWriterTest.java
@@ -113,7 +113,20 @@ public abstract class AbstractStreamMessageAndWriterTest extends AbstractStreamM
         await().untilAsserted(() -> assertThat(stream.isOpen()).isFalse());
         assertThat(stream.tryWrite(buf)).isFalse();
         assertThat(buf.refCnt()).isOne();
-        assertThatThrownBy(() -> stream.write(buf)).isInstanceOf(IllegalStateException.class);
+        assertThatThrownBy(() -> stream.write(buf)).isInstanceOf(ClosedPublisherException.class);
+        assertThat(buf.refCnt()).isZero();
+    }
+
+    @Test
+    public void releaseWhenWritingToClosedStream_ByteBuf_Supplier() {
+        StreamMessageAndWriter<Object> stream = newStreamWriter(ImmutableList.of());
+        final ByteBuf buf = PooledByteBufAllocator.DEFAULT.buffer().retain();
+        stream.close();
+
+        await().untilAsserted(() -> assertThat(stream.isOpen()).isFalse());
+        assertThat(stream.tryWrite(() -> buf)).isFalse();
+        assertThat(buf.refCnt()).isOne();
+        assertThatThrownBy(() -> stream.write(() -> buf)).isInstanceOf(ClosedPublisherException.class);
         assertThat(buf.refCnt()).isZero();
     }
 
@@ -126,7 +139,20 @@ public abstract class AbstractStreamMessageAndWriterTest extends AbstractStreamM
         await().untilAsserted(() -> assertThat(stream.isOpen()).isFalse());
         assertThat(stream.tryWrite(data)).isFalse();
         assertThat(data.refCnt()).isOne();
-        assertThatThrownBy(() -> stream.write(data)).isInstanceOf(IllegalStateException.class);
+        assertThatThrownBy(() -> stream.write(data)).isInstanceOf(ClosedPublisherException.class);
+        assertThat(data.refCnt()).isZero();
+    }
+
+    @Test
+    public void releaseWhenWritingToClosedStream_HttpData_Supplier() {
+        StreamMessageAndWriter<Object> stream = newStreamWriter(ImmutableList.of());
+        final ByteBufHttpData data = new ByteBufHttpData(newPooledBuffer(), true).retain();
+        stream.close();
+
+        await().untilAsserted(() -> assertThat(stream.isOpen()).isFalse());
+        assertThat(stream.tryWrite(() -> data)).isFalse();
+        assertThat(data.refCnt()).isOne();
+        assertThatThrownBy(() -> stream.write(() -> data)).isInstanceOf(ClosedPublisherException.class);
         assertThat(data.refCnt()).isZero();
     }
 }


### PR DESCRIPTION
Motivation:

StreamWriter.write() throws IllegalStateException. However, we have a
dedicated exception for that - ClosedPublisherException.

Modifications:

- Throw ClosedPublisherException instead of IllegalStateException

Result:

- Easier to catch