### PR TITLE
Only create composite bytebufs if there is more than one incoming gRPC frame.

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/internal/grpc/ArmeriaMessageDeframer.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/grpc/ArmeriaMessageDeframer.java
@@ -175,10 +175,13 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
 
     private boolean compressedFlag;
     private boolean endOfStream;
+
     @Nullable
-    private CompositeByteBuf nextFrame;
+    private ByteBuf firstFrame;
+
     @Nullable
     private CompositeByteBuf unprocessed;
+
     private long pendingDeliveries;
     private boolean deliveryStalled = true;
     private boolean inDelivery;
@@ -244,7 +247,16 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
                 buf = alloc.buffer(data.length());
                 buf.writeBytes(data.array(), data.offset(), data.length());
             }
-            unprocessed.addComponent(true, buf);
+            if (unprocessed != null) {
+                unprocessed.addComponent(true, buf);
+            } else if (firstFrame == null) {
+                firstFrame = buf;
+            } else {
+                unprocessed = alloc.compositeBuffer();
+                unprocessed.addComponent(true, firstFrame);
+                unprocessed.addComponent(true, buf);
+                firstFrame = null;
+            }
         }
 
         // Indicate that all of the data for this stream has been received.
@@ -259,15 +271,15 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
     @Override
     public void close() {
         try {
+            if (firstFrame != null) {
+                firstFrame.release();
+            }
             if (unprocessed != null) {
                 unprocessed.release();
             }
-            if (nextFrame != null) {
-                nextFrame.release();
-            }
         } finally {
+            firstFrame = null;
             unprocessed = null;
-            nextFrame = null;
         }
     }
 
@@ -275,7 +287,7 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
      * Indicates whether or not this deframer has been closed.
      */
     public boolean isClosed() {
-        return unprocessed == null;
+        return firstFrame == null && unprocessed == null;
     }
 
     public ArmeriaMessageDeframer decompressor(Decompressor decompressor) {
@@ -303,14 +315,14 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
         inDelivery = true;
         try {
             // Process the uncompressed bytes.
-            while (pendingDeliveries > 0 && readRequiredBytes()) {
+            while (pendingDeliveries > 0 && hasRequiredBytes()) {
                 switch (state) {
                     case HEADER:
-                        processHeader();
+                        readHeader();
                         break;
                     case BODY:
                         // Read the body and deliver the message.
-                        processBody();
+                        readBody();
 
                         // Since we've delivered a message, decrement the number of pending
                         // deliveries remaining.
@@ -329,10 +341,10 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
             * frame and not in unprocessed.  If there is extra data but no pending deliveries, it will
             * be in unprocessed.
             */
-            final boolean stalled = !unprocessed.isReadable();
+            final boolean stalled = !hasRequiredBytes();
 
             if (endOfStream && stalled) {
-                final boolean havePartialMessage = nextFrame != null && nextFrame.isReadable();
+                final boolean havePartialMessage = readableBuf().isReadable();
                 if (!havePartialMessage) {
                     listener.endOfStream();
                     deliveryStalled = false;
@@ -350,39 +362,17 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
         }
     }
 
-    /**
-     * Attempts to read the required bytes into nextFrame.
-     *
-     * @return {@code true} if all of the required bytes have been read.
-     */
-    private boolean readRequiredBytes() {
-        if (nextFrame == null) {
-            nextFrame = alloc.compositeBuffer();
-        }
-
-        // Read until the buffer contains all the required bytes.
-        int missingBytes;
-        while ((missingBytes = requiredLength - nextFrame.readableBytes()) > 0) {
-            final int numUnprocessedBytes = unprocessed.readableBytes();
-            if (numUnprocessedBytes == 0) {
-                // No more data is available.
-                return false;
-            }
-            final int toRead = Math.min(missingBytes, numUnprocessedBytes);
-            if (toRead > 0) {
-                nextFrame.addComponent(true, unprocessed.readBytes(toRead));
-                unprocessed.discardReadComponents();
-            }
-        }
-        return true;
+    private boolean hasRequiredBytes() {
+        return readableBuf().readableBytes() >= requiredLength;
     }
 
     /**
      * Processes the gRPC compression header which is composed of the compression flag and the outer
      * frame length.
      */
-    private void processHeader() {
-        final int type = nextFrame.readUnsignedByte();
+    private void readHeader() {
+        final ByteBuf buf = readableBuf();
+        final int type = buf.readUnsignedByte();
         if ((type & RESERVED_MASK) != 0) {
             throw Status.INTERNAL.withDescription(
                     DEBUG_STRING + ": Frame header malformed: reserved bits not zero")
@@ -391,7 +381,7 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
         compressedFlag = (type & COMPRESSED_FLAG_MASK) != 0;
 
         // Update the required length to include the length of the frame.
-        requiredLength = nextFrame.readInt();
+        requiredLength = buf.readInt();
         if (requiredLength < 0 || requiredLength > maxMessageSizeBytes) {
             throw Status.RESOURCE_EXHAUSTED.withDescription(
                     String.format("%s: Frame size %d exceeds maximum: %d. ",
@@ -407,9 +397,9 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
      * Processes the body of the gRPC compression frame. A single compression frame may contain
      * several gRPC messages within it.
      */
-    private void processBody() {
-        final ByteBufOrStream msg = compressedFlag ? getCompressedBody() : getUncompressedBody();
-        nextFrame = null;
+    private void readBody() {
+        final ByteBuf buf = readBytes(requiredLength);
+        final ByteBufOrStream msg = compressedFlag ? getCompressedBody(buf) : getUncompressedBody(buf);
         listener.messageRead(msg);
 
         // Done with this frame, begin processing the next header.
@@ -417,12 +407,37 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
         requiredLength = HEADER_LENGTH;
     }
 
-    private ByteBufOrStream getUncompressedBody() {
-        return new ByteBufOrStream(nextFrame.consolidate());
+    private ByteBuf readableBuf() {
+        if (firstFrame != null) {
+            return firstFrame;
+        } else {
+            assert unprocessed != null;
+            return unprocessed;
+        }
     }
 
-    private ByteBufOrStream getCompressedBody() {
+    private ByteBuf readBytes(int length) {
+        if (firstFrame != null) {
+            if (firstFrame.readableBytes() == length) {
+                return firstFrame;
+            } else {
+                return firstFrame.retainedSlice(firstFrame.readerIndex(), length);
+            }
+        } else {
+            assert unprocessed != null;
+            ByteBuf buf = unprocessed.readBytes(length);
+            unprocessed.discardReadComponents();
+            return buf;
+        }
+    }
+
+    private ByteBufOrStream getUncompressedBody(ByteBuf buf) {
+        return new ByteBufOrStream(buf);
+    }
+
+    private ByteBufOrStream getCompressedBody(ByteBuf buf) {
         if (decompressor == Codec.Identity.NONE) {
+            buf.release();
             throw Status.INTERNAL.withDescription(
                     DEBUG_STRING + ": Can't decode compressed frame as compression not configured.")
                                  .asRuntimeException();
@@ -431,7 +446,7 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
         try {
             // Enforce the maxMessageSizeBytes limit on the returned stream.
             final InputStream unlimitedStream =
-                    decompressor.decompress(new ByteBufInputStream(nextFrame, true));
+                    decompressor.decompress(new ByteBufInputStream(buf, true));
             return new ByteBufOrStream(
                     new SizeEnforcingInputStream(unlimitedStream, maxMessageSizeBytes, DEBUG_STRING));
         } catch (IOException e) {


### PR DESCRIPTION
Currently, we use a `CompositeByteBuf` to collect incoming frames, and we read required bytes into another `CompositeByteBuf` as data is available. This causes a lot of overhead for the common case where the message fits in one frame. There also doesn't seem to be a good reason to read into a `nextFrame` as we get bytes, instead of when we have enough bytes (I had copied the pattern in this code pretty much verbatim from upstream without thinking too much about it).

Now, a `CompositeByteBuf` for incoming frames is only created on the second one. If the stream is finished with a single frame, no composites will ever be allocated. Also, incoming bytes are only read when we have enough bytes to deliver a message - this means we don't need to allocate a composite to keep track of read bytes pre-delivery.

After
```
# Run complete. Total time: 00:01:13

Benchmark                        (clientType)   Mode  Cnt      Score     Error  Units
DownstreamSimpleBenchmark.empty        NORMAL  thrpt   20  13314.558 ± 223.515  ops/s

Benchmark result is saved to /home/anuraag/git/armeria/benchmarks/build/reports/jmh/results.txt
```

Before
```
# Run complete. Total time: 00:01:13

Benchmark                        (clientType)   Mode  Cnt      Score     Error  Units
DownstreamSimpleBenchmark.empty        NORMAL  thrpt   20  12508.147 ± 180.084  ops/s

Benchmark result is saved to /home/anuraag/git/armeria/benchmarks/build/reports/jmh/results.txt
`