### PR TITLE
Use the reference to the dedicated page about service discovery in th…

### DIFF
--- a/site/src/sphinx/index.rst
+++ b/site/src/sphinx/index.rst
@@ -64,7 +64,7 @@ Essential features for building microservices
 - Client-side health-check and load-balancing
 - Service discovery from various sources such as DNS and ZooKeeper
 
-  - See :ref:`advanced-zookeeper`.
+  - See :ref:`client-service-discovery`.
 
 - Distributed call tracing via `Zipkin`_
 


### PR DESCRIPTION
…e site front page

.. because it covers both DNS and ZooKeeper