### PR TITLE
Fill all necessary pseudo headers in RequestLog headers / Deprecate RequestLog.host() in favor of authority()

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/HttpRequestSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpRequestSubscriber.java
@@ -42,7 +42,6 @@ import com.linecorp.armeria.common.stream.AbortedStreamException;
 import com.linecorp.armeria.common.stream.ClosedPublisherException;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.internal.HttpObjectEncoder;
-import com.linecorp.armeria.internal.logging.LoggingUtil;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
@@ -151,11 +150,10 @@ final class HttpRequestSubscriber implements Subscriber<HttpObject>, ChannelFutu
         }
 
         final HttpHeaders firstHeaders = autoFillHeaders(ch);
-        final String host = LoggingUtil.remoteHost(firstHeaders, ch);
 
         final SessionProtocol protocol = session.protocol();
         assert protocol != null;
-        logBuilder.startRequest(ch, protocol, host);
+        logBuilder.startRequest(ch, protocol);
         logBuilder.requestHeaders(firstHeaders);
 
         if (request.isEmpty()) {

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultHttpHeaders.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultHttpHeaders.java
@@ -100,11 +100,8 @@ public final class DefaultHttpHeaders
             return null;
         }
 
-        try {
-            return this.method = HttpMethod.valueOf(methodStr);
-        } catch (IllegalArgumentException ignored) {
-            throw new IllegalStateException("unknown method: " + methodStr);
-        }
+        return this.method = HttpMethod.isSupported(methodStr) ? HttpMethod.valueOf(methodStr)
+                                                               : HttpMethod.UNKNOWN;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/HttpHeaders.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpHeaders.java
@@ -120,6 +120,8 @@ public interface HttpHeaders extends HttpObject, Headers<AsciiString, String, Ht
 
     /**
      * Gets the {@link HttpHeaderNames#METHOD} header or {@code null} if there is no such header.
+     * {@link HttpMethod#UNKNOWN} is returned if the value of the {@link HttpHeaderNames#METHOD} header is
+     * not defined in {@link HttpMethod}.
      */
     @Nullable
     HttpMethod method();

