### PR TITLE
Removes old dependencies via Brave 5

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -158,12 +158,9 @@ io.reactivex.rxjava2:
 
 io.zipkin.brave:
   brave:
-    version: &BRAVE_VERSION '4.19.2'
+    version: &BRAVE_VERSION '5.0.0'
     javadocs:
-    - https://static.javadoc.io/io.zipkin.brave/brave/4.19.2/
-
-io.zipkin.java:
-  zipkin: { version: &ZIPKIN_VERSION '2.8.3' }
+    - https://static.javadoc.io/io.zipkin.brave/brave/5.0.0/
 
 it.unimi.dsi:
   fastutil:

--- a/zipkin/build.gradle
+++ b/zipkin/build.gradle
@@ -3,5 +3,4 @@ dependencies {
 
     // Zipkin
     compile 'io.zipkin.brave:brave'
-    compile 'io.zipkin.java:zipkin'
 }

--- a/zipkin/src/main/java/com/linecorp/armeria/internal/tracing/SpanTags.java
+++ b/zipkin/src/main/java/com/linecorp/armeria/internal/tracing/SpanTags.java
@@ -22,8 +22,6 @@ import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.logging.RequestLog;
 
 import brave.Span;
-import zipkin.Constants;
-import zipkin.TraceKeys;
 
 /**
  * Adds standard Zipkin tags to a span with the information in a {@link RequestLog}.
@@ -35,7 +33,7 @@ public final class SpanTags {
      */
     public static void addTags(Span span, RequestLog log) {
         if (log.host() != null) {
-            span.tag(TraceKeys.HTTP_HOST, log.host());
+            span.tag("http.host", log.host());
         }
         final StringBuilder uriBuilder = new StringBuilder()
                 .append(log.scheme().uriText())
@@ -45,13 +43,13 @@ public final class SpanTags {
         if (log.query() != null) {
             uriBuilder.append('?').append(log.query());
         }
-        span.tag(TraceKeys.HTTP_METHOD, log.method().name())
-            .tag(TraceKeys.HTTP_PATH, log.path())
-            .tag(TraceKeys.HTTP_URL, uriBuilder.toString())
-            .tag(TraceKeys.HTTP_STATUS_CODE, String.valueOf(log.statusCode()));
+        span.tag("http.method", log.method().name())
+            .tag("http.path", log.path())
+            .tag("http.url", uriBuilder.toString())
+            .tag("http.status_code", String.valueOf(log.statusCode()));
         final Throwable responseCause = log.responseCause();
         if (responseCause != null) {
-            span.tag(Constants.ERROR, responseCause.toString());
+            span.tag("error", responseCause.toString());
         }
 
         final SocketAddress raddr = log.context().remoteAddress();

--- a/zipkin/src/main/java/com/linecorp/armeria/server/tracing/HttpTracingService.java
+++ b/zipkin/src/main/java/com/linecorp/armeria/server/tracing/HttpTracingService.java
@@ -73,7 +73,7 @@ public class HttpTracingService extends SimpleDecoratingService<HttpRequest, Htt
     public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
         final TraceContextOrSamplingFlags contextOrFlags = extractor.extract(req.headers());
         final Span span = contextOrFlags.context() != null ? tracer.joinSpan(contextOrFlags.context())
-                                                           : tracer.newTrace(contextOrFlags.samplingFlags());
+                                                           : tracer.nextSpan(contextOrFlags);
         // For no-op spans, nothing special to do.
         if (span.isNoop()) {
             return delegate().serve(ctx, req);


### PR DESCRIPTION
Brave v5 is the same as v4 except no old deps. Notably, there is no
current constant file, so that's why literals are used in this change.

See https://github.com/openzipkin/brave/issues/699