### PR TITLE
Add more flexibility in adding token-based authentication to HttpAuth…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/auth/AuthTokenExtractors.java
+++ b/core/src/main/java/com/linecorp/armeria/server/auth/AuthTokenExtractors.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.server.auth;
 
 import java.util.function.Function;
 
+import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 
 /**
@@ -28,17 +29,20 @@ public final class AuthTokenExtractors {
     /**
      * A {@link BasicToken} extractor function instance.
      */
-    public static final Function<HttpHeaders, BasicToken> BASIC = new BasicTokenExtractor();
+    public static final Function<HttpHeaders, BasicToken> BASIC =
+            new BasicTokenExtractor(HttpHeaderNames.AUTHORIZATION);
 
     /**
      * An {@link OAuth1aToken} extractor function instance.
      */
-    public static final Function<HttpHeaders, OAuth1aToken> OAUTH1A = new OAuth1aTokenExtractor();
+    public static final Function<HttpHeaders, OAuth1aToken> OAUTH1A =
+            new OAuth1aTokenExtractor(HttpHeaderNames.AUTHORIZATION);
 
     /**
      * An {@link OAuth2Token} extractor function instance.
      */
-    public static final Function<HttpHeaders, OAuth2Token> OAUTH2 = new OAuth2TokenExtractor();
+    public static final Function<HttpHeaders, OAuth2Token> OAUTH2 =
+            new OAuth2TokenExtractor(HttpHeaderNames.AUTHORIZATION);
 
     private AuthTokenExtractors() {}
 }

--- a/core/src/main/java/com/linecorp/armeria/server/auth/BasicTokenExtractor.java
+++ b/core/src/main/java/com/linecorp/armeria/server/auth/BasicTokenExtractor.java
@@ -30,8 +30,9 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Strings;
 
