### PR TITLE
Fix a bug where contentType is not reset

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/DefaultHttpHeaders.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultHttpHeaders.java
@@ -22,6 +22,8 @@ import java.util.List;
 
 import javax.annotation.Nullable;
 
+import com.google.common.base.Ascii;
+
 import com.linecorp.armeria.internal.ArmeriaHttpUtil;
 
 import io.netty.handler.codec.DefaultHeaders;
@@ -186,12 +188,13 @@ public final class DefaultHttpHeaders
     @Nullable
     @Override
     public MediaType contentType() {
-        final MediaType contentType = this.contentType;
         final String contentTypeString = get(HttpHeaderNames.CONTENT_TYPE);
         if (contentTypeString == null) {
             return null;
         }
-        if (contentType != null && contentType.toString().equals(contentTypeString)) {
+
+        final MediaType contentType = this.contentType;
+        if (contentType != null && Ascii.equalsIgnoreCase(contentType.toString(), contentTypeString.trim())) {
             return contentType;
         }
 

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultHttpHeaders.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultHttpHeaders.java
@@ -187,13 +187,12 @@ public final class DefaultHttpHeaders
     @Override
     public MediaType contentType() {
         final MediaType contentType = this.contentType;
-        if (contentType != null) {
-            return contentType;
-        }
-
         final String contentTypeString = get(HttpHeaderNames.CONTENT_TYPE);
         if (contentTypeString == null) {
             return null;
+        }
+        if (contentType != null && contentType.toString().equals(contentTypeString)) {
+            return contentType;
         }
 
         try {

--- a/core/src/test/java/com/linecorp/armeria/common/HttpHeadersTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/HttpHeadersTest.java
@@ -37,7 +37,7 @@ public class HttpHeadersTest {
         assertThat(headers.get(of("HEADER3"))).isEqualTo("VALUE3");
 
         assertThat(headers.names())
-                  .containsExactlyInAnyOrder(of("header1"), of("header2"), of("header3"));
+                .containsExactlyInAnyOrder(of("header1"), of("header2"), of("header3"));
     }
 
     @Test
@@ -47,5 +47,27 @@ public class HttpHeadersTest {
 
         assertThatThrownBy(() -> HttpHeaders.of(AsciiString.of(""), "value1"))
                 .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void contentType() {
+        final HttpHeaders headers = HttpHeaders.of();
+        headers.contentType(MediaType.ANY_TYPE);
+        assertThat(headers.contentType()).isSameAs(MediaType.ANY_TYPE);
+
+        headers.contentType(MediaType.ANY_APPLICATION_TYPE);
+        assertThat(headers.contentType()).isSameAs(MediaType.ANY_APPLICATION_TYPE);
+        assertThat(headers.get(HttpHeaderNames.CONTENT_TYPE))
+                .isEqualTo(MediaType.ANY_APPLICATION_TYPE.toString());
+
+        headers.setObject(HttpHeaderNames.CONTENT_TYPE, MediaType.ANY_TEXT_TYPE);
+        assertThat(headers.contentType()).isSameAs(MediaType.ANY_TEXT_TYPE);
+        assertThat(headers.get(HttpHeaderNames.CONTENT_TYPE))
+                .isEqualTo(MediaType.ANY_TEXT_TYPE.toString());
+
+        headers.set(HttpHeaderNames.CONTENT_TYPE, MediaType.ANY_AUDIO_TYPE.toString());
+        assertThat(headers.contentType()).isSameAs(MediaType.ANY_AUDIO_TYPE);
+        assertThat(headers.get(HttpHeaderNames.CONTENT_TYPE))
+                .isEqualTo(MediaType.ANY_AUDIO_TYPE.toString());
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/common/HttpHeadersTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/HttpHeadersTest.java
@@ -16,6 +16,11 @@
 
 package com.linecorp.armeria.common;
 
+import static com.linecorp.armeria.common.HttpHeaderNames.CONTENT_TYPE;
+import static com.linecorp.armeria.common.MediaType.ANY_APPLICATION_TYPE;
+import static com.linecorp.armeria.common.MediaType.ANY_AUDIO_TYPE;
+import static com.linecorp.armeria.common.MediaType.ANY_TEXT_TYPE;
+import static com.linecorp.armeria.common.MediaType.ANY_TYPE;
 import static io.netty.util.AsciiString.of;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -52,22 +57,21 @@ public class HttpHeadersTest {
     @Test
     public void contentType() {
         final HttpHeaders headers = HttpHeaders.of();
-        headers.contentType(MediaType.ANY_TYPE);
-        assertThat(headers.contentType()).isSameAs(MediaType.ANY_TYPE);
 
-        headers.contentType(MediaType.ANY_APPLICATION_TYPE);
-        assertThat(headers.contentType()).isSameAs(MediaType.ANY_APPLICATION_TYPE);
-        assertThat(headers.get(HttpHeaderNames.CONTENT_TYPE))
-                .isEqualTo(MediaType.ANY_APPLICATION_TYPE.toString());
+        headers.contentType(ANY_TYPE);
+        assertThat(headers.contentType()).isSameAs(ANY_TYPE);
+        assertThat(headers.get(CONTENT_TYPE)).isEqualTo(ANY_TYPE.toString());
 
-        headers.setObject(HttpHeaderNames.CONTENT_TYPE, MediaType.ANY_TEXT_TYPE);
-        assertThat(headers.contentType()).isSameAs(MediaType.ANY_TEXT_TYPE);
-        assertThat(headers.get(HttpHeaderNames.CONTENT_TYPE))
-                .isEqualTo(MediaType.ANY_TEXT_TYPE.toString());
+        headers.contentType(ANY_APPLICATION_TYPE);
+        assertThat(headers.contentType()).isSameAs(ANY_APPLICATION_TYPE);
+        assertThat(headers.get(CONTENT_TYPE)).isEqualTo(ANY_APPLICATION_TYPE.toString());
 
-        headers.set(HttpHeaderNames.CONTENT_TYPE, MediaType.ANY_AUDIO_TYPE.toString());
-        assertThat(headers.contentType()).isSameAs(MediaType.ANY_AUDIO_TYPE);
-        assertThat(headers.get(HttpHeaderNames.CONTENT_TYPE))
-                .isEqualTo(MediaType.ANY_AUDIO_TYPE.toString());
+        headers.setObject(CONTENT_TYPE, ANY_TEXT_TYPE);
+        assertThat(headers.contentType()).isSameAs(ANY_TEXT_TYPE);
+        assertThat(headers.get(CONTENT_TYPE)).isEqualTo(ANY_TEXT_TYPE.toString());
+
+        headers.set(CONTENT_TYPE, ANY_AUDIO_TYPE.toString());
+        assertThat(headers.contentType()).isSameAs(ANY_AUDIO_TYPE);
+        assertThat(headers.get(CONTENT_TYPE)).isEqualTo(ANY_AUDIO_TYPE.toString());
     }
 }


### PR DESCRIPTION
Motivation:
If a user set a `contentType` once, and then set it again using `setObject(...)`,
the `contentType()` returns the previous one.

Modification:
- Check the contentType again when `contentType()` is called`

Result:
- No surprise