### PR TITLE
Add more methods related with accessing IP addresses to Endpoint

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientDelegate.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientDelegate.java
@@ -28,8 +28,6 @@ import com.google.common.base.Strings;
 import com.linecorp.armeria.client.pool.KeyedChannelPool;
 import com.linecorp.armeria.client.pool.PoolKey;
 import com.linecorp.armeria.common.ClosedSessionException;
-import com.linecorp.armeria.common.HttpHeaderNames;
-import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.SessionProtocol;
@@ -88,8 +86,7 @@ final class HttpClientDelegate implements Client<HttpRequest, HttpResponse> {
 
     @VisibleForTesting
     static String extractHost(ClientRequestContext ctx, HttpRequest req, Endpoint endpoint) {
-        final HttpHeaders additionalHeaders = ctx.additionalRequestHeaders();
-        String authority = additionalHeaders.get(HttpHeaderNames.AUTHORITY);
+        String authority = ctx.additionalRequestHeaders().authority();
         if (Strings.isNullOrEmpty(authority)) {
             authority = req.authority();
             if (Strings.isNullOrEmpty(authority)) {

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/KeyedCircuitBreakerMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/KeyedCircuitBreakerMapping.java
@@ -86,10 +86,10 @@ public class KeyedCircuitBreakerMapping<K> implements CircuitBreakerMapping {
                         return endpoint.authority();
                     } else {
                         final String ipAddr = endpoint.ipAddr();
-                        if (ipAddr != null && !endpoint.host().equals(ipAddr)) {
-                            return endpoint.authority() + '/' + ipAddr;
-                        } else {
+                        if (ipAddr == null || endpoint.isIpAddrOnly()) {
                             return endpoint.authority();
+                        } else {
+                            return endpoint.authority() + '/' + ipAddr;
                         }
                     }
                 };

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroup.java
@@ -17,6 +17,7 @@ package com.linecorp.armeria.client.endpoint.healthcheck;
 
 import static java.util.Objects.requireNonNull;
 
+import java.net.StandardProtocolFamily;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 
@@ -108,7 +109,7 @@ public final class HttpHealthCheckedEndpointGroup extends HealthCheckedEndpointG
             } else {
                 final int port = endpoint.port(protocol.defaultPort());
                 final HttpClientBuilder builder;
-                if (ipAddr.indexOf(':') < 0) {
+                if (endpoint.ipFamily() == StandardProtocolFamily.INET) {
                     builder = new HttpClientBuilder(scheme + "://" + ipAddr + ':' + port);
                 } else {
                     builder = new HttpClientBuilder(scheme + "://[" + ipAddr + "]:" + port);


### PR DESCRIPTION
Motivation:

Endpoint internally knows:

- whether it is hostname-only endpoint or IP-address-only endpoint
- whether its IP address is IPv4 or IPv6

However, we do not provide any getters for such information.

Modifications:

- Add Endpoint.hasIpAddr()
- Add Endpoint.isIpAddrOnly()
- Add Endpoint.ipFamily()
- .. and use the new methods where applicable

Result:

- Efficiency