-import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
+
+import io.netty.util.AsciiString;
 
 /**
  * Extracts {@link BasicToken} from {@link HttpHeaders}, in order to be used by {@link HttpAuthServiceBuilder}.
@@ -44,10 +45,16 @@ final class BasicTokenExtractor implements Function<HttpHeaders, BasicToken> {
             "\\s*(?i)basic\\s+(?<encoded>\\S+)\\s*");
     private static final Decoder BASE64_DECODER = Base64.getDecoder();
 
+    private final AsciiString header;
+
+    BasicTokenExtractor(AsciiString header) {
+        this.header = header;
+    }
+
     @Nullable
     @Override
     public BasicToken apply(HttpHeaders headers) {
-        final String authorization = headers.get(HttpHeaderNames.AUTHORIZATION);
+        final String authorization = headers.get(header);
         if (Strings.isNullOrEmpty(authorization)) {
             return null;
         }

--- a/core/src/main/java/com/linecorp/armeria/server/auth/HttpAuthServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/auth/HttpAuthServiceBuilder.java
@@ -83,7 +83,7 @@ public final class HttpAuthServiceBuilder {
      * Adds an OAuth1a {@link Authorizer} for the given {@code header}.
      */
     public HttpAuthServiceBuilder addOAuth1a(Authorizer<? super OAuth1aToken> authorizer, AsciiString header) {
-        return addTokenAuthorizer(new OAuth1aTokenExtractor(header),
+        return addTokenAuthorizer(new OAuth1aTokenExtractor(requireNonNull(header, "header")),
                                   requireNonNull(authorizer, "authorizer"));
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/auth/HttpAuthServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/auth/HttpAuthServiceBuilder.java
@@ -30,6 +30,8 @@ import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.server.Service;
 
+import io.netty.util.AsciiString;
+
 /**
  * Builds a new {@link HttpAuthService}.
  */
@@ -57,26 +59,64 @@ public final class HttpAuthServiceBuilder {
      * Adds an HTTP basic {@link Authorizer}.
      */
     public HttpAuthServiceBuilder addBasicAuth(Authorizer<? super BasicToken> authorizer) {
-        authorizers.add(
-                tokenAuthorizer(AuthTokenExtractors.BASIC, requireNonNull(authorizer, "authorizer")));
-        return this;
+        return addTokenAuthorizer(AuthTokenExtractors.BASIC,
+                                  requireNonNull(authorizer, "authorizer"));
+    }
+
+    /**
+     * Adds an HTTP basic {@link Authorizer} for the given {@code header}.
+     */
+    public HttpAuthServiceBuilder addBasicAuth(Authorizer<? super BasicToken> authorizer, AsciiString header) {
+        return addTokenAuthorizer(new BasicTokenExtractor(requireNonNull(header, "header")),
+                                  requireNonNull(authorizer, "authorizer"));
     }
 
     /**
      * Adds an OAuth1a {@link Authorizer}.
      */
     public HttpAuthServiceBuilder addOAuth1a(Authorizer<? super OAuth1aToken> authorizer) {
-        authorizers.add(
-                tokenAuthorizer(AuthTokenExtractors.OAUTH1A, requireNonNull(authorizer, "authorizer")));
-        return this;
+        return addTokenAuthorizer(AuthTokenExtractors.OAUTH1A,
+                                  requireNonNull(authorizer, "authorizer"));
+    }
+
+    /**
+     * Adds an OAuth1a {@link Authorizer} for the given {@code header}.
+     */
+    public HttpAuthServiceBuilder addOAuth1a(Authorizer<? super OAuth1aToken> authorizer, AsciiString header) {
+        return addTokenAuthorizer(new OAuth1aTokenExtractor(header),
+                                  requireNonNull(authorizer, "authorizer"));
     }
 
     /**
      * Adds an OAuth2 {@link Authorizer}.
      */
     public HttpAuthServiceBuilder addOAuth2(Authorizer<? super OAuth2Token> authorizer) {
-        authorizers.add(
-                tokenAuthorizer(AuthTokenExtractors.OAUTH2, requireNonNull(authorizer, "authorizer")));
+        return addTokenAuthorizer(AuthTokenExtractors.OAUTH2, requireNonNull(authorizer, "authorizer"));
+    }
+
+    /**
+     * Adds an OAuth2 {@link Authorizer} for the given {@code header}.
+     */
+    public HttpAuthServiceBuilder addOAuth2(Authorizer<? super OAuth2Token> authorizer, AsciiString header) {
+        return addTokenAuthorizer(new OAuth2TokenExtractor(requireNonNull(header, "header")),
+                                  requireNonNull(authorizer, "authorizer"));
+    }
+
+    /**
+     * Adds a token-based {@link Authorizer}.
+     */
+    public <T> HttpAuthServiceBuilder addTokenAuthorizer(
+            Function<HttpHeaders, T> tokenExtractor, Authorizer<? super T> authorizer) {
+        requireNonNull(tokenExtractor, "tokenExtractor");
+        requireNonNull(authorizer, "authorizer");
+        final Authorizer<HttpRequest> requestAuthorizer = (ctx, req) -> {
+            T token = tokenExtractor.apply(req.headers());
+            if (token == null) {
+                return CompletableFuture.completedFuture(false);
+            }
+            return authorizer.authorize(ctx, token);
+        };
+        authorizers.add(requestAuthorizer);
         return this;
     }
 
@@ -93,16 +133,5 @@ public final class HttpAuthServiceBuilder {
      */
     public Function<Service<HttpRequest, HttpResponse>, HttpAuthService> newDecorator() {
         return HttpAuthService.newDecorator(authorizers);
-    }
-
-    private static <T> Authorizer<HttpRequest> tokenAuthorizer(
-            Function<HttpHeaders, T> tokenExtractor, Authorizer<? super T> authorizer) {
-        return (ctx, req) -> {
-            T token = tokenExtractor.apply(req.headers());
-            if (token == null) {
-                return CompletableFuture.completedFuture(false);
-            }
-            return authorizer.authorize(ctx, token);
-        };
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/auth/OAuth1aTokenExtractor.java
+++ b/core/src/main/java/com/linecorp/armeria/server/auth/OAuth1aTokenExtractor.java
@@ -28,8 +28,9 @@ import org.slf4j.LoggerFactory;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 
-import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
+
+import io.netty.util.AsciiString;
 
 /**
  * Extracts {@link OAuth1aToken} from {@link HttpHeaders}, in order to be used by
@@ -41,10 +42,16 @@ final class OAuth1aTokenExtractor implements Function<HttpHeaders, OAuth1aToken>
     private static final Pattern AUTHORIZATION_HEADER_PATTERN = Pattern.compile(
             "\\s*(?i)oauth\\s+(?<parameters>\\S+)\\s*");
 
+    private final AsciiString header;
+
+    OAuth1aTokenExtractor(AsciiString header) {
+        this.header = header;
+    }
+
     @Nullable
     @Override
     public OAuth1aToken apply(HttpHeaders headers) {
-        final String authorization = headers.get(HttpHeaderNames.AUTHORIZATION);
+        final String authorization = headers.get(header);
         if (Strings.isNullOrEmpty(authorization)) {
             return null;
         }

--- a/core/src/main/java/com/linecorp/armeria/server/auth/OAuth2TokenExtractor.java
+++ b/core/src/main/java/com/linecorp/armeria/server/auth/OAuth2TokenExtractor.java
@@ -27,8 +27,9 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Strings;
 
-import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
+
+import io.netty.util.AsciiString;
 
 /**
  * Extracts {@link OAuth2Token} from {@link HttpHeaders}, in order to be used by {@link HttpAuthServiceBuilder}.
@@ -39,10 +40,16 @@ final class OAuth2TokenExtractor implements Function<HttpHeaders, OAuth2Token> {
     private static final Pattern AUTHORIZATION_HEADER_PATTERN = Pattern.compile(
             "\\s*(?i)bearer\\s+(?<accessToken>\\S+)\\s*");
 
+    private final AsciiString header;
+
+    OAuth2TokenExtractor(AsciiString header) {
+        this.header = header;
+    }
+
     @Nullable
     @Override
     public OAuth2Token apply(HttpHeaders headers) {
-        final String authorization = headers.get(HttpHeaderNames.AUTHORIZATION);
+        final String authorization = headers.get(header);
         if (Strings.isNullOrEmpty(authorization)) {
             return null;
         }


### PR DESCRIPTION
…ServiceBuilder.

Currently if a user wants to use a bearer token on a header other than `Authorization` (perhaps they need to be able to assert two identities, a user and a server), it would require a lot of code duplication. This change allows users to specify a header name when adding token authorization. It also exposes a generic `addTokenAuthorizer` method which can be used for different token types too, there doesn't seem to be a great reason to keep the method private.