### PR TITLE
Add a simple benchmark to check retrofit performance.

### DIFF
--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -24,7 +24,11 @@ dependencies {
 
 dependencies {
     compile project(':grpc')
+    compile project(':retrofit2')
     compile project(':thrift')
+
+    compile 'com.squareup.retrofit2:adapter-java8'
+    compile 'com.squareup.retrofit2:converter-jackson'
 
     if (grpcUpstream) {
         // Since project(':core') is automatically added in the top-level build, it's difficult to exclude

--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -76,6 +76,9 @@ jmh {
     if (rootProject.hasProperty('jmh.profilers')) {
         profilers = String.valueOf(rootProject.findProperty('jmh.profilers')).split(',')
     }
+    if (rootProject.hasProperty('jmh.threads')) {
+        threads = Integer.parseInt(String.valueOf(rootProject.findProperty('jmh.threads')))
+    }
     if (rootProject.hasProperty('jmh.verbose')) {
         verbosity = 'EXTRA'
     }

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/retrofit2/downstream/DownstreamSimpleBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/retrofit2/downstream/DownstreamSimpleBenchmark.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.linecorp.armeria.retrofit2.downstream;
 
 import org.openjdk.jmh.annotations.Scope;
@@ -16,16 +32,17 @@ import retrofit2.converter.jackson.JacksonConverterFactory;
 @State(Scope.Benchmark)
 public class DownstreamSimpleBenchmark extends SimpleBenchmarkBase {
 
-  @Override
-  protected SimpleBenchmarkClient client() {
-    ClientFactory factory = new ClientFactoryBuilder()
-            .sslContextCustomizer(ssl -> ssl.trustManager(InsecureTrustManagerFactory.INSTANCE))
-            .build();
-    return new ArmeriaRetrofitBuilder(factory)
-            .baseUrl(baseUrl())
-            .addConverterFactory(JacksonConverterFactory.create())
-            .addCallAdapterFactory(Java8CallAdapterFactory.create())
-            .build()
-            .create(SimpleBenchmarkClient.class);
+    @Override
+    protected SimpleBenchmarkClient client() {
+        ClientFactory factory =
+                new ClientFactoryBuilder()
+                        .sslContextCustomizer(ssl -> ssl.trustManager(InsecureTrustManagerFactory.INSTANCE))
+                        .build();
+        return new ArmeriaRetrofitBuilder(factory)
+                .baseUrl(baseUrl())
+                .addConverterFactory(JacksonConverterFactory.create())
+                .addCallAdapterFactory(Java8CallAdapterFactory.create())
+                .build()
+                .create(SimpleBenchmarkClient.class);
   }
 }

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/retrofit2/downstream/DownstreamSimpleBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/retrofit2/downstream/DownstreamSimpleBenchmark.java
@@ -1,0 +1,31 @@
+package com.linecorp.armeria.retrofit2.downstream;
+
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+import com.linecorp.armeria.client.ClientFactory;
+import com.linecorp.armeria.client.ClientFactoryBuilder;
+import com.linecorp.armeria.client.retrofit2.ArmeriaRetrofitBuilder;
+import com.linecorp.armeria.retrofit2.shared.SimpleBenchmarkBase;
+import com.linecorp.armeria.retrofit2.shared.SimpleBenchmarkClient;
+
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import retrofit2.adapter.java8.Java8CallAdapterFactory;
+import retrofit2.converter.jackson.JacksonConverterFactory;
+
+@State(Scope.Benchmark)
+public class DownstreamSimpleBenchmark extends SimpleBenchmarkBase {
+
+  @Override
+  protected SimpleBenchmarkClient client() {
+    ClientFactory factory = new ClientFactoryBuilder()
+            .sslContextCustomizer(ssl -> ssl.trustManager(InsecureTrustManagerFactory.INSTANCE))
+            .build();
+    return new ArmeriaRetrofitBuilder(factory)
+            .baseUrl(baseUrl())
+            .addConverterFactory(JacksonConverterFactory.create())
+            .addCallAdapterFactory(Java8CallAdapterFactory.create())
+            .build()
+            .create(SimpleBenchmarkClient.class);
+  }
+}

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/retrofit2/downstream/DownstreamSimpleBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/retrofit2/downstream/DownstreamSimpleBenchmark.java
@@ -44,5 +44,5 @@ public class DownstreamSimpleBenchmark extends SimpleBenchmarkBase {
                 .addCallAdapterFactory(Java8CallAdapterFactory.create())
                 .build()
                 .create(SimpleBenchmarkClient.class);
-  }
+    }
 }

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/retrofit2/shared/SimpleBenchmarkBase.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/retrofit2/shared/SimpleBenchmarkBase.java
@@ -31,6 +31,7 @@ import com.linecorp.armeria.server.ServerPort;
 public abstract class SimpleBenchmarkBase {
 
     private Server server;
+    private SimpleBenchmarkClient client;
 
     @Setup
     public void start() throws Exception {
@@ -40,6 +41,7 @@ public abstract class SimpleBenchmarkBase {
                 .tlsSelfSigned()
                 .build();
         server.start().join();
+        client = client();
     }
 
     @TearDown
@@ -57,7 +59,7 @@ public abstract class SimpleBenchmarkBase {
     }
 
     @Benchmark
-    public void empty() throws Exception {
-        client().empty().join();
+    public void empty() {
+        client.empty().join();
     }
 }

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/retrofit2/shared/SimpleBenchmarkBase.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/retrofit2/shared/SimpleBenchmarkBase.java
@@ -1,0 +1,47 @@
+package com.linecorp.armeria.retrofit2.shared;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.ServerPort;
+
+@State(Scope.Benchmark)
+public abstract class SimpleBenchmarkBase {
+
+    private Server server;
+
+    @Setup
+    public void start() throws Exception {
+        server = new ServerBuilder()
+                .https(0)
+                .service("/empty", (ctx, req) -> HttpResponse.of("\"\""))
+                .tlsSelfSigned()
+                .build();
+        server.start().join();
+    }
+
+    @TearDown
+    public void stop() {
+        server.stop().join();
+    }
+
+    protected abstract SimpleBenchmarkClient client() throws Exception;
+
+    protected String baseUrl() {
+        final ServerPort httpPort = server.activePorts().values().stream()
+                                          .filter(ServerPort::hasHttps).findAny()
+                                          .get();
+        return "https://localhost:" + httpPort.localAddress().getPort();
+    }
+
+    @Benchmark
+    public void empty() throws Exception {
+        client().empty().join();
+    }
+}

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/retrofit2/shared/SimpleBenchmarkBase.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/retrofit2/shared/SimpleBenchmarkBase.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.linecorp.armeria.retrofit2.shared;
 
 import org.openjdk.jmh.annotations.Benchmark;

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/retrofit2/shared/SimpleBenchmarkClient.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/retrofit2/shared/SimpleBenchmarkClient.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.linecorp.armeria.retrofit2.shared;
 
 import java.util.concurrent.CompletableFuture;

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/retrofit2/shared/SimpleBenchmarkClient.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/retrofit2/shared/SimpleBenchmarkClient.java
@@ -1,0 +1,10 @@
+package com.linecorp.armeria.retrofit2.shared;
+
+import java.util.concurrent.CompletableFuture;
+
+import retrofit2.http.GET;
+
+public interface SimpleBenchmarkClient {
+    @GET("/empty")
+    CompletableFuture<String> empty();
+}

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/retrofit2/upstream/UpstreamSimpleBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/retrofit2/upstream/UpstreamSimpleBenchmark.java
@@ -1,0 +1,40 @@
+package com.linecorp.armeria.retrofit2.upstream;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.X509TrustManager;
+
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+import com.linecorp.armeria.retrofit2.shared.SimpleBenchmarkBase;
+import com.linecorp.armeria.retrofit2.shared.SimpleBenchmarkClient;
+
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import okhttp3.OkHttpClient;
+import okhttp3.internal.platform.Platform;
+import retrofit2.Retrofit;
+import retrofit2.adapter.java8.Java8CallAdapterFactory;
+import retrofit2.converter.jackson.JacksonConverterFactory;
+
+@State(Scope.Benchmark)
+public class UpstreamSimpleBenchmark extends SimpleBenchmarkBase {
+
+  @Override
+  protected SimpleBenchmarkClient client() throws Exception {
+    SSLContext context = SSLContext.getInstance("TLS");
+    context.init(null, InsecureTrustManagerFactory.INSTANCE.getTrustManagers(), null);
+    OkHttpClient client = new OkHttpClient.Builder()
+            .sslSocketFactory(context.getSocketFactory(),
+                              (X509TrustManager) InsecureTrustManagerFactory.INSTANCE.getTrustManagers()[0])
+            .hostnameVerifier((s, session) -> true)
+            .build();
+
+    return new Retrofit.Builder()
+        .baseUrl(baseUrl())
+        .client(client)
+        .addConverterFactory(JacksonConverterFactory.create())
+        .addCallAdapterFactory(Java8CallAdapterFactory.create())
+        .build()
+        .create(SimpleBenchmarkClient.class);
+  }
+}

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/retrofit2/upstream/UpstreamSimpleBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/retrofit2/upstream/UpstreamSimpleBenchmark.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.linecorp.armeria.retrofit2.upstream;
 
 import javax.net.ssl.SSLContext;
@@ -11,7 +27,6 @@ import com.linecorp.armeria.retrofit2.shared.SimpleBenchmarkClient;
 
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import okhttp3.OkHttpClient;
-import okhttp3.internal.platform.Platform;
 import retrofit2.Retrofit;
 import retrofit2.adapter.java8.Java8CallAdapterFactory;
 import retrofit2.converter.jackson.JacksonConverterFactory;
@@ -19,22 +34,22 @@ import retrofit2.converter.jackson.JacksonConverterFactory;
 @State(Scope.Benchmark)
 public class UpstreamSimpleBenchmark extends SimpleBenchmarkBase {
 
-  @Override
-  protected SimpleBenchmarkClient client() throws Exception {
-    SSLContext context = SSLContext.getInstance("TLS");
-    context.init(null, InsecureTrustManagerFactory.INSTANCE.getTrustManagers(), null);
-    OkHttpClient client = new OkHttpClient.Builder()
-            .sslSocketFactory(context.getSocketFactory(),
-                              (X509TrustManager) InsecureTrustManagerFactory.INSTANCE.getTrustManagers()[0])
-            .hostnameVerifier((s, session) -> true)
-            .build();
+    @Override
+    protected SimpleBenchmarkClient client() throws Exception {
+        SSLContext context = SSLContext.getInstance("TLS");
+        context.init(null, InsecureTrustManagerFactory.INSTANCE.getTrustManagers(), null);
+        OkHttpClient client = new OkHttpClient.Builder()
+                .sslSocketFactory(context.getSocketFactory(),
+                                  (X509TrustManager) InsecureTrustManagerFactory.INSTANCE.getTrustManagers()[0])
+                .hostnameVerifier((s, session) -> true)
+                .build();
 
-    return new Retrofit.Builder()
-        .baseUrl(baseUrl())
-        .client(client)
-        .addConverterFactory(JacksonConverterFactory.create())
-        .addCallAdapterFactory(Java8CallAdapterFactory.create())
-        .build()
-        .create(SimpleBenchmarkClient.class);
-  }
+        return new Retrofit.Builder()
+                .baseUrl(baseUrl())
+                .client(client)
+                .addConverterFactory(JacksonConverterFactory.create())
+                .addCallAdapterFactory(Java8CallAdapterFactory.create())
+                .build()
+                .create(SimpleBenchmarkClient.class);
+    }
 }


### PR DESCRIPTION
For #1185 - it's good to have some benchmarks to establish a baseline. This first one doesn't intend to be representative of all use cases, but has minimal business logic to try to stress the integration itself as much as possible. Indeed seeing about a 10% improvement in performance using upstream okhttp, similar to the report.

Edit: Was stupidly creating new client every benchmark iteration, ignore emails.

```
Benchmark                                            Mode  Cnt     Score     Error  Units
c.l.a.r.downstream.DownstreamSimpleBenchmark.empty  thrpt   20  3406.076 ▒ 105.094  ops/s
c.l.a.r.upstream.UpstreamSimpleBenchmark.empty      thrpt   20  3785.867 ▒ 130.965  ops/s
```

By the way, to not feel too down, here are the results with 20 JMH threads - as expected our throughput is way better.

```
Benchmark                                            Mode  Cnt      Score     Error  Units
c.l.a.r.downstream.DownstreamSimpleBenchmark.empty  thrpt   20  12852.210 ▒ 261.126  ops/s
c.l.a.r.upstream.UpstreamSimpleBenchmark.empty      thrpt   20   7064.704 ▒ 112.538  ops/s
```