### PR TITLE
Only enable verbose exceptions for tests.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,13 +27,15 @@ allprojects {
         // Use larger heap when test coverage is enabled.
         maxHeapSize = project.hasFlags('coverage') ? '384m' : '128m'
 
-        // Use verbose exception reporting for easier debugging.
-        systemProperties 'com.linecorp.armeria.verboseExceptions': 'true'
-
         // Enable leak detection when '-Pleak' option is specified.
-        if (project.hasProperty('leak')) {
+        if (rootProject.hasProperty('leak')) {
             systemProperties 'io.netty.leakDetectionLevel': 'paranoid'
         }
+    }
+
+    tasks.withType(Test) {
+        // Use verbose exception reporting for easier debugging.
+        systemProperty 'com.linecorp.armeria.verboseExceptions', 'true'
     }
 }
 


### PR DESCRIPTION
Currently, verbose exceptions are enabled for all Java executions. This even applies to manual execution with the Gradle runner in IntelliJ, and when doing profiling, it causes the profiles to have extra noise. Now only test have verbose exceptions enabled, which is probably where they are useful.

Also fix `leak` property should be read from `rootProject` as with all gradle properties AFAIU. I recall us not getting leak traces at some point maybe related to this.