### PR TITLE
Have DynamicEndpointGroup ignore updates that do not change the list …

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroupTest.java
@@ -34,19 +34,25 @@ public class DynamicEndpointGroupTest {
         endpointGroup.addListener(l -> updateListenerCalled.incrementAndGet());
 
         assertThat(updateListenerCalled.get()).isEqualTo(0);
+        endpointGroup.setEndpoints(ImmutableList.of(Endpoint.of("127.0.0.1", 3333),
+                                                    Endpoint.of("127.0.0.1", 1111)));
+        assertThat(endpointGroup.endpoints()).containsExactly(Endpoint.of("127.0.0.1", 1111),
+                                                              Endpoint.of("127.0.0.1", 3333));
+        assertThat(updateListenerCalled.get()).isEqualTo(1);
         endpointGroup.setEndpoints(ImmutableList.of(Endpoint.of("127.0.0.1", 1111),
-                                                    Endpoint.of("127.0.0.1", 2222)));
+                                                    Endpoint.of("127.0.0.1", 3333)));
+        // Same endpoints, nothing happens.
         assertThat(updateListenerCalled.get()).isEqualTo(1);
 
-        endpointGroup.addEndpoint(Endpoint.of("127.0.0.1", 3333));
+        endpointGroup.addEndpoint(Endpoint.of("127.0.0.1", 2222));
         assertThat(updateListenerCalled.get()).isEqualTo(2);
-        assertThat(endpointGroup.endpoints()).isEqualTo(ImmutableList.of(Endpoint.of("127.0.0.1", 1111),
-                                                                         Endpoint.of("127.0.0.1", 2222),
-                                                                         Endpoint.of("127.0.0.1", 3333)));
+        assertThat(endpointGroup.endpoints()).containsExactly(Endpoint.of("127.0.0.1", 1111),
+                                                              Endpoint.of("127.0.0.1", 2222),
+                                                              Endpoint.of("127.0.0.1", 3333));
 
         endpointGroup.removeEndpoint(Endpoint.of("127.0.0.1", 2222));
         assertThat(updateListenerCalled.get()).isEqualTo(3);
-        assertThat(endpointGroup.endpoints()).isEqualTo(ImmutableList.of(Endpoint.of("127.0.0.1", 1111),
-                                                                         Endpoint.of("127.0.0.1", 3333)));
+        assertThat(endpointGroup.endpoints()).containsExactly(Endpoint.of("127.0.0.1", 1111),
+                                                              Endpoint.of("127.0.0.1", 3333));
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroupTest.java
@@ -106,7 +106,7 @@ public class HttpHealthCheckedEndpointGroupTest {
         endpointGroup.newMeterBinder("foo").bindTo(registry);
 
         await().untilAsserted(() -> {
-            assertThat(endpointGroup.endpoints()).containsExactly(
+            assertThat(endpointGroup.endpoints()).containsExactlyInAnyOrder(
                     Endpoint.of("127.0.0.1", portOne),
                     Endpoint.of("127.0.0.1", portTwo));
 


### PR DESCRIPTION
…of endpoints and order them for more stable comparison.

Currently, `DynamicEndpointGroup` listeners are notified anytime an endpoint refresh happens, even if the endpoints didn't change. This doesn't seem useful so now `DynamicEndpointGroup` compares the old and new endpoints and only notifies when they change.

I guess insertion sort can be used for `addEndpoint` to avoid a copy but the complexity didn't seem worth it for a method that shouldn't be called with that much concurrency, but let me know if you'd prefer it.

Fixes #1216 