### PR TITLE
Fix a bug where RetryingClient does not stop when StreamMessage is ab…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerRpcClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerRpcClient.java
@@ -108,7 +108,9 @@ public final class CircuitBreakerRpcClient extends CircuitBreakerClient<RpcReque
             throw cause;
         }
 
-        reportSuccessOrFailure(circuitBreaker, strategy().shouldReportAsSuccess(response));
+        response.whenComplete((unused1, unused2) -> {
+            reportSuccessOrFailure(circuitBreaker, strategy().shouldReportAsSuccess(response));
+        });
         return response;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingHttpClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingHttpClient.java
@@ -120,7 +120,8 @@ public final class RetryingHttpClient extends RetryingClient<HttpRequest, HttpRe
                             HttpRequest originalReq, HttpResponse returnedRes,
                             CompletableFuture<HttpResponse> future) {
         if (originalReq.completionFuture().isCompletedExceptionally() || returnedRes.isComplete()) {
-            // The request or response is aborted by the client before it receives a response, so stop retrying.
+            // The request or response has been aborted by the client before it receives a response,
+            // so stop retrying.
             handleException(ctx, rootReqDuplicator, future, AbortedStreamException.get());
             return;
         }

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClient.java
@@ -89,8 +89,9 @@ public final class RetryingRpcClient extends RetryingClient<RpcRequest, RpcRespo
     private void doExecute0(ClientRequestContext ctx, RpcRequest req,
                             RpcResponse returnedRes, CompletableFuture<RpcResponse> future) {
         if (returnedRes.isDone()) {
-            // The response is cancelled by the client before it receives a response, so stop retrying.
-            handleException(ctx, future, new CancellationException());
+            // The response has been cancelled by the client before it receives a response, so stop retrying.
+            handleException(ctx, future, new CancellationException(
+                    "the response returned to the client has been cancelled"));
             return;
         }
         if (!setResponseTimeout(ctx)) {

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClient.java
@@ -15,6 +15,7 @@
  */
 package com.linecorp.armeria.client.retry;
 
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -82,14 +83,19 @@ public final class RetryingRpcClient extends RetryingClient<RpcRequest, RpcRespo
     protected RpcResponse doExecute(ClientRequestContext ctx, RpcRequest req) throws Exception {
         final CompletableFuture<RpcResponse> future = new CompletableFuture<>();
         final RpcResponse res = RpcResponse.from(future);
-        doExecute0(ctx, req, future);
+        doExecute0(ctx, req, res, future);
         return res;
     }
 
-    private void doExecute0(ClientRequestContext ctx, RpcRequest req, CompletableFuture<RpcResponse> future) {
+    private void doExecute0(ClientRequestContext ctx, RpcRequest req,
+                            RpcResponse returnedRes, CompletableFuture<RpcResponse> future) {
+        if (returnedRes.isDone()) {
+            // The response is cancelled by the client before it receives a response, so stop retrying.
+            actionOnException(ctx, future).accept(new CancellationException());
+            return;
+        }
         if (!setResponseTimeout(ctx)) {
-            onRetryingComplete(ctx);
-            future.completeExceptionally(ResponseTimeoutException.get());
+            actionOnException(ctx, future).accept(ResponseTimeoutException.get());
             return;
         }
 
@@ -104,18 +110,22 @@ public final class RetryingRpcClient extends RetryingClient<RpcRequest, RpcRespo
                         return;
                     }
 
-                    final Consumer<? super Throwable> actionOnException = cause -> {
-                        onRetryingComplete(ctx);
-                        future.completeExceptionally(cause);
-                    };
-                    final Runnable retryTask = () -> doExecute0(ctx, req, future);
-                    scheduleNextRetry(ctx, actionOnException, retryTask, nextDelay);
+                    scheduleNextRetry(ctx, actionOnException(ctx, future),
+                                      () -> doExecute0(ctx, req, returnedRes, future), nextDelay);
                 } else {
                     onRetryingComplete(ctx);
                     future.complete(res);
                 }
             });
         });
