### PR TITLE
Reject most duplicate path mappings

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/AnnotatedHttpServiceFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AnnotatedHttpServiceFactory.java
@@ -216,10 +216,9 @@ final class AnnotatedHttpServiceFactory {
         }
 
         final Class<?> clazz = object.getClass();
-        final HttpHeaderPathMapping pathMapping =
-                new HttpHeaderPathMapping(pathStringMapping(pathPrefix, method, methodAnnotations),
-                                          methods, consumableMediaTypes(method, clazz),
-                                          producibleMediaTypes(method, clazz));
+        final PathMapping pathMapping = new HttpHeaderPathMapping(
+                pathStringMapping(pathPrefix, method, methodAnnotations),
+                methods, consumableMediaTypes(method, clazz), producibleMediaTypes(method, clazz));
 
         final List<ExceptionHandlerFunction> eh =
                 exceptionHandlers(method, clazz).addAll(baseExceptionHandlers)
@@ -854,7 +853,7 @@ final class AnnotatedHttpServiceFactory {
         /**
          * Path param extractor with placeholders, e.g., "/const1/{var1}/{var2}/const2"
          */
-        private final HttpHeaderPathMapping pathMapping;
+        private final PathMapping pathMapping;
 
         /**
          * The {@link AnnotatedHttpService} that will handle the request actually.
@@ -867,7 +866,7 @@ final class AnnotatedHttpServiceFactory {
         private final Function<Service<HttpRequest, HttpResponse>,
                 ? extends Service<HttpRequest, HttpResponse>> decorator;
 
-        private AnnotatedHttpServiceElement(HttpHeaderPathMapping pathMapping,
+        private AnnotatedHttpServiceElement(PathMapping pathMapping,
                                             AnnotatedHttpService service,
                                             Function<Service<HttpRequest, HttpResponse>,
                                                     ? extends Service<HttpRequest, HttpResponse>> decorator) {
@@ -876,7 +875,7 @@ final class AnnotatedHttpServiceFactory {
             this.decorator = requireNonNull(decorator, "decorator");
         }
 
-        HttpHeaderPathMapping pathMapping() {
+        PathMapping pathMapping() {
             return pathMapping;
         }
 

--- a/core/src/main/java/com/linecorp/armeria/server/CatchAllPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/CatchAllPathMapping.java
@@ -26,6 +26,7 @@ final class CatchAllPathMapping extends AbstractPathMapping {
     static final CatchAllPathMapping INSTANCE = new CatchAllPathMapping();
 
     private static final Optional<String> PREFIX_PATH_OPT = Optional.of("/");
+    private static final Optional<String> TRIE_PATH_OPT = Optional.of("/*");
     private static final String LOGGER_NAME = loggerName("/"); // "__ROOT__"
 
     private CatchAllPathMapping() {}
@@ -53,6 +54,11 @@ final class CatchAllPathMapping extends AbstractPathMapping {
     @Override
     public Optional<String> prefix() {
         return PREFIX_PATH_OPT;
+    }
+
+    @Override
+    public Optional<String> triePath() {
+        return TRIE_PATH_OPT;
     }
 
     @Override

--- a/thrift/src/test/java/com/linecorp/armeria/server/thrift/AbstractThriftOverHttpTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/server/thrift/AbstractThriftOverHttpTest.java
@@ -108,8 +108,6 @@ public abstract class AbstractThriftOverHttpTest {
                     (AsyncIface) (name, resultHandler) ->
                             resultHandler.onError(new AnticipatedException(name))));
 
-            sb.service("/hellochild", THttpService.of(new HelloServiceChild()));
-
             sb.service("/sleep", THttpService.of(
                     (SleepService.AsyncIface) (milliseconds, resultHandler) ->
                             RequestContext.current().eventLoop().schedule(


### PR DESCRIPTION
Motivation:

When a user binds more than one service at the same path mapping,
`ServerBuilder` should reject such a configuration.

Modifications:

- Add duplicate mapping detection to `Routers.routers()`
- Miscellaneous:
  - Weaken `PathMapping` types in `AnnotatedHttpServiceFactory`

Result:

- Almost fixes #529
- Note that this changeset does not detect all possible cases. For
  example, it does not consider the relationship between media types.
  It will detect most silly mistakes though, which should be enough.