### PR TITLE
Don't allocate / copy when constructing retrofit url with no query an…

### DIFF
--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/ArmeriaCallFactory.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/ArmeriaCallFactory.java
@@ -39,6 +39,7 @@ import com.linecorp.armeria.common.util.Exceptions;
 import okhttp3.Call;
 import okhttp3.Call.Factory;
 import okhttp3.Callback;
+import okhttp3.Headers;
 import okhttp3.HttpUrl;
 import okhttp3.MediaType;
 import okhttp3.Request;
@@ -152,10 +153,11 @@ final class ArmeriaCallFactory implements Factory {
                 default:
                     throw new IllegalArgumentException("Invalid HTTP method:" + request.method());
             }
-            final int numHeaders = request.headers().size();
+            final Headers requestHeaders = request.headers();
+            final int numHeaders = requestHeaders.size();
             for (int i = 0; i < numHeaders; i++) {
-                headers.add(HttpHeaderNames.of(request.headers().name(i)),
-                            request.headers().value(i));
+                headers.add(HttpHeaderNames.of(requestHeaders.name(i)),
+                            requestHeaders.value(i));
             }
             final RequestBody body = request.body();
             if (body != null) {


### PR DESCRIPTION
…d don't copy headers into a map to iterate them.

Very tiny but obvious microoptimizations.

After
```
Benchmark                         Mode  Cnt      Score     Error  Units
DownstreamSimpleBenchmark.empty  thrpt   20  11639.101 ± 389.186  ops/s
```

Before
```
Benchmark                         Mode  Cnt      Score     Error  Units
DownstreamSimpleBenchmark.empty  thrpt   20  11426.577 ± 329.674  ops/
```