### PR TITLE
More robust host name extraction in HttpClientDelegate

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientDelegateTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientDelegateTest.java
@@ -60,6 +60,18 @@ public class HttpClientDelegateTest {
         assertThat(extractHost(context(HttpHeaders.of(HttpHeaderNames.AUTHORITY, ":8080")),
                                HttpRequest.of(HttpMethod.GET, "/"),
                                Endpoint.of("baz", 8080))).isEqualTo("baz");
+
+        // If additionalRequestHeader's authority is invalid but req.authority() is valid,
+        // use the authority from 'req'.
+        assertThat(extractHost(context(HttpHeaders.of(HttpHeaderNames.AUTHORITY, "[::1")),
+                               HttpRequest.of(HttpHeaders.of(HttpMethod.GET, "/")
+                                                         .set(HttpHeaderNames.AUTHORITY, "bar")),
+                               Endpoint.of("baz", 8080))).isEqualTo("bar");
+
+        assertThat(extractHost(context(HttpHeaders.of(HttpHeaderNames.AUTHORITY, ":8080")),
+                               HttpRequest.of(HttpHeaders.of(HttpMethod.GET, "/")
+                                                         .set(HttpHeaderNames.AUTHORITY, "bar")),
+                               Endpoint.of("baz", 8080))).isEqualTo("bar");
     }
 
     private static ClientRequestContext context(HttpHeaders additionalHeaders) {


### PR DESCRIPTION
Motivation:

HttpClientDelegate.extractHost() currently always falls back to
`Endpoint.host()` when `ctx.additionalRequestHeaders().authority()` is
not valid. Instead, we could try to extract a host name from
`req.authority()` before falling back to `Endpoint.host()`.

Modifications:

- Try to extract a host name from `req.authority()` rather than falling
  back immediately to `Endpoint.host()` when `ctx.additionalRequestHeaders()`
  contains an invalid authority.

Result:

- Robustness