### PR TITLE
Add 'apiplural' directive for referring to a type in plural form

### DIFF
--- a/site/src/sphinx/_static/overrides.css
+++ b/site/src/sphinx/_static/overrides.css
@@ -254,6 +254,11 @@ p, .rst-content li {
   text-align: center;
 }
 
+/* Plural suffix inside code should not be monospaced. */
+code .plural-suffix {
+  font-family: 'Source Sans Pro', 'Helvetica', 'Arial', sans-serif;
+}
+
 /* Armeria branding begins. */
 .wy-nav-top, .wy-side-nav-search {
   background-color: #3a3a3a;

--- a/site/src/sphinx/advanced-zookeeper.rst
+++ b/site/src/sphinx/advanced-zookeeper.rst
@@ -6,20 +6,15 @@
 
 Service discovery with ZooKeeper
 ================================
-You can put the list of available endpoints into a zNode in `Apache ZooKeeper`_ cluster, as a node tree or
-as a node value, like the following:
+You can put the list of available :apiplural:`Endpoint` into a zNode in `Apache ZooKeeper`_ cluster
+as a node tree, like the following:
 
 .. code-block:: yaml
 
-    # (Recommended) When stored as a node tree:
     # Note: Only child node values are used. i.e. Child node names are ignored.
     - /myProductionEndpoints
       - /192.168.1.10_8080: 192.168.1.10:8080
       - /192.168.1.11_8080: 192.168.1.11:8080:100
-
-    # When stored as a node value:
-    - /myProductionEndpoints: 192.168.1.10:8080,192.168.1.11:8080:100
-
 
 In the examples above, ``192.168.1.10`` and other IP strings are your servers' IP addresses, ``8080`` is a
 service port number and ``100`` is a weight value. You can omit a weight value as it is optional.
@@ -62,17 +57,15 @@ Use :api:`ZooKeeperUpdatingListenerBuilder` to register your server to a ZooKeep
     import com.linecorp.armeria.server.ServerListener;
     import com.linecorp.armeria.server.zookeeper.ZooKeeperUpdatingListenerBuilder;
 
-    // This constructor will use server's default host name, port and weight.
-    // Use 'nodeValueCodec' method to override the defaults.
     ZookeeperUpdatingListener listener =
             new ZooKeeperUpdatingListenerBuilder("myZooKeeperHost:2181", "/myProductionEndpoints")
-            .sessionTimeout(10000)
-            .build();
+                    .sessionTimeout(10000)
+                    .build();
     server.addListener(listener);
     server.start();
     ...
 
-You can use an existing `CuratorFramework`_ instance instead of Zookeeper connection string.
+You can also use an existing `CuratorFramework`_ instance instead of ZooKeeper connection string:
 
 .. code-block:: java
 
@@ -83,8 +76,8 @@ You can use an existing `CuratorFramework`_ instance instead of Zookeeper connec
     CuratorFramework client = ...
     ZookeeperUpdatingListener listener =
             new ZooKeeperUpdatingListenerBuilder(client, "/myProductionEndpoints")
-            .nodeValueCodec(NodeValueCodec.DEFAULT)
-            .build();
+                    .nodeValueCodec(NodeValueCodec.DEFAULT)
+                    .build();
     server.addListener(listener);
     server.start();
     ...


### PR DESCRIPTION
Motivation:

While documenting, it is often necessary to refer to a type in plural
form:

    This class retrieves the list of :api:`Endpoint`\s from ZooKeeper.

Although `\` does its job here, the rendered output isn't very pretty,
mainly because:

- There's spacing between `Endpoint` and `s`. The spacing between them
  should be moved after the plural suffix `s`.
- There's gray background at `Endpoint` but not at `s`. Both `Endpoint`
  and `s` should have the same background color.

Modifications:

- Introduce a new directive `apiplural` which pluralizes a type
  reference automatically

Result:

- Aesthetics and convenience

Before:
![screenshot from 2018-05-03 12-09-31](https://user-images.githubusercontent.com/173918/39558603-f6458392-4eca-11e8-9fcd-fe25fa7c5ea9.png)

After:
![screenshot from 2018-05-03 12-08-26](https://user-images.githubusercontent.com/173918/39558606-fb9b8f26-4eca-11e8-8c28-4a5b5ebb2444.png)