### PR TITLE
Add more convenience methods to HttpData

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/HttpData.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpData.java
@@ -18,6 +18,9 @@ package com.linecorp.armeria.common;
 
 import static java.util.Objects.requireNonNull;
 
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Formatter;
@@ -25,6 +28,7 @@ import java.util.Locale;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
+import it.unimi.dsi.fastutil.io.FastByteArrayInputStream;
 
 /**
  * HTTP/2 data. Helpers in this class create {@link HttpData} objects that leave the stream open.
@@ -228,5 +232,37 @@ public interface HttpData extends HttpObject {
      */
     default String toStringAscii() {
         return toString(StandardCharsets.US_ASCII);
+    }
+
+    /**
+     * Returns a new {@link InputStream} that is sourced from this data.
+     */
+    default InputStream toInputStream() {
+        return new FastByteArrayInputStream(array(), offset(), length());
+    }
+
+    /**
+     * Returns a new {@link Reader} that is sourced from this data and decoded using the specified
+     * {@link Charset}.
+     */
+    default Reader toReader(Charset charset) {
+        requireNonNull(charset, "charset");
+        return new InputStreamReader(toInputStream(), charset);
+    }
+
+    /**
+     * Returns a new {@link Reader} that is sourced from this data and decoded using
+     * {@link StandardCharsets#UTF_8}.
+     */
+    default Reader toReaderUtf8() {
+        return toReader(StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Returns a new {@link Reader} that is sourced from this data and decoded using
+     * {@link StandardCharsets#US_ASCII}.
+     */
+    default Reader toReaderAscii() {
+        return toReader(StandardCharsets.US_ASCII);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/common/HttpDataTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/HttpDataTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.InputStream;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.Test;
+
+public class HttpDataTest {
+    @Test
+    public void toInputStream() throws Exception {
+        assertThat(HttpData.EMPTY_DATA.toInputStream().read()).isEqualTo(-1);
+
+        final InputStream in1 = HttpData.of(new byte[] { 1, 2, 3, 4 }).toInputStream();
+        assertThat(in1.read()).isOne();
+        assertThat(in1.read()).isEqualTo(2);
+        assertThat(in1.read()).isEqualTo(3);
+        assertThat(in1.read()).isEqualTo(4);
+        assertThat(in1.read()).isEqualTo(-1);
+
+        final InputStream in2 = HttpData.of(new byte[] { 1, 2, 3, 4 }, 1, 2).toInputStream();
+        assertThat(in2.read()).isEqualTo(2);
+        assertThat(in2.read()).isEqualTo(3);
+        assertThat(in2.read()).isEqualTo(-1);
+    }
+
+    @Test
+    public void toReader() throws Exception {
+        final Reader in = HttpData.ofUtf8("가A").toReader(StandardCharsets.UTF_8);
+        assertThat(in.read()).isEqualTo((int) '가');
+        assertThat(in.read()).isEqualTo((int) 'A');
+        assertThat(in.read()).isEqualTo(-1);
+    }
+
+    @Test
+    public void toReaderUtf8() throws Exception {
+        final Reader in = HttpData.ofUtf8("あB").toReaderUtf8();
+        assertThat(in.read()).isEqualTo((int) 'あ');
+        assertThat(in.read()).isEqualTo((int) 'B');
+        assertThat(in.read()).isEqualTo(-1);
+    }
+
+    @Test
+    public void toReaderAscii() throws Exception {
+        final Reader in = HttpData.ofUtf8("天C").toReaderAscii();
+        // '天' will be decoded into 3 bytes of unknown characters
+        assertThat(in.read()).isEqualTo(65533);
+        assertThat(in.read()).isEqualTo(65533);
+        assertThat(in.read()).isEqualTo(65533);
+        assertThat(in.read()).isEqualTo((int) 'C');
+        assertThat(in.read()).isEqualTo(-1);
+    }
+}


### PR DESCRIPTION
Motivation:

It would be useful to have stream-related methods in `HttpData`.

Modifications:

- Add `HttpData.toInputStream()`
- Add `HttpData.toReader()`
- Add `HttpData.toReaderUtf8()`
- Add `HttpData.toReaderAscii()`

Result:

- Better user experience
- Fixes #1188 