### PR TITLE
Use non-suffixed content-type for default gRPC proto encoding.

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/common/grpc/GrpcSerializationFormatProvider.java
+++ b/grpc/src/main/java/com/linecorp/armeria/common/grpc/GrpcSerializationFormatProvider.java
@@ -32,7 +32,7 @@ public final class GrpcSerializationFormatProvider extends SerializationFormatPr
     @Override
     protected Set<Entry> entries() {
         return ImmutableSet.of(
-                new Entry("gproto", create("application", "grpc+proto"), create("application", "grpc")),
+                new Entry("gproto", create("application", "grpc"), create("application", "grpc+proto")),
                 new Entry("gjson", create("application", "grpc+json")),
                 new Entry("gproto-web", create("application", "grpc-web+proto"),
                           create("application", "grpc-web")),


### PR DESCRIPTION
I have found in the wild (Stackdriver Trace API) that some gRPC servers will not accept `application/grpc+proto` content type. Of course, this isn't compliant with the spec, but I guess reproducing the default behavior of upstream gRPC clients is better than not, so now gRPC client will send `application/grpc` as the proto content-type, matching the behavior of upstream grpc-java.