### PR TITLE
Add SAML configurator in order to easily enable SAML authentication o…

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -8,6 +8,12 @@ ch.qos.logback:
     javadocs:
     - https://logback.qos.ch/apidocs/
 
+com.auth0:
+  java-jwt:
+    version: '3.4.0'
+    javadocs:
+    - https://www.javadoc.io/doc/com.auth0/java-jwt/3.4.0/
+
 com.fasterxml.jackson.core:
   jackson-annotations:
     version: &JACKSON_VERSION '2.9.6'
@@ -203,6 +209,9 @@ net.javacrumbs.json-unit:
 net.sf.proguard:
   proguard-gradle: { version: '6.0.3' }
 
+net.shibboleth.utilities:
+  java-support: { version: '7.3.0' }
+
 org.apache.curator:
   curator-recipes:
     version: '4.0.1'
@@ -309,6 +318,9 @@ org.jctools:
     - from: org.jctools
       to: com.linecorp.armeria.internal.shaded.jctools
 
+org.jsoup:
+  jsoup: { version: '1.11.3' }
+
 org.mockito:
   mockito-core: { version: '2.21.0' }
 
@@ -318,6 +330,15 @@ org.mortbay.jetty.alpn:
 org.openjdk.jmh:
   jmh-core: { version: &JMH_VERSION '1.21' }
   jmh-generator-annprocess: { version: *JMH_VERSION }
+
+org.opensaml:
+  opensaml-core: { version: &OPENSAML_VERSION '3.3.0' }
+  opensaml-saml-api: { version: *OPENSAML_VERSION }
+  opensaml-saml-impl: { version: *OPENSAML_VERSION }
+  opensaml-messaging-api: { version: *OPENSAML_VERSION }
+  opensaml-messaging-impl: { version: *OPENSAML_VERSION }
+  opensaml-soap-api: { version: *OPENSAML_VERSION }
+  opensaml-soap-impl: { version: *OPENSAML_VERSION }
 
 org.reactivestreams:
   reactive-streams: { version: &REACTIVE_STREAMS_VERSION '1.0.2' }

--- a/licenses/LICENSE.java-jwt.mit.txt
+++ b/licenses/LICENSE.java-jwt.mit.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Auth0, Inc. <support@auth0.com> (http://auth0.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/licenses/LICENSE.java-support.al20.txt
+++ b/licenses/LICENSE.java-support.al20.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/licenses/LICENSE.jsoup.mit.txt
+++ b/licenses/LICENSE.jsoup.mit.txt
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) 2009-2018 Jonathan Hedley <jonathan@hedley.net>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/licenses/LICENSE.opensaml.al20.txt
+++ b/licenses/LICENSE.opensaml.al20.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/saml/build.gradle
+++ b/saml/build.gradle
@@ -1,0 +1,12 @@
+dependencies {
+    compile 'com.auth0:java-jwt'
+    compile 'net.shibboleth.utilities:java-support'
+    compile 'org.opensaml:opensaml-core'
+    compile 'org.opensaml:opensaml-saml-api'
+    compile 'org.opensaml:opensaml-saml-impl'
+    compile 'org.opensaml:opensaml-messaging-api'
+    compile 'org.opensaml:opensaml-messaging-impl'
+    compile 'org.opensaml:opensaml-soap-api'
+    compile 'org.opensaml:opensaml-soap-impl'
+    testCompile 'org.jsoup:jsoup'
+}

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/HttpPostBindingUtil.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/HttpPostBindingUtil.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.saml;
+
+import static com.linecorp.armeria.server.saml.SamlHttpParameterNames.RELAY_STATE;
+import static com.linecorp.armeria.server.saml.SamlMessageUtil.deserialize;
+import static com.linecorp.armeria.server.saml.SamlMessageUtil.serialize;
+import static com.linecorp.armeria.server.saml.SamlMessageUtil.sign;
+import static java.util.Objects.requireNonNull;
+import static net.shibboleth.utilities.java.support.xml.SerializeSupport.nodeToString;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import javax.annotation.Nullable;
+
+import org.opensaml.messaging.context.MessageContext;
+import org.opensaml.saml.common.SAMLObject;
+import org.opensaml.saml.common.SignableSAMLObject;
+import org.opensaml.saml.common.messaging.context.SAMLBindingContext;
+import org.opensaml.security.credential.Credential;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.escape.Escaper;
+import com.google.common.html.HtmlEscapers;
+
+import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.server.saml.SamlService.SamlParameters;
+
+/**
+ * A utility class which supports HTTP POST binding protocol.
+ */
+final class HttpPostBindingUtil {
+
+    private static final ImmutableList<String> XHTML = ImmutableList.of(
+            // 0
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+            "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\" \"DTD/xhtml1-strict.dtd\">" +
+            "<html xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\" lang=\"en\">" +
+            "<head><meta http-equiv=\"content-type\" content=\"text/html;charset=utf-8\" /></head>" +
+            "<body onload=\"document.forms[0].submit()\">",
+            // 1, 2
+            "<form method=\"post\" action=\"", "\">",
+            // 3, 4, 5
+            "<input type=\"hidden\" name=\"", "\" value=\"", "\" />",
+            // 6
+            "</form></body></html>");
+
+    private static final Escaper HTML_ESCAPER = HtmlEscapers.htmlEscaper();
+
+    /**
+     * Returns an {@link HttpData} which holds a SSO form.
+     */
+    static HttpData getSsoForm(String remoteEndpointUrl,
+                               String paramName, String paramValue,
+                               @Nullable String relayState) {
+        requireNonNull(remoteEndpointUrl, "remoteEndpointUrl");
+        requireNonNull(paramName, "paramName");
+        requireNonNull(paramValue, "paramValue");
+
+        final StringBuilder html = new StringBuilder();
+        html.append(XHTML.get(0))
+            .append(XHTML.get(1)).append(HTML_ESCAPER.escape(remoteEndpointUrl)).append(XHTML.get(2))
+            .append(XHTML.get(3)).append(HTML_ESCAPER.escape(paramName))
+            .append(XHTML.get(4)).append(HTML_ESCAPER.escape(paramValue)).append(XHTML.get(5));
+
+        if (relayState != null) {
+            html.append(XHTML.get(3)).append(RELAY_STATE)
+                .append(XHTML.get(4)).append(HTML_ESCAPER.escape(relayState)).append(XHTML.get(5));
+        }
+        html.append(XHTML.get(6));
+
+        return HttpData.ofUtf8(html.toString());
+    }
+
+    /**
+     * Signs the specified {@link SignableSAMLObject} with the specified {@link Credential} and
+     * {@code signatureAlgorithm}, and then encodes the object into a base64 string.
+     */
+    static String toSignedBase64(SignableSAMLObject signableObj,
+                                 Credential signingCredential,
+                                 String signatureAlgorithm) throws SamlException {
+        sign(signableObj, signingCredential, signatureAlgorithm);
+        final String messageStr = nodeToString(serialize(signableObj));
+        return Base64.getEncoder().encodeToString(messageStr.getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Converts an {@link AggregatedHttpMessage} which is received from the remote entity to
+     * a {@link SAMLObject}.
+     */
+    static <T extends SAMLObject> MessageContext<T> toSamlObject(AggregatedHttpMessage msg,
+                                                                 String name) throws SamlException {
+        final SamlParameters parameters = new SamlParameters(msg);
+        final byte[] decoded;
+        try {
+            decoded = Base64.getDecoder().decode(parameters.getFirstValue(name));
+        } catch (IllegalArgumentException e) {
+            throw new SamlException("failed to decode a base64 string of the parameter: " + name, e);
+        }
+
+        @SuppressWarnings("unchecked")
+        final T message = (T) deserialize(decoded);
+
+        final MessageContext<T> messageContext = new MessageContext<>();
+        messageContext.setMessage(message);
+
+        final String relayState = parameters.getFirstValueOrNull(RELAY_STATE);
+        if (relayState != null) {
+            final SAMLBindingContext context = messageContext.getSubcontext(SAMLBindingContext.class, true);
+            assert context != null;
+            context.setRelayState(relayState);
+        }
+
+        return messageContext;
+    }
+
+    private HttpPostBindingUtil() {}
+}

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/HttpRedirectBindingUtil.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/HttpRedirectBindingUtil.java
@@ -1,0 +1,290 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.saml;
+
+import static com.linecorp.armeria.server.saml.SamlHttpParameterNames.RELAY_STATE;
+import static com.linecorp.armeria.server.saml.SamlHttpParameterNames.SIGNATURE;
+import static com.linecorp.armeria.server.saml.SamlHttpParameterNames.SIGNATURE_ALGORITHM;
+import static java.util.Objects.requireNonNull;
+import static net.shibboleth.utilities.java.support.xml.SerializeSupport.nodeToString;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+import java.util.zip.Deflater;
+import java.util.zip.DeflaterOutputStream;
+import java.util.zip.Inflater;
+import java.util.zip.InflaterOutputStream;
+
+import javax.annotation.Nullable;
+
+import org.opensaml.core.xml.XMLObject;
+import org.opensaml.core.xml.io.MarshallingException;
+import org.opensaml.core.xml.util.XMLObjectSupport;
+import org.opensaml.messaging.context.MessageContext;
+import org.opensaml.saml.common.SAMLObject;
+import org.opensaml.saml.common.messaging.context.SAMLBindingContext;
+import org.opensaml.saml.saml2.core.Issuer;
+import org.opensaml.saml.saml2.core.RequestAbstractType;
+import org.opensaml.saml.saml2.core.StatusResponseType;
+import org.opensaml.security.SecurityException;
+import org.opensaml.security.credential.Credential;
+import org.opensaml.xmlsec.crypto.XMLSigningUtil;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.server.saml.SamlService.SamlParameters;
+
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.handler.codec.http.QueryStringEncoder;
+
+/**
+ * A utility class which supports HTTP-Redirect binding protocol.
+ */
+final class HttpRedirectBindingUtil {
+
+    private static final String DEFAULT_CACHE_CONTROL =
+            String.join(",", HttpHeaderValues.NO_CACHE, HttpHeaderValues.NO_STORE);
+    private static final String DEFAULT_PRAGMA = HttpHeaderValues.NO_CACHE.toString();
+
+    /**
+     * Returns an {@link HttpHeaders} with the specified {@code location}, the default {@code cache-control}
+     * and the default {@code pragma} headers.
+     */
+    static HttpHeaders headersWithLocation(String location) {
+        return HttpHeaders.of(HttpStatus.FOUND)
+                          .add(HttpHeaderNames.LOCATION, location)
+                          .add(HttpHeaderNames.CACHE_CONTROL, DEFAULT_CACHE_CONTROL)
+                          .add(HttpHeaderNames.PRAGMA, DEFAULT_PRAGMA);
+    }
+
+    /**
+     * Returns an {@link HttpResponse} with the specified {@code location}, the default {@code cache-control}
+     * and the default {@code pragma} headers.
+     */
+    static HttpResponse responseWithLocation(String location) {
+        return HttpResponse.of(headersWithLocation(location));
+    }
+
+    /**
+     * Returns a redirected URL which includes a deflated base64 string that is converted from the specified
+     * {@link SAMLObject}. The URL must contain a signature of the generated query string.
+     */
+    static String toRedirectionUrl(SAMLObject msg,
+                                   String endpointUrl,
+                                   String messageParamName,
+                                   Credential signingCredential,
+                                   String signatureAlgorithm,
+                                   @Nullable String relayState) throws SamlException {
+        requireNonNull(msg, "msg");
+        requireNonNull(endpointUrl, "endpointUrl");
+        requireNonNull(messageParamName, "messageParamName");
+        requireNonNull(signingCredential, "signingCredential");
+        requireNonNull(signatureAlgorithm, "signatureAlgorithm");
+
+        final QueryStringEncoder encoder = new QueryStringEncoder("");
+        encoder.addParam(messageParamName, toDeflatedBase64(msg));
+
+        if (relayState != null) {
+            // RelayState data MAY be included with a SAML protocol message transmitted with this binding.
+            // The value MUST NOT exceed 80 bytes in length and SHOULD be integrity protected by the entity
+            // creating the message independent of any other protections that may or may not exist
+            // during message transmission.
+            if (relayState.length() > 80) {
+                throw new IllegalArgumentException("too long relayState string: " + relayState.length());
+            }
+            encoder.addParam(RELAY_STATE, relayState);
+        }
+
+        encoder.addParam(SIGNATURE_ALGORITHM, signatureAlgorithm);
+
+        // Use URL-encoded query string as input.
+        final String input = encoder.toString().substring(1);
+        final String output = generateSignature(signingCredential, signatureAlgorithm, input);
+        encoder.addParam(SIGNATURE, output);
+
+        return endpointUrl + encoder;
+    }
+
+    /**
+     * Validates a signature in the specified {@link AggregatedHttpMessage}.
+     */
+    private static void validateSignature(Credential validationCredential,
+                                          SamlParameters parameters,
+                                          String messageParamName) throws SamlException {
+        requireNonNull(validationCredential, "validationCredential");
+        requireNonNull(parameters, "parameters");
+        requireNonNull(messageParamName, "messageParamName");
+
+        final String signature = parameters.getFirstValue(SIGNATURE);
+        final String sigAlg = parameters.getFirstValue(SIGNATURE_ALGORITHM);
+
+        // The order is one of the followings:
+        // - SAMLRequest={value}&RelayState={value}=SigAlg={value}
+        // - SAMLResponse={value}&RelayState={value}=SigAlg={value}
+        final QueryStringEncoder encoder = new QueryStringEncoder("");
+        encoder.addParam(messageParamName, parameters.getFirstValue(messageParamName));
+
+        final String relayState = parameters.getFirstValueOrNull(RELAY_STATE);
+        if (relayState != null) {
+            encoder.addParam(RELAY_STATE, relayState);
+        }
+        encoder.addParam(SIGNATURE_ALGORITHM, sigAlg);
+
+        final byte[] input = encoder.toString().substring(1).getBytes(StandardCharsets.UTF_8);
+
+        try {
+            final byte[] decodedSignature = Base64.getDecoder().decode(signature);
+            if (!XMLSigningUtil.verifyWithURI(validationCredential, sigAlg, decodedSignature, input)) {
+                throw new SamlException("failed to validate a signature");
+            }
+        } catch (IllegalArgumentException e) {
+            throw new SamlException("failed to decode a base64 signature string", e);
+        } catch (SecurityException e) {
+            throw new SamlException("failed to validate a signature", e);
+        }
+    }
+
+    /**
+     * Generates a signature of the specified {@code input}.
+     */
+    @VisibleForTesting
+    static String generateSignature(Credential signingCredential,
+                                    String algorithmURI, String input) throws SamlException {
+        try {
+            final byte[] signature =
+                    XMLSigningUtil.signWithURI(signingCredential, algorithmURI,
+                                               input.getBytes(StandardCharsets.UTF_8));
+            return Base64.getEncoder().encodeToString(signature);
+        } catch (SecurityException e) {
+            throw new SamlException("failed to generate a signature", e);
+        }
+    }
+
+    /**
+     * Encodes the specified {@code message} into a deflated base64 string.
+     */
+    static String toDeflatedBase64(SAMLObject message) throws SamlException {
+        requireNonNull(message, "message");
+
+        final String messageStr;
+        try {
+            messageStr = nodeToString(XMLObjectSupport.marshall(message));
+        } catch (MarshallingException e) {
+            throw new SamlException("failed to serialize a SAML message", e);
+        }
+
+        final ByteArrayOutputStream bytesOut = new ByteArrayOutputStream();
+        try (DeflaterOutputStream deflaterStream =
+                     new DeflaterOutputStream(Base64.getEncoder().wrap(bytesOut),
+                                              new Deflater(Deflater.DEFLATED, true))) {
+            deflaterStream.write(messageStr.getBytes(StandardCharsets.UTF_8));
+        } catch (IOException e) {
+            throw new SamlException("failed to deflate a SAML message", e);
+        }
+        return bytesOut.toString();
+    }
+
+    /**
+     * Decodes, inflates and deserializes the specified base64-encoded message to an {@link XMLObject}.
+     */
+    static XMLObject fromDeflatedBase64(String base64Encoded) throws SamlException {
+        requireNonNull(base64Encoded, "base64Encoded");
+
+        final byte[] base64decoded;
+        try {
+            base64decoded = Base64.getDecoder().decode(base64Encoded);
+        } catch (IllegalArgumentException e) {
+            throw new SamlException("failed to decode a deflated base64 string", e);
+        }
+
+        final ByteArrayOutputStream bytesOut = new ByteArrayOutputStream();
+        try (InflaterOutputStream inflaterOutputStream =
+                     new InflaterOutputStream(bytesOut, new Inflater(true))) {
+            inflaterOutputStream.write(base64decoded);
+        } catch (IOException e) {
+            throw new SamlException("failed to inflate a SAML message", e);
+        }
+
+        return SamlMessageUtil.deserialize(bytesOut.toByteArray());
+    }
+
+    /**
+     * Converts an {@link AggregatedHttpMessage} which is received from the remote entity to
+     * a {@link SAMLObject}.
+     */
+    @SuppressWarnings("unchecked")
+    static <T extends SAMLObject> MessageContext<T> toSamlObject(
+            AggregatedHttpMessage msg, String name,
+            Map<String, SamlIdentityProviderConfig> idpConfigs,
+            @Nullable SamlIdentityProviderConfig defaultIdpConfig) throws SamlException {
+        requireNonNull(msg, "msg");
+        requireNonNull(name, "name");
+        requireNonNull(idpConfigs, "idpConfigs");
+
+        final SamlParameters parameters = new SamlParameters(msg);
+        final T message = (T) fromDeflatedBase64(parameters.getFirstValue(name));
+
+        final MessageContext<T> messageContext = new MessageContext<>();
+        messageContext.setMessage(message);
+
+        final Issuer issuer;
+        if (message instanceof RequestAbstractType) {
+            issuer = ((RequestAbstractType) message).getIssuer();
+        } else if (message instanceof StatusResponseType) {
+            issuer = ((StatusResponseType) message).getIssuer();
+        } else {
+            throw new SamlException("invalid message type: " + message.getClass().getSimpleName());
+        }
+
+        // Use the default identity provider config if there's no issuer.
+        final SamlIdentityProviderConfig config;
+        if (issuer != null) {
+            final String idpEntityId = issuer.getValue();
+            config = idpConfigs.get(idpEntityId);
+            if (config == null) {
+                throw new SamlException("a message from unknown identity provider: " + idpEntityId);
+            }
+        } else {
+            if (defaultIdpConfig == null) {
+                throw new SamlException("failed to get an Issuer element");
+            }
+            config = defaultIdpConfig;
+        }
+
+        // If this message is sent via HTTP-redirect binding protocol, its signature parameter should
+        // be validated.
+        validateSignature(config.signingCredential(), parameters, name);
+
+        final String relayState = parameters.getFirstValueOrNull(RELAY_STATE);
+        if (relayState != null) {
+            final SAMLBindingContext context = messageContext.getSubcontext(SAMLBindingContext.class, true);
+            assert context != null;
+            context.setRelayState(relayState);
+        }
+
+        return messageContext;
+    }
+
+    private HttpRedirectBindingUtil() {}
+}

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/JwtBasedSamlRequestIdManager.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/JwtBasedSamlRequestIdManager.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.saml;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.netty.util.internal.MacAddressUtil.defaultMachineId;
+import static java.util.Objects.requireNonNull;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Base64;
+import java.util.Base64.Encoder;
+import java.util.Date;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.JWTVerifier;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.google.common.base.MoreObjects;
+
+import io.netty.util.internal.ThreadLocalRandom;
+
+/**
+ * A {@link SamlRequestIdManager} implementation based on JSON Web Tokens specification.
+ * See <a href="https://jwt.io/">JSON Web Tokens</a> for more information.
+ */
+final class JwtBasedSamlRequestIdManager implements SamlRequestIdManager {
+    private static final Logger logger = LoggerFactory.getLogger(JwtBasedSamlRequestIdManager.class);
+
+    private static final String CLAIM_NAME_UNIQUIFIER1 = "un1";
+    private static final String CLAIM_NAME_UNIQUIFIER2 = "un2";
+
+    private final String issuer;
+    private final Algorithm algorithm;
+    private final int validSeconds;
+    private final int leewaySeconds;
+
+    private final String un1;
+    private final JWTVerifier verifier;
+
+    JwtBasedSamlRequestIdManager(String issuer, Algorithm algorithm,
+                                 int validSeconds, int leewaySeconds) {
+        this.issuer = requireNonNull(issuer, "issuer");
+        this.algorithm = requireNonNull(algorithm, "algorithm");
+        this.validSeconds = validSeconds;
+        this.leewaySeconds = leewaySeconds;
+
+        checkArgument(validSeconds > 0,
+                      "invalid valid duration: " + validSeconds + " (expected: > 0)");
+        checkArgument(leewaySeconds >= 0,
+                      "invalid leeway duration:" + leewaySeconds + " (expected: >= 0)");
+
+        un1 = getUniquifierPrefix();
+        verifier = JWT.require(algorithm)
+                      .withIssuer(issuer)
+                      .acceptLeeway(leewaySeconds)
+                      .build();
+    }
+
+    @Override
+    public String newId() {
+        final Instant now = Instant.now();
+        final int un2 = ThreadLocalRandom.current().nextInt(Integer.MAX_VALUE) & 0x7fffffff;
+        return JWT.create()
+                  .withIssuer(issuer)
+                  .withIssuedAt(Date.from(now))
+                  .withExpiresAt(Date.from(now.plus(validSeconds, ChronoUnit.SECONDS)))
+                  // To make multiple tokens issued in the same second unique, we add uniquifiers.
+                  .withClaim(CLAIM_NAME_UNIQUIFIER1, un1)
+                  .withClaim(CLAIM_NAME_UNIQUIFIER2, un2)
+                  .sign(algorithm);
+    }
+
+    @Override
+    public boolean validateId(String id) {
+        requireNonNull(id, "id");
+        try {
+            // Verifier will check whether its issuer is me and also check whether it has been expired or not.
+            verifier.verify(id);
+            return true;
+        } catch (Throwable cause) {
+            logger.trace("JWT token validation failed", cause);
+            return false;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("issuer", issuer)
+                          .add("algorithm", algorithm)
+                          .add("validSeconds", validSeconds)
+                          .add("leewaySeconds", leewaySeconds)
+                          .toString();
+    }
+
+    private static String getUniquifierPrefix() {
+        // To make a request ID globally unique, we will add MAC-based machine ID and a random number.
+        // The random number tries to make this instance unique in the same machine and process.
+        final byte[] r = new byte[6];
+        ThreadLocalRandom.current().nextBytes(r);
+        final Encoder encoder = Base64.getEncoder();
+        return new StringBuilder().append(encoder.encodeToString(defaultMachineId()))
+                                  .append(encoder.encodeToString(r))
+                                  .toString();
+    }
+}

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/KeyStoreCredentialResolverBuilder.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/KeyStoreCredentialResolverBuilder.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.saml;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.opensaml.security.credential.CredentialResolver;
+import org.opensaml.security.credential.impl.KeyStoreCredentialResolver;
+
+/**
+ * A builder class which creates a new {@link KeyStoreCredentialResolver} instance.
+ */
+public final class KeyStoreCredentialResolverBuilder {
+
+    private final String path;
+    private final String keystorePassword;
+    private final Map<String, String> keyPasswords = new HashMap<>();
+
+    /**
+     * Creates a builder instance for {@link KeyStoreCredentialResolver}.
+     */
+    public KeyStoreCredentialResolverBuilder(String path, String keystorePassword) {
+        this.path = requireNonNull(path, "path");
+        this.keystorePassword = requireNonNull(keystorePassword, "keystorePassword");
+    }
+
+    /**
+     * Adds a key name and its password to the {@link KeyStoreCredentialResolverBuilder}.
+     */
+    public KeyStoreCredentialResolverBuilder addKeyPassword(String name, String password) {
+        requireNonNull(name, "name");
+        requireNonNull(password, "password");
+        checkArgument(!keyPasswords.containsKey(name), "key already exists: %s", name);
+        keyPasswords.put(name, password);
+        return this;
+    }
+
+    /**
+     * Creates a new {@link KeyStoreCredentialResolver}.
+     */
+    public CredentialResolver build() throws IOException, GeneralSecurityException {
+        final KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
+        try (InputStream is = KeyStoreCredentialResolverBuilder.class.getClassLoader()
+                                                                     .getResourceAsStream(path)) {
+            ks.load(is, keystorePassword.toCharArray());
+        }
+        return new KeyStoreCredentialResolver(ks, keyPasswords);
+    }
+}

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/SamlAssertionConsumerConfig.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/SamlAssertionConsumerConfig.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.saml;
+
+import static java.util.Objects.requireNonNull;
+
+import com.google.common.base.MoreObjects;
+
+/**
+ * A configuration for an assertion consumer service of a service provider.
+ */
+public final class SamlAssertionConsumerConfig {
+    private final SamlEndpoint endpoint;
+    private final boolean isDefault;
+
+    SamlAssertionConsumerConfig(SamlEndpoint endpoint, boolean isDefault) {
+        this.endpoint = requireNonNull(endpoint, "endpoint");
+        this.isDefault = isDefault;
+    }
+
+    /**
+     * Returns a {@link SamlEndpoint} that an assertion consumer service is to be bound to.
+     */
+    public SamlEndpoint endpoint() {
+        return endpoint;
+    }
+
+    /**
+     * Returns whether this configuration is a default.
+     */
+    public boolean isDefault() {
+        return isDefault;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("endpoint", endpoint)
+                          .add("default", isDefault)
+                          .toString();
+    }
+}

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/SamlAssertionConsumerConfigBuilder.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/SamlAssertionConsumerConfigBuilder.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.saml;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A builder which builds a {@link SamlAssertionConsumerConfig}.
+ */
+public final class SamlAssertionConsumerConfigBuilder {
+
+    private final SamlServiceProviderBuilder parent;
+
+    private SamlEndpoint endpoint;
+    private boolean isDefault;
+
+    SamlAssertionConsumerConfigBuilder(SamlServiceProviderBuilder parent) {
+        this.parent = parent;
+    }
+
+    /**
+     * Returns a {@link SamlEndpoint} of this assertion consumer service.
+     */
+    SamlEndpoint endpoint() {
+        return endpoint;
+    }
+
+    /**
+     * Sets an endpoint of this assertion consumer service.
+     */
+    public SamlAssertionConsumerConfigBuilder endpoint(SamlEndpoint endpoint) {
+        this.endpoint = requireNonNull(endpoint, "endpoint");
+        return this;
+    }
+
+    /**
+     * Sets this assertion consumer service as a default.
+     */
+    public SamlAssertionConsumerConfigBuilder asDefault() {
+        isDefault = true;
+        return this;
+    }
+
+    /**
+     * Returns a {@link SamlServiceProvider} which is the parent of this builder.
+     */
+    public SamlServiceProviderBuilder and() {
+        return parent;
+    }
+
+    /**
+     * Builds a {@link SamlAssertionConsumerConfig}.
+     */
+    SamlAssertionConsumerConfig build() {
+        return new SamlAssertionConsumerConfig(endpoint, isDefault);
+    }
+}

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/SamlAssertionConsumerFunction.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/SamlAssertionConsumerFunction.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.saml;
+
+import static com.linecorp.armeria.server.saml.SamlHttpParameterNames.SAML_RESPONSE;
+import static com.linecorp.armeria.server.saml.SamlMessageUtil.validateSignature;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.Nullable;
+
+import org.joda.time.DateTime;
+import org.opensaml.messaging.context.MessageContext;
+import org.opensaml.saml.common.messaging.context.SAMLBindingContext;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.AuthnStatement;
+import org.opensaml.saml.saml2.core.Conditions;
+import org.opensaml.saml.saml2.core.EncryptedAssertion;
+import org.opensaml.saml.saml2.core.Issuer;
+import org.opensaml.saml.saml2.core.Response;
+import org.opensaml.saml.saml2.core.Status;
+import org.opensaml.saml.saml2.core.StatusCode;
+import org.opensaml.saml.saml2.core.Subject;
+import org.opensaml.saml.saml2.core.SubjectConfirmation;
+import org.opensaml.saml.saml2.core.SubjectConfirmationData;
+import org.opensaml.saml.saml2.encryption.Decrypter;
+import org.opensaml.security.credential.Credential;
+import org.opensaml.xmlsec.encryption.support.DecryptionException;
+import org.opensaml.xmlsec.encryption.support.InlineEncryptedKeyResolver;
+import org.opensaml.xmlsec.keyinfo.impl.StaticKeyInfoCredentialResolver;
+
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.server.ServiceRequestContext;
+
+/**
+ * A service which receives an assertion from the remote identity provider.
+ */
+final class SamlAssertionConsumerFunction implements SamlServiceFunction {
+
+    private static long MILLIS_IN_MINUTE = TimeUnit.MINUTES.toMillis(1);
+
+    private final SamlAssertionConsumerConfig cfg;
+    private final String entityId;
+    private final Map<String, SamlIdentityProviderConfig> idpConfigs;
+    @Nullable
+    private final SamlIdentityProviderConfig defaultIdpConfig;
+
+    private final SamlRequestIdManager requestIdManager;
+    private final SamlSingleSignOnHandler ssoHandler;
+
+    SamlAssertionConsumerFunction(SamlAssertionConsumerConfig cfg, String entityId,
+                                  Map<String, SamlIdentityProviderConfig> idpConfigs,
+                                  @Nullable SamlIdentityProviderConfig defaultIdpConfig,
+                                  SamlRequestIdManager requestIdManager,
+                                  SamlSingleSignOnHandler ssoHandler) {
+        this.cfg = cfg;
+        this.entityId = entityId;
+        this.idpConfigs = idpConfigs;
+        this.defaultIdpConfig = defaultIdpConfig;
+        this.requestIdManager = requestIdManager;
+        this.ssoHandler = ssoHandler;
+    }
+
+    @Override
+    public HttpResponse serve(ServiceRequestContext ctx, AggregatedHttpMessage msg,
+                              String defaultHostname, SamlPortConfig portConfig) {
+        try {
+            final MessageContext<Response> messageContext;
+            if (cfg.endpoint().bindingProtocol() == SamlBindingProtocol.HTTP_REDIRECT) {
+                messageContext = HttpRedirectBindingUtil.toSamlObject(msg, SAML_RESPONSE,
+                                                                      idpConfigs, defaultIdpConfig);
+            } else {
+                messageContext = HttpPostBindingUtil.toSamlObject(msg, SAML_RESPONSE);
+            }
+
+            final String endpointUri = cfg.endpoint().toUriString(portConfig.scheme().uriText(),
+                                                                  defaultHostname, portConfig.port());
+            final Response response = messageContext.getMessage();
+            final Assertion assertion = getValidatedAssertion(response, endpointUri);
+
+            // Find a session index which is sent by an identity provider.
+            final String sessionIndex = assertion.getAuthnStatements().stream()
+                                                 .map(AuthnStatement::getSessionIndex)
+                                                 .filter(Objects::nonNull)
+                                                 .findFirst().orElse(null);
+
+            final SAMLBindingContext bindingContext = messageContext.getSubcontext(SAMLBindingContext.class);
+            final String relayState = bindingContext != null ? bindingContext.getRelayState() : null;
+
+            return ssoHandler.loginSucceeded(ctx, msg, messageContext, sessionIndex, relayState);
+        } catch (SamlException e) {
+            return ssoHandler.loginFailed(ctx, msg, null, e);
+        }
+    }
+
+    private SamlIdentityProviderConfig resolveIdpConfig(Issuer issuer) throws SamlException {
+        final String value = issuer.getValue();
+        if (value != null) {
+            final SamlIdentityProviderConfig config = idpConfigs.get(value);
+            if (config != null) {
+                return config;
+            }
+        }
+        throw new SamlException("failed to find identity provider from configuration " +
+                                issuer.getValue());
+    }
+
+    private Assertion getValidatedAssertion(Response response, String endpointUri) throws SamlException {
+        final Status status = response.getStatus();
+        final String statusCode = status.getStatusCode().getValue();
+        if (!StatusCode.SUCCESS.equals(statusCode)) {
+            throw new SamlException("response status code: " + statusCode +
+                                    " (expected: " + StatusCode.SUCCESS + ')');
+        }
+
+        final DateTime now = new DateTime();
+        final DateTime issueInstant = response.getIssueInstant();
+        if (issueInstant == null) {
+            throw new SamlException("failed to get IssueInstant attribute");
+        }
+        if (Math.abs(now.getMillis() - issueInstant.getMillis()) > MILLIS_IN_MINUTE) {
+            // Allow if 'issueInstant' is in [now - 60s, now + 60s] because there might be the
+            // time difference between SP's timer and IdP's timer.
+            throw new SamlException("invalid IssueInstant: " + issueInstant);
+        }
+
+        final List<Assertion> assertions;
+        if (response.getEncryptedAssertions().isEmpty()) {
+            assertions = response.getAssertions();
+        } else {
+            // - The <Issuer> element MAY be omitted, but if present it MUST contain the unique identifier
+            //   of the issuing identity provider; the Format attribute MUST be omitted or have a value of
+            //   urn:oasis:names:tc:SAML:2.0:nameid-format:entity.
+            final SamlIdentityProviderConfig idp;
+            final Issuer issuer = response.getIssuer();
+            if (issuer != null) {
+                idp = resolveIdpConfig(issuer);
+            } else {
+                // If assertions are encrypted, IdP's encryption credential is necessary to decrypt them.
+                // A default IdP configuration will be used if there is no Issuer element in the response.
+                if (defaultIdpConfig == null) {
+                    throw new SamlException("failed to decrypt an assertion because there is no credential");
+                }
+                idp = defaultIdpConfig;
+            }
+
+            final ImmutableList.Builder<Assertion> builder = new ImmutableList.Builder<>();
+            for (final EncryptedAssertion encryptedAssertion : response.getEncryptedAssertions()) {
+                builder.add(decryptAssertion(encryptedAssertion, idp.encryptionCredential()));
+            }
+            builder.addAll(response.getAssertions());
+            assertions = builder.build();
+        }
+
+        // - It MUST contain at least one <Assertion>. Each assertion's <Issuer> element MUST contain the
+        //   unique identifier of the issuing identity provider; the Format attribute MUST be omitted or
+        //   have a value of urn:oasis:names:tc:SAML:2.0:nameid-format:entity.
+        if (assertions.isEmpty()) {
+            throw new SamlException("failed to get Assertion elements from the response");
+        }
+
+        // - The set of one or more assertions MUST contain at least one <AuthnStatement> that reflects the
+        //   authentication of the principal to the identity provider.
+        for (final Assertion assertion : assertions) {
+            final Issuer issuer = assertion.getIssuer();
+            if (issuer == null || issuer.getValue() == null) {
+                throw new SamlException("failed to get an Issuer element from the assertion");
+            }
+
+            final SamlIdentityProviderConfig idp = resolveIdpConfig(issuer);
+
+            validateSignature(idp.signingCredential(), response);
+            validateSignature(idp.signingCredential(), assertion);
+
+            final List<AuthnStatement> authnStatements = assertion.getAuthnStatements();
+            if (authnStatements.isEmpty()) {
+                continue;
+            }
+
+            final Subject subject = assertion.getSubject();
+            if (subject == null) {
+                continue;
+            }
+
+            // - At least one assertion containing an <AuthnStatement> MUST contain a <Subject> element with
+            //   at least one <SubjectConfirmation> element containing a Method of
+            //   urn:oasis:names:tc:SAML:2.0:cm:bearer. If the identity provider supports the Single Logout
+            //   idp, defined in Section 4.4, any such authentication statements MUST include a SessionIndex
+            //   attribute to enable per-session logout requests by the service provider.
+            //
+            // - The bearer <SubjectConfirmation> element described above MUST contain a
+            //   <SubjectConfirmationData> element that contains a Recipient attribute containing the service
+            //   provider's assertion consumer service URL and a NotOnOrAfter attribute that limits the window
+            //   during which the assertion can be delivered. It MAY contain an Address attribute limiting
+            //   the client address from which the assertion can be delivered.
+            //   It MUST NOT contain a NotBefore attribute. If the containing message is in response to
+            //   an <AuthnRequest>, then the InResponseTo attribute MUST match the request's ID.
+            final List<SubjectConfirmation> subjectConfirmations = subject.getSubjectConfirmations();
+            for (final SubjectConfirmation subjectConfirmation : subjectConfirmations) {
+                if (!"urn:oasis:names:tc:SAML:2.0:cm:bearer".equals(subjectConfirmation.getMethod())) {
+                    continue;
+                }
+                final SubjectConfirmationData data = subjectConfirmation.getSubjectConfirmationData();
+                if (data == null) {
+                    continue;
+                }
+
+                if (!endpointUri.equals(data.getRecipient())) {
+                    throw new SamlException("recipient is not matched: " + data.getRecipient());
+                }
+                if (now.isAfter(data.getNotOnOrAfter())) {
+                    throw new SamlException("response has been expired: " + data.getNotOnOrAfter());
+                }
+                if (!requestIdManager.validateId(data.getInResponseTo())) {
+                    throw new SamlException("request ID is not valid: " + data.getInResponseTo());
+                }
+
+                final Conditions conditions = assertion.getConditions();
+                if (conditions == null) {
+                    throw new SamlException("no condition found from the assertion");
+                }
+
+                // - The assertion(s) containing a bearer subject confirmation MUST contain an
+                //   <AudienceRestriction> including the service provider's unique identifier as an <Audience>.
+                //
+                // - Other conditions (and other <Audience> elements) MAY be included as requested by the
+                //   service provider or at the discretion of the identity provider. (Of course, all such
+                //   conditions MUST be understood by and accepted by the service provider in order for
+                //   the assertion to be considered valid.) The identity provider is NOT obligated to honor
+                //   the requested set of <Conditions> in the <AuthnRequest>, if any.
+                conditions.getAudienceRestrictions().stream()
+                          .flatMap(r -> r.getAudiences().stream())
+                          .filter(audience -> entityId.equals(audience.getAudienceURI()))
+                          .findAny()
+                          .orElseThrow(() -> new SamlException("no audience found from the assertion"));
+
+                return assertion;
+            }
+        }
+        throw new SamlException("no subject found from the assertions");
+    }
+
+    private static Assertion decryptAssertion(EncryptedAssertion encryptedAssertion,
+                                              Credential decryptionCredential) throws SamlException {
+        final StaticKeyInfoCredentialResolver keyInfoCredentialResolver =
+                new StaticKeyInfoCredentialResolver(decryptionCredential);
+        final Decrypter decrypter =
+                new Decrypter(null, keyInfoCredentialResolver, new InlineEncryptedKeyResolver());
+        decrypter.setRootInNewDocument(true);
+        try {
+            return decrypter.decrypt(encryptedAssertion);
+        } catch (DecryptionException e) {
+            throw new SamlException("failed to decrypt an assertion", e);
+        }
+    }
+}

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/SamlBindingProtocol.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/SamlBindingProtocol.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.saml;
+
+/**
+ * SAML binding protocols. Only HTTP Redirect and HTTP POST binding protocols are supported.
+ * The other protocols, such as HTTP Artifact binding protocol, are not supported yet.
+ */
+public enum SamlBindingProtocol {
+    /**
+     * HTTP Redirect binding protocol.
+     */
+    HTTP_REDIRECT("urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"),
+
+    /**
+     * HTTP POST binding protocol.
+     */
+    HTTP_POST("urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST");
+
+    private final String urn;
+
+    SamlBindingProtocol(String urn) {
+        this.urn = urn;
+    }
+
+    /**
+     * Returns the URN of this binding protocol.
+     */
+    public String urn() {
+        return urn;
+    }
+}

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/SamlDecorator.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/SamlDecorator.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.saml;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.linecorp.armeria.server.saml.HttpPostBindingUtil.getSsoForm;
+import static com.linecorp.armeria.server.saml.HttpPostBindingUtil.toSignedBase64;
+import static com.linecorp.armeria.server.saml.HttpRedirectBindingUtil.responseWithLocation;
+import static com.linecorp.armeria.server.saml.HttpRedirectBindingUtil.toRedirectionUrl;
+import static com.linecorp.armeria.server.saml.SamlHttpParameterNames.SAML_REQUEST;
+import static com.linecorp.armeria.server.saml.SamlMessageUtil.build;
+import static java.util.Objects.requireNonNull;
+
+import java.util.concurrent.CompletionStage;
+
+import javax.annotation.Nullable;
+
+import org.joda.time.DateTime;
+import org.opensaml.messaging.context.MessageContext;
+import org.opensaml.saml.common.messaging.context.SAMLBindingContext;
+import org.opensaml.saml.saml2.core.AuthnContext;
+import org.opensaml.saml.saml2.core.AuthnContextClassRef;
+import org.opensaml.saml.saml2.core.AuthnContextComparisonTypeEnumeration;
+import org.opensaml.saml.saml2.core.AuthnRequest;
+import org.opensaml.saml.saml2.core.Issuer;
+import org.opensaml.saml.saml2.core.NameIDPolicy;
+import org.opensaml.saml.saml2.core.RequestedAuthnContext;
+import org.opensaml.security.credential.Credential;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.util.Exceptions;
+import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.Service;
+import com.linecorp.armeria.server.ServiceConfig;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.SimpleDecoratingService;
+import com.linecorp.armeria.server.auth.Authorizer;
+
+/**
+ * A decorator which initiates an authentication request to the remote identity provider if the request is
+ * not authenticated.
+ */
+final class SamlDecorator extends SimpleDecoratingService<HttpRequest, HttpResponse> {
+    private static final Logger logger = LoggerFactory.getLogger(SamlDecorator.class);
+
+    private final SamlServiceProvider sp;
+    private final SamlPortConfigAutoFiller portConfigHolder;
+
+    private final String myEntityId;
+    private final Credential signingCredential;
+    private final Authorizer<HttpRequest> authorizer;
+
+    private final SamlRequestIdManager requestIdManager;
+    private final SamlSingleSignOnHandler ssoHandler;
+
+    @Nullable
+    private Server server;
+
+    SamlDecorator(SamlServiceProvider sp, Service<HttpRequest, HttpResponse> delegate) {
+        super(delegate);
+        this.sp = sp;
+        portConfigHolder = sp.portConfigAutoFiller();
+
+        myEntityId = sp.entityId();
+        signingCredential = sp.signingCredential();
+        authorizer = sp.authorizer();
+        ssoHandler = sp.ssoHandler();
+        requestIdManager = sp.requestIdManager();
+    }
+
+    @Override
+    public void serviceAdded(ServiceConfig cfg) throws Exception {
+        super.serviceAdded(cfg);
+
+        if (server != null) {
+            if (server != cfg.server()) {
+                throw new IllegalStateException("cannot be added to more than one server");
+            } else {
+                return;
+            }
+        }
+
+        server = cfg.server();
+
+        // Auto-detect the primary port number and its session protocol after the server started.
+        server.addListener(portConfigHolder);
+    }
+
+    @Override
+    public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+        return HttpResponse.from(authorizer.authorize(ctx, req).handle((result, cause) -> {
+            if (cause == null && result) {
+                // Already authenticated.
+                try {
+                    return delegate().serve(ctx, req);
+                } catch (Exception e) {
+                    return Exceptions.throwUnsafely(e);
+                }
+            }
+
+            final CompletionStage<SamlIdentityProviderConfig> f;
+            if (portConfigHolder.isDone()) {
+                f = sp.idpConfigSelector().select(sp, ctx, req);
+            } else {
+                f = portConfigHolder.future().thenCompose(
+                        unused -> sp.idpConfigSelector().select(sp, ctx, req));
+            }
+            // Find an identity provider first where the request is to be sent to.
+            return HttpResponse.from(f.thenApply(idp -> {
+                if (idp == null) {
+                    throw new RuntimeException("cannot find a suitable identity provider from configurations");
+                }
+                final String defaultHostname = firstNonNull(sp.hostname(), ctx.virtualHost().defaultHostname());
+                final AuthnRequest request = createAuthRequest(idp, defaultHostname);
+                final MessageContext<AuthnRequest> messageContext = new MessageContext<>();
+                messageContext.setMessage(request);
+                return new MessageContextAndIdpConfig(messageContext, idp);
+            }).thenCompose(arg -> {
+                return ssoHandler.beforeInitiatingSso(ctx, req, arg.messageContext, arg.idpConfig)
+                                 .thenApply(unused -> arg);
+            }).thenApply(arg -> {
+                final SAMLBindingContext bindingContext =
+                        arg.messageContext.getSubcontext(SAMLBindingContext.class);
+                final String relayState = bindingContext != null ? bindingContext.getRelayState() : null;
+
+                // Support HTTP Redirect and HTTP POST binding protocols when sending
+                // an authentication request.
+                final SamlEndpoint endpoint = arg.idpConfig.ssoEndpoint();
+                try {
+                    if (endpoint.bindingProtocol() == SamlBindingProtocol.HTTP_REDIRECT) {
+                        return responseWithLocation(toRedirectionUrl(
+                                arg.messageContext.getMessage(),
+                                endpoint.toUriString(), SAML_REQUEST,
+                                signingCredential, sp.signatureAlgorithm(),
+                                relayState));
+                    } else {
+                        final String value = toSignedBase64(
+                                arg.messageContext.getMessage(),
+                                signingCredential,
+                                sp.signatureAlgorithm());
+                        final HttpData body = getSsoForm(endpoint.toUriString(),
+                                                         SAML_REQUEST, value,
+                                                         relayState);
+                        return HttpResponse.of(HttpStatus.OK, MediaType.HTML_UTF_8,
+                                               body);
+                    }
+                } catch (SamlException e) {
+                    return fail(ctx, e);
+                }
+            }).exceptionally(e -> fail(ctx, e)));
+        }));
+    }
+
+    /**
+     * Returns an {@link HttpResponse} for SAML authentication failure.
+     */
+    private HttpResponse fail(ServiceRequestContext ctx, Throwable cause) {
+        logger.trace("{} Cannot initiate SAML authentication", ctx, cause);
+        return HttpResponse.of(HttpStatus.UNAUTHORIZED);
+    }
+
+    /**
+     * Returns an {@link AuthnRequest} which is mapped to the specified identity provider.
+     */
+    private AuthnRequest createAuthRequest(SamlIdentityProviderConfig idp, String defaultHostname) {
+        requireNonNull(idp, "idp");
+
+        final AuthnRequest authnRequest = build(AuthnRequest.DEFAULT_ELEMENT_NAME);
+
+        final Issuer issuer = build(Issuer.DEFAULT_ELEMENT_NAME);
+        issuer.setValue(myEntityId);
+        authnRequest.setIssuer(issuer);
+
+        authnRequest.setIssueInstant(DateTime.now());
+        authnRequest.setDestination(idp.ssoEndpoint().toUriString());
+        authnRequest.setID(requestIdManager.newId());
+
+        // The ProtocolBinding attribute is mutually exclusive with the AssertionConsumerServiceIndex attribute
+        // and is typically accompanied by the AssertionConsumerServiceURL attribute.
+        final SamlPortConfig portConfig = portConfigHolder.config().get();
+        final SamlEndpoint acsEndpoint = idp.acsEndpoint()
+                                            .orElse(sp.defaultAcsConfig().endpoint());
+        authnRequest.setAssertionConsumerServiceURL(acsEndpoint.toUriString(portConfig.scheme().uriText(),
+                                                                            defaultHostname,
+                                                                            portConfig.port()));
+        authnRequest.setProtocolBinding(acsEndpoint.bindingProtocol().urn());
+
+        final SamlNameIdPolicy policy = idp.nameIdPolicy();
+        final NameIDPolicy nameIdPolicy = build(NameIDPolicy.DEFAULT_ELEMENT_NAME);
+        nameIdPolicy.setFormat(policy.format().urn());
+        nameIdPolicy.setAllowCreate(policy.isCreatable());
+        authnRequest.setNameIDPolicy(nameIdPolicy);
+
+        final AuthnContextClassRef passwordAuthnCtxRef = build(AuthnContextClassRef.DEFAULT_ELEMENT_NAME);
+        passwordAuthnCtxRef.setAuthnContextClassRef(AuthnContext.PASSWORD_AUTHN_CTX);
+
+        final RequestedAuthnContext requestedAuthnContext = build(RequestedAuthnContext.DEFAULT_ELEMENT_NAME);
+        requestedAuthnContext.setComparison(AuthnContextComparisonTypeEnumeration.EXACT);
+        requestedAuthnContext.getAuthnContextClassRefs().add(passwordAuthnCtxRef);
+
+        authnRequest.setRequestedAuthnContext(requestedAuthnContext);
+
+        return authnRequest;
+    }
+
+    /**
+     * An immutable object holder for {@link MessageContext} and {@link SamlIdentityProviderConfig}.
+     */
+    private static final class MessageContextAndIdpConfig {
+        private final MessageContext<AuthnRequest> messageContext;
+        private final SamlIdentityProviderConfig idpConfig;
+
+        private MessageContextAndIdpConfig(MessageContext<AuthnRequest> messageContext,
+                                           SamlIdentityProviderConfig idpConfig) {
+            this.messageContext = messageContext;
+            this.idpConfig = idpConfig;
+        }
+    }
+}

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/SamlEndpoint.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/SamlEndpoint.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.saml;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.linecorp.armeria.server.saml.SamlPortConfig.validatePort;
+import static java.util.Objects.requireNonNull;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import com.google.common.base.MoreObjects;
+
+import com.linecorp.armeria.common.util.Exceptions;
+
+/**
+ * A SAML service URL and its binding protocol.
+ */
+public final class SamlEndpoint {
+    /**
+     * Creates a {@link SamlEndpoint} of the specified {@code uri} and the HTTP Redirect binding protocol.
+     */
+    public static SamlEndpoint ofHttpRedirect(String uri) {
+        requireNonNull(uri, "uri");
+        try {
+            return ofHttpRedirect(new URI(uri));
+        } catch (URISyntaxException e) {
+            return Exceptions.throwUnsafely(e);
+        }
+    }
+
+    /**
+     * Creates a {@link SamlEndpoint} of the specified {@code uri} and the HTTP Redirect binding protocol.
+     */
+    public static SamlEndpoint ofHttpRedirect(URI uri) {
+        requireNonNull(uri, "uri");
+        return new SamlEndpoint(uri, SamlBindingProtocol.HTTP_REDIRECT);
+    }
+
+    /**
+     * Creates a {@link SamlEndpoint} of the specified {@code uri} and the HTTP POST binding protocol.
+     */
+    public static SamlEndpoint ofHttpPost(String uri) {
+        requireNonNull(uri, "uri");
+        try {
+            return ofHttpPost(new URI(uri));
+        } catch (URISyntaxException e) {
+            return Exceptions.throwUnsafely(e);
+        }
+    }
+
+    /**
+     * Creates a {@link SamlEndpoint} of the specified {@code uri} and the HTTP POST binding protocol.
+     */
+    public static SamlEndpoint ofHttpPost(URI uri) {
+        requireNonNull(uri, "uri");
+        return new SamlEndpoint(uri, SamlBindingProtocol.HTTP_POST);
+    }
+
+    private final URI uri;
+    private final SamlBindingProtocol bindingProtocol;
+    private final String uriAsString;
+
+    private SamlEndpoint(URI uri, SamlBindingProtocol bindingProtocol) {
+        this.uri = uri;
+        this.bindingProtocol = bindingProtocol;
+        uriAsString = uri.toString();
+    }
+
+    /**
+     * Returns a {@link URI} of this endpoint.
+     */
+    public URI uri() {
+        return uri;
+    }
+
+    /**
+     * Returns a {@link URI} of this endpoint as a string.
+     */
+    public String toUriString() {
+        return uriAsString;
+    }
+
+    /**
+     * Returns a {@link URI} of this endpoint as a string. The omitted values in the {@link URI} will be
+     * replaced with the specified default values, such as {@code defaultScheme}, {@code defaultHostname}
+     * and {@code defaultPort}.
+     */
+    String toUriString(String defaultScheme, String defaultHostname, int defaultPort) {
+        requireNonNull(defaultScheme, "defaultScheme");
+        requireNonNull(defaultHostname, "defaultHostname");
+        validatePort(defaultPort);
+
+        final StringBuilder sb = new StringBuilder();
+        sb.append(firstNonNull(uri.getScheme(), defaultScheme)).append("://")
+          .append(firstNonNull(uri.getHost(), defaultHostname)).append(':')
+          .append(uri.getPort() > 0 ? uri.getPort() : defaultPort)
+          .append(uri.getPath());
+        return sb.toString();
+    }
+
+    /**
+     * Returns a {@link SamlBindingProtocol} of this endpoint.
+     */
+    public SamlBindingProtocol bindingProtocol() {
+        return bindingProtocol;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof SamlEndpoint)) {
+            return false;
+        }
+        final SamlEndpoint that = (SamlEndpoint) o;
+        return uri().equals(that.uri()) && bindingProtocol() == that.bindingProtocol();
+    }
+
+    @Override
+    public int hashCode() {
+        return uri().hashCode() * 31 + bindingProtocol().hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("uri", uri)
+                          .add("bindingProtocol", bindingProtocol)
+                          .toString();
+    }
+}

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/SamlException.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/SamlException.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.saml;
+
+/**
+ * A checked {@link Exception} which is raised from SAML services.
+ */
+public class SamlException extends Exception {
+    private static final long serialVersionUID = -6694912876733624005L;
+
+    /**
+     * Creates a new exception.
+     */
+    public SamlException() {}
+
+    /**
+     * Creates a new instance with the specified {@code message}.
+     */
+    public SamlException(String message) {
+        super(message);
+    }
+
+    /**
+     * Creates a new instance with the specified {@code message} and {@code cause}.
+     */
+    public SamlException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Creates a new instance with the specified {@code cause}.
+     */
+    public SamlException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Creates a new instance with the specified {@code message}, {@code cause}, suppression enabled or
+     * disabled, and writable stack trace enabled or disabled.
+     */
+    protected SamlException(String message, Throwable cause,
+                            boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+
+    @Override
+    public Throwable fillInStackTrace() {
+        return this;
+    }
+}

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/SamlHttpParameterNames.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/SamlHttpParameterNames.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.saml;
+
+/**
+ * HTTP parameter names for SAML messages.
+ */
+final class SamlHttpParameterNames {
+
+    static final String SAML_REQUEST = "SAMLRequest";
+    static final String SAML_RESPONSE = "SAMLResponse";
+    static final String SIGNATURE = "Signature";
+    static final String SIGNATURE_ALGORITHM = "SigAlg";
+    static final String RELAY_STATE = "RelayState";
+
+    private SamlHttpParameterNames() {}
+}

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/SamlIdentityProviderConfig.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/SamlIdentityProviderConfig.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.saml;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Optional;
+
+import javax.annotation.Nullable;
+
+import org.opensaml.saml.saml2.core.NameIDPolicy;
+import org.opensaml.security.credential.Credential;
+
+import com.google.common.base.MoreObjects;
+
+/**
+ * A configuration for an identity provider.
+ */
+public final class SamlIdentityProviderConfig {
+
+    // IdP(Identity Provider) related:
+    private final String entityId;
+    private final Credential signingCredential;
+    private final Credential encryptionCredential;
+    private final SamlEndpoint ssoEndpoint;
+    private final Optional<SamlEndpoint> sloReqEndpoint;
+    private final Optional<SamlEndpoint> sloResEndpoint;
+
+    // SP(Service Provider) related:
+    private final Optional<SamlEndpoint> acsEndpoint;
+
+    // AuthnRequest related:
+    private final SamlNameIdPolicy nameIdPolicy;
+
+    SamlIdentityProviderConfig(String entityId,
+                               Credential signingCredential,
+                               Credential encryptionCredential,
+                               SamlEndpoint ssoEndpoint,
+                               @Nullable SamlEndpoint sloReqEndpoint,
+                               @Nullable SamlEndpoint sloResEndpoint,
+                               @Nullable SamlEndpoint acsEndpoint,
+                               SamlNameIdPolicy nameIdPolicy) {
+        this.entityId = requireNonNull(entityId, "entityId");
+        this.signingCredential = requireNonNull(signingCredential, "signingCredential");
+        this.encryptionCredential = requireNonNull(encryptionCredential, "encryptionCredential");
+        this.ssoEndpoint = requireNonNull(ssoEndpoint, "ssoEndpoint");
+        this.sloReqEndpoint = Optional.ofNullable(sloReqEndpoint);
+        this.sloResEndpoint = Optional.ofNullable(sloResEndpoint);
+        this.acsEndpoint = Optional.ofNullable(acsEndpoint);
+        this.nameIdPolicy = requireNonNull(nameIdPolicy, "nameIdPolicy");
+    }
+
+    /**
+     * Returns an entity ID of the identity provider.
+     */
+    public String entityId() {
+        return entityId;
+    }
+
+    /**
+     * Returns a {@link Credential} of the identity provider for signing.
+     */
+    public Credential signingCredential() {
+        return signingCredential;
+    }
+
+    /**
+     * Returns a {@link Credential} of the identity provider for encryption.
+     */
+    public Credential encryptionCredential() {
+        return encryptionCredential;
+    }
+
+    /**
+     * Returns a {@link SamlEndpoint} of the identity provider for receiving an authentication request.
+     */
+    public SamlEndpoint ssoEndpoint() {
+        return ssoEndpoint;
+    }
+
+    /**
+     * Returns a {@link SamlEndpoint} of the identity provider for receiving a single logout request.
+     */
+    public Optional<SamlEndpoint> sloReqEndpoint() {
+        return sloReqEndpoint;
+    }
+
+    /**
+     * Returns a {@link SamlEndpoint} of the identity provider for receiving a single logout response.
+     */
+    public Optional<SamlEndpoint> sloResEndpoint() {
+        return sloResEndpoint;
+    }
+
+    /**
+     * Returns a {@link SamlEndpoint} of the service provider that the assertion will be sent to in response
+     * to the authentication request.
+     */
+    public Optional<SamlEndpoint> acsEndpoint() {
+        return acsEndpoint;
+    }
+
+    /**
+     * Returns a {@link NameIDPolicy} of the service provider which is sent to the identity provider via
+     * an authentication request.
+     */
+    public SamlNameIdPolicy nameIdPolicy() {
+        return nameIdPolicy;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("entityId", entityId)
+                          .add("signingCredential", signingCredential)
+                          .add("encryptionCredential", encryptionCredential)
+                          .add("ssoEndpoint", ssoEndpoint)
+                          .add("sloReqEndpoint", sloReqEndpoint)
+                          .add("sloResEndpoint", sloResEndpoint)
+                          .add("acsEndpoint", acsEndpoint)
+                          .add("nameIdPolicy", nameIdPolicy)
+                          .toString();
+    }
+}

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/SamlIdentityProviderConfigBuilder.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/SamlIdentityProviderConfigBuilder.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.saml;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+import javax.annotation.Nullable;
+
+import org.opensaml.saml.saml2.core.AuthnRequest;
+import org.opensaml.security.credential.Credential;
+
+import com.linecorp.armeria.server.saml.SamlServiceProviderBuilder.CredentialResolverAdapter;
+
+/**
+ * A builder which builds a {@link SamlIdentityProviderConfig}.
+ */
+public final class SamlIdentityProviderConfigBuilder {
+
+    private static final SamlNameIdPolicy defaultNameIdPolicy =
+            SamlNameIdPolicy.ofCreatable(SamlNameIdFormat.EMAIL);
+
+    private final SamlServiceProviderBuilder parent;
+
+    // IdP(Identity Provider) related:
+    @Nullable
+    private String entityId;
+    @Nullable
+    private String signingKey;
+    @Nullable
+    private String encryptionKey;
+    @Nullable
+    private SamlEndpoint ssoEndpoint;
+    @Nullable
+    private SamlEndpoint sloReqEndpoint;
+    @Nullable
+    private SamlEndpoint sloResEndpoint;
+
+    // SP(Service Provider) related:
+    @Nullable
+    private SamlEndpoint acsEndpoint;
+
+    // AuthnRequest related:
+    private SamlNameIdPolicy nameIdPolicy = defaultNameIdPolicy;
+
+    private boolean isDefault;
+
+    SamlIdentityProviderConfigBuilder(SamlServiceProviderBuilder parent) {
+        this.parent = parent;
+    }
+
+    /**
+     * Sets an entity ID for an identity provider.
+     */
+    public SamlIdentityProviderConfigBuilder entityId(String entityId) {
+        this.entityId = requireNonNull(entityId, "entityId");
+        return this;
+    }
+
+    /**
+     * Sets a {@code signing} key name for an identity provider.
+     */
+    public SamlIdentityProviderConfigBuilder signingKey(String signingKey) {
+        this.signingKey = requireNonNull(signingKey, "signingKey");
+        return this;
+    }
+
+    /**
+     * Sets an {@code encryption} key name for an identity provider.
+     */
+    public SamlIdentityProviderConfigBuilder encryptionKey(String encryptionKey) {
+        this.encryptionKey = requireNonNull(encryptionKey, "encryptionKey");
+        return this;
+    }
+
+    /**
+     * Sets a single sign-on endpoint of an identity provider.
+     */
+    public SamlIdentityProviderConfigBuilder ssoEndpoint(SamlEndpoint ssoEndpoint) {
+        this.ssoEndpoint = requireNonNull(ssoEndpoint, "ssoEndpoint");
+        return this;
+    }
+
+    /**
+     * Sets a single logout request endpoint of an identity provider.
+     */
+    public SamlIdentityProviderConfigBuilder sloReqEndpoint(SamlEndpoint sloReqEndpoint) {
+        this.sloReqEndpoint = requireNonNull(sloReqEndpoint, "sloReqEndpoint");
+        return this;
+    }
+
+    /**
+     * Sets a single logout response endpoint of an identity provider.
+     */
+    public SamlIdentityProviderConfigBuilder sloResEndpoint(SamlEndpoint sloResEndpoint) {
+        this.sloResEndpoint = requireNonNull(sloResEndpoint, "sloResEndpoint");
+        return this;
+    }
+
+    /**
+     * Returns a {@link SamlEndpoint} of the service provider for receiving an assertion from an identity
+     * provider.
+     */
+    @Nullable
+    SamlEndpoint acsEndpoint() {
+        return acsEndpoint;
+    }
+
+    /**
+     * Sets an assertion consumer service URL of this service provider.
+     */
+    public SamlIdentityProviderConfigBuilder acsEndpoint(SamlEndpoint acsEndpoint) {
+        this.acsEndpoint = requireNonNull(acsEndpoint, "acsEndpoint");
+        return this;
+    }
+
+    /**
+     * Sets a {@link SamlNameIdPolicy} to configure an {@link AuthnRequest}.
+     */
+    public SamlIdentityProviderConfigBuilder nameIdPolicy(SamlNameIdPolicy nameIdPolicy) {
+        this.nameIdPolicy = requireNonNull(nameIdPolicy, "nameIdPolicy");
+        return this;
+    }
+
+    /**
+     * Returns whether the identity provider is set as a default.
+     */
+    boolean isDefault() {
+        return isDefault;
+    }
+
+    /**
+     * Sets this idp as a default.
+     */
+    public SamlIdentityProviderConfigBuilder asDefault() {
+        isDefault = true;
+        return this;
+    }
+
+    /**
+     * Returns a {@link SamlServiceProvider} which is the parent of this builder.
+     */
+    public SamlServiceProviderBuilder and() {
+        return parent;
+    }
+
+    /**
+     * Builds a {@link SamlIdentityProviderConfig}.
+     */
+    SamlIdentityProviderConfig build(CredentialResolverAdapter credentialResolver) {
+        checkState(entityId != null, "entity ID of the identity provider is not set");
+
+        // Use the entityId as a default key name.
+        final Credential signing = credentialResolver.apply(firstNonNull(signingKey, entityId));
+        final Credential encryption = credentialResolver.apply(firstNonNull(encryptionKey, entityId));
+
+        return new SamlIdentityProviderConfig(entityId,
+                                              signing,
+                                              encryption,
+                                              ssoEndpoint,
+                                              sloReqEndpoint,
+                                              sloResEndpoint,
+                                              acsEndpoint,
+                                              nameIdPolicy);
+    }
+}

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/SamlIdentityProviderConfigSelector.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/SamlIdentityProviderConfigSelector.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.saml;
+
+import java.util.concurrent.CompletionStage;
+
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.server.ServiceRequestContext;
+
+/**
+ * A {@link SamlIdentityProviderConfig} selector for the request.
+ */
+@FunctionalInterface
+public interface SamlIdentityProviderConfigSelector {
+    /**
+     * Returns a {@link SamlIdentityProviderConfig} which is used for authenticating the request.
+     */
+    CompletionStage<SamlIdentityProviderConfig> select(SamlServiceProvider sp,
+                                                       ServiceRequestContext ctx,
+                                                       HttpRequest req);
+}

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/SamlInitializer.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/SamlInitializer.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.saml;
+
+import javax.annotation.Nullable;
+
+import org.opensaml.core.config.InitializationService;
+import org.opensaml.xmlsec.config.JavaCryptoValidationInitializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A utility class which initializes the OpenSAML library.
+ * See <a href="https://wiki.shibboleth.net/confluence/display/OS30/Home">OpenSAML 3</a> for more information.
+ */
+final class SamlInitializer {
+    private static final Logger logger = LoggerFactory.getLogger(SamlInitializer.class);
+
+    @Nullable
+    private static final Throwable UNAVAILABILITY_CAUSE;
+
+    static {
+        Throwable cause = null;
+        try {
+            // To help confirm that your JCE implementations have everything needed by OpenSAML,
+            // the following method is provided:
+            final JavaCryptoValidationInitializer javaCryptoValidationInitializer =
+                    new JavaCryptoValidationInitializer();
+            javaCryptoValidationInitializer.init();
+
+            // The configuration files must be loaded before the OpenSAML library can be used.
+            // To load the default configuration files, run:
+            InitializationService.initialize();
+
+            logger.debug("OpenSAML has been initialized.");
+        } catch (Throwable cause0) {
+            cause = cause0;
+        } finally {
+            UNAVAILABILITY_CAUSE = cause;
+        }
+    }
+
+    /**
+     * Returns {@code true} if and only if the OpenSAML library is available.
+     */
+    static boolean isAvailable() {
+        return UNAVAILABILITY_CAUSE == null;
+    }
+
+    /**
+     * Ensures that the OpenSAML library is available.
+     *
+     * @throws Error if unavailable
+     */
+    static void ensureAvailability() {
+        if (UNAVAILABILITY_CAUSE != null) {
+            throw new Error("failed to initialize OpenSAML library", UNAVAILABILITY_CAUSE);
+        }
+    }
+
+    /**
+     * Returns the cause of unavailability of the OpenSAML library.
+     *
+     * @return the cause if unavailable. {@code null} if available.
+     */
+    @Nullable
+    static Throwable unavailabilityCause() {
+        return UNAVAILABILITY_CAUSE;
+    }
+
+    private SamlInitializer() {}
+}

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/SamlMessageUtil.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/SamlMessageUtil.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.saml;
+
+import static java.util.Objects.requireNonNull;
+import static org.opensaml.xmlsec.signature.support.SignatureConstants.ALGO_ID_C14N_EXCL_OMIT_COMMENTS;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import javax.annotation.Nullable;
+import javax.xml.namespace.QName;
+
+import org.opensaml.core.xml.XMLObject;
+import org.opensaml.core.xml.XMLObjectBuilderFactory;
+import org.opensaml.core.xml.config.XMLObjectProviderRegistrySupport;
+import org.opensaml.core.xml.io.Marshaller;
+import org.opensaml.core.xml.io.MarshallingException;
+import org.opensaml.core.xml.io.UnmarshallingException;
+import org.opensaml.core.xml.util.XMLObjectSupport;
+import org.opensaml.saml.common.SAMLObject;
+import org.opensaml.saml.common.SAMLObjectBuilder;
+import org.opensaml.saml.common.SignableSAMLObject;
+import org.opensaml.saml.security.impl.SAMLSignatureProfileValidator;
+import org.opensaml.security.SecurityException;
+import org.opensaml.security.credential.Credential;
+import org.opensaml.xmlsec.keyinfo.KeyInfoGenerator;
+import org.opensaml.xmlsec.keyinfo.impl.X509KeyInfoGeneratorFactory;
+import org.opensaml.xmlsec.signature.Signature;
+import org.opensaml.xmlsec.signature.impl.SignatureBuilder;
+import org.opensaml.xmlsec.signature.support.SignatureException;
+import org.opensaml.xmlsec.signature.support.SignatureValidator;
+import org.opensaml.xmlsec.signature.support.Signer;
+import org.w3c.dom.Element;
+
+import net.shibboleth.utilities.java.support.xml.ParserPool;
+import net.shibboleth.utilities.java.support.xml.XMLParserException;
+
+/**
+ * A utility class for SAML messages.
+ */
+final class SamlMessageUtil {
+
+    private static final XMLObjectBuilderFactory builderFactory;
+
+    private static final KeyInfoGenerator keyInfoGenerator;
+
+    private static final SignatureBuilder signatureBuilder = new SignatureBuilder();
+
+    private static final SAMLSignatureProfileValidator signatureProfileValidator
+            = new SAMLSignatureProfileValidator();
+
+    static {
+        SamlInitializer.ensureAvailability();
+
+        builderFactory = XMLObjectProviderRegistrySupport.getBuilderFactory();
+
+        final X509KeyInfoGeneratorFactory keyInfoGeneratorFactory = new X509KeyInfoGeneratorFactory();
+        keyInfoGeneratorFactory.setEmitEntityCertificate(true);
+        keyInfoGeneratorFactory.setEmitEntityCertificateChain(true);
+        keyInfoGenerator = keyInfoGeneratorFactory.newInstance();
+    }
+
+    @SuppressWarnings("unchecked")
+    static <T extends SAMLObject> SAMLObjectBuilder<T> builder(@Nullable final QName key) {
+        final SAMLObjectBuilder<T> builder = (SAMLObjectBuilder<T>) builderFactory.getBuilder(key);
+        assert builder != null;
+        return builder;
+    }
+
+    @SuppressWarnings("unchecked")
+    static <T extends SAMLObject> T build(@Nullable final QName key) {
+        return (T) builder(key).buildObject();
+    }
+
+    static Element serialize(XMLObject message) throws SamlException {
+        requireNonNull(message, "message");
+
+        if (message.getDOM() != null) {
+            // Return cached DOM if it exists.
+            return message.getDOM();
+        }
+
+        final Marshaller marshaller =
+                XMLObjectProviderRegistrySupport.getMarshallerFactory().getMarshaller(message);
+        if (marshaller == null) {
+            throw new SamlException("failed to serialize a SAML object into an XML document, " +
+                                    "no serializer registered for message object: " +
+                                    message.getElementQName());
+        }
+
+        try {
+            return marshaller.marshall(message);
+        } catch (MarshallingException e) {
+            throw new SamlException("failed to serialize a SAML object into an XML document", e);
+        }
+    }
+
+    static XMLObject deserialize(byte[] bytes) throws SamlException {
+        requireNonNull(bytes, "bytes");
+        final ParserPool parserPool = XMLObjectProviderRegistrySupport.getParserPool();
+        assert parserPool != null;
+
+        final InputStream is = new ByteArrayInputStream(bytes);
+        try {
+            return XMLObjectSupport.unmarshallFromInputStream(parserPool, is);
+        } catch (XMLParserException | UnmarshallingException e) {
+            throw new SamlException("failed to deserialize an XML document bytes into a SAML object", e);
+        }
+    }
+
+    /**
+     * Signs the specified {@link SignableSAMLObject} with the specified {@link Credential} and
+     * {@code signatureAlgorithm}.
+     */
+    static void sign(SignableSAMLObject signableObj,
+                     Credential signingCredential, String signatureAlgorithm) throws SamlException {
+        requireNonNull(signableObj, "signableObj");
+        requireNonNull(signingCredential, "signingCredential");
+        requireNonNull(signatureAlgorithm, "signatureAlgorithm");
+
+        final Signature signature = signatureBuilder.buildObject();
+        signature.setSignatureAlgorithm(signatureAlgorithm);
+        signature.setSigningCredential(signingCredential);
+        signature.setCanonicalizationAlgorithm(ALGO_ID_C14N_EXCL_OMIT_COMMENTS);
+        try {
+            signature.setKeyInfo(keyInfoGenerator.generate(signingCredential));
+        } catch (SecurityException e) {
+            throw new SamlException("failed to create a key info of signing credential", e);
+        }
+
+        signableObj.setSignature(signature);
+        serialize(signableObj);
+
+        try {
+            Signer.signObject(signature);
+        } catch (SignatureException e) {
+            throw new SamlException("failed to sign a SAML object", e);
+        }
+    }
+
+    static void validateSignature(Credential validationCredential,
+                                  SignableSAMLObject signableObj) throws SamlException {
+        requireNonNull(validationCredential, "validationCredential");
+        requireNonNull(signableObj, "signableObj");
+
+        // Skip signature validation if the object is not signed.
+        if (!signableObj.isSigned()) {
+            return;
+        }
+
+        final Signature signature = signableObj.getSignature();
+        if (signature == null) {
+            throw new SamlException("failed to validate a signature because no signature exists");
+        }
+
+        try {
+            signatureProfileValidator.validate(signature);
+            SignatureValidator.validate(signature, validationCredential);
+        } catch (SignatureException e) {
+            throw new SamlException("failed to validate a signature", e);
+        }
+    }
+
+    private SamlMessageUtil() {}
+}

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/SamlMetadataServiceFunction.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/SamlMetadataServiceFunction.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.saml;
+
+import static com.linecorp.armeria.server.saml.SamlMessageUtil.build;
+import static com.linecorp.armeria.server.saml.SamlMessageUtil.builder;
+import static net.shibboleth.utilities.java.support.xml.SerializeSupport.nodeToString;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
+
+import org.opensaml.saml.common.SAMLObjectBuilder;
+import org.opensaml.saml.common.xml.SAMLConstants;
+import org.opensaml.saml.saml2.metadata.AssertionConsumerService;
+import org.opensaml.saml.saml2.metadata.EntityDescriptor;
+import org.opensaml.saml.saml2.metadata.KeyDescriptor;
+import org.opensaml.saml.saml2.metadata.NameIDFormat;
+import org.opensaml.saml.saml2.metadata.SPSSODescriptor;
+import org.opensaml.saml.saml2.metadata.SingleLogoutService;
+import org.opensaml.security.SecurityException;
+import org.opensaml.security.credential.Credential;
+import org.opensaml.security.credential.UsageType;
+import org.opensaml.xmlsec.keyinfo.KeyInfoGenerator;
+import org.opensaml.xmlsec.keyinfo.impl.X509KeyInfoGeneratorFactory;
+import org.opensaml.xmlsec.signature.KeyInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Element;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.MapMaker;
+
+import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.server.ServiceRequestContext;
+
+/**
+ * A service which returns the SAML metadata in response to a user request.
+ */
+final class SamlMetadataServiceFunction implements SamlServiceFunction {
+    private static final Logger logger = LoggerFactory.getLogger(SamlMetadataServiceFunction.class);
+
+    @VisibleForTesting
+    static final MediaType CONTENT_TYPE_SAML_METADATA = MediaType.parse("application/samlmetadata+xml");
+
+    private static final HttpHeaders HTTP_HEADERS =
+            HttpHeaders.of(HttpStatus.OK)
+                       .contentType(CONTENT_TYPE_SAML_METADATA)
+                       .add(HttpHeaderNames.CONTENT_DISPOSITION,
+                            "attachment; filename=\"saml_metadata.xml\"")
+                       .asImmutable();
+
+    private final String entityId;
+    private final Credential signingCredential;
+    private final Credential encryptionCredential;
+    private final Map<String, SamlIdentityProviderConfig> idpConfigs;
+    private final Collection<SamlAssertionConsumerConfig> assertionConsumerConfigs;
+    private final Collection<SamlEndpoint> singleLogoutEndpoints;
+
+    private final ConcurrentMap<String, HttpData> metadataMap = new MapMaker().makeMap();
+
+    SamlMetadataServiceFunction(String entityId,
+                                Credential signingCredential,
+                                Credential encryptionCredential,
+                                Map<String, SamlIdentityProviderConfig> idpConfigs,
+                                Collection<SamlAssertionConsumerConfig> assertionConsumerConfigs,
+                                Collection<SamlEndpoint> singleLogoutEndpoints) {
+        this.entityId = entityId;
+        this.signingCredential = signingCredential;
+        this.encryptionCredential = encryptionCredential;
+        this.idpConfigs = idpConfigs;
+        this.assertionConsumerConfigs = assertionConsumerConfigs;
+        this.singleLogoutEndpoints = singleLogoutEndpoints;
+    }
+
+    @Override
+    public HttpResponse serve(ServiceRequestContext ctx, AggregatedHttpMessage msg,
+                              String defaultHostname, SamlPortConfig portConfig) {
+        final HttpData metadata = metadataMap.computeIfAbsent(defaultHostname, h -> {
+            try {
+                final Element element =
+                        SamlMessageUtil.serialize(buildMetadataEntityDescriptorElement(h, portConfig));
+                final HttpData newMetadata = HttpData.ofUtf8(nodeToString(element));
+                logger.debug("SAML service provider metadata has been prepared for: {}.", h);
+                return newMetadata;
+            } catch (Throwable cause) {
+                logger.warn("{} Unexpected metadata request.", ctx, cause);
+                return HttpData.EMPTY_DATA;
+            }
+        });
+
+        if (metadata != HttpData.EMPTY_DATA) {
+            return HttpResponse.of(HTTP_HEADERS, metadata);
+        } else {
+            return HttpResponse.of(HttpStatus.NOT_FOUND);
+        }
+    }
+
+    private EntityDescriptor buildMetadataEntityDescriptorElement(
+            String defaultHostname, SamlPortConfig portConfig) throws SamlException {
+        final EntityDescriptor entityDescriptor = build(EntityDescriptor.DEFAULT_ELEMENT_NAME);
+        entityDescriptor.setEntityID(entityId);
+
+        final SPSSODescriptor spSsoDescriptor = build(SPSSODescriptor.DEFAULT_ELEMENT_NAME);
+        spSsoDescriptor.setAuthnRequestsSigned(true);
+        spSsoDescriptor.setWantAssertionsSigned(true);
+        spSsoDescriptor.addSupportedProtocol(SAMLConstants.SAML20P_NS);
+
+        final List<String> nameIdFormats = idpConfigs.values().stream()
+                                                     .map(p -> p.nameIdPolicy().format())
+                                                     .distinct()
+                                                     .map(SamlNameIdFormat::urn)
+                                                     .collect(Collectors.toList());
+        spSsoDescriptor.getNameIDFormats().addAll(buildNameIdFormatElements(nameIdFormats));
+
+        final List<SingleLogoutService> sloList = spSsoDescriptor.getSingleLogoutServices();
+        singleLogoutEndpoints.forEach(endpoint -> {
+            final SingleLogoutService slo = build(SingleLogoutService.DEFAULT_ELEMENT_NAME);
+            slo.setBinding(endpoint.bindingProtocol().urn());
+            slo.setLocation(endpoint.toUriString(portConfig.scheme().uriText(),
+                                                 defaultHostname,
+                                                 portConfig.port()));
+            sloList.add(slo);
+        });
+
+        int acsIndex = 0;
+        final List<AssertionConsumerService> services = spSsoDescriptor.getAssertionConsumerServices();
+        for (final SamlAssertionConsumerConfig acs : assertionConsumerConfigs) {
+            services.add(buildAssertionConsumerServiceElement(acs, portConfig, defaultHostname, acsIndex++));
+        }
+
+        final X509KeyInfoGeneratorFactory keyInfoGeneratorFactory = new X509KeyInfoGeneratorFactory();
+        keyInfoGeneratorFactory.setEmitEntityCertificate(true);
+        keyInfoGeneratorFactory.setEmitEntityCertificateChain(true);
+        final KeyInfoGenerator keyInfoGenerator = keyInfoGeneratorFactory.newInstance();
+
+        try {
+            spSsoDescriptor.getKeyDescriptors().add(
+                    buildKeyDescriptorElement(UsageType.SIGNING,
+                                              keyInfoGenerator.generate(signingCredential)));
+            spSsoDescriptor.getKeyDescriptors().add(
+                    buildKeyDescriptorElement(UsageType.ENCRYPTION,
+                                              keyInfoGenerator.generate(encryptionCredential)));
+        } catch (SecurityException e) {
+            throw new SamlException("failed to generate KeyInfo element", e);
+        }
+
+        entityDescriptor.getRoleDescriptors().add(spSsoDescriptor);
+        return entityDescriptor;
+    }
+
+    private static AssertionConsumerService buildAssertionConsumerServiceElement(
+            SamlAssertionConsumerConfig config, SamlPortConfig portConfig, String hostname, int index) {
+        final AssertionConsumerService consumer = build(AssertionConsumerService.DEFAULT_ELEMENT_NAME);
+
+        consumer.setLocation(config.endpoint().toUriString(portConfig.scheme().uriText(),
+                                                           hostname,
+                                                           portConfig.port()));
+        consumer.setBinding(config.endpoint().bindingProtocol().urn());
+        consumer.setIndex(index);
+
+        // Add 'isDefault' attribute only when told so.
+        if (config.isDefault()) {
+            consumer.setIsDefault(true);
+        }
+        return consumer;
+    }
+
+    private static Collection<NameIDFormat> buildNameIdFormatElements(Collection<String> nameIds) {
+        final SAMLObjectBuilder<NameIDFormat> builder = builder(NameIDFormat.DEFAULT_ELEMENT_NAME);
+        final Collection<NameIDFormat> formats = new ArrayList<>();
+        for (final String value : nameIds) {
+            final NameIDFormat nameIdFormat = builder.buildObject();
+            nameIdFormat.setFormat(value);
+            formats.add(nameIdFormat);
+        }
+        return formats;
+    }
+
+    private static KeyDescriptor buildKeyDescriptorElement(UsageType type, KeyInfo key) {
+        final KeyDescriptor descriptor = build(KeyDescriptor.DEFAULT_ELEMENT_NAME);
+        descriptor.setUse(type);
+        descriptor.setKeyInfo(key);
+        return descriptor;
+    }
+}

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/SamlNameIdFormat.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/SamlNameIdFormat.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.saml;
+
+/**
+ * SAML name ID formats.
+ */
+public enum SamlNameIdFormat {
+    /**
+     * Unspecified name format.
+     */
+    UNSPECIFIED("urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified"),
+
+    /**
+     * Email name format.
+     */
+    EMAIL("urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"),
+
+    /**
+     * X509 subject name format.
+     */
+    X509_SUBJECT("urn:oasis:names:tc:SAML:1.1:nameid-format:X509SubjectName"),
+
+    /**
+     * Windows domain qualified name format.
+     */
+    WIN_DOMAIN_QUALIFIED("urn:oasis:names:tc:SAML:1.1:nameid-format:WindowsDomainQualifiedName"),
+
+    /**
+     * Kerberos name format.
+     */
+    KERBEROS("urn:oasis:names:tc:SAML:2.0:nameid-format:kerberos"),
+
+    /**
+     * SAML entity name format.
+     */
+    ENTITY("urn:oasis:names:tc:SAML:2.0:nameid-format:entity"),
+
+    /**
+     * Persistent name format.
+     */
+    PERSISTENT("urn:oasis:names:tc:SAML:2.0:nameid-format:persistent"),
+
+    /**
+     * Transient name format.
+     */
+    TRANSIENT("urn:oasis:names:tc:SAML:2.0:nameid-format:transient"),
+
+    /**
+     * Used by NameIDPolicy to indicate a NameID should be encrypted.
+     */
+    ENCRYPTED("urn:oasis:names:tc:SAML:2.0:nameid-format:encrypted");
+
+    private final String urn;
+
+    SamlNameIdFormat(String urn) {
+        this.urn = urn;
+    }
+
+    /**
+     * Returns the URN of this name ID format.
+     */
+    public String urn() {
+        return urn;
+    }
+}

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/SamlNameIdPolicy.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/SamlNameIdPolicy.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.saml;
+
+import static java.util.Objects.requireNonNull;
+
+import com.google.common.base.MoreObjects;
+
+/**
+ * SAML name ID format and its option.
+ */
+public final class SamlNameIdPolicy {
+    /**
+     * Returns a {@link SamlNameIdPolicy} with the specified {@link SamlNameIdFormat} and
+     * {@code isCreatable = true}.
+     */
+    public static SamlNameIdPolicy ofCreatable(SamlNameIdFormat format) {
+        return of(format, true);
+    }
+
+    /**
+     * Returns a {@link SamlNameIdPolicy} with the specified {@link SamlNameIdFormat} and
+     * {@code isCreatable}.
+     */
+    public static SamlNameIdPolicy of(SamlNameIdFormat format, boolean isCreatable) {
+        requireNonNull(format, "format");
+        return new SamlNameIdPolicy(format, isCreatable);
+    }
+
+    private final SamlNameIdFormat format;
+    private final boolean isCreatable;
+
+    private SamlNameIdPolicy(SamlNameIdFormat format, boolean isCreatable) {
+        this.format = format;
+        this.isCreatable = isCreatable;
+    }
+
+    /**
+     * Returns a {@link SamlNameIdFormat} of this {@link SamlNameIdPolicy}.
+     */
+    public SamlNameIdFormat format() {
+        return format;
+    }
+
+    /**
+     * Returns whether this {@link SamlNameIdPolicy} allows to create a new name ID.
+     */
+    public boolean isCreatable() {
+        return isCreatable;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("format", format)
+                          .add("isCreatable", isCreatable)
+                          .toString();
+    }
+}

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/SamlPortConfig.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/SamlPortConfig.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.saml;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+import com.google.common.base.MoreObjects;
+
+import com.linecorp.armeria.common.SessionProtocol;
+
+/**
+ * A scheme and port of a service provider.
+ */
+final class SamlPortConfig {
+
+    private final SessionProtocol scheme;
+    private final int port;
+
+    SamlPortConfig(SessionProtocol scheme, int port) {
+        this.scheme = requireNonNull(scheme, "scheme");
+        this.port = validatePort(port);
+    }
+
+    /**
+     * Returns a {@link SessionProtocol} that a service provider is bound to.
+     */
+    SessionProtocol scheme() {
+        return scheme;
+    }
+
+    /**
+     * Returns a port number that a service provider is bound to.
+     */
+    int port() {
+        return port;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("scheme", scheme)
+                          .add("port", port)
+                          .toString();
+    }
+
+    /**
+     * Returns whether the specified {@code port} is in the valid range.
+     */
+    static boolean isValidPort(int port) {
+        return port > 0 && port <= 65535;
+    }
+
+    /**
+     * Raises an {@link IllegalArgumentException} if the specified {@code port} is not in the valid range.
+     */
+    static int validatePort(int port) {
+        checkArgument(isValidPort(port), "port: %s (expected: 1-65535)", port);
+        return port;
+    }
+}

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/SamlPortConfigAutoFiller.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/SamlPortConfigAutoFiller.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.saml;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.annotation.Nullable;
+
+import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.ServerListenerAdapter;
+
+/**
+ * Fill unspecified scheme and port in the {@link SamlPortConfigBuilder}. They will be resolved by
+ * the primary server port after the server started.
+ */
+final class SamlPortConfigAutoFiller extends ServerListenerAdapter {
+
+    private final SamlPortConfigBuilder builder;
+    private final CompletableFuture<SamlPortConfig> future = new CompletableFuture<>();
+    private final AtomicBoolean completed = new AtomicBoolean();
+
+    @Nullable
+    private SamlPortConfig config;
+
+    SamlPortConfigAutoFiller(SamlPortConfigBuilder builder) {
+        this.builder = builder;
+    }
+
+    /**
+     * Returns a future of a {@link SamlPortConfig}.
+     */
+    CompletableFuture<SamlPortConfig> future() {
+        return future;
+    }
+
+    /**
+     * Returns a {@link SamlPortConfig} wrapped by an {@link Optional}.
+     */
+    Optional<SamlPortConfig> config() {
+        return Optional.ofNullable(config);
+    }
+
+    /**
+     * Returns whether a {@link SamlPortConfig} has been configured.
+     */
+    boolean isDone() {
+        return config != null;
+    }
+
+    @Override
+    public void serverStarted(Server server) throws Exception {
+        // Ensure that the following work will be done once.
+        if (completed.compareAndSet(false, true)) {
+            builder.setSchemeAndPortIfAbsent(server.activePort().get());
+            assert builder.scheme() != null;
+            config = new SamlPortConfig(builder.scheme(), builder.port());
+            future.complete(config);
+        }
+    }
+}

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/SamlPortConfigBuilder.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/SamlPortConfigBuilder.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.saml;
+
+import static com.linecorp.armeria.server.saml.SamlPortConfig.isValidPort;
+import static com.linecorp.armeria.server.saml.SamlPortConfig.validatePort;
+import static java.util.Objects.requireNonNull;
+
+import javax.annotation.Nullable;
+
+import com.google.common.base.MoreObjects;
+
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.server.ServerPort;
+
+/**
+ * A builder for a {@link SamlPortConfig}.
+ */
+final class SamlPortConfigBuilder {
+
+    @Nullable
+    private SessionProtocol scheme;
+    private int port;
+
+    /**
+     * Returns a {@link SessionProtocol} for a SAML service port.
+     */
+    @Nullable
+    SessionProtocol scheme() {
+        return scheme;
+    }
+
+    /**
+     * Returns a port number for a SAML service.
+     */
+    int port() {
+        return port;
+    }
+
+    /**
+     * Sets a {@link SessionProtocol} only if it has not been specified before.
+     */
+    SamlPortConfigBuilder setSchemeIfAbsent(SessionProtocol scheme) {
+        requireNonNull(scheme, "scheme");
+        if (this.scheme == null) {
+            if (scheme == SessionProtocol.HTTPS ||
+                scheme == SessionProtocol.HTTP) {
+                this.scheme = scheme;
+            } else {
+                throw new IllegalArgumentException("unexpected session protocol: " + scheme);
+            }
+        }
+        return this;
+    }
+
+    /**
+     * Sets a port number only if it has not been specified before.
+     */
+    SamlPortConfigBuilder setPortIfAbsent(int port) {
+        if (this.port == 0) {
+            this.port = validatePort(port);
+        }
+        return this;
+    }
+
+    /**
+     * Sets a {@link SessionProtocol} and its port number only if it has not been specified before.
+     */
+    SamlPortConfigBuilder setSchemeAndPortIfAbsent(ServerPort serverPort) {
+        requireNonNull(serverPort, "serverPort");
+        if (serverPort.hasHttps()) {
+            setSchemeIfAbsent(SessionProtocol.HTTPS);
+        } else if (serverPort.hasHttp()) {
+            setSchemeIfAbsent(SessionProtocol.HTTP);
+        } else {
+            throw new IllegalArgumentException("unexpected session protocol: " + serverPort.protocols());
+        }
+
+        // Do not set a port if the port number is 0 which means that the port will be automatically chosen.
+        final int port = serverPort.localAddress().getPort();
+        if (isValidPort(port)) {
+            setPortIfAbsent(port);
+        }
+        return this;
+    }
+
+    /**
+     * Converts this builder to a {@link SamlPortConfigAutoFiller} in order to fill unspecified values
+     * after the server started.
+     */
+    SamlPortConfigAutoFiller toAutoFiller() {
+        return new SamlPortConfigAutoFiller(copyOf(this));
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("scheme", scheme)
+                          .add("port", port)
+                          .toString();
+    }
+
+    private static SamlPortConfigBuilder copyOf(SamlPortConfigBuilder that) {
+        final SamlPortConfigBuilder builder = new SamlPortConfigBuilder();
+        if (that.scheme != null) {
+            builder.scheme = that.scheme;
+        }
+        if (isValidPort(that.port)) {
+            builder.port = that.port;
+        }
+        return builder;
+    }
+}

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/SamlRequestIdManager.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/SamlRequestIdManager.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.saml;
+
+import static java.util.Objects.requireNonNull;
+
+import java.io.UnsupportedEncodingException;
+
+import com.auth0.jwt.algorithms.Algorithm;
+
+/**
+ * An interface which generates and validates a request ID when transferring a SAML message between
+ * a service provider and an identity provider.
+ */
+public interface SamlRequestIdManager {
+    /**
+     * Returns a {@link SamlRequestIdManager} implementation based on JSON Web Tokens specification.
+     *
+     * @param issuer the ID of the entity who issues a token
+     * @param algorithm the algorithm instance which is used to create a signature
+     * @param validSeconds the valid period of a token in seconds
+     * @param leewaySeconds the leeway when there is a clock skew times between the signer and the verifier,
+     *                      in seconds.
+     */
+    static SamlRequestIdManager ofJwt(String issuer, Algorithm algorithm,
+                                      int validSeconds, int leewaySeconds) {
+        return new JwtBasedSamlRequestIdManager(issuer, algorithm, validSeconds, leewaySeconds);
+    }
+
+    /**
+     * Returns a {@link SamlRequestIdManager} implementation based on JSON Web Tokens specification with
+     * the {@link Algorithm} instance using {@code HmacSHA384}.
+     *
+     * @param issuer the ID of the entity who issues a token
+     * @param secret the secret which is used to generate a signature
+     * @param validSeconds the valid period of a token in seconds
+     * @param leewaySeconds the leeway when there is a clock skew times between the signer and the verifier,
+     *                      in seconds.
+     */
+    static SamlRequestIdManager ofJwt(String issuer, String secret,
+                                      int validSeconds, int leewaySeconds) throws UnsupportedEncodingException {
+        final Algorithm algorithm = Algorithm.HMAC384(requireNonNull(secret, "secret"));
+        return ofJwt(issuer, algorithm, validSeconds, leewaySeconds);
+    }
+
+    /**
+     * Returns a newly-generated request ID.
+     */
+    String newId();
+
+    /**
+     * Returns whether the specified ID is valid or not.
+     */
+    boolean validateId(String id);
+}

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/SamlService.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/SamlService.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.saml;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static java.util.Objects.requireNonNull;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletionStage;
+
+import javax.annotation.Nullable;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMap.Builder;
+
+import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.server.PathMapping;
+import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.Service;
+import com.linecorp.armeria.server.ServiceConfig;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.ServiceWithPathMappings;
+
+import io.netty.handler.codec.http.QueryStringDecoder;
+
+/**
+ * A {@link Service} which handles SAML APIs, such as consuming an assertion, retrieving a metadata
+ * or handling a logout request from an identity provider.
+ */
+final class SamlService implements ServiceWithPathMappings<HttpRequest, HttpResponse> {
+
+    private final SamlServiceProvider sp;
+    private final SamlPortConfigAutoFiller portConfigHolder;
+
+    @Nullable
+    private Server server;
+
+    private final Map<String, SamlServiceFunction> serviceMap;
+    private final Set<PathMapping> pathMappings;
+
+    SamlService(SamlServiceProvider sp) {
+        this.sp = requireNonNull(sp, "sp");
+        portConfigHolder = sp.portConfigAutoFiller();
+
+        final ImmutableMap.Builder<String, SamlServiceFunction> builder = new Builder<>();
+        sp.acsConfigs().forEach(
+                cfg -> builder.put(cfg.endpoint().uri().getPath(),
+                                   new SamlAssertionConsumerFunction(cfg,
+                                                                     sp.entityId(),
+                                                                     sp.idpConfigs(),
+                                                                     sp.defaultIdpConfig(),
+                                                                     sp.requestIdManager(),
+                                                                     sp.ssoHandler())));
+        sp.sloEndpoints().forEach(
+                cfg -> builder.put(cfg.uri().getPath(),
+                                   new SamlSingleLogoutFunction(cfg,
+                                                                sp.entityId(),
+                                                                sp.signingCredential(),
+                                                                sp.signatureAlgorithm(),
+                                                                sp.idpConfigs(),
+                                                                sp.defaultIdpConfig(),
+                                                                sp.requestIdManager(),
+                                                                sp.sloHandler())));
+        final PathMapping metadata = sp.metadataPath();
+        metadata.exactPath().ifPresent(
+                path -> builder.put(path,
+                                    new SamlMetadataServiceFunction(sp.entityId(),
+                                                                    sp.signingCredential(),
+                                                                    sp.encryptionCredential(),
+                                                                    sp.idpConfigs(),
+                                                                    sp.acsConfigs(),
+                                                                    sp.sloEndpoints())));
+        serviceMap = builder.build();
+        pathMappings = serviceMap.keySet().stream().map(PathMapping::ofExact).collect(toImmutableSet());
+    }
+
+    @Override
+    public void serviceAdded(ServiceConfig cfg) throws Exception {
+        if (server != null) {
+            if (server != cfg.server()) {
+                throw new IllegalStateException("cannot be added to more than one server");
+            } else {
+                return;
+            }
+        }
+
+        server = cfg.server();
+
+        // Auto-detect the primary port number and its session protocol after the server started.
+        server.addListener(portConfigHolder);
+    }
+
+    @Override
+    public Set<PathMapping> pathMappings() {
+        return pathMappings;
+    }
+
+    @Override
+    public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+        final SamlServiceFunction func = serviceMap.get(req.path());
+        if (func == null) {
+            return HttpResponse.of(HttpStatus.BAD_REQUEST);
+        }
+
+        final CompletionStage<AggregatedHttpMessage> f;
+        if (portConfigHolder.isDone()) {
+            f = req.aggregate();
+        } else {
+            f = portConfigHolder.future().thenCompose(unused -> req.aggregate());
+        }
+        return HttpResponse.from(f.handle((msg, cause) -> {
+            if (cause != null) {
+                return HttpResponse.of(HttpStatus.BAD_REQUEST);
+            }
+            final SamlPortConfig portConfig = portConfigHolder.config().get();
+            if (portConfig.scheme().isTls() != ctx.sessionProtocol().isTls()) {
+                return HttpResponse.of(HttpStatus.BAD_REQUEST);
+            }
+
+            // Use user-specified hostname if it exists.
+            // If there's no hostname set by a user, the default virtual hostname will be used.
+            final String defaultHostname = firstNonNull(sp.hostname(), ctx.virtualHost().defaultHostname());
+            return func.serve(ctx, msg, defaultHostname, portConfig);
+        }));
+    }
+
+    /**
+     * A wrapper class which holds parameters resolved from a query string.
+     */
+    static final class SamlParameters {
+        private final Map<String, List<String>> parameters;
+
+        /**
+         * Creates a {@link SamlParameters} instance with the specified {@link AggregatedHttpMessage}.
+         */
+        SamlParameters(AggregatedHttpMessage msg) {
+            requireNonNull(msg, "msg");
+            final MediaType contentType = msg.headers().contentType();
+
+            final QueryStringDecoder decoder;
+            if (contentType != null && contentType.belongsTo(MediaType.FORM_DATA)) {
+                final String query = msg.content().toString(
+                        contentType.charset().orElse(StandardCharsets.UTF_8));
+                decoder = new QueryStringDecoder(query, false);
+            } else {
+                final String path = msg.path();
+                assert path != null : "path";
+                decoder = new QueryStringDecoder(path, true);
+            }
+
+            parameters = decoder.parameters();
+        }
+
+        /**
+         * Returns the first value of the parameter with the specified {@code name}.
+         *
+         * @throws SamlException if a parameter with the specified {@code name} does not exist
+         */
+        String getFirstValue(String name) throws SamlException {
+            final String value = getFirstValueOrNull(name);
+            if (value == null) {
+                throw new SamlException("failed to get the value of a parameter: " + name);
+            }
+            return value;
+        }
+
+        /**
+         * Returns the first value of the parameter with the specified {@code name}. If it does not exist,
+         * {@code null} is returned.
+         */
+        @Nullable
+        String getFirstValueOrNull(String name) {
+            requireNonNull(name, "name");
+            final List<String> values = parameters.get(name);
+            if (values == null || values.isEmpty()) {
+                return null;
+            }
+            final String value = values.get(0);
+            if (value.isEmpty()) {
+                return null;
+            }
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(this)
+                              .add("parameters", parameters)
+                              .toString();
+        }
+    }
+}

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/SamlServiceFunction.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/SamlServiceFunction.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.saml;
+
+import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.server.ServiceRequestContext;
+
+/**
+ * A callback which is invoked to handle SAML messages.
+ */
+@FunctionalInterface
+interface SamlServiceFunction {
+    /**
+     * Invoked by the {@link SamlService} when a SAML message is received.
+     *
+     * @param ctx the {@link ServiceRequestContext} of {@code req}
+     * @param msg the {@link AggregatedHttpMessage} being handled
+     * @param defaultHostname the hostname which is specified by a user via the {@link SamlServiceProvider},
+     *                        or the virtual hostname of the server if a user did not specify his or her
+     *                        hostname
+     * @param portConfig the port number and its {@link SessionProtocol} which the server is bound to
+     */
+    HttpResponse serve(ServiceRequestContext ctx, AggregatedHttpMessage msg,
+                       String defaultHostname, SamlPortConfig portConfig);
+}

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/SamlServiceProvider.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/SamlServiceProvider.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.saml;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.function.Function;
+
+import javax.annotation.Nullable;
+
+import org.opensaml.security.credential.Credential;
+import org.opensaml.xmlsec.signature.support.SignatureConstants;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.server.PathMapping;
+import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.Service;
+import com.linecorp.armeria.server.ServiceWithPathMappings;
+import com.linecorp.armeria.server.auth.Authorizer;
+
+/**
+ * A SAML service provider implementation.
+ *
+ * @see <a href="https://line.github.io/armeria/advanced-saml.html">SAML Single Sign-On</a>
+ */
+public final class SamlServiceProvider {
+
+    private final Authorizer<HttpRequest> authorizer;
+
+    private final String entityId;
+    @Nullable
+    private final String hostname;
+
+    private final Credential signingCredential;
+    private final Credential encryptionCredential;
+
+    private final String signatureAlgorithm;
+
+    private final SamlPortConfigAutoFiller portConfigAutoFiller;
+
+    private final PathMapping metadataPath;
+
+    private final Map<String, SamlIdentityProviderConfig> idpConfigs;
+    @Nullable
+    private final SamlIdentityProviderConfig defaultIdpConfig;
+    private final SamlIdentityProviderConfigSelector idpConfigSelector;
+
+    private final Collection<SamlAssertionConsumerConfig> acsConfigs;
+    private final SamlAssertionConsumerConfig defaultAcsConfig;
+    private final Collection<SamlEndpoint> sloEndpoints;
+
+    private final SamlRequestIdManager requestIdManager;
+
+    private final SamlSingleSignOnHandler ssoHandler;
+    private final SamlSingleLogoutHandler sloHandler;
+
+    /**
+     * A class which helps a {@link Server} have a SAML-based authentication.
+     */
+    SamlServiceProvider(Authorizer<HttpRequest> authorizer,
+                        String entityId,
+                        @Nullable String hostname,
+                        Credential signingCredential,
+                        Credential encryptionCredential,
+                        String signatureAlgorithm,
+                        SamlPortConfigAutoFiller portConfigAutoFiller,
+                        String metadataPath,
+                        Map<String, SamlIdentityProviderConfig> idpConfigs,
+                        @Nullable SamlIdentityProviderConfig defaultIdpConfig,
+                        SamlIdentityProviderConfigSelector idpConfigSelector,
+                        Collection<SamlAssertionConsumerConfig> acsConfigs,
+                        Collection<SamlEndpoint> sloEndpoints,
+                        SamlRequestIdManager requestIdManager,
+                        SamlSingleSignOnHandler ssoHandler,
+                        SamlSingleLogoutHandler sloHandler) {
+        this.authorizer = requireNonNull(authorizer, "authorizer");
+        this.entityId = requireNonNull(entityId, "entityId");
+        this.hostname = hostname;
+        this.signingCredential = requireNonNull(signingCredential, "signingCredential");
+        this.encryptionCredential = requireNonNull(encryptionCredential, "encryptionCredential");
+        this.signatureAlgorithm = requireNonNull(signatureAlgorithm, "signatureAlgorithm");
+        this.portConfigAutoFiller = requireNonNull(portConfigAutoFiller, "portConfigAutoFiller");
+        this.metadataPath = PathMapping.ofExact(requireNonNull(metadataPath, "metadataPath"));
+        this.idpConfigs = ImmutableMap.copyOf(requireNonNull(idpConfigs, "idpConfigs"));
+        this.defaultIdpConfig = defaultIdpConfig;
+        this.idpConfigSelector = requireNonNull(idpConfigSelector, "idpConfigSelector");
+        this.acsConfigs = ImmutableList.copyOf(requireNonNull(acsConfigs, "acsConfigs"));
+        this.sloEndpoints = ImmutableList.copyOf(requireNonNull(sloEndpoints, "sloEndpoints"));
+        this.requestIdManager = requireNonNull(requestIdManager, "requestIdManager");
+        this.ssoHandler = requireNonNull(ssoHandler, "ssoHandler");
+        this.sloHandler = requireNonNull(sloHandler, "sloHandler");
+
+        defaultAcsConfig = acsConfigs.stream().filter(SamlAssertionConsumerConfig::isDefault).findFirst()
+                                     .orElseThrow(() -> new IllegalArgumentException(
+                                             "no default assertion consumer config"));
+    }
+
+    /**
+     * An {@link Authorizer} which authenticates the received {@link HttpRequest}.
+     */
+    Authorizer<HttpRequest> authorizer() {
+        return authorizer;
+    }
+
+    /**
+     * An entity ID of the service provider.
+     */
+    String entityId() {
+        return entityId;
+    }
+
+    /**
+     * A hostname of the service provider which is configured by a user. If a user did not specify a hostname,
+     * the virtual hostname of the {@link Server} will be used.
+     */
+    @Nullable
+    String hostname() {
+        return hostname;
+    }
+
+    /**
+     * A {@link Credential} for signing SAML messages.
+     */
+    Credential signingCredential() {
+        return signingCredential;
+    }
+
+    /**
+     * A {@link Credential} for encrypting SAML messages.
+     */
+    Credential encryptionCredential() {
+        return encryptionCredential;
+    }
+
+    /**
+     * An algorithm which is used when signing SAML messages. The default value is
+     * {@value SignatureConstants#ALGO_ID_SIGNATURE_DSA}.
+     */
+    String signatureAlgorithm() {
+        return signatureAlgorithm;
+    }
+
+    /**
+     * A {@link SamlPortConfigAutoFiller} which fills the port number and its {@link SessionProtocol} that
+     * the {@link Server} is bound to.
+     */
+    SamlPortConfigAutoFiller portConfigAutoFiller() {
+        return portConfigAutoFiller;
+    }
+
+    /**
+     * A path for returning the metadata of the service provider.
+     */
+    PathMapping metadataPath() {
+        return metadataPath;
+    }
+
+    /**
+     * A map of identity provider configurations.
+     */
+    Map<String, SamlIdentityProviderConfig> idpConfigs() {
+        return idpConfigs;
+    }
+
+    /**
+     * A default identity provider configuration.
+     */
+    @Nullable
+    SamlIdentityProviderConfig defaultIdpConfig() {
+        return defaultIdpConfig;
+    }
+
+    /**
+     * A selector which selects an identity provider configuration.
+     */
+    SamlIdentityProviderConfigSelector idpConfigSelector() {
+        return idpConfigSelector;
+    }
+
+    /**
+     * The configurations of the assertion consumer services provided by the service provider.
+     */
+    Collection<SamlAssertionConsumerConfig> acsConfigs() {
+        return acsConfigs;
+    }
+
+    /**
+     * A default assertion consumer service configuration.
+     */
+    SamlAssertionConsumerConfig defaultAcsConfig() {
+        return defaultAcsConfig;
+    }
+
+    /**
+     * {@link SamlEndpoint}s for single logout service provided by the service provider.
+     */
+    Collection<SamlEndpoint> sloEndpoints() {
+        return sloEndpoints;
+    }
+
+    /**
+     * A {@link SamlRequestIdManager} which generates and validates a request ID.
+     */
+    SamlRequestIdManager requestIdManager() {
+        return requestIdManager;
+    }
+
+    /**
+     * An event handler for single sign-on.
+     */
+    SamlSingleSignOnHandler ssoHandler() {
+        return ssoHandler;
+    }
+
+    /**
+     * An event handler for single logout.
+     */
+    SamlSingleLogoutHandler sloHandler() {
+        return sloHandler;
+    }
+
+    /**
+     * Creates a decorator which initiates a SAML authentication if a request is not authenticated.
+     */
+    public Function<Service<HttpRequest, HttpResponse>,
+            Service<HttpRequest, HttpResponse>> newSamlDecorator() {
+        return delegate -> new SamlDecorator(this, delegate);
+    }
+
+    /**
+     * Creates a {@link Service} which handles SAML messages.
+     */
+    public ServiceWithPathMappings<HttpRequest, HttpResponse> newSamlService() {
+        return new SamlService(this);
+    }
+}

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/SamlServiceProviderBuilder.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/SamlServiceProviderBuilder.java
@@ -1,0 +1,485 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.saml;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static com.linecorp.armeria.server.saml.HttpRedirectBindingUtil.responseWithLocation;
+import static com.linecorp.armeria.server.saml.SamlEndpoint.ofHttpPost;
+import static com.linecorp.armeria.server.saml.SamlEndpoint.ofHttpRedirect;
+import static java.util.Objects.requireNonNull;
+
+import java.io.UnsupportedEncodingException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.Signature;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+
+import javax.annotation.Nullable;
+
+import org.opensaml.core.criterion.EntityIdCriterion;
+import org.opensaml.messaging.context.MessageContext;
+import org.opensaml.saml.common.messaging.context.SAMLBindingContext;
+import org.opensaml.saml.saml2.core.AuthnRequest;
+import org.opensaml.saml.saml2.core.LogoutRequest;
+import org.opensaml.saml.saml2.core.Response;
+import org.opensaml.security.credential.Credential;
+import org.opensaml.security.credential.CredentialResolver;
+import org.opensaml.xmlsec.algorithm.AlgorithmSupport;
+import org.opensaml.xmlsec.signature.support.SignatureConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import net.shibboleth.utilities.java.support.resolver.CriteriaSet;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.util.Exceptions;
+import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.ServerPort;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.auth.Authorizer;
+
+/**
+ * A builder which builds a {@link SamlServiceProvider}.
+ */
+public final class SamlServiceProviderBuilder {
+    private static final Logger logger = LoggerFactory.getLogger(SamlServiceProviderBuilder.class);
+
+    private final List<SamlIdentityProviderConfigBuilder> idpConfigBuilders = new ArrayList<>();
+    private final List<SamlAssertionConsumerConfigBuilder> acsConfigBuilders = new ArrayList<>();
+
+    private final List<SamlEndpoint> sloEndpoints = new ArrayList<>();
+
+    private final SamlPortConfigBuilder hostConfigBuilder = new SamlPortConfigBuilder();
+
+    @Nullable
+    private String entityId;
+    @Nullable
+    private String hostname;
+    @Nullable
+    private Authorizer<HttpRequest> authorizer;
+
+    @Nullable
+    private CredentialResolverAdapter credentialResolver;
+    private String signingKey = "signing";
+    private String encryptionKey = "encryption";
+
+    private String signatureAlgorithm = SignatureConstants.ALGO_ID_SIGNATURE_DSA;
+
+    private String metadataPath = "/saml/metadata";
+
+    @Nullable
+    private SamlIdentityProviderConfigSelector idpConfigSelector;
+
+    @Nullable
+    private SamlRequestIdManager requestIdManager;
+
+    private SamlSingleSignOnHandler ssoHandler = new SamlSingleSignOnHandler() {
+        @Override
+        public CompletionStage<Void> beforeInitiatingSso(ServiceRequestContext ctx, HttpRequest req,
+                                                         MessageContext<AuthnRequest> message,
+                                                         SamlIdentityProviderConfig idpConfig) {
+            final String requestedPath = req.path();
+            if (requestedPath.length() <= 80) {
+                // Relay the requested path by default.
+                final SAMLBindingContext sub = message.getSubcontext(SAMLBindingContext.class, true);
+                assert sub != null : "SAMLBindingContext";
+                sub.setRelayState(requestedPath);
+            }
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public HttpResponse loginSucceeded(ServiceRequestContext ctx, AggregatedHttpMessage req,
+                                           MessageContext<Response> message, @Nullable String sessionIndex,
+                                           @Nullable String relayState) {
+            return responseWithLocation(firstNonNull(relayState, "/"));
+        }
+
+        @Override
+        public HttpResponse loginFailed(ServiceRequestContext ctx, AggregatedHttpMessage req,
+                                        @Nullable MessageContext<Response> message, Throwable cause) {
+            logger.warn("{} SAML SSO failed", ctx, cause);
+            return responseWithLocation("/error");
+        }
+    };
+
+    private SamlSingleLogoutHandler sloHandler = new SamlSingleLogoutHandler() {
+        @Override
+        public CompletionStage<Void> logoutSucceeded(ServiceRequestContext ctx, AggregatedHttpMessage req,
+                                                     MessageContext<LogoutRequest> message) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public CompletionStage<Void> logoutFailed(ServiceRequestContext ctx, AggregatedHttpMessage req,
+                                                  Throwable cause) {
+            logger.warn("{} SAML SLO failed", ctx, cause);
+            return CompletableFuture.completedFuture(null);
+        }
+    };
+
+    /**
+     * Set an {@link Authorizer} which is used for this service provider's authentication.
+     */
+    public SamlServiceProviderBuilder authorizer(Authorizer<HttpRequest> authorizer) {
+        this.authorizer = requireNonNull(authorizer, "authorizer");
+        return this;
+    }
+
+    /**
+     * Sets an entity ID for this service provider.
+     */
+    public SamlServiceProviderBuilder entityId(String entityId) {
+        this.entityId = requireNonNull(entityId, "entityId");
+        return this;
+    }
+
+    /**
+     * Sets a {@link CredentialResolver} for this service provider.
+     */
+    public SamlServiceProviderBuilder credentialResolver(CredentialResolver credentialResolver) {
+        this.credentialResolver =
+                new CredentialResolverAdapter(requireNonNull(credentialResolver, "credentialResolver"));
+        return this;
+    }
+
+    /**
+     * Sets a {@code signing} key name for this service provider.
+     */
+    public SamlServiceProviderBuilder signingKey(String signingKey) {
+        this.signingKey = requireNonNull(signingKey, "signingKey");
+        return this;
+    }
+
+    /**
+     * Sets an {@code encryption} key name for this service provider.
+     */
+    public SamlServiceProviderBuilder encryptionKey(String encryptionKey) {
+        this.encryptionKey = requireNonNull(encryptionKey, "encryptionKey");
+        return this;
+    }
+
+    /**
+     * Sets a signature algorithm which is used for signing by this service provider.
+     */
+    public SamlServiceProviderBuilder signatureAlgorithm(String signatureAlgorithm) {
+        this.signatureAlgorithm = requireNonNull(signatureAlgorithm, "signatureAlgorithm");
+        return this;
+    }
+
+    /**
+     * Sets a hostname of this service provider.
+     */
+    public SamlServiceProviderBuilder hostname(String hostname) {
+        this.hostname = requireNonNull(hostname, "hostname");
+        return this;
+    }
+
+    /**
+     * Sets a protocol scheme of this service provider.
+     */
+    public SamlServiceProviderBuilder scheme(SessionProtocol scheme) {
+        hostConfigBuilder.setSchemeIfAbsent(requireNonNull(scheme, "scheme"));
+        return this;
+    }
+
+    /**
+     * Sets a port of this service provider.
+     */
+    public SamlServiceProviderBuilder port(int port) {
+        hostConfigBuilder.setPortIfAbsent(port);
+        return this;
+    }
+
+    /**
+     * Sets a {@link ServerPort} of this service provider.
+     */
+    public SamlServiceProviderBuilder schemeAndPort(ServerPort serverPort) {
+        hostConfigBuilder.setSchemeAndPortIfAbsent(requireNonNull(serverPort, "serverPort"));
+        return this;
+    }
+
+    /**
+     * Sets a URL for retrieving a metadata of this service provider.
+     */
+    public SamlServiceProviderBuilder metadataPath(String metadataPath) {
+        this.metadataPath = requireNonNull(metadataPath, "metadataPath");
+        return this;
+    }
+
+    /**
+     * Sets a {@link SamlIdentityProviderConfigSelector} which determines a suitable idp for a request.
+     */
+    public SamlServiceProviderBuilder idpConfigSelector(
+            SamlIdentityProviderConfigSelector idpConfigSelector) {
+        this.idpConfigSelector = requireNonNull(idpConfigSelector, "idpConfigSelector");
+        return this;
+    }
+
+    /**
+     * Adds a new single logout service endpoint of this service provider.
+     */
+    public SamlServiceProviderBuilder sloEndpoint(SamlEndpoint sloEndpoint) {
+        sloEndpoints.add(requireNonNull(sloEndpoint, "sloEndpoint"));
+        return this;
+    }
+
+    /**
+     * Sets a {@link SamlRequestIdManager} which creates and validates a SAML request ID.
+     */
+    public SamlServiceProviderBuilder requestIdManager(SamlRequestIdManager requestIdManager) {
+        this.requestIdManager = requireNonNull(requestIdManager, "requestIdManager");
+        return this;
+    }
+
+    /**
+     * Sets a {@link SamlSingleSignOnHandler} which handles SAML messages for a single sign-on.
+     */
+    public SamlServiceProviderBuilder ssoHandler(SamlSingleSignOnHandler ssoHandler) {
+        this.ssoHandler = requireNonNull(ssoHandler, "ssoHandler");
+        return this;
+    }
+
+    /**
+     * Sets a {@link SamlSingleLogoutHandler} which handles SAML messages for a single sign-on.
+     */
+    public SamlServiceProviderBuilder sloHandler(SamlSingleLogoutHandler sloHandler) {
+        this.sloHandler = requireNonNull(sloHandler, "sloHandler");
+        return this;
+    }
+
+    /**
+     * Returns a {@link SamlIdentityProviderConfigBuilder} to configure a new idp for authentication.
+     */
+    public SamlIdentityProviderConfigBuilder idp() {
+        final SamlIdentityProviderConfigBuilder config = new SamlIdentityProviderConfigBuilder(this);
+        idpConfigBuilders.add(config);
+        return config;
+    }
+
+    /**
+     * Returns a {@link SamlAssertionConsumerConfigBuilder} to configure a new assertion consumer service
+     * of this service provider.
+     */
+    public SamlAssertionConsumerConfigBuilder acs() {
+        final SamlAssertionConsumerConfigBuilder config = new SamlAssertionConsumerConfigBuilder(this);
+        acsConfigBuilders.add(config);
+        return config;
+    }
+
+    /**
+     * Builds a {@link SamlServiceProvider} which helps a {@link Server} have a SAML-based
+     * authentication.
+     */
+    public SamlServiceProvider build() {
+
+        // Must ensure that OpenSAML is initialized before building a SAML service provider.
+        SamlInitializer.ensureAvailability();
+
+        if (entityId == null) {
+            throw new IllegalStateException("entity ID is not specified");
+        }
+        if (credentialResolver == null) {
+            throw new IllegalStateException(CredentialResolver.class.getSimpleName() + " is not specified");
+        }
+        if (authorizer == null) {
+            throw new IllegalStateException(Authorizer.class.getSimpleName() + " is not specified");
+        }
+
+        final Credential signingCredential = credentialResolver.apply(signingKey);
+        if (signingCredential == null) {
+            throw new IllegalStateException("cannot resolve a " + Credential.class.getSimpleName() +
+                                            " for signing: " + signingKey);
+        }
+        final Credential encryptionCredential = credentialResolver.apply(encryptionKey);
+        if (encryptionCredential == null) {
+            throw new IllegalStateException("cannot resolve a " + Credential.class.getSimpleName() +
+                                            " for encryption: " + encryptionKey);
+        }
+        validateSignatureAlgorithm(signatureAlgorithm, signingCredential);
+        validateSignatureAlgorithm(signatureAlgorithm, encryptionCredential);
+
+        // Initialize single logout service configurations.
+        final List<SamlEndpoint> sloEndpoints;
+        if (this.sloEndpoints.isEmpty()) {
+            // Add two endpoints by default if there's no SLO endpoint specified by a user.
+            sloEndpoints = ImmutableList.of(ofHttpPost("/saml/slo/post"),
+                                            ofHttpRedirect("/saml/slo/redirect"));
+        } else {
+            sloEndpoints = ImmutableList.copyOf(this.sloEndpoints);
+        }
+
+        // Initialize assertion consumer service configurations.
+        final List<SamlAssertionConsumerConfig> assertionConsumerConfigs;
+        if (acsConfigBuilders.isEmpty()) {
+            // Add two endpoints by default if there's no ACS endpoint specified by a user.
+            assertionConsumerConfigs =
+                    ImmutableList.of(new SamlAssertionConsumerConfigBuilder(this)
+                                             .endpoint(ofHttpPost("/saml/acs/post")).asDefault(),
+                                     new SamlAssertionConsumerConfigBuilder(this)
+                                             .endpoint(ofHttpRedirect("/saml/acs/redirect")))
+                                 .stream()
+                                 .map(SamlAssertionConsumerConfigBuilder::build)
+                                 .collect(toImmutableList());
+        } else {
+            // If there is only one ACS, it will be automatically a default ACS.
+            if (acsConfigBuilders.size() == 1) {
+                acsConfigBuilders.get(0).asDefault();
+            }
+
+            assertionConsumerConfigs = acsConfigBuilders.stream()
+                                                        .map(SamlAssertionConsumerConfigBuilder::build)
+                                                        .collect(toImmutableList());
+        }
+
+        // Collect assertion consumer service endpoints for checking duplication and existence.
+        final Set<SamlEndpoint> acsEndpoints =
+                assertionConsumerConfigs.stream().map(SamlAssertionConsumerConfig::endpoint)
+                                        .collect(toImmutableSet());
+        if (acsEndpoints.size() != assertionConsumerConfigs.size()) {
+            throw new IllegalStateException("duplicated access consumer services exist");
+        }
+
+        // Initialize identity provider configurations.
+        if (idpConfigBuilders.isEmpty()) {
+            throw new IllegalStateException("no identity provider configuration is specified");
+        }
+        // If there is only one IdP, it will be automatically a default IdP.
+        if (idpConfigBuilders.size() == 1) {
+            idpConfigBuilders.get(0).asDefault();
+        }
+
+        final ImmutableMap.Builder<String, SamlIdentityProviderConfig> idpConfigs = ImmutableMap.builder();
+        SamlIdentityProviderConfig defaultIdpConfig = null;
+        for (final SamlIdentityProviderConfigBuilder builder : idpConfigBuilders) {
+            if (builder.acsEndpoint() != null && !acsEndpoints.contains(builder.acsEndpoint())) {
+                throw new IllegalStateException("unspecified access consumer service at " +
+                                                builder.acsEndpoint());
+            }
+
+            final SamlIdentityProviderConfig config = builder.build(credentialResolver);
+
+            validateSignatureAlgorithm(signatureAlgorithm, config.signingCredential());
+            validateSignatureAlgorithm(signatureAlgorithm, config.encryptionCredential());
+
+            idpConfigs.put(config.entityId(), config);
+
+            if (builder.isDefault()) {
+                if (defaultIdpConfig != null) {
+                    throw new IllegalStateException("there has to be only one default identity provider");
+                }
+                defaultIdpConfig = config;
+            }
+        }
+
+        if (idpConfigSelector == null) {
+            if (defaultIdpConfig == null) {
+                throw new IllegalStateException("default identity provider does not exist");
+            }
+
+            // Configure a default identity provider selector which always returns a default identity provider.
+            final SamlIdentityProviderConfig defaultConfig = defaultIdpConfig;
+            idpConfigSelector =
+                    (unused1, unused2, unused3) -> CompletableFuture.completedFuture(defaultConfig);
+        }
+
+        // entityID would be used as a secret by default.
+        try {
+            requestIdManager = firstNonNull(requestIdManager,
+                                            SamlRequestIdManager.ofJwt(entityId, entityId,
+                                                                       60, 5));
+        } catch (UnsupportedEncodingException e) {
+            throw new IllegalStateException("cannot create a " + SamlRequestIdManager.class.getSimpleName(),
+                                            e);
+        }
+
+        return new SamlServiceProvider(authorizer,
+                                       entityId,
+                                       hostname,
+                                       signingCredential,
+                                       encryptionCredential,
+                                       signatureAlgorithm,
+                                       hostConfigBuilder.toAutoFiller(),
+                                       metadataPath,
+                                       idpConfigs.build(),
+                                       defaultIdpConfig,
+                                       idpConfigSelector,
+                                       assertionConsumerConfigs,
+                                       sloEndpoints,
+                                       requestIdManager,
+                                       ssoHandler,
+                                       sloHandler);
+    }
+
+    private static void validateSignatureAlgorithm(String signatureAlgorithm, Credential credential) {
+        final String jcaAlgorithmID = AlgorithmSupport.getAlgorithmID(signatureAlgorithm);
+        if (jcaAlgorithmID == null) {
+            throw new IllegalStateException("unsupported signature algorithm: " + signatureAlgorithm);
+        }
+        try {
+            final Signature signature = Signature.getInstance(jcaAlgorithmID);
+            final PrivateKey key = credential.getPrivateKey();
+            if (key != null) {
+                signature.initSign(key);
+            } else {
+                signature.initVerify(credential.getPublicKey());
+            }
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("unsupported signature algorithm: " + signatureAlgorithm, e);
+        } catch (InvalidKeyException e) {
+            throw new IllegalStateException("failed to initialize a signature with an algorithm: " +
+                                            signatureAlgorithm, e);
+        }
+    }
+
+    /**
+     * An adapter for {@link CredentialResolver} which helps to resolve a {@link Credential} from
+     * the specified {@code keyName}.
+     */
+    static class CredentialResolverAdapter implements Function<String, Credential> {
+        private final CredentialResolver resolver;
+
+        CredentialResolverAdapter(CredentialResolver resolver) {
+            this.resolver = requireNonNull(resolver, "resolver");
+        }
+
+        @Nullable
+        @Override
+        public Credential apply(String keyName) {
+            final CriteriaSet cs = new CriteriaSet();
+            cs.add(new EntityIdCriterion(keyName));
+            try {
+                return resolver.resolveSingle(cs);
+            } catch (Throwable cause) {
+                return Exceptions.throwUnsafely(cause);
+            }
+        }
+    }
+}

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/SamlSingleLogoutFunction.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/SamlSingleLogoutFunction.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.saml;
+
+import static com.linecorp.armeria.server.saml.HttpPostBindingUtil.getSsoForm;
+import static com.linecorp.armeria.server.saml.HttpPostBindingUtil.toSignedBase64;
+import static com.linecorp.armeria.server.saml.HttpRedirectBindingUtil.responseWithLocation;
+import static com.linecorp.armeria.server.saml.HttpRedirectBindingUtil.toRedirectionUrl;
+import static com.linecorp.armeria.server.saml.SamlHttpParameterNames.SAML_REQUEST;
+import static com.linecorp.armeria.server.saml.SamlHttpParameterNames.SAML_RESPONSE;
+import static com.linecorp.armeria.server.saml.SamlMessageUtil.build;
+import static com.linecorp.armeria.server.saml.SamlMessageUtil.validateSignature;
+
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
+import org.joda.time.DateTime;
+import org.opensaml.messaging.context.MessageContext;
+import org.opensaml.saml.saml2.core.Issuer;
+import org.opensaml.saml.saml2.core.LogoutRequest;
+import org.opensaml.saml.saml2.core.LogoutResponse;
+import org.opensaml.saml.saml2.core.Status;
+import org.opensaml.saml.saml2.core.StatusCode;
+import org.opensaml.security.credential.Credential;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.server.ServiceRequestContext;
+
+/**
+ * A service which receives a single logout request from an identity provider in order to perform a global
+ * logout.
+ */
+final class SamlSingleLogoutFunction implements SamlServiceFunction {
+    private static final Logger logger = LoggerFactory.getLogger(SamlSingleLogoutFunction.class);
+
+    private final SamlEndpoint endpoint;
+    private final String entityId;
+    private final Credential signingCredential;
+    private final String signatureAlgorithm;
+
+    private final Map<String, SamlIdentityProviderConfig> idpConfigs;
+    @Nullable
+    private final SamlIdentityProviderConfig defaultIdpConfig;
+
+    private final SamlRequestIdManager requestIdManager;
+    private final SamlSingleLogoutHandler sloHandler;
+
+    SamlSingleLogoutFunction(SamlEndpoint endpoint, String entityId,
+                             Credential signingCredential,
+                             String signatureAlgorithm,
+                             Map<String, SamlIdentityProviderConfig> idpConfigs,
+                             @Nullable SamlIdentityProviderConfig defaultIdpConfig,
+                             SamlRequestIdManager requestIdManager,
+                             SamlSingleLogoutHandler sloHandler) {
+        this.endpoint = endpoint;
+        this.entityId = entityId;
+        this.signingCredential = signingCredential;
+        this.signatureAlgorithm = signatureAlgorithm;
+        this.idpConfigs = idpConfigs;
+        this.defaultIdpConfig = defaultIdpConfig;
+        this.requestIdManager = requestIdManager;
+        this.sloHandler = sloHandler;
+    }
+
+    @Override
+    public HttpResponse serve(ServiceRequestContext ctx, AggregatedHttpMessage msg,
+                              String defaultHostname, SamlPortConfig portConfig) {
+        try {
+            final MessageContext<LogoutRequest> messageContext;
+            if (endpoint.bindingProtocol() == SamlBindingProtocol.HTTP_REDIRECT) {
+                messageContext = HttpRedirectBindingUtil.toSamlObject(msg, SAML_REQUEST,
+                                                                      idpConfigs, defaultIdpConfig);
+            } else {
+                messageContext = HttpPostBindingUtil.toSamlObject(msg, SAML_REQUEST);
+            }
+
+            final String endpointUri = endpoint.toUriString(portConfig.scheme().uriText(),
+                                                            defaultHostname, portConfig.port());
+            final LogoutRequest logoutRequest = messageContext.getMessage();
+            final SamlIdentityProviderConfig idp = validateAndGetIdPConfig(logoutRequest, endpointUri);
+
+            if (endpoint.bindingProtocol() == SamlBindingProtocol.HTTP_POST) {
+                validateSignature(idp.signingCredential(), logoutRequest);
+            }
+
+            final SamlEndpoint sloResEndpoint = idp.sloResEndpoint().orElse(null);
+            if (sloResEndpoint == null) {
+                // No response URL. Just return 200 OK.
+                return HttpResponse.from(sloHandler.logoutSucceeded(ctx, msg, messageContext)
+                                                   .thenApply(unused -> HttpResponse.of(HttpStatus.OK)));
+            }
+
+            final LogoutResponse logoutResponse = createLogoutResponse(logoutRequest, StatusCode.SUCCESS);
+            try {
+                final HttpResponse response = respond(logoutResponse, sloResEndpoint);
+                return HttpResponse.from(sloHandler.logoutSucceeded(ctx, msg, messageContext)
+                                                   .thenApply(unused -> response));
+            } catch (SamlException e) {
+                logger.warn("{} Cannot respond a logout response in response to {}",
+                            ctx, logoutRequest.getID(), e);
+                final HttpResponse response = fail(ctx, logoutRequest, sloResEndpoint);
+                return HttpResponse.from(sloHandler.logoutFailed(ctx, msg, e)
+                                                   .thenApply(unused -> response));
+            }
+        } catch (SamlException e) {
+            return fail(ctx, e);
+        }
+    }
+
+    private HttpResponse fail(ServiceRequestContext ctx, Throwable cause) {
+        logger.warn("{} Cannot handle a logout request", ctx, cause);
+        return HttpResponse.of(HttpStatus.SERVICE_UNAVAILABLE);
+    }
+
+    private HttpResponse fail(ServiceRequestContext ctx,
+                              LogoutRequest logoutRequest,
+                              SamlEndpoint sloResEndpoint) {
+        // Try to send a LogoutResponse with the following status code. It's one of the top-level status code
+        // which is defined in SAML 2.0 specifications.
+        //
+        // "urn:oasis:names:tc:SAML:2.0:status:Responder"
+        // - The request could not be performed due to an error on the part of the SAML responder
+        //   or SAML authority.
+        final LogoutResponse failureResponse = createLogoutResponse(logoutRequest, StatusCode.RESPONDER);
+        try {
+            return respond(failureResponse, sloResEndpoint);
+        } catch (SamlException e) {
+            return fail(ctx, e);
+        }
+    }
+
+    private HttpResponse respond(LogoutResponse logoutResponse,
+                                 SamlEndpoint sloResEndpoint) throws SamlException {
+        if (sloResEndpoint.bindingProtocol() == SamlBindingProtocol.HTTP_REDIRECT) {
+            return responseWithLocation(toRedirectionUrl(
+                    logoutResponse, sloResEndpoint.toUriString(), SAML_RESPONSE,
+                    signingCredential, signatureAlgorithm, null));
+        } else {
+            final String value = toSignedBase64(logoutResponse, signingCredential,
+                                                signatureAlgorithm);
+            final HttpData body = getSsoForm(sloResEndpoint.toUriString(),
+                                             SAML_RESPONSE, value, null);
+            return HttpResponse.of(HttpStatus.OK, MediaType.HTML_UTF_8, body);
+        }
+    }
+
+    private SamlIdentityProviderConfig validateAndGetIdPConfig(LogoutRequest logoutRequest,
+                                                               String endpointUri) throws SamlException {
+        final String issuer = logoutRequest.getIssuer().getValue();
+        if (issuer == null) {
+            throw new SamlException("no issuer found from the logout request: " + logoutRequest.getID());
+        }
+        if (!endpointUri.equals(logoutRequest.getDestination())) {
+            throw new SamlException("unexpected destination: " + logoutRequest.getDestination());
+        }
+        final SamlIdentityProviderConfig config = idpConfigs.get(issuer);
+        if (config == null) {
+            throw new SamlException("unexpected identity provider: " + issuer);
+        }
+        return config;
+    }
+
+    private LogoutResponse createLogoutResponse(LogoutRequest logoutRequest,
+                                                String statusCode) {
+        final StatusCode success = build(StatusCode.DEFAULT_ELEMENT_NAME);
+        success.setValue(statusCode);
+
+        final Status status = build(Status.DEFAULT_ELEMENT_NAME);
+        status.setStatusCode(success);
+
+        final Issuer me = build(Issuer.DEFAULT_ELEMENT_NAME);
+        me.setValue(entityId);
+
+        final LogoutResponse logoutResponse = build(LogoutResponse.DEFAULT_ELEMENT_NAME);
+        logoutResponse.setIssuer(me);
+        logoutResponse.setID(requestIdManager.newId());
+        logoutResponse.setIssueInstant(DateTime.now());
+        logoutResponse.setStatus(status);
+        logoutResponse.setInResponseTo(logoutRequest.getID());
+
+        return logoutResponse;
+    }
+}

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/SamlSingleLogoutHandler.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/SamlSingleLogoutHandler.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.saml;
+
+import java.util.concurrent.CompletionStage;
+
+import org.opensaml.messaging.context.MessageContext;
+import org.opensaml.saml.saml2.core.LogoutRequest;
+
+import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.server.ServiceRequestContext;
+
+/**
+ * A callback which is invoked when a SAML single logout request is received.
+ *
+ * @see SamlServiceProviderBuilder#sloHandler(SamlSingleLogoutHandler)
+ */
+public interface SamlSingleLogoutHandler {
+    /**
+     * Invoked when the single logout request is succeeded. It can do the local logout using session indexes
+     * containing in the {@link LogoutRequest}.
+     *
+     * @param ctx the {@link ServiceRequestContext} of {@code req}
+     * @param req the {@link AggregatedHttpMessage} being handled
+     * @param message the {@link MessageContext} of the {@link LogoutRequest} received from the identity
+     *                provider.
+     */
+    CompletionStage<Void> logoutSucceeded(ServiceRequestContext ctx, AggregatedHttpMessage req,
+                                          MessageContext<LogoutRequest> message);
+
+    /**
+     * Invoked when the single logout request is failed.
+     *
+     * @param ctx the {@link ServiceRequestContext} of {@code req}
+     * @param req the {@link AggregatedHttpMessage} being handled
+     * @param cause the reason of the failure
+     */
+    CompletionStage<Void> logoutFailed(ServiceRequestContext ctx, AggregatedHttpMessage req,
+                                       Throwable cause);
+}

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/SamlSingleSignOnHandler.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/SamlSingleSignOnHandler.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.saml;
+
+import java.util.concurrent.CompletionStage;
+
+import javax.annotation.Nullable;
+
+import org.opensaml.messaging.context.MessageContext;
+import org.opensaml.saml.saml2.core.AuthnRequest;
+import org.opensaml.saml.saml2.core.Response;
+
+import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.Request;
+import com.linecorp.armeria.server.ServiceRequestContext;
+
+/**
+ * Callbacks which are invoked to handle SAML messages exchanging with an identity provider.
+ *
+ * @see SamlServiceProviderBuilder#ssoHandler(SamlSingleSignOnHandler)
+ */
+public interface SamlSingleSignOnHandler {
+    /**
+     * Invoked before the service provider sends an authentication request to an identity provider.
+     *
+     * @param ctx the {@link ServiceRequestContext} of {@code req}
+     * @param req the {@link Request} being handled
+     * @param message the {@link MessageContext} of the {@link AuthnRequest} being sent to the identity
+     *                provider
+     * @param idpConfig the configuration of the identity provider that the request is sending to
+     */
+    CompletionStage<Void> beforeInitiatingSso(ServiceRequestContext ctx, HttpRequest req,
+                                              MessageContext<AuthnRequest> message,
+                                              SamlIdentityProviderConfig idpConfig);
+
+    /**
+     * Invoked when the single sign-on is succeeded. It should return an {@link HttpResponse} which sends
+     * to the client in response to the incoming {@code req}.
+     *
+     * @param ctx the {@link ServiceRequestContext} of {@code req}
+     * @param req the {@link AggregatedHttpMessage} being handled
+     * @param message the {@link MessageContext} of the {@link Response} received from the identity provider
+     * @param sessionIndex the retrieved value from the {@link Response} message. {@code null} if it is omitted.
+     * @param relayState the string which is sent with the {@link AuthnRequest} message and is returned
+     *                   with the {@link Response} message. {@code null} if it is omitted.
+     */
+    HttpResponse loginSucceeded(ServiceRequestContext ctx, AggregatedHttpMessage req,
+                                MessageContext<Response> message,
+                                @Nullable String sessionIndex,
+                                @Nullable String relayState);
+
+    /**
+     * Invoked when the single sign-on is failed. It should return an {@link HttpResponse} which sends
+     * to the client in response to the incoming {@code req}. Sending an error HTML page is one of the
+     * examples.
+     *
+     * @param ctx the {@link ServiceRequestContext} of {@code req}
+     * @param req the {@link AggregatedHttpMessage} being handled
+     * @param message the {@link MessageContext} of the {@link Response} received from the identity provider.
+     *                {@code null} if the content of the {@code req} was failed to be parsed as a
+     *                {@link Response} message.
+     * @param cause the reason of the failure
+     */
+    HttpResponse loginFailed(ServiceRequestContext ctx, AggregatedHttpMessage req,
+                             @Nullable MessageContext<Response> message,
+                             Throwable cause);
+}

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/package-info.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * <a href="https://en.wikipedia.org/wiki/Security_Assertion_Markup_Language">SAML</a>-based single sign-on
+ * service.
+ */
+@NonNullByDefault
+package com.linecorp.armeria.server.saml;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/saml/src/test/java/com/linecorp/armeria/server/saml/SamlRequestIdManagerTest.java
+++ b/saml/src/test/java/com/linecorp/armeria/server/saml/SamlRequestIdManagerTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.saml;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+
+import java.io.UnsupportedEncodingException;
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+
+import org.awaitility.Duration;
+import org.junit.Test;
+
+public class SamlRequestIdManagerTest {
+
+    @Test
+    public void shouldBeDifferentToEachOther() throws UnsupportedEncodingException {
+        final SamlRequestIdManager manager =
+                SamlRequestIdManager.ofJwt("me", "test", 60, 5);
+
+        final String id1 = manager.newId();
+        final String id2 = manager.newId();
+        final String id3 = manager.newId();
+
+        assertThat(id1).isNotEqualTo(id2).isNotEqualTo(id3);
+        assertThat(id2).isNotEqualTo(id3);
+    }
+
+    @Test
+    public void shouldMatchJWTPattern() throws UnsupportedEncodingException {
+        final Pattern p = Pattern.compile("[a-zA-Z0-9-_]+\\.[a-zA-Z0-9-_]+\\.[a-zA-Z0-9-_]+");
+        final SamlRequestIdManager manager =
+                SamlRequestIdManager.ofJwt("me", "test", 60, 5);
+        final String id = manager.newId();
+        assertThat(p.matcher(id).matches()).isTrue();
+        assertThat(manager.validateId(id)).isTrue();
+    }
+
+    @Test
+    public void shouldBeExpired() throws InterruptedException, UnsupportedEncodingException {
+        final SamlRequestIdManager manager =
+                SamlRequestIdManager.ofJwt("me", "test", 1, 0);
+
+        final Instant started = Instant.now();
+        final String id = manager.newId();
+        assertThat(manager.validateId(id)).isTrue();
+
+        await().pollDelay(Duration.TWO_HUNDRED_MILLISECONDS)
+               .atMost(Duration.FIVE_SECONDS)
+               .untilAsserted(() -> assertThat(manager.validateId(id)).isFalse());
+
+        assertThat(java.time.Duration.between(started, Instant.now()).toMillis())
+                .isGreaterThan(TimeUnit.SECONDS.toMillis(1));
+    }
+
+    @Test
+    public void shouldBeAcceptedBecauseOfLeeway() throws InterruptedException, UnsupportedEncodingException {
+        final SamlRequestIdManager manager =
+                SamlRequestIdManager.ofJwt("me", "test", 1, 1);
+
+        final Instant started = Instant.now();
+        final String id = manager.newId();
+        assertThat(manager.validateId(id)).isTrue();
+
+        await().pollDelay(Duration.TWO_HUNDRED_MILLISECONDS)
+               .atMost(Duration.FIVE_SECONDS)
+               .untilAsserted(() -> assertThat(manager.validateId(id)).isFalse());
+
+        assertThat(java.time.Duration.between(started, Instant.now()).toMillis())
+                .isGreaterThan(TimeUnit.SECONDS.toMillis(2));
+    }
+
+    @Test
+    public void shouldFail() {
+        assertThatThrownBy(() -> SamlRequestIdManager.ofJwt("me", "test", 0, 0))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> SamlRequestIdManager.ofJwt("me", "test", -1, 0))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> SamlRequestIdManager.ofJwt("me", "test", 1, -1))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/saml/src/test/java/com/linecorp/armeria/server/saml/SamlServiceProviderTest.java
+++ b/saml/src/test/java/com/linecorp/armeria/server/saml/SamlServiceProviderTest.java
@@ -1,0 +1,550 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.saml;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.linecorp.armeria.server.saml.HttpPostBindingUtil.toSignedBase64;
+import static com.linecorp.armeria.server.saml.HttpRedirectBindingUtil.generateSignature;
+import static com.linecorp.armeria.server.saml.HttpRedirectBindingUtil.headersWithLocation;
+import static com.linecorp.armeria.server.saml.HttpRedirectBindingUtil.toDeflatedBase64;
+import static com.linecorp.armeria.server.saml.SamlEndpoint.ofHttpPost;
+import static com.linecorp.armeria.server.saml.SamlEndpoint.ofHttpRedirect;
+import static com.linecorp.armeria.server.saml.SamlHttpParameterNames.RELAY_STATE;
+import static com.linecorp.armeria.server.saml.SamlHttpParameterNames.SAML_REQUEST;
+import static com.linecorp.armeria.server.saml.SamlHttpParameterNames.SAML_RESPONSE;
+import static com.linecorp.armeria.server.saml.SamlHttpParameterNames.SIGNATURE;
+import static com.linecorp.armeria.server.saml.SamlHttpParameterNames.SIGNATURE_ALGORITHM;
+import static com.linecorp.armeria.server.saml.SamlMessageUtil.build;
+import static com.linecorp.armeria.server.saml.SamlMessageUtil.deserialize;
+import static com.linecorp.armeria.server.saml.SamlMessageUtil.sign;
+import static com.linecorp.armeria.server.saml.SamlMetadataServiceFunction.CONTENT_TYPE_SAML_METADATA;
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.security.KeyStore;
+import java.security.cert.Certificate;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Pattern;
+
+import javax.annotation.Nullable;
+
+import org.joda.time.DateTime;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.opensaml.core.criterion.EntityIdCriterion;
+import org.opensaml.core.xml.util.XMLObjectSupport;
+import org.opensaml.messaging.context.MessageContext;
+import org.opensaml.saml.common.SAMLObject;
+import org.opensaml.saml.common.SignableSAMLObject;
+import org.opensaml.saml.common.messaging.context.SAMLBindingContext;
+import org.opensaml.saml.common.xml.SAMLConstants;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.Audience;
+import org.opensaml.saml.saml2.core.AudienceRestriction;
+import org.opensaml.saml.saml2.core.AuthnRequest;
+import org.opensaml.saml.saml2.core.AuthnStatement;
+import org.opensaml.saml.saml2.core.Conditions;
+import org.opensaml.saml.saml2.core.Issuer;
+import org.opensaml.saml.saml2.core.LogoutRequest;
+import org.opensaml.saml.saml2.core.NameID;
+import org.opensaml.saml.saml2.core.Response;
+import org.opensaml.saml.saml2.core.Status;
+import org.opensaml.saml.saml2.core.StatusCode;
+import org.opensaml.saml.saml2.core.Subject;
+import org.opensaml.saml.saml2.core.SubjectConfirmation;
+import org.opensaml.saml.saml2.core.SubjectConfirmationData;
+import org.opensaml.saml.saml2.metadata.AssertionConsumerService;
+import org.opensaml.saml.saml2.metadata.EntityDescriptor;
+import org.opensaml.saml.saml2.metadata.KeyDescriptor;
+import org.opensaml.saml.saml2.metadata.SPSSODescriptor;
+import org.opensaml.saml.saml2.metadata.SingleLogoutService;
+import org.opensaml.security.credential.Credential;
+import org.opensaml.security.credential.CredentialResolver;
+import org.opensaml.security.credential.impl.KeyStoreCredentialResolver;
+import org.opensaml.xmlsec.signature.support.SignatureConstants;
+
+import net.shibboleth.utilities.java.support.resolver.CriteriaSet;
+
+import com.google.common.collect.ImmutableMap;
+
+import com.linecorp.armeria.client.ClientOptions;
+import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.annotation.Get;
+import com.linecorp.armeria.server.auth.Authorizer;
+import com.linecorp.armeria.testing.server.ServerRule;
+
+import io.netty.handler.codec.http.QueryStringDecoder;
+import io.netty.handler.codec.http.QueryStringEncoder;
+import io.netty.handler.codec.http.cookie.Cookie;
+import io.netty.handler.codec.http.cookie.DefaultCookie;
+import io.netty.handler.codec.http.cookie.ServerCookieDecoder;
+import io.netty.handler.codec.http.cookie.ServerCookieEncoder;
+import io.netty.handler.ssl.util.SelfSignedCertificate;
+
+public class SamlServiceProviderTest {
+
+    private static final String signatureAlgorithm = SignatureConstants.ALGO_ID_SIGNATURE_RSA;
+
+    private static final String spHostname = "localhost";
+    // Entity ID can be any form of a string. An URI string is one of the general forms of that.
+    private static final String spEntityId = "http://127.0.0.1";
+    private static final CredentialResolver spCredentialResolver;
+
+    private static final Credential idpCredential;
+
+    private static final SamlRequestIdManager requestIdManager = new SequentialRequestIdManager();
+
+    static {
+        try {
+            // Create IdP's key store for testing.
+            final KeyStore idpKeyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+            idpKeyStore.load(null, null);
+
+            final SelfSignedCertificate idp = new SelfSignedCertificate();
+            idpKeyStore.setKeyEntry("signing", idp.key(), "".toCharArray(),
+                                    new Certificate[] { idp.cert() });
+            final CredentialResolver idpCredentialResolver =
+                    new KeyStoreCredentialResolver(idpKeyStore, ImmutableMap.of("signing", ""));
+
+            final CriteriaSet cs = new CriteriaSet();
+            cs.add(new EntityIdCriterion("signing"));
+            idpCredential = idpCredentialResolver.resolveSingle(cs);
+
+            // Create my key store for testing.
+            final KeyStore myKeyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+            myKeyStore.load(null, null);
+
+            final SelfSignedCertificate mine = new SelfSignedCertificate();
+            // Add my keys for signing and encryption.
+            myKeyStore.setKeyEntry("signing", mine.key(), "".toCharArray(),
+                                   new Certificate[] { mine.cert() });
+            myKeyStore.setKeyEntry("encryption", mine.key(), "".toCharArray(),
+                                   new Certificate[] { mine.cert() });
+
+            // Add IdPs' certificates for validating a SAML message from the IdP.
+            // By default, Armeria finds the certificate whose name equals to the entity ID of an IdP,
+            // so we are adding the certificate with IdP's entity ID.
+            myKeyStore.setCertificateEntry("http://idp.example.com/post", idp.cert());
+            myKeyStore.setCertificateEntry("http://idp.example.com/redirect", idp.cert());
+
+            // Create a password map for my keys.
+            final Map<String, String> myKeyPasswords = ImmutableMap.of("signing", "",
+                                                                       "encryption", "");
+            spCredentialResolver = new KeyStoreCredentialResolver(myKeyStore, myKeyPasswords);
+        } catch (Exception e) {
+            throw new Error(e);
+        }
+    }
+
+    @ClassRule
+    public static ServerRule rule = new ServerRule() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            final SamlServiceProvider sp = new SamlServiceProviderBuilder()
+                    // A request will be authenticated if it contains 'test=test' cookie in Cookie header.
+                    .authorizer(new CookieBasedAuthorizer("test", "test"))
+                    .ssoHandler(new CookieBasedSsoHandler("test", "test"))
+                    // My entity ID
+                    .entityId(spEntityId)
+                    .hostname(spHostname)
+                    //.scheme(SessionProtocol.HTTP)
+                    .credentialResolver(spCredentialResolver)
+                    .signatureAlgorithm(signatureAlgorithm)
+                    // Add a dummy IdP which supports HTTP-Post binding protocol for SSO.
+                    .idp()
+                    .entityId("http://idp.example.com/post")
+                    .ssoEndpoint(ofHttpPost("http://idp.example.com/saml/sso/post"))
+                    .sloResEndpoint(ofHttpPost("http://idp.example.com/saml/slo/post"))
+                    .and()
+                    // Add one more dummy IdP which supports HTTP-Redirect binding protocol for SSO.
+                    .idp()
+                    .entityId("http://idp.example.com/redirect")
+                    .ssoEndpoint(ofHttpRedirect("http://idp.example.com/saml/sso/redirect"))
+                    .sloResEndpoint(ofHttpRedirect("http://idp.example.com/saml/slo/redirect"))
+                    .and()
+                    // We have two IdP config so one of them will be selected by the path variable.
+                    .idpConfigSelector((configurator, ctx, req) -> {
+                        final String idpEntityId = "http://idp.example.com/" +
+                                                   ctx.pathParam("bindingProtocol");
+                        return CompletableFuture.completedFuture(
+                                configurator.idpConfigs().get(idpEntityId));
+                    })
+                    .requestIdManager(requestIdManager)
+                    .build();
+
+            sb.service(sp.newSamlService())
+              .annotatedService("/", new Object() {
+                  @Get("/{bindingProtocol}")
+                  public String root() {
+                      return "authenticated";
+                  }
+              }, sp.newSamlDecorator());
+        }
+    };
+
+    static class CookieBasedAuthorizer implements Authorizer<HttpRequest> {
+        private final String cookieName;
+        private final String cookieValue;
+
+        CookieBasedAuthorizer(String cookieName, String cookieValue) {
+            this.cookieName = requireNonNull(cookieName, "cookieName");
+            this.cookieValue = requireNonNull(cookieValue, "cookieValue");
+        }
+
+        @Override
+        public CompletionStage<Boolean> authorize(ServiceRequestContext ctx, HttpRequest req) {
+            final String value = req.headers().get(HttpHeaderNames.COOKIE);
+            if (value == null) {
+                return CompletableFuture.completedFuture(false);
+            }
+
+            // Authentication will be succeeded only if both the specified cookie name and value are matched.
+            final Set<Cookie> cookies = ServerCookieDecoder.STRICT.decode(value);
+            final boolean result = cookies.stream().anyMatch(
+                    cookie -> cookieName.equals(cookie.name()) && cookieValue.equals(cookie.value()));
+            return CompletableFuture.completedFuture(result);
+        }
+    }
+
+    static class CookieBasedSsoHandler implements SamlSingleSignOnHandler {
+        private final String setCookie;
+
+        CookieBasedSsoHandler(String cookieName, String cookieValue) {
+            requireNonNull(cookieName, "cookieName");
+            requireNonNull(cookieValue, "cookieValue");
+
+            final Cookie cookie = new DefaultCookie(cookieName, cookieValue);
+            cookie.setDomain(spHostname);
+            cookie.setPath("/");
+            cookie.setHttpOnly(true);
+            setCookie = ServerCookieEncoder.STRICT.encode(cookie);
+        }
+
+        @Override
+        public CompletionStage<Void> beforeInitiatingSso(ServiceRequestContext ctx, HttpRequest req,
+                                                         MessageContext<AuthnRequest> message,
+                                                         SamlIdentityProviderConfig idpConfig) {
+            message.getSubcontext(SAMLBindingContext.class, true)
+                   .setRelayState(req.path());
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public HttpResponse loginSucceeded(ServiceRequestContext ctx, AggregatedHttpMessage req,
+                                           MessageContext<Response> message, @Nullable String sessionIndex,
+                                           @Nullable String relayState) {
+            return HttpResponse.of(headersWithLocation(firstNonNull(relayState, "/"))
+                                           .add(HttpHeaderNames.SET_COOKIE, setCookie));
+        }
+
+        @Override
+        public HttpResponse loginFailed(ServiceRequestContext ctx, AggregatedHttpMessage req,
+                                        @Nullable MessageContext<Response> message, Throwable cause) {
+            // Handle as an error so that a test client can detect the failure.
+            return HttpResponse.of(HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    static class SequentialRequestIdManager implements SamlRequestIdManager {
+        private final AtomicInteger id = new AtomicInteger();
+
+        @Override
+        public String newId() {
+            return String.valueOf(id.getAndIncrement());
+        }
+
+        @Override
+        public boolean validateId(String id) {
+            try {
+                Integer.parseInt(id);
+                return true;
+            } catch (NumberFormatException e) {
+                return false;
+            }
+        }
+    }
+
+    final HttpClient client = HttpClient.of(rule.uri("/"), ClientOptions.DEFAULT);
+
+    @Test
+    public void shouldRespondAuthnRequest_HttpRedirect() throws Exception {
+        final AggregatedHttpMessage resp = client.get("/redirect").aggregate().join();
+        assertThat(resp.status()).isEqualTo(HttpStatus.FOUND);
+
+        // Check the order of the parameters in the quest string.
+        final String location = resp.headers().get(HttpHeaderNames.LOCATION);
+        final Pattern p = Pattern.compile(
+                "http://idp\\.example\\.com/saml/sso/redirect\\?" +
+                "SAMLRequest=([^&]+)&RelayState=([^&]+)&SigAlg=([^&]+)&Signature=(.+)$");
+        assertThat(p.matcher(location).matches()).isTrue();
+
+        final QueryStringDecoder decoder = new QueryStringDecoder(location, true);
+        assertThat(decoder.parameters().get(SIGNATURE_ALGORITHM).get(0)).isEqualTo(signatureAlgorithm);
+    }
+
+    @Test
+    public void shouldRespondAuthnRequest_HttpPost() throws Exception {
+        final AggregatedHttpMessage resp = client.get("/post").aggregate().join();
+        assertThat(resp.status()).isEqualTo(HttpStatus.OK);
+        assertThat(resp.headers().contentType()).isEqualTo(MediaType.HTML_UTF_8);
+
+        final Document doc = Jsoup.parse(resp.content().toStringUtf8());
+        assertThat(doc.body().attr("onLoad")).isEqualTo("document.forms[0].submit()");
+
+        // SAMLRequest will be posted to the IdP's SSO URL.
+        final Element form = doc.body().child(0);
+        assertThat(form.attr("method")).isEqualTo("post");
+        assertThat(form.attr("action")).isEqualTo("http://idp.example.com/saml/sso/post");
+        assertThat(form.child(0).attr("name")).isEqualTo(SAML_REQUEST);
+        assertThat(form.child(1).attr("name")).isEqualTo(RELAY_STATE);
+    }
+
+    @Test
+    public void shouldBeAlreadyAuthenticated() throws Exception {
+        final HttpHeaders req = HttpHeaders.of(HttpMethod.GET, "/redirect")
+                                           .add(HttpHeaderNames.COOKIE, "test=test");
+        final AggregatedHttpMessage resp = client.execute(req).aggregate().join();
+        assertThat(resp.status()).isEqualTo(HttpStatus.OK);
+        assertThat(resp.content().toStringUtf8()).isEqualTo("authenticated");
+    }
+
+    @Test
+    public void shouldRespondMetadataWithoutAuthentication() throws Exception {
+        final AggregatedHttpMessage resp = client.get("/saml/metadata").aggregate().join();
+        assertThat(resp.status()).isEqualTo(HttpStatus.OK);
+        assertThat(resp.headers().contentType()).isEqualTo(CONTENT_TYPE_SAML_METADATA);
+
+        final EntityDescriptor metadata =
+                (EntityDescriptor) deserialize(resp.content().toStringUtf8().getBytes());
+        assertThat(metadata).isNotNull();
+
+        final SPSSODescriptor sp = metadata.getSPSSODescriptor(SAMLConstants.SAML20P_NS);
+        assertThat(sp.isAuthnRequestsSigned()).isTrue();
+        assertThat(sp.getWantAssertionsSigned()).isTrue();
+
+        final List<KeyDescriptor> kd = sp.getKeyDescriptors();
+        assertThat(kd.get(0).getUse().name()).isEqualToIgnoringCase("signing");
+        assertThat(kd.get(1).getUse().name()).isEqualToIgnoringCase("encryption");
+
+        final List<SingleLogoutService> slo = sp.getSingleLogoutServices();
+        assertThat(slo.get(0).getLocation())
+                .isEqualTo("http://" + spHostname + ':' + rule.httpPort() + "/saml/slo/post");
+        assertThat(slo.get(0).getBinding()).isEqualTo(SAMLConstants.SAML2_POST_BINDING_URI);
+        assertThat(slo.get(1).getLocation())
+                .isEqualTo("http://" + spHostname + ':' + rule.httpPort() + "/saml/slo/redirect");
+        assertThat(slo.get(1).getBinding()).isEqualTo(SAMLConstants.SAML2_REDIRECT_BINDING_URI);
+
+        final List<AssertionConsumerService> acs = sp.getAssertionConsumerServices();
+        // index 0 (default)
+        assertThat(acs.get(0).getIndex()).isEqualTo(0);
+        assertThat(acs.get(0).isDefault()).isTrue();
+        assertThat(acs.get(0).getLocation())
+                .isEqualTo("http://" + spHostname + ':' + rule.httpPort() + "/saml/acs/post");
+        assertThat(acs.get(0).getBinding()).isEqualTo(SAMLConstants.SAML2_POST_BINDING_URI);
+        // index 1
+        assertThat(acs.get(1).getIndex()).isEqualTo(1);
+        assertThat(acs.get(1).isDefault()).isFalse();
+        assertThat(acs.get(1).getLocation())
+                .isEqualTo("http://" + spHostname + ':' + rule.httpPort() + "/saml/acs/redirect");
+        assertThat(acs.get(1).getBinding()).isEqualTo(SAMLConstants.SAML2_REDIRECT_BINDING_URI);
+    }
+
+    @Test
+    public void shouldConsumeAssertion_HttpPost() throws Exception {
+        final Response response =
+                getAuthResponse("http://" + spHostname + ':' + rule.httpPort() + "/saml/acs/post");
+        final AggregatedHttpMessage msg = sendViaHttpPostBindingProtocol("/saml/acs/post",
+                                                                         SAML_RESPONSE, response);
+
+        assertThat(msg.status()).isEqualTo(HttpStatus.FOUND);
+        assertThat(msg.headers().get(HttpHeaderNames.LOCATION)).isEqualTo("/");
+    }
+
+    @Test
+    public void shouldConsumeAssertion_HttpRedirect() throws Exception {
+        final Response response =
+                getAuthResponse("http://" + spHostname + ':' + rule.httpPort() + "/saml/acs/redirect");
+        final AggregatedHttpMessage msg = sendViaHttpRedirectBindingProtocol("/saml/acs/redirect",
+                                                                             SAML_RESPONSE, response);
+
+        assertThat(msg.status()).isEqualTo(HttpStatus.FOUND);
+        assertThat(msg.headers().get(HttpHeaderNames.LOCATION)).isEqualTo("/");
+    }
+
+    private Response getAuthResponse(String recipient) throws Exception {
+        // IdP entity ID
+        final Issuer issuer = build(Issuer.DEFAULT_ELEMENT_NAME);
+        issuer.setValue("http://idp.example.com/post");
+
+        final Assertion assertion = build(Assertion.DEFAULT_ELEMENT_NAME);
+        final Subject subject = build(Subject.DEFAULT_ELEMENT_NAME);
+        final SubjectConfirmation subjectConfirmation = build(SubjectConfirmation.DEFAULT_ELEMENT_NAME);
+        final SubjectConfirmationData data = build(SubjectConfirmationData.DEFAULT_ELEMENT_NAME);
+
+        data.setInResponseTo(requestIdManager.newId());
+        data.setNotOnOrAfter(DateTime.now().plusMinutes(1));
+        data.setRecipient(recipient);
+
+        subjectConfirmation.setSubjectConfirmationData(data);
+        subjectConfirmation.setMethod("urn:oasis:names:tc:SAML:2.0:cm:bearer");
+
+        subject.getSubjectConfirmations().add(subjectConfirmation);
+
+        assertion.setSubject(subject);
+
+        assertion.setIssuer(XMLObjectSupport.cloneXMLObject(issuer));
+        assertion.setIssueInstant(DateTime.now());
+        assertion.setID(requestIdManager.newId());
+
+        final AuthnStatement authnStatement = build(AuthnStatement.DEFAULT_ELEMENT_NAME);
+        authnStatement.setSessionIndex("1");
+        assertion.getAuthnStatements().add(authnStatement);
+
+        final Conditions conditions = build(Conditions.DEFAULT_ELEMENT_NAME);
+        conditions.setNotBefore(DateTime.now().minusMinutes(1));
+        conditions.setNotOnOrAfter(DateTime.now().plusMinutes(1));
+
+        final AudienceRestriction audienceRestriction = build(AudienceRestriction.DEFAULT_ELEMENT_NAME);
+        final Audience audience = build(Audience.DEFAULT_ELEMENT_NAME);
+        // Set SP entity ID as an audience.
+        audience.setAudienceURI(spEntityId);
+        audienceRestriction.getAudiences().add(audience);
+        conditions.getAudienceRestrictions().add(audienceRestriction);
+
+        assertion.setConditions(conditions);
+
+        sign(assertion, idpCredential, signatureAlgorithm);
+
+        final Response response = build(Response.DEFAULT_ELEMENT_NAME);
+        response.getAssertions().add(assertion);
+
+        response.setID(requestIdManager.newId());
+        response.setIssuer(issuer);
+        response.setIssueInstant(DateTime.now());
+
+        final Status status = build(Status.DEFAULT_ELEMENT_NAME);
+        final StatusCode statusCode = build(StatusCode.DEFAULT_ELEMENT_NAME);
+        statusCode.setValue(StatusCode.SUCCESS);
+        status.setStatusCode(statusCode);
+        response.setStatus(status);
+
+        return response;
+    }
+
+    @Test
+    public void shouldConsumeLogoutRequest_HttpPost() throws Exception {
+        final LogoutRequest logoutRequest =
+                getLogoutRequest("http://" + spHostname + ':' + rule.httpPort() + "/saml/slo/post",
+                                 "http://idp.example.com/post");
+
+        final AggregatedHttpMessage msg = sendViaHttpPostBindingProtocol("/saml/slo/post",
+                                                                         SAML_REQUEST, logoutRequest);
+
+        assertThat(msg.status()).isEqualTo(HttpStatus.OK);
+        assertThat(msg.headers().contentType()).isEqualTo(MediaType.HTML_UTF_8);
+
+        final Document doc = Jsoup.parse(msg.content().toStringUtf8());
+        assertThat(doc.body().attr("onLoad")).isEqualTo("document.forms[0].submit()");
+
+        // SAMLResponse will be posted to the IdP's logout response URL.
+        final Element form = doc.body().child(0);
+        assertThat(form.attr("method")).isEqualTo("post");
+        assertThat(form.attr("action")).isEqualTo("http://idp.example.com/saml/slo/post");
+        assertThat(form.child(0).attr("name")).isEqualTo(SAML_RESPONSE);
+    }
+
+    @Test
+    public void shouldConsumeLogoutRequest_HttpRedirect() throws Exception {
+        final LogoutRequest logoutRequest =
+                getLogoutRequest("http://" + spHostname + ':' + rule.httpPort() + "/saml/slo/redirect",
+                                 "http://idp.example.com/redirect");
+
+        final AggregatedHttpMessage msg =
+                sendViaHttpRedirectBindingProtocol("/saml/slo/redirect", SAML_REQUEST, logoutRequest);
+
+        assertThat(msg.status()).isEqualTo(HttpStatus.FOUND);
+
+        // Check the order of the parameters in the quest string.
+        final String location = msg.headers().get(HttpHeaderNames.LOCATION);
+        final Pattern p = Pattern.compile(
+                "http://idp\\.example\\.com/saml/slo/redirect\\?" +
+                "SAMLResponse=([^&]+)&SigAlg=([^&]+)&Signature=(.+)$");
+        assertThat(p.matcher(location).matches()).isTrue();
+    }
+
+    private LogoutRequest getLogoutRequest(String destination, String issuerId) {
+        final LogoutRequest logoutRequest = build(LogoutRequest.DEFAULT_ELEMENT_NAME);
+
+        logoutRequest.setID(requestIdManager.newId());
+        logoutRequest.setDestination(destination);
+
+        final Issuer issuer = build(Issuer.DEFAULT_ELEMENT_NAME);
+        issuer.setValue(issuerId);
+        logoutRequest.setIssuer(issuer);
+        logoutRequest.setIssueInstant(DateTime.now());
+
+        final NameID nameID = build(NameID.DEFAULT_ELEMENT_NAME);
+        nameID.setFormat(SamlNameIdFormat.EMAIL.urn());
+
+        logoutRequest.setNameID(nameID);
+
+        return logoutRequest;
+    }
+
+    private AggregatedHttpMessage sendViaHttpPostBindingProtocol(
+            String path, String paramName, SignableSAMLObject sinableObj) throws Exception {
+        final String encoded = toSignedBase64(sinableObj, idpCredential, signatureAlgorithm);
+        final QueryStringEncoder encoder = new QueryStringEncoder("/");
+        encoder.addParam(paramName, encoded);
+
+        final HttpRequest req = HttpRequest.of(HttpMethod.POST, path, MediaType.FORM_DATA,
+                                               encoder.toUri().getRawQuery());
+        return client.execute(req).aggregate().join();
+    }
+
+    private AggregatedHttpMessage sendViaHttpRedirectBindingProtocol(
+            String path, String paramName, SAMLObject samlObject) throws Exception {
+
+        final QueryStringEncoder encoder = new QueryStringEncoder("/");
+        encoder.addParam(paramName, toDeflatedBase64(samlObject));
+        encoder.addParam(SIGNATURE_ALGORITHM, signatureAlgorithm);
+        final String input = encoder.toUri().getRawQuery();
+        final String output = generateSignature(idpCredential, signatureAlgorithm, input);
+        encoder.addParam(SIGNATURE, output);
+
+        final HttpRequest req = HttpRequest.of(HttpMethod.POST, path, MediaType.FORM_DATA,
+                                               encoder.toUri().getRawQuery());
+        return client.execute(req).aggregate().join();
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -25,6 +25,7 @@ includeWithFlags ':tomcat8.0',                  'java', 'publish', 'relocate', '
 includeWithFlags ':tomcat8.5',                  'java', 'publish', 'relocate', 'no_aggregation'
 includeWithFlags ':zipkin',                     'java', 'publish', 'relocate'
 includeWithFlags ':zookeeper',                  'java', 'publish', 'relocate'
+includeWithFlags ':saml',                       'java', 'publish', 'relocate'
 
 // Unpublished Java projects
 includeWithFlags ':benchmarks',               'java'

--- a/site/src/sphinx/advanced-saml.rst
+++ b/site/src/sphinx/advanced-saml.rst
@@ -1,0 +1,6 @@
+.. _advanced-saml:
+
+SAML Single Sign-On
+===================
+
+TBW - See :api:`SamlServiceProvider` and :api:`SamlServiceProviderBuilder`

--- a/site/src/sphinx/advanced.rst
+++ b/site/src/sphinx/advanced.rst
@@ -12,3 +12,4 @@ Advanced topics
     advanced-zipkin
     advanced-zookeeper
     advanced-production-checklist
+    advanced-saml


### PR DESCRIPTION
…n Armeria services

Motivation:
Nowdays a service doesn't need to provide a login service by itself because there are single sign-on specifications such as OAuth and SAML already.
So it would be better to support those specifications by Armeria so that a user can enable SSO on his or her services easily.

Modifications:
- Add saml module based on opensaml 3.x
- Add SamlServiceProvider class which helps a user enable SAML authentication for his or her services

Result:
Armeria provides SAML authentication for service providers.