### PR TITLE
Update dependencies

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -128,7 +128,7 @@ io.micrometer:
     - org.springframework:spring-webmvc
 
 io.netty:
-  netty-codec-http2: { version: &NETTY_VERSION '4.1.23.Final' }
+  netty-codec-http2: { version: &NETTY_VERSION '4.1.24.Final' }
   netty-codec-haproxy: { version: *NETTY_VERSION }
   netty-handler: { version: *NETTY_VERSION }
   netty-resolver-dns: { version: *NETTY_VERSION }
@@ -148,12 +148,12 @@ io.prometheus:
 
 io.zipkin.brave:
   brave:
-    version: &BRAVE_VERSION '4.18.2'
+    version: &BRAVE_VERSION '4.19.1'
     javadocs:
-    - https://static.javadoc.io/io.zipkin.brave/brave/4.18.2/
+    - https://static.javadoc.io/io.zipkin.brave/brave/4.19.1/
 
 io.zipkin.java:
-  zipkin: { version: &ZIPKIN_VERSION '2.7.0' }
+  zipkin: { version: &ZIPKIN_VERSION '2.7.1' }
 
 it.unimi.dsi:
   fastutil:
@@ -175,7 +175,7 @@ junit:
     - https://junit.org/junit4/javadoc/4.12/
 
 kr.motd.gradle:
-  sphinx-gradle-plugin: { version: '2.0.2' }
+  sphinx-gradle-plugin: { version: '2.1.1' }
 
 # We do not depend on log4j. We just need this to stop dependency-management-plugin from
 # complaining about its bad POM.
@@ -185,6 +185,11 @@ log4j:
 
 me.champeau.gradle:
   jmh-gradle-plugin: { version: '0.4.5' }
+
+# TODO(trustin): Remove this once protobuf-jackson works with Byte Buddy 1.8.4+.
+net.bytebuddy:
+  byte-buddy: { version: &BYTE_BUDDY_VERSION '1.8.3' }
+  byte-buddy-agent: { version: *BYTE_BUDDY_VERSION }
 
 net.javacrumbs.json-unit:
   json-unit: { version: &JSON_UNIT_VERSION '1.28.2' }
@@ -233,7 +238,7 @@ org.apache.thrift:
 
 org.apache.tomcat.embed:
   tomcat-embed-core:
-    version: &TOMCAT_VERSION '9.0.6'
+    version: &TOMCAT_VERSION '9.0.7'
     javadocs:
     - https://tomcat.apache.org/tomcat-9.0-doc/api/
   tomcat-embed-jasper: { version: *TOMCAT_VERSION }
@@ -303,7 +308,7 @@ org.jctools:
       to: com.linecorp.armeria.internal.shaded.jctools
 
 org.mockito:
-  mockito-core: { version: '2.17.0' }
+  mockito-core: { version: '2.18.3' }
 
 org.mortbay.jetty.alpn:
   jetty-alpn-agent: { version: '2.0.7' }

--- a/spring/boot1-autoconfigure/build.gradle
+++ b/spring/boot1-autoconfigure/build.gradle
@@ -9,9 +9,9 @@ dependencies {
     compile 'io.dropwizard.metrics:metrics-json'
     compile 'javax.inject:javax.inject'
     compile 'javax.validation:validation-api'
-    compile 'org.springframework.boot:spring-boot-starter:1.5.11.RELEASE'
+    compile 'org.springframework.boot:spring-boot-starter:1.5.12.RELEASE'
 
-    testCompile 'org.springframework.boot:spring-boot-starter-test:1.5.11.RELEASE'
+    testCompile 'org.springframework.boot:spring-boot-starter-test:1.5.12.RELEASE'
     testCompile 'org.hibernate.validator:hibernate-validator'
 }
 

--- a/tomcat8.0/build.gradle
+++ b/tomcat8.0/build.gradle
@@ -1,6 +1,6 @@
 dependencyManagement {
     dependencies {
-        dependencySet(group: 'org.apache.tomcat.embed', version: '8.0.50') {
+        dependencySet(group: 'org.apache.tomcat.embed', version: '8.0.51') {
             entry 'tomcat-embed-core'
             entry 'tomcat-embed-jasper'
             entry 'tomcat-embed-el'

--- a/tomcat8.5/build.gradle
+++ b/tomcat8.5/build.gradle
@@ -1,7 +1,7 @@
 dependencyManagement {
     // Override Tomcat versions.
     dependencies {
-        dependencySet(group: 'org.apache.tomcat.embed', version: '8.5.29') {
+        dependencySet(group: 'org.apache.tomcat.embed', version: '8.5.30') {
             entry 'tomcat-embed-core'
             entry 'tomcat-embed-jasper'
             entry 'tomcat-embed-el'


### PR DESCRIPTION
- Netty 4.1.23 -> 4.1.24
- Brave 4.18.2 -> 4.19.1
- Zipkin 2.7.0 -> 2.7.1
- sphinx-gradle-plugin 2.0.2 -> 2.1.1
- Tomcat 9.0.6 -> 9.0.7, 8.5.29 -> 8.5.30, 8.0.50 -> 8.0.51
- Mockito 2.17.0 -> 2.18.3
- Spring Boot 1.5.11 -> 1.5.12
- Pin Byte Buddy version to 1.8.3 because protobuf-jackson does not work
  with 1.8.4+