### PR TITLE
Rename the `status` tag to `httpStatus` in `MeterIdPrefixFunction.ofDefault()`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/metric/MeterIdPrefixFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/MeterIdPrefixFunction.java
@@ -87,7 +87,7 @@ public interface MeterIdPrefixFunction {
 
             if (log.isAvailable(RequestLogAvailability.RESPONSE_HEADERS) &&
                 log.status() != null) {
-                tags.add(Tag.of("status", String.valueOf(log.statusCode())));
+                tags.add(Tag.of("httpStatus", String.valueOf(log.statusCode())));
             }
 
             return new MeterIdPrefix(name, tags);

--- a/core/src/test/java/com/linecorp/armeria/internal/metric/RequestMetricSupportTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/metric/RequestMetricSupportTest.java
@@ -70,12 +70,14 @@ public class RequestMetricSupportTest {
 
         measurements = measureAll(registry);
         assertThat(measurements).containsEntry("foo.activeRequests#value{method=POST}", 0.0)
-                                .containsEntry("foo.requests#count{method=POST,result=success,status=200}", 1.0)
-                                .containsEntry("foo.requests#count{method=POST,result=failure,status=200}", 0.0)
-                                .containsEntry("foo.responseDuration#count{method=POST,status=200}", 1.0)
-                                .containsEntry("foo.responseLength#count{method=POST,status=200}", 1.0)
-                                .containsEntry("foo.responseLength#total{method=POST,status=200}", 456.0)
-                                .containsEntry("foo.totalDuration#count{method=POST,status=200}", 1.0);
+                                .containsEntry("foo.requests#count{httpStatus=200,method=POST,result=success}",
+                                               1.0)
+                                .containsEntry("foo.requests#count{httpStatus=200,method=POST,result=failure}",
+                                               0.0)
+                                .containsEntry("foo.responseDuration#count{httpStatus=200,method=POST}", 1.0)
+                                .containsEntry("foo.responseLength#count{httpStatus=200,method=POST}", 1.0)
+                                .containsEntry("foo.responseLength#total{httpStatus=200,method=POST}", 456.0)
+                                .containsEntry("foo.totalDuration#count{httpStatus=200,method=POST}", 1.0);
     }
 
     @Test
@@ -99,11 +101,13 @@ public class RequestMetricSupportTest {
 
         final Map<String, Double> measurements = measureAll(registry);
         assertThat(measurements).containsEntry("foo.activeRequests#value{method=POST}", 0.0)
-                                .containsEntry("foo.requests#count{method=POST,result=success,status=500}", 0.0)
-                                .containsEntry("foo.requests#count{method=POST,result=failure,status=500}", 1.0)
-                                .containsEntry("foo.responseDuration#count{method=POST,status=500}", 1.0)
-                                .containsEntry("foo.responseLength#count{method=POST,status=500}", 1.0)
-                                .containsEntry("foo.totalDuration#count{method=POST,status=500}", 1.0);
+                                .containsEntry("foo.requests#count{httpStatus=500,method=POST,result=success}",
+                                               0.0)
+                                .containsEntry("foo.requests#count{httpStatus=500,method=POST,result=failure}",
+                                               1.0)
+                                .containsEntry("foo.responseDuration#count{httpStatus=500,method=POST}", 1.0)
+                                .containsEntry("foo.responseLength#count{httpStatus=500,method=POST}", 1.0)
+                                .containsEntry("foo.totalDuration#count{httpStatus=500,method=POST}", 1.0);
     }
 
     @Test

--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcMetricsIntegrationTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcMetricsIntegrationTest.java
@@ -126,22 +126,23 @@ public class GrpcMetricsIntegrationTest {
 
         // Chance that get() returns NPE before the metric is first added, so ignore exceptions.
         given().ignoreExceptions().untilAsserted(() -> assertThat(
-                findServerMeter("UnaryCall", "requests", COUNT, "result", "success", "status", "200"))
+                findServerMeter("UnaryCall", "requests", COUNT, "result", "success", "httpStatus", "200"))
                 .contains(4.0));
         given().ignoreExceptions().untilAsserted(() -> assertThat(
-                findServerMeter("UnaryCall", "requests", COUNT, "result", "failure", "status", "200"))
+                findServerMeter("UnaryCall", "requests", COUNT, "result", "failure", "httpStatus", "200"))
                 .contains(3.0));
         given().ignoreExceptions().untilAsserted(() -> assertThat(
                 findClientMeter("UnaryCall", "requests", COUNT, "result", "success")).contains(4.0));
         given().ignoreExceptions().untilAsserted(() -> assertThat(
                 findClientMeter("UnaryCall", "requests", COUNT, "result", "failure")).contains(3.0));
 
-        assertThat(findServerMeter("UnaryCall", "requestLength", COUNT, "status", "200")).contains(7.0);
-        assertThat(findServerMeter("UnaryCall", "requestLength", TOTAL, "status", "200")).contains(7.0 * 14);
+        assertThat(findServerMeter("UnaryCall", "requestLength", COUNT, "httpStatus", "200")).contains(7.0);
+        assertThat(findServerMeter("UnaryCall", "requestLength", TOTAL, "httpStatus", "200"))
+                .contains(7.0 * 14);
         assertThat(findClientMeter("UnaryCall", "requestLength", COUNT)).contains(7.0);
         assertThat(findClientMeter("UnaryCall", "requestLength", TOTAL)).contains(7.0 * 14);
-        assertThat(findServerMeter("UnaryCall", "responseLength", COUNT, "status", "200")).contains(7.0);
-        assertThat(findServerMeter("UnaryCall", "responseLength", TOTAL, "status", "200"))
+        assertThat(findServerMeter("UnaryCall", "responseLength", COUNT, "httpStatus", "200")).contains(7.0);
+        assertThat(findServerMeter("UnaryCall", "responseLength", TOTAL, "httpStatus", "200"))
                 .contains(4.0 * 5 /* + 3 * 0 */);
         assertThat(findClientMeter("UnaryCall", "responseLength", COUNT)).contains(7.0);
         assertThat(findClientMeter("UnaryCall", "responseLength", TOTAL)).contains(4.0 * 5 /* + 3 * 0 */);
@@ -159,15 +160,15 @@ public class GrpcMetricsIntegrationTest {
 
         // Chance that get() returns NPE before the metric is first added, so ignore exceptions.
         given().ignoreExceptions().untilAsserted(() -> assertThat(
-                findServerMeter("UnaryCall2", "requests", COUNT, "result", "success", "status", "200"))
+                findServerMeter("UnaryCall2", "requests", COUNT, "result", "success", "httpStatus", "200"))
                 .contains(4.0));
         given().ignoreExceptions().untilAsserted(() -> assertThat(
-                findServerMeter("UnaryCall2", "requests", COUNT, "result", "failure", "status", "500"))
+                findServerMeter("UnaryCall2", "requests", COUNT, "result", "failure", "httpStatus", "500"))
                 .contains(3.0));
-        assertThat(findServerMeter("UnaryCall2", "responseLength", COUNT, "status", "200")).contains(4.0);
-        assertThat(findServerMeter("UnaryCall2", "responseLength", COUNT, "status", "500")).contains(3.0);
-        assertThat(findServerMeter("UnaryCall2", "responseLength", TOTAL, "status", "200")).contains(0.0);
-        assertThat(findServerMeter("UnaryCall2", "responseLength", TOTAL, "status", "500")).contains(42.0);
+        assertThat(findServerMeter("UnaryCall2", "responseLength", COUNT, "httpStatus", "200")).contains(4.0);
+        assertThat(findServerMeter("UnaryCall2", "responseLength", COUNT, "httpStatus", "500")).contains(3.0);
+        assertThat(findServerMeter("UnaryCall2", "responseLength", TOTAL, "httpStatus", "200")).contains(0.0);
+        assertThat(findServerMeter("UnaryCall2", "responseLength", TOTAL, "httpStatus", "500")).contains(42.0);
     }
 
     private static Optional<Double> findServerMeter(
@@ -186,7 +187,7 @@ public class GrpcMetricsIntegrationTest {
         final MeterIdPrefix prefix = new MeterIdPrefix(
                 "client." + suffix + '#' + type.getTagValueRepresentation(),
                 "method", "armeria.grpc.testing.TestService/" + method,
-                "status", "200");
+                "httpStatus", "200");
         final String meterIdStr = prefix.withTags(keyValues).toString();
         return Optional.ofNullable(MoreMeters.measureAll(registry).get(meterIdStr));
     }

--- a/thrift/src/test/java/com/linecorp/armeria/it/metric/DropwizardMetricsIntegrationTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/metric/DropwizardMetricsIntegrationTest.java
@@ -133,30 +133,31 @@ public class DropwizardMetricsIntegrationTest {
                 .isPositive();
     }
 
-    private static String serverMetricName(String property) {
+    private static String serverMetricName(String property, int status) {
         return MetricRegistry.name("armeria", "server", "HelloService", property,
-                                   "hostnamePattern:*", "method:hello", "pathMapping:exact:/helloservice");
+                                   "hostnamePattern:*", "httpStatus:" + status,
+                                   "method:hello", "pathMapping:exact:/helloservice");
     }
 
     private static String serverMetricNameWithStatus(String property, int status) {
-        return serverMetricName(property) + ".status:" + status;
+        return serverMetricName(property, status);
     }
 
     private static String serverMetricNameWithStatusAndResult(String property, int status, String result) {
-        return serverMetricName(property) + ".result:" + result + ".status:" + status;
+        return serverMetricName(property, status) + ".result:" + result;
     }
 
-    private static String clientMetricName(String property) {
+    private static String clientMetricName(String property, int status) {
         return MetricRegistry.name("armeria", "client", "HelloService", property,
-                                   "method:hello");
+                                   "httpStatus:" + status, "method:hello");
     }
 
     private static String clientMetricNameWithStatus(String prop, int status) {
-        return clientMetricName(prop) + ".status:" + status;
+        return clientMetricName(prop, status);
     }
 
     private static String clientMetricNameWithStatusAndResult(String prop, int status, String result) {
-        return clientMetricName(prop) + ".result:" + result + ".status:" + status;
+        return clientMetricName(prop, status) + ".result:" + result;
     }
 
     private static void makeRequest(String name) {

--- a/thrift/src/test/java/com/linecorp/armeria/it/metric/PrometheusMetricsIntegrationTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/metric/PrometheusMetricsIntegrationTest.java
@@ -156,46 +156,48 @@ public class PrometheusMetricsIntegrationTest {
         // Server entry count check
         assertThat(content).containsPattern(
                 multilinePattern("server_request_duration_seconds_count",
-                                 "{handler=\"Foo\",hostnamePattern=\"*\",",
-                                 "method=\"hello\",pathMapping=\"exact:/foo\",status=\"200\",} 7.0"));
+                                 "{handler=\"Foo\",hostnamePattern=\"*\",httpStatus=\"200\",",
+                                 "method=\"hello\",pathMapping=\"exact:/foo\",} 7.0"));
         assertThat(content).containsPattern(
                 multilinePattern("server_request_length_count",
-                                 "{handler=\"Foo\",hostnamePattern=\"*\",",
-                                 "method=\"hello\",pathMapping=\"exact:/foo\",status=\"200\",} 7.0"));
+                                 "{handler=\"Foo\",hostnamePattern=\"*\",httpStatus=\"200\",",
+                                 "method=\"hello\",pathMapping=\"exact:/foo\",} 7.0"));
         assertThat(content).containsPattern(
                 multilinePattern("server_response_length_count",
-                                 "{handler=\"Foo\",hostnamePattern=\"*\",",
-                                 "method=\"hello\",pathMapping=\"exact:/foo\",status=\"200\",} 7.0"));
+                                 "{handler=\"Foo\",hostnamePattern=\"*\",httpStatus=\"200\",",
+                                 "method=\"hello\",pathMapping=\"exact:/foo\",} 7.0"));
         // Client entry count check
         assertThat(content).containsPattern(
                 multilinePattern("client_request_duration_seconds_count",
-                                 "{handler=\"Foo\",method=\"hello\",status=\"200\",} 7.0"));
+                                 "{handler=\"Foo\",httpStatus=\"200\",method=\"hello\",} 7.0"));
         assertThat(content).containsPattern(
                 multilinePattern("client_request_length_count",
-                                 "{handler=\"Foo\",method=\"hello\",status=\"200\",} 7.0"));
+                                 "{handler=\"Foo\",httpStatus=\"200\",method=\"hello\",} 7.0"));
         assertThat(content).containsPattern(
                 multilinePattern("client_response_length_count",
-                                 "{handler=\"Foo\",method=\"hello\",status=\"200\",} 7.0"));
+                                 "{handler=\"Foo\",httpStatus=\"200\",method=\"hello\",} 7.0"));
 
         // Failure count
         assertThat(content).containsPattern(
                 multilinePattern("server_requests_total",
-                                 "{handler=\"Foo\",hostnamePattern=\"*\",",
+                                 "{handler=\"Foo\",hostnamePattern=\"*\",httpStatus=\"200\",",
                                  "method=\"hello\",pathMapping=\"exact:/foo\",",
-                                 "result=\"failure\",status=\"200\",} 3.0"));
+                                 "result=\"failure\",} 3.0"));
         assertThat(content).containsPattern(
                 multilinePattern("client_requests_total",
-                                 "{handler=\"Foo\",method=\"hello\",result=\"failure\",status=\"200\",} 3.0"));
+                                 "{handler=\"Foo\",httpStatus=\"200\",method=\"hello\"," +
+                                 "result=\"failure\",} 3.0"));
 
         // Success count
         assertThat(content).containsPattern(
                 multilinePattern("server_requests_total",
-                                 "{handler=\"Foo\",hostnamePattern=\"*\",",
+                                 "{handler=\"Foo\",hostnamePattern=\"*\",httpStatus=\"200\",",
                                  "method=\"hello\",pathMapping=\"exact:/foo\",",
-                                 "result=\"success\",status=\"200\",} 4.0"));
+                                 "result=\"success\",} 4.0"));
         assertThat(content).containsPattern(
                 multilinePattern("client_requests_total",
-                                 "{handler=\"Foo\",method=\"hello\",result=\"success\",status=\"200\",} 4.0"));
+                                 "{handler=\"Foo\",httpStatus=\"200\",method=\"hello\"," +
+                                 "result=\"success\",} 4.0"));
 
         // Active Requests 0
         assertThat(content).containsPattern(
@@ -243,36 +245,37 @@ public class PrometheusMetricsIntegrationTest {
         // Server entry count check
         assertThat(content).containsPattern(
                 multilinePattern("server_request_duration_seconds_count",
-                                 "{handler=\"Bar\",hostnamePattern=\"*\",",
-                                 "method=\"hello\",pathMapping=\"exact:/bar\",status=\"200\",} 1.0"));
+                                 "{handler=\"Bar\",hostnamePattern=\"*\",httpStatus=\"200\",",
+                                 "method=\"hello\",pathMapping=\"exact:/bar\",} 1.0"));
         assertThat(content).containsPattern(
                 multilinePattern("server_request_length_count",
-                                 "{handler=\"Bar\",hostnamePattern=\"*\",",
-                                 "method=\"hello\",pathMapping=\"exact:/bar\",status=\"200\",} 1.0"));
+                                 "{handler=\"Bar\",hostnamePattern=\"*\",httpStatus=\"200\",",
+                                 "method=\"hello\",pathMapping=\"exact:/bar\",} 1.0"));
         assertThat(content).containsPattern(
                 multilinePattern("server_response_length_count",
-                                 "{handler=\"Bar\",hostnamePattern=\"*\",",
-                                 "method=\"hello\",pathMapping=\"exact:/bar\",status=\"200\",} 1.0"));
+                                 "{handler=\"Bar\",hostnamePattern=\"*\",httpStatus=\"200\",",
+                                 "method=\"hello\",pathMapping=\"exact:/bar\",} 1.0"));
         // Client entry count check
         assertThat(content).containsPattern(
                 multilinePattern("client_request_duration_seconds_count",
-                                 "{handler=\"Bar\",method=\"hello\",status=\"200\",} 1.0"));
+                                 "{handler=\"Bar\",httpStatus=\"200\",method=\"hello\",} 1.0"));
         assertThat(content).containsPattern(
                 multilinePattern("client_request_length_count",
-                                 "{handler=\"Bar\",method=\"hello\",status=\"200\",} 1.0"));
+                                 "{handler=\"Bar\",httpStatus=\"200\",method=\"hello\",} 1.0"));
         assertThat(content).containsPattern(
                 multilinePattern("client_response_length_count",
-                                 "{handler=\"Bar\",method=\"hello\",status=\"200\",} 1.0"));
+                                 "{handler=\"Bar\",httpStatus=\"200\",method=\"hello\",} 1.0"));
 
         // Success count
         assertThat(content).containsPattern(
                 multilinePattern("server_requests_total",
-                                 "{handler=\"Bar\",hostnamePattern=\"*\",",
+                                 "{handler=\"Bar\",hostnamePattern=\"*\",httpStatus=\"200\",",
                                  "method=\"hello\",pathMapping=\"exact:/bar\",",
-                                 "result=\"success\",status=\"200\",} 1.0"));
+                                 "result=\"success\",} 1.0"));
         assertThat(content).containsPattern(
                 multilinePattern("client_requests_total",
-                                 "{handler=\"Bar\",method=\"hello\",result=\"success\",status=\"200\",} 1.0"));
+                                 "{handler=\"Bar\",httpStatus=\"200\",method=\"hello\"," +
+                                 "result=\"success\",} 1.0"));
 
         // Active Requests 0
         assertThat(content).containsPattern(


### PR DESCRIPTION


Fixes #1215