### PR TITLE
Inject `Cookie` header automatically

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/AnnotatedValueResolver.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AnnotatedValueResolver.java
@@ -398,13 +398,13 @@ final class AnnotatedValueResolver {
                     .resolver((unused, ctx) -> {
                         final List<String> values = ctx.request().headers().getAll(HttpHeaderNames.COOKIE);
                         if (values.isEmpty()) {
-                            return new Cookies(ImmutableSet.of());
+                            return Cookies.from(ImmutableSet.of());
                         }
                         final ImmutableSet.Builder<Cookie> cookies = ImmutableSet.builder();
                         values.stream()
                               .map(ServerCookieDecoder.STRICT::decode)
                               .forEach(cookies::addAll);
-                        return new Cookies(cookies.build());
+                        return Cookies.from(cookies.build());
                     })
                     .build();
         }

--- a/core/src/main/java/com/linecorp/armeria/server/AnnotatedValueResolver.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AnnotatedValueResolver.java
@@ -59,9 +59,11 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Ascii;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.MapMaker;
 
 import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpParameters;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.MediaType;
@@ -71,6 +73,7 @@ import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.internal.FallthroughException;
 import com.linecorp.armeria.server.AnnotatedBeanFactory.BeanFactoryId;
 import com.linecorp.armeria.server.annotation.ByteArrayRequestConverterFunction;
+import com.linecorp.armeria.server.annotation.Cookies;
 import com.linecorp.armeria.server.annotation.Default;
 import com.linecorp.armeria.server.annotation.Header;
 import com.linecorp.armeria.server.annotation.JacksonRequestConverterFunction;
@@ -81,6 +84,8 @@ import com.linecorp.armeria.server.annotation.StringRequestConverterFunction;
 
 import io.netty.handler.codec.http.HttpConstants;
 import io.netty.handler.codec.http.QueryStringDecoder;
+import io.netty.handler.codec.http.cookie.Cookie;
+import io.netty.handler.codec.http.cookie.ServerCookieDecoder;
 import io.netty.util.AsciiString;
 
 final class AnnotatedValueResolver {
@@ -387,6 +392,23 @@ final class AnnotatedValueResolver {
                     .aggregation(AggregationStrategy.FOR_FORM_DATA)
                     .build();
         }
+
+        if (type == Cookies.class) {
+            return builder(annotatedElement, Cookies.class)
+                    .resolver((unused, ctx) -> {
+                        final List<String> values = ctx.request().headers().getAll(HttpHeaderNames.COOKIE);
+                        if (values.isEmpty()) {
+                            return new Cookies(ImmutableSet.of());
+                        }
+                        final ImmutableSet.Builder<Cookie> cookies = ImmutableSet.builder();
+                        values.stream()
+                              .map(ServerCookieDecoder.STRICT::decode)
+                              .forEach(cookies::addAll);
+                        return new Cookies(cookies.build());
+                    })
+                    .build();
+        }
+
         // Unsupported type.
         return null;
     }

--- a/core/src/main/java/com/linecorp/armeria/server/AnnotatedValueResolver.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AnnotatedValueResolver.java
@@ -398,13 +398,13 @@ final class AnnotatedValueResolver {
                     .resolver((unused, ctx) -> {
                         final List<String> values = ctx.request().headers().getAll(HttpHeaderNames.COOKIE);
                         if (values.isEmpty()) {
-                            return Cookies.from(ImmutableSet.of());
+                            return Cookies.copyOf(ImmutableSet.of());
                         }
                         final ImmutableSet.Builder<Cookie> cookies = ImmutableSet.builder();
                         values.stream()
                               .map(ServerCookieDecoder.STRICT::decode)
                               .forEach(cookies::addAll);
-                        return Cookies.from(cookies.build());
+                        return Cookies.copyOf(cookies.build());
                     })
                     .build();
         }

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/Cookies.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/Cookies.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.annotation;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Set;
+
+import com.google.common.collect.ForwardingSet;
+
+import io.netty.handler.codec.http.cookie.Cookie;
+
+/**
+ * A class which holds a set of {@link Cookie}s.
+ */
+public final class Cookies extends ForwardingSet<Cookie> {
+
+    private final Set<Cookie> delegate;
+
+    public Cookies(Set<Cookie> delegate) {
+        this.delegate = requireNonNull(delegate, "delegate");
+    }
+
+    @Override
+    protected Set<Cookie> delegate() {
+        return delegate;
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/Cookies.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/Cookies.java
@@ -32,14 +32,13 @@ public interface Cookies extends Set<Cookie> {
      * Creates an instance with a copy of the specified set of {@link Cookie}s.
      */
     static Cookies of(Cookie... cookies) {
-        return new DefaultCookies(ImmutableSet.copyOf(cookies));
+        return new DefaultCookies(ImmutableSet.copyOf(requireNonNull(cookies, "cookies")));
     }
 
     /**
      * Creates an instance with a copy of the specified {@link Iterable} of {@link Cookie}s.
      */
     static Cookies copyOf(Iterable<? extends Cookie> cookies) {
-        requireNonNull(cookies, "cookies");
-        return new DefaultCookies(ImmutableSet.copyOf(cookies));
+        return new DefaultCookies(ImmutableSet.copyOf(requireNonNull(cookies, "cookies")));
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/Cookies.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/Cookies.java
@@ -15,7 +15,11 @@
  */
 package com.linecorp.armeria.server.annotation;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.Set;
+
+import com.google.common.collect.ImmutableSet;
 
 import io.netty.handler.codec.http.cookie.Cookie;
 
@@ -25,9 +29,17 @@ import io.netty.handler.codec.http.cookie.Cookie;
 public interface Cookies extends Set<Cookie> {
 
     /**
-     * Creates an instance with the specified set of {@link Cookie}s.
+     * Creates an instance with a copy of the specified set of {@link Cookie}s.
      */
-    static Cookies from(Set<Cookie> cookies) {
-        return new DefaultCookies(cookies);
+    static Cookies of(Cookie... cookies) {
+        return new DefaultCookies(ImmutableSet.copyOf(cookies));
+    }
+
+    /**
+     * Creates an instance with a copy of the specified {@link Iterable} of {@link Cookie}s.
+     */
+    static Cookies copyOf(Iterable<? extends Cookie> cookies) {
+        requireNonNull(cookies, "cookies");
+        return new DefaultCookies(ImmutableSet.copyOf(cookies));
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/DefaultCookies.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/DefaultCookies.java
@@ -15,19 +15,27 @@
  */
 package com.linecorp.armeria.server.annotation;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.Set;
+
+import com.google.common.collect.ForwardingSet;
 
 import io.netty.handler.codec.http.cookie.Cookie;
 
 /**
- * An interface which holds decoded {@link Cookie} instances for an HTTP request.
+ * A default implementation of {@link Cookies} interface.
  */
-public interface Cookies extends Set<Cookie> {
+final class DefaultCookies extends ForwardingSet<Cookie> implements Cookies {
 
-    /**
-     * Creates an instance with the specified set of {@link Cookie}s.
-     */
-    static Cookies from(Set<Cookie> cookies) {
-        return new DefaultCookies(cookies);
+    private final Set<Cookie> delegate;
+
+    DefaultCookies(Set<Cookie> delegate) {
+        this.delegate = requireNonNull(delegate, "delegate");
+    }
+
+    @Override
+    protected Set<Cookie> delegate() {
+        return delegate;
     }
 }

--- a/site/src/sphinx/server-annotated-service.rst
+++ b/site/src/sphinx/server-annotated-service.rst
@@ -326,6 +326,7 @@ The following classes are automatically injected when you specify them on the pa
 - :api:`HttpRequest`
 - :api:`AggregatedHttpMessage`
 - :api:`HttpParameters`
+- :api:`Cookies`
 
 .. code-block:: java
 
@@ -349,6 +350,11 @@ The following classes are automatically injected when you specify them on the pa
         @Post("/hello4")
         public HttpResponse hello4(HttpParameters httpParameters) {
             // If a request has a url-encoded form as its body, it can be accessed via 'httpParameters'.
+        }
+
+        @Post("/hello5")
+        public HttpResponse hello5(Cookies cookies) {
+            // If 'Cookie' header exists, it will be injected into the specified 'cookies' parameter.
         }
     }
 


### PR DESCRIPTION
Motivation:
It would be better to inject `Cookie` header value into a parameter automatically when a user uses an annotated HTTP service.

Modifications:
- Add `Cookies` class to let Armeria know where `Cookie` header is injected into.

Result:
- Closes #1026