### PR TITLE
Support `List<String>` type for `@Header` annotation

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/AnnotatedHttpServiceParamUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/AnnotatedHttpServiceParamUtil.java
@@ -143,9 +143,7 @@ public final class AnnotatedHttpServiceParamUtil {
      * it is not supported.
      *
      * @param clazz parameter type to be validated and normalized
-     *
      * @return normalized parameter type
-     *
      * @throws IllegalArgumentException if {@code clazz} is not a supported data type.
      */
     public static Class<?> validateAndNormalizeSupportedType(Class<?> clazz) {

--- a/core/src/main/java/com/linecorp/armeria/server/AnnotatedHttpServiceMethod.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AnnotatedHttpServiceMethod.java
@@ -338,11 +338,11 @@ final class AnnotatedHttpServiceMethod {
         if (parameterizedType instanceof ParameterizedType) {
             try {
                 type = (Class<?>) ((ParameterizedType) parameterizedType).getActualTypeArguments()[0];
-                wrapperType = validateWrapperAndElementType(paramType, parameterInfo.getType(), type);
             } catch (Throwable cause) {
                 throw new IllegalArgumentException("Invalid optional parameter: " + parameterInfo.getName(),
                                                    cause);
             }
+            wrapperType = validateWrapperAndElementType(paramType, parameterInfo.getType(), type);
         } else {
             type = parameterInfo.getType();
             wrapperType = null;
@@ -365,7 +365,7 @@ final class AnnotatedHttpServiceMethod {
 
         // A list of string is supported only for HTTP headers.
         if (paramType == ParameterType.HEADER && elementClazz == String.class) {
-            if (clazz == Iterable.class || clazz == List.class) {
+            if (clazz == Iterable.class || clazz == List.class || clazz == Collection.class) {
                 return ArrayList.class;
             }
             if (clazz == Set.class) {

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/BeanRequestConverterFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/BeanRequestConverterFunction.java
@@ -157,22 +157,24 @@ public final class BeanRequestConverterFunction implements RequestConverterFunct
 
         @Nullable
         private static BeanParamInfo from(final Class<?> beanType) {
-            final List<AbstractParamSetter> paramSetterList = new ArrayList<>();
-
-            getAllFields(beanType).forEach(
-                    field -> addIfNotNull(paramSetterList, FieldParamSetter.from(field)));
-            getAllMethods(beanType).forEach(
-                    method -> addIfNotNull(paramSetterList, MethodParamSetter.from(method)));
 
             final ConstructorInfo constructorInfo = ConstructorInfo.from(beanType);
             if (constructorInfo == null) {
                 // No annotated constructor or default constructor. Skip this.
                 return null;
             }
+
+            final List<AbstractParamSetter> paramSetterList = new ArrayList<>();
+            getAllFields(beanType).forEach(
+                    field -> addIfNotNull(paramSetterList, FieldParamSetter.from(field)));
+            getAllMethods(beanType).forEach(
+                    method -> addIfNotNull(paramSetterList, MethodParamSetter.from(method)));
+
             if (constructorInfo.getParameterCount() == 0 && paramSetterList.isEmpty()) {
                 // No arg constructor exists but there is no annotated field or method. Skip this.
                 return null;
             }
+
             return new BeanParamInfo(constructorInfo, paramSetterList);
         }
 

--- a/core/src/test/java/com/linecorp/armeria/server/AnnotatedHttpServiceBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/AnnotatedHttpServiceBuilderTest.java
@@ -45,70 +45,56 @@ public class AnnotatedHttpServiceBuilderTest {
     public void successfulOf() {
         new ServerBuilder().annotatedService(new Object() {
             @Get("/")
-            public Object root() {
-                return null;
-            }
+            public void root() {}
         });
 
         new ServerBuilder().annotatedService(new Object() {
             @Path("/")
             @Get
-            public Object root() {
-                return null;
-            }
+            public void root() {}
         });
 
         new ServerBuilder().annotatedService(new Object() {
             @Path("/")
             @Get
             @Post
-            public Object root() {
-                return null;
-            }
+            public void root() {}
         });
 
         new ServerBuilder().annotatedService(new Object() {
             @Options
             @Get
             @Post("/")
-            public Object root() {
-                return null;
-            }
+            public void root() {}
         });
 
         new ServerBuilder().annotatedService(new Object() {
             @Get("/")
-            public Object root(@Param("a") Optional<Byte> a,
-                               @Param("b") Optional<Short> b,
-                               @Param("c") Optional<Boolean> c,
-                               @Param("d") Optional<Integer> d,
-                               @Param("e") Optional<Long> e,
-                               @Param("f") Optional<Float> f,
-                               @Param("g") Optional<Double> g,
-                               @Param("h") Optional<String> h) {
-                return null;
-            }
+            public void root(@Param("a") Optional<Byte> a,
+                             @Param("b") Optional<Short> b,
+                             @Param("c") Optional<Boolean> c,
+                             @Param("d") Optional<Integer> d,
+                             @Param("e") Optional<Long> e,
+                             @Param("f") Optional<Float> f,
+                             @Param("g") Optional<Double> g,
+                             @Param("h") Optional<String> h) {}
         });
 
         new ServerBuilder().annotatedService(new Object() {
             @Get("/")
-            public Object root(@Param("a") byte a,
-                               @Param("b") short b,
-                               @Param("c") boolean c,
-                               @Param("d") int d,
-                               @Param("e") long e,
-                               @Param("f") float f,
-                               @Param("g") double g,
-                               @Param("h") String h) {
-                return null;
-            }
+            public void root(@Param("a") byte a,
+                             @Param("b") short b,
+                             @Param("c") boolean c,
+                             @Param("d") int d,
+                             @Param("e") long e,
+                             @Param("f") float f,
+                             @Param("g") double g,
+                             @Param("h") String h) {}
         });
 
         new ServerBuilder().annotatedService(new Object() {
                                                  @Get("/")
-                                                 public Object root(@Param("a") byte a) {
-                                                     return null;
-                                                 }
+                                                 public void root(@Param("a") byte a) {}
                                              },
                                              new JacksonRequestConverterFunction(),
                                              new ByteArrayRequestConverterFunction(),
@@ -116,25 +102,19 @@ public class AnnotatedHttpServiceBuilderTest {
 
         new ServerBuilder().annotatedService(new Object() {
                                                  @Get("/")
-                                                 public Object root(@Param("a") byte a) {
-                                                     return null;
-                                                 }
+                                                 public void root(@Param("a") byte a) {}
                                              },
                                              LoggingService.newDecorator());
 
         new ServerBuilder().annotatedService(new Object() {
             @Get("/")
-            public Object root(@Header("a") List<String> a) {
-                return null;
-            }
+            public void root(@Header("a") List<String> a) {}
         });
 
         new ServerBuilder().annotatedService(new Object() {
             @Get("/")
-            public Object root(@Header("a") ArrayList<String> a,
-                               @Header("a") LinkedList<String> b) {
-                return null;
-            }
+            public void root(@Header("a") ArrayList<String> a,
+                             @Header("a") LinkedList<String> b) {}
         });
     }
 
@@ -143,87 +123,63 @@ public class AnnotatedHttpServiceBuilderTest {
         assertThatThrownBy(() -> new ServerBuilder().annotatedService(new Object() {
             @Path("/")
             @Get("/")
-            public Object root() {
-                return null;
-            }
+            public void root() {}
         })).isInstanceOf(IllegalArgumentException.class);
 
         assertThatThrownBy(() -> new ServerBuilder().annotatedService(new Object() {
             @Post("/")
             @Get("/")
-            public Object root() {
-                return null;
-            }
+            public void root() {}
         })).isInstanceOf(IllegalArgumentException.class);
 
         assertThatThrownBy(() -> new ServerBuilder().annotatedService(new Object() {
             @Get
-            public Object root() {
-                return null;
-            }
+            public void root() {}
         })).isInstanceOf(IllegalArgumentException.class);
 
         assertThatThrownBy(() -> new ServerBuilder().annotatedService(new Object() {
             @Get("")
-            public Object root() {
-                return null;
-            }
+            public void root() {}
         })).isInstanceOf(IllegalArgumentException.class);
 
         assertThatThrownBy(() -> new ServerBuilder().annotatedService(new Object() {
             @Get("  ")
-            public Object root() {
-                return null;
-            }
+            public void root() {}
         })).isInstanceOf(IllegalArgumentException.class);
 
         assertThatThrownBy(() -> new ServerBuilder().annotatedService(new Object() {
             @Get("/{name}")
-            public Object root(@Param("name") Optional<String> name) {
-                return null;
-            }
+            public void root(@Param("name") Optional<String> name) {}
         })).isInstanceOf(IllegalArgumentException.class);
 
         assertThatThrownBy(() -> new ServerBuilder().annotatedService(new Object() {
             @Get("/{name}")
-            public Object root(@Param("name") Optional<AnnotatedHttpServiceBuilderTest> name) {
-                return null;
-            }
+            public void root(@Param("name") Optional<AnnotatedHttpServiceBuilderTest> name) {}
         })).isInstanceOf(IllegalArgumentException.class);
 
         assertThatThrownBy(() -> new ServerBuilder().annotatedService(new Object() {
             @Get("/{name}")
-            public Object root(@Param("name") List<String> name) {
-                return null;
-            }
+            public void root(@Param("name") List<String> name) {}
         })).isInstanceOf(IllegalArgumentException.class);
 
         assertThatThrownBy(() -> new ServerBuilder().annotatedService(new Object() {
             @Get("/test")
-            public Object root(@Param("name") Optional<AnnotatedHttpServiceBuilderTest> name) {
-                return null;
-            }
+            public void root(@Param("name") Optional<AnnotatedHttpServiceBuilderTest> name) {}
         })).isInstanceOf(IllegalArgumentException.class);
 
         assertThatThrownBy(() -> new ServerBuilder().annotatedService(new Object() {
             @Get("/test")
-            public Object root(@Param("name") List<String> name) {
-                return null;
-            }
+            public void root(@Param("name") List<String> name) {}
         })).isInstanceOf(IllegalArgumentException.class);
 
         assertThatThrownBy(() -> new ServerBuilder().annotatedService(new Object() {
             @Get("/test")
-            public Object root(@Header("name") List<Object> name) {
-                return null;
-            }
+            public void root(@Header("name") List<Object> name) {}
         })).isInstanceOf(IllegalArgumentException.class);
 
         assertThatThrownBy(() -> new ServerBuilder().annotatedService(new Object() {
             @Get("/test")
-            public Object root(@Header("name") NoDefaultConstructorList<String> name) {
-                return null;
-            }
+            public void root(@Header("name") NoDefaultConstructorList<String> name) {}
         })).isInstanceOf(IllegalArgumentException.class);
     }
 

--- a/core/src/test/java/com/linecorp/armeria/server/AnnotatedHttpServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/AnnotatedHttpServiceTest.java
@@ -40,6 +40,7 @@ import org.apache.http.impl.client.HttpClients;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.protocol.HTTP;
 import org.apache.http.util.EntityUtils;
+import org.assertj.core.util.Strings;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -590,8 +591,8 @@ public class AnnotatedHttpServiceTest {
         }
 
         @Post("/customHeader")
-        public String customHeader(@Header String aName) {
-            return aName + " is awesome";
+        public String customHeader(@Header List<String> aName) {
+            return Strings.join(aName).with(":") + " is awesome";
         }
 
         @Get("/headerDefault")
@@ -819,6 +820,11 @@ public class AnnotatedHttpServiceTest {
             request = post("/11/customHeader");
             request.setHeader("a-name", "minwoox");
             testBody(hc, request, "minwoox is awesome");
+
+            request = post("/11/customHeader");
+            request.addHeader("a-name", "minwoox");
+            request.addHeader("a-name", "giraffe");
+            testBody(hc, request, "minwoox:giraffe is awesome");
 
             request = get("/11/headerDefault");
             testBody(hc, request, "hello/world/(null)");


### PR DESCRIPTION
Motivation:
Several HTTP headers can be sent with the same name. We missed that kind of situation before. Need to enhance annotated HTTP service to support it.

Modifications:
- Support `List<String>` type for `@Header` annotation.