### PR TITLE
Mitigate to return CompletionStage instead of CompletableFuture where…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClient.java
@@ -19,7 +19,7 @@ package com.linecorp.armeria.client.circuitbreaker;
 import static com.linecorp.armeria.common.util.Functions.voidFunction;
 import static java.util.Objects.requireNonNull;
 
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -89,7 +89,7 @@ public abstract class CircuitBreakerClient<I extends Request, O extends Response
      * of the specified {@code future}. If the completed value is {@code null}, this doesn't do anything.
      */
     protected static void reportSuccessOrFailure(CircuitBreaker circuitBreaker,
-                                                 CompletableFuture<Boolean> future) {
+                                                 CompletionStage<Boolean> future) {
         future.handle(voidFunction((success, unused) -> {
             if (success != null) {
                 if (success) {

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerStrategy.java
@@ -16,7 +16,7 @@
 
 package com.linecorp.armeria.client.circuitbreaker;
 
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.function.BiFunction;
 
 import com.linecorp.armeria.common.HttpResponse;
@@ -60,11 +60,11 @@ public interface CircuitBreakerStrategy<T extends Response> {
     }
 
     /**
-     * Returns a {@link CompletableFuture} that contains {@code true}, {@code false} or
+     * Returns a {@link CompletionStage} that contains {@code true}, {@code false} or
      * {@code null} according to the specified {@link Response}. If {@code true} is returned,
      * {@link CircuitBreaker#onSuccess()} is called so that the {@link CircuitBreaker} increases its success
      * count and use it to make a decision to close or open the switch. If {@code false} is returned, it works
      * the other way around. If {@code null} is returned, the {@link CircuitBreaker} ignores it.
      */
-    CompletableFuture<Boolean> shouldReportAsSuccess(T response);
+    CompletionStage<Boolean> shouldReportAsSuccess(T response);
 }

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/HttpStatusBasedCircuitBreakerStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/HttpStatusBasedCircuitBreakerStrategy.java
@@ -19,6 +19,7 @@ package com.linecorp.armeria.client.circuitbreaker;
 import static java.util.Objects.requireNonNull;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.function.BiFunction;
 
 import com.linecorp.armeria.common.HttpHeaders;
@@ -35,7 +36,7 @@ final class HttpStatusBasedCircuitBreakerStrategy implements CircuitBreakerStrat
     }
 
     @Override
-    public CompletableFuture<Boolean> shouldReportAsSuccess(HttpResponse response) {
+    public CompletionStage<Boolean> shouldReportAsSuccess(HttpResponse response) {
         final CompletableFuture<HttpHeaders> future = new CompletableFuture<>();
         final HttpHeaderSubscriber subscriber = new HttpHeaderSubscriber(future);
         response.completionFuture().whenComplete(subscriber);

--- a/core/src/main/java/com/linecorp/armeria/client/retry/HttpStatusBasedRetryStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/HttpStatusBasedRetryStrategy.java
@@ -19,6 +19,7 @@ package com.linecorp.armeria.client.retry;
 import static java.util.Objects.requireNonNull;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.function.BiFunction;
 
 import com.linecorp.armeria.common.HttpHeaders;
@@ -43,7 +44,7 @@ final class HttpStatusBasedRetryStrategy implements RetryStrategy<HttpRequest, H
     }
 
     @Override
-    public CompletableFuture<Backoff> shouldRetry(HttpRequest request, HttpResponse response) {
+    public CompletionStage<Backoff> shouldRetry(HttpRequest request, HttpResponse response) {
         final CompletableFuture<HttpHeaders> future = new CompletableFuture<>();
         final HttpHeaderSubscriber subscriber = new HttpHeaderSubscriber(future);
         response.completionFuture().whenComplete(subscriber);

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryStrategy.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.client.retry;
 import static java.util.Objects.requireNonNull;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.function.BiFunction;
 
 import com.linecorp.armeria.client.ResponseTimeoutException;
@@ -84,7 +85,7 @@ public interface RetryStrategy<I extends Request, O extends Response> {
     }
 
     /**
-     * Returns a {@link CompletableFuture} that contains {@link Backoff} which will be used for retry.
+     * Returns a {@link CompletionStage} that contains {@link Backoff} which will be used for retry.
      * If the condition does not match, this will return {@code null} to stop retry attempt.
      * Note that {@link ResponseTimeoutException} is not retriable for the whole retry, but each attempt.
      *
@@ -93,5 +94,5 @@ public interface RetryStrategy<I extends Request, O extends Response> {
      * @see <a href="https://line.github.io/armeria/advanced-retry.html#per-attempt-timeout">Per-attempt
      *      timeout</a>
      */
-    CompletableFuture<Backoff> shouldRetry(I request, O response);
+    CompletionStage<Backoff> shouldRetry(I request, O response);
 }

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/ManagedHttpHealthCheckService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/ManagedHttpHealthCheckService.java
@@ -17,7 +17,7 @@
 package com.linecorp.armeria.server.healthcheck;
 
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import com.google.common.base.Ascii;
 
@@ -42,7 +42,7 @@ import com.linecorp.armeria.server.ServiceRequestContext;
  * <pre>{@code
  * > Server server = new ServerBuilder().serviceUnder("health", new ManagedHttpHealthCheckService() {
  * >         @Override
- * >         public CompletableFuture<Optional<Boolean>> mode(HttpRequest req) {
+ * >         public CompletionStage<Optional<Boolean>> mode(HttpRequest req) {
  * >             return CompletableFuture.completedFuture(Optional.empty());
  * >         }
  * >     }).build();
@@ -66,7 +66,7 @@ public class ManagedHttpHealthCheckService extends HttpHealthCheckService {
     /**
      * Updates health status using the specified {@link HttpRequest}.
      */
-    private CompletableFuture<AggregatedHttpMessage> updateHealthStatus(
+    private CompletionStage<AggregatedHttpMessage> updateHealthStatus(
             ServiceRequestContext ctx, HttpRequest req) {
         return mode(ctx, req).thenApply(mode -> {
             if (!mode.isPresent()) {
@@ -89,8 +89,8 @@ public class ManagedHttpHealthCheckService extends HttpHealthCheckService {
      *
      * @param req HttpRequest
      */
-    protected CompletableFuture<Optional<Boolean>> mode(@SuppressWarnings("unused") ServiceRequestContext ctx,
-                                                        HttpRequest req) {
+    protected CompletionStage<Optional<Boolean>> mode(@SuppressWarnings("unused") ServiceRequestContext ctx,
+                                                      HttpRequest req) {
         return req.aggregate()
                   .thenApply(AggregatedHttpMessage::content)
                   .thenApply(HttpData::toStringAscii)

--- a/core/src/main/java/com/linecorp/armeria/server/throttling/RateLimitingThrottlingStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/server/throttling/RateLimitingThrottlingStrategy.java
@@ -19,7 +19,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import javax.annotation.Nullable;
 
@@ -63,7 +63,7 @@ public final class RateLimitingThrottlingStrategy<T extends Request> extends Thr
     }
 
     @Override
-    public CompletableFuture<Boolean> accept(ServiceRequestContext ctx, T request) {
+    public CompletionStage<Boolean> accept(ServiceRequestContext ctx, T request) {
         return completedFuture(rateLimiter.tryAcquire());
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/throttling/ThrottlingStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/server/throttling/ThrottlingStrategy.java
@@ -17,7 +17,7 @@ package com.linecorp.armeria.server.throttling;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
 
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
 
@@ -35,7 +35,7 @@ public abstract class ThrottlingStrategy<T extends Request> {
     private static final ThrottlingStrategy<?> NEVER =
             new ThrottlingStrategy<Request>("throttling-strategy-never") {
                 @Override
-                public CompletableFuture<Boolean> accept(ServiceRequestContext ctx, Request request) {
+                public CompletionStage<Boolean> accept(ServiceRequestContext ctx, Request request) {
                     return completedFuture(false);
                 }
             };
@@ -43,7 +43,7 @@ public abstract class ThrottlingStrategy<T extends Request> {
     private static final ThrottlingStrategy<?> ALWAYS =
             new ThrottlingStrategy<Request>("throttling-strategy-always") {
                 @Override
-                public CompletableFuture<Boolean> accept(ServiceRequestContext ctx, Request request) {
+                public CompletionStage<Boolean> accept(ServiceRequestContext ctx, Request request) {
                     return completedFuture(true);
                 }
             };
@@ -51,7 +51,7 @@ public abstract class ThrottlingStrategy<T extends Request> {
     private final String name;
 
     /**
-     * Creates a new anonymous {@link ThrottlingStrategy}.
+     * Creates a new {@link ThrottlingStrategy} with a default name.
      */
     protected ThrottlingStrategy() {
         this(null);
@@ -91,11 +91,11 @@ public abstract class ThrottlingStrategy<T extends Request> {
      * using a given {@link BiFunction} instance.
      */
     public static <T extends Request> ThrottlingStrategy<T> of(
-            BiFunction<ServiceRequestContext, T, CompletableFuture<Boolean>> function,
+            BiFunction<ServiceRequestContext, T, CompletionStage<Boolean>> function,
             String strategyName) {
         return new ThrottlingStrategy<T>(strategyName) {
             @Override
-            public CompletableFuture<Boolean> accept(ServiceRequestContext ctx, T request) {
+            public CompletionStage<Boolean> accept(ServiceRequestContext ctx, T request) {
                 return function.apply(ctx, request);
             }
         };
@@ -106,10 +106,10 @@ public abstract class ThrottlingStrategy<T extends Request> {
      * using a given {@link BiFunction} instance.
      */
     public static <T extends Request> ThrottlingStrategy<T> of(
-            BiFunction<ServiceRequestContext, T, CompletableFuture<Boolean>> function) {
+            BiFunction<ServiceRequestContext, T, CompletionStage<Boolean>> function) {
         return new ThrottlingStrategy<T>(null) {
             @Override
-            public CompletableFuture<Boolean> accept(ServiceRequestContext ctx, T request) {
+            public CompletionStage<Boolean> accept(ServiceRequestContext ctx, T request) {
                 return function.apply(ctx, request);
             }
         };
@@ -118,7 +118,7 @@ public abstract class ThrottlingStrategy<T extends Request> {
     /**
      * Returns whether a given request should be treated as failed before it is handled actually.
      */
-    public abstract CompletableFuture<Boolean> accept(ServiceRequestContext ctx, T request);
+    public abstract CompletionStage<Boolean> accept(ServiceRequestContext ctx, T request);
 
     /**
      * Returns the name of this {@link ThrottlingStrategy}.

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryingHttpClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryingHttpClientTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
@@ -359,7 +360,7 @@ public class RetryingHttpClientTest {
         }
 
         @Override
-        public CompletableFuture<Backoff> shouldRetry(HttpRequest request, HttpResponse response) {
+        public CompletionStage<Backoff> shouldRetry(HttpRequest request, HttpResponse response) {
             final CompletableFuture<AggregatedHttpMessage> future = response.aggregate();
             return future.handle((message, unused) -> {
                 if (message != null &&

--- a/core/src/test/java/com/linecorp/armeria/server/throttling/RateLimitingThrottlingStrategyTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/throttling/RateLimitingThrottlingStrategyTest.java
@@ -36,14 +36,14 @@ public class RateLimitingThrottlingStrategyTest {
     private RateLimiter rateLimiter;
 
     @Test
-    public void rateLimit() throws Exception {
+    public void rateLimit() {
         final RateLimitingThrottlingStrategy<Request> strategy =
                 new RateLimitingThrottlingStrategy<>(rateLimiter);
         when(rateLimiter.tryAcquire()).thenReturn(true)
                                       .thenReturn(false)
                                       .thenReturn(true);
-        assertThat(strategy.accept(null, null).get()).isEqualTo(true);
-        assertThat(strategy.accept(null, null).get()).isEqualTo(false);
-        assertThat(strategy.accept(null, null).get()).isEqualTo(true);
+        assertThat(strategy.accept(null, null).toCompletableFuture().join()).isEqualTo(true);
+        assertThat(strategy.accept(null, null).toCompletableFuture().join()).isEqualTo(false);
+        assertThat(strategy.accept(null, null).toCompletableFuture().join()).isEqualTo(true);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/throttling/ThrottlingStrategyTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/throttling/ThrottlingStrategyTest.java
@@ -19,7 +19,7 @@ package com.linecorp.armeria.server.throttling;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import org.junit.Test;
 
@@ -39,7 +39,7 @@ public class ThrottlingStrategyTest {
 
     private static class TestThrottlingStrategy extends ThrottlingStrategy<RpcRequest> {
         @Override
-        public CompletableFuture<Boolean> accept(ServiceRequestContext ctx, RpcRequest request) {
+        public CompletionStage<Boolean> accept(ServiceRequestContext ctx, RpcRequest request) {
             return completedFuture(true);
         }
     }

--- a/site/src/sphinx/client-circuit-breaker.rst
+++ b/site/src/sphinx/client-circuit-breaker.rst
@@ -116,7 +116,7 @@ is raised or the status is ``5xx``, succeeds when the status is ``2xx`` and igno
     final CircuitBreakerStrategy<HttpResponse> myStrategy = new CircuitBreakerStrategy<HttpResponse>() {
 
         @Override
-        public CompletableFuture<Boolean> shouldReportAsSuccess(HttpResponse response) {
+        public CompletionStage<Boolean> shouldReportAsSuccess(HttpResponse response) {
             return response.aggregate().handle((res, cause) -> {
                 if (cause != null) { // A failure if an Exception is raised.
                     return false;

--- a/site/src/sphinx/client-retry.rst
+++ b/site/src/sphinx/client-retry.rst
@@ -71,8 +71,7 @@ You can customize the ``strategy`` by implementing :api:`RetryStrategy`.
         final Backoff backoff = RetryStrategy.defaultBackoff;
 
         @Override
-        public CompletableFuture<Backoff> shouldRetry(HttpRequest request,
-                                                      HttpResponse response) {
+        public CompletionStage<Backoff> shouldRetry(HttpRequest request, HttpResponse response) {
             return response.aggregate().handle((result, cause) -> { // Do not use get() or join()!
                 if (cause != null) {
                     if (cause instanceof ResponseTimeoutException) {
@@ -111,8 +110,7 @@ You can return a different :api:`Backoff` according to the response.
         final Backoff backoffOnConflict = Backoff.fixed(100);
 
         @Override
-        public CompletableFuture<Backoff> shouldRetry(HttpRequest request,
-                                                      HttpResponse response) {
+        public CompletionStage<Backoff> shouldRetry(HttpRequest request, HttpResponse response) {
             return response.aggregate().handle((result, cause) -> {
                 if (cause != null) {
                     if (cause instanceof ResponseTimeoutException) {


### PR DESCRIPTION
… applicable

Motivation:
Consider following example:
```
new CircuitBreakerStrategy<RpcResponse>() {
    @Override
    public CompletableFuture<Boolean> shouldReportAsSuccess(RpcResponse response) {
        return response.thenApply(...)
                       .exceptionally(...)
                       .toCompletableFuture();
    }
};
```
The user who implements his or her own strategy has to put `toCompletableFuture` at the end. But
we use the methods of `CompletionStage` in returned codes, so the user doe not have to convert it.
So we can save one more method call.

Modification:
- Mitigate to return `CompletionStage` where applicable mostly in stategy classes

Result:
- Save the world by one more step