### PR TITLE
Fix a bug where HttpClient connects to a wrong host when custom authority is used

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientDelegate.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientDelegate.java
@@ -17,6 +17,7 @@ package com.linecorp.armeria.client;
 
 import static java.util.Objects.requireNonNull;
 
+import java.net.InetSocketAddress;
 import java.util.concurrent.CompletableFuture;
 
 import javax.annotation.Nullable;
@@ -37,53 +38,78 @@ import com.linecorp.armeria.internal.PathAndQuery;
 
 import io.netty.channel.Channel;
 import io.netty.channel.EventLoop;
+import io.netty.resolver.AddressResolverGroup;
 import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.FutureListener;
 
 final class HttpClientDelegate implements Client<HttpRequest, HttpResponse> {
 
     private static final Logger logger = LoggerFactory.getLogger(HttpClientDelegate.class);
 
     private final HttpClientFactory factory;
+    private final AddressResolverGroup<InetSocketAddress> addressResolverGroup;
 
-    HttpClientDelegate(HttpClientFactory factory) {
+    HttpClientDelegate(HttpClientFactory factory,
+                       AddressResolverGroup<InetSocketAddress> addressResolverGroup) {
         this.factory = requireNonNull(factory, "factory");
+        this.addressResolverGroup = requireNonNull(addressResolverGroup, "addressResolverGroup");
     }
 
     @Override
     public HttpResponse execute(ClientRequestContext ctx, HttpRequest req) throws Exception {
-        final Endpoint endpoint = ctx.endpoint().resolve(ctx)
-                                     .withDefaultPort(ctx.sessionProtocol().defaultPort());
         if (!sanitizePath(req)) {
             req.abort();
             return HttpResponse.ofFailure(new IllegalArgumentException("invalid path: " + req.path()));
         }
 
-        final String host = extractHost(ctx, req, endpoint);
+        final Endpoint endpoint = ctx.endpoint().resolve(ctx)
+                                     .withDefaultPort(ctx.sessionProtocol().defaultPort());
         final EventLoop eventLoop = ctx.eventLoop();
-        final PoolKey poolKey = new PoolKey(host, endpoint.ipAddr(),
-                                            endpoint.port(), ctx.sessionProtocol());
-        final Future<Channel> channelFuture = factory.pool(eventLoop).acquire(poolKey);
         final DecodedHttpResponse res = new DecodedHttpResponse(eventLoop);
 
-        if (channelFuture.isDone()) {
-            if (channelFuture.isSuccess()) {
-                final Channel ch = channelFuture.getNow();
-                invoke0(ch, ctx, req, res, poolKey);
-            } else {
-                res.close(channelFuture.cause());
-            }
+        if (endpoint.hasIpAddr()) {
+            // IP address has been resolved already.
+            execute(ctx, endpoint, endpoint.ipAddr(), req, res);
         } else {
-            channelFuture.addListener((Future<Channel> future) -> {
+            // IP address has not been resolved yet.
+            final Future<InetSocketAddress> resolveFuture =
+                    addressResolverGroup.getResolver(eventLoop)
+                                        .resolve(InetSocketAddress.createUnresolved(endpoint.host(),
+                                                                                    endpoint.port()));
+            resolveFuture.addListener((FutureListener<InetSocketAddress>) future -> {
                 if (future.isSuccess()) {
-                    final Channel ch = future.getNow();
-                    invoke0(ch, ctx, req, res, poolKey);
+                    execute(ctx, endpoint, future.getNow().getAddress().getHostAddress(), req, res);
                 } else {
-                    res.close(channelFuture.cause());
+                    res.close(future.cause());
                 }
             });
         }
 
         return res;
+    }
+
+    private void execute(ClientRequestContext ctx, Endpoint endpoint, String ipAddr,
+                         HttpRequest req, DecodedHttpResponse res) {
+        final String host = extractHost(ctx, req, endpoint);
+        final PoolKey poolKey = new PoolKey(host, ipAddr, endpoint.port(), ctx.sessionProtocol());
+        final Future<Channel> channelFuture = factory.pool(ctx.eventLoop()).acquire(poolKey);
+
+        if (channelFuture.isDone()) {
+            finishExecute(ctx, poolKey, channelFuture, req, res);
+        } else {
+            channelFuture.addListener(
+                    (Future<Channel> future) -> finishExecute(ctx, poolKey, future, req, res));
+        }
+    }
+
+    private void finishExecute(ClientRequestContext ctx, PoolKey poolKey, Future<Channel> channelFuture,
+                               HttpRequest req, DecodedHttpResponse res) {
+        if (channelFuture.isSuccess()) {
+            final Channel ch = channelFuture.getNow();
+            invoke0(ch, ctx, req, res, poolKey);
+        } else {
+            res.close(channelFuture.cause());
+        }
     }
 
     @VisibleForTesting

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientFactory.java
@@ -106,9 +106,13 @@ final class HttpClientFactory extends AbstractClientFactory {
             long idleTimeoutMillis, boolean useHttp2Preface, boolean useHttp1Pipelining,
             KeyedChannelPoolHandler<? super PoolKey> connectionPoolListener, MeterRegistry meterRegistry) {
 
+        @SuppressWarnings("unchecked")
+        final AddressResolverGroup<InetSocketAddress> addressResolverGroup =
+                (AddressResolverGroup<InetSocketAddress>) addressResolverGroupFactory.apply(workerGroup);
+
         final Bootstrap baseBootstrap = new Bootstrap();
         baseBootstrap.channel(TransportType.socketChannelType(workerGroup));
-        baseBootstrap.resolver(addressResolverGroupFactory.apply(workerGroup));
+        baseBootstrap.resolver(addressResolverGroup);
 
         channelOptions.forEach((option, value) -> {
             @SuppressWarnings("unchecked")
@@ -132,7 +136,7 @@ final class HttpClientFactory extends AbstractClientFactory {
         this.connectionPoolListener = new ConnectionPoolListenerImpl(connectionPoolListener);
         this.meterRegistry = meterRegistry;
 
-        clientDelegate = new HttpClientDelegate(this);
+        clientDelegate = new HttpClientDelegate(this, addressResolverGroup);
         eventLoopScheduler = new EventLoopScheduler(workerGroup);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/HttpSessionChannelFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpSessionChannelFactory.java
@@ -82,16 +82,9 @@ class HttpSessionChannelFactory implements Function<PoolKey, Future<Channel>> {
     }
 
     private static InetSocketAddress toRemoteAddress(PoolKey key) throws UnknownHostException {
-        final InetSocketAddress remoteAddress;
-        final String ipAddr = key.ipAddr();
-        if (ipAddr == null) {
-            remoteAddress = InetSocketAddress.createUnresolved(key.host(), key.port());
-        } else {
-            final InetAddress inetAddr = InetAddress.getByAddress(
-                        key.host(), NetUtil.createByteArrayFromIpAddressString(ipAddr));
-            remoteAddress = new InetSocketAddress(inetAddr, key.port());
-        }
-        return remoteAddress;
+        final InetAddress inetAddr = InetAddress.getByAddress(
+                    key.host(), NetUtil.createByteArrayFromIpAddressString(key.ipAddr()));
+        return new InetSocketAddress(inetAddr, key.port());
     }
 
     void connect(SocketAddress remoteAddress, SessionProtocol protocol, Promise<Channel> sessionPromise) {

--- a/core/src/main/java/com/linecorp/armeria/client/pool/PoolKey.java
+++ b/core/src/main/java/com/linecorp/armeria/client/pool/PoolKey.java
@@ -18,10 +18,6 @@ package com.linecorp.armeria.client.pool;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.Objects;
-
-import javax.annotation.Nullable;
-
 import com.google.common.base.MoreObjects;
 
 import com.linecorp.armeria.common.SessionProtocol;
@@ -38,7 +34,6 @@ import com.linecorp.armeria.common.SessionProtocol;
 public final class PoolKey {
 
     private final String host;
-    @Nullable
     private final String ipAddr;
     private final int port;
     private final SessionProtocol sessionProtocol;
@@ -47,9 +42,9 @@ public final class PoolKey {
      * Creates a new key with the specified {@code host}, {@code ipAddr}, {@code port} and
      * {@code sessionProtocol}.
      */
-    public PoolKey(String host, @Nullable String ipAddr, int port, SessionProtocol sessionProtocol) {
+    public PoolKey(String host, String ipAddr, int port, SessionProtocol sessionProtocol) {
         this.host = requireNonNull(host, "host");
-        this.ipAddr = ipAddr;
+        this.ipAddr = requireNonNull(ipAddr, "ipAddr");
         this.port = port;
         this.sessionProtocol = requireNonNull(sessionProtocol, "sessionProtocol");
     }
@@ -63,10 +58,7 @@ public final class PoolKey {
 
     /**
      * Returns the IP address of the server associated with this key.
-     *
-     * @return the IP address, or {@code null} if the host name is not resolved.
      */
-    @Nullable
     public String ipAddr() {
         return ipAddr;
     }
@@ -96,19 +88,18 @@ public final class PoolKey {
         }
 
         final PoolKey that = (PoolKey) o;
-        return host.equals(that.host) && Objects.equals(ipAddr, that.ipAddr) &&
+        return host.equals(that.host) && ipAddr.equals(that.ipAddr) &&
                port == that.port && sessionProtocol == that.sessionProtocol;
     }
 
     @Override
     public int hashCode() {
-        return ((host.hashCode() * 31 + Objects.hashCode(ipAddr)) * 31 + port) * 31 +
-               sessionProtocol.hashCode();
+        return ((host.hashCode() * 31 + ipAddr.hashCode()) * 31 + port) * 31 + sessionProtocol.hashCode();
     }
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this).omitNullValues()
+        return MoreObjects.toStringHelper(this)
                           .add("sessionProtocol", sessionProtocol.uriText())
                           .add("host", host)
                           .add("ipAddr", ipAddr)


### PR DESCRIPTION
Motivation:

When a user specifies both:

- an Endpoint without an IP address and
- a custom authority

the expected behavior is to use the custom authority as a host name (so
that it sends the correct server name on a TLS connection) and to
connect to the IP address of the host specified by the Endpoint.

However, currently, HttpClientDelegate always uses the IP address of the
host name in the custom authority. As a result, HttpClient ends up with
connecting to a wrong host.

Modifications:

- Made sure that HttpClientDelegate resolves the IP address of the
  Endpoint.
  - PoolKey.ipAddr is now non-null.
  - HttpSessionChannelFactory now assumes PoolKey always has an IP address.
- Added test cases
- Miscellaneous
  - Removed small code duplication in HttpClientDelegate

Result:

- HttpClient does not connect to a wrong host anymore.