### PR TITLE
Use getServiceDescriptor to get stub methods instead of removed API. …

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -59,7 +59,7 @@ com.google.guava:
       to: com.linecorp.armeria.internal.shaded.guava
 
 com.google.protobuf:
-  protoc: { version: '3.5.1-1' }
+  protoc: { version: '3.6.0' }
   protobuf-gradle-plugin: { version: '0.8.5' }
 
 com.puppycrawl.tools:
@@ -92,7 +92,7 @@ io.dropwizard.metrics:
 
 io.grpc:
   grpc-core:
-    version: &GRPC_VERSION '1.12.0'
+    version: &GRPC_VERSION '1.13.1'
     javadocs:
     - https://grpc.io/grpc-java/javadoc/
     - https://developers.google.com/protocol-buffers/docs/reference/java/

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -59,7 +59,7 @@ com.google.guava:
       to: com.linecorp.armeria.internal.shaded.guava
 
 com.google.protobuf:
-  protoc: { version: '3.6.0' }
+  protoc: { version: '3.5.1-1' }
   protobuf-gradle-plugin: { version: '0.8.5' }
 
 com.puppycrawl.tools:

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientFactory.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientFactory.java
@@ -15,12 +15,10 @@
  */
 package com.linecorp.armeria.client.grpc;
 
-import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
@@ -29,6 +27,8 @@ import java.util.Optional;
 import java.util.Set;
 
 import org.curioswitch.common.protobuf.json.MessageMarshaller;
+
+import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.client.ClientBuilderParams;
@@ -46,6 +46,7 @@ import com.linecorp.armeria.internal.grpc.GrpcJsonUtil;
 
 import io.grpc.Channel;
 import io.grpc.MethodDescriptor;
+import io.grpc.ServiceDescriptor;
 import io.grpc.stub.AbstractStub;
 
 /**
@@ -145,18 +146,19 @@ final class GrpcClientFactory extends DecoratingClientFactory {
     }
 
     private static List<MethodDescriptor<?, ?>> stubMethods(Class<?> stubClass) {
-        return Arrays.stream(stubClass.getDeclaredFields())
-                     .filter(field -> (field.getModifiers() & Modifier.PUBLIC) != 0 &&
-                                      (field.getModifiers() & Modifier.STATIC) != 0 &&
-                                      MethodDescriptor.class.isAssignableFrom(field.getType()))
-                     .map(field -> {
-                         try {
-                             return (MethodDescriptor<?, ?>) field.get(null);
-                         } catch (IllegalAccessException e) {
-                             throw new IllegalStateException("Modifier is public so can't happen.", e);
-                         }
-                     })
-                     .collect(toImmutableList());
+        final Method getServiceDescriptorMethod;
+        try {
+            getServiceDescriptorMethod = stubClass.getDeclaredMethod("getServiceDescriptor");
+        } catch (NoSuchMethodException e) {
+            throw new IllegalStateException("Could not find getServiceDescriptor on gRPC client stub.");
+        }
+        final ServiceDescriptor descriptor;
+        try {
+            descriptor = (ServiceDescriptor) getServiceDescriptorMethod.invoke(stubClass);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new IllegalStateException("Could not invoke getServiceDescriptor on a gRPC client stub.");
+        }
+        return ImmutableList.copyOf(descriptor.getMethods());
     }
 
     private Client<HttpRequest, HttpResponse> newHttpClient(URI uri, Scheme scheme, ClientOptions options) {


### PR DESCRIPTION
…getServiceDescriptor has existed since 1.0.0.

I must have missed this method when first implementing since it's at the end of the file...