### PR TITLE
Reproduce Tomcat 9.0 Issue w/o predefined ports.

### DIFF
--- a/it/spring/boot-tomcat/src/main/resources/config/application.yml
+++ b/it/spring/boot-tomcat/src/main/resources/config/application.yml
@@ -1,6 +1,4 @@
 armeria:
   ports:
-    - port: 8081
+    - port: 0
       protocol: HTTP
-server:
-  port: 8080


### PR DESCRIPTION
* application.yml armeria.ports.port=0.
* SpringTomcatApplication cleanup to use @Autowired, for consistency.
* SpringTomcatApplicationItTest added test that validated that only one connector is present.
  Tomcat starts on random port.