### PR TITLE
Allow to register duplicated endpoints under HealthCheckedEndpointGroup

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
@@ -110,7 +110,8 @@ public abstract class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
         final Map<Endpoint, ServerConnection> allServersByEndpoint = allServers
                 .stream()
                 .collect(toImmutableMap(ServerConnection::endpoint,
-                                        Function.identity()));
+                                        Function.identity(),
+                                        (l, r) -> l));
         return allServers = delegate
                 .endpoints()
                 .stream()

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroupTest.java
@@ -190,6 +190,8 @@ public class HttpHealthCheckedEndpointGroupTest {
                     .containsEntry("armeria.client.endpointGroup.healthy#value" +
                                    "{authority=127.0.0.1:" + portOne + ",name=baz}", 1.0);
         });
+        serverOne.stop();
+        await().untilAsserted(() -> assertThat(endpointGroup.endpoints()).isEmpty());
     }
 
     /**


### PR DESCRIPTION
Motivations:
- A user sometimes want to register duplicated entries to EndpointGroup
  to implement `virtual node` to balance requests. But if duplicated
  entries are added to an `EndpointGroups`, it stops to update EndpointGroup
  refresh.

Modifications:
- Apply merging function not to throw exception when duplicated entries
  are found in endpoint group list.