### PR TITLE
Add unsafe gRPC buffer wrap option to client.

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaChannel.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaChannel.java
@@ -115,7 +115,8 @@ class ArmeriaChannel extends Channel implements ClientBuilderParams {
                 CompressorRegistry.getDefaultInstance(),
                 DecompressorRegistry.getDefaultInstance(),
                 serializationFormat,
-                jsonMarshaller);
+                jsonMarshaller,
+                options().getOrElse(GrpcClientOptions.UNSAFE_WRAP_RESPONSE_BUFFERS, false));
     }
 
     @Override

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientOptions.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientOptions.java
@@ -16,7 +16,11 @@
 
 package com.linecorp.armeria.client.grpc;
 
+import com.google.protobuf.ByteString;
+
 import com.linecorp.armeria.client.ClientOption;
+import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.unsafe.grpc.GrpcUnsafeBufferUtil;
 
 /**
  * {@link ClientOption}s to control gRPC-specific behavior.
@@ -34,6 +38,31 @@ public final class GrpcClientOptions {
      */
     public static final ClientOption<Integer> MAX_OUTBOUND_MESSAGE_SIZE_BYTES = ClientOption.valueOf(
             "MAX_OUTBOUND_MESSAGE_SIZE_BYTES");
+
+    /**
+     * Enables unsafe retention of response buffers. Can improve performance when working with very large
+     * (i.e., several megabytes) payloads.
+     *
+     * <p><strong>DISCLAIMER:</strong> Do not use this if you don't know what you are doing. It is very easy to
+     * introduce memory leaks when using this method. You will probably spend much time debugging memory leaks
+     * during development if this is enabled. You will probably spend much time debugging memory leaks in
+     * production if this is enabled. You probably don't want to do this and should turn back now.
+     *
+     * <p>When enabled, the reference-counted buffer received from the server will be stored into
+     * {@link RequestContext} instead of being released. All {@link ByteString} in a
+     * protobuf message will reference sections of this buffer instead of having their own copies. When done
+     * with a response message, call {@link GrpcUnsafeBufferUtil#releaseBuffer(Object, RequestContext)}
+     * with the message and the request's context to release the buffer. The message must be the same
+     * reference as what was passed to the client stub - a message with the same contents will not
+     * work. If {@link GrpcUnsafeBufferUtil#releaseBuffer(Object, RequestContext)} is not called, the memory
+     * will be leaked.
+     *
+     * <p>Due to the limited lifetime of {@link RequestContext} for blocking and async clients, this option
+     * is only really useful in conjunction with streaming clients. Even when using unary methods, it is
+     * recommended to use a streaming stub for easy access to the {@link RequestContext}.
+     */
+    public static final ClientOption<Boolean> UNSAFE_WRAP_RESPONSE_BUFFERS =
+            ClientOption.valueOf("UNSAFE_WRAP_RESPONSE_BUFFERS");
 
     private GrpcClientOptions() {}
 }

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
@@ -69,7 +69,7 @@ public final class GrpcServiceBuilder {
 
     private boolean enableUnframedRequests;
 
-    private boolean unsafeRetainRequestBuffers;
+    private boolean unsafeWrapRequestBuffers;
 
     /**
      * Adds a gRPC {@link ServerServiceDefinition} to this {@link GrpcServiceBuilder}, such as
@@ -195,8 +195,8 @@ public final class GrpcServiceBuilder {
      * work. If {@link GrpcUnsafeBufferUtil#releaseBuffer(Object, RequestContext)} is not called, the memory
      * will be leaked.
      */
-    public GrpcServiceBuilder unsafeWrapRequestBuffers(boolean unsafeRetainRequestBuffers) {
-        this.unsafeRetainRequestBuffers = unsafeRetainRequestBuffers;
+    public GrpcServiceBuilder unsafeWrapRequestBuffers(boolean unsafeWrapRequestBuffers) {
+        this.unsafeWrapRequestBuffers = unsafeWrapRequestBuffers;
         return this;
     }
 
@@ -220,7 +220,7 @@ public final class GrpcServiceBuilder {
                 firstNonNull(compressorRegistry, CompressorRegistry.getDefaultInstance()),
                 supportedSerializationFormats,
                 maxOutboundMessageSizeBytes,
-                unsafeRetainRequestBuffers,
+                unsafeWrapRequestBuffers,
                 maxInboundMessageSizeBytes);
         return enableUnframedRequests ? grpcService.decorate(UnframedGrpcService::new) : grpcService;
     }


### PR DESCRIPTION
Going to be writing a Pub/Sub *client* that deals with large payloads :) This PR allows streaming clients to handle large payloads more efficiently at the expensive of unsafe, manual memory management.

Also fixed a typo on the server side.