### PR TITLE
Update dependencies

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -10,7 +10,7 @@ ch.qos.logback:
 
 com.fasterxml.jackson.core:
   jackson-annotations:
-    version: &JACKSON_VERSION '2.9.5'
+    version: &JACKSON_VERSION '2.9.6'
     javadocs:
     - https://fasterxml.github.io/jackson-annotations/javadoc/2.9/
   jackson-core:
@@ -59,11 +59,11 @@ com.google.guava:
       to: com.linecorp.armeria.internal.shaded.guava
 
 com.google.protobuf:
-  protoc: { version: '3.5.1-1' }
-  protobuf-gradle-plugin: { version: '0.8.5' }
+  protoc: { version: '3.6.0' }
+  protobuf-gradle-plugin: { version: '0.8.6' }
 
 com.puppycrawl.tools:
-  checkstyle: { version: '8.10' }
+  checkstyle: { version: '8.10.1' }
 
 com.spotify:
   completable-futures:
@@ -116,17 +116,17 @@ io.grpc:
 
 io.micrometer:
   micrometer-core:
-    version: &MICROMETER_VERSION '1.0.4'
+    version: &MICROMETER_VERSION '1.0.5'
     javadocs:
-    - https://static.javadoc.io/io.micrometer/micrometer-core/1.0.4/
+    - https://static.javadoc.io/io.micrometer/micrometer-core/1.0.5/
   micrometer-registry-prometheus:
     version: *MICROMETER_VERSION
     javadocs:
-    - https://static.javadoc.io/io.micrometer/micrometer-registry-prometheus/1.0.4/
+    - https://static.javadoc.io/io.micrometer/micrometer-registry-prometheus/1.0.5/
   micrometer-spring-legacy:
     version: *MICROMETER_VERSION
     javadocs:
-    - https://static.javadoc.io/io.micrometer/micrometer-spring-legacy/1.0.4/
+    - https://static.javadoc.io/io.micrometer/micrometer-spring-legacy/1.0.5/
     exclusions:
     - org.springframework:spring-web
     - org.springframework:spring-webmvc
@@ -142,7 +142,7 @@ io.netty:
     - https://netty.io/4.1/api/
   netty-transport-native-epoll: { version: *NETTY_VERSION }
   netty-transport-native-unix-common: { version: *NETTY_VERSION }
-  netty-tcnative-boringssl-static: { version: '2.0.8.Final' }
+  netty-tcnative-boringssl-static: { version: '2.0.11.Final' }
 
 io.prometheus:
   simpleclient_common:
@@ -152,15 +152,15 @@ io.prometheus:
 
 io.reactivex.rxjava2:
   rxjava:
-    version: '2.1.14'
+    version: '2.1.16'
     javadocs:
     - http://reactivex.io/RxJava/2.x/javadoc/
 
 io.zipkin.brave:
   brave:
-    version: &BRAVE_VERSION '5.0.0'
+    version: &BRAVE_VERSION '5.1.2'
     javadocs:
-    - https://static.javadoc.io/io.zipkin.brave/brave/5.0.0/
+    - https://static.javadoc.io/io.zipkin.brave/brave/5.1.2/
 
 it.unimi.dsi:
   fastutil:
@@ -191,10 +191,10 @@ log4j:
   log4j: { version: '1.2.17' }
 
 me.champeau.gradle:
-  jmh-gradle-plugin: { version: '0.4.5' }
+  jmh-gradle-plugin: { version: '0.4.6' }
 
 net.javacrumbs.json-unit:
-  json-unit: { version: &JSON_UNIT_VERSION '1.29.1' }
+  json-unit: { version: &JSON_UNIT_VERSION '1.31.1' }
   json-unit-fluent: { version: *JSON_UNIT_VERSION }
 
 net.sf.proguard:
@@ -240,7 +240,7 @@ org.apache.thrift:
 
 org.apache.tomcat.embed:
   tomcat-embed-core:
-    version: &TOMCAT_VERSION '9.0.8'
+    version: &TOMCAT_VERSION '9.0.10'
     javadocs:
     - https://tomcat.apache.org/tomcat-9.0-doc/api/
   tomcat-embed-jasper: { version: *TOMCAT_VERSION }
@@ -268,7 +268,7 @@ org.bouncycastle:
       to: com.linecorp.armeria.internal.shaded.bouncycastle
 
 org.checkerframework:
-  checker-compat-qual: { version: '2.5.1' }
+  checker-compat-qual: { version: '2.5.2' }
 
 org.curioswitch.curiostack:
   protobuf-jackson: { version: '0.2.1' }
@@ -277,7 +277,7 @@ org.dmonix.junit:
   zookeeper-junit: { version: '1.2' }
 
 org.eclipse.jetty:
-  apache-jsp: { version: &JETTY_VERSION '9.4.10.v20180503' }
+  apache-jsp: { version: &JETTY_VERSION '9.4.11.v20180605' }
   apache-jstl: { version: *JETTY_VERSION }
   jetty-annotations:
     version: *JETTY_VERSION
@@ -300,7 +300,7 @@ org.hibernate.validator:
   hibernate-validator: { version: '6.0.10.Final' }
 
 org.javassist:
