### PR TITLE
Add more concise variants of HttpResponse.of()

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -111,6 +111,50 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
     }
 
     /**
+     * Creates a new HTTP response of OK status with the content as UTF_8 and closes the stream.
+     *
+     * @param content the content of the response
+     */
+    static HttpResponse of(String content) {
+        return of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, content);
+    }
+
+    /**
+     * Creates a new HTTP response of OK status with the content as UTF_8 and closes the stream.
+     * The content of the response is formatted by {@link String#format(Locale, String, Object...)} with
+     * {@linkplain Locale#ENGLISH English locale}.
+     *
+     * @param format {@linkplain Formatter the format string} of the response content
+     * @param args the arguments referenced by the format specifiers in the format string
+     */
+    static HttpResponse of(String format, Object... args) {
+        return of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, format, args);
+    }
+
+    /**
+     * Creates a new HTTP response of OK status with the content and closes the stream.
+     *
+     * @param mediaType the {@link MediaType} of the response content
+     * @param content the content of the response
+     */
+    static HttpResponse of(MediaType mediaType, String content) {
+        return of(HttpStatus.OK, mediaType, content);
+    }
+
+    /**
+     * Creates a new HTTP response of OK status with the content and closes the stream.
+     * The content of the response is formatted by {@link String#format(Locale, String, Object...)} with
+     * {@linkplain Locale#ENGLISH English locale}.
+     *
+     * @param mediaType the {@link MediaType} of the response content
+     * @param format {@linkplain Formatter the format string} of the response content
+     * @param args the arguments referenced by the format specifiers in the format string
+     */
+    static HttpResponse of(MediaType mediaType, String format, Object... args) {
+        return of(HttpStatus.OK, mediaType, format, args);
+    }
+
+    /**
      * Creates a new HTTP response of the specified {@link HttpStatus} and closes the stream.
      * The content of the response is formatted by {@link String#format(Locale, String, Object...)} with
      * {@linkplain Locale#ENGLISH English locale}.

--- a/core/src/test/java/com/linecorp/armeria/common/HttpResponseTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/HttpResponseTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class HttpResponseTest {
+
+    @Test
+    public void ofWithPlainContent() {
+        // Using non-ascii to test UTF-8 conversion
+        HttpResponse res = HttpResponse.of("Armeriaはいろんな使い方がアルメリア");
+        AggregatedHttpMessage message = res.aggregate().join();
+        assertThat(message.status()).isEqualTo(HttpStatus.OK);
+        assertThat(message.content().toStringUtf8())
+                .isEqualTo("Armeriaはいろんな使い方がアルメリア");
+    }
+
+    @Test
+    public void ofWithPlainFormat() {
+        // Using non-ascii to test UTF-8 conversion
+        HttpResponse res = HttpResponse.of(
+                "%sはいろんな使い方が%s", "Armeria", "アルメリア");
+        AggregatedHttpMessage message = res.aggregate().join();
+        assertThat(message.status()).isEqualTo(HttpStatus.OK);
+        assertThat(message.content().toStringUtf8())
+                .isEqualTo("Armeriaはいろんな使い方がアルメリア");
+    }
+
+    @Test
+    public void ofWithContent() {
+        // Using non-ascii to test UTF-8 conversion
+        HttpResponse res = HttpResponse.of(
+                MediaType.PLAIN_TEXT_UTF_8, "Armeriaはいろんな使い方がアルメリア");
+        AggregatedHttpMessage message = res.aggregate().join();
+        assertThat(message.status()).isEqualTo(HttpStatus.OK);
+        assertThat(message.content().toStringUtf8())
+                .isEqualTo("Armeriaはいろんな使い方がアルメリア");
+    }
+
+    @Test
+    public void ofWithFormat() {
+        // Using non-ascii to test UTF-8 conversion
+        HttpResponse res = HttpResponse.of(
+                MediaType.PLAIN_TEXT_UTF_8,
+                "%sはいろんな使い方が%s", "Armeria", "アルメリア");
+        AggregatedHttpMessage message = res.aggregate().join();
+        assertThat(message.status()).isEqualTo(HttpStatus.OK);
+        assertThat(message.content().toStringUtf8())
+                .isEqualTo("Armeriaはいろんな使い方がアルメリア");
+    }
+}

--- a/site/src/sphinx/server-basics.rst
+++ b/site/src/sphinx/server-basics.rst
@@ -67,15 +67,14 @@ Even if we opened a port, it's of no use if we didn't bind any services to them.
     sb.http(8080);
 
     // Add a simple 'Hello, world!' service.
-    sb.service("/", (ctx, res) -> HttpResponse.of(
-            HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "Hello, world!"));
+    sb.service("/", (ctx, res) -> HttpResponse.of("Hello, world!"));
 
     // Using path variables:
     sb.service("/greet/{name}", new AbstractHttpService() {
         @Override
         protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) throws Exception {
             String name = ctx.pathParam("name");
-            return HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "Hello, %s!", name);
+            return HttpResponse.of("Hello, %s!", name);
         }
     }.decorate(LoggingService.newDecorator())); // Enable logging
 
@@ -83,7 +82,7 @@ Even if we opened a port, it's of no use if we didn't bind any services to them.
     sb.annotatedService(new Object() {
         @Get("/greet2/:name") // `:name` style is also available
         public HttpResponse greet(@Param("name") String name) {
-            return HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "Hello, %s!", name);
+            return HttpResponse.of("Hello, %s!", name);
         }
     });
 
@@ -91,14 +90,14 @@ Even if we opened a port, it's of no use if we didn't bind any services to them.
     sb.serviceUnder("/greet3", (ctx, req) -> {
         String path = ctx.mappedPath();  // Get the path without the prefix ('/greet3')
         String name = path.substring(1); // Strip the leading slash ('/')
-        return HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "Hello, %s!", name);
+        return HttpResponse.of("Hello, %s!", name);
     });
 
     // Using an annotated service object:
     sb.annotatedService(new Object() {
         @Get("regex:^/greet4/(?<name>.*)$")
         public HttpResponse greet(@Param("name") String name) {
-            return HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "Hello, %s!", name);
+            return HttpResponse.of("Hello, %s!", name);
         }
     });
 
@@ -108,7 +107,7 @@ Even if we opened a port, it's of no use if we didn't bind any services to them.
         public HttpResponse greet(@Param("name") String name,
                                   @Param("title") @Default("Mr.") String title) {
             // "Mr." is used by default if there is no title parameter in the request.
-            return HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "Hello, %s %s!", title, name);
+            return HttpResponse.of("Hello, %s %s!", title, name);
         }
     });
 
@@ -116,8 +115,7 @@ Even if we opened a port, it's of no use if we didn't bind any services to them.
     sb.annotatedService(new Object() {
         @Get("/greet6")
         public HttpResponse greet(HttpParameters parameters) {
-            return HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "Hello, %s!",
-                                   parameters.get("name"));
+            return HttpResponse.of("Hello, %s!", parameters.get("name"));
         }
     });
 


### PR DESCRIPTION
Motivations
- There are many boiler plate code in the document.
- Make it more simple and friendly.
- Light code will be more light.
- It will make more user. I hope.

Changes
- Introduce `of(String)` and `of(String, Object...)` for `HttpResponse` with `HttpStatus.OK` and `MediaType.PLAIN_TEXT_UTF_8` as a default.