### PR TITLE
Publish Tomcat8.5 project

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -22,6 +22,7 @@ includeWithFlags ':thrift',                     'java', 'publish', 'relocate'
 includeWithFlags ':thrift0.9',                  'java', 'publish', 'relocate', 'no_aggregation'
 includeWithFlags ':tomcat',                     'java', 'publish', 'relocate'
 includeWithFlags ':tomcat8.0',                  'java', 'publish', 'relocate', 'no_aggregation'
+includeWithFlags ':tomcat8.5',                  'java', 'publish', 'relocate', 'no_aggregation'
 includeWithFlags ':zipkin',                     'java', 'publish', 'relocate'
 includeWithFlags ':zookeeper',                  'java', 'publish', 'relocate'
 
@@ -29,8 +30,6 @@ includeWithFlags ':zookeeper',                  'java', 'publish', 'relocate'
 includeWithFlags ':benchmarks',       'java'
 includeWithFlags ':it',               'java', 'relocate'
 includeWithFlags ':testing-internal', 'java', 'relocate'
-// No need to publish for Tomcat 8.5 because it's ABI-compatible with Tomcat 9.0
-includeWithFlags ':tomcat8.5',        'java', 'relocate'
 
 // Site generation project
 includeWithFlags ':site'


### PR DESCRIPTION
Motivations:
- Because some Tomcat API were removed from Tomcat 9, ABI compatibility is broken up (for example, [`Context#addServletMapping(String pattern, String name)`](https://tomcat.apache.org/tomcat-8.5-doc/api/org/apache/catalina/Context.html#addServletMapping(java.lang.String,%20java.lang.String)) is used in TomcatEmbeddedServletContainerFactory(spring-boot-1.5.x) was removed from Tomcat 9). For this, if Tomcat 9 dependency comes first, fails to startup spring-boot application with NoSuchMethodException.

Modifications:
- Publish armeria-tomcat8.5