### PR TITLE
Update Netty from 4.1.26 to 4.1.27

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -132,7 +132,7 @@ io.micrometer:
     - org.springframework:spring-webmvc
 
 io.netty:
-  netty-codec-http2: { version: &NETTY_VERSION '4.1.26.Final' }
+  netty-codec-http2: { version: &NETTY_VERSION '4.1.27.Final' }
   netty-codec-haproxy: { version: *NETTY_VERSION }
   netty-handler: { version: *NETTY_VERSION }
   netty-resolver-dns: { version: *NETTY_VERSION }


### PR DESCRIPTION
Netty 4.1.27 has been released to fix some regressions showed up in 4.1.26.