### PR TITLE
Fix a StackOverflowError when stopping a starting server or starting a stopping server

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/Server.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Server.java
@@ -242,7 +242,8 @@ public final class Server implements AutoCloseable {
         case STOPPING:
             // A user called start() to restart the server, but the server is not stopped completely.
             // Try again after stopping.
-            state.future.handle(voidFunction((ret, cause) -> start(future)))
+            state.future.handleAsync(voidFunction((ret, cause) -> start(future)),
+                                     GlobalEventExecutor.INSTANCE)
                         .exceptionally(CompletionActions::log);
             return;
         }
@@ -274,7 +275,7 @@ public final class Server implements AutoCloseable {
 
     private ChannelFuture start(ServerPort port) {
         final ServerBootstrap b = new ServerBootstrap();
-        this.serverBootstrap = b;
+        serverBootstrap = b;
         config.channelOptions().forEach((k, v) -> {
             @SuppressWarnings("unchecked")
             final ChannelOption<Object> castOption = (ChannelOption<Object>) k;
@@ -341,7 +342,8 @@ public final class Server implements AutoCloseable {
                 return;
             case STARTING:
                 // Wait until the start process is finished, and then try again.
-                state.future.handle(voidFunction((ret, cause) -> stop(future)))
+                state.future.handleAsync(voidFunction((ret, cause) -> stop(future)),
+                                         GlobalEventExecutor.INSTANCE)
                             .exceptionally(CompletionActions::log);
                 return;
             }


### PR DESCRIPTION
Motivation:

When a user attempts to stop a server that's currently starting up or to
start a server that's currently shutting down, `Server` re-attempts to
stop/start the server after the current job (start/stop) is finished.

In a rare case, such a follow-up re-attempt is invoked even before the
state machine of the server gets a chance to enter `STOPPED` or `STARTED`
state, leading to infinite recursion.

Modifications:

- Use `handleAsync` rather than `handle` for potentially recursive
  operations, so that the state machine is given a chance to enter a new
  state.

Result:

`StackOverflowError` is gone.