--- a/core/src/main/java/com/linecorp/armeria/common/HttpMethod.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpMethod.java
@@ -40,7 +40,7 @@ public enum HttpMethod {
     // Forked from Netty at 93b144b7b4872ea623a378c75b92d33bea28ab51
 
     /**
-     * The OPTIONS method represents a request for information about the communication options
+     * The OPTIONS method which represents a request for information about the communication options
      * available on the request/response chain identified by the Request-URI. This method allows
      * the client to determine the options and/or requirements associated with a resource, or the
      * capabilities of a server, without implying a resource action or initiating a resource
@@ -49,7 +49,7 @@ public enum HttpMethod {
     OPTIONS,
 
     /**
-     * The GET method means retrieve whatever information (in the form of an entity) is identified
+     * The GET method which means retrieve whatever information (in the form of an entity) is identified
      * by the Request-URI.  If the Request-URI refers to a data-producing process, it is the
      * produced data which shall be returned as the entity in the response and not the source text
      * of the process, unless that text happens to be the output of the process.
@@ -57,45 +57,51 @@ public enum HttpMethod {
     GET,
 
     /**
-     * The HEAD method is identical to GET except that the server MUST NOT return a message-body
+     * The HEAD method which is identical to GET except that the server MUST NOT return a message-body
      * in the response.
      */
     HEAD,
 
     /**
-     * The POST method is used to request that the origin server accept the entity enclosed in the
+     * The POST method which is used to request that the origin server accept the entity enclosed in the
      * request as a new subordinate of the resource identified by the Request-URI in the
      * Request-Line.
      */
     POST,
 
     /**
-     * The PUT method requests that the enclosed entity be stored under the supplied Request-URI.
+     * The PUT method which requests that the enclosed entity be stored under the supplied Request-URI.
      */
     PUT,
 
     /**
-     * The PATCH method requests that a set of changes described in the
+     * The PATCH method which requests that a set of changes described in the
      * request entity be applied to the resource identified by the Request-URI.
      */
     PATCH,
 
     /**
-     * The DELETE method requests that the origin server delete the resource identified by the
+     * The DELETE method which requests that the origin server delete the resource identified by the
      * Request-URI.
      */
     DELETE,
 
     /**
-     * The TRACE method is used to invoke a remote, application-layer loop- back of the request
+     * The TRACE method which is used to invoke a remote, application-layer loop-back of the request
      * message.
      */
     TRACE,
 
     /**
-     * The CONNECT method is used for a proxy that can dynamically switch to being a tunnel.
+     * The CONNECT method which is used for a proxy that can dynamically switch to being a tunnel.
      */
-    CONNECT;
+    CONNECT,
+
+    /**
+     * A special method which represents the client sent a method that is none of the constants defined in
+     * this enum.
+     */
+    UNKNOWN;
 
     /**
      * Returns whether the specified {@link String} is one of the supported method names.

--- a/core/src/main/java/com/linecorp/armeria/common/HttpStatus.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpStatus.java
@@ -312,6 +312,11 @@ public final class HttpStatus implements Comparable<HttpStatus> {
     public static final HttpStatus NETWORK_AUTHENTICATION_REQUIRED =
             newConstant(511, "Network Authentication Required");
 
+    /**
+     * A special status code '0' which represents that the response status is unknown.
+     */
+    public static final HttpStatus UNKNOWN = newConstant(0, "Unknown reason");
+
     static {
         for (int i = 0; i < 1000; i++) {
             if (!map.containsKey(i)) {

--- a/core/src/main/java/com/linecorp/armeria/common/logging/NoopRequestLogBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/NoopRequestLogBuilder.java
@@ -33,7 +33,7 @@ final class NoopRequestLogBuilder implements RequestLogBuilder {
     public void endResponseWithLastChild() {}
 
     @Override
-    public void startRequest(Channel ch, SessionProtocol sessionProtocol, String host) {}
+    public void startRequest(Channel ch, SessionProtocol sessionProtocol) {}
 
     @Override
     public void serializationFormat(SerializationFormat serializationFormat) {}

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogBuilder.java
@@ -56,11 +56,30 @@ public interface RequestLogBuilder {
      * properties:
      * <ul>
      *   <li>{@link RequestLog#requestStartTimeMillis()}</li>
+     *   <li>{@link RequestLog#channel()}</li>
      *   <li>{@link RequestLog#sessionProtocol()}</li>
      *   <li>{@link RequestLog#host()}</li>
      * </ul>
      */
-    void startRequest(Channel channel, SessionProtocol sessionProtocol, String host);
+    void startRequest(Channel channel, SessionProtocol sessionProtocol);
+
+    /**
+     * Starts the collection of information for the {@link Request}. This method sets the following
+     * properties:
+     * <ul>
+     *   <li>{@link RequestLog#requestStartTimeMillis()}</li>
+     *   <li>{@link RequestLog#channel()}</li>
+     *   <li>{@link RequestLog#sessionProtocol()}</li>
+     *   <li>{@link RequestLog#host()}</li>
+     * </ul>
+     *
+     * @deprecated Use {@link #startRequest(Channel, SessionProtocol)}.
+     */
+    @Deprecated
+    default void startRequest(Channel channel, SessionProtocol sessionProtocol,
+                              @SuppressWarnings("unused") String host) {
+        startRequest(channel, sessionProtocol);
+    }
 
     /**
      * Sets the {@link SerializationFormat}.

--- a/core/src/main/java/com/linecorp/armeria/common/metric/MeterIdPrefixFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/MeterIdPrefixFunction.java
@@ -85,9 +85,8 @@ public interface MeterIdPrefixFunction {
                 tags.add(Tag.of("pathMapping", sCtx.pathMapping().meterTag()));
             }
 
-            if (log.isAvailable(RequestLogAvailability.RESPONSE_HEADERS) &&
-                log.status() != null) {
-                tags.add(Tag.of("httpStatus", String.valueOf(log.statusCode())));
+            if (log.isAvailable(RequestLogAvailability.RESPONSE_HEADERS)) {
+                tags.add(Tag.of("httpStatus", log.status().codeAsText()));
             }
 
             return new MeterIdPrefix(name, tags);

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
@@ -111,7 +111,7 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
         this.proxiedAddresses = proxiedAddresses;
 
         log = new DefaultRequestLog(this);
-        log.startRequest(ch, sessionProtocol, cfg.virtualHost().defaultHostname());
+        log.startRequest(ch, sessionProtocol);
         logger = newLogger(cfg);
 
         final ServerConfig serverCfg = cfg.server().config();
@@ -154,7 +154,9 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
     private HttpHeaders createAdditionalHeadersIfAbsent() {
         final HttpHeaders additionalResponseHeaders = this.additionalResponseHeaders;
         if (additionalResponseHeaders == null) {
-            return this.additionalResponseHeaders = new DefaultHttpHeaders();
+            final HttpHeaders newHeaders = new DefaultHttpHeaders();
+            this.additionalResponseHeaders = newHeaders;
+            return newHeaders;
         } else {
             return additionalResponseHeaders;
         }
@@ -292,6 +294,7 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
 
     @Override
     public HttpHeaders additionalResponseHeaders() {
+        final HttpHeaders additionalResponseHeaders = this.additionalResponseHeaders;
         if (additionalResponseHeaders == null) {
             return HttpHeaders.EMPTY_HEADERS;
         }

--- a/core/src/main/java/com/linecorp/armeria/server/logging/AccessLogComponent.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/AccessLogComponent.java
@@ -261,10 +261,9 @@ interface AccessLogComponent {
                 case REQUEST_LINE:
                     final StringBuilder requestLine = new StringBuilder();
 
-                    final HttpHeaders headers = log.requestHeaders();
-                    requestLine.append(headers.method().name())
+                    requestLine.append(log.method())
                                .append(' ')
-                               .append(headers.path());
+                               .append(log.requestHeaders().path());
 
                     final Object requestContent = log.requestContent();
                     if (requestContent instanceof RpcRequest) {
@@ -439,7 +438,15 @@ interface AccessLogComponent {
                 case "scheme":
                     return RequestLog::scheme;
                 case "host":
-                    return RequestLog::host;
+                    return log -> {
+                        final String authority = log.responseHeaders().authority();
+                        if ("?".equals(authority)) {
+                            final InetSocketAddress remoteAddr = log.context().remoteAddress();
+                            assert remoteAddr != null;
+                            return remoteAddr.getHostString();
+                        }
+                        return authority;
+                    };
                 case "status":
                     return RequestLog::status;
                 case "statusCode":

--- a/core/src/test/java/com/linecorp/armeria/internal/metric/RequestMetricSupportTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/metric/RequestMetricSupportTest.java
@@ -52,7 +52,7 @@ public class RequestMetricSupportTest {
 
         final MeterIdPrefixFunction meterIdPrefixFunction = MeterIdPrefixFunction.ofDefault("foo");
 
-        ctx.logBuilder().startRequest(mock(Channel.class), SessionProtocol.H2C, "example.com");
+        ctx.logBuilder().startRequest(mock(Channel.class), SessionProtocol.H2C);
         RequestMetricSupport.setup(ctx, meterIdPrefixFunction);
 
         ctx.logBuilder().requestHeaders(HttpHeaders.of(HttpMethod.POST, "/foo"));
@@ -90,7 +90,7 @@ public class RequestMetricSupportTest {
 
         final MeterIdPrefixFunction meterIdPrefixFunction = MeterIdPrefixFunction.ofDefault("foo");
 
-        ctx.logBuilder().startRequest(mock(Channel.class), SessionProtocol.H2C, "example.com");
+        ctx.logBuilder().startRequest(mock(Channel.class), SessionProtocol.H2C);
         RequestMetricSupport.setup(ctx, meterIdPrefixFunction);
 
         ctx.logBuilder().requestHeaders(HttpHeaders.of(HttpMethod.POST, "/foo"));
@@ -120,7 +120,7 @@ public class RequestMetricSupportTest {
 
         final MeterIdPrefixFunction meterIdPrefixFunction = MeterIdPrefixFunction.ofDefault("bar");
 
-        ctx.logBuilder().startRequest(mock(Channel.class), SessionProtocol.H2C, "example.com");
+        ctx.logBuilder().startRequest(mock(Channel.class), SessionProtocol.H2C);
         RequestMetricSupport.setup(ctx, meterIdPrefixFunction);
 
         ctx.logBuilder().requestHeaders(HttpHeaders.of(HttpMethod.POST, "/bar"));

--- a/core/src/test/java/com/linecorp/armeria/server/logging/AccessLogFormatsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/logging/AccessLogFormatsTest.java
@@ -185,7 +185,7 @@ public class AccessLogFormatsTest {
 
         ctx.attr(Attr.ATTR_KEY).set(new Attr("line"));
 
-        log.startRequest(channel, SessionProtocol.H2, "www.example.com");
+        log.startRequest(channel, SessionProtocol.H2);
         log.requestHeaders(HttpHeaders.of(HttpMethod.GET, "/armeria/log")
                                       .add(HttpHeaderNames.USER_AGENT, "armeria/x.y.z")
                                       .add(HttpHeaderNames.REFERER, "http://log.example.com")
@@ -259,7 +259,7 @@ public class AccessLogFormatsTest {
         log.addListener(l -> assertThat(AccessLogger.format(AccessLogFormats.COMMON, l))
                 .endsWith(expectedLogMessage), RequestLogAvailability.COMPLETE);
 
-        log.startRequest(channel, SessionProtocol.H2, "www.example.com");
+        log.startRequest(channel, SessionProtocol.H2);
         log.requestHeaders(HttpHeaders.of(HttpMethod.GET, "/armeria/log")
                                       .add(HttpHeaderNames.USER_AGENT, "armeria/x.y.z")
                                       .add(HttpHeaderNames.REFERER, "http://log.example.com")
@@ -286,7 +286,7 @@ public class AccessLogFormatsTest {
 
         List<AccessLogComponent> format;
 
-        log.startRequest(channel, SessionProtocol.H2, "www.example.com");
+        log.startRequest(channel, SessionProtocol.H2);
         log.requestHeaders(HttpHeaders.of(HttpMethod.GET, "/armeria/log"));
 
         final Instant requestStartTime = Instant.ofEpochMilli(requestStartTimeMillis);
@@ -343,7 +343,7 @@ public class AccessLogFormatsTest {
         final DummyRequestContext ctx = new DummyRequestContext();
         final DefaultRequestLog log = spy(new DefaultRequestLog(ctx));
 
-        log.startRequest(channel, SessionProtocol.H2, "www.example.com");
+        log.startRequest(channel, SessionProtocol.H2);
 
         // To generate the same datetime string always.
         when(log.requestStartTimeMillis()).thenReturn(requestStartTimeMillis);

--- a/logback/src/main/java/com/linecorp/armeria/common/logback/RequestContextExporter.java
+++ b/logback/src/main/java/com/linecorp/armeria/common/logback/RequestContextExporter.java
@@ -55,7 +55,6 @@ import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpRequest;
-import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.RpcRequest;
@@ -64,7 +63,6 @@ import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.logging.RequestLogAvailability;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
-import io.netty.channel.Channel;
 import io.netty.util.AsciiString;
 import io.netty.util.AttributeKey;
 
@@ -238,17 +236,8 @@ final class RequestContextExporter {
         }
 
         if (log.isAvailable(RequestLogAvailability.REQUEST_START)) {
-            String authority = log.host();
-            if (authority != null) {
-                final Channel ch = log.channel();
-                assert ch != null;
-                final InetSocketAddress addr = (InetSocketAddress)
-                        (ctx instanceof ServiceRequestContext ? ch.localAddress() : ch.remoteAddress());
-                final int port = addr.getPort();
-
-                if (ctx.sessionProtocol().defaultPort() != port) {
-                    authority = authority + ':' + port;
-                }
+            final String authority = log.authority();
+            if (!"?".equals(authority)) {
                 out.put(REQ_AUTHORITY.mdcKey, authority);
                 return;
             }
@@ -318,8 +307,7 @@ final class RequestContextExporter {
 
     private static void exportStatusCode(Map<String, String> out, RequestLog log) {
         if (log.isAvailable(RequestLogAvailability.RESPONSE_HEADERS)) {
-            final HttpStatus status = log.status();
-            out.put(RES_STATUS_CODE.mdcKey, status != null ? status.codeAsText() : "-1");
+            out.put(RES_STATUS_CODE.mdcKey, log.status().codeAsText());
         }
     }
 

--- a/zipkin/src/main/java/com/linecorp/armeria/client/tracing/HttpTracingClient.java
+++ b/zipkin/src/main/java/com/linecorp/armeria/client/tracing/HttpTracingClient.java
@@ -127,10 +127,15 @@ public class HttpTracingClient extends SimpleDecoratingClient<HttpRequest, HttpR
         final String remoteServiceName;
         if (this.remoteServiceName != null) {
             remoteServiceName = this.remoteServiceName;
-        } else if (log.host() != null) {
-            remoteServiceName = log.host();
         } else {
-            remoteServiceName = null;
+            final String authority = log.requestHeaders().authority();
+            if (!"?".equals(authority)) {
+                remoteServiceName = authority;
+            } else if (address != null) {
+                remoteServiceName = String.valueOf(remoteAddress);
+            } else {
+                remoteServiceName = null;
+            }
         }
 
         if (remoteServiceName == null && address == null) {

--- a/zipkin/src/main/java/com/linecorp/armeria/internal/tracing/SpanTags.java
+++ b/zipkin/src/main/java/com/linecorp/armeria/internal/tracing/SpanTags.java
@@ -32,13 +32,13 @@ public final class SpanTags {
      * Adds information about the raw HTTP request, RPC request, and endpoint to the span.
      */
     public static void addTags(Span span, RequestLog log) {
-        if (log.host() != null) {
-            span.tag("http.host", log.host());
-        }
+        final String host = log.requestHeaders().authority();
+        assert host != null;
+        span.tag("http.host", host);
         final StringBuilder uriBuilder = new StringBuilder()
                 .append(log.scheme().uriText())
                 .append("://")
-                .append(log.host())
+                .append(host)
                 .append(log.path());
         if (log.query() != null) {
             uriBuilder.append('?').append(log.query());
@@ -46,7 +46,7 @@ public final class SpanTags {
         span.tag("http.method", log.method().name())
             .tag("http.path", log.path())
             .tag("http.url", uriBuilder.toString())
-            .tag("http.status_code", String.valueOf(log.statusCode()));
+            .tag("http.status_code", log.status().codeAsText());
         final Throwable responseCause = log.responseCause();
         if (responseCause != null) {
             span.tag("error", responseCause.toString());


### PR DESCRIPTION
Motivation:

It is currently possible that `RequestLog.requestHeaders()` and
`responseHeaders()` return an empty `HttpHeaders`, which can trigger
various issues because we often assume they have at least essential
HTTP headers such as `:scheme`, `:authority`, `:method`, `:path` and
`:status`.

Modifications:

- Send a `400 Bad Request` response if a request does not have the
  `:method` header.
- Do not fail with an exception if a client sent a weird method name
  which is not recognized by `HttpMethod.valueOf()`.
  - Add `HttpMethod.UNKNOWN` to represent an 'unknown' method
  - Add `HttpStatus.UNKNOWN` to represent an 'unknown' status
- Auto-fill `:scheme` header if missing.
- Return a dummy `HttpHeaders` with the essential headers are filled
  instead of returning an empty `HttpHeaders`.
- Deprecate `RequestLog.host()` in favor of `RequestLog.authority()`

Result:

- Robustness