### PR TITLE
Fix bugs where a resolved Endpoint is not handled correctly

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
@@ -249,14 +249,13 @@ public final class Endpoint implements Comparable<Endpoint> {
     /**
      * Returns the port number of this endpoint.
      *
-     * @param defaultPort the default port number to use when this endpoint does not have its port specified
+     * @param defaultValue the default value to return when this endpoint does not have its port specified
      *
      * @throws IllegalStateException if this endpoint is not a host endpoint
      */
-    public int port(int defaultPort) {
+    public int port(int defaultValue) {
         ensureSingle();
-        validatePort("defaultPort", defaultPort);
-        return port != 0 ? port : defaultPort;
+        return port != 0 ? port : defaultValue;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientDelegate.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientDelegate.java
@@ -22,6 +22,7 @@ import java.util.concurrent.CompletableFuture;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 
 import com.linecorp.armeria.client.pool.KeyedChannelPool;
@@ -57,7 +58,7 @@ final class HttpClientDelegate implements Client<HttpRequest, HttpResponse> {
             return HttpResponse.ofFailure(new IllegalArgumentException("invalid path: " + req.path()));
         }
 
-        final String host = extractHost(ctx, endpoint, req);
+        final String host = extractHost(ctx, req, endpoint);
         final EventLoop eventLoop = ctx.eventLoop();
         final PoolKey poolKey = new PoolKey(host, endpoint.ipAddr(),
                                             endpoint.port(), ctx.sessionProtocol());
@@ -85,7 +86,8 @@ final class HttpClientDelegate implements Client<HttpRequest, HttpResponse> {
         return res;
     }
 
-    private static String extractHost(ClientRequestContext ctx, Endpoint endpoint, HttpRequest req) {
+    @VisibleForTesting
+    static String extractHost(ClientRequestContext ctx, HttpRequest req, Endpoint endpoint) {
         final HttpHeaders additionalHeaders = ctx.additionalRequestHeaders();
         String authority = additionalHeaders.get(HttpHeaderNames.AUTHORITY);
         if (Strings.isNullOrEmpty(authority)) {

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientDelegate.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientDelegate.java
@@ -22,9 +22,13 @@ import java.util.concurrent.CompletableFuture;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Strings;
+
 import com.linecorp.armeria.client.pool.KeyedChannelPool;
 import com.linecorp.armeria.client.pool.PoolKey;
 import com.linecorp.armeria.common.ClosedSessionException;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.SessionProtocol;
@@ -53,8 +57,9 @@ final class HttpClientDelegate implements Client<HttpRequest, HttpResponse> {
             return HttpResponse.ofFailure(new IllegalArgumentException("invalid path: " + req.path()));
         }
 
+        final String host = extractHost(ctx, endpoint, req);
         final EventLoop eventLoop = ctx.eventLoop();
-        final PoolKey poolKey = new PoolKey(endpoint.host(), endpoint.ipAddr(),
+        final PoolKey poolKey = new PoolKey(host, endpoint.ipAddr(),
                                             endpoint.port(), ctx.sessionProtocol());
         final Future<Channel> channelFuture = factory.pool(eventLoop).acquire(poolKey);
         final DecodedHttpResponse res = new DecodedHttpResponse(eventLoop);
@@ -78,6 +83,42 @@ final class HttpClientDelegate implements Client<HttpRequest, HttpResponse> {
         }
 
         return res;
+    }
+
+    private static String extractHost(ClientRequestContext ctx, Endpoint endpoint, HttpRequest req) {
+        final HttpHeaders additionalHeaders = ctx.additionalRequestHeaders();
+        String authority = additionalHeaders.get(HttpHeaderNames.AUTHORITY);
+        if (Strings.isNullOrEmpty(authority)) {
+            authority = req.authority();
+            if (Strings.isNullOrEmpty(authority)) {
+                return endpoint.host();
+            }
+        }
+
+        if (authority.charAt(0) == '[') {
+            // Surrounded by '[' and ']'
+            final int closingBracketPos = authority.lastIndexOf(']');
+            if (closingBracketPos > 0) {
+                return authority.substring(1, closingBracketPos);
+            } else {
+                // Invalid authority - no matching ']'
+                return endpoint.host();
+            }
+        }
+
+        // Not surrounded by '[' and ']'
+        final int colonPos = authority.lastIndexOf(':');
+        if (colonPos > 0) {
+            // Strip the port number.
+            return authority.substring(0, colonPos);
+        }
+        if (colonPos < 0) {
+            // authority does not have a port number.
+            return authority;
+        }
+
+        // Invalid authority - ':' is the first character.
+        return endpoint.host();
     }
 
     private static boolean sanitizePath(HttpRequest req) {

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/KeyedCircuitBreakerMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/KeyedCircuitBreakerMapping.java
@@ -23,6 +23,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
 
 import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.RpcRequest;
 
@@ -76,13 +77,26 @@ public class KeyedCircuitBreakerMapping<K> implements CircuitBreakerMapping {
                 (ctx, req) -> req instanceof RpcRequest ? ((RpcRequest) req).method() : ctx.method().name();
 
         /**
-         * A {@link KeySelector} that returns a key consisted of remote host name and port number.
+         * A {@link KeySelector} that returns a key consisted of remote host name, IP address and port number.
          */
         KeySelector<String> HOST =
-                (ctx, req) -> ctx.endpoint().authority();
+                (ctx, req) -> {
+                    final Endpoint endpoint = ctx.endpoint();
+                    if (endpoint.isGroup()) {
+                        return endpoint.authority();
+                    } else {
+                        final String ipAddr = endpoint.ipAddr();
+                        if (ipAddr != null) {
+                            return endpoint.authority() + '/' + ipAddr;
+                        } else {
+                            return endpoint.authority();
+                        }
+                    }
+                };
 
         /**
-         * A {@link KeySelector} that returns a key consisted of remote host name, port number, and method name.
+         * A {@link KeySelector} that returns a key consisted of remote host name, IP address, port number
+         * and method name.
          */
         KeySelector<String> HOST_AND_METHOD =
                 (ctx, req) -> HOST.get(ctx, req) + '#' + METHOD.get(ctx, req);

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/KeyedCircuitBreakerMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/KeyedCircuitBreakerMapping.java
@@ -86,7 +86,7 @@ public class KeyedCircuitBreakerMapping<K> implements CircuitBreakerMapping {
                         return endpoint.authority();
                     } else {
                         final String ipAddr = endpoint.ipAddr();
-                        if (ipAddr != null) {
+                        if (ipAddr != null && !endpoint.host().equals(ipAddr)) {
                             return endpoint.authority() + '/' + ipAddr;
                         } else {
                             return endpoint.authority();

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroup.java
@@ -29,8 +29,6 @@ import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.SessionProtocol;
 
-import io.netty.util.NetUtil;
-
 /**
  * HTTP implementation of {@link HealthCheckedEndpointGroup}.
  */
@@ -110,7 +108,7 @@ public final class HttpHealthCheckedEndpointGroup extends HealthCheckedEndpointG
             } else {
                 final int port = endpoint.port(protocol.defaultPort());
                 final HttpClientBuilder builder;
-                if (NetUtil.isValidIpV4Address(ipAddr)) {
+                if (ipAddr.indexOf(':') < 0) {
                     builder = new HttpClientBuilder(scheme + "://" + ipAddr + ':' + port);
                 } else {
                     builder = new HttpClientBuilder(scheme + "://[" + ipAddr + "]:" + port);

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroup.java
@@ -23,9 +23,13 @@ import java.util.concurrent.CompletableFuture;
 import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.client.HttpClientBuilder;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
+import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.SessionProtocol;
+
+import io.netty.util.NetUtil;
 
 /**
  * HTTP implementation of {@link HealthCheckedEndpointGroup}.
@@ -98,8 +102,24 @@ public final class HttpHealthCheckedEndpointGroup extends HealthCheckedEndpointG
                                           Endpoint endpoint,
                                           SessionProtocol protocol,
                                           String healthCheckPath) {
-            httpClient = HttpClient.of(clientFactory,
-                                       protocol.uriText() + "://" + endpoint.authority());
+
+            final String scheme = protocol.uriText();
+            final String ipAddr = endpoint.ipAddr();
+            if (ipAddr == null) {
+                httpClient = HttpClient.of(clientFactory, scheme + "://" + endpoint.authority());
+            } else {
+                final int port = endpoint.port(protocol.defaultPort());
+                final HttpClientBuilder builder;
+                if (NetUtil.isValidIpV4Address(ipAddr)) {
+                    builder = new HttpClientBuilder(scheme + "://" + ipAddr + ':' + port);
+                } else {
+                    builder = new HttpClientBuilder(scheme + "://[" + ipAddr + "]:" + port);
+                }
+
+                builder.factory(clientFactory);
+                builder.setHttpHeader(HttpHeaderNames.AUTHORITY, endpoint.authority());
+                httpClient = builder.build();
+            }
             this.healthCheckPath = healthCheckPath;
         }
 

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientDelegateTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientDelegateTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client;
+
+import static com.linecorp.armeria.client.HttpClientDelegate.extractHost;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+
+public class HttpClientDelegateTest {
+    @Test
+    public void testExtractHost() {
+        // additionalRequestHeaders has the highest precedence.
+        assertThat(extractHost(context(HttpHeaders.of(HttpHeaderNames.AUTHORITY, "foo")),
+                               HttpRequest.of(HttpHeaders.of(HttpMethod.GET, "/")
+                                          .set(HttpHeaderNames.AUTHORITY, "bar:8080")),
+                               Endpoint.of("baz", 8080))).isEqualTo("foo");
+
+        // Request header
+        assertThat(extractHost(context(HttpHeaders.EMPTY_HEADERS),
+                               HttpRequest.of(HttpHeaders.of(HttpMethod.GET, "/")
+                                                         .set(HttpHeaderNames.AUTHORITY, "bar:8080")),
+                               Endpoint.of("baz", 8080))).isEqualTo("bar");
+
+        // Endpoint.host() has the lowest precedence.
+        assertThat(extractHost(context(HttpHeaders.EMPTY_HEADERS),
+                               HttpRequest.of(HttpMethod.GET, "/"),
+                               Endpoint.of("baz", 8080))).isEqualTo("baz");
+
+        // IPv6 address authority
+        assertThat(extractHost(context(HttpHeaders.of(HttpHeaderNames.AUTHORITY, "[::1]:8443")),
+                               HttpRequest.of(HttpMethod.GET, "/"),
+                               Endpoint.of("baz", 8080))).isEqualTo("::1");
+
+        // An invalid authority should be ignored.
+        assertThat(extractHost(context(HttpHeaders.of(HttpHeaderNames.AUTHORITY, "[::1")),
+                               HttpRequest.of(HttpMethod.GET, "/"),
+                               Endpoint.of("baz", 8080))).isEqualTo("baz");
+
+        assertThat(extractHost(context(HttpHeaders.of(HttpHeaderNames.AUTHORITY, ":8080")),
+                               HttpRequest.of(HttpMethod.GET, "/"),
+                               Endpoint.of("baz", 8080))).isEqualTo("baz");
+    }
+
+    private static ClientRequestContext context(HttpHeaders additionalHeaders) {
+        final ClientRequestContext ctx = mock(ClientRequestContext.class);
+        when(ctx.additionalRequestHeaders()).thenReturn(additionalHeaders.asImmutable());
+        return ctx;
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/KeyedCircuitBreakerMappingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/KeyedCircuitBreakerMappingTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client.circuitbreaker;
+
+import static com.linecorp.armeria.client.circuitbreaker.KeyedCircuitBreakerMapping.KeySelector.HOST;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.Endpoint;
+
+public class KeyedCircuitBreakerMappingTest {
+    @Test
+    public void hostSelector() throws Exception {
+        assertThat(HOST.get(context(Endpoint.ofGroup("foo")), null)).isEqualTo("group:foo");
+        assertThat(HOST.get(context(Endpoint.of("foo")), null)).isEqualTo("foo");
+        assertThat(HOST.get(context(Endpoint.of("foo", 8080)), null)).isEqualTo("foo:8080");
+        assertThat(HOST.get(context(Endpoint.of("foo").withIpAddr("1.2.3.4")), null)).isEqualTo("foo/1.2.3.4");
+        assertThat(HOST.get(context(Endpoint.of("1.2.3.4", 80)), null)).isEqualTo("1.2.3.4:80");
+        assertThat(HOST.get(context(Endpoint.of("::1", 80)), null)).isEqualTo("[::1]:80");
+    }
+
+    private static ClientRequestContext context(Endpoint endpoint) {
+        final ClientRequestContext ctx = mock(ClientRequestContext.class);
+        when(ctx.endpoint()).thenReturn(endpoint);
+        return ctx;
+    }
+}


### PR DESCRIPTION
Motivation:

Endpoint can have an IP address with its host name, which is called
'resolved Endpoint'. This is useful when you signify a specific host out
of many that have the same host name but different IP addresses, which
is often found when using a DnsEndpointGroup.

However, there are a few places in Armeria that the resolved Endpoints
with the same host name and different IP addresses are not handled
properly:

- KeyedCircuitBreakerMapping.KeySelector.HOST does not include an IP
  address in the return value. This can make a CircuitBreaker enter the
  OPEN state for all endpoints in a DnsEndpointGroup even if only one of
  them is faulty.
- HttpHealthCheckedEndpointGroup does not use an IP address when sending
  a health check request. This can make the health checker send a health
  check request to a wrong host.

Modifications:

- Fix KeyedCircuitBreakerMapping.KeySelector.HOST so that it includes an
  IP address in the return value
- Fix HttpHealthCheckedEndpointGroup so that it uses an IP address when
  sending a health check request
- Modify HttpClientDelegate to extract the remote host name from the
  `:authority` header so that SNI works as expected.
  - Add the test case to HttpClientSniTest
- Miscellaneous:
  - Allow specifying any integer value as a parameter of Endpoint.port(int)
    so that a user can use it to check if port was specified or not:

        if (endpoint.port(-1) == -1) { /* port not specified */ }

Result:

- No unexpected misbehavior of CircuitBreakers and HttpHealthCheckedEndpointGroup
- Client-side SNI works when a user specified a custom `:authority` header.
