### PR TITLE
Do not use framed version of Javadoc

### DIFF
--- a/site/src/sphinx/_extensions/api.py
+++ b/site/src/sphinx/_extensions/api.py
@@ -73,8 +73,8 @@ def api_visit_literal(self, node, next_visitor):
         uri = javadoc_mappings[text]
         text = text.replace('$', '.')
 
-    # Prepend the frame index.html path.
-    uri = os.path.relpath(javadoc_dir, env.app.outdir).replace(os.sep, '/') + '/index.html?' + uri
+    # Prepend the path to the Javadoc directory.
+    uri = os.path.relpath(javadoc_dir, env.app.outdir).replace(os.sep, '/') + '/' + uri
     # Prepend the '@' back again if necessary
     if is_annotation:
         text = '@' + text

--- a/site/src/sphinx/client-grpc.rst
+++ b/site/src/sphinx/client-grpc.rst
@@ -1,4 +1,4 @@
-.. _CompletableFuture: https://docs.oracle.com/javase/8/docs/api/index.html?java/util/concurrent/CompletableFuture.html
+.. _CompletableFuture: https://docs.oracle.com/javase/10/docs/api/java/util/concurrent/CompletableFuture.html
 .. _Futures: https://google.github.io/guava/releases/21.0/api/docs/com/google/common/util/concurrent/Futures.html
 .. _ListenableFuture: https://google.github.io/guava/releases/21.0/api/docs/com/google/common/util/concurrent/ListenableFuture.html
 .. _gRPC: https://grpc.io/

--- a/site/src/sphinx/client-thrift.rst
+++ b/site/src/sphinx/client-thrift.rst
@@ -1,5 +1,5 @@
 .. _AsyncMethodCallback: https://github.com/apache/thrift/blob/bd964c7f3460c308161cb6eb90583874a7d8d848/lib/java/src/org/apache/thrift/async/AsyncMethodCallback.java#L22
-.. _CompletableFuture: https://docs.oracle.com/javase/8/docs/api/index.html?java/util/concurrent/CompletableFuture.html
+.. _CompletableFuture: https://docs.oracle.com/javase/10/docs/api/java/util/concurrent/CompletableFuture.html
 
 .. _client-thrift:
 

--- a/site/src/sphinx/server-access-log.rst
+++ b/site/src/sphinx/server-access-log.rst
@@ -1,4 +1,4 @@
-.. _DateTimeFormatter: https://docs.oracle.com/javase/8/docs/api/index.html?java/time/format/DateTimeFormatter.html
+.. _DateTimeFormatter: https://docs.oracle.com/javase/10/docs/api/java/time/format/DateTimeFormatter.html
 
 .. _server-access-log:
 


### PR DESCRIPTION
Motivation:

Since Java 9, Javadoc defaults to non-framed version. We should be
consistent across our web site for hyperlinks to Javadoc.

Modifications:

- Use hyperlinks to non-framed versions of Javadoc

Result:

Consistency