### PR TITLE
Add a Sphinx extension that simplifies Javadoc linking

### DIFF
--- a/site/build.gradle
+++ b/site/build.gradle
@@ -32,7 +32,6 @@ task javadoc(type: Javadoc,
 
     destinationDir = project.file("${project.buildDir}/site/apidocs")
 
-
     aggregatedProjects.each { source it.sourceSets.main.java.srcDirs }
     classpath = aggregatedProjects.inject(project.files()) { ConfigurableFileCollection result, project ->
         result.from(project.sourceSets.main.compileClasspath)
@@ -136,6 +135,7 @@ task test(group: 'Verification',
     }
 }
 
+tasks.sphinx.dependsOn tasks.javadoc
 tasks.site {
     group = 'Documentation'
     description = 'Generates the project web site.'
@@ -143,13 +143,9 @@ tasks.site {
     dependsOn javadoc
 }
 
-tasks.assemble {
-    dependsOn tasks.site
+tasks.assemble.dependsOn tasks.site
+tasks.check.dependsOn tasks.test
+tasks.build {
+  dependsOn tasks.assemble
+  dependsOn tasks.check
 }
-
-tasks.check {
-    dependsOn tasks.test
-}
-
-tasks.build.dependsOn tasks.assemble
-tasks.build.dependsOn tasks.check

--- a/site/src/sphinx/_extensions/api.py
+++ b/site/src/sphinx/_extensions/api.py
@@ -1,0 +1,96 @@
+from docutils.parsers.rst.roles import register_canonical_role, set_classes
+from docutils.parsers.rst import directives
+from docutils import nodes
+from sphinx.writers.html import HTMLTranslator
+from sphinx.errors import ExtensionError
+
+import os
+import re
+
+
+def api_role(role, rawtext, text, lineno, inliner, options={}, content=[]):
+    set_classes(options)
+
+    classes = ['code', 'api-reference']
+
+    if 'classes' in options:
+        classes.extend(options['classes'])
+
+    node = nodes.literal(rawtext, text, classes=classes, api_reference=True)
+    return [node], []
+
+
+def api_visit_literal(self, node, next_visitor):
+    if 'api_reference' not in node.attributes:
+        return next_visitor(self, node)
+
+    env = self.builder.env
+    javadoc_dir = os.path.abspath(env.config['javadoc_dir'])
+
+    # Build the mappings from a simple class name to its Javadoc file.
+    if not hasattr(env, '__javadoc_cache__'):
+        env.__javadoc_mappings__ = javadoc_mappings = {}
+        for dirname, subdirs, files in os.walk(javadoc_dir):
+            for basename in files:
+                if re.match(r'^[^A-Z]', basename) or not basename.endswith('.html'):
+                    # Ignore the non-class files. We rely on the simple assumption that
+                    # a class name always starts with an upper-case English alphabet.
+                    continue
+                simple_class_name = basename[:-5].replace('.', '$')
+                javadoc_mappings[simple_class_name] = os.path.relpath(dirname, javadoc_dir) \
+                                                        .replace(os.sep, '/') + '/' + basename
+    else:
+        javadoc_mappings = env.__javadoc_mappings__
+
+    text = node.astext()
+    if text.startswith('@'):
+        text = text[1:]
+        is_annotation = True
+    else:
+        is_annotation = False
+
+    if text.find('.') != -1:
+        # FQCN or package name.
+        if re.fullmatch(r'^[^A-Z$]+$', text):
+            # Package
+            uri = text.replace('.', '/') + '/package-summary.html'
+        else:
+            # Class
+            uri = text.replace('.', '/').replace('$', '.') + '.html'
+            text = re.sub(r'^.*\.', '', text).replace('$', '.')
+    else:
+        # Simple class name; find from the pre-calculated mappings.
+        if text not in javadoc_mappings:
+            raise ExtensionError('Cannot find a class from Javadoc: ' + text)
+        uri = javadoc_mappings[text]
+        text = text.replace('$', '.')
+
+    # Prepend the frame index.html path.
+    uri = os.path.relpath(javadoc_dir, env.app.outdir).replace(os.sep, '/') + '/index.html?' + uri
+    # Prepend the '@' back again if necessary
+    if is_annotation:
+        text = '@' + text
+
+    # Emit the tags.
+    self.body.append(self.starttag(node, 'a', suffix='',
+                                   CLASS='reference external javadoc',
+                                   HREF=uri) +
+                     self.starttag(node, 'code', suffix='',
+                                   CLASS='docutils literal javadoc') +
+                     text + '</code></a>')
+
+    raise nodes.SkipNode
+
+
+def setup(app):
+    app.add_config_value('javadoc_dir', os.path.join(app.outdir, 'apidocs'), 'html')
+
+    # Register the 'javadoc' role.
+    api_role.options = {'class': directives.class_option}
+    register_canonical_role('api', api_role)
+
+    # Intercept the rendering of HTML literals.
+    old_visitor = HTMLTranslator.visit_literal
+    HTMLTranslator.visit_literal = lambda self, node: api_visit_literal(self, node, old_visitor)
+
+    pass

--- a/site/src/sphinx/_static/overrides.css
+++ b/site/src/sphinx/_static/overrides.css
@@ -179,6 +179,11 @@ samp::before, samp::after {
   content: "";
 }
 
+/* Do not add color to the literals in a hyperlink. */
+a .highlight * {
+  color: inherit !important;
+}
+
 h1, h2, h3, h4, h5, h6 {
   font-family: 'Source Sans Pro', 'Helvetica', 'Arial', sans-serif;
 }

--- a/site/src/sphinx/advanced-logging.rst
+++ b/site/src/sphinx/advanced-logging.rst
@@ -1,15 +1,12 @@
 .. _`Logback`: https://logback.qos.ch/
-.. _`RequestContextExportingAppender`: apidocs/index.html?com/linecorp/armeria/common/logback/RequestContextExportingAppender.html
-.. _`BuiltInProperty`: apidocs/index.html?com/linecorp/armeria/common/logback/BuiltInProperty.html
-.. _`RequestContext`: apidocs/index.html?com/linecorp/armeria/common/RequestContext.html
 .. _`MDC`: https://logback.qos.ch/manual/mdc.html
 
 .. _advanced-logging:
 
 Logging contextual information
 ==============================
-With Armeria's `Logback`_ integration, you can log the properties of the `RequestContext`_ of the
-request being handled. `RequestContextExportingAppender`_ is a Logback appender that exports the properties
+With Armeria's `Logback`_ integration, you can log the properties of the :api:`RequestContext` of the
+request being handled. :api:`RequestContextExportingAppender` is a Logback appender that exports the properties
 of the current ``RequestContext`` to `MDC`_ (mapped diagnostic context).
 
 For example, the following configuration:
@@ -61,12 +58,12 @@ will define an appender called ``RCEA`` which exports the following:
 ... to the `MDC`_ property map and forwards the log message to the appender ``CONSOLE``, as defined in the
 ``<appender-ref />`` element.
 
-There are three types of properties you can export using `RequestContextExportingAppender`_.
+There are three types of properties you can export using :api:`RequestContextExportingAppender`.
 
 Built-in properties
 -------------------
 A built-in property is a common property available for most requests. See the complete list of the built-in
-properties and their MDC keys at `BuiltInProperty`_.
+properties and their MDC keys at :api:`BuiltInProperty`.
 
 HTTP request and response headers
 ---------------------------------
@@ -79,9 +76,9 @@ request and response. The MDC key of the exported header is ``"req.http_headers.
 
 Custom attributes
 -----------------
-A user can attach an arbitrary custom attribute to a ``RequestContext`` by using
+A user can attach an arbitrary custom attribute to a :api:`RequestContext` by using
 ``RequestContext.attr(...).set(...)`` to store the information associated with the request being handled.
-`RequestContextExportingAppender`_ can export such attributes to the `MDC`_ property map as well.
+:api:`RequestContextExportingAppender` can export such attributes to the `MDC`_ property map as well.
 
 Unlike other property types, you need to specify the full name of an attribute as well as its alias.
 For example, if you want to export an attribute ``com.example.Foo#ATTR_BAR`` with the alias ``bar``, you need to add
@@ -90,8 +87,8 @@ access the attribute value is ``attrs.bar``, which follows the form of ``attrs.<
 
 Using an alternative string converter for a custom attribute
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-By default, `RequestContextExportingAppender`_ uses ``Object.toString()`` to convert an attribute value into
-an `MDC`_ value. If you want an alternative string representation of an attribute value, you can define
+By default, :api:`RequestContextExportingAppender` uses ``Object.toString()`` to convert an attribute value
+into an `MDC`_ value. If you want an alternative string representation of an attribute value, you can define
 a ``Function`` class with a public no-args constructor that transforms an attribute value into a ``String``:
 
 .. code-block:: java

--- a/site/src/sphinx/advanced-structured-logging-kafka.rst
+++ b/site/src/sphinx/advanced-structured-logging-kafka.rst
@@ -1,8 +1,6 @@
-.. _KafkaStructuredLoggingService: apidocs/index.html?com/linecorp/armeria/server/logging/structured/kafka/KafkaStructuredLoggingService.html
-
 .. _advanced-structured-logging-kafka:
 
 Structured logging with Kafka
 =============================
 
-TBW - See KafkaStructuredLoggingService_.
+TBW - See :api:`KafkaStructuredLoggingService`.

--- a/site/src/sphinx/advanced-structured-logging.rst
+++ b/site/src/sphinx/advanced-structured-logging.rst
@@ -1,8 +1,3 @@
-.. _`RequestLog`: apidocs/index.html?com/linecorp/armeria/common/logging/RequestLog.html
-.. _`RequestLogAvailability`: apidocs/index.html?com/linecorp/armeria/common/logging/RequestLogAvailability.html
-.. _`RequestContext`: apidocs/index.html?com/linecorp/armeria/common/RequestContext.html
-.. _`RetryingClient`: apidocs/index.html?com/linecorp/armeria/client/retry/RetryingClient.html
-
 .. _advanced-structured-logging:
 
 Structured logging
@@ -13,7 +8,7 @@ retrieving the information collected during request life cycle in a machine-frie
 
 What properties can be retrieved?
 ---------------------------------
-`RequestLog`_ provides all the properties you can retrieve:
+:api:`RequestLog` provides all the properties you can retrieve:
 
 +----------------------------------------------------------------------------------------------------+
 | Request properties                                                                                 |
@@ -94,9 +89,9 @@ To get notified when a certain set of properties are available, you can add a li
         }
     }
 
-Note that `RequestLogAvailability`_ is specified when adding a listener. `RequestLogAvailability`_ is an enum
-that is used to express which `RequestLog`_ properties you are interested in. ``COMPLETE`` will make your
-listener invoked when all properties are available.
+Note that :api:`RequestLogAvailability` is specified when adding a listener.
+:api:`RequestLogAvailability` is an enum that is used to express which :api:`RequestLog` properties
+you are interested in. ``COMPLETE`` will make your listener invoked when all properties are available.
 
 Set ``serializationFormat`` and ``requestContent`` early if possible
 --------------------------------------------------------------------
@@ -159,8 +154,8 @@ Nested log
 ----------
 
 When you retry a failed attempt, you might want to record the result of each attempt and to group them under
-a single RequestLog_. A RequestLog_ can contain more than one child RequestLog_ to support this sort of
-use cases.
+a single :api:`RequestLog`. A :api:`RequestLog` can contain more than one child :api:`RequestLog`
+to support this sort of use cases.
 
 .. code-block:: java
 
@@ -168,16 +163,16 @@ use cases.
 
     RequestLogBuilder.addChild(RequestLog);
 
-If the added RequestLog_ is the first child, the request-side log of the `RequestLog`_ will be propagated to the
-parent log. You can add as many child logs as you want, but the rest of logs would not effect.
-If you want to fill the response-side log of the parent log, please invoke:
+If the added :api:`RequestLog` is the first child, the request-side log of the :api:`RequestLog` will
+be propagated to the parent log. You can add as many child logs as you want, but the rest of logs would not
+be affected. If you want to fill the response-side log of the parent log, please invoke:
 
 .. code-block:: java
 
     RequestLogBuilder.endResponseWithLastChild();
 
 This will propagate the response-side log of the last added child to the parent log. The following diagram
-illustrates how a RequestLog_ with child logs looks like:
+illustrates how a :api:`RequestLog` with child logs looks like:
 
 .. uml::
 
@@ -230,5 +225,5 @@ You can retrieve the child logs using ``RequestLog.children()``.
         }
     }, RequestLogAvailability.COMPLETE);
 
