### PR TITLE
Add access log writer as a listener of RequestLog

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -560,7 +560,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
                 // Respect the first specified cause.
                 logBuilder.endResponse(firstNonNull(cause, f.cause()));
             }
-            accessLogWriter.accept(reqCtx.log());
+            reqCtx.log().addListener(accessLogWriter::accept, RequestLogAvailability.COMPLETE);
         });
         return future;
     }


### PR DESCRIPTION
Motivation:
Currently, the access log writer gets components of `RequestLog` regardless of `RequestLogAvailability`.
So it sometimes might raise `RequestLogAvailabilityException` when the component is not ready.

Modifications:
- Add access log writer as a listener of `RequestLog`