### PR TITLE
Make CorsService response headers compatible with IE

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsService.java
@@ -27,6 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Ascii;
+import com.google.common.base.Joiner;
 
 import com.linecorp.armeria.common.FilteredHttpResponse;
 import com.linecorp.armeria.common.HttpHeaderNames;
@@ -56,6 +57,7 @@ public final class CorsService extends SimpleDecoratingService<HttpRequest, Http
 
     private static final String ANY_ORIGIN = "*";
     private static final String NULL_ORIGIN = "null";
+    private static final Joiner HEADER_JOINER = Joiner.on(',');
 
     private final CorsConfig config;
 
@@ -259,15 +261,15 @@ public final class CorsService extends SimpleDecoratingService<HttpRequest, Http
             return;
         }
 
-        for (AsciiString header : exposedHeaders) {
-            headers.add(HttpHeaderNames.ACCESS_CONTROL_EXPOSE_HEADERS, header.toString());
-        }
+        headers.set(
+            HttpHeaderNames.ACCESS_CONTROL_EXPOSE_HEADERS, HEADER_JOINER.join(exposedHeaders));
     }
 
     private void setCorsAllowMethods(final HttpHeaders headers) {
         List<String> methods = config.allowedRequestMethods()
                                      .stream().map(HttpMethod::name).collect(Collectors.toList());
-        headers.set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS, methods);
+        headers.set(
+            HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS, HEADER_JOINER.join(methods));
     }
 
     private void setCorsAllowHeaders(final HttpHeaders headers) {
@@ -276,9 +278,8 @@ public final class CorsService extends SimpleDecoratingService<HttpRequest, Http
             return;
         }
 
-        for (AsciiString header : allowedHeaders) {
-            headers.add(HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS, header.toString());
-        }
+        headers.set(
+            HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS, HEADER_JOINER.join(allowedHeaders));
     }
 
     private void setCorsMaxAge(final HttpHeaders headers) {

--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsService.java
@@ -266,7 +266,7 @@ public final class CorsService extends SimpleDecoratingService<HttpRequest, Http
 
     private void setCorsAllowMethods(final HttpHeaders headers) {
         String methods = config.allowedRequestMethods()
-                                     .stream().map(HttpMethod::name).collect(Collectors.joining(DELIMITER));
+                .stream().map(HttpMethod::name).collect(Collectors.joining(DELIMITER));
         headers.set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS, methods);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsService.java
@@ -18,7 +18,6 @@ package com.linecorp.armeria.server.cors;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -57,7 +56,8 @@ public final class CorsService extends SimpleDecoratingService<HttpRequest, Http
 
     private static final String ANY_ORIGIN = "*";
     private static final String NULL_ORIGIN = "null";
-    private static final Joiner HEADER_JOINER = Joiner.on(',');
+    private static final String DELIMITER = ",";
+    private static final Joiner HEADER_JOINER = Joiner.on(DELIMITER);
 
     private final CorsConfig config;
 
@@ -261,15 +261,13 @@ public final class CorsService extends SimpleDecoratingService<HttpRequest, Http
             return;
         }
 
-        headers.set(
-            HttpHeaderNames.ACCESS_CONTROL_EXPOSE_HEADERS, HEADER_JOINER.join(exposedHeaders));
+        headers.set(HttpHeaderNames.ACCESS_CONTROL_EXPOSE_HEADERS, HEADER_JOINER.join(exposedHeaders));
     }
 
     private void setCorsAllowMethods(final HttpHeaders headers) {
-        List<String> methods = config.allowedRequestMethods()
-                                     .stream().map(HttpMethod::name).collect(Collectors.toList());
-        headers.set(
-            HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS, HEADER_JOINER.join(methods));
+        String methods = config.allowedRequestMethods()
+                                     .stream().map(HttpMethod::name).collect(Collectors.joining(DELIMITER));
+        headers.set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS, methods);
     }
 
     private void setCorsAllowHeaders(final HttpHeaders headers) {
@@ -278,8 +276,7 @@ public final class CorsService extends SimpleDecoratingService<HttpRequest, Http
             return;
         }
 
-        headers.set(
-            HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS, HEADER_JOINER.join(allowedHeaders));
+        headers.set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS, HEADER_JOINER.join(allowedHeaders));
     }
 
     private void setCorsMaxAge(final HttpHeaders headers) {

--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsService.java
@@ -266,7 +266,7 @@ public final class CorsService extends SimpleDecoratingService<HttpRequest, Http
 
     private void setCorsAllowMethods(final HttpHeaders headers) {
         String methods = config.allowedRequestMethods()
-                .stream().map(HttpMethod::name).collect(Collectors.joining(DELIMITER));
+                               .stream().map(HttpMethod::name).collect(Collectors.joining(DELIMITER));
         headers.set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS, methods);
     }
 

--- a/core/src/test/java/com/linecorp/armeria/server/cors/HttpServerCorsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/cors/HttpServerCorsTest.java
@@ -68,9 +68,8 @@ public class HttpServerCorsTest {
             }.decorate(CorsServiceBuilder.forOrigin("http://example.com")
                                          .allowRequestMethods(HttpMethod.POST, HttpMethod.GET)
                                          .allowRequestHeaders(HttpHeaderNames.of("allow_request_header"))
-                                         .exposeHeaders(
-                                             HttpHeaderNames.of("expose_header_1"),
-                                             HttpHeaderNames.of("expose_header_2"))
+                                         .exposeHeaders(HttpHeaderNames.of("expose_header_1"),
+                                                        HttpHeaderNames.of("expose_header_2"))
                                          .preflightResponseHeader("x-preflight-cors", "Hello CORS")
                                          .newDecorator()));
         }
@@ -109,15 +108,15 @@ public class HttpServerCorsTest {
         HttpClient client = HttpClient.of(clientFactory, server.uri("/"));
         AggregatedHttpMessage response = client.execute(
                 HttpHeaders.of(HttpMethod.OPTIONS, "/cors")
-                        .set(HttpHeaderNames.ACCEPT, "utf-8")
-                        .set(HttpHeaderNames.ORIGIN, "http://example.com")
-                        .set(HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD, "POST")).aggregate().get();
+                           .set(HttpHeaderNames.ACCEPT, "utf-8")
+                           .set(HttpHeaderNames.ORIGIN, "http://example.com")
+                           .set(HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD, "POST")).aggregate().get();
 
         assertEquals(HttpStatus.OK, response.status());
         assertEquals("http://example.com", response.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN));
         assertEquals("GET,POST", response.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS));
-        assertEquals(
-            "allow_request_header", response.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS));
+        assertEquals("allow_request_header",
+                     response.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS));
     }
 
     @Test
@@ -125,16 +124,16 @@ public class HttpServerCorsTest {
         HttpClient client = HttpClient.of(clientFactory, server.uri("/"));
         AggregatedHttpMessage response = client.execute(
                 HttpHeaders.of(HttpMethod.POST, "/cors")
-                        .set(HttpHeaderNames.ACCEPT, "utf-8")
-                        .set(HttpHeaderNames.ORIGIN, "http://example.com")
-                        .set(HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD, "POST")).aggregate().get();
+                           .set(HttpHeaderNames.ACCEPT, "utf-8")
+                           .set(HttpHeaderNames.ORIGIN, "http://example.com")
+                           .set(HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD, "POST")).aggregate().get();
 
         assertEquals(HttpStatus.OK, response.status());
         assertEquals("http://example.com", response.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN));
         assertEquals(
             "allow_request_header", response.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS));
         assertEquals("expose_header_1,expose_header_2",
-                response.headers().get(HttpHeaderNames.ACCESS_CONTROL_EXPOSE_HEADERS));
+                     response.headers().get(HttpHeaderNames.ACCESS_CONTROL_EXPOSE_HEADERS));
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/server/cors/HttpServerCorsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/cors/HttpServerCorsTest.java
@@ -66,7 +66,11 @@ public class HttpServerCorsTest {
                     return HttpResponse.of(HttpStatus.OK);
                 }
             }.decorate(CorsServiceBuilder.forOrigin("http://example.com")
-                                         .allowRequestMethods(HttpMethod.POST)
+                                         .allowRequestMethods(HttpMethod.POST, HttpMethod.GET)
+                                         .allowRequestHeaders(HttpHeaderNames.of("allow_request_header"))
+                                         .exposeHeaders(
+                                             HttpHeaderNames.of("expose_header_1"),
+                                             HttpHeaderNames.of("expose_header_2"))
                                          .preflightResponseHeader("x-preflight-cors", "Hello CORS")
                                          .newDecorator()));
         }
@@ -98,6 +102,39 @@ public class HttpServerCorsTest {
 
         assertEquals(HttpStatus.OK, response.status());
         assertEquals("http://example.com", response.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN));
+    }
+
+    @Test
+    public void testCorsAccessControlHeaders() throws Exception {
+        HttpClient client = HttpClient.of(clientFactory, server.uri("/"));
+        AggregatedHttpMessage response = client.execute(
+            HttpHeaders.of(HttpMethod.OPTIONS, "/cors")
+                .set(HttpHeaderNames.ACCEPT, "utf-8")
+                .set(HttpHeaderNames.ORIGIN, "http://example.com")
+                .set(HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD, "POST")).aggregate().get();
+
+        assertEquals(HttpStatus.OK, response.status());
+        assertEquals("http://example.com", response.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN));
+        assertEquals("GET,POST", response.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS));
+        assertEquals(
+            "allow_request_header", response.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS));
+    }
+
+    @Test
+    public void testCorsExposeHeaders() throws Exception {
+        HttpClient client = HttpClient.of(clientFactory, server.uri("/"));
+        AggregatedHttpMessage response = client.execute(
+            HttpHeaders.of(HttpMethod.POST, "/cors")
+                .set(HttpHeaderNames.ACCEPT, "utf-8")
+                .set(HttpHeaderNames.ORIGIN, "http://example.com")
+                .set(HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD, "POST")).aggregate().get();
+
+        assertEquals(HttpStatus.OK, response.status());
+        assertEquals("http://example.com", response.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN));
+        assertEquals(
+            "allow_request_header", response.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS));
+        assertEquals("expose_header_1,expose_header_2",
+            response.headers().get(HttpHeaderNames.ACCESS_CONTROL_EXPOSE_HEADERS));
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/server/cors/HttpServerCorsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/cors/HttpServerCorsTest.java
@@ -108,10 +108,10 @@ public class HttpServerCorsTest {
     public void testCorsAccessControlHeaders() throws Exception {
         HttpClient client = HttpClient.of(clientFactory, server.uri("/"));
         AggregatedHttpMessage response = client.execute(
-            HttpHeaders.of(HttpMethod.OPTIONS, "/cors")
-                .set(HttpHeaderNames.ACCEPT, "utf-8")
-                .set(HttpHeaderNames.ORIGIN, "http://example.com")
-                .set(HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD, "POST")).aggregate().get();
+                HttpHeaders.of(HttpMethod.OPTIONS, "/cors")
+                        .set(HttpHeaderNames.ACCEPT, "utf-8")
+                        .set(HttpHeaderNames.ORIGIN, "http://example.com")
+                        .set(HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD, "POST")).aggregate().get();
 
         assertEquals(HttpStatus.OK, response.status());
         assertEquals("http://example.com", response.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN));
@@ -124,17 +124,17 @@ public class HttpServerCorsTest {
     public void testCorsExposeHeaders() throws Exception {
         HttpClient client = HttpClient.of(clientFactory, server.uri("/"));
         AggregatedHttpMessage response = client.execute(
-            HttpHeaders.of(HttpMethod.POST, "/cors")
-                .set(HttpHeaderNames.ACCEPT, "utf-8")
-                .set(HttpHeaderNames.ORIGIN, "http://example.com")
-                .set(HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD, "POST")).aggregate().get();
+                HttpHeaders.of(HttpMethod.POST, "/cors")
+                        .set(HttpHeaderNames.ACCEPT, "utf-8")
+                        .set(HttpHeaderNames.ORIGIN, "http://example.com")
+                        .set(HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD, "POST")).aggregate().get();
 
         assertEquals(HttpStatus.OK, response.status());
         assertEquals("http://example.com", response.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN));
         assertEquals(
             "allow_request_header", response.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS));
         assertEquals("expose_header_1,expose_header_2",
-            response.headers().get(HttpHeaderNames.ACCESS_CONTROL_EXPOSE_HEADERS));
+                response.headers().get(HttpHeaderNames.ACCESS_CONTROL_EXPOSE_HEADERS));
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/server/cors/HttpServerCorsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/cors/HttpServerCorsTest.java
@@ -130,8 +130,8 @@ public class HttpServerCorsTest {
 
         assertEquals(HttpStatus.OK, response.status());
         assertEquals("http://example.com", response.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN));
-        assertEquals(
-            "allow_request_header", response.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS));
+        assertEquals("allow_request_header",
+                     response.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS));
         assertEquals("expose_header_1,expose_header_2",
                      response.headers().get(HttpHeaderNames.ACCESS_CONTROL_EXPOSE_HEADERS));
     }


### PR DESCRIPTION
> Despite the RFC permitting multi-value response headers
to appear as individual header fields instead of a
single header field with a comma delimitted value,
Internet Explorer does not deal well with this and hence,
this commit ensures that multi-value CORS response
headers are serialized as a single header field with
a comma delimitted value.

https://github.com/elastic/elasticsearch/commit/4566378cd58415f84bde2252b6b95f6b24e96dff

Got compatible issues when using CorsService, IE don't handle multi-value response headers for CORS OPTIONS response, so try to combine multi-value to a comma delimited value.