### PR TITLE
Skip pending request counting at health check service

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -374,7 +374,10 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
 
             // Keep track of the number of unfinished requests and
             // clean up the request stream when response stream ends.
-            service.startToProcessRequest(req, gracefulShutdownSupport);
+            final boolean isTransient = service.as(TransientService.class).isPresent();
+            if (!isTransient) {
+                gracefulShutdownSupport.inc();
+            }
             unfinishedRequests++;
             unfinishedResponses.put(res, true);
 
@@ -399,7 +402,9 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
             res.completionFuture().handleAsync(voidFunction((ret, cause) -> {
                 req.abort();
                 // NB: logBuilder.endResponse() is called by HttpResponseSubscriber below.
-                service.finishToProcessRequest(gracefulShutdownSupport);
+                if (!isTransient) {
+                    gracefulShutdownSupport.dec();
+                }
                 unfinishedResponses.remove(res);
                 if (--unfinishedRequests == 0 && handledLastRequest) {
                     ctx.writeAndFlush(Unpooled.EMPTY_BUFFER).addListener(CLOSE);

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -374,7 +374,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
 
             // Keep track of the number of unfinished requests and
             // clean up the request stream when response stream ends.
-            gracefulShutdownSupport.inc();
+            service.startToProcessRequest(req, gracefulShutdownSupport);
             unfinishedRequests++;
             unfinishedResponses.put(res, true);
 
@@ -399,7 +399,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
             res.completionFuture().handleAsync(voidFunction((ret, cause) -> {
                 req.abort();
                 // NB: logBuilder.endResponse() is called by HttpResponseSubscriber below.
-                gracefulShutdownSupport.dec();
+                service.finishToProcessRequest(gracefulShutdownSupport);
                 unfinishedResponses.remove(res);
                 if (--unfinishedRequests == 0 && handledLastRequest) {
                     ctx.writeAndFlush(Unpooled.EMPTY_BUFFER).addListener(CLOSE);

--- a/core/src/main/java/com/linecorp/armeria/server/Service.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Service.java
@@ -140,19 +140,4 @@ public interface Service<I extends Request, O extends Response> {
     default boolean shouldCachePath(String path, @Nullable String query, PathMapping pathMapping) {
         return pathMapping.exactPath().isPresent() && query == null;
     }
-
-    /**
-     * Invoked when this {@link Service} starts to process a {@link Request}.
-     */
-    default void startToProcessRequest(HttpRequest req,
-                                       GracefulShutdownSupport gracefulShutdownSupport) {
-        gracefulShutdownSupport.inc();
-    }
-
-    /**
-     * Invoked when this {@link Service} finishes to process a {@link Request}.
-     */
-    default void finishToProcessRequest(GracefulShutdownSupport gracefulShutdownSupport) {
-        gracefulShutdownSupport.dec();
-    }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/Service.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Service.java
@@ -140,4 +140,19 @@ public interface Service<I extends Request, O extends Response> {
     default boolean shouldCachePath(String path, @Nullable String query, PathMapping pathMapping) {
         return pathMapping.exactPath().isPresent() && query == null;
     }
+
+    /**
+     * Invoked when this {@link Service} starts to process a {@link Request}.
+     */
+    default void startToProcessRequest(HttpRequest req,
+                                       GracefulShutdownSupport gracefulShutdownSupport) {
+        gracefulShutdownSupport.inc();
+    }
+
+    /**
+     * Invoked when this {@link Service} finishes to process a {@link Request}.
+     */
+    default void finishToProcessRequest(GracefulShutdownSupport gracefulShutdownSupport) {
+        gracefulShutdownSupport.dec();
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/TransientService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/TransientService.java
@@ -20,7 +20,7 @@ import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
 
 /**
- * A {@link Service} that indicates to handles transient requests, for example, health check request.
+ * A {@link Service} handles transient requests, for example, health check requests.
  */
 public interface TransientService<I extends Request, O extends Response> extends Service<I, O> {
 }

--- a/core/src/main/java/com/linecorp/armeria/server/TransientService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/TransientService.java
@@ -20,7 +20,7 @@ import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
 
 /**
- * A {@link Service} handles transient requests, for example, health check requests.
+ * A {@link Service} that handles transient requests, for example, health check requests.
  */
 public interface TransientService<I extends Request, O extends Response> extends Service<I, O> {
 }

--- a/core/src/main/java/com/linecorp/armeria/server/TransientService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/TransientService.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import com.linecorp.armeria.common.Request;
+import com.linecorp.armeria.common.Response;
+
+/**
+ * A {@link Service} that indicates to handles transient requests, for example, health check request.
+ */
+public interface TransientService<I extends Request, O extends Response> extends Service<I, O> {
+}

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/HttpHealthCheckService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/HttpHealthCheckService.java
@@ -29,6 +29,7 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.server.AbstractHttpService;
+import com.linecorp.armeria.server.GracefulShutdownSupport;
 import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerListener;
@@ -150,6 +151,19 @@ public class HttpHealthCheckService extends AbstractHttpService {
             }
         }
         return serverHealth.isHealthy();
+    }
+
+    @Override
+    public void startToProcessRequest(HttpRequest req,
+                                      GracefulShutdownSupport gracefulShutdownSupport) {
+        // NB: Do not call gracefulShutdownSupport.inc() to allow Server to shutdown itself even if
+        //     health check requests are coming.
+    }
+
+    @Override
+    public void finishToProcessRequest(GracefulShutdownSupport gracefulShutdownSupport) {
+        // NB: Do not call gracefulShutdownSupport.dec() to allow Server to shutdown itself even if
+        //     health check requests are coming.
     }
 
     final class ServerHealthUpdater extends ServerListenerAdapter {

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/HttpHealthCheckService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/HttpHealthCheckService.java
@@ -29,13 +29,13 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.server.AbstractHttpService;
-import com.linecorp.armeria.server.GracefulShutdownSupport;
 import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerListener;
 import com.linecorp.armeria.server.ServerListenerAdapter;
 import com.linecorp.armeria.server.ServiceConfig;
 import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.TransientService;
 
 /**
  * An {@link HttpService} that responds with HTTP status {@code "200 OK"} if the server is healthy and can
@@ -71,7 +71,8 @@ import com.linecorp.armeria.server.ServiceRequestContext;
  *         .build();
  * }</pre>
  */
-public class HttpHealthCheckService extends AbstractHttpService {
+public class HttpHealthCheckService extends AbstractHttpService
+        implements TransientService<HttpRequest, HttpResponse> {
 
     private static final HttpData RES_OK = HttpData.ofUtf8("ok");
     private static final HttpData RES_NOT_OK = HttpData.ofUtf8("not ok");
@@ -151,19 +152,6 @@ public class HttpHealthCheckService extends AbstractHttpService {
             }
         }
         return serverHealth.isHealthy();
-    }
-
-    @Override
-    public void startToProcessRequest(HttpRequest req,
-                                      GracefulShutdownSupport gracefulShutdownSupport) {
-        // NB: Do not call gracefulShutdownSupport.inc() to allow Server to shutdown itself even if
-        //     health check requests are coming.
-    }
-
-    @Override
-    public void finishToProcessRequest(GracefulShutdownSupport gracefulShutdownSupport) {
-        // NB: Do not call gracefulShutdownSupport.dec() to allow Server to shutdown itself even if
-        //     health check requests are coming.
     }
 
     final class ServerHealthUpdater extends ServerListenerAdapter {


### PR DESCRIPTION
Motivations:
- Armeria server counts the number of pending requests including healthcheck requests.
- If a server has many healthcheck clients and these healthcheck clients send a request
  frequently, it makes difficult for a server to shutdown on time because graceful
  shutdown depends on the number of pending requests.

Modifications:
- Adds methods to track start/finish of processing requests to Server
- Stop to count a pending healthcheck request