-`RetryingClient`_ is a good example that leverages this feature.
+:api:`RetryingClient` is a good example that leverages this feature.
 See :ref:`retry-with-logging` for more information.

--- a/site/src/sphinx/advanced-zipkin.rst
+++ b/site/src/sphinx/advanced-zipkin.rst
@@ -1,9 +1,6 @@
-.. _HttpTracingClient: apidocs/index.html?com/linecorp/armeria/client/tracing/HttpTracingClient.html
-.. _HttpTracingService: apidocs/index.html?com/linecorp/armeria/server/tracing/HttpTracingService.html
-
 .. _advanced-zipkin:
 
 Zipkin integration
 ==================
 
-TBW - See HttpTracingService_ and HttpTracingClient_
+TBW - See :api:`HttpTracingService` and :api:`HttpTracingClient`

--- a/site/src/sphinx/advanced-zookeeper.rst
+++ b/site/src/sphinx/advanced-zookeeper.rst
@@ -1,20 +1,12 @@
 .. _`an EPHEMERAL node`: https://zookeeper.apache.org/doc/r3.4.10/zookeeperOver.html#Nodes+and+ephemeral+nodes
 .. _`Apache ZooKeeper`: https://zookeeper.apache.org/
-.. _com.linecorp.armeria.client.zookeeper: apidocs/index.html?com/linecorp/armeria/client/zookeeper/package-summary.html
-.. _com.linecorp.armeria.server.zookeeper: apidocs/index.html?com/linecorp/armeria/server/zookeeper/package-summary.html
 .. _CuratorFramework: https://curator.apache.org/apidocs/org/apache/curator/framework/CuratorFramework.html
-.. _Endpoints: apidocs/index.html?com/linecorp/armeria/client/Endpoint.html
-.. _EndpointGroup: apidocs/index.html?com/linecorp/armeria/client/EndpointGroup.html
-.. _EndpointGroupRegistry: apidocs/index.html?com/linecorp/armeria/client/endpoint/EndpointGroupRegistry.html
-.. _ZooKeeperEndpointGroup: apidocs/index.html?com/linecorp/armeria/client/zookeeper/ZooKeeperEndpointGroup.html
-.. _ZooKeeperUpdatingListener: apidocs/index.html?com/linecorp/armeria/server/zookeeper/ZooKeeperUpdatingListener.html
-.. _ZooKeeperUpdatingListenerBuilder: apidocs/index.html?com/linecorp/armeria/server/zookeeper/ZooKeeperUpdatingListenerBuilder.html
 
 .. _advanced-zookeeper:
 
 Service discovery with ZooKeeper
 ================================
-You can put the list of available `Endpoints`_ into a zNode in `Apache ZooKeeper`_ cluster, as a node tree or
+You can put the list of available endpoints into a zNode in `Apache ZooKeeper`_ cluster, as a node tree or
 as a node value, like the following:
 
 .. code-block:: yaml
@@ -32,7 +24,7 @@ as a node value, like the following:
 In the examples above, ``192.168.1.10`` and other IP strings are your servers' IP addresses, ``8080`` is a
 service port number and ``100`` is a weight value. You can omit a weight value as it is optional.
 
-Create a `ZooKeeperEndpointGroup`_ to retrieve this information:
+Create a :api:`ZooKeeperEndpointGroup` to retrieve this information:
 
 .. code-block:: java
 
@@ -45,7 +37,7 @@ Create a `ZooKeeperEndpointGroup`_ to retrieve this information:
             /* sessionTimeout  */ 10000);
 
 
-And then register it to the `EndpointGroupRegistry`_, and specify it in a client URI:
+And then register it to the :api:`EndpointGroupRegistry`, and specify it in a client URI:
 
 .. code-block:: java
 
@@ -57,12 +49,13 @@ And then register it to the `EndpointGroupRegistry`_, and specify it in a client
     HelloService.Iface helloClient = Clients.newClient(
             "tbinary+http://group:myProductionGroup/hello", HelloService.Iface.class);
 
-For more information, please refer to the API documentation of the `com.linecorp.armeria.client.zookeeper`_ package.
+For more information, please refer to the API documentation of the
+:api:`com.linecorp.armeria.client.zookeeper` package.
 
 Automatic service registration
 ------------------------------
 
-Use `ZooKeeperUpdatingListenerBuilder`_ to register your server to a ZooKeeper cluster:
+Use :api:`ZooKeeperUpdatingListenerBuilder` to register your server to a ZooKeeper cluster:
 
 .. code-block:: java
 
@@ -70,7 +63,7 @@ Use `ZooKeeperUpdatingListenerBuilder`_ to register your server to a ZooKeeper c
     import com.linecorp.armeria.server.zookeeper.ZooKeeperUpdatingListenerBuilder;
 
     // This constructor will use server's default host name, port and weight.
-    // Use `nodeValueCodec` method to override the defaults.
+    // Use 'nodeValueCodec' method to override the defaults.
     ZookeeperUpdatingListener listener =
             new ZooKeeperUpdatingListenerBuilder("myZooKeeperHost:2181", "/myProductionEndpoints")
             .sessionTimeout(10000)
@@ -96,11 +89,12 @@ You can use an existing `CuratorFramework`_ instance instead of Zookeeper connec
     server.start();
     ...
 
-When your server starts up, `ZooKeeperUpdatingListener`_ will register the server automatically to the
+When your server starts up, :api:`ZooKeeperUpdatingListener` will register the server automatically to the
 specified zNode as a member of the cluster. Each server will represent itself as `an EPHEMERAL node`_, which
 means when a server stops or a network partition between your server and ZooKeeper cluster occurs, the node of
 the server that became unreachable will be deleted automatically by ZooKeeper. As a result, the clients that
-use a `ZooKeeperEndpointGroup`_ will be notified and they will update their endpoint list automatically so that
-they do not attempt to connect to the unreachable servers.
+use a :api:`ZooKeeperEndpointGroup` will be notified and they will update their endpoint list automatically
+so that they do not attempt to connect to the unreachable servers.
 
-For more information, please refer to the API documentation of the `com.linecorp.armeria.server.zookeeper`_ package.
+For more information, please refer to the API documentation of the
+:api:`com.linecorp.armeria.server.zookeeper` package.

--- a/site/src/sphinx/client-circuit-breaker.rst
+++ b/site/src/sphinx/client-circuit-breaker.rst
@@ -1,8 +1,6 @@
-.. _com.linecorp.armeria.client.circuitbreaker: apidocs/index.html?com/linecorp/armeria/client/circuitbreaker/package-summary.html
-
 .. _client-circuit-breaker:
 
 Circuit breakers
 ================
 
-TBW - See `com.linecorp.armeria.client.circuitbreaker`_.
+TBW - See :api:`com.linecorp.armeria.client.circuitbreaker`.

--- a/site/src/sphinx/client-decorator.rst
+++ b/site/src/sphinx/client-decorator.rst
@@ -1,7 +1,4 @@
-.. _DecoratingClientFunction: apidocs/index.html?com/linecorp/armeria/client/DecoratingClientFunction.html
 .. _separating concerns: https://en.wikipedia.org/wiki/Separation_of_concerns
-.. _Client: apidocs/index.html?com/linecorp/armeria/client/Client.html
-.. _SimpleDecoratingClient: apidocs/index.html?com/linecorp/armeria/client/SimpleDecoratingClient.html
 .. _the decorator pattern: https://en.wikipedia.org/wiki/Decorator_pattern
 
 .. _client-decorator:
@@ -16,15 +13,15 @@ distributed tracing are implemented as decorators and you will also find it usef
 
 There are basically two ways to write a decorating client:
 
-- Implementing DecoratingClientFunction_
-- Extending SimpleDecoratingClient_
+- Implementing :api:`DecoratingClientFunction`
+- Extending :api:`SimpleDecoratingClient`
 
 
-Implementing DecoratingClientFunction_
---------------------------------------
+Implementing ``DecoratingClientFunction``
+-----------------------------------------
 
-DecoratingClientFunction_ is a functional interface that greatly simplifies the implementation of a decorating
-client. It enables you to write a decorating client with a single lambda expression:
+:api:`DecoratingClientFunction` is a functional interface that greatly simplifies the implementation of a
+decorating client. It enables you to write a decorating client with a single lambda expression:
 
 .. code-block:: java
 
@@ -41,11 +38,11 @@ client. It enables you to write a decorating client with a single lambda express
 
     MyService.Iface client = cb.build(MyService.Iface.class);
 
-Extending SimpleDecoratingClient_
----------------------------------
+Extending ``SimpleDecoratingClient``
+------------------------------------
 
 If your decorator is expected to be reusable, it is recommended to define a new top-level class that extends
-SimpleDecoratingClient_ :
+:api:`SimpleDecoratingClient`:
 
 .. code-block:: java
 