-  javassist: { version: '3.22.0-GA' }
+  javassist: { version: '3.23.0-GA' }
 
 org.jctools:
   jctools-core:
@@ -310,13 +310,13 @@ org.jctools:
       to: com.linecorp.armeria.internal.shaded.jctools
 
 org.mockito:
-  mockito-core: { version: '2.18.3' }
+  mockito-core: { version: '2.19.0' }
 
 org.mortbay.jetty.alpn:
   jetty-alpn-agent: { version: '2.0.7' }
 
 org.openjdk.jmh:
-  jmh-core: { version: &JMH_VERSION '1.20' }
+  jmh-core: { version: &JMH_VERSION '1.21' }
   jmh-generator-annprocess: { version: *JMH_VERSION }
 
 org.reactivestreams:
@@ -344,8 +344,9 @@ org.slf4j:
 
 org.springframework.boot:
   spring-boot-starter:
-    version: &SPRING_BOOT_VERSION '2.0.2.RELEASE'
+    version: &SPRING_BOOT_VERSION '2.0.3.RELEASE'
     javadocs:
     - https://docs.spring.io/spring/docs/current/javadoc-api/
   spring-boot-starter-actuator: { version: *SPRING_BOOT_VERSION }
   spring-boot-starter-test: { version: *SPRING_BOOT_VERSION }
+  spring-boot-gradle-plugin: { version: *SPRING_BOOT_VERSION }

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -59,7 +59,7 @@ com.google.guava:
       to: com.linecorp.armeria.internal.shaded.guava
 
 com.google.protobuf:
-  protoc: { version: '3.6.0' }
+  protoc: { version: '3.5.1-1' }
   protobuf-gradle-plugin: { version: '0.8.6' }
 
 com.puppycrawl.tools:

--- a/it/spring/boot-tomcat/build.gradle
+++ b/it/spring/boot-tomcat/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'org.springframework.boot:spring-boot-gradle-plugin:2.0.2.RELEASE'
+        classpath "org.springframework.boot:spring-boot-gradle-plugin:${managedVersions['org.springframework.boot:spring-boot-gradle-plugin']}"
     }
 }
 

--- a/it/spring/boot-tomcat8.5/build.gradle
+++ b/it/spring/boot-tomcat8.5/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'org.springframework.boot:spring-boot-gradle-plugin:2.0.2.RELEASE'
+        classpath "org.springframework.boot:spring-boot-gradle-plugin:${managedVersions['org.springframework.boot:spring-boot-gradle-plugin']}"
     }
 }
 
@@ -13,7 +13,7 @@ apply plugin: 'org.springframework.boot'
 dependencyManagement {
     // Override Tomcat versions.
     dependencies {
-        dependencySet(group: 'org.apache.tomcat.embed', version: '8.5.31') {
+        dependencySet(group: 'org.apache.tomcat.embed', version: '8.5.32') {
             entry 'tomcat-embed-core'
             entry 'tomcat-embed-jasper'
             entry 'tomcat-embed-el'

--- a/spring/boot1-autoconfigure/build.gradle
+++ b/spring/boot1-autoconfigure/build.gradle
@@ -9,9 +9,9 @@ dependencies {
     compile 'io.dropwizard.metrics:metrics-json'
     compile 'javax.inject:javax.inject'
     compile 'javax.validation:validation-api'
-    compile 'org.springframework.boot:spring-boot-starter:1.5.13.RELEASE'
+    compile 'org.springframework.boot:spring-boot-starter:1.5.14.RELEASE'
 
-    testCompile 'org.springframework.boot:spring-boot-starter-test:1.5.13.RELEASE'
+    testCompile 'org.springframework.boot:spring-boot-starter-test:1.5.14.RELEASE'
     testCompile 'org.hibernate.validator:hibernate-validator'
 }
 

--- a/tomcat8.5/build.gradle
+++ b/tomcat8.5/build.gradle
@@ -1,7 +1,7 @@
 dependencyManagement {
     // Override Tomcat versions.
     dependencies {
-        dependencySet(group: 'org.apache.tomcat.embed', version: '8.5.31') {
+        dependencySet(group: 'org.apache.tomcat.embed', version: '8.5.32') {
             entry 'tomcat-embed-core'
             entry 'tomcat-embed-jasper'
             entry 'tomcat-embed-el'


### PR DESCRIPTION
- Jackson 2.9.5 -> 2.9.6
- protobuf-gradle-plugin 0.8.5 -> 0.8.6
- Checkstyle 8.10.0 -> 8.10.1
- Micrometer 1.0.4 -> 1.0.5
- Netty TCNative BorringSSL 2.0.8 -> 2.0.11
- RxJava 2.1.14 -> 2.1.16
- Brave 5.0.0 -> 5.1.2
- jmh-gradle-plugin 0.4.5 -> 0.4.6
- JSON-unit 1.29.1 -> 1.31.1
- Tomcat 9.0.8 -> 9.0.10, 8.5.31 -> 8.5.32
- Jetty 9.4.10 -> 9.4.11
- Javassist 3.22.0 -> 3.23.0
- Mockito 2.18.3 -> 2.19.0
- JMH 1.20 -> 1.21
- Spring Boot 2.0.2 -> 2.0.3, 1.5.13 -> 1.5.14