### PR TITLE
Move 'automatic retry' and 'circuit breaker' to 'client' section

### DIFF
--- a/site/src/sphinx/advanced.rst
+++ b/site/src/sphinx/advanced.rst
@@ -9,7 +9,5 @@ Advanced topics
     advanced-logging
     advanced-structured-logging
     advanced-structured-logging-kafka
-    advanced-circuitbreaker
-    advanced-retry
     advanced-zipkin
     advanced-zookeeper

--- a/site/src/sphinx/client-circuit-breaker.rst
+++ b/site/src/sphinx/client-circuit-breaker.rst
@@ -1,6 +1,6 @@
 .. _com.linecorp.armeria.client.circuitbreaker: apidocs/index.html?com/linecorp/armeria/client/circuitbreaker/package-summary.html
 
-.. _advanced-circuitbreaker:
+.. _client-circuit-breaker:
 
 Circuit breakers
 ================

--- a/site/src/sphinx/client-retry.rst
+++ b/site/src/sphinx/client-retry.rst
@@ -9,7 +9,7 @@
 .. _LoggingClient: apidocs/index.html?com/linecorp/armeria/client/logging/LoggingClient.html
 .. _ResponseTimeoutException: apidocs/index.html?com/linecorp/armeria/client/ResponseTimeoutException.html
 
-.. _advanced-retry:
+.. _client-retry:
 
 Automatic retry
 ===============

--- a/site/src/sphinx/client.rst
+++ b/site/src/sphinx/client.rst
@@ -12,3 +12,5 @@ Writing a client
     client-grpc
     client-decorator
     client-custom-http-headers
+    client-retry
+    client-circuit-breaker

--- a/site/src/sphinx/setup-common.rst
+++ b/site/src/sphinx/setup-common.rst
@@ -1,21 +1,15 @@
-.. _`Caffeine`: https://github.com/ben-manes/caffeine
-.. _`completable-futures`: https://github.com/spotify/completable-futures
-.. _`fastutil`: http://fastutil.di.unimi.it/
-.. _`Guava`: https://github.com/google/guava
-.. _`JCTools`: https://jctools.github.io/JCTools/
-.. _`Reflections`: https://github.com/ronmamo/reflections
-
 You may not need all Armeria modules depending on your use case. Please remove unused ones.
 
 Armeria also provides its artifacts as a shaded JAR so that it can coexist with other components
 better. The following is the list of the shaded dependencies:
 
-- `Caffeine`_
-- `completable-futures`_
-- `fastutil`_
-- `Guava`_
-- `JCTools`_
-- `Reflections`_
+- `Bouncy Castle <http://www.bouncycastle.org/>`_
+- `Caffeine <https://github.com/ben-manes/caffeine>`_
+- `completable-futures <https://github.com/spotify/completable-futures>`_
+- `fastutil <http://fastutil.di.unimi.it/>`_
+- `Guava <https://github.com/google/guava>`_
+- `JCTools <https://jctools.github.io/JCTools/>`_
+- `Reflections <https://github.com/ronmamo/reflections>`_
 
 Please append the ``-shaded`` suffix to the artifact ID to use the shaded dependencies.
 e.g. ``armeria`` to ``armeria-shaded`` and ``armeria-thrift`` to ``armeria-thrift-shaded``


### PR DESCRIPTION
.. because it gives more visibility to the features. A user will see all
client-side features just by clicking 'Writing a client.'

Also:

- Updated setup-common.rst to add Bouncy Castle to the list