### PR TITLE
Do not add HTTP port if TLS was enabled and no port was specified

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -1037,7 +1037,7 @@ public final class ServerBuilder {
             if (!this.ports.isEmpty()) {
                 ports = ImmutableList.copyOf(this.ports);
             } else {
-                ports = ImmutableList.of(new ServerPort(0, HTTP, HTTPS));
+                ports = ImmutableList.of(new ServerPort(0, HTTPS));
             }
 
             final DomainNameMappingBuilder<SslContext>


### PR DESCRIPTION
Motivation:

When a user sets up his or her server like the following:

    new ServerBuilder()
            .tls(...)
            .service(...)
            .build();

The server will listen at two ephemeral ports, one for HTTP and the
other for HTTPS.

This is a surprising behavior - a user would expect the server to listen
at an HTTPS port only.

Modifications:

- Do not add HTTP port but only HTTPS port if TLS was enabled and no
  port was specified.

Result:

- Fixes #1279