### PR TITLE
More sensible default DistributionStatisticConfig for Timer and Distr…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/metric/MoreMeters.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/MoreMeters.java
@@ -41,9 +41,27 @@ public final class MoreMeters {
 
     private static final double[] PERCENTILES = { 0, 0.5, 0.75, 0.9, 0.95, 0.98, 0.99, 0.999, 1.0 };
 
+    /**
+     * Export the percentile values only by default. We specify all properties so that we get consistent values
+     * even if Micrometer changes its defaults. Most notably, we changed {@code percentilePrecision},
+     * {@code expiry} and {@code bufferLength} due to the following reasons:
+     * <ul>
+     *   <li>The default {@code percentilePrecision} of 1 is way too inaccurate.</li>
+     *   <li>Histogram buckets should be rotated every minute rather than every some-arbitrary-seconds
+     *       because that fits better to human's mental model of time. Micrometer's 2 minutes / 3 buffers
+     *       (i.e. rotate every 40 seconds) does not make much sense.</li>
+     * </ul>
+     */
     private static volatile DistributionStatisticConfig distStatCfg =
             DistributionStatisticConfig.builder()
+                                       .percentilesHistogram(false)
+                                       .sla()
                                        .percentiles(PERCENTILES)
+                                       .percentilePrecision(2)
+                                       .minimumExpectedValue(1L)
+                                       .maximumExpectedValue(Long.MAX_VALUE)
+                                       .expiry(Duration.ofMinutes(3))
+                                       .bufferLength(3)
                                        .build();
 
     /**


### PR DESCRIPTION
…ibutionSummary

Related: https://github.com/micrometer-metrics/micrometer/commit/ef2dad5bd5542c6f88c02f11c6df93ebabe02e7c#diff-a428c30af987802231f5617fea57ea4dR38

Motivation:

Micrometer folks changed the default DistributionStatisticConfig in
Micrometer 1.0.3. Our users observed unexpectedly reduced accuracy in
their percentile values.

Modification:

- Define all properties related with percentile histograms so that our
  users are not surprised.

Result:

- Less surprises

Note: The values in this PR is not final. I'd like to listen to your preferences and choose the most sensible one. What `percentilePrecision`, `bufferLength` and `expiry` would you expect as a sensible default? /cc @imasahiro @taicki @huydx @anuraaga @jwills