### PR TITLE
Add PrometheusMeterRegistries.defaultRegistry

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/metric/PrometheusMeterRegistries.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/PrometheusMeterRegistries.java
@@ -32,6 +32,12 @@ import io.prometheus.client.CollectorRegistry;
 public final class PrometheusMeterRegistries {
 
     /**
+     * The default {@link PrometheusMeterRegistry} that uses {@link CollectorRegistry#defaultRegistry}.
+     */
+    public static final PrometheusMeterRegistry defaultRegistry =
+            newRegistry(CollectorRegistry.defaultRegistry);
+
+    /**
      * Returns a newly-created {@link PrometheusMeterRegistry} instance with a new {@link CollectorRegistry}.
      */
     public static PrometheusMeterRegistry newRegistry() {


### PR DESCRIPTION
Motivation:

Like most Micrometer users use Metrics.globalRegistry, most Prometheus
users use CollectorRegistry.defaultRegistry. To create a
PrometheusMeterRegistry with CollectorRegistry.defaultRegistry, a user
has to do the following:

    PrometheusMeterRegistries.newRegistry(CollectorRegistry.defaultRegistry)

.. which is too verbose.

Modifications:

- Add PrometheusMeterRegistries.defaultRegistry

Result:

- Fixes #1171