### PR TITLE
Get `@Param` or `@Header` annotation value from a variable if the val…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/AnnotatedHttpServiceMethod.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AnnotatedHttpServiceMethod.java
@@ -19,6 +19,8 @@ package com.linecorp.armeria.server;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.linecorp.armeria.internal.AnnotatedHttpServiceParamUtil.aggregationAvailable;
+import static com.linecorp.armeria.internal.AnnotatedHttpServiceParamUtil.findHeaderName;
+import static com.linecorp.armeria.internal.AnnotatedHttpServiceParamUtil.findParamName;
 import static com.linecorp.armeria.internal.AnnotatedHttpServiceParamUtil.httpParametersOf;
 import static com.linecorp.armeria.internal.AnnotatedHttpServiceParamUtil.validateAndNormalizeSupportedType;
 import static com.linecorp.armeria.internal.DefaultValues.getSpecifiedValue;
@@ -56,7 +58,6 @@ import com.linecorp.armeria.internal.FallthroughException;
 import com.linecorp.armeria.server.annotation.BeanRequestConverterFunction;
 import com.linecorp.armeria.server.annotation.Default;
 import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
-import com.linecorp.armeria.server.annotation.Header;
 import com.linecorp.armeria.server.annotation.Param;
 import com.linecorp.armeria.server.annotation.RequestConverterFunction;
 import com.linecorp.armeria.server.annotation.RequestObject;
@@ -247,26 +248,26 @@ final class AnnotatedHttpServiceMethod {
         boolean hasRequestMessage = false;
         final ImmutableList.Builder<Parameter> entries = ImmutableList.builder();
         for (java.lang.reflect.Parameter parameterInfo : method.getParameters()) {
-            final Param param = parameterInfo.getAnnotation(Param.class);
+            final String param = findParamName(parameterInfo);
             if (param != null) {
-                if (pathParams.contains(param.value())) {
+                if (pathParams.contains(param)) {
                     if (parameterInfo.getAnnotation(Default.class) != null ||
                         parameterInfo.getType() == Optional.class) {
                         throw new IllegalArgumentException(
-                                "Path variable '" + param.value() + "' should not be an optional.");
+                                "Path variable '" + param + "' should not be an optional.");
                     }
                     entries.add(Parameter.ofPathParam(
-                            validateAndNormalizeSupportedType(parameterInfo.getType()), param.value()));
+                            validateAndNormalizeSupportedType(parameterInfo.getType()), param));
                 } else {
                     entries.add(createOptionalSupportedParam(
-                            parameterInfo, ParameterType.PARAM, param.value()));
+                            parameterInfo, ParameterType.PARAM, param));
                 }
                 continue;
             }
 
-            final Header header = parameterInfo.getAnnotation(Header.class);
+            final String header = findHeaderName(parameterInfo);
             if (header != null) {
-                entries.add(createOptionalSupportedParam(parameterInfo, ParameterType.HEADER, header.value()));
+                entries.add(createOptionalSupportedParam(parameterInfo, ParameterType.HEADER, header));
                 continue;
             }
 

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/Header.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/Header.java
@@ -21,6 +21,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import com.linecorp.armeria.internal.DefaultValues;
+
 /**
  * Annotation for mapping an HTTP request header onto the following elements.
  *
@@ -45,5 +47,5 @@ public @interface Header {
     /**
      * The name of the HTTP request header to bind to.
      */
-    String value();
+    String value() default DefaultValues.UNSPECIFIED;
 }

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/Param.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/Param.java
@@ -21,6 +21,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import com.linecorp.armeria.internal.DefaultValues;
+
 /**
  * Annotation for mapping a parameter of a request onto the following elements.
  *
@@ -47,5 +49,5 @@ public @interface Param {
      * The path variable, the parameter name in a query string or a URL-encoded form data,
      * or the name of a multipart.
      */
-    String value();
+    String value() default DefaultValues.UNSPECIFIED;
 }

--- a/core/src/test/java/com/linecorp/armeria/internal/AnnotatedHttpServiceParamUtilTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/AnnotatedHttpServiceParamUtilTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.internal;
+
+import static com.linecorp.armeria.internal.AnnotatedHttpServiceParamUtil.toHeaderName;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class AnnotatedHttpServiceParamUtilTest {
+    @Test
+    public void ofHeaderName() {
+        assertThat(toHeaderName("camelCase")).isEqualTo("camel-case");
+        assertThat(toHeaderName("CamelCase")).isEqualTo("camel-case");
+        assertThat(toHeaderName("snake_case")).isEqualTo("snake-case");
+        assertThat(toHeaderName("SNAKE_CASE")).isEqualTo("snake-case");
+        assertThat(toHeaderName("lowercase")).isEqualTo("lowercase");
+        assertThat(toHeaderName("UPPERCASE")).isEqualTo("uppercase");
+
+        // Just converted to lower case.
+        assertThat(toHeaderName("What_Case")).isEqualTo("what_case");
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/AnnotatedHttpServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/AnnotatedHttpServiceTest.java
@@ -136,14 +136,14 @@ public class AnnotatedHttpServiceTest {
         // Case 1: returns Integer type and handled by builder-default Integer -> HttpResponse converter.
         @Get
         @Path("/int/:var")
-        public int returnInt(@Param("var") int var) {
+        public int returnInt(@Param int var) {
             return var;
         }
 
         // Case 2: returns Long type and handled by class-default Number -> HttpResponse converter.
         @Post
         @Path("/long/{var}")
-        public CompletionStage<Long> returnLong(@Param("var") long var) {
+        public CompletionStage<Long> returnLong(@Param long var) {
             return CompletableFuture.supplyAsync(() -> var);
         }
 
@@ -151,20 +151,20 @@ public class AnnotatedHttpServiceTest {
         @Get
         @Path("/string/:var")
         @ResponseConverter(NaiveStringConverterFunction.class)
-        public CompletionStage<String> returnString(@Param("var") String var) {
+        public CompletionStage<String> returnString(@Param String var) {
             return CompletableFuture.supplyAsync(() -> var);
         }
 
         // Asynchronously returns Integer type and handled by builder-default Integer -> HttpResponse converter.
         @Get
         @Path("/int-async/:var")
-        public CompletableFuture<Integer> returnIntAsync(@Param("var") int var) {
+        public CompletableFuture<Integer> returnIntAsync(@Param int var) {
             return CompletableFuture.completedFuture(var).thenApply(n -> n + 1);
         }
 
         @Get
         @Path("/path/ctx/async/:var")
-        public static CompletableFuture<String> returnPathCtxAsync(@Param("var") int var,
+        public static CompletableFuture<String> returnPathCtxAsync(@Param int var,
                                                                    ServiceRequestContext ctx,
                                                                    Request req) {
             validateContextAndRequest(ctx, req);
@@ -173,7 +173,7 @@ public class AnnotatedHttpServiceTest {
 
         @Get
         @Path("/path/req/async/:var")
-        public static CompletableFuture<String> returnPathReqAsync(@Param("var") int var,
+        public static CompletableFuture<String> returnPathReqAsync(@Param int var,
                                                                    HttpRequest req,
                                                                    ServiceRequestContext ctx) {
             validateContextAndRequest(ctx, req);
@@ -182,7 +182,7 @@ public class AnnotatedHttpServiceTest {
 
         @Get
         @Path("/path/ctx/sync/:var")
-        public static String returnPathCtxSync(@Param("var") int var,
+        public static String returnPathCtxSync(@Param int var,
                                                RequestContext ctx,
                                                Request req) {
             validateContextAndRequest(ctx, req);
@@ -191,7 +191,7 @@ public class AnnotatedHttpServiceTest {
 
         @Get
         @Path("/path/req/sync/:var")
-        public static String returnPathReqSync(@Param("var") int var,
+        public static String returnPathReqSync(@Param int var,
                                                HttpRequest req,
                                                RequestContext ctx) {
             validateContextAndRequest(ctx, req);
@@ -201,14 +201,14 @@ public class AnnotatedHttpServiceTest {
         // Throws an exception synchronously
         @Get
         @Path("/exception/:var")
-        public int exception(@Param("var") int var) {
+        public int exception(@Param int var) {
             throw new AnticipatedException("bad var!");
         }
 
         // Throws an exception asynchronously
         @Get
         @Path("/exception-async/:var")
-        public CompletableFuture<Integer> exceptionAsync(@Param("var") int var) {
+        public CompletableFuture<Integer> exceptionAsync(@Param int var) {
             CompletableFuture<Integer> future = new CompletableFuture<>();
             future.completeExceptionally(new AnticipatedException("bad var!"));
             return future;
@@ -563,7 +563,7 @@ public class AnnotatedHttpServiceTest {
     public static class MyAnnotatedService11 {
 
         @Get("/aHeader")
-        public String aHeader(@Header("if-match") String ifMatch) {
+        public String aHeader(@Header String ifMatch) {
             if ("737060cd8c284d8af7ad3082f209582d".equalsIgnoreCase(ifMatch)) {
                 return "matched";
             }
@@ -571,16 +571,16 @@ public class AnnotatedHttpServiceTest {
         }
 
         @Post("/customHeader")
-        public String customHeader(@Header("a-name") String name) {
-            return name + " is awesome";
+        public String customHeader(@Header String aName) {
+            return aName + " is awesome";
         }
 
         @Get("/headerDefault")
         public String headerDefault(RequestContext ctx,
-                                    @Header("username") @Default("hello") String username,
-                                    @Header("password") @Default("world") Optional<String> password,
-                                    @Header("extra") Optional<String> extra,
-                                    @Header("number") Optional<Integer> number) {
+                                    @Header @Default("hello") String username,
+                                    @Header @Default("world") Optional<String> password,
+                                    @Header Optional<String> extra,
+                                    @Header Optional<Integer> number) {
             validateContext(ctx);
             return username + "/" + password.get() + "/" + extra.orElse("(null)") +
                    (number.isPresent() ? "/" + number.get() : "");

--- a/site/src/sphinx/server-annotated-service.rst
+++ b/site/src/sphinx/server-annotated-service.rst
@@ -180,6 +180,46 @@ one of the following supported types:
 - ``String``
 - ``Enum``
 
+Note that you can omit the value of `@Param`_ if you compiled your code with ``-parameters`` javac option.
+In this case the variable name is used as the value.
+
+.. code-block:: java
+
+    public class MyAnnotatedServiceClass {
+        @Get("/hello/{name}")
+        public HttpResponse hello1(@Param String name) { ... }
+    }
+
+.. note::
+
+    You can configure your build tool to add ``-parameters`` javac option as follows.
+
+    .. code-block:: groovy
+
+        // Gradle:
+        tasks.withType(JavaCompile) {
+            options.compilerArgs += '-parameters'
+        }
+
+    .. code-block:: xml
+
+        <!-- Maven -->
+        <project>
+          <build>
+            <pluigins>
+              <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                  <compilerArgs>
+                    <arg>-parameters</arg>
+                  </compilerArgs>
+                </configuration>
+              </plugin>
+            </plugins>
+          </build>
+        </project>
+
 Injecting a parameter as an ``Enum`` type
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -275,6 +315,19 @@ annotated with `@Header`_ can also be specified as one of the built-in types as 
 
         @Post("/hello2")
         public HttpResponse hello2(@Header("Content-Length") long contentLength) { ... }
+    }
+
+Note that you can omit the value of `@Header`_  if you compiled your code with ``-parameters`` javac option.
+Read :ref:`parameter-injection` for more information.
+In this case the variable name is used as the value, but it will be converted to hyphen-separated lowercase
+string to be suitable for general HTTP header names. e.g. a variable name ``contentLength`` or
+``content_length`` will be converted to ``content-length`` as the value of `@Header`_.
+
+.. code-block:: java
+
+    public class MyAnnotatedServiceClass {
+        @Post("/hello2")
+        public HttpResponse hello2(@Header long contentLength) { ... }
     }
 
 Other classes automatically injected
@@ -466,11 +519,18 @@ or HTTP headers:
 .. code-block:: java
 
     public class MyRequestObject {
-        @Param("name") // This field will be injected by value of parameter "name".
+        @Param("name") // This field will be injected by the value of parameter "name".
         private String name;
 
-        @Header("age") // This field will be injected by value of HTTP header "age".
+        @Header("age") // This field will be injected by the value of HTTP header "age".
         private int age;
+
+        // You can omit the value of @Param or @Header if you compiled your code with ``-parameters`` javac option.
+        @Param         // This field will be injected by the value of parameter "gender".
+        private String gender;
+
+        @Header        // This field will be injected by the value of HTTP header "accept-language".
+        private String acceptLanguage;
 
         @Param("address") // You can annotate a single parameter method with @Param or @Header.
         public void setAddress(String address) { ... }


### PR DESCRIPTION
…ue is not specified

Modifications:
- Add `findParamName` and `findHeaderName` to `AnnotatedHttpServiceParamUtil` in order to
  obtain the variable name if a `@Param` or `@Header` annotation does not have a value.
- Refactor `BeanRequestConverterFunction` for cleanup.
- Documentation.

Result:
- Closes #570