### PR TITLE
Log request when response is failed and request wasn't logged.

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/logging/LoggingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/logging/LoggingClient.java
@@ -145,7 +145,9 @@ public final class LoggingClient<I extends Request, O extends Response> extends 
             ctx.log().addListener(log -> logRequest(logger, log, requestLogLevel,
                                                     requestHeadersSanitizer, requestContentSanitizer),
                                   RequestLogAvailability.REQUEST_END);
-            ctx.log().addListener(log -> logResponse(logger, log, successfulResponseLogLevel,
+            ctx.log().addListener(log -> logResponse(logger, log, requestLogLevel,
+                                                     requestHeadersSanitizer, requestContentSanitizer,
+                                                     successfulResponseLogLevel,
                                                      failedResponseLogLevel, responseHeadersSanitizer,
                                                      responseContentSanitizer),
                                   RequestLogAvailability.COMPLETE);

--- a/core/src/main/java/com/linecorp/armeria/common/logging/LoggingDecoratorBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/LoggingDecoratorBuilder.java
@@ -76,7 +76,7 @@ public abstract class LoggingDecoratorBuilder<T extends LoggingDecoratorBuilder<
 
     /**
      * Sets the {@link LogLevel} to use when logging failure responses (e.g., failed with an exception).
-     * If unset, will use {@link LogLevel#WARN}.
+     * If unset, will use {@link LogLevel#WARN}. The request will be logged too if it was not otherwise.
      */
     public T failureResponseLogLevel(LogLevel failedResponseLogLevel) {
         this.failedResponseLogLevel = requireNonNull(failedResponseLogLevel, "failedResponseLogLevel");

--- a/core/src/main/java/com/linecorp/armeria/internal/logging/LoggingDecorators.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/logging/LoggingDecorators.java
@@ -48,7 +48,9 @@ public final class LoggingDecorators {
     /**
      * Logs a stringified response of {@link RequestLog}.
      */
-    public static void logResponse(Logger logger, RequestLog log,
+    public static void logResponse(Logger logger, RequestLog log, LogLevel requestLogLevel,
+                                   Function<HttpHeaders, HttpHeaders> requestHeadersSanitizer,
+                                   Function<Object, Object> requestContentSanitizer,
                                    LogLevel successfulResponseLogLevel,
                                    LogLevel failedResponseLogLevel,
                                    Function<HttpHeaders, HttpHeaders> responseHeadersSanitizer,
@@ -60,6 +62,12 @@ public final class LoggingDecorators {
                 level.log(logger, RESPONSE_FORMAT,
                           log.toStringResponseOnly(responseHeadersSanitizer, responseContentSanitizer));
             } else {
+                if (!requestLogLevel.isEnabled(logger)) {
+                    // Request wasn't logged but this is an unsuccessful response, log the request too to help
+                    // debugging.
+                    level.log(logger, REQUEST_FORMAT, log.toStringRequestOnly(requestHeadersSanitizer,
+                                                                              responseContentSanitizer));
+                }
                 level.log(logger, RESPONSE_FORMAT,
                           log.toStringResponseOnly(responseHeadersSanitizer, responseContentSanitizer),
                           log.responseCause());

--- a/core/src/main/java/com/linecorp/armeria/server/logging/LoggingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/LoggingService.java
@@ -137,6 +137,8 @@ public final class LoggingService<I extends Request, O extends Response> extends
                                                     requestContentSanitizer),
                                   RequestLogAvailability.REQUEST_END);
             ctx.log().addListener(log -> logResponse(((ServiceRequestContext) log.context()).logger(), log,
+                                                     requestLogLevel, requestHeadersSanitizer,
+                                                     requestContentSanitizer,
                                                      successfulResponseLogLevel, failedResponseLogLevel,
                                                      responseHeadersSanitizer, responseContentSanitizer),
                                   RequestLogAvailability.COMPLETE);

--- a/core/src/test/java/com/linecorp/armeria/server/logging/LoggingServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/logging/LoggingServiceTest.java
@@ -121,6 +121,8 @@ public class LoggingServiceTest {
         final IllegalStateException cause = new IllegalStateException("Failed");
         when(log.responseCause()).thenReturn(cause);
         service.serve(ctx, REQUEST);
+        verify(logger).warn(REQUEST_FORMAT,
+                            "headers: " + REQUEST_HEADERS + ", content: " + REQUEST_CONTENT);
         verify(logger).warn(RESPONSE_FORMAT,
                             "headers: " + RESPONSE_HEADERS + ", content: " + RESPONSE_CONTENT,
                             cause);


### PR DESCRIPTION
Currently, we allow setting different log levels for successful and failed responses. This is to allow the common case where successful requests / responses don't need to be logged (would be noise) but unsuccessful ones should for debugging. Unfortunately, the request is not logged for the latter right now, making it quite hard to debug. I think the default behavior should be to log the request in addition to the response when the response failed.

This change checks if request logging is enabled, and if not, logs request anyways if the response was unsuccessful. It admittedly feels a little weird, but I think it's less surprising for users. Open to any suggestions though.