### PR TITLE
Optimize complexity of client endpoint WeightedRoundRobinStrategy

### DIFF
--- a/benchmarks/src/jmh/java/com/linecorp/armeria/core/client/endpoint/WeightedRoundRobinStrategyBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/core/client/endpoint/WeightedRoundRobinStrategyBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 LINE Corporation
+ * Copyright 2018 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/core/client/endpoint/WeightedRoundRobinStrategyBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/core/client/endpoint/WeightedRoundRobinStrategyBenchmark.java
@@ -36,20 +36,20 @@ public class WeightedRoundRobinStrategyBenchmark {
 
     final int numEndpoints = 500;
 
-    // Case 1: normal round robin, all weight: 3
-    EndpointSelector selector1;
+    // normal round robin, all weight: 3
+    EndpointSelector selectorSameWeight;
 
-    // Case 3: mainly weight: 1, max weight: 30
-    EndpointSelector selector2;
+    // mainly weight: 1, max weight: 30
+    EndpointSelector selectorRandomMainly1Max30;
 
-    // Case 4: randomly, max weight: 10
-    EndpointSelector selector4;
+    // randomly, max weight: 10
+    EndpointSelector selectorRandomMax10;
 
-    // Case 5: randomly, max weight: 100
-    EndpointSelector selector5;
+    // randomly, max weight: 100
+    EndpointSelector selectorRandomMax100;
 
-    // Case 6: all weights are unique
-    EndpointSelector selector6;
+    // all weights are unique
+    EndpointSelector selectorUnique;
 
     interface EndpointGenerator {
         Endpoint generate(int id);
@@ -74,49 +74,55 @@ public class WeightedRoundRobinStrategyBenchmark {
     public void setupCases() {
         Random rand = new Random();
 
-        selector1 = getEndpointSelector(generateEndpoints(id -> Endpoint.of("127.0.0.1", id + 1).withWeight(
-                3
-        )), "group1");
+        selectorSameWeight = getEndpointSelector(generateEndpoints(
+                id -> Endpoint.of("127.0.0.1", id + 1)
+                        .withWeight(
+                                30
+                        )), "same-weight");
 
-        selector2 = getEndpointSelector(generateEndpoints(id -> Endpoint.of("127.0.0.1", id + 1).withWeight(
-                1 + (id % 50 == 0 ? 29 : 0)
-        )), "group3");
+        selectorRandomMainly1Max30 = getEndpointSelector(generateEndpoints(
+                id -> Endpoint.of("127.0.0.1", id + 1).withWeight(
+                        1 + (id % 50 == 0 ? 29 : 0)
+                )), "main-1-max-30");
 
-        selector4 = getEndpointSelector(generateEndpoints(id -> Endpoint.of("127.0.0.1", id + 1).withWeight(
-                1 + rand.nextInt(10)
-        )), "group4");
+        selectorRandomMax10 = getEndpointSelector(generateEndpoints(
+                id -> Endpoint.of("127.0.0.1", id + 1).withWeight(
+                        1 + rand.nextInt(10)
+                )), "random-max-10");
 
-        selector5 = getEndpointSelector(generateEndpoints(id -> Endpoint.of("127.0.0.1", id + 1).withWeight(
-                1 + rand.nextInt(100)
-        )), "group5");
+        selectorRandomMax100 = getEndpointSelector(generateEndpoints(
+                id -> Endpoint.of("127.0.0.1", id + 1).withWeight(
+                        1 + rand.nextInt(100)
+                )), "random-max-100");
 
-        selector6 = getEndpointSelector(generateEndpoints(id -> Endpoint.of("127.0.0.1", id + 1).withWeight(
-                id + 1
-        )), "group6");
+        selectorUnique = getEndpointSelector(generateEndpoints(
+                id -> Endpoint.of("127.0.0.1", id + 1).withWeight(
+                        id + 1
+                )), "unique");
     }
 
     @Benchmark
     public Endpoint sameWeight() throws Exception {
-        return selector1.select(null);
+        return selectorSameWeight.select(null);
     }
 
     @Benchmark
     public Endpoint randomMainly1Max30() throws Exception {
-        return selector2.select(null);
+        return selectorRandomMainly1Max30.select(null);
     }
 
     @Benchmark
     public Endpoint randomMax10() throws Exception {
-        return selector4.select(null);
+        return selectorRandomMax10.select(null);
     }
 
     @Benchmark
     public Endpoint randomMax100() throws Exception {
-        return selector5.select(null);
+        return selectorRandomMax100.select(null);
     }
 
     @Benchmark
     public Endpoint unique() throws Exception {
-        return selector6.select(null);
+        return selectorUnique.select(null);
     }
 }

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/core/client/endpoint/WeightedRoundRobinStrategyBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/core/client/endpoint/WeightedRoundRobinStrategyBenchmark.java
@@ -36,7 +36,7 @@ public class WeightedRoundRobinStrategyBenchmark {
 
     final int numEndpoints = 500;
 
-    // normal round robin, all weight: 3
+    // normal round robin, all weight: 300
     EndpointSelector selectorSameWeight;
 
     // mainly weight: 1, max weight: 30
@@ -77,7 +77,7 @@ public class WeightedRoundRobinStrategyBenchmark {
         selectorSameWeight = getEndpointSelector(generateEndpoints(
                 id -> Endpoint.of("127.0.0.1", id + 1)
                         .withWeight(
-                                30
+                                300
                         )), "same-weight");
 
         selectorRandomMainly1Max30 = getEndpointSelector(generateEndpoints(

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/core/client/endpoint/WeightedRoundRobinStrategyBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/core/client/endpoint/WeightedRoundRobinStrategyBenchmark.java
@@ -16,30 +16,23 @@
 
 package com.linecorp.armeria.core.client.endpoint;
 
-import com.linecorp.armeria.client.Endpoint;
-import com.linecorp.armeria.client.endpoint.EndpointGroupRegistry;
-import com.linecorp.armeria.client.endpoint.EndpointSelector;
-import com.linecorp.armeria.client.endpoint.StaticEndpointGroup;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.runner.RunnerException;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Random;
-
-import static com.linecorp.armeria.client.endpoint.EndpointSelectionStrategy.WEIGHTED_ROUND_ROBIN;
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.endpoint.EndpointGroupRegistry;
+import com.linecorp.armeria.client.endpoint.EndpointSelectionStrategy;
+import com.linecorp.armeria.client.endpoint.EndpointSelector;
+import com.linecorp.armeria.client.endpoint.StaticEndpointGroup;
 
 @State(Scope.Thread)
 public class WeightedRoundRobinStrategyBenchmark {
-
-    public static void main(String[] args) throws IOException, RunnerException {
-        org.openjdk.jmh.Main.main(args);
-    }
 
     final int numEndpoints = 500;
 
@@ -58,7 +51,6 @@ public class WeightedRoundRobinStrategyBenchmark {
     // Case 6: all weights are unique
     EndpointSelector selector6;
 
-
     interface EndpointGenerator {
         Endpoint generate(int id);
     }
@@ -72,7 +64,9 @@ public class WeightedRoundRobinStrategyBenchmark {
     }
 
     private EndpointSelector getEndpointSelector(List<Endpoint> endpoints, String groupName) {
-        EndpointGroupRegistry.register(groupName, new StaticEndpointGroup(endpoints), WEIGHTED_ROUND_ROBIN);
+        EndpointGroupRegistry.register(groupName,
+                new StaticEndpointGroup(endpoints),
+                EndpointSelectionStrategy.WEIGHTED_ROUND_ROBIN);
         return EndpointGroupRegistry.getNodeSelector(groupName);
     }
 

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/core/client/endpoint/WeightedRoundRobinStrategyBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/core/client/endpoint/WeightedRoundRobinStrategyBenchmark.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.core.client.endpoint;
+
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.endpoint.EndpointGroupRegistry;
+import com.linecorp.armeria.client.endpoint.EndpointSelector;
+import com.linecorp.armeria.client.endpoint.StaticEndpointGroup;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.runner.RunnerException;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import static com.linecorp.armeria.client.endpoint.EndpointSelectionStrategy.WEIGHTED_ROUND_ROBIN;
+
+@State(Scope.Thread)
+public class WeightedRoundRobinStrategyBenchmark {
+
+    public static void main(String[] args) throws IOException, RunnerException {
+        org.openjdk.jmh.Main.main(args);
+    }
+
+    final int numEndpoints = 500;
+
+    // Case 1: normal round robin, all weight: 3
+    EndpointSelector selector1;
+
+    // Case 3: mainly weight: 1, max weight: 30
+    EndpointSelector selector2;
+
+    // Case 4: randomly, max weight: 10
+    EndpointSelector selector4;
+
+    // Case 5: randomly, max weight: 100
+    EndpointSelector selector5;
+
+    // Case 6: all weights are unique
+    EndpointSelector selector6;
+
+
+    interface EndpointGenerator {
+        Endpoint generate(int id);
+    }
+
+    private List<Endpoint> generateEndpoints(EndpointGenerator e) {
+        List<Endpoint> result = new ArrayList<>();
+        for (int i = 0; i < numEndpoints; i++) {
+            result.add(e.generate(i));
+        }
+        return result;
+    }
+
+    private EndpointSelector getEndpointSelector(List<Endpoint> endpoints, String groupName) {
+        EndpointGroupRegistry.register(groupName, new StaticEndpointGroup(endpoints), WEIGHTED_ROUND_ROBIN);
+        return EndpointGroupRegistry.getNodeSelector(groupName);
+    }
+
+    @Setup
+    public void setupCases() {
+        Random rand = new Random();
+
+        selector1 = getEndpointSelector(generateEndpoints(id -> Endpoint.of("127.0.0.1", id + 1).withWeight(
+                3
+        )), "group1");
+
+        selector2 = getEndpointSelector(generateEndpoints(id -> Endpoint.of("127.0.0.1", id + 1).withWeight(
+                1 + (id % 50 == 0 ? 29 : 0)
+        )), "group3");
+
+        selector4 = getEndpointSelector(generateEndpoints(id -> Endpoint.of("127.0.0.1", id + 1).withWeight(
+                1 + rand.nextInt(10)
+        )), "group4");
+
+        selector5 = getEndpointSelector(generateEndpoints(id -> Endpoint.of("127.0.0.1", id + 1).withWeight(
+                1 + rand.nextInt(100)
+        )), "group5");
+
+        selector6 = getEndpointSelector(generateEndpoints(id -> Endpoint.of("127.0.0.1", id + 1).withWeight(
+                id + 1
+        )), "group6");
+    }
+
+    @Benchmark
+    public Endpoint sameWeight() throws Exception {
+        return selector1.select(null);
+    }
+
+    @Benchmark
+    public Endpoint randomMainly1Max30() throws Exception {
+        return selector2.select(null);
+    }
+
+    @Benchmark
+    public Endpoint randomMax10() throws Exception {
+        return selector4.select(null);
+    }
+
+    @Benchmark
+    public Endpoint randomMax100() throws Exception {
+        return selector5.select(null);
+    }
+
+    @Benchmark
+    public Endpoint unique() throws Exception {
+        return selector6.select(null);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightedRoundRobinStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightedRoundRobinStrategy.java
@@ -16,8 +16,8 @@
 
 package com.linecorp.armeria.client.endpoint;
 
+import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -71,82 +71,123 @@ final class WeightedRoundRobinStrategy implements EndpointSelectionStrategy {
             return endpointsAndWeights.selectEndpoint(currentSequence);
         }
 
+        // endpoints accumulation which are grouped by weight
+        private static final class EndpointsGroupByWeight {
+            final long startIndex;
+            final int weight;
+            final long accumulatedWeight;
+
+            EndpointsGroupByWeight(long startIndex, int weight, long accumulatedWeight) {
+                this.startIndex = startIndex;
+                this.weight = weight;
+                this.accumulatedWeight = accumulatedWeight;
+            }
+        }
+
+        //
+        // In general, assume the weights are w0 < w1 < ... < wM where M = N - 1, N is number of endpoints.
+        //
+        // * The first part of result: (a0..aM)(a0..aM)...(a0..aM) [w0 times for N elements].
+        // * The second part of result: (a1..aM)...(a1..aM) [w1 - w0 times for N - 1 elements].
+        // * and so on
+        //
+        // In this way:
+        //
+        // * Total number of elements of first part is: X(0) = w0 * N.
+        // * Total number of elements of second part is: X(1) = (w1 - w0) * (N - 1)
+        // * and so on
+        //
+        // Therefore, to find endpoint for a sequence S = currentSequence % totalWeight, firstly we find
+        // the part which sequence belongs, and then modular by the number of elements in this part.
+        //
+        // Accumulation function F:
+        //
+        // * F(0) = X(0)
+        // * F(1) = X(0) + X(1)
+        // * F(2) = X(0) + X(1) + X(2)
+        // * F(i) = F(i-1) + X(i)
+        //
+        // We could easily find the part (which sequence S belongs) using binary search on F.
+        // Just find the index k where:
+        //
+        //                               F(k) <= S < F(k + 1).
+        //
+        // So, S belongs to part number (k + 1), index of the sequence in this part is P = S - F(k).
+        // Because part (k + 1) start at index (k + 1), and contains (N - k - 1) elements,
+        // then the real index is:
+        //
+        //                              (k + 1) + (P % (N - k - 1))
+        //
+        // For special case like w(i) == w(i+1). We just group them all together
+        // and mark the start index of the group.
+        //
         private static final class EndpointsAndWeights {
             private final List<Endpoint> endpoints;
             private final boolean weighted;
             private final long totalWeight; // prevent overflow by using long
-
-            private static final class EndpointsGroupByWeight {
-                int startIndex;
-                int weight;
-                long accumulatedWeight;
-
-                EndpointsGroupByWeight(int startIndex, int weight, long accumulatedWeight) {
-                    this.startIndex = startIndex;
-                    this.weight = weight;
-                    this.accumulatedWeight = accumulatedWeight;
-                }
-            }
-
             private final EndpointsGroupByWeight[] endpointsGroupByWeight;
 
             EndpointsAndWeights(Iterable<Endpoint> endpoints) {
+                long totalWeight = 0;
                 int minWeight = Integer.MAX_VALUE;
                 int maxWeight = Integer.MIN_VALUE;
-                long totalWeight = 0;
+                int numberDistinctWeight = 0;
 
-                // get min and max weight
-                for (Endpoint endpoint : endpoints) {
-                    final int weight = endpoint.weight();
-                    minWeight = Math.min(minWeight, weight);
-                    maxWeight = Math.max(maxWeight, weight);
-                }
-
-                // prepare endpoints
-                List<Endpoint> endps = ImmutableList.copyOf(endpoints)
+                // prepare endpoints by copying
+                this.endpoints = ImmutableList.copyOf(endpoints)
                         .stream()
-                        .filter(endpoint -> endpoint.weight() > 0) // only process endpoint with weight > 0
+                        .filter(e -> e.weight() > 0) // only process endpoint with weight > 0
                         .sorted(Comparator
                                 .comparing(Endpoint::weight)
                                 .thenComparing(Endpoint::host)
                                 .thenComparingInt(Endpoint::port))
-                        .collect(Collectors.toList());
-                int numEndpoints = endps.size();
+                        .collect(Collectors.toCollection(ArrayList::new));
+                long numEndpoints = this.endpoints.size();
+
+                // get min weight, max weight and number of distinct weight
+                int oldWeight = -1;
+                for (Endpoint endpoint : this.endpoints) {
+                    final int weight = endpoint.weight();
+                    minWeight = Math.min(minWeight, weight);
+                    maxWeight = Math.max(maxWeight, weight);
+                    numberDistinctWeight += weight == oldWeight ? 0 : 1;
+                    oldWeight = weight;
+                }
 
                 // accumulation
-                LinkedList<EndpointsGroupByWeight> accumulatedGroups = new LinkedList<>();
+                EndpointsGroupByWeight[] accumulatedGroups = new EndpointsGroupByWeight[numberDistinctWeight];
                 EndpointsGroupByWeight currentGroup = null;
-                int rest = numEndpoints;
-                for (Endpoint endpoint : endps) {
+                int index = -1;
+
+                long rest = numEndpoints;
+                for (Endpoint endpoint : this.endpoints) {
                     if (currentGroup == null || currentGroup.weight != endpoint.weight()) {
                         totalWeight += currentGroup == null ?
-                                (long) endpoint.weight() * (long) rest
-                                : (long) (endpoint.weight() - currentGroup.weight) * (long) rest;
-                        currentGroup = new EndpointsGroupByWeight(numEndpoints - rest,
-                                endpoint.weight(), totalWeight);
-                        accumulatedGroups.addLast(currentGroup);
+                                (long) endpoint.weight() * rest
+                                : (long) (endpoint.weight() - currentGroup.weight) * rest;
+                        currentGroup = new EndpointsGroupByWeight(
+                                numEndpoints - rest, endpoint.weight(), totalWeight
+                        );
+                        accumulatedGroups[++index] = currentGroup;
                     }
 
                     rest--;
                 }
 
-                this.endpoints = endps;
-                this.endpointsGroupByWeight = accumulatedGroups.toArray(
-                        new EndpointsGroupByWeight[accumulatedGroups.size()]
-                );
+                this.endpointsGroupByWeight = accumulatedGroups;
                 this.totalWeight = totalWeight;
                 this.weighted = minWeight != maxWeight;
             }
 
-            Endpoint selectEndpoint(int currentSequence) {
+            Endpoint selectEndpoint(long currentSequence) {
                 if (endpoints.isEmpty()) {
                     throw new EndpointGroupException(endpoints + " is empty");
                 }
 
-                int numberEndpoints = endpoints.size();
+                long numberEndpoints = endpoints.size();
 
                 if (weighted) {
-                    long mod = Math.abs((long) (currentSequence) % totalWeight);
+                    long mod = Math.abs(currentSequence % totalWeight);
 
                     if (mod < endpointsGroupByWeight[0].accumulatedWeight) {
                         return endpoints.get((int) (mod % numberEndpoints));
@@ -170,13 +211,13 @@ final class WeightedRoundRobinStrategy implements EndpointSelectionStrategy {
                     }
 
                     // (left + 1) is the part where sequence belongs
-                    int indexInPart = (int) (mod - endpointsGroupByWeight[left].accumulatedWeight);
-                    int realIndex = endpointsGroupByWeight[left + 1].startIndex +
+                    long indexInPart = mod - endpointsGroupByWeight[left].accumulatedWeight;
+                    long realIndex = endpointsGroupByWeight[left + 1].startIndex +
                             indexInPart % (numberEndpoints - endpointsGroupByWeight[left + 1].startIndex);
-                    return endpoints.get(realIndex);
+                    return endpoints.get((int) realIndex);
                 }
 
-                return endpoints.get(Math.abs(currentSequence % numberEndpoints));
+                return endpoints.get((int) Math.abs(currentSequence % numberEndpoints));
             }
         }
     }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightedRoundRobinStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightedRoundRobinStrategy.java
@@ -16,16 +16,16 @@
 
 package com.linecorp.armeria.client.endpoint;
 
-import com.google.common.collect.ImmutableList;
-
-import com.linecorp.armeria.client.ClientRequestContext;
-import com.linecorp.armeria.client.Endpoint;
-
 import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
+
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.Endpoint;
 
 final class WeightedRoundRobinStrategy implements EndpointSelectionStrategy {
 
@@ -36,6 +36,7 @@ final class WeightedRoundRobinStrategy implements EndpointSelectionStrategy {
 
     /**
      * A weighted round robin select strategy.
+     *
      * <p>For example, with node a, b and c:
      * <ul>
      *   <li>if endpoint weights are 1,1,1 (or 2,2,2), then select result is abc abc ...</li>
@@ -151,7 +152,9 @@ final class WeightedRoundRobinStrategy implements EndpointSelectionStrategy {
                         return endpoints.get((int) (mod % numberEndpoints));
                     }
 
-                    int left = 0, right = endpointsGroupByWeight.length - 1, mid;
+                    int left = 0;
+                    int right = endpointsGroupByWeight.length - 1;
+                    int mid;
                     while (left < right) {
                         mid = left + ((right - left) >> 1);
 

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightedRoundRobinStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightedRoundRobinStrategy.java
@@ -179,14 +179,14 @@ final class WeightedRoundRobinStrategy implements EndpointSelectionStrategy {
                 this.weighted = minWeight != maxWeight;
             }
 
-            Endpoint selectEndpoint(long currentSequence) {
+            Endpoint selectEndpoint(int currentSequence) {
                 if (endpoints.isEmpty()) {
                     throw new EndpointGroupException(endpoints + " is empty");
                 }
 
-                long numberEndpoints = endpoints.size();
-
                 if (weighted) {
+                    long numberEndpoints = endpoints.size();
+
                     long mod = Math.abs(currentSequence % totalWeight);
 
                     if (mod < endpointsGroupByWeight[0].accumulatedWeight) {
@@ -218,7 +218,7 @@ final class WeightedRoundRobinStrategy implements EndpointSelectionStrategy {
                     return endpoints.get((int) realIndex);
                 }
 
-                return endpoints.get((int) Math.abs(currentSequence % numberEndpoints));
+                return endpoints.get(Math.abs(currentSequence % endpoints.size()));
             }
         }
     }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightedRoundRobinStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightedRoundRobinStrategy.java
@@ -212,8 +212,9 @@ final class WeightedRoundRobinStrategy implements EndpointSelectionStrategy {
 
                     // (left + 1) is the part where sequence belongs
                     long indexInPart = mod - endpointsGroupByWeight[left].accumulatedWeight;
-                    long realIndex = endpointsGroupByWeight[left + 1].startIndex +
-                            indexInPart % (numberEndpoints - endpointsGroupByWeight[left + 1].startIndex);
+                    long startIndex = endpointsGroupByWeight[left + 1].startIndex;
+                    long realIndex = startIndex +
+                            indexInPart % (numberEndpoints - startIndex);
                     return endpoints.get((int) realIndex);
                 }
 

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightedRoundRobinStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightedRoundRobinStrategy.java
@@ -16,13 +16,16 @@
 
 package com.linecorp.armeria.client.endpoint;
 
-import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
-
 import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
+
+import java.util.Comparator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 final class WeightedRoundRobinStrategy implements EndpointSelectionStrategy {
 
@@ -37,6 +40,7 @@ final class WeightedRoundRobinStrategy implements EndpointSelectionStrategy {
      * <p>For example, with node a, b and c:
      * <ul>
      *   <li>if endpoint weights are 1,1,1 (or 2,2,2), then select result is abc abc ...</li>
+     *   <li>if endpoint weights are 1,1,2,3 (or 2,2,4,6), then select result is abcdcdd (or abcdabcdcdcddd) ...</li>
      *   <li>if endpoint weights are 1,2,3 (or 2,4,6), then select result is abcbcc(or abcabcbcbccc) ...</li>
      *   <li>if endpoint weights are 3,5,7, then select result is abcabcabcbcbcbb abcabcabcbcbcbb ...</li>
      * </ul>
@@ -71,23 +75,107 @@ final class WeightedRoundRobinStrategy implements EndpointSelectionStrategy {
         private static final class EndpointsAndWeights {
             private final List<Endpoint> endpoints;
             private final boolean weighted;
-            private final int maxWeight;
-            private final int totalWeight;
+            private final long totalWeight; // prevent overflow by using long
 
+            private static final class EndpointsGroupByWeight {
+                int startIndex;
+                int weight;
+                long accumulatedWeight;
+
+                EndpointsGroupByWeight(int startIndex, int weight, long accumulatedWeight) {
+                    this.startIndex = startIndex;
+                    this.weight = weight;
+                    this.accumulatedWeight = accumulatedWeight;
+                }
+            }
+
+            private final EndpointsGroupByWeight[] endpointsGroupByWeight;
+
+            /**
+             * In general, assume the weights are w0 < w1 < ... < wM where M = N - 1, N is number of endpoints.
+             * <p>
+             * <ul>
+             *   <li>The first part of result: (a0..aM)(a0..aM)...(a0..aM) [w0 times for N elements].</li>
+             *   <li>The second part of result: (a1..aM)...(a1..aM) [w1 - w0 times for N - 1 elements].</li>
+             *   <li>The third part of result: (a2..aM)...(a2..aM) [w2 - w1 times for N - 2 elements].</li>
+             *   <li>...</li>
+             * </ul>
+             * <p>In this way:
+             * <ul>
+             *   <li>Total number of elements of first part is: X0 = w0 * N</li>
+             *   <li>Total number of elements of second part is: X1 = (w1 - w0) * (N - 1)</li>
+             *   <li>Total number of elements of third part is: X2 = (w2 - w1) * (N - 2)</li>
+             *   <li>...</li>
+             * </ul>
+             * <p>
+             * Therefore, to find index of endpoint for a sequence S = current_sequence % total_weight, we could find
+             * the part which sequence belongs first, and then modular by the number of elements in this part for real index.
+             * <p>
+             * Let F denote accumulation function:
+             * <ul>
+             *   <li>F(0) = X0</li>
+             *   <li>F(1) = X0 + X1</li>
+             *   <li>F(2) = X0 + X1 + X2</li>
+             *   <li>...</li>
+             * </ul>
+             * Note: X0 X1 ... are all positive.
+             * <p>
+             * We could easily find the part (which sequence belongs) by binary search on F.
+             * Just find the index k where: F(k) <= S < F(k + 1)
+             * <p>
+             * So, S belongs to part number (k + 1), index_in_this_part = S - F(k).
+             * If we are able to map index_in_this_part to real_index of endpoints (w0..wM), then we get final result.
+             * <p>
+             * The formula is: real_index = (k + 1) + (index_in_this_part % (N - k - 1))
+             * Proven: the part number (k + 1) start at index (k + 1), and contains (N - k - 1) elements.
+             * <p>
+             * For special case like wi == w(i+1). We just group them all together and mark the start index of the group.
+             * <p>
+             * The complexity of selecting endpoint is: O(log(N))
+             */
             EndpointsAndWeights(Iterable<Endpoint> endpoints) {
                 int minWeight = Integer.MAX_VALUE;
                 int maxWeight = Integer.MIN_VALUE;
-                int totalWeight = 0;
+                long totalWeight = 0;
+
+                // get min and max weight
                 for (Endpoint endpoint : endpoints) {
                     final int weight = endpoint.weight();
                     minWeight = Math.min(minWeight, weight);
                     maxWeight = Math.max(maxWeight, weight);
-                    totalWeight += weight;
                 }
-                this.endpoints = ImmutableList.copyOf(endpoints);
-                this.maxWeight = maxWeight;
+
+                // prepare endpoints
+                List<Endpoint> _endpoints = ImmutableList.copyOf(endpoints)
+                        .stream()
+                        .filter(endpoint -> endpoint.weight() > 0) // only process endpoint with weight > 0
+                        .sorted(Comparator
+                                .comparing(Endpoint::weight)
+                                .thenComparing(Endpoint::host)
+                                .thenComparingInt(Endpoint::port))
+                        .collect(Collectors.toList());
+                int numEndpoints = _endpoints.size();
+
+                // accumulation
+                LinkedList<EndpointsGroupByWeight> accumulatedGroups = new LinkedList<>();
+                EndpointsGroupByWeight currentGroup = null;
+                int rest = numEndpoints;
+                for (Endpoint endpoint : _endpoints) {
+                    if (currentGroup == null || currentGroup.weight != endpoint.weight()) {
+                        totalWeight += currentGroup == null ?
+                                (long) endpoint.weight() * (long) rest
+                                : (long) (endpoint.weight() - currentGroup.weight) * (long) rest;
+                        currentGroup = new EndpointsGroupByWeight(numEndpoints - rest, endpoint.weight(), totalWeight);
+                        accumulatedGroups.addLast(currentGroup);
+                    }
+
+                    rest--;
+                }
+
+                this.endpoints = _endpoints;
+                this.endpointsGroupByWeight = accumulatedGroups.toArray(new EndpointsGroupByWeight[accumulatedGroups.size()]);
                 this.totalWeight = totalWeight;
-                weighted = minWeight != maxWeight;
+                this.weighted = minWeight != maxWeight;
             }
 
             Endpoint selectEndpoint(int currentSequence) {
@@ -95,25 +183,35 @@ final class WeightedRoundRobinStrategy implements EndpointSelectionStrategy {
                     throw new EndpointGroupException(endpoints + " is empty");
                 }
 
-                if (weighted) {
-                    final int[] weights = endpoints.stream()
-                                                   .mapToInt(Endpoint::weight)
-                                                   .toArray();
+                int numberEndpoints = endpoints.size();
 
-                    int mod = currentSequence % totalWeight;
-                    for (int i = 0; i < maxWeight; i++) {
-                        for (int j = 0; j < weights.length; j++) {
-                            if (mod == 0 && weights[j] > 0) {
-                                return endpoints.get(j);
-                            }
-                            if (weights[j] > 0) {
-                                weights[j]--;
-                                mod--;
-                            }
-                        }
+                if (weighted) {
+                    long mod = Math.abs((long) (currentSequence) % totalWeight);
+
+                    if (mod < endpointsGroupByWeight[0].accumulatedWeight)
+                        return endpoints.get((int) (mod % numberEndpoints));
+
+                    int left = 0, right = endpointsGroupByWeight.length - 1, mid;
+                    while (left < right) {
+                        mid = left + ((right - left) >> 1);
+
+                        if (mid == left)
+                            break;
+
+                        if (endpointsGroupByWeight[mid].accumulatedWeight <= mod)
+                            left = mid;
+                        else
+                            right = mid;
                     }
+
+                    // (left + 1) is the part where sequence belongs
+                    int indexInPart = (int) (mod - endpointsGroupByWeight[left].accumulatedWeight);
+                    int realIndex = endpointsGroupByWeight[left + 1].startIndex +
+                            indexInPart % (numberEndpoints - endpointsGroupByWeight[left + 1].startIndex);
+                    return endpoints.get(realIndex);
                 }
-                return endpoints.get(Math.abs(currentSequence % endpoints.size()));
+
+                return endpoints.get(Math.abs(currentSequence % numberEndpoints));
             }
         }
     }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightedRoundRobinStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightedRoundRobinStrategy.java
@@ -36,11 +36,9 @@ final class WeightedRoundRobinStrategy implements EndpointSelectionStrategy {
 
     /**
      * A weighted round robin select strategy.
-     *
      * <p>For example, with node a, b and c:
      * <ul>
      *   <li>if endpoint weights are 1,1,1 (or 2,2,2), then select result is abc abc ...</li>
-     *   <li>if endpoint weights are 1,1,2,3 (or 2,2,4,6), then select result is abcdcdd (or abcdabcdcdcddd) ...</li>
      *   <li>if endpoint weights are 1,2,3 (or 2,4,6), then select result is abcbcc(or abcabcbcbccc) ...</li>
      *   <li>if endpoint weights are 3,5,7, then select result is abcabcabcbcbcbb abcabcabcbcbcbb ...</li>
      * </ul>
@@ -91,48 +89,6 @@ final class WeightedRoundRobinStrategy implements EndpointSelectionStrategy {
 
             private final EndpointsGroupByWeight[] endpointsGroupByWeight;
 
-            /**
-             * In general, assume the weights are w0 < w1 < ... < wM where M = N - 1, N is number of endpoints.
-             * <p>
-             * <ul>
-             *   <li>The first part of result: (a0..aM)(a0..aM)...(a0..aM) [w0 times for N elements].</li>
-             *   <li>The second part of result: (a1..aM)...(a1..aM) [w1 - w0 times for N - 1 elements].</li>
-             *   <li>The third part of result: (a2..aM)...(a2..aM) [w2 - w1 times for N - 2 elements].</li>
-             *   <li>...</li>
-             * </ul>
-             * <p>In this way:
-             * <ul>
-             *   <li>Total number of elements of first part is: X0 = w0 * N</li>
-             *   <li>Total number of elements of second part is: X1 = (w1 - w0) * (N - 1)</li>
-             *   <li>Total number of elements of third part is: X2 = (w2 - w1) * (N - 2)</li>
-             *   <li>...</li>
-             * </ul>
-             * <p>
-             * Therefore, to find index of endpoint for a sequence S = current_sequence % total_weight, we could find
-             * the part which sequence belongs first, and then modular by the number of elements in this part for real index.
-             * <p>
-             * Let F denote accumulation function:
-             * <ul>
-             *   <li>F(0) = X0</li>
-             *   <li>F(1) = X0 + X1</li>
-             *   <li>F(2) = X0 + X1 + X2</li>
-             *   <li>...</li>
-             * </ul>
-             * Note: X0 X1 ... are all positive.
-             * <p>
-             * We could easily find the part (which sequence belongs) by binary search on F.
-             * Just find the index k where: F(k) <= S < F(k + 1)
-             * <p>
-             * So, S belongs to part number (k + 1), index_in_this_part = S - F(k).
-             * If we are able to map index_in_this_part to real_index of endpoints (w0..wM), then we get final result.
-             * <p>
-             * The formula is: real_index = (k + 1) + (index_in_this_part % (N - k - 1))
-             * Proven: the part number (k + 1) start at index (k + 1), and contains (N - k - 1) elements.
-             * <p>
-             * For special case like wi == w(i+1). We just group them all together and mark the start index of the group.
-             * <p>
-             * The complexity of selecting endpoint is: O(log(N))
-             */
             EndpointsAndWeights(Iterable<Endpoint> endpoints) {
                 int minWeight = Integer.MAX_VALUE;
                 int maxWeight = Integer.MIN_VALUE;
@@ -146,7 +102,7 @@ final class WeightedRoundRobinStrategy implements EndpointSelectionStrategy {
                 }
 
                 // prepare endpoints
-                List<Endpoint> _endpoints = ImmutableList.copyOf(endpoints)
+                List<Endpoint> endps = ImmutableList.copyOf(endpoints)
                         .stream()
                         .filter(endpoint -> endpoint.weight() > 0) // only process endpoint with weight > 0
                         .sorted(Comparator
@@ -154,26 +110,29 @@ final class WeightedRoundRobinStrategy implements EndpointSelectionStrategy {
                                 .thenComparing(Endpoint::host)
                                 .thenComparingInt(Endpoint::port))
                         .collect(Collectors.toList());
-                int numEndpoints = _endpoints.size();
+                int numEndpoints = endps.size();
 
                 // accumulation
                 LinkedList<EndpointsGroupByWeight> accumulatedGroups = new LinkedList<>();
                 EndpointsGroupByWeight currentGroup = null;
                 int rest = numEndpoints;
-                for (Endpoint endpoint : _endpoints) {
+                for (Endpoint endpoint : endps) {
                     if (currentGroup == null || currentGroup.weight != endpoint.weight()) {
                         totalWeight += currentGroup == null ?
                                 (long) endpoint.weight() * (long) rest
                                 : (long) (endpoint.weight() - currentGroup.weight) * (long) rest;
-                        currentGroup = new EndpointsGroupByWeight(numEndpoints - rest, endpoint.weight(), totalWeight);
+                        currentGroup = new EndpointsGroupByWeight(numEndpoints - rest,
+                                endpoint.weight(), totalWeight);
                         accumulatedGroups.addLast(currentGroup);
                     }
 
                     rest--;
                 }
 
-                this.endpoints = _endpoints;
-                this.endpointsGroupByWeight = accumulatedGroups.toArray(new EndpointsGroupByWeight[accumulatedGroups.size()]);
+                this.endpoints = endps;
+                this.endpointsGroupByWeight = accumulatedGroups.toArray(
+                        new EndpointsGroupByWeight[accumulatedGroups.size()]
+                );
                 this.totalWeight = totalWeight;
                 this.weighted = minWeight != maxWeight;
             }
@@ -188,20 +147,23 @@ final class WeightedRoundRobinStrategy implements EndpointSelectionStrategy {
                 if (weighted) {
                     long mod = Math.abs((long) (currentSequence) % totalWeight);
 
-                    if (mod < endpointsGroupByWeight[0].accumulatedWeight)
+                    if (mod < endpointsGroupByWeight[0].accumulatedWeight) {
                         return endpoints.get((int) (mod % numberEndpoints));
+                    }
 
                     int left = 0, right = endpointsGroupByWeight.length - 1, mid;
                     while (left < right) {
                         mid = left + ((right - left) >> 1);
 
-                        if (mid == left)
+                        if (mid == left) {
                             break;
+                        }
 
-                        if (endpointsGroupByWeight[mid].accumulatedWeight <= mod)
+                        if (endpointsGroupByWeight[mid].accumulatedWeight <= mod) {
                             left = mid;
-                        else
+                        } else {
                             right = mid;
+                        }
                     }
 
                     // (left + 1) is the part where sequence belongs

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightedRoundRobinStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightedRoundRobinStrategy.java
@@ -137,7 +137,7 @@ final class WeightedRoundRobinStrategy implements EndpointSelectionStrategy {
                                 .thenComparing(Endpoint::host)
                                 .thenComparingInt(Endpoint::port))
                         .collect(toImmutableList());
-                long numEndpoints = this.endpoints.size();
+                final long numEndpoints = this.endpoints.size();
 
                 // get min weight, max weight and number of distinct weight
                 int minWeight = Integer.MAX_VALUE;
@@ -186,9 +186,9 @@ final class WeightedRoundRobinStrategy implements EndpointSelectionStrategy {
                 }
 
                 if (weighted) {
-                    long numberEndpoints = endpoints.size();
+                    final long numberEndpoints = endpoints.size();
 
-                    long mod = Math.abs(currentSequence % totalWeight);
+                    final long mod = Math.abs(currentSequence % totalWeight);
 
                     if (mod < accumulatedGroups.get(0).accumulatedWeight) {
                         return endpoints.get((int) (mod % numberEndpoints));
@@ -212,8 +212,8 @@ final class WeightedRoundRobinStrategy implements EndpointSelectionStrategy {
                     }
 
                     // (left + 1) is the part where sequence belongs
-                    long indexInPart = mod - accumulatedGroups.get(left).accumulatedWeight;
-                    long startIndex = accumulatedGroups.get(left + 1).startIndex;
+                    final long indexInPart = mod - accumulatedGroups.get(left).accumulatedWeight;
+                    final long startIndex = accumulatedGroups.get(left + 1).startIndex;
                     return endpoints.get((int) (startIndex + indexInPart % (numberEndpoints - startIndex)));
                 }
 

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/WeightedRoundRobinStrategyTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/WeightedRoundRobinStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 LINE Corporation
+ * Copyright 2018 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/thrift/src/test/java/com/linecorp/armeria/it/client/endpoint/StaticEndpointGroupIntegrationTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/client/endpoint/StaticEndpointGroupIntegrationTest.java
@@ -50,9 +50,9 @@ public class StaticEndpointGroupIntegrationTest {
         serverThree.start();
 
         final EndpointGroup endpointGroup = new StaticEndpointGroup(
-                Endpoint.of("127.0.0.1", serverOne.httpPort()),
-                Endpoint.of("127.0.0.1", serverTwo.httpPort()),
-                Endpoint.of("127.0.0.1", serverThree.httpPort()));
+                Endpoint.of("127.0.0.1", serverOne.httpPort()).withWeight(1),
+                Endpoint.of("127.0.0.1", serverTwo.httpPort()).withWeight(2),
+                Endpoint.of("127.0.0.1", serverThree.httpPort()).withWeight(3));
         final String groupName = name.getMethodName();
         final String endpointGroupMark = "group:";
 
@@ -70,7 +70,7 @@ public class StaticEndpointGroupIntegrationTest {
         final StaticEndpointGroup serverGroup2 = new StaticEndpointGroup(
                 Endpoint.of("127.0.0.1", serverOne.httpPort()).withWeight(2),
                 Endpoint.of("127.0.0.1", serverTwo.httpPort()).withWeight(4),
-                Endpoint.of("127.0.0.1", serverThree.httpPort()).withWeight(2));
+                Endpoint.of("127.0.0.1", serverThree.httpPort()).withWeight(3));
 
         EndpointGroupRegistry.register(groupName, serverGroup2, WEIGHTED_ROUND_ROBIN);
 
@@ -83,6 +83,7 @@ public class StaticEndpointGroupIntegrationTest {
         assertThat(ipService.hello("ip")).isEqualTo("host:127.0.0.1:" + serverOne.httpPort());
         assertThat(ipService.hello("ip")).isEqualTo("host:127.0.0.1:" + serverThree.httpPort());
         assertThat(ipService.hello("ip")).isEqualTo("host:127.0.0.1:" + serverTwo.httpPort());
+        assertThat(ipService.hello("ip")).isEqualTo("host:127.0.0.1:" + serverThree.httpPort());
         assertThat(ipService.hello("ip")).isEqualTo("host:127.0.0.1:" + serverTwo.httpPort());
         assertThat(ipService.hello("ip")).isEqualTo("host:127.0.0.1:" + serverTwo.httpPort());
 
@@ -93,6 +94,7 @@ public class StaticEndpointGroupIntegrationTest {
         assertThat(ipService.hello("ip")).isEqualTo("host:127.0.0.1:" + serverOne.httpPort());
         assertThat(ipService.hello("ip")).isEqualTo("host:127.0.0.1:" + serverThree.httpPort());
         assertThat(ipService.hello("ip")).isEqualTo("host:127.0.0.1:" + serverTwo.httpPort());
+        assertThat(ipService.hello("ip")).isEqualTo("host:127.0.0.1:" + serverThree.httpPort());
         assertThat(ipService.hello("ip")).isEqualTo("host:127.0.0.1:" + serverTwo.httpPort());
         assertThat(ipService.hello("ip")).isEqualTo("host:127.0.0.1:" + serverTwo.httpPort());
 

--- a/thrift/src/test/java/com/linecorp/armeria/it/client/endpoint/StaticEndpointGroupIntegrationTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/client/endpoint/StaticEndpointGroupIntegrationTest.java
@@ -78,21 +78,21 @@ public class StaticEndpointGroupIntegrationTest {
                                       HelloService.Iface.class);
 
         assertThat(ipService.hello("ip")).isEqualTo("host:127.0.0.1:" + serverOne.httpPort());
-        assertThat(ipService.hello("ip")).isEqualTo("host:127.0.0.1:" + serverTwo.httpPort());
         assertThat(ipService.hello("ip")).isEqualTo("host:127.0.0.1:" + serverThree.httpPort());
+        assertThat(ipService.hello("ip")).isEqualTo("host:127.0.0.1:" + serverTwo.httpPort());
         assertThat(ipService.hello("ip")).isEqualTo("host:127.0.0.1:" + serverOne.httpPort());
-        assertThat(ipService.hello("ip")).isEqualTo("host:127.0.0.1:" + serverTwo.httpPort());
         assertThat(ipService.hello("ip")).isEqualTo("host:127.0.0.1:" + serverThree.httpPort());
+        assertThat(ipService.hello("ip")).isEqualTo("host:127.0.0.1:" + serverTwo.httpPort());
         assertThat(ipService.hello("ip")).isEqualTo("host:127.0.0.1:" + serverTwo.httpPort());
         assertThat(ipService.hello("ip")).isEqualTo("host:127.0.0.1:" + serverTwo.httpPort());
 
         //new round
         assertThat(ipService.hello("ip")).isEqualTo("host:127.0.0.1:" + serverOne.httpPort());
-        assertThat(ipService.hello("ip")).isEqualTo("host:127.0.0.1:" + serverTwo.httpPort());
         assertThat(ipService.hello("ip")).isEqualTo("host:127.0.0.1:" + serverThree.httpPort());
+        assertThat(ipService.hello("ip")).isEqualTo("host:127.0.0.1:" + serverTwo.httpPort());
         assertThat(ipService.hello("ip")).isEqualTo("host:127.0.0.1:" + serverOne.httpPort());
-        assertThat(ipService.hello("ip")).isEqualTo("host:127.0.0.1:" + serverTwo.httpPort());
         assertThat(ipService.hello("ip")).isEqualTo("host:127.0.0.1:" + serverThree.httpPort());
+        assertThat(ipService.hello("ip")).isEqualTo("host:127.0.0.1:" + serverTwo.httpPort());
         assertThat(ipService.hello("ip")).isEqualTo("host:127.0.0.1:" + serverTwo.httpPort());
         assertThat(ipService.hello("ip")).isEqualTo("host:127.0.0.1:" + serverTwo.httpPort());
 


### PR DESCRIPTION
Motivation:

Client using EndpointGroup with current WeightedRoundRobinStrategy is slow. 
* Current algorithm complexity for selectEndpoint operation is O(N * MaxWeight) where N is number of endpoints. Arbitrary weight value (>1000 for example) cause it slow. 

Modifications:
- Sort endpoints by weight, then by host and port.
- Find the correct endpoint faster by binary search on accumulated sum of weight.
- The complexity is O(log(N)) and not depend on weight value.

Algorithm details:
- In comment code block

Result:
* Faster selectEndpoint operation.

Benchmarks:

Before
```
Result "com.linecorp.armeria.core.client.endpoint.WeightedRoundRobinStrategyBenchmark.randomMainly1Max30":
  392327.218 ±(99.9%) 9226.013 ops/s [Average]

Result "com.linecorp.armeria.core.client.endpoint.WeightedRoundRobinStrategyBenchmark.randomMax10":
  289799.381 ±(99.9%) 3761.818 ops/s [Average]

Result "com.linecorp.armeria.core.client.endpoint.WeightedRoundRobinStrategyBenchmark.randomMax100":
  75949.628 ±(99.9%) 1970.120 ops/s [Average]

Result "com.linecorp.armeria.core.client.endpoint.WeightedRoundRobinStrategyBenchmark.sameWeight":
  54412957.573 ±(99.9%) 1253690.454 ops/s [Average]

Result "com.linecorp.armeria.core.client.endpoint.WeightedRoundRobinStrategyBenchmark.unique":
  21152.272 ±(99.9%) 11486.626 ops/s [Average]
```

After
```
Result "com.linecorp.armeria.core.client.endpoint.WeightedRoundRobinStrategyBenchmark.randomMainly1Max30":
  28586820.346 ±(99.9%) 145391.823 ops/s [Average]

Result "com.linecorp.armeria.core.client.endpoint.WeightedRoundRobinStrategyBenchmark.randomMax10":
  25691640.444 ±(99.9%) 574921.960 ops/s [Average]

Result "com.linecorp.armeria.core.client.endpoint.WeightedRoundRobinStrategyBenchmark.randomMax100":
  24246013.498 ±(99.9%) 994566.750 ops/s [Average]

Result "com.linecorp.armeria.core.client.endpoint.WeightedRoundRobinStrategyBenchmark.sameWeight":
  54149030.441 ±(99.9%) 1580181.334 ops/s [Average]

Result "com.linecorp.armeria.core.client.endpoint.WeightedRoundRobinStrategyBenchmark.unique":
  21813513.256 ±(99.9%) 1958592.548 ops/s [Average]
```
