### PR TITLE
Add a dedicated factory method for active request gauges to MeterIdPrefixFunction

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/metric/MeterIdPrefixFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/MeterIdPrefixFunction.java
@@ -27,12 +27,14 @@ import com.google.common.base.MoreObjects;
 import com.linecorp.armeria.client.metric.MetricCollectingClient;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.logging.RequestLogAvailability;
 import com.linecorp.armeria.server.PathMapping;
 import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.VirtualHost;
 import com.linecorp.armeria.server.metric.MetricCollectingService;
 
 import io.micrometer.core.instrument.MeterRegistry;
@@ -50,46 +52,71 @@ public interface MeterIdPrefixFunction {
 
     /**
      * Returns the default function that creates a {@link MeterIdPrefix} with the specified name and
-     * the {@link Tag}s derived from the current {@link PathMapping} (if available) and HTTP (or RPC)
-     * method name. e.g. {@code my_service_name{pathMapping="exact:/service/path",method="POST"}}
+     * the {@link Tag}s derived from the {@link RequestLog} properties.
+     * <ul>
+     *   <li>Server-side tags:<ul>
+     *     <li>{@code hostnamePattern} - {@link VirtualHost#hostnamePattern()}
+     *     <li>{@code pathMapping} - {@link PathMapping#meterTag()}</li>
+     *     <li>{@code method} - RPC method name or {@link HttpMethod#name()} if RPC method name is not
+     *                          available</li>
+     *     <li>{@code httpStatus} - {@link HttpStatus#code()}</li>
+     *   </ul></li>
+     *   <li>Client-side tags:<ul>
+     *     <li>{@code method} - RPC method name or {@link HttpMethod#name()} if RPC method name is not
+     *                          available</li>
+     *     <li>{@code httpStatus} - {@link HttpStatus#code()}</li>
+     *   </ul></li>
+     * </ul>
      */
     static MeterIdPrefixFunction ofDefault(String name) {
         requireNonNull(name, "name");
-        return (registry, log) -> {
-            final RequestContext ctx = log.context();
-            final Object requestContent = log.requestContent();
-
-            String methodName = null;
-            if (requestContent instanceof RpcRequest) {
-                methodName = ((RpcRequest) requestContent).method();
+        return new MeterIdPrefixFunction() {
+            @Override
+            public MeterIdPrefix activeRequestPrefix(MeterRegistry registry, RequestLog log) {
+                return new MeterIdPrefix(name, buildTags(log));
             }
 
-            if (methodName == null) {
-                final HttpHeaders requestHeaders = log.requestHeaders();
-                final HttpMethod httpMethod = requestHeaders.method();
-                if (httpMethod != null) {
-                    methodName = httpMethod.name();
+            @Override
+            public MeterIdPrefix apply(MeterRegistry registry, RequestLog log) {
+                final List<Tag> tags = buildTags(log);
+                if (log.isAvailable(RequestLogAvailability.RESPONSE_HEADERS)) {
+                    tags.add(Tag.of("httpStatus", log.status().codeAsText()));
                 }
+
+                return new MeterIdPrefix(name, tags);
             }
 
-            if (methodName == null) {
-                methodName = MoreObjects.firstNonNull(log.method().name(), "__UNKNOWN_METHOD__");
+            private List<Tag> buildTags(RequestLog log) {
+                final RequestContext ctx = log.context();
+                final Object requestContent = log.requestContent();
+
+                String methodName = null;
+                if (requestContent instanceof RpcRequest) {
+                    methodName = ((RpcRequest) requestContent).method();
+                }
+
+                if (methodName == null) {
+                    final HttpHeaders requestHeaders = log.requestHeaders();
+                    final HttpMethod httpMethod = requestHeaders.method();
+                    if (httpMethod != null) {
+                        methodName = httpMethod.name();
+                    }
+                }
+
+                if (methodName == null) {
+                    methodName = MoreObjects.firstNonNull(log.method().name(), "__UNKNOWN_METHOD__");
+                }
+
+                final List<Tag> tags = new ArrayList<>(4); // method, hostNamePattern, pathMapping, status
+                tags.add(Tag.of("method", methodName));
+
+                if (ctx instanceof ServiceRequestContext) {
+                    final ServiceRequestContext sCtx = (ServiceRequestContext) ctx;
+                    tags.add(Tag.of("hostnamePattern", sCtx.virtualHost().hostnamePattern()));
+                    tags.add(Tag.of("pathMapping", sCtx.pathMapping().meterTag()));
+                }
+                return tags;
             }
-
-            final List<Tag> tags = new ArrayList<>(4); // method, hostNamePattern, pathMapping, status
-            tags.add(Tag.of("method", methodName));
-
-            if (ctx instanceof ServiceRequestContext) {
-                final ServiceRequestContext sCtx = (ServiceRequestContext) ctx;
-                tags.add(Tag.of("hostnamePattern", sCtx.virtualHost().hostnamePattern()));
-                tags.add(Tag.of("pathMapping", sCtx.pathMapping().meterTag()));
-            }
-
-            if (log.isAvailable(RequestLogAvailability.RESPONSE_HEADERS)) {
-                tags.add(Tag.of("httpStatus", log.status().codeAsText()));
-            }
-
-            return new MeterIdPrefix(name, tags);
         };
     }
 
@@ -97,6 +124,17 @@ public interface MeterIdPrefixFunction {
      * Creates a {@link MeterIdPrefix} from the specified {@link RequestLog}.
      */
     MeterIdPrefix apply(MeterRegistry registry, RequestLog log);
+
+    /**
+     * Creates a {@link MeterIdPrefix} for the active request counter gauges from the specified
+     * {@link RequestLog}. This method by default delegates to {@link #apply(MeterRegistry, RequestLog)}.
+     * You must override this method if your {@link #apply(MeterRegistry, RequestLog)} implementation builds
+     * a {@link MeterIdPrefix} using response properties that's not always available when the active request
+     * counter is increased, such as HTTP status.
+     */
+    default MeterIdPrefix activeRequestPrefix(MeterRegistry registry,  RequestLog log) {
+        return apply(registry, log);
+    }
 
     /**
      * Returns a {@link MeterIdPrefixFunction} that returns a newly created {@link MeterIdPrefix} which has
@@ -121,6 +159,16 @@ public interface MeterIdPrefixFunction {
      * returned by this function.
      */
     default MeterIdPrefixFunction andThen(BiFunction<MeterRegistry, MeterIdPrefix, MeterIdPrefix> function) {
-        return (registry, log) -> function.apply(registry, apply(registry, log));
+        return new MeterIdPrefixFunction() {
+            @Override
+            public MeterIdPrefix activeRequestPrefix(MeterRegistry registry, RequestLog log) {
+                return function.apply(registry, MeterIdPrefixFunction.this.activeRequestPrefix(registry, log));
+            }
+
+            @Override
+            public MeterIdPrefix apply(MeterRegistry registry, RequestLog log) {
+                return function.apply(registry, MeterIdPrefixFunction.this.apply(registry, log));
+            }
+        };
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/internal/metric/RequestMetricSupport.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/metric/RequestMetricSupport.java
@@ -58,12 +58,11 @@ public final class RequestMetricSupport {
     private static void onRequest(RequestLog log, MeterIdPrefixFunction meterIdPrefixFunction) {
         final RequestContext ctx = log.context();
         final MeterRegistry registry = ctx.meterRegistry();
-        final MeterIdPrefix idPrefix = meterIdPrefixFunction.apply(registry, log);
-        final MeterIdPrefix idPrefixActive = new MeterIdPrefix(idPrefix.name("activeRequests"),
-                                                               idPrefix.tags());
+        final MeterIdPrefix activeRequestsId = meterIdPrefixFunction.activeRequestPrefix(registry, log)
+                                                                    .append("activeRequests");
 
         final ActiveRequestMetrics activeRequestMetrics = MicrometerUtil.register(
-                registry, idPrefixActive, ActiveRequestMetrics.class,
+                registry, activeRequestsId, ActiveRequestMetrics.class,
                 (reg, prefix) ->
                         reg.gauge(prefix.name(), prefix.tags(),
                                   new ActiveRequestMetrics(), ActiveRequestMetrics::doubleValue));


### PR DESCRIPTION
Motivation:

`MeterIdFunction.apply()` is currently used for generating both 1)
active request gauges and 2) other meters. This can make the active
request gauges have unexpected tags such as `httpStatus`, which does not
make sense for 'active' requests.

Modifications:

- Add `MeterIdFunction.activeRequestsPrefix()`
- Modify `MeterIdFunction.andThen()` so that the given `BiFunction` is
  applied to both `apply()` and `activeRequestsPrefix()`
- Modify `RequestMetricSupport` to use `activeRequestsPrefix()` for
  active request gauges

Result:

- Active request gauges does not happen to have a weird `httpStatus` tag.
- Fixes #1258