### PR TITLE
Use OpenJDK 10 instead of Oracle JDK 10 for build stability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-- oraclejdk10
+- openjdk10
 sudo: false
 os:
 - linux
@@ -13,6 +13,7 @@ notifications:
     secure: xMyh/I52KQnz9SAaCGyHJ09AvNIAUQ1tx2aeDW5mxNyreazYUHxLxJIt59XUGC3/++qOP5nZsrISwmdP7AlAvR6u3H8XdfixpOgUCPvP4v9lmKqoSJwD59j+Q9P470t0yudlHI/3RJURPK762m5ABziPV94nMf98Afe71FfmTNWa4VJvbi0TC/OhAtwQQqtpqRYWendtJ/N/iE0ad4qV9kJGT4D9MFRaklHZVmzz8tMVz5Yfz5FItAazZmnaHnfbCFPmBbWyFIjbtjQI6HURqNC9WgnRXXEAie03Dq9TxoKBsI50NhACDZVZ6SEgeaO2eTc8iubzc5RSpSzcabkYck0pWbmbsSHiXlwpJEN2Z2HkSWxk6F3WXXWoVBwxhB4Vv661YKpu9uoAp+1Fj8yOFZMxTdsycpHgEN+nQF1+7+7T4Krc+jc1B9y/RK9eNRwlmd7fCw+evGShRtuwgKRw5IJsaKMzEPmynqAbhm7wlm997Sr4OA2LTwA2fGhsXa0lFHyvRGFQ4aXAHHiuep0SAQ+x968/xPkb6lY9O18pQBOPbJtR1sZl6iRzByGjWwVR0OIMUcKUi5kHEeUbvI7XVUB3CSNBGvE95RAEO+JVkvoRBSTksgnXUV9rTVRk3cQztqDGc0dVMBEgVep2Cx5u5Dh+IDBxZszELEWD/dA7DUc=
 cache:
   directories:
+  - "$HOME/.cache/install-jdk"
   - "$HOME/.gradle/wrapper/dists"
   - "$HOME/.gradle/caches/jars-3"
   - "$HOME/.gradle/caches/modules-2"
@@ -20,8 +21,8 @@ cache:
   - "$HOME/.gradle/caches/sphinx-binary"
 env:
   global:
-  - _JAVA_OPTIONS=
-  - GRADLE_OPTS=-Xmx1280m
+  - "_JAVA_OPTIONS=-Djavax.net.ssl.trustStore=/etc/ssl/certs/java/cacerts"
+  - "GRADLE_OPTS=-Xmx1280m"
 before_install:
 - "./gradlew --version"
 install:


### PR DESCRIPTION
Motivation:

Oracle keeps removing the old JDK download URLs whenever they release a
new version.

Modifications:

- Use `openjdk10` instead of `oraclejdk10`
- Pass `-Djavax.net.ssl.trustStore` to use the system certificates
- Add `~/.cache/install-jdk` to the build cache

Result:

Build stability