### PR TITLE
Add documentation - production checklist / Deprecate ClientFactoryBuilder.socketOption() over channelOption()

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientFactory.java
@@ -97,7 +97,7 @@ final class HttpClientFactory extends AbstractClientFactory {
 
     HttpClientFactory(
             EventLoopGroup workerGroup, boolean shutdownWorkerGroupOnClose,
-            Map<ChannelOption<?>, Object> socketOptions,
+            Map<ChannelOption<?>, Object> channelOptions,
             Consumer<? super SslContextBuilder> sslContextCustomizer,
             Function<? super EventLoopGroup,
                     ? extends AddressResolverGroup<? extends InetSocketAddress>> addressResolverGroupFactory,
@@ -110,7 +110,7 @@ final class HttpClientFactory extends AbstractClientFactory {
         baseBootstrap.channel(TransportType.socketChannelType(workerGroup));
         baseBootstrap.resolver(addressResolverGroupFactory.apply(workerGroup));
 
-        socketOptions.forEach((option, value) -> {
+        channelOptions.forEach((option, value) -> {
             @SuppressWarnings("unchecked")
             final ChannelOption<Object> castOption = (ChannelOption<Object>) option;
             baseBootstrap.option(castOption, value);

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -31,7 +31,6 @@ import java.net.InetSocketAddress;
 import java.security.cert.CertificateException;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -66,6 +65,7 @@ import io.netty.channel.epoll.EpollChannelOption;
 import io.netty.handler.ssl.SslContext;
 import io.netty.util.DomainNameMapping;
 import io.netty.util.DomainNameMappingBuilder;
+import it.unimi.dsi.fastutil.objects.Object2ObjectArrayMap;
 
 /**
  * Builds a new {@link Server} and its {@link ServerConfig}.
@@ -144,8 +144,8 @@ public final class ServerBuilder {
     private VirtualHost defaultVirtualHost;
     private EventLoopGroup workerGroup = CommonPools.workerGroup();
     private boolean shutdownWorkerGroupOnStop;
-    private final Map<ChannelOption<?>, Object> channelOptions = new LinkedHashMap<>();
-    private final Map<ChannelOption<?>, Object> childChannelOptions = new LinkedHashMap<>();
+    private final Map<ChannelOption<?>, Object> channelOptions = new Object2ObjectArrayMap<>();
+    private final Map<ChannelOption<?>, Object> childChannelOptions = new Object2ObjectArrayMap<>();
     private int maxNumConnections = DEFAULT_MAX_NUM_CONNECTIONS;
     private long idleTimeoutMillis = Flags.defaultServerIdleTimeoutMillis();
     private long defaultRequestTimeoutMillis = Flags.defaultRequestTimeoutMillis();
@@ -347,7 +347,7 @@ public final class ServerBuilder {
                       "prohibited socket option: %s", option);
 
         option.validate(value);
-        this.channelOptions.put(option, value);
+        channelOptions.put(option, value);
         return this;
     }
 
@@ -367,7 +367,7 @@ public final class ServerBuilder {
                       "prohibited socket option: %s", option);
 
         option.validate(value);
-        this.childChannelOptions.put(option, value);
+        childChannelOptions.put(option, value);
         return this;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
@@ -31,8 +31,6 @@ import java.util.function.Consumer;
 
 import javax.annotation.Nullable;
 
-import com.google.common.collect.ImmutableMap;
-
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.internal.ConnectionLimitingHandler;
@@ -42,6 +40,7 @@ import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.util.DomainNameMapping;
 import io.netty.util.DomainNameMappingBuilder;
+import it.unimi.dsi.fastutil.objects.Object2ObjectArrayMap;
 
 /**
  * {@link Server} configuration.
@@ -136,9 +135,10 @@ public final class ServerConfig {
         this.meterRegistry = requireNonNull(meterRegistry, "meterRegistry");
         this.serviceLoggerPrefix = ServiceConfig.validateLoggerName(serviceLoggerPrefix, "serviceLoggerPrefix");
         this.accessLogWriter = requireNonNull(accessLogWriter, "accessLogWriter");
-        this.channelOptions = ImmutableMap.copyOf(requireNonNull(channelOptions, "channelOptions"));
-        this.childChannelOptions = ImmutableMap.copyOf(requireNonNull(childChannelOptions,
-                                                                      "childChannelOptions"));
+        this.channelOptions = Collections.unmodifiableMap(
+                new Object2ObjectArrayMap<>(requireNonNull(channelOptions, "channelOptions")));
+        this.childChannelOptions = Collections.unmodifiableMap(
+                new Object2ObjectArrayMap<>(requireNonNull(childChannelOptions, "childChannelOptions")));
 
         // Set localAddresses.
         final List<ServerPort> portsCopy = new ArrayList<>();

--- a/site/src/sphinx/advanced-production-checklist.rst
+++ b/site/src/sphinx/advanced-production-checklist.rst
@@ -1,0 +1,96 @@
+.. _advanced-production-checklist:
+
+Production checklist
+====================
+
+.. note::
+
+    Note that the advices in this page are not always applicable for every use case and thus should be
+    applied with caution. Do not apply the changes you really do not need.
+
+You may want to consider the following options before putting your Armeria application into production.
+
+- Specify the maximum number of accepted connections. The default is *unbounded*.
+
+  .. code-block:: java
+
+      import com.linecorp.armeria.server.ServerBuilder;
+
+      ServerBuilder sb = new ServerBuilder();
+      sb.maxNumConnections(500);
+
+- Specify an alternative ``blockingTaskExecutor`` based on expected workload if your server has
+  a :api:`Service` that uses it, such as :api:`TomcatService`, :api:`JettyService` and :api:`THttpService` with
+  synchronous service implementation. The default is a simple ``ThreadPoolExecutor`` with 200 threads and an
+  *unbounded* queue, provided by :api:`CommonPools`.
+
+  .. code-block:: java
+
+      import com.linecorp.armeria.server.ServerBuilder;
+
+      ServerBuilder sb = new ServerBuilder();
+      sb.blockingTaskExecutor(myBoundedExecutor);
+
+- Specify the default limits of an HTTP request or response.
+
+  .. code-block:: java
+
+      import java.time.Duration;
+      import com.linecorp.armeria.client.ClientBuilder;
+      import com.linecorp.armeria.server.ServerBuilder;
+
+      // Server-side
+      ServerBuilder sb = new ServerBuilder();
+      sb.defaultMaxRequestLength(1048576); // bytes (default: 10 MiB)
+      sb.defaultRequestTimeout(Duration.ofSeconds(7)); // (default: 10 seconds)
+
+      // Client-side
+      ClientBuilder cb = new ClientBuilder(...); // or HttpClientBuilder
+      cb.defaultMaxResponseLength(1048576); // bytes (default: 10 MiB)
+      cb.defaultResponseTimeout(Duration.ofSeconds(10)); // (default: 15 seconds)
+
+- Decorate your services with :api:`ThrottlingService` which lets you fail the incoming requests based on a
+  policy, such as 'fail if the rate of requests exceed a certain threshold.'
+
+  .. code-block:: java
+
+      import com.linecorp.armeria.server.throttling.RateLimitingThrottlingStrategy;
+      import com.linecorp.armeria.server.throttling.ThrottlingHttpService;
+
+      ServerBuilder sb = new ServerBuilder();
+      sb.service("/my_service", // Allow up to 1000 requests/sec.
+                 myService.decorate(ThrottlingHttpService.newDecorator(
+                         new RateLimitingThrottlingStrategy(1000.0))));
+
+- Decorate your clients with :api:`RetryingClient`. See :ref:`client-retry`.
+- Decorate your clients with :api:`CircuitBreakerClient`. See :ref:`client-circuit-breaker`.
+
+  .. tip::
+
+      You can use Armeria's :api:`CircuitBreaker` API for non-Armeria clients without circuit breaker support.
+      See :ref:`circuit-breaker-with-non-armeria-client`.
+
+- Tune the socket options.
+
+  .. code-block:: java
+
+      import com.linecorp.armeria.client.ClientBuilder;
+      import com.linecorp.armeria.client.ClientFactory;
+      import com.linecorp.armeria.client.ClientFactoryBuilder;
+      import com.linecorp.armeria.server.ServerBuilder;
+      import io.netty.channel.ChannelOption;
+
+      // Server-side
+      ServerBuilder sb = new ServerBuilder();
+      sb.channelOption(ChannelOption.SO_BACKLOG, ...);
+      sb.channelOption(ChannelOption.SO_SNDBUF, ...);
+      sb.channelOption(ChannelOption.SO_RCVBUF, ...);
+
+      // Client-side
+      ClientFactoryBuilder cfb = new ClientFactoryBuilder();
+      cfb.channelOption(ChannelOption.SO_REUSEADDR, ...);
+      cfb.channelOption(ChannelOption.SO_SNDBUF, ...);
+      cfb.channelOption(ChannelOption.SO_RCVBUF, ...);
+      ClientFactory cf = cfb.build();
+      ClientBuilder cb = new ClientBuilder(...);
+      cb.factory(cf);

--- a/site/src/sphinx/advanced.rst
+++ b/site/src/sphinx/advanced.rst
@@ -11,3 +11,4 @@ Advanced topics
     advanced-structured-logging-kafka
     advanced-zipkin
     advanced-zookeeper
+    advanced-production-checklist


### PR DESCRIPTION
Motivation:

A simple checklist before putting an Armeria application into production
would be very useful for our users.

Modifications:

- Added `advanced-production-checklist.rst` which is based on the recent
  Slack thread with @jwills, @anuraaga and @huydx
- Added how to use the `CircuitBreaker` API with non-Armeria clients
- Deprecate ClientFactoryBuilder.socketOption() with channelOption() for
  consistency
- Use Object2ObjectArrayMap for storing channel options

Result:

- Better UX
- A little bit of efficiency

/cc @jwills