### PR TITLE
Do not fail but warn when Optional and Default are used redundantly

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/AnnotatedElementNameUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AnnotatedElementNameUtil.java
@@ -76,7 +76,7 @@ final class AnnotatedElementNameUtil {
                         "cannot obtain the name of the parameter or field automatically. " +
                         "Please make sure you compiled your code with '-parameters' option. " +
                         "If not, you need to specify parameter and header names with @" +
-                        Param.class.getName() + " and @" + Header.class.getName() + '.');
+                        Param.class.getSimpleName() + " and @" + Header.class.getSimpleName() + '.');
             }
             return parameter.getName();
         }

--- a/core/src/main/java/com/linecorp/armeria/server/AnnotatedValueResolver.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AnnotatedValueResolver.java
@@ -571,12 +571,12 @@ final class AnnotatedValueResolver {
     }
 
     @VisibleForTesting
-    public boolean shouldExist() {
+    boolean shouldExist() {
         return shouldExist;
     }
 
     @VisibleForTesting
-    public boolean shouldWrapValueAsOptional() {
+    boolean shouldWrapValueAsOptional() {
         return shouldWrapValueAsOptional;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/AnnotatedValueResolver.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AnnotatedValueResolver.java
@@ -299,6 +299,7 @@ final class AnnotatedValueResolver {
                 .annotation(param)
                 .httpElementName(name)
                 .typeElement(typeElement)
+                .supportOptional(true)
                 .pathVariable(true)
                 .resolver(resolver(ctx -> ctx.context().pathParam(name)))
                 .build();
@@ -575,6 +576,11 @@ final class AnnotatedValueResolver {
     }
 
     @VisibleForTesting
+    public boolean shouldWrapValueAsOptional() {
+        return shouldWrapValueAsOptional;
+    }
+
+    @VisibleForTesting
     @Nullable
     Class<?> containerType() {
         // 'List' or 'Set'
@@ -806,33 +812,48 @@ final class AnnotatedValueResolver {
 
             final Default aDefault = annotatedElement.getAnnotation(Default.class);
             if (aDefault != null) {
-                if (!supportDefault) {
-                    throw new IllegalArgumentException(
-                            '@' + Default.class.getSimpleName() + " is not supported for: " +
-                            (annotation != null ? annotation.annotationType().getSimpleName()
-                                                : type.getTypeName()));
-                }
+                if (supportDefault) {
+                    // Warn unusual usage. e.g. @Param @Default("a") Optional<String> param
+                    if (shouldWrapValueAsOptional) {
+                        // 'annotatedElement' can be one of constructor, field, method or parameter.
+                        // So, it may be printed verbosely but it's okay because it provides where this message
+                        // is caused.
+                        logger.warn("@{} was used with '{}'. " +
+                                    "Optional is redundant because the value is always present.",
+                                    Default.class.getSimpleName(), annotatedElement);
+                    }
 
-                // Warn unusual usage. e.g. @Param @Default("a") Optional<String> param
-                if (shouldWrapValueAsOptional) {
-                    // 'annotatedElement' can be one of constructor, field, method or parameter.
-                    // So, it may be printed verbosely but it's okay because it provides where this message
-                    // is caused.
-                    logger.warn("Both {} type and @{} are specified on {}. One of them can be omitted.",
-                                Optional.class.getSimpleName(), Default.class.getSimpleName(),
-                                annotatedElement);
-                }
+                    shouldExist = false;
+                    defaultValue = getSpecifiedValue(aDefault.value()).get();
+                } else {
+                    // Warn if @Default exists in an unsupported place.
+                    final StringBuilder msg = new StringBuilder();
+                    msg.append('@');
+                    msg.append(Default.class.getSimpleName());
+                    msg.append(" is redundant for ");
+                    if (pathVariable) {
+                        msg.append("path variable '").append(httpElementName).append('\'');
+                    } else if (annotation != null) {
+                        msg.append("annotation @").append(annotation.annotationType().getSimpleName());
+                    } else {
+                        msg.append("type '").append(type.getTypeName()).append('\'');
+                    }
+                    msg.append(" because the value is always present.");
+                    logger.warn(msg.toString());
 
-                shouldExist = false;
-                defaultValue = getSpecifiedValue(aDefault.value()).get();
+                    shouldExist = !shouldWrapValueAsOptional;
+                    // Set the default value to null just like it was not specified.
+                    defaultValue = null;
+                }
             } else {
                 shouldExist = !shouldWrapValueAsOptional;
-                // Set the default value to 'null' if it was not specified.
+                // Set the default value to null if it was not specified.
                 defaultValue = null;
             }
 
             if (pathVariable && !shouldExist) {
-                throw new IllegalArgumentException("Path variable should be mandatory: " + annotatedElement);
+                logger.warn("Optional is redundant for path variable '{}' because the value is always present.",
+                            httpElementName);
             }
 
             final Entry<Class<?>, Class<?>> types;

--- a/core/src/test/java/com/linecorp/armeria/server/AnnotatedHttpServiceBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/AnnotatedHttpServiceBuilderTest.java
@@ -190,6 +190,24 @@ public class AnnotatedHttpServiceBuilderTest {
             public void root(@Header("a") ArrayList<String> a,
                              @Header("a") LinkedList<String> b) {}
         });
+
+        // Optional is redundant, but we just warn.
+        new ServerBuilder().annotatedService(new Object() {
+            @Get("/{name}")
+            public void root(@Param("name") Optional<String> name) {}
+        });
+
+        // @Default and Optional were used together, but we just warn.
+        new ServerBuilder().annotatedService(new Object() {
+            @Get("/test")
+            public void root(@Param("name") @Default("a") Optional<String> name) {}
+        });
+
+        // @Default is redundant, but we just warn.
+        new ServerBuilder().annotatedService(new Object() {
+            @Get("/test")
+            public void root(@Default("a") ServiceRequestContext ctx) {}
+        });
     }
 
     @Test
@@ -243,11 +261,6 @@ public class AnnotatedHttpServiceBuilderTest {
 
         assertThatThrownBy(() -> new ServerBuilder().annotatedService(new Object() {
             @Get("/{name}")
-            public void root(@Param("name") Optional<String> name) {}
-        })).isInstanceOf(IllegalArgumentException.class);
-
-        assertThatThrownBy(() -> new ServerBuilder().annotatedService(new Object() {
-            @Get("/{name}")
             public void root(@Param("name") Optional<AnnotatedHttpServiceBuilderTest> name) {}
         })).isInstanceOf(IllegalArgumentException.class);
 
@@ -280,11 +293,6 @@ public class AnnotatedHttpServiceBuilderTest {
             @Get("/test")
             @Default("a")
             public void root(ServiceRequestContext ctx) {}
-        })).isInstanceOf(IllegalArgumentException.class);
-
-        assertThatThrownBy(() -> new ServerBuilder().annotatedService(new Object() {
-            @Get("/test")
-            public void root(@Default("a") ServiceRequestContext ctx) {}
         })).isInstanceOf(IllegalArgumentException.class);
     }
 

--- a/core/src/test/java/com/linecorp/armeria/server/AnnotatedValueResolverTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/AnnotatedValueResolverTest.java
@@ -53,6 +53,7 @@ import com.linecorp.armeria.server.AnnotatedValueResolver.RequestObjectResolver;
 import com.linecorp.armeria.server.AnnotatedValueResolver.ResolverContext;
 import com.linecorp.armeria.server.annotation.Cookies;
 import com.linecorp.armeria.server.annotation.Default;
+import com.linecorp.armeria.server.annotation.Get;
 import com.linecorp.armeria.server.annotation.Header;
 import com.linecorp.armeria.server.annotation.Param;
 import com.linecorp.armeria.server.annotation.RequestObject;
@@ -122,6 +123,11 @@ public class AnnotatedValueResolverTest {
     static boolean shouldHttpParameterExist(AnnotatedValueResolver element) {
         return element.shouldExist() ||
                existingHttpParameters.contains(element.httpElementName());
+    }
+
+    static boolean shouldPathVariableExist(AnnotatedValueResolver element) {
+        return element.shouldExist() ||
+               pathParams.contains(element.httpElementName());
     }
 
     @Test
@@ -282,9 +288,13 @@ public class AnnotatedValueResolverTest {
         }
 
         if (resolver.annotation().annotationType() == Param.class) {
-            if (shouldHttpParameterExist(resolver)) {
+            if (shouldHttpParameterExist(resolver) ||
+                shouldPathVariableExist(resolver)) {
+                assertThat(resolver.httpElementName()).isNotNull();
                 if (resolver.elementType().isEnum()) {
                     testEnum(value, resolver.httpElementName());
+                } else if (resolver.shouldWrapValueAsOptional()) {
+                    assertThat(value).isEqualTo(Optional.of(resolver.httpElementName()));
                 } else {
                     assertThat(value).isEqualTo(resolver.httpElementName());
                 }
@@ -296,6 +306,8 @@ public class AnnotatedValueResolverTest {
                                                     .containsOnly(resolver.defaultValue());
                     assertThat(((List<Object>) value).get(0).getClass())
                             .isEqualTo(resolver.elementType());
+                } else if (resolver.shouldWrapValueAsOptional()) {
+                    assertThat(value).isEqualTo(Optional.of(resolver.defaultValue()));
                 } else {
                     assertThat(value).isEqualTo(resolver.defaultValue());
                 }
@@ -383,6 +395,14 @@ public class AnnotatedValueResolverTest {
         public void dummy1() {}
 
         public void dummy2(String a) {}
+
+        public void redundant1(@Param @Default("defaultValue") Optional<String> value) {}
+
+        @Get("/r2/:var1")
+        public void redundant2(@Param @Default("defaultValue") String var1) {}
+
+        @Get("/r3/:var1")
+        public void redundant3(@Param Optional<String> var1) {}
     }
 
     interface Bean {

--- a/core/src/test/java/com/linecorp/armeria/server/AnnotatedValueResolverTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/AnnotatedValueResolverTest.java
@@ -121,13 +121,11 @@ public class AnnotatedValueResolverTest {
     }
 
     static boolean shouldHttpParameterExist(AnnotatedValueResolver element) {
-        return element.shouldExist() ||
-               existingHttpParameters.contains(element.httpElementName());
+        return existingHttpParameters.contains(element.httpElementName());
     }
 
     static boolean shouldPathVariableExist(AnnotatedValueResolver element) {
-        return element.shouldExist() ||
-               pathParams.contains(element.httpElementName());
+        return pathParams.contains(element.httpElementName());
     }
 
     @Test


### PR DESCRIPTION
Motivation:

Armeria currently raises an exception when a user creates an annotated
service with redundant use of Optional and Default:

    // No need to use Optional because 'value' is always present.
    @Get("/foo/:value")
    public String foo(@Param Optional<String> value) {}

    // No need to use @Default because 'value' is always present.
    @Get("/bar/:value")
    public String bar(@Param @Default("defVal") String value) {}

    // Optional and @Default were used together. 'value' will always be present.
    @Get("/baz")
    public String baz(@Param @Default("defVal") Optional<String> value) {}

We could relax a little bit and just warn so that the server starts up
anyway because it wouldn't harm and it would give a user less surprise.

Modifications:

- Log a warning message instead of raising an exception when a redundant
  usage of `@Default` and `Optional` was detected.
- Clean up the warning message a little bit so it is easier to
  understand.

Result:

- Better UX