--- a/site/src/sphinx/client-grpc.rst
+++ b/site/src/sphinx/client-grpc.rst
@@ -1,9 +1,6 @@
-.. _Clients: apidocs/index.html?com/linecorp/armeria/client/Clients.html
-.. _ClientBuilder: apidocs/index.html?com/linecorp/armeria/client/ClientBuilder.html
 .. _CompletableFuture: https://docs.oracle.com/javase/8/docs/api/index.html?java/util/concurrent/CompletableFuture.html
 .. _Futures: https://google.github.io/guava/releases/21.0/api/docs/com/google/common/util/concurrent/Futures.html
 .. _ListenableFuture: https://google.github.io/guava/releases/21.0/api/docs/com/google/common/util/concurrent/ListenableFuture.html
-.. _LoggingClient: apidocs/index.html?com/linecorp/armeria/client/logging/LoggingClient.html
 .. _gRPC: https://grpc.io/
 .. _futures-extra: https://github.com/spotify/futures-extra
 
@@ -156,9 +153,9 @@ You can also use the builder pattern for client construction:
     HelloReply reply = helloService.hello(request);
     assert reply.getMessage().equals("Hello, Armerian World!");
 
-As you might have noticed already, we decorated the client using LoggingClient_, which logs all requests
-and responses. You might be interested in decorating a client using other decorators, for example to gather
-metrics. Please also refer to `ClientBuilder`_ for more configuration options.
+As you might have noticed already, we decorated the client using :api:`LoggingClient`, which logs all
+requests and responses. You might be interested in decorating a client using other decorators, for example
+to gather metrics. Please also refer to :api:`ClientBuilder` for more configuration options.
 
 See also
 --------

--- a/site/src/sphinx/client-retrofit.rst
+++ b/site/src/sphinx/client-retrofit.rst
@@ -1,6 +1,4 @@
 .. _`an API gateway`: http://microservices.io/patterns/apigateway.html
-.. _`ArmeriaRetrofit`: apidocs/index.html?com/linecorp/armeria/client/retrofit2/ArmeriaRetrofit.html
-.. _`com.linecorp.armeria.client.retrofit2`: apidocs/index.html?com/linecorp/armeria/client/retrofit2/package-summary.html
 .. _`Netty`: https://netty.io/
 .. _`OkHttp`: https://square.github.io/okhttp/
 .. _`Retrofit`: https://square.github.io/retrofit/
@@ -13,15 +11,13 @@ Retrofit integration
 `Retrofit`_ is a library that simplifies the access to RESTful services by turning an HTTP API into a Java
 interface.
 
-Armeria provides a class called `ArmeriaRetrofit`_ that replaces the networking engine of `Retrofit`_ from
-`OkHttp`_ to Armeria. By doing so, you get the following benefits:
+Armeria provides a builder class called :api:`ArmeriaRetrofitBuilder` that builds an alternative
+``Retrofit`` implementation that replaces the networking engine of from `OkHttp`_ to Armeria. By doing so,
+you get the following benefits:
 
 - Better performance, thanks to `Netty`_ and its JNI-based I/O and TLS implementation
 - Leverage other advanced features of Armeria, such as client-side load-balancing and service discovery
 - Cleartext HTTP/2 support, as known as ``h2c``
-
-The integration is done by creating an ``HttpClient`` that connects to the desired endpoint and passing it to
-``ArmeriaRetrofit.builder()`` to construct the Armeria-based ``Retrofit`` implementation:
 
 .. code-block:: java
 
@@ -50,4 +46,5 @@ The integration is done by creating an ``HttpClient`` that connects to the desir
     MyService service = retrofit.create(MyService.class);
     UserInfo userInfo = service.getUserInfo("foo").get();
 
-For more information, please refer to the API documentation of the `com.linecorp.armeria.client.retrofit2`_ package.
+For more information, please refer to the API documentation of the
+:api:`com.linecorp.armeria.client.retrofit2` package.

--- a/site/src/sphinx/client-retry.rst
+++ b/site/src/sphinx/client-retry.rst
@@ -1,13 +1,4 @@
 .. _decorator: client-decorator.html
-.. _RetryingClient: apidocs/index.html?com/linecorp/armeria/client/retry/RetryingClient.html
-.. _RetryingHttpClient: apidocs/index.html?com/linecorp/armeria/client/retry/RetryingHttpClient.html
-.. _RetryingRpcClient: apidocs/index.html?com/linecorp/armeria/client/retry/RetryingRpcClient.html
-.. _ClientBuilder: apidocs/index.html?com/linecorp/armeria/client/ClientBuilder.html
-.. _RetryStrategy: apidocs/index.html?com/linecorp/armeria/client/retry/RetryStrategy.html
-.. _Backoff: apidocs/index.html?com/linecorp/armeria/client/retry/Backoff.html
-.. _com.linecorp.armeria.client.retry: apidocs/index.html?com/linecorp/armeria/client/retry/package-summary.html
-.. _LoggingClient: apidocs/index.html?com/linecorp/armeria/client/logging/LoggingClient.html
-.. _ResponseTimeoutException: apidocs/index.html?com/linecorp/armeria/client/ResponseTimeoutException.html
 
 .. _client-retry:
 
@@ -17,16 +8,16 @@ Automatic retry
 When a client gets an error response, it might want to retry the request depending on the response.
 This can be accomplished using a decorator_, and Armeria provides the following implementations out-of-the box.
 
-- RetryingHttpClient_
-- RetryingRpcClient_
+- :api:`RetryingHttpClient`
+- :api:`RetryingRpcClient`
 
 Both behave the same except for the different request and response types.
-So, let's find out what we can do with RetryingClient_.
+So, let's find out what we can do with :api:`RetryingClient`.
 
 ``RetryingClient``
 ------------------
 
-You can just use the ``decorator()`` method in ClientBuilder_ to build a RetryingHttpClient_:
+You can just use the ``decorator()`` method in :api:`ClientBuilder` to build a :api:`RetryingHttpClient`:
 
 .. code-block:: java
 
@@ -69,7 +60,7 @@ an exception is raised.
 ``RetryStrategy``
 -----------------
 
-You can customize the ``strategy`` by implementing RetryStrategy_.
+You can customize the ``strategy`` by implementing :api:`RetryStrategy`.
 
 .. code-block:: java
 
@@ -95,20 +86,20 @@ You can customize the ``strategy`` by implementing RetryStrategy_.
         }
     };
 
-This will retry when the response's status is ``409 Conflict`` or ResponseTimeoutException_ is raised.
+This will retry when the response's status is ``409 Conflict`` or :api:`ResponseTimeoutException` is raised.
 
 .. note::
 
-    We declare a Backoff_ as a member and reuse it when a ``strategy`` returns it, so that we do not return
-    a different Backoff_ instance for each ``shouldRetry()``. RetryingClient_ internally tracks the
-    reference of the returned Backoff_ and increases the counter that keeps the number of attempts made so far,
-    and resets it to 0 when the Backoff_ returned by the strategy is not the same as before. Therefore, it is
-    important to return the same Backoff_ instance unless you decided to change your Backoff_ strategy. If you
-    do not return the same one, when the Backoff_ yields a different delay based on the number of retries,
-    such as an exponential backoff, it will not work as expected. We will take a close look into a Backoff_
-    at the next section.
+    We declare a :api:`Backoff` as a member and reuse it when a ``strategy`` returns it, so that we do not
+    return a different :api:`Backoff` instance for each ``shouldRetry()``. :api:`RetryingClient`
+    internally tracks the reference of the returned :api:`Backoff` and increases the counter that keeps
+    the number of attempts made so far, and resets it to 0 when the :api:`Backoff` returned by the strategy
+    is not the same as before. Therefore, it is important to return the same :api:`Backoff` instance unless
+    you decided to change your :api:`Backoff` strategy. If you do not return the same one, when the
+    :api:`Backoff` yields a different delay based on the number of retries, such as an exponential backoff,
+    it will not work as expected. We will take a close look into a :api:`Backoff` at the next section.
 
-You can return a different Backoff_ according to the response.
+You can return a different :api:`Backoff` according to the response.
 
 .. code-block:: java
 
@@ -140,8 +131,8 @@ You can return a different Backoff_ according to the response.
 ``Backoff``
 -----------
 
-You can use a Backoff_ to determine the delay between attempts. Armeria provides Backoff_ implementations which
-produce the following delays out of the box:
+You can use a :api:`Backoff` to determine the delay between attempts. Armeria provides :api:`Backoff`
+implementations which produce the following delays out of the box:
 
 - Fixed delay, created with ``Backoff.fixed()``
 - Random delay, created with ``Backoff.random()``
@@ -157,18 +148,20 @@ Armeria provides ``RetryStrategy.defaultBackoff`` that you might use by default.
 The delay starts from ``minDelayMillis`` until it reaches ``maxDelayMillis`` multiplying by multiplier every
 retry. Please note that the ``.withJitter()`` will add jitter value to the calculated delay.
 
-For more information, please refer to the API documentation of the `com.linecorp.armeria.client.retry`_ package.
+For more information, please refer to the API documentation of the :api:`com.linecorp.armeria.client.retry`
+package.
 
 ``maxTotalAttempts`` vs per-Backoff ``maxAttempts``
 ---------------------------------------------------
 
-If you create a Backoff_ using ``.withMaxAttempts(maxAttempts)`` in a RetryStrategy_, the RetryingClient_
-which uses the RetryStrategy_ will stop retrying when the number of attempts passed ``maxAttempts``.
-However, if you have more than one Backoff_ and return one after the other continuously, it will keep retrying
-over and over again because the counter that RetryingClient_ internally tracks is initialized every time the
-different Backoff_ is returned. To limit the number of attempts in a whole retry session, RetryingClient_ limits
+If you create a :api:`Backoff` using ``.withMaxAttempts(maxAttempts)`` in a :api:`RetryStrategy`,
+the :api:`RetryingClient` which uses the :api:`RetryStrategy` will stop retrying when the number of
+attempts passed ``maxAttempts``. However, if you have more than one :api:`Backoff` and return one after
+the other continuously, it will keep retrying over and over again because the counter that
+:api:`RetryingClient` internally tracks is initialized every time the different :api:`Backoff` is
+returned. To limit the number of attempts in a whole retry session, :api:`RetryingClient` limits
 the maximum number of total attempts to 10 by default. You can change this value by specifying
-``maxTotalAttempts`` when you build a RetryingClient_:
+``maxTotalAttempts`` when you build a :api:`RetryingClient`:
 
 .. code-block:: java
 
@@ -180,8 +173,8 @@ Or, you can override the default value of 10 using the JVM system property
 Per-attempt timeout
 -------------------
 
-ResponseTimeoutException_ can occur in two different situations while retrying. First, it occurs when the
-time of whole retry session has passed the time previously configured using:
+:api:`ResponseTimeoutException` can occur in two different situations while retrying. First, it occurs
+when the time of whole retry session has passed the time previously configured using:
 
 .. code-block:: java
 
