### PR TITLE
Only compute advertised encodings header once since it doesn't change.

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaChannel.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaChannel.java
@@ -72,6 +72,7 @@ class ArmeriaChannel extends Channel implements ClientBuilderParams {
     private final SerializationFormat serializationFormat;
     @Nullable
     private final MessageMarshaller jsonMarshaller;
+    private final String advertisedEncodingsHeader;
 
     ArmeriaChannel(ClientBuilderParams params,
                    Client<HttpRequest, HttpResponse> httpClient,
@@ -87,6 +88,9 @@ class ArmeriaChannel extends Channel implements ClientBuilderParams {
         this.endpoint = endpoint;
         this.serializationFormat = serializationFormat;
         this.jsonMarshaller = jsonMarshaller;
+
+        advertisedEncodingsHeader = String.join(
+                ",", DecompressorRegistry.getDefaultInstance().getAdvertisedMessageEncodings());
     }
 
     @Override
@@ -116,7 +120,8 @@ class ArmeriaChannel extends Channel implements ClientBuilderParams {
                 DecompressorRegistry.getDefaultInstance(),
                 serializationFormat,
                 jsonMarshaller,
-                options().getOrElse(GrpcClientOptions.UNSAFE_WRAP_RESPONSE_BUFFERS, false));
+                options().getOrElse(GrpcClientOptions.UNSAFE_WRAP_RESPONSE_BUFFERS, false),
+                advertisedEncodingsHeader);
     }
 
     @Override

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
@@ -91,6 +91,7 @@ public final class GrpcService extends AbstractHttpService
     private final MessageMarshaller jsonMarshaller;
     private final int maxOutboundMessageSizeBytes;
     private final boolean unsafeWrapRequestBuffers;
+    private final String advertisedEncodingsHeader;
 
     private int maxInboundMessageSizeBytes;
 
@@ -111,6 +112,8 @@ public final class GrpcService extends AbstractHttpService
         this.maxOutboundMessageSizeBytes = maxOutboundMessageSizeBytes;
         this.unsafeWrapRequestBuffers = unsafeWrapRequestBuffers;
         this.maxInboundMessageSizeBytes = maxInboundMessageSizeBytes;
+
+        advertisedEncodingsHeader = String.join(",", decompressorRegistry.getAdvertisedMessageEncodings());
     }
 
     @Override
@@ -181,7 +184,8 @@ public final class GrpcService extends AbstractHttpService
                 ctx,
                 serializationFormat,
                 jsonMarshaller,
-                unsafeWrapRequestBuffers);
+                unsafeWrapRequestBuffers,
+                advertisedEncodingsHeader);
         final ServerCall.Listener<I> listener;
         try (SafeCloseable ignored = RequestContext.push(ctx)) {
             listener = methodDef.getServerCallHandler().startCall(call, EMPTY_METADATA);

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/ArmeriaServerCallTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/ArmeriaServerCallTest.java
@@ -125,7 +125,8 @@ public class ArmeriaServerCallTest {
                 ctx,
                 GrpcSerializationFormats.PROTO,
                 MessageMarshaller.builder().build(),
-                false);
+                false,
+                "gzip");
         call.setListener(listener);
         call.messageReader().onSubscribe(subscription);
         when(ctx.logBuilder()).thenReturn(new DefaultRequestLog(ctx));
@@ -166,7 +167,8 @@ public class ArmeriaServerCallTest {
                 ctx,
                 GrpcSerializationFormats.PROTO,
                 MessageMarshaller.builder().build(),
-                true);
+                true,
+                "gzip");
 
         final ByteBuf buf = GrpcTestUtil.requestByteBuf();
         call.messageRead(new ByteBufOrStream(buf));


### PR DESCRIPTION
The advertised encodings of a server or client are constant throughout multiple calls, so we don't need to do slightly expensive computation of the header string every time.

Just a micro-optimization

After (only 1 fork isn't enough for a reliable measurement)
```
Benchmark                                           (clientType)   Mode  Cnt      Score     Error  Units
c.l.a.g.downstream.DownstreamSimpleBenchmark.empty        OKHTTP  thrpt   20  17927.598 ± 670.447  ops/s
c.l.a.g.upstream.UpstreamSimpleBenchmark.empty            OKHTTP  thrpt   20  22614.173 ± 705.504  ops/s
```

Before
```
Benchmark                                           (clientType)   Mode  Cnt      Score      Error  Units
c.l.a.g.downstream.DownstreamSimpleBenchmark.empty        OKHTTP  thrpt   20  17344.866 ±  568.339  ops/s
c.l.a.g.upstream.UpstreamSimpleBenchmark.empty            OKHTTP  thrpt   20  21301.553 ± 1204.546  ops/s
```