### PR TITLE
Add the git checkout action to post-release-msg

### DIFF
--- a/.post-release-msg
+++ b/.post-release-msg
@@ -18,6 +18,7 @@
 5. Copy the web site generated to the 'gh-pages' branch, e.g.
 
    cd ../site-armeria
+   git checkout gh-pages
    rm -fr .buildinfo .doctrees .gradle *
    rsync -aiP --exclude '.*' ../upstream-armeria/site/build/site/ .
    git add -A .


### PR DESCRIPTION
So that a user(me) never forget to checkout gh-pages before publishes the site.