+    }
+
+    private static Consumer<? super Throwable> actionOnException(ClientRequestContext ctx,
+                                                                 CompletableFuture<RpcResponse> future) {
+        return cause -> {
+            onRetryingComplete(ctx);
+            future.completeExceptionally(cause);
+        };
     }
 
     private RpcResponse getResponse(ClientRequestContext ctx, RpcRequest req) {

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryingHttpClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryingHttpClientTest.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.client.retry;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
 
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
@@ -35,6 +36,8 @@ import org.junit.Test;
 import org.junit.rules.DisableOnDebug;
 import org.junit.rules.TestRule;
 import org.junit.rules.Timeout;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
 
 import com.google.common.base.Stopwatch;
 
@@ -45,9 +48,13 @@ import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.client.HttpClientBuilder;
 import com.linecorp.armeria.client.ResponseTimeoutException;
 import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpObject;
 import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpRequestWriter;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
@@ -60,8 +67,19 @@ import com.linecorp.armeria.testing.server.ServerRule;
 public class RetryingHttpClientTest {
 
     // use different eventLoop from server's so that clients don't hang when the eventLoop in server hangs
-    private static ClientFactory clientFactory = new ClientFactoryBuilder()
+    private static final ClientFactory clientFactory = new ClientFactoryBuilder()
             .workerGroup(EventLoopGroups.newEventLoopGroup(2), true).build();
+
+    private static final RetryStrategy<HttpRequest, HttpResponse> retryAlways =
+            (request, response) -> response.aggregate().handle((msg, cause) -> {
+                return Backoff.fixed(500);
+            });
+
+    private final AtomicInteger responseAbortServiceCallCounter = new AtomicInteger();
+
+    private final AtomicInteger requestAbortServiceCallCounter = new AtomicInteger();
+
+    private final AtomicInteger subscriberCancelServiceCallCounter = new AtomicInteger();
 
     @AfterClass
     public static void destroy() {
@@ -204,6 +222,38 @@ public class RetryingHttpClientTest {
                                                    message.content().toStringUtf8());
                         }
                     }));
+                }
+            });
+
+            sb.service("/response-abort", new AbstractHttpService() {
+
+                @Override
+                protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req)
+                        throws Exception {
+                    responseAbortServiceCallCounter.incrementAndGet();
+                    return HttpResponse.of(HttpStatus.SERVICE_UNAVAILABLE);
+                }
+            });
+
+            sb.service("/request-abort", new AbstractHttpService() {
+
+                @Override
+                protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req)
+                        throws Exception {
+                    requestAbortServiceCallCounter.incrementAndGet();
+                    return HttpResponse.of(HttpStatus.SERVICE_UNAVAILABLE);
+                }
+            });
+
+            sb.service("/subscriber-cancel", new AbstractHttpService() {
+                @Override
+                protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req)
+                        throws Exception {
+                    if (subscriberCancelServiceCallCounter.getAndIncrement() < 2) {
+                        return HttpResponse.of(HttpStatus.SERVICE_UNAVAILABLE);
+                    } else {
+                        return HttpResponse.of("Succeeded after retry");
+                    }
                 }
             });
         }
@@ -355,6 +405,59 @@ public class RetryingHttpClientTest {
                 .build();
         assertThatThrownBy(() -> client.get("/service-unavailable").aggregate().join())
                 .hasCauseInstanceOf(ClosedClientFactoryException.class);
+    }
+
+    @Test
+    public void doNotRetryWhenResponseIsAborted() throws Exception {
+        final HttpClient client = client(retryAlways);
+        final HttpResponse httpResponse = client.get("/response-abort");
+        httpResponse.abort();
+
+        await().untilAsserted(() -> assertThat(responseAbortServiceCallCounter.get()).isOne());
+        // Sleep 3 seconds more to check if there was another retrying.
+        TimeUnit.SECONDS.sleep(3);
+        assertThat(responseAbortServiceCallCounter.get()).isOne();
+    }
+
+    @Test
+    public void retryDoNotStopUntilGetResponseWhenSubscriberCancel() {
+        final HttpClient client = client(retryAlways);
+        client.get("/subscriber-cancel").subscribe(
+                new Subscriber<HttpObject>() {
+                    @Override
+                    public void onSubscribe(Subscription s) {
+                        s.cancel(); // Cancel as soon as getting the subscription.
+                    }
+
+                    @Override
+                    public void onNext(HttpObject httpObject) {
+                    }
+
+                    @Override
+                    public void onError(Throwable t) {
+                    }
+
+                    @Override
+                    public void onComplete() {
+                    }
+                });
+
+        await().untilAsserted(() -> assertThat(subscriberCancelServiceCallCounter.get()).isEqualTo(3));
+    }
+
+    @Test
+    public void doNotRetryWhenRequestIsAborted() throws Exception {
+        final HttpClient client = client(retryAlways);
+
+        final HttpRequestWriter req = HttpRequest.streaming(
+                HttpHeaders.of(HttpMethod.GET, "/request-abort"));
+        req.write(HttpData.ofUtf8("I'm going to abort this request"));
+        req.abort();
+        client.execute(req);
+
+        TimeUnit.SECONDS.sleep(1);
+        // No request is made.
+        assertThat(responseAbortServiceCallCounter.get()).isZero();
     }
 
     private HttpClient client(RetryStrategy<HttpRequest, HttpResponse> strategy) {

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryingHttpClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryingHttpClientTest.java
@@ -430,16 +430,13 @@ public class RetryingHttpClientTest {
                     }
 
                     @Override
-                    public void onNext(HttpObject httpObject) {
-                    }
+                    public void onNext(HttpObject httpObject) {}
 
                     @Override
-                    public void onError(Throwable t) {
-                    }
+                    public void onError(Throwable t) {}
 
                     @Override
-                    public void onComplete() {
-                    }
+                    public void onComplete() {}
                 });
 
         await().untilAsserted(() -> assertThat(subscriberCancelServiceCallCounter.get()).isEqualTo(3));
@@ -449,8 +446,7 @@ public class RetryingHttpClientTest {
     public void doNotRetryWhenRequestIsAborted() throws Exception {
         final HttpClient client = client(retryAlways);
 
-        final HttpRequestWriter req = HttpRequest.streaming(
-                HttpHeaders.of(HttpMethod.GET, "/request-abort"));
+        final HttpRequestWriter req = HttpRequest.streaming(HttpMethod.GET, "/request-abort");
         req.write(HttpData.ofUtf8("I'm going to abort this request"));
         req.abort();
         client.execute(req);

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryingHttpClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryingHttpClientTest.java
@@ -414,7 +414,7 @@ public class RetryingHttpClientTest {
         httpResponse.abort();
 
         await().untilAsserted(() -> assertThat(responseAbortServiceCallCounter.get()).isOne());
-        // Sleep 3 seconds more to check if there was another retrying.
+        // Sleep 3 seconds more to check if there was another retry.
         TimeUnit.SECONDS.sleep(3);
         assertThat(responseAbortServiceCallCounter.get()).isOne();
     }

--- a/thrift/src/test/java/com/linecorp/armeria/it/client/retry/RetryingRpcClientTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/client/retry/RetryingRpcClientTest.java
@@ -19,6 +19,7 @@ import static com.linecorp.armeria.common.thrift.ThriftSerializationFormats.BINA
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -27,12 +28,12 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.thrift.TApplicationException;
-import org.apache.thrift.TException;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -54,14 +55,14 @@ import com.linecorp.armeria.service.test.thrift.main.HelloService;
 import com.linecorp.armeria.testing.server.ServerRule;
 
 public class RetryingRpcClientTest {
-    private static final RetryStrategy<RpcRequest, RpcResponse> ALWAYS =
+    private static final RetryStrategy<RpcRequest, RpcResponse> retryAlways =
             (request, response) -> {
                 final CompletableFuture<Backoff> future = new CompletableFuture<>();
                 response.whenComplete((unused1, unused2) -> future.complete(Backoff.withoutDelay()));
                 return future;
             };
 
-    private static final RetryStrategy<RpcRequest, RpcResponse> ONLY_HANDLES_EXCEPTION =
+    private static final RetryStrategy<RpcRequest, RpcResponse> retryOnException =
             (request, response) -> {
                 final CompletableFuture<Backoff> future = new CompletableFuture<>();
                 response.whenComplete((unused1, cause) -> {
@@ -88,7 +89,7 @@ public class RetryingRpcClientTest {
 
     @Test
     public void execute() throws Exception {
-        final HelloService.Iface client = helloClient(ONLY_HANDLES_EXCEPTION, 100);
+        final HelloService.Iface client = helloClient(retryOnException, 100);
         when(serviceHandler.hello(anyString())).thenReturn("world");
 
         assertThat(client.hello("hello")).isEqualTo("world");
@@ -97,7 +98,7 @@ public class RetryingRpcClientTest {
 
     @Test
     public void execute_retry() throws Exception {
-        final HelloService.Iface client = helloClient(ONLY_HANDLES_EXCEPTION, 100);
+        final HelloService.Iface client = helloClient(retryOnException, 100);
         when(serviceHandler.hello(anyString()))
                 .thenThrow(new IllegalArgumentException())
                 .thenThrow(new IllegalArgumentException())
@@ -109,7 +110,7 @@ public class RetryingRpcClientTest {
 
     @Test
     public void execute_reachedMaxAttempts() throws Exception {
-        final HelloService.Iface client = helloClient(ALWAYS, 2);
+        final HelloService.Iface client = helloClient(retryAlways, 2);
         when(serviceHandler.hello(anyString())).thenThrow(new IllegalArgumentException());
 
         final Throwable thrown = catchThrowable(() -> client.hello("hello"));
@@ -148,7 +149,7 @@ public class RetryingRpcClientTest {
     public void execute_void() throws Exception {
         final DevNullService.Iface client = new ClientBuilder(server.uri(BINARY, "/thrift-devnull"))
                 .decorator(RpcRequest.class, RpcResponse.class,
-                           RetryingRpcClient.newDecorator(ONLY_HANDLES_EXCEPTION, 10)
+                           RetryingRpcClient.newDecorator(retryOnException, 10)
                 )
                 .build(DevNullService.Iface.class);
 
@@ -161,7 +162,7 @@ public class RetryingRpcClientTest {
     }
 
     @Test
-    public void shouldGetExceptionWhenFactoryIsClosed() throws TException {
+    public void shouldGetExceptionWhenFactoryIsClosed() throws Exception {
         final ClientFactory factory = new ClientFactoryBuilder()
                 .workerGroup(EventLoopGroups.newEventLoopGroup(2), true).build();
 
@@ -186,5 +187,27 @@ public class RetryingRpcClientTest {
         when(serviceHandler.hello(anyString())).thenThrow(new IllegalArgumentException());
         assertThatThrownBy(() -> client.hello("hello"))
                 .isInstanceOf(ClosedClientFactoryException.class);
+    }
+
+    @Test
+    public void doNotRetryWhenResponseIsCancelled() throws Exception {
+        final HelloService.Iface client = new ClientBuilder(server.uri(BINARY, "/thrift"))
+                .decorator(RpcRequest.class, RpcResponse.class,
+                           new RetryingRpcClientBuilder(retryAlways).newDecorator())
+                .decorator(RpcRequest.class, RpcResponse.class,
+                           (delegate, ctx, req) -> {
+                               final RpcResponse res = delegate.execute(ctx, req);
+                               res.cancel(true);
+                               return res;
+                           })
+                .build(HelloService.Iface.class);
+        when(serviceHandler.hello(anyString())).thenThrow(new IllegalArgumentException());
+
+        assertThatThrownBy(() -> client.hello("hello")).isInstanceOf(CancellationException.class);
+        await().untilAsserted(() -> verify(serviceHandler, only()).hello("hello"));
+
+        // Sleep 1 second more to check if there was another retrying.
+        TimeUnit.SECONDS.sleep(1);
+        verify(serviceHandler, only()).hello("hello");
     }
 }

--- a/thrift/src/test/java/com/linecorp/armeria/it/client/retry/RetryingRpcClientTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/client/retry/RetryingRpcClientTest.java
@@ -206,7 +206,7 @@ public class RetryingRpcClientTest {
         assertThatThrownBy(() -> client.hello("hello")).isInstanceOf(CancellationException.class);
         await().untilAsserted(() -> verify(serviceHandler, only()).hello("hello"));
 
-        // Sleep 1 second more to check if there was another retrying.
+        // Sleep 1 second more to check if there was another retry.
         TimeUnit.SECONDS.sleep(1);
         verify(serviceHandler, only()).hello("hello");
     }


### PR DESCRIPTION
…orted

Motivation:
If the `Client` aborts the `Request` or `Response`, `RetryingClient` has to
stop retrying.

Modifications:
- Track the `Request` from the `Client` and `Respone` which handed over to the `Client` to check if it's aborted

Result:
- Fixed another bug