@@ -190,7 +183,7 @@ time of whole retry session has passed the time previously configured using:
     // or..
     ClientRequestContext.setResponseTimeoutMillis(millis);
 
-You cannot retry on this ResponseTimeoutException_.
+You cannot retry on this :api:`ResponseTimeoutException`.
 Second, it occurs when the time of individual attempt in retry has passed the time which is per-attempt timeout.
 You can configure it when you create the decorator:
 
@@ -198,13 +191,13 @@ You can configure it when you create the decorator:
 
     RetryingHttpClient.newDecorator(strategy, maxTotalAttempts, responseTimeoutMillisForEachAttempt);
 
-You can retry on this ResponseTimeoutException_.
+You can retry on this :api:`ResponseTimeoutException`.
 
 For example, when making a retrying request to an unresponsive service
-with responseTimeoutMillis = 10,000, responseTimeoutMillisForEachAttempt = 3,000 and disabled Backoff_, the
-first three attempts will be timed out by the per-attempt timeout (3,000ms). The 4th one will be aborted
-after 1,000ms since the request session has reached at 10,000ms before it is timed out by the per-attempt
-timeout.
+with responseTimeoutMillis = 10,000, responseTimeoutMillisForEachAttempt = 3,000 and disabled
+:api:`Backoff`, the first three attempts will be timed out by the per-attempt timeout (3,000ms).
+The 4th one will be aborted after 1,000ms since the request session has reached at 10,000ms before
+it is timed out by the per-attempt timeout.
 
 .. uml::
 
@@ -225,8 +218,8 @@ timeout.
 RetryingClient with logging
 ---------------------------
 
-You can use RetryingClient_ with LoggingClient_ to log. If you want to log all of the requests and responses,
-decorate LoggingClient_ with RetryingClient_. That is:
+You can use :api:`RetryingClient` with :api:`LoggingClient` to log. If you want to log all of the
+requests and responses, decorate :api:`LoggingClient` with :api:`RetryingClient`. That is:
 
 .. code-block:: java
 

--- a/site/src/sphinx/client-thrift.rst
+++ b/site/src/sphinx/client-thrift.rst
@@ -1,9 +1,5 @@
 .. _AsyncMethodCallback: https://github.com/apache/thrift/blob/bd964c7f3460c308161cb6eb90583874a7d8d848/lib/java/src/org/apache/thrift/async/AsyncMethodCallback.java#L22
-.. _Clients: apidocs/index.html?com/linecorp/armeria/client/Clients.html
-.. _ClientBuilder: apidocs/index.html?com/linecorp/armeria/client/ClientBuilder.html
 .. _CompletableFuture: https://docs.oracle.com/javase/8/docs/api/index.html?java/util/concurrent/CompletableFuture.html
-.. _LoggingClient: apidocs/index.html?com/linecorp/armeria/client/logging/LoggingClient.html
-.. _ThriftCompletableFuture: apidocs/index.html?com/linecorp/armeria/common/thrift/ThriftCompletableFuture.html
 
 .. _client-thrift:
 
@@ -63,10 +59,10 @@ the following:
     // You can also wait until the call is finished.
     String reply = future.get();
 
-The example above introduces a new class called ThriftCompletableFuture_. It is a subtype of Java 8
+The example above introduces a new class called :api:`ThriftCompletableFuture`. It is a subtype of Java 8
 CompletableFuture_ that implements Thrift AsyncMethodCallback_. Once passed as a callback of an asynchronous
-Thrift call, ThriftCompletableFuture_ will complete itself when the reply is received or the call fails.
-You'll find it way more convenient to consume the reply than AsyncMethodCallback_ thanks to the rich set
+Thrift call, :api:`ThriftCompletableFuture` will complete itself when the reply is received or the call
+fails. You'll find it way more convenient to consume the reply than AsyncMethodCallback_ thanks to the rich set
 of methods provided by CompletableFuture_.
 
 You can also use the builder pattern for client construction:
@@ -84,9 +80,9 @@ You can also use the builder pattern for client construction:
     String greeting = helloService.hello("Armerian World");
     assert greeting.equals("Hello, Armerian World!");
 
-As you might have noticed already, we decorated the client using LoggingClient_, which logs all requests
-and responses. You might be interested in decorating a client using other decorators, for example to gather
-metrics. Please also refer to `ClientBuilder`_ for more configuration options.
+As you might have noticed already, we decorated the client using :api:`LoggingClient`, which logs all
+requests and responses. You might be interested in decorating a client using other decorators, for example
+to gather metrics. Please also refer to :api:`ClientBuilder` for more configuration options.
 
 See also
 --------

--- a/site/src/sphinx/conf.py
+++ b/site/src/sphinx/conf.py
@@ -52,10 +52,12 @@ for groupId in dependencies.keys():
 rst_epilog += '\n'
 
 needs_sphinx = '1.0'
+sys.path.append(os.path.abspath('_extensions'))
 extensions = ['sphinx.ext.autodoc', 
               'sphinxcontrib.httpdomain', 
               'sphinxcontrib.inlinesyntaxhighlight',
-              'sphinxcontrib.plantuml']
+              'sphinxcontrib.plantuml',
+              'api']
 templates_path = ['_templates']
 source_suffix = '.rst'
 source_encoding = 'utf-8-sig'

--- a/site/src/sphinx/index.rst
+++ b/site/src/sphinx/index.rst
@@ -17,6 +17,7 @@
 
 Welcome to Armeria
 ==================
+
 *Armeria* is an open-source asynchronous `HTTP/2`_ RPC/REST client/server library built on top of `Java 8`_,
 `Netty`_, `Thrift`_ and `gRPC`_. Its primary goal is to help engineers build high-performance asynchronous
 microservices that use HTTP/2 as a session layer protocol.

--- a/site/src/sphinx/server-access-log.rst
+++ b/site/src/sphinx/server-access-log.rst
@@ -1,6 +1,3 @@
-.. _ServerBuilder: apidocs/index.html?com/linecorp/armeria/server/ServerBuilder.html
-.. _`RequestLog`: apidocs/index.html?com/linecorp/armeria/common/logging/RequestLog.html
-
 .. _server-access-log:
 
 Writing an access log
@@ -92,7 +89,7 @@ Customizing a log format
 ------------------------
 
 Access logging is disabled by default. If you want to enable it, you need to specify an access log writer
-using `ServerBuilder`_. You may use one of the pre-defined log formats.
+using :api:`ServerBuilder`. You may use one of the pre-defined log formats.
 
 .. code-block:: java
 
@@ -170,7 +167,7 @@ the condition.
 Customizing an access log writer
 --------------------------------
 
-You can specify your own log writer which implements Consumer<`RequestLog`_ >.
+You can specify your own log writer which implements a ``Consumer`` of :api:`RequestLog`.
 
 .. code-block:: java
 

--- a/site/src/sphinx/server-annotated-service.rst
+++ b/site/src/sphinx/server-annotated-service.rst
@@ -1,49 +1,3 @@
-.. _@ConsumeType: apidocs/index.html?com/linecorp/armeria/server/annotation/ConsumeType.html
-.. _@Decorator: apidocs/index.html?com/linecorp/armeria/server/annotation/Decorator.html
-.. _@Decorators: apidocs/index.html?com/linecorp/armeria/server/annotation/Decorators.html
-.. _@DecoratorFactory: apidocs/index.html?com/linecorp/armeria/server/annotation/DecoratorFactory.html
-.. _@Default: apidocs/index.html?com/linecorp/armeria/server/annotation/Default.html
-.. _@Delete: apidocs/index.html?com/linecorp/armeria/server/annotation/Delete.html
-.. _@ExceptionHandler: apidocs/index.html?com/linecorp/armeria/server/annotation/ExceptionHandler.html
-.. _@Get: apidocs/index.html?com/linecorp/armeria/server/annotation/Get.html
-.. _@Head: apidocs/index.html?com/linecorp/armeria/server/annotation/Head.html
-.. _@Header: apidocs/index.html?com/linecorp/armeria/server/annotation/Header.html
-.. _@LoggingDecorator: apidocs/index.html?com/linecorp/armeria/server/annotation/decorator/LoggingDecorator.html
-.. _@Options: apidocs/index.html?com/linecorp/armeria/server/annotation/Options.html
-.. _@Order: apidocs/index.html?com/linecorp/armeria/server/annotation/Order.html
-.. _@Param: apidocs/index.html?com/linecorp/armeria/server/annotation/Param.html
-.. _@Patch: apidocs/index.html?com/linecorp/armeria/server/annotation/Patch.html
-.. _@Path: apidocs/index.html?com/linecorp/armeria/server/annotation/Path.html
-.. _@Post: apidocs/index.html?com/linecorp/armeria/server/annotation/Post.html
-.. _@ProduceType: apidocs/index.html?com/linecorp/armeria/server/annotation/ProduceType.html
-.. _@Put: apidocs/index.html?com/linecorp/armeria/server/annotation/Put.html
-.. _@RequestConverter: apidocs/index.html?com/linecorp/armeria/server/annotation/RequestConverter.html
-.. _@RequestObject: apidocs/index.html?com/linecorp/armeria/server/annotation/RequestObject.html
-.. _@ResponseConverter: apidocs/index.html?com/linecorp/armeria/server/annotation/ResponseConverter.html
-.. _@Trace: apidocs/index.html?com/linecorp/armeria/server/annotation/Trace.html
-.. _AggregatedHttpMessage: apidocs/index.html?com/linecorp/armeria/common/AggregatedHttpMessage.html
-.. _BeanRequestConverterFunction: apidocs/index.html?com/linecorp/armeria/server/annotation/BeanRequestConverterFunction.html
-.. _ByteArrayRequestConverterFunction: apidocs/index.html?com/linecorp/armeria/server/annotation/ByteArrayRequestConverterFunction.html
-.. _DecoratingServiceFunction: apidocs/index.html?com/linecorp/armeria/server/DecoratingServiceFunction.html
-.. _DecoratorFactoryFunction: apidocs/index.html?com/linecorp/armeria/server/annotation/DecoratorFactoryFunction.html
-.. _ExceptionHandlerFunction: apidocs/index.html?com/linecorp/armeria/server/annotation/ExceptionHandlerFunction.html
-.. _HttpParameters: apidocs/index.html?com/linecorp/armeria/common/HttpParameters.html
-.. _HttpRequest: apidocs/index.html?com/linecorp/armeria/common/HttpRequest.html
-.. _HttpResponse: apidocs/index.html?com/linecorp/armeria/common/HttpResponse.html
-.. _HttpResponseException: apidocs/index.html?com/linecorp/armeria/server/HttpResponseException.html
-.. _HttpStatusException: apidocs/index.html?com/linecorp/armeria/server/HttpStatusException.html
-.. _JacksonRequestConverterFunction: apidocs/index.html?com/linecorp/armeria/server/annotation/JacksonRequestConverterFunction.html
-.. _LoggingService: apidocs/index.html?com/linecorp/armeria/server/logging/LoggingService.html
-.. _PathMapping: apidocs/index.html?com/linecorp/armeria/server/PathMapping.html
-.. _Request: apidocs/index.html?com/linecorp/armeria/common/Request.html
-.. _RequestContext: apidocs/index.html?com/linecorp/armeria/common/RequestContext.html
-.. _RequestConverterFunction: apidocs/index.html?com/linecorp/armeria/server/annotation/RequestConverterFunction.html
-.. _ResponseConverterFunction: apidocs/index.html?com/linecorp/armeria/server/annotation/ResponseConverterFunction.html
-.. _ServerBuilder: apidocs/index.html?com/linecorp/armeria/server/ServerBuilder.html
-.. _Service: apidocs/index.html?com/linecorp/armeria/server/Service.html
-.. _ServiceRequestContext: apidocs/index.html?com/linecorp/armeria/server/ServiceRequestContext.html
-.. _StringRequestConverterFunction: apidocs/index.html?com/linecorp/armeria/server/annotation/StringRequestConverterFunction.html
-
 .. _server-annotated-service:
 
 Annotated HTTP Service
@@ -73,14 +27,14 @@ To map a service method in an annotated HTTP service class to an HTTP path, it h
 HTTP method annotations. The following is the list of HTTP method annotations where each of them is mapped
 to an HTTP method.
 
-- `@Get`_
-- `@Head`_
-- `@Post`_
-- `@Put`_
-- `@Delete`_
-- `@Options`_
-- `@Patch`_
-- `@Trace`_
+- :api:`@Get`
+- :api:`@Head`
+- :api:`@Post`
+- :api:`@Put`
+- :api:`@Delete`
+- :api:`@Options`
+- :api:`@Patch`
+- :api:`@Trace`
 
 To handle an HTTP request with a service method, you can annotate your service method simply as follows.
 
@@ -91,7 +45,7 @@ To handle an HTTP request with a service method, you can annotate your service m
         public HttpResponse hello() { ... }
     }
 
-There are 5 PathMapping_ types provided for describing a path.
+There are 5 :api:`PathMapping` types provided for describing a path.
 
 - Exact mapping, e.g. ``/hello`` or ``exact:/hello``
 
@@ -117,8 +71,8 @@ There are 5 PathMapping_ types provided for describing a path.
     an index which starts with ``0``, so it may be mapped to a parameter of the service method.
 
 You can get the value of a path variable, a named capturing group of the regular expression or wildcards of
-the glob pattern in your service method by annotating a parameter with `@Param`_ as follows.
-Please refer to :ref:`parameter-injection` for more information about `@Param`_.
+the glob pattern in your service method by annotating a parameter with :api:`@Param` as follows.
+Please refer to :ref:`parameter-injection` for more information about :api:`@Param`.
 
 .. code-block:: java
 
@@ -135,8 +89,8 @@ Please refer to :ref:`parameter-injection` for more information about `@Param`_.
     }
 
 Every service method in the examples so far had a single HTTP method annotation with it. What if you want
-to map more than one HTTP method to your service method? You can use `@Path`_ annotation to specify a path
-and use the HTTP method annotations without a path to map multiple HTTP methods, e.g.
+to map more than one HTTP method to your service method? You can use :api:`@Path` annotation to specify
+a path and use the HTTP method annotations without a path to map multiple HTTP methods, e.g.
 
 .. code-block:: java
 
@@ -185,8 +139,8 @@ one of the following supported types:
 - ``String``
 - ``Enum``
 
-Note that you can omit the value of `@Param`_ if you compiled your code with ``-parameters`` javac option.
-In this case the variable name is used as the value.
+Note that you can omit the value of :api:`@Param` if you compiled your code with ``-parameters`` javac
+option. In this case the variable name is used as the value.
 
 .. code-block:: java
 
@@ -229,7 +183,7 @@ Injecting a parameter as an ``Enum`` type
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 ``Enum`` type is also automatically converted if you annotate a parameter of your service method with
-`@Param`_ annotation. If your ``Enum`` type can be handled in a case-insensitive way, Armeria
+:api:`@Param` annotation. If your ``Enum`` type can be handled in a case-insensitive way, Armeria
 automatically converts the string value of a parameter to a value of ``Enum`` in a case-insensitive way.
 Otherwise, case-sensitive exact match will be performed.
 
@@ -264,12 +218,12 @@ Otherwise, case-sensitive exact match will be performed.
 Getting an HTTP parameter
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-When the value of `@Param`_ annotation is not shown in the path pattern, it will be handled as a parameter
-name of the query string of the request. If you have a service class like the example below and a user sends an
-HTTP GET request with URI of ``/hello1?name=armeria``, the service method will get ``armeria`` as the value
-of parameter ``name``. If there is no parameter named ``name`` in the query string, the parameter ``name``
-of the method would be ``null``. If you want to avoid ``null`` in this case, you can use `@Default`_
-annotation or ``Optional<?>`` class, e.g. ``hello2`` and ``hello3`` methods below, respectively.
+When the value of :api:`@Param` annotation is not shown in the path pattern, it will be handled as a
+parameter name of the query string of the request. If you have a service class like the example below and
+a user sends an HTTP GET request with URI of ``/hello1?name=armeria``, the service method will get ``armeria``
+as the value of parameter ``name``. If there is no parameter named ``name`` in the query string, the parameter
+``name`` of the method would be ``null``. If you want to avoid ``null`` in this case, you can use
+:api:`@Default` annotation or ``Optional<?>`` class, e.g. ``hello2`` and ``hello3`` methods below, respectively.
 
 .. code-block:: java
 
@@ -288,9 +242,9 @@ annotation or ``Optional<?>`` class, e.g. ``hello2`` and ``hello3`` methods belo
         }
     }
 
-If an HTTP POST request with a ``Content-Type: x-www-form-urlencoded`` is received and no `@Param`_ value
-appears in the path pattern, Armeria will aggregate the received request and decode its body as a URL-encoded
-form. After that, Armeria will inject the decoded value into the parameter.
+If an HTTP POST request with a ``Content-Type: x-www-form-urlencoded`` is received and no :api:`@Param`
+value appears in the path pattern, Armeria will aggregate the received request and decode its body as
+a URL-encoded form. After that, Armeria will inject the decoded value into the parameter.
 
 .. code-block:: java
 
@@ -307,9 +261,9 @@ form. After that, Armeria will inject the decoded value into the parameter.
 Getting an HTTP header
 ^^^^^^^^^^^^^^^^^^^^^^
 
-Armeria also provides `@Header`_ annotation to inject an HTTP header value into a parameter. The parameter
-annotated with `@Header`_ can also be specified as one of the built-in types as follows. `@Default`_ and
-``Optional<?>`` are also supported.
+Armeria also provides :api:`@Header` annotation to inject an HTTP header value into a parameter.
+The parameter annotated with :api:`@Header` can also be specified as one of the built-in types as follows.
+:api:`@Default` and ``Optional<?>`` are also supported.
 
 .. code-block:: java
 
@@ -322,11 +276,11 @@ annotated with `@Header`_ can also be specified as one of the built-in types as 
         public HttpResponse hello2(@Header("Content-Length") long contentLength) { ... }
     }
 
-Note that you can omit the value of `@Header`_  if you compiled your code with ``-parameters`` javac option.
-Read :ref:`parameter-injection` for more information.
-In this case the variable name is used as the value, but it will be converted to hyphen-separated lowercase
+Note that you can omit the value of :api:`@Header` if you compiled your code with ``-parameters`` javac
+option. Read :ref:`parameter-injection` for more information.
+In this case, the variable name is used as the value, but it will be converted to hyphen-separated lowercase
 string to be suitable for general HTTP header names. e.g. a variable name ``contentLength`` or
-``content_length`` will be converted to ``content-length`` as the value of `@Header`_.
+``content_length`` will be converted to ``content-length`` as the value of :api:`@Header`.
 
 .. code-block:: java
 
@@ -340,12 +294,12 @@ Other classes automatically injected
 
 The following classes are automatically injected when you specify them on the parameter list of your method.
 
-- RequestContext_
-- ServiceRequestContext_
-- Request_
-- HttpRequest_
-- AggregatedHttpMessage_
-- HttpParameters_
+- :api:`RequestContext`
+- :api:`ServiceRequestContext`
+- :api:`Request`
+- :api:`HttpRequest`
+- :api:`AggregatedHttpMessage`
+- :api:`HttpParameters`
 
 .. code-block:: java
 
@@ -376,10 +330,10 @@ Handling exceptions
 -------------------
 
 It is often useful to extract exception handling logic from service methods into a separate common class.
-Armeria provides `@ExceptionHandler`_ annotation to transform an exception into a response. You can write
-your own exception handler by implementing ExceptionHandlerFunction_ interface and annotate your service
-object or method with `@ExceptionHandler`_ annotation. Here is an example of an exception handler.
-If your exception handler is not able to handle a given exception, you can call
+Armeria provides :api:`@ExceptionHandler` annotation to transform an exception into a response.
+You can write your own exception handler by implementing :api:`ExceptionHandlerFunction` interface and
+annotate your service object or method with :api:`@ExceptionHandler` annotation. Here is an example of
+an exception handler. If your exception handler is not able to handle a given exception, you can call
 ``ExceptionHandlerFunction.fallthrough()`` to pass the exception to the next exception handler.
 
 .. code-block:: java
@@ -417,10 +371,11 @@ You can also annotate at method level to catch an exception from a single method
     }
 
 If there is no exception handler which is able to handle an exception, the exception would be passed to
-the default exception handler. It handles ``IllegalArgumentException``, HttpStatusException_ and
-HttpResponseException_ by default. ``IllegalArgumentException`` would be converted into ``400 Bad Request``
-response, and the other two exceptions would be converted into a response with the status code which
-they are holding. For another exceptions, ``500 Internal Server Error`` would be sent to the client.
+the default exception handler. It handles ``IllegalArgumentException``, :api:`HttpStatusException` and
+:api:`HttpResponseException` by default. ``IllegalArgumentException`` would be converted into
+``400 Bad Request`` response, and the other two exceptions would be converted into a response with
+the status code which they are holding. For another exceptions, ``500 Internal Server Error`` would be
+sent to the client.
 
 Conversion between an HTTP message and a Java object
 ----------------------------------------------------
@@ -429,9 +384,9 @@ Converting an HTTP request to a Java object
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 In some cases like receiving a JSON document from a client, it may be useful to convert the document to
-a Java object automatically. Armeria provides `@RequestConverter`_ and `@RequestObject`_ annotations
-so that such conversion can be done conveniently.
-You can write your own request converter by implementing RequestConverterFunction_ as follows.
+a Java object automatically. Armeria provides :api:`@RequestConverter` and :api:`@RequestObject`
+annotations so that such conversion can be done conveniently.
+You can write your own request converter by implementing :api:`RequestConverterFunction` as follows.
 Similar to the exception handler, you can call ``RequestConverterFunction.fallthrough()`` when your request
 converter is not able to convert the request.
 
@@ -452,7 +407,7 @@ converter is not able to convert the request.
     }
 
 Then, you can write your service method as follows. Note that a request converter will work on the parameters
-which are annotated with `@RequestObject`_.
+which are annotated with :api:`@RequestObject`.
 
 .. code-block:: java
 
@@ -474,17 +429,17 @@ which are annotated with `@RequestObject`_.
         }
     }
 
-Armeria also provides built-in request converters such as, BeanRequestConverterFunction_ for Java Beans,
-JacksonRequestConverterFunction_ for JSON documents, StringRequestConverterFunction_ for text contents
-and ByteArrayRequestConverterFunction_ for binary contents. They will be applied after your request converters
-by default, so you can use these built-in converters by just putting `@RequestObject`_ annotation on the
-parameters which you want to convert.
+Armeria also provides built-in request converters such as, :api:`BeanRequestConverterFunction`
+for Java Beans, :api:`JacksonRequestConverterFunction` for JSON documents, :api:`StringRequestConverterFunction`
+for text contents and :api:`ByteArrayRequestConverterFunction` for binary contents. They will be applied
+after your request converters by default, so you can use these built-in converters by just putting
+:api:`@RequestObject` annotation on the parameters which you want to convert.
 
-In some cases, `@RequestObject`_ annotation may have a request converter as its value.
+In some cases, :api:`@RequestObject` annotation may have a request converter as its value.
 Assume that you have a Java class named ``MyRequest`` that it is usually able to be converted by
 ``MyDefaultRequestConverter``. But what if there is only one method which has a parameter of ``MyRequest``
 that you have to convert it differently? In this case, you may specify a request converter with
-`@RequestObject`_ annotation. In the example, ``MySpecialRequestConverter`` will be used first for
+:api:`@RequestObject` annotation. In the example, ``MySpecialRequestConverter`` will be used first for
 converting ``MyRequest``.
 
 .. code-block:: java
@@ -500,8 +455,8 @@ converting ``MyRequest``.
 Injecting value of parameters and HTTP headers into a Java object
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
-BeanRequestConverterFunction_ is a built-in request converter for Java object. You can use it by putting
-`@RequestObject`_ annotation on the parameters which you want to convert.
+:api:`BeanRequestConverterFunction` is a built-in request converter for Java object. You can use it by
+putting :api:`@RequestObject` annotation on the parameters which you want to convert.
 
 .. code-block:: java
 
@@ -510,8 +465,8 @@ BeanRequestConverterFunction_ is a built-in request converter for Java object. Y
         public HttpResponse hello(@RequestObject MyRequestObject myRequestObject) { ... }
     }
 
-Besides the annotated service class, you also need to create ``MyRequestObject`` and put `@Param`_ or
-`@Header`_ annotations on any of the following elements, to inject the path parameters, HTTP parameters
+Besides the annotated service class, you also need to create ``MyRequestObject`` and put :api:`@Param` or
+:api:`@Header` annotations on any of the following elements, to inject the path parameters, HTTP parameters
 or HTTP headers:
 
 - Fields
@@ -547,8 +502,8 @@ or HTTP headers:
         public void init(@Header("permissions") String permissions, @Param("client-id") int clientId)
     }
 
-The usage of `@Param`_ or `@Header`_ annotations on Java object elements is much like using them on the
-parameters of service method.
+The usage of :api:`@Param` or :api:`@Header` annotations on Java object elements is much like
+using them on the parameters of service method.
 Please refer to :ref:`parameter-injection`, and :ref:`header-injection` for more information.
 
 
@@ -556,11 +511,11 @@ Converting a Java object to an HTTP response
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Every object returned by an annotated service method can be converted to an HTTP response message by
-response converters, except for HttpResponse_ and AggregatedHttpMessage_ which are already in a
-form of response message. You can also write your own response converter by implementing
-ResponseConverterFunction_ as follows. Also similar to RequestConverterFunction_, you can call
-``ResponseConverterFunction.fallthrough()`` when your response converter is not able to convert the result
-to an HttpResponse_.
+response converters, except for :api:`HttpResponse` and :api:`AggregatedHttpMessage` which are already
+in a form of response message. You can also write your own response converter by implementing
+:api:`ResponseConverterFunction` as follows. Also similar to :api:`RequestConverterFunction`,
+you can call ``ResponseConverterFunction.fallthrough()`` when your response converter is not able to
+convert the result to an :api:`HttpResponse`.
 
 .. code-block:: java
 
@@ -619,17 +574,17 @@ as follows.
 
 .. _configure-using-serverbuilder:
 
-Using ServerBuilder_ to configure converters and exception handlers
--------------------------------------------------------------------
+Using ``ServerBuilder`` to configure converters and exception handlers
+----------------------------------------------------------------------
 
-You can specify converters and exception handlers using ServerBuilder_, without using the annotations
+You can specify converters and exception handlers using :api:`ServerBuilder`, without using the annotations
 explained in the previous sections::
 
     sb.annotatedService(new MyAnnotatedService(),
                         new MyExceptionHandler(), new MyRequestConverter(), new MyResponseConverter());
 
 Also, they have a different method signature for conversion and exception handling so you can even write them
-in a single class and add it to your ServerBuilder_ at once, e.g.
+in a single class and add it to your :api:`ServerBuilder` at once, e.g.
 
 .. code-block:: java
 
@@ -675,9 +630,9 @@ order commented. It is also the same as the evaluation order of the converters.
 Decorating an annotated service
 -------------------------------
 
-Every Service_ can be wrapped by another Service_ in Armeria (Refer to :ref:`server-decorator` for more
-information). Simply, you can write your own decorator by implementing DecoratingServiceFunction_ interface
-as follows.
+Every :api:`Service` can be wrapped by another :api:`Service` in Armeria (Refer to :ref:`server-decorator`
+for more information). Simply, you can write your own decorator by implementing :api:`DecoratingServiceFunction`
+interface as follows.
 
 .. code-block:: java
 
@@ -690,9 +645,9 @@ as follows.
         }
     }
 
-Then, annotate your class or method with a `@Decorator`_ annotation. In the following example, ``MyDecorator``
-will handle a request first, then ``AnotherDecorator`` will handle the request next, and finally ``hello()``
-method will handle the request.
+Then, annotate your class or method with a :api:`@Decorator` annotation. In the following example,
+``MyDecorator`` will handle a request first, then ``AnotherDecorator`` will handle the request next,
+and finally ``hello()`` method will handle the request.
 
 .. code-block:: java
 
@@ -706,15 +661,15 @@ method will handle the request.
 Decorating an annotated service with a custom decorator annotation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-As you read earlier, you can write your own decorator with DecoratingServiceFunction_ interface. If your
-decorator does not require any parameter, that is fine. However, what if your decorator requires a parameter?
-In this case, you can create your own decorator annotation. Let's see the following custom decorator
-annotation which applies LoggingService_ to an annotated service.
+As you read earlier, you can write your own decorator with :api:`DecoratingServiceFunction` interface.
+If your decorator does not require any parameter, that is fine. However, what if your decorator requires
+a parameter? In this case, you can create your own decorator annotation. Let's see the following custom
+decorator annotation which applies :api:`LoggingService` to an annotated service.
 
 .. note::
 
     This example is actually just a copy of what Armeria provides out of the box. In reality,
-    you could just use `@LoggingDecorator`_, without writing your own one.
+    you could just use :api:`@LoggingDecorator`, without writing your own one.
 
 .. code-block:: java
 
@@ -749,9 +704,9 @@ annotation which applies LoggingService_ to an annotated service.
         }
     }
 
-You can see `@DecoratorFactory`_ annotation at the first line of the example. It specifies a factory class
-which implements DecoratorFactoryFunction_ interface. The factory will create an instance of LoggingService_
-with parameters which you specified on the class or method like below.
+You can see :api:`@DecoratorFactory` annotation at the first line of the example. It specifies
+a factory class which implements :api:`DecoratorFactoryFunction` interface. The factory will create
+an instance of :api:`LoggingService` with parameters which you specified on the class or method like below.
 
 .. code-block:: java
 
@@ -792,11 +747,12 @@ class-level decorators and method-level decorators.
     sb.annotatedService(new MyAnnotatedService(),
                         new MyGlobalDecorator1());      // order 1
 
-The first rule is as explained before. However, if your own decorator annotations and `@Decorator`_ annotations
-are specified in a mixed order like below, you need to clearly specify their order using ``order()`` attribute
-of the annotation. In the following example, you cannot make sure in what order they decorate the service
-because Java collects repeatable annotations like `@Decorator`_ into a single container annotation like
-`@Decorators`_ so it does not know the specified order between `@Decorator`_ and `@LoggingDecorator`_.
+The first rule is as explained before. However, if your own decorator annotations and :api:`@Decorator`
+annotations are specified in a mixed order like below, you need to clearly specify their order using ``order()``
+attribute of the annotation. In the following example, you cannot make sure in what order they decorate
+the service because Java collects repeatable annotations like :api:`@Decorator` into a single container
+annotation like :api:`@Decorators` so it does not know the specified order between :api:`@Decorator`
+and :api:`@LoggingDecorator`.
 
 .. code-block:: java
 
@@ -855,7 +811,7 @@ by adjusting the ``order()`` attribute:
         public HttpResponse hello2() { ... }
     }
 
-If you built a custom decorator annotation like `@LoggingDecorator`_, it is recommended to
+If you built a custom decorator annotation like :api:`@LoggingDecorator`, it is recommended to
 add an ``order()`` attribute so that the user of the custom annotation is able to adjust
 the order value of the decorator:
 
@@ -876,9 +832,9 @@ the order value of the decorator:
 Media type negotiation
 ----------------------
 
-Armeria provides `@ProduceType`_ and `@ConsumeType`_ annotations to support media type negotiation. It is not
-necessary if you have only one service method for a path and an HTTP method. However, assume that you have
-multiple service methods for the same path and the same HTTP method as follows.
+Armeria provides :api:`@ProduceType` and :api:`@ConsumeType` annotations to support media type
+negotiation. It is not necessary if you have only one service method for a path and an HTTP method.
+However, assume that you have multiple service methods for the same path and the same HTTP method as follows.
 
 .. code-block:: java
 
@@ -935,16 +891,16 @@ A request like the following would get a JSON object::
 .. note::
 
     Note that a ``Content-Type`` header of a response is not automatically set. You may want to get the
-    negotiated `@ProduceType`_ from ``ServiceRequestContext.negotiatedProduceType()`` method and set it
-    as the value of the ``Content-Type`` header of your response.
+    negotiated :api:`@ProduceType` from ``ServiceRequestContext.negotiatedProduceType()`` method and
+    set it as the value of the ``Content-Type`` header of your response.
 
 If a client sends a request without an ``Accept`` header (or sending an ``Accept`` header with an unsupported
 content type), it would be usually mapped to ``helloJson()`` method because the methods are sorted by the
 name of the type in an alphabetical order.
 
-In this case, you can adjust the order of the methods with `@Order`_ annotation. The default value of
-`@Order`_ annotation is ``0``. If you set the value less than ``0``, the method is used earlier than the
-other methods, which means that it would be used as a default when there is no matched produce type.
+In this case, you can adjust the order of the methods with :api:`@Order` annotation. The default value of
+:api:`@Order` annotation is ``0``. If you set the value less than ``0``, the method is used earlier than
+the other methods, which means that it would be used as a default when there is no matched produce type.
 In this example, it would also make the same effect to annotate ``helloJson()`` with ``@Order(1)``.
 
 .. code-block:: java
@@ -969,7 +925,7 @@ In this example, it would also make the same effect to annotate ``helloJson()`` 
 
 Next, let's learn how to handle a ``Content-Type`` header of a request. Assume that there are two service
 methods that expect a text document and a JSON object as a content of a request, respectively.
-You can annotate them with `@ConsumeType`_ annotation.
+You can annotate them with :api:`@ConsumeType` annotation.
 
 .. code-block:: java
 
@@ -1005,7 +961,7 @@ A request like the following would be handled by ``helloJson()`` method::
     { "name": "Armeria" }
 
 However, if a client sends a request with a ``Content-Type: application/octet-stream`` header which is not
-specified with `@ConsumeType`_, the client would get an HTTP status code of 415 which means
+specified with :api:`@ConsumeType`, the client would get an HTTP status code of 415 which means
 ``Unsupported Media Type``. If you want to make one of the methods catch-all, you can remove the annotation
 as follows. ``helloCatchAll()`` method would accept every request except for the request with a
 ``Content-Type: application/json`` header.

--- a/site/src/sphinx/server-basics.rst
+++ b/site/src/sphinx/server-basics.rst
@@ -1,15 +1,11 @@
 .. _`a name-based virtual host`: https://en.wikipedia.org/wiki/Virtual_hosting#Name-based
-.. _LoggingService: apidocs/index.html?com/linecorp/armeria/server/logging/LoggingService.html
-.. _ServerBuilder: apidocs/index.html?com/linecorp/armeria/server/ServerBuilder.html
-.. _VirtualHost: apidocs/index.html?com/linecorp/armeria/server/VirtualHost.html
-.. _VirtualHostBuilder: apidocs/index.html?com/linecorp/armeria/server/VirtualHostBuilder.html
 
 .. _server-basics:
 
 Server basics
 =============
 
-To start a server, you need to build it first. Use `ServerBuilder`_:
+To start a server, you need to build it first. Use :api:`ServerBuilder`:
 
 .. code-block:: java
 
@@ -139,11 +135,11 @@ Even if we opened a port, it's of no use if we didn't bind any services to them.
     future.join();
 
 As described in the example, ``service()`` and ``serviceUnder()`` perform an exact match and a prefix match
-on a request path respectively. `ServerBuilder`_ also provides advanced path mapping such as regex and glob
-pattern matching.
+on a request path respectively. :api:`ServerBuilder` also provides advanced path mapping such as regex and
+glob pattern matching.
 
-Also, we decorated the second service using LoggingService_, which logs all requests and responses. You might
-be interested in decorating a service using other decorators, for example to gather metrics.
+Also, we decorated the second service using :api:`LoggingService`, which logs all requests and responses.
+You might be interested in decorating a service using other decorators, for example to gather metrics.
 
 You can also use an arbitrary object that's annotated by the ``@Path`` annotation using ``annotatedService()``.
 

--- a/site/src/sphinx/server-decorator.rst
+++ b/site/src/sphinx/server-decorator.rst
@@ -1,8 +1,4 @@
-.. _DecoratingService: apidocs/index.html?com/linecorp/armeria/server/DecoratingService.html
-.. _DecoratingServiceFunction: apidocs/index.html?com/linecorp/armeria/server/DecoratingServiceFunction.html
 .. _separating concerns: https://en.wikipedia.org/wiki/Separation_of_concerns
-.. _Service: apidocs/index.html?com/linecorp/armeria/server/Service.html
-.. _SimpleDecoratingService: apidocs/index.html?com/linecorp/armeria/server/SimpleDecoratingService.html
 .. _the decorator pattern: https://en.wikipedia.org/wiki/Decorator_pattern
 
 .. _server-decorator:
@@ -10,22 +6,23 @@
 Decorating a service
 ====================
 
-A 'decorating service' (or a 'decorator') is a Service_ that wraps another Service_ to intercept an incoming
-request or an outgoing response. As its name says, it is an implementation of `the decorator pattern`_.
-Service decoration takes a crucial role in Armeria. A lot of core features such as logging, metrics and
-distributed tracing are implemented as decorators and you will also find it useful when `separating concerns`_.
+A 'decorating service' (or a 'decorator') is a :api:`Service` that wraps another :api:`Service`
+to intercept an incoming request or an outgoing response. As its name says, it is an implementation of
+`the decorator pattern`_. Service decoration takes a crucial role in Armeria. A lot of core features
+such as logging, metrics and distributed tracing are implemented as decorators and you will also find it
+useful when `separating concerns`_.
 
 There are basically three ways to write a decorating service:
 
-- Implementing DecoratingServiceFunction_
-- Extending SimpleDecoratingService_
-- Extending DecoratingService_
+- Implementing :api:`DecoratingServiceFunction`
+- Extending :api:`SimpleDecoratingService`
+- Extending :api:`DecoratingService`
 
-Implementing DecoratingServiceFunction_
----------------------------------------
+Implementing ``DecoratingServiceFunction``
+------------------------------------------
 
-DecoratingServiceFunction_ is a functional interface that greatly simplifies the implementation of a decorating
-service. It enables you to write a decorating service with a single lambda expression:
+:api:`DecoratingServiceFunction` is a functional interface that greatly simplifies the implementation of
+a decorating service. It enables you to write a decorating service with a single lambda expression:
 
 .. code-block:: java
 
@@ -46,11 +43,11 @@ service. It enables you to write a decorating service with a single lambda expre
                         return delegate.serve(ctx, req);
                     });
 
-Extending SimpleDecoratingService_
-----------------------------------
+Extending ``SimpleDecoratingService``
+-------------------------------------
 
 If your decorator is expected to be reusable, it is recommended to define a new top-level class that extends
-SimpleDecoratingService_ :
+:api:`SimpleDecoratingService` :
 
 .. code-block:: java
 
@@ -78,11 +75,11 @@ SimpleDecoratingService_ :
     // Using reflection:
     sb.serviceUnder("/web", service.decorate(AuthService.class));
 
-Extending DecoratingService_
-----------------------------
+Extending ``DecoratingService``
+-------------------------------
 
 So far, we only demonstrated the case where a decorating service does not transform the type of the request and
-response. You can do that as well, of course, using DecoratingService_:
+response. You can do that as well, of course, using :api:`DecoratingService`:
 
 .. code-block:: java
 
@@ -110,8 +107,8 @@ response. You can do that as well, of course, using DecoratingService_:
 Unwrapping decoration
 ---------------------
 
-Once a Service_ is decorated, the type of the service is not that of the original Service_ anymore.
-Therefore, you cannot simply down-cast it to access the method exposed by the original Service_.
+Once a :api:`Service` is decorated, the type of the service is not that of the original :api:`Service`
+anymore. Therefore, you cannot simply down-cast it to access the method exposed by the original :api:`Service`.
 Instead, you need to 'unwrap' the decorator using the ``Service.as()`` method:
 
 .. code-block:: java
@@ -124,8 +121,8 @@ Instead, you need to 'unwrap' the decorator using the ``Service.as()`` method:
     assert decoratedService.as(MyDecoratedService.class).get() == decoratedService;
     assert !decoratedService.as(SomeOtherService.class).isPresent();
 
-``as()`` is especially useful when you are looking for the Service_ instances that implements a certain type
-from a server:
+``as()`` is especially useful when you are looking for the :api:`Service` instances that implements
+a certain type from a server:
 
 .. code-block:: java
 

--- a/site/src/sphinx/server-docservice.rst
+++ b/site/src/sphinx/server-docservice.rst
@@ -1,20 +1,15 @@
-.. _DocService: apidocs/index.html?com/linecorp/armeria/server/docs/DocService.html
-.. _DocServiceBuilder: apidocs/index.html?com/linecorp/armeria/server/docs/DocServiceBuilder.html
-.. _Server: apidocs/index.html?com/linecorp/armeria/server/Server.html
-.. _ServerBuilder: apidocs/index.html?com/linecorp/armeria/server/ServerBuilder.html
-
 .. _server-docservice:
 
 Browsing and invoking services with ``DocService``
 ==================================================
 
-DocService_ is a single-page web application which provides the following useful features:
+:api:`DocService` is a single-page web application which provides the following useful features:
 
 - Browsing the list of services and operations available in the server
 - Invoking a service operation from a web form
 - Creating a permalink for the invocation you've made
 
-First, add DocService_ to the ServerBuilder_:
+First, add :api:`DocService` to the :api:`ServerBuilder`:
 
 .. code-block:: java
 
@@ -27,8 +22,8 @@ First, add DocService_ to the ServerBuilder_:
     Server server = sb.build();
     server.start().join();
 
-DocService_ will scan for the supported services when the Server_ starts up. Open http://127.0.0.1:8080/docs/
-in your web browser and you'll see the following screen:
+:api:`DocService` will scan for the supported services when the :api:`Server` starts up.
+Open http://127.0.0.1:8080/docs/ in your web browser and you'll see the following screen:
 
 .. image:: _images/docservice_1.png
 
@@ -39,9 +34,9 @@ the exceptions which may be thrown:
 
 .. image:: _images/docservice_2.png
 
-As you may have noticed, the 'description' column is empty. DocService_ can even show the docstrings you put
-into your ``.thrift`` or ``.proto`` files with a little bit of build configuration. We will visit this later
-in this document.
+As you may have noticed, the 'description' column is empty. :api:`DocService` can even show the docstrings
+you put into your ``.thrift`` or ``.proto`` files with a little bit of build configuration. We will visit this
+later in this document.
 
 Debug form
 ----------
@@ -84,7 +79,7 @@ Example requests and headers
 ----------------------------
 
 You can specify the example requests and HTTP headers which will be used as the default value of the debug form
-when building a DocService_ with a DocServiceBuilder_:
+when building a :api:`DocService` with a :api:`DocServiceBuilder`:
 
 .. code-block:: java
 
@@ -99,8 +94,8 @@ when building a DocService_ with a DocServiceBuilder_:
             .build());
     ...
 
-By adding examples to DocService_, your users will be able to play with the services you wrote without a hassle
-and thus will understand them sooner and better.
+By adding examples to :api:`DocService`, your users will be able to play with the services you wrote
+without a hassle and thus will understand them sooner and better.
 
 Adding docstrings
 -----------------

--- a/site/src/sphinx/server-grpc.rst
+++ b/site/src/sphinx/server-grpc.rst
@@ -1,13 +1,8 @@
 .. _gRPC: https://grpc.io/
 .. _gRPC-Web: https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB.md
 .. _gRPC-Web-Client: https://github.com/improbable-eng/grpc-web
-.. _GrpcSerializationFormats: https://github.com/line/armeria/blob/master/grpc/src/main/java/com/linecorp/armeria/common/grpc/GrpcSerializationFormats.java
-.. _GrpcService: apidocs/index.html?com/linecorp/armeria/server/grpc/GrpcService.html
-.. _GrpcServiceBuilder: apidocs/index.html?com/linecorp/armeria/server/grpc/GrpcServiceBuilder.html
 .. _protobuf-gradle-plugin: https://github.com/google/protobuf-gradle-plugin
 .. _Protobuf-JSON: https://developers.google.com/protocol-buffers/docs/proto3#json
-.. _ServerBuilder: apidocs/index.html?com/linecorp/armeria/server/ServerBuilder.html
-.. _ServiceWithPathMappings: apidocs/index.html?com/linecorp/armeria/server/ServiceWithPathMappings.html
 .. _the gRPC-Java README: https://github.com/grpc/grpc-java/blob/master/README.md#download
 
 .. _server-grpc:
@@ -76,8 +71,8 @@ Our implementation would look like the following:
 ``GrpcService``
 ---------------
 
-Once you've finished the implementation of the service, you need to build a GrpcService_ using
-a GrpcServiceBuilder_ and add it to the ServerBuilder_:
+Once you've finished the implementation of the service, you need to build a :api:`GrpcService` using
+a :api:`GrpcServiceBuilder` and add it to the :api:`ServerBuilder`:
 
 .. code-block:: java
 
@@ -91,15 +86,16 @@ a GrpcServiceBuilder_ and add it to the ServerBuilder_:
 
 .. note::
 
-    We bound the GrpcService_ without specifying any path mappings. It is because GrpcService_ implements
-    ServiceWithPathMappings_, which dynamically provides path mappings by itself.
+    We bound the :api:`GrpcService` without specifying any path mappings. It is because :api:`GrpcService`
+    implements :api:`ServiceWithPathMappings`, which dynamically provides path mappings by itself.
 
 ``gRPC-Web``
 ------------
 
-GrpcService_ suppors the gRPC-Web_ protocol, a small modification to the gRPC_ wire format that can be used from
-a browser. To enable it for a GrpcService_, add the web formats from GrpcSerializationFormats_ to the
-GrpcServiceBuilder_. It is usually convenient to just pass GrpcSerializationFormats_.values().
+:api:`GrpcService` supports the gRPC-Web_ protocol, a small modification to the gRPC_ wire format
+that can be used from a browser. To enable it for a :api:`GrpcService`, add the web formats from
+:api:`GrpcSerializationFormats` to the :api:`GrpcServiceBuilder`. It is usually convenient
+to just pass ``GrpcSerializationFormats.values()``.
 
 .. code-block:: java
 
@@ -119,9 +115,10 @@ requests.
 Unframed requests
 -----------------
 
-GrpcService_ supports serving unary RPC methods (no streaming request or response) without gRPC_ wire format
-framing. This can be useful for gradually migrating an existing HTTP POST based API to gRPC_. As GrpcService_
-supports both binary protobuf and Protobuf-JSON_, either legacy protobuf or JSON APIs can be used.
+:api:`GrpcService` supports serving unary RPC methods (no streaming request or response) without
+gRPC_ wire format framing. This can be useful for gradually migrating an existing HTTP POST based API to gRPC_.
+As :api:`GrpcService` supports both binary protobuf and Protobuf-JSON_, either legacy protobuf or JSON APIs
+can be used.
 
 .. code-block:: java
 
@@ -141,8 +138,8 @@ body.
 Blocking service implementation
 -------------------------------
 
-Unlike upstream gRPC-java, Armeria does not run service logic in a separate threadpool. If your service
-implementation requires blocking, either run the individual blocking logic in a threadpool, or just wrap the
+Unlike upstream gRPC-java, Armeria does not run service logic in a separate thread pool. If your service
+implementation requires blocking, either run the individual blocking logic in a thread pool, or just wrap the
 entire service implementation in ``RequestContext.current().blockingTaskExecutor().submit``
 
 .. code-block:: java

--- a/site/src/sphinx/server-http-file.rst
+++ b/site/src/sphinx/server-http-file.rst
@@ -1,11 +1,9 @@
-.. _`HttpFileService`: apidocs/index.html?com/linecorp/armeria/server/file/HttpFileService.html
-.. _`HttpFileServiceBuilder`: apidocs/index.html?com/linecorp/armeria/server/file/HttpFileServiceBuilder.html
-
 .. _server-http-file:
 
 Serving static files
 ====================
-For more information, please refer to the API documentation of `HttpFileService`_ and `HttpFileServiceBuilder`_.
+For more information, please refer to the API documentation of :api:`HttpFileService` and
+:api:`HttpFileServiceBuilder`.
 
 .. code-block:: java
 

--- a/site/src/sphinx/server-servlet.rst
+++ b/site/src/sphinx/server-servlet.rst
@@ -1,10 +1,5 @@
 .. _Apache Tomcat: https://tomcat.apache.org/
 .. _Jetty: https://www.eclipse.org/jetty/
-.. _JettyService: apidocs/index.html?com/linecorp/armeria/server/jetty/JettyService.html
-.. _JettyServiceBuilder: apidocs/index.html?com/linecorp/armeria/server/jetty/JettyServiceBuilder.html
-.. _ServerBuilder: apidocs/index.html?com/linecorp/armeria/server/ServerBuilder.html
-.. _TomcatService: apidocs/index.html?com/linecorp/armeria/server/tomcat/TomcatService.html
-.. _TomcatServiceBuilder: apidocs/index.html?com/linecorp/armeria/server/tomcat/TomcatServiceBuilder.html
 
 .. _server-servlet:
 
@@ -20,7 +15,7 @@ connection. All HTTP requests and responses go through Armeria. As a result, you
 Embedding Apache Tomcat
 -----------------------
 
-Add a TomcatService_ to a ServerBuilder_:
+Add a :api:`TomcatService` to a :api:`ServerBuilder`:
 
 .. code-block:: java
 
@@ -35,7 +30,8 @@ Add a TomcatService_ to a ServerBuilder_:
     sb.serviceUnder("/tomcat/api/rest/v1/",
                     TomcatService.forFileSystem("/var/lib/webapps/old_api.war"));
 
-For more information, please refer to the API documentation of TomcatService_ and TomcatServiceBuilder_.
+For more information, please refer to the API documentation of :api:`TomcatService` and
+:api:`TomcatServiceBuilder`.
 
 Embedding Jetty
 ---------------
@@ -77,4 +73,5 @@ Unlike Apache Tomcat, you need more dependencies and bootstrap code due to its m
         return handler;
     }
 
-For more information, please refer to the API documentation of JettyService_ and JettyServiceBuilder_.
+For more information, please refer to the API documentation of :api:`JettyService` and
+:api:`JettyServiceBuilder`.

--- a/site/src/sphinx/server-thrift.rst
+++ b/site/src/sphinx/server-thrift.rst
@@ -1,6 +1,4 @@
 .. _`Calling a Thrift service`: client-thrift.html
-.. _`ServerBuilder`: apidocs/index.html?com/linecorp/armeria/server/ServerBuilder.html
-.. _`THttpService`: apidocs/index.html?com/linecorp/armeria/server/thrift/THttpService.html
 .. _`TMultiplexedProcessor`: https://github.com/apache/thrift/blob/400b346db2510fffa06c0ced11105e3618ce5367/lib/java/src/org/apache/thrift/TMultiplexedProcessor.java#L28
 
 .. _server-thrift:
@@ -63,8 +61,8 @@ although it is easier to implement the synchronous ``Iface`` interface:
 ``THttpService``
 ----------------
 
-Once you've finished the implementation of the interface, you need to wrap it with a `THttpService`_ and add it
-to the `ServerBuilder`_:
+Once you've finished the implementation of the interface, you need to wrap it with a :api:`THttpService`
+and add it to the :api:`ServerBuilder`:
 
 .. code-block:: java
 
@@ -78,8 +76,8 @@ to the `ServerBuilder`_:
 Serialization formats
 ---------------------
 
-`THttpService`_ supports four Thrift serialization formats: TBINARY, TCOMPACT, TJSON and TTEXT. It chooses
-the serialization format based on the value of the ``content-type`` HTTP header.
+:api:`THttpService` supports four Thrift serialization formats: TBINARY, TCOMPACT, TJSON and TTEXT.
+It chooses the serialization format based on the value of the ``content-type`` HTTP header.
 
 +--------------------------------------------------+----------------------------------------+
 | Header value                                     | Serialization format                   |
@@ -101,14 +99,14 @@ the serialization format based on the value of the ``content-type`` HTTP header.
 +--------------------------------------------------+----------------------------------------+
 
 To change the default serialization format from TBINARY to something else, specify it when creating a
-`THttpService`_:
+:api:`THttpService`:
 
 .. code-block:: java
 
     import com.linecorp.armeria.common.thrift.ThriftSerializationFormats;
 
     ServerBuilder sb = new ServerBuilder();
-    // Use TCOMACT as the default serialization format.
+    // Use TCOMPACT as the default serialization format.
     sb.service("/hello", THttpService.of(new MyHelloService(),
                                          ThriftSerializationFormats.COMPACT));
 
@@ -130,7 +128,7 @@ You can also choose the list of allowed serialization formats:
 Service multiplexing
 --------------------
 
-`THttpService`_ supports service multiplexing fully compatible with Apache Thrift `TMultiplexedProcessor`_.
+:api:`THttpService` supports service multiplexing fully compatible with Apache Thrift `TMultiplexedProcessor`_.
 
 .. code-block:: java
 


### PR DESCRIPTION
Motivation:

A documentation writer has to use a very long URI to a Javadoc entry
whenever he or she refers to a class or a package.

Modifications:

- Add a Sphinx extension that provides a role called `api` which greatly
  simplifies adding an Armeria Javadoc link
- Replace all hard-coded Armeria Javadoc links with the `api` role

Result:

- Simplicity