### PR TITLE
Use gRPC shaded in benchmarks to avoid needing classpath workarounds …

### DIFF
--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -11,26 +11,14 @@ apply plugin: 'me.champeau.gradle.jmh'
 
 def jmhInclude = rootProject.findProperty('jmh.include') ?: ''
 
-// Do a simple check of include for gRPC upstream, where we need to control dependencies to prevent conflicts.
-// It should be reliable enough.
-def grpcUpstream = jmhInclude.contains('grpc.upstream') || jmhInclude.contains('grpc\\.upstream')
-
 dependencies {
     compile 'io.grpc:grpc-okhttp'
-    if (grpcUpstream) {
-        compile 'io.grpc:grpc-netty'
-    }
+    compile 'io.grpc:grpc-netty-shaded'
 }
 
 dependencies {
     compile project(':grpc')
     compile project(':thrift')
-
-    if (grpcUpstream) {
-        // Since project(':core') is automatically added in the top-level build, it's difficult to exclude
-        // its transitive dependencies just for upstream benchmarks. Fixing the versions to upstream works ok.
-        compile 'com.google.guava:guava:19.0'
-    }
 }
 
 jmh {

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -108,7 +108,7 @@ io.grpc:
     - io.netty:netty-handler-proxy
     - io.netty:netty-transport
     - io.netty:netty-tcnative-boringssl-static
-  grpc-netty: { version: *GRPC_VERSION }
+  grpc-netty-shaded: { version: *GRPC_VERSION }
   grpc-okhttp: { version: *GRPC_VERSION }
   grpc-protobuf: { version: *GRPC_VERSION }
   grpc-stub: { version: *GRPC_VERSION }


### PR DESCRIPTION
…in build script. For #799 

Guava version conflict also seems to be fixed. Being able to run both benchmarks at the same time is very convenient.

We're still slow, hmm :/ 

```
Benchmark                                           (clientType)   Mode  Cnt     Score     Error  Units
c.l.a.g.downstream.DownstreamSimpleBenchmark.empty        OKHTTP  thrpt   20  3859.725 ± 182.180  ops/s
c.l.a.g.upstream.UpstreamSimpleBenchmark.empty            OKHTTP  thrpt   20  5577.127 ± 147.109  ops/s
```