### PR TITLE
Update dependencies

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -63,7 +63,7 @@ com.google.protobuf:
   protobuf-gradle-plugin: { version: '0.8.6' }
 
 com.puppycrawl.tools:
-  checkstyle: { version: '8.10.1' }
+  checkstyle: { version: '8.11' }
 
 com.spotify:
   completable-futures:
@@ -132,7 +132,7 @@ io.micrometer:
     - org.springframework:spring-webmvc
 
 io.netty:
-  netty-codec-http2: { version: &NETTY_VERSION '4.1.25.Final' }
+  netty-codec-http2: { version: &NETTY_VERSION '4.1.26.Final' }
   netty-codec-haproxy: { version: *NETTY_VERSION }
   netty-handler: { version: *NETTY_VERSION }
   netty-resolver-dns: { version: *NETTY_VERSION }
@@ -142,7 +142,7 @@ io.netty:
     - https://netty.io/4.1/api/
   netty-transport-native-epoll: { version: *NETTY_VERSION }
   netty-transport-native-unix-common: { version: *NETTY_VERSION }
-  netty-tcnative-boringssl-static: { version: '2.0.10.Final' }
+  netty-tcnative-boringssl-static: { version: '2.0.12.Final' }
 
 io.prometheus:
   simpleclient_common:
@@ -219,7 +219,7 @@ org.apache.hbase:
 
 org.apache.httpcomponents:
   httpclient:
-    version: '4.5.5'
+    version: '4.5.6'
     exclusions:
     - commons-logging:commons-logging
 
@@ -258,17 +258,17 @@ org.assertj:
   assertj-core: { version: '3.10.0' }
 
 org.awaitility:
-  awaitility: { version: '3.1.0' }
+  awaitility: { version: '3.1.1' }
 
 org.bouncycastle:
   bcprov-jdk15on:
-    version: '1.59'
+    version: '1.60'
     relocations:
     - from: org.bouncycastle
       to: com.linecorp.armeria.internal.shaded.bouncycastle
 
 org.checkerframework:
-  checker-compat-qual: { version: '2.5.2' }
+  checker-compat-qual: { version: '2.5.3' }
 
 org.curioswitch.curiostack:
   protobuf-jackson: { version: '0.2.1' }

--- a/tomcat8.0/build.gradle
+++ b/tomcat8.0/build.gradle
@@ -1,6 +1,6 @@
 dependencyManagement {
     dependencies {
-        dependencySet(group: 'org.apache.tomcat.embed', version: '8.0.52') {
+        dependencySet(group: 'org.apache.tomcat.embed', version: '8.0.53') {
             entry 'tomcat-embed-core'
             entry 'tomcat-embed-jasper'
             entry 'tomcat-embed-el'


### PR DESCRIPTION
- Netty 4.1.25 -> 4.1.26
  - Netty TCNative BoringSSL 2.0.10 -> 2.0.12
- Bouncy Castle 1.59 -> 1.60
- Tomcat 8.0.52 -> 8.0.53
- Build-time only dependencies
  - Apache HttpComponents 4.5.5 -> 4.5.6
  - Awaitility 3.1.0 -> 3.1.1
  - Checker framework 2.5.2 -> 2.5.3
  - Checkstyle 8.10.1 -> 8.11