### PR TITLE
Fix a bug where a RST frame for a non-existent stream can be sent

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/Http2ResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http2ResponseDecoder.java
@@ -147,8 +147,13 @@ final class Http2ResponseDecoder extends HttpResponseDecoder implements Http2Con
 
         final HttpHeaders converted = ArmeriaHttpUtil.toArmeria(headers);
         try {
-            res.scheduleTimeout(ctx);
-            res.write(converted);
+            // If this tryWrite() returns false, it means the response stream has been closed due to
+            // disconnection or by the response consumer. We do not need to handle such cases here because
+            // it will be notified to the response consumer anyway.
+            if (!res.tryWrite(converted)) {
+                // Schedule only when the response stream is still open.
+                res.scheduleTimeout(ctx);
+            }
         } catch (Throwable t) {
             res.close(t);
             throw connectionError(INTERNAL_ERROR, t, "failed to consume a HEADERS frame");


### PR DESCRIPTION
Motivation:

When a client-side subscriber of a response stream closes the response
stream even before any HEADERS frame is sent to the stream, Armeria
tries to send a RST frame to that stream, which is a violation of
HTTP/2.

Modifications:

- Do not send a RST frame if the stream does not exist yet.
- Do not fail a client-side HTTP/2 connection even if
  Http2ResponseDecoder failed to write a received HttpObject to a
  response stream.
- Remove the test skip code in GrpcClientTest

Result:

- GrpcClientTest is not flaky anymore.
- HTTP/2 connections are not closed unexpectedly.