### PR TITLE
Do not confuse an IDE by having a source directory with two output directories

### DIFF
--- a/it/spring/boot-tomcat/build.gradle
+++ b/it/spring/boot-tomcat/build.gradle
@@ -12,7 +12,6 @@ apply plugin: 'org.springframework.boot'
 dependencies {
     compile project(':spring:boot-starter')
     compile project(':tomcat')
-    compile project(':thrift0.9')
     compile('org.springframework.boot:spring-boot-starter-web') {
         exclude group: 'org.springframework.boot', module: 'spring-boot-starter-tomcat'
     }

--- a/it/spring/boot-tomcat8.5/build.gradle
+++ b/it/spring/boot-tomcat8.5/build.gradle
@@ -1,3 +1,15 @@
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'org.springframework.boot:spring-boot-gradle-plugin:2.0.2.RELEASE'
+    }
+}
+
+apply plugin: 'java'
+apply plugin: 'org.springframework.boot'
+
 dependencyManagement {
     // Override Tomcat versions.
     dependencies {
@@ -9,29 +21,28 @@ dependencyManagement {
     }
 }
 
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'org.springframework.boot:spring-boot-gradle-plugin:2.0.2.RELEASE'
-    }
-}
-apply plugin: 'java'
-apply plugin: 'org.springframework.boot'
-
-sourceSets {
-    main.java.srcDir project(':it:spring:boot-tomcat').sourceSets.main.java
-    main.resources.srcDir project(':it:spring:boot-tomcat').sourceSets.main.resources
-    test.java.srcDir project(':it:spring:boot-tomcat').sourceSets.test.java
-}
-
 dependencies {
     compile project(':spring:boot-starter')
     compile project(':tomcat')
-    compile project(':thrift0.9')
     compile('org.springframework.boot:spring-boot-starter-web') {
         exclude group: 'org.springframework.boot', module: 'spring-boot-starter-tomcat'
     }
     testCompile('org.springframework.boot:spring-boot-starter-test')
 }
+
+// Use the sources from ':it:spring:boot-tomcat'.
+// NB: We should not add these in the 'sourceSets' directive because that will make the directories mentioned
+//     below are added to two projects and having a source directory with two output directories will confuse
+//     the IDE.
+def tomcatProjectDir = "${rootProject.projectDir}/it/spring/boot-tomcat"
+tasks.compileJava.source "${tomcatProjectDir}/src/main/java"
+tasks.processResources.from "${tomcatProjectDir}/src/main/resources"
+tasks.compileTestJava.source "${tomcatProjectDir}/src/test/java", "${tomcatProjectDir}/gen-src/test/java"
+tasks.processTestResources.from "${tomcatProjectDir}/src/test/resources"
+tasks.sourceJar.from "${tomcatProjectDir}/src/main/java"
+tasks.sourceJar.from "${tomcatProjectDir}/src/main/resources"
+tasks.javadoc.source "${tomcatProjectDir}/src/main/java"
+
+// Disable checkstyle because it's checked by ':it:spring:boot-tomcat'.
+tasks.checkstyleMain.onlyIf { false }
+tasks.checkstyleTest.onlyIf { false }

--- a/it/spring/boot-tomcat8.5/build.gradle
+++ b/it/spring/boot-tomcat8.5/build.gradle
@@ -31,9 +31,9 @@ dependencies {
 }
 
 // Use the sources from ':it:spring:boot-tomcat'.
-// NB: We should not add these in the 'sourceSets' directive because that will make the directories mentioned
-//     below are added to two projects and having a source directory with two output directories will confuse
-//     the IDE.
+// NB: We should never add these directories using the 'sourceSets' directive because that will make
+//     them added to more than one project and having a source directory with more than one output directory
+//     will confuse IDEs such as IntelliJ IDEA.
 def tomcatProjectDir = "${rootProject.projectDir}/it/spring/boot-tomcat"
 tasks.compileJava.source "${tomcatProjectDir}/src/main/java"
 tasks.processResources.from "${tomcatProjectDir}/src/main/resources"

--- a/spring/boot1-autoconfigure/build.gradle
+++ b/spring/boot1-autoconfigure/build.gradle
@@ -15,10 +15,10 @@ dependencies {
     testCompile 'org.hibernate.validator:hibernate-validator'
 }
 
-// Use the sources from 'armeria-spring-boot-autoconfigure'.
-// NB: We should not add these in the 'sourceSets' directive because that will make the directories mentioned
-//     below are added to two projects and having a source directory with two output directories will confuse
-//     the IDE.
+// Use the sources from ':spring:boot-autoconfigure'.
+// NB: We should never add these directories using the 'sourceSets' directive because that will make
+//     them added to more than one project and having a source directory with more than one output directory
+//     will confuse IDEs such as IntelliJ IDEA.
 def autoconfigureProjectDir = "${rootProject.projectDir}/spring/boot-autoconfigure"
 tasks.compileJava.source "${autoconfigureProjectDir}/src/main/java"
 tasks.processResources.from "${autoconfigureProjectDir}/src/main/resources"
@@ -30,6 +30,6 @@ tasks.javadoc.source "${autoconfigureProjectDir}/src/main/java"
 
 tasks.compileTestJava.dependsOn(project(':spring:boot-autoconfigure').tasks.findByName('compileTestThrift'))
 
-// Disable checkstyle because it's checked by 'armeria-spring-boot-autoconfigure'
+// Disable checkstyle because it's checked by ':spring:boot-autoconfigure'.
 tasks.checkstyleMain.onlyIf { false }
 tasks.checkstyleTest.onlyIf { false }

--- a/thrift0.9/build.gradle
+++ b/thrift0.9/build.gradle
@@ -20,10 +20,10 @@ dependencies {
     testCompile 'io.prometheus:simpleclient_common'
 }
 
-// Use the sources from 'armeria-thrift'.
-// NB: We should not add these in the 'sourceSets' directive because that will make the directories mentioned
-//     below are added to two projects and having a source directory with two output directories will confuse
-//     the IDE.
+// Use the sources from ':thrift'.
+// NB: We should never add these directories using the 'sourceSets' directive because that will make
+//     them added to more than one project and having a source directory with more than one output directory
+//     will confuse IDEs such as IntelliJ IDEA.
 tasks.compileJava.source "${rootProject.projectDir}/thrift/src/main/java"
 tasks.processResources.from "${rootProject.projectDir}/thrift/src/main/resources"
 tasks.compileTestJava.source "${rootProject.projectDir}/thrift/src/test/java"
@@ -40,7 +40,7 @@ ext {
 
 // Keep the original Guava references in ThriftListenableFuture,
 // which is the only place we expose Guava classes in our public API.
-// NB: Keep this same with 'armeria-thrift'.
+// NB: Keep this same with ':thrift'.
 tasks.shadedJar.exclude 'com/linecorp/armeria/common/thrift/ThriftListenableFuture*'
 tasks.shadedJar.doLast {
     ant.jar(update: true, destfile: tasks.shadedJar.archivePath) {
@@ -51,6 +51,6 @@ tasks.shadedJar.doLast {
     }
 }
 
-// Disable checkstyle because it's checked by 'armeria-thrift'
+// Disable checkstyle because it's checked by ':thrift'.
 tasks.checkstyleMain.onlyIf { false }
 tasks.checkstyleTest.onlyIf { false }

--- a/tomcat8.0/build.gradle
+++ b/tomcat8.0/build.gradle
@@ -18,10 +18,10 @@ dependencies {
     runtime 'org.slf4j:jcl-over-slf4j'
 }
 
-// Use the sources from 'armeria-tomcat' as well as ours.
-// NB: We should not add these in the 'sourceSets' directive because that will make the directories mentioned
-//     below are added to more than one project and having a source dir with more than one output dir will
-//     confuse the IDE.
+// Use the sources from ':tomcat' as well as ours.
+// NB: We should never add these directories using the 'sourceSets' directive because that will make
+//     them added to more than one project and having a source directory with more than one output directory
+//     will confuse IDEs such as IntelliJ IDEA.
 tasks.compileJava.source "${rootProject.projectDir}/tomcat/src/main/java"
 tasks.compileJava.exclude '**/Tomcat90*'
 tasks.processResources.from "${rootProject.projectDir}/tomcat/src/main/resources"

--- a/tomcat8.5/build.gradle
+++ b/tomcat8.5/build.gradle
@@ -19,10 +19,10 @@ dependencies {
     runtime 'org.slf4j:jcl-over-slf4j'
 }
 
-// Use the sources from 'armeria-tomcat' as well as ours.
-// NB: We should not add these in the 'sourceSets' directive because that will make the directories mentioned
-//     below are added to more than one project and having a source dir with more than one output dir will
-//     confuse the IDE.
+// Use the sources from ':tomcat' as well as ours.
+// NB: We should never add these directories using the 'sourceSets' directive because that will make
+//     them added to more than one project and having a source directory with more than one output directory
+//     will confuse IDEs such as IntelliJ IDEA.
 tasks.compileJava.source "${rootProject.projectDir}/tomcat/src/main/java"
 tasks.processResources.from "${rootProject.projectDir}/tomcat/src/main/resources"
 tasks.compileTestJava.source "${rootProject.projectDir}/tomcat/src/test/java"


### PR DESCRIPTION
Motivation:

IntelliJ IDEA generates an error event like the following when a source
directory has more than one output directory:

    java.lang.Throwable: Module 'boot-tomcat_main' and module 'boot-tomcat8.5_main' have the same content root: file:///home/trustin/Workspaces/armeria/it/spring/boot-tomcat/src/main/java

Modifications:

- Do not use the `sourceSets` directive for a derived project.
- Miscellaneous
  - Reorder the directives in `:it:spring:boot-tomcat8.5` so that build
    plugin part comes first
  - Remove an unused dependency

Result:

- IDE devs are happy.