### PR TITLE
Make Armeria Retrofit subscriber not buffer response

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/CommonPools.java
+++ b/core/src/main/java/com/linecorp/armeria/common/CommonPools.java
@@ -51,8 +51,8 @@ public final class CommonPools {
     }
 
     /**
-     * Returns the common blocking task {@link Executor} which is used when
-     * {@link ServerBuilder#blockingTaskExecutor(Executor)} is not specified.
+     * Returns the default common blocking task {@link Executor} which is used for
+     * running a potentially long-running tasks which may block I/O threads.
      */
     public static Executor blockingTaskExecutor() {
         return BLOCKING_TASK_EXECUTOR;

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/ArmeriaCallFactory.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/ArmeriaCallFactory.java
@@ -59,13 +59,16 @@ final class ArmeriaCallFactory implements Factory {
     private final ClientFactory clientFactory;
     private final BiFunction<String, ? super ClientOptionsBuilder, ClientOptionsBuilder> configurator;
     private final String baseAuthority;
+    private final SubscriberFactory subscriberFactory;
 
     ArmeriaCallFactory(HttpClient baseHttpClient,
                        ClientFactory clientFactory,
-                       BiFunction<String, ? super ClientOptionsBuilder, ClientOptionsBuilder> configurator) {
+                       BiFunction<String, ? super ClientOptionsBuilder, ClientOptionsBuilder> configurator,
+                       SubscriberFactory subscriberFactory) {
         this.baseHttpClient = baseHttpClient;
         this.clientFactory = clientFactory;
         this.configurator = configurator;
+        this.subscriberFactory = subscriberFactory;
         baseAuthority = baseHttpClient.uri().getAuthority();
         httpClients.put(baseAuthority, baseHttpClient);
     }
@@ -207,7 +210,7 @@ final class ArmeriaCallFactory implements Factory {
         @Override
         public void enqueue(Callback callback) {
             createRequest();
-            httpResponse.subscribe(new ArmeriaCallSubscriber(this, callback, request));
+            httpResponse.subscribe(callFactory.subscriberFactory.create(this, callback, request));
         }
 
         @Override

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/BlockingCallSubscriber.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/BlockingCallSubscriber.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client.retrofit2;
+
+import java.io.IOException;
+
+import com.google.common.util.concurrent.MoreExecutors;
+
+import com.linecorp.armeria.client.retrofit2.ArmeriaCallFactory.ArmeriaCall;
+import com.linecorp.armeria.common.HttpData;
+
+import okhttp3.Callback;
+import okhttp3.Request;
+import okio.Buffer;
+
+final class BlockingCallSubscriber extends AbstractSubscriber {
+
+    private final Buffer responseDataBuffer = new Buffer();
+
+    BlockingCallSubscriber(ArmeriaCall armeriaCall, Callback callback, Request request) {
+        super(armeriaCall, request, callback, MoreExecutors.directExecutor());
+    }
+
+    @Override
+    public void onError0(IOException e) {
+        safeOnFailure(e);
+    }
+
+    @Override
+    public void onComplete0() {
+        safeOnResponse(responseDataBuffer);
+    }
+
+    @Override
+    void onSubscribe0() {
+        request(Long.MAX_VALUE);
+    }
+
+    @Override
+    void onHttpData(HttpData data) {
+        responseDataBuffer.write(data.array(), data.offset(), data.length());
+    }
+
+    @Override
+    void onHttpHeaders() {
+    }
+
+    @Override
+    void onCancelled() {
+        safeOnFailure(newCancelledException());
+    }
+}

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/PipeBuffer.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/PipeBuffer.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client.retrofit2;
+
+import java.io.IOException;
+
+import javax.annotation.Nullable;
+
+import okio.Buffer;
+import okio.Source;
+import okio.Timeout;
+
+class PipeBuffer {
+
+    private final Buffer buffer = new Buffer();
+    private final PipeSource source = new PipeSource();
+    private boolean sinkClosed;
+    private boolean sourceClosed;
+    @Nullable
+    private Throwable sinkClosedException;
+
+    void write(byte[] source, int offset, int byteCount) {
+        if (byteCount == 0) {
+            return;
+        }
+        synchronized (buffer) {
+            if (sourceClosed) {
+                return;
+            }
+            if (sinkClosed) {
+                throw new IllegalStateException("closed");
+            }
+            buffer.write(source, offset, byteCount);
+            buffer.notifyAll();
+        }
+    }
+
+    void close(@Nullable Throwable throwable) {
+        synchronized (buffer) {
+            if (sinkClosed) {
+                return;
+            }
+            sinkClosed = true;
+            sinkClosedException = throwable;
+            buffer.notifyAll();
+        }
+    }
+
+    Source source() {
+        return source;
+    }
+
+    private final class PipeSource implements Source {
+        final Timeout timeout = new Timeout();
+
+        @Override
+        public long read(Buffer sink, long byteCount) throws IOException {
+            synchronized (buffer) {
+                if (sourceClosed) {
+                    throw new IllegalStateException("closed");
+                }
+
+                while (buffer.size() == 0) {
+                    if (sinkClosed) {
+                        if (sinkClosedException == null) {
+                            return -1L;
+                        }
+                        throw new IOException(sinkClosedException);
+                    }
+                    timeout.waitUntilNotified(buffer);
+                }
+
+                final long result = buffer.read(sink, byteCount);
+                buffer.notifyAll();
+                return result;
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+            synchronized (buffer) {
+                sourceClosed = true;
+                buffer.notifyAll();
+            }
+        }
+
+        @Override
+        public Timeout timeout() {
+            return timeout;
+        }
+    }
+}

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/StreamingCallSubscriber.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/StreamingCallSubscriber.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client.retrofit2;
+
+import java.io.IOException;
+import java.util.concurrent.Executor;
+
+import com.linecorp.armeria.client.retrofit2.ArmeriaCallFactory.ArmeriaCall;
+import com.linecorp.armeria.common.HttpData;
+
+import okhttp3.Callback;
+import okhttp3.Request;
+import okio.Buffer;
+import okio.ForwardingSource;
+import okio.Okio;
+
+final class StreamingCallSubscriber extends AbstractSubscriber {
+
+    private final PipeBuffer pipeBuffer = new PipeBuffer();
+    private boolean responseCalled;
+
+    StreamingCallSubscriber(ArmeriaCall armeriaCall, Callback callback, Request request,
+                            Executor callbackExecutor) {
+        super(armeriaCall, request, callback, callbackExecutor);
+    }
+
+    @Override
+    void onSubscribe0() {
+        request(1);
+    }
+
+    @Override
+    void onCancelled() {
+        final IOException canceledException = newCancelledException();
+        safeOnFailure(canceledException);
+        pipeBuffer.close(canceledException);
+    }
+
+    @Override
+    void onHttpHeaders() {
+        request(1);
+    }
+
+    @Override
+    void onHttpData(HttpData data) {
+        if (!responseCalled) {
+            safeOnResponse(Okio.buffer(new ForwardingSource(pipeBuffer.source()) {
+                @Override
+                public long read(Buffer sink, long byteCount) throws IOException {
+                    request(1);
+                    return super.read(sink, byteCount);
+                }
+            }));
+            responseCalled = true;
+        }
+        pipeBuffer.write(data.array(), data.offset(), data.length());
+    }
+
+    @Override
+    void onError0(IOException e) {
+        safeOnFailure(e);
+        pipeBuffer.close(e);
+    }
+
+    @Override
+    void onComplete0() {
+        pipeBuffer.close(null);
+    }
+}

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/SubscriberFactory.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/SubscriberFactory.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client.retrofit2;
+
+import java.util.concurrent.Executor;
+
+import org.reactivestreams.Subscriber;
+
+import com.linecorp.armeria.client.retrofit2.ArmeriaCallFactory.ArmeriaCall;
+import com.linecorp.armeria.common.HttpObject;
+
+import okhttp3.Callback;
+import okhttp3.Request;
+
+@FunctionalInterface
+interface SubscriberFactory {
+    Subscriber<HttpObject> create(ArmeriaCall armeriaCall, Callback callback, Request request);
+
+    static SubscriberFactory blocking() {
+        return BlockingCallSubscriber::new;
+    }
+
+    static SubscriberFactory streaming(Executor callbackExecutor) {
+        return (ArmeriaCall armeriaCall, Callback callback, Request request) -> new StreamingCallSubscriber(
+                armeriaCall, callback, request, callbackExecutor);
+    }
+}

--- a/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/ArmeriaCallFactoryLargeStreamTest.java
+++ b/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/ArmeriaCallFactoryLargeStreamTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client.retrofit2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.BufferedInputStream;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.reactivestreams.Subscription;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.server.AbstractHttpService;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.testing.server.ServerRule;
+
+import okhttp3.ResponseBody;
+import retrofit2.adapter.java8.Java8CallAdapterFactory;
+import retrofit2.converter.jackson.JacksonConverterFactory;
+import retrofit2.http.GET;
+import retrofit2.http.Streaming;
+
+public class ArmeriaCallFactoryLargeStreamTest {
+
+    interface Service {
+        @Streaming
+        @GET("/large-stream")
+        CompletableFuture<ResponseBody> largeStream();
+    }
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @ClassRule
+    public static final ServerRule server = new ServerRule() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.service("/large-stream", new AbstractHttpService() {
+                @Override
+                protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+                    return HttpResponse.of(s -> s.onSubscribe(new Subscription() {
+                        int count;
+
+                        @Override
+                        public void request(long n) {
+                            for (int i = 0; i < n; i++) {
+                                if (count == 0) {
+                                    s.onNext(HttpHeaders.of(HttpStatus.OK));
+                                } else {
+                                    s.onNext(HttpData.of(new byte[1024]));
+                                }
+                            }
+                            count += n;
+                            // 10MB
+                            if (count > 1024 * 10) {
+                                s.onComplete();
+                            }
+                        }
+
+                        @Override
+                        public void cancel() {
+                        }
+                    }));
+                }
+            });
+            sb.defaultRequestTimeout(Duration.of(30, ChronoUnit.SECONDS));
+        }
+    };
+
+    @Test(timeout = 30 * 1000L)
+    public void largeStream() throws Exception {
+        final Service downloadService = new ArmeriaRetrofitBuilder()
+                .baseUrl(server.uri("/"))
+                .addConverterFactory(JacksonConverterFactory.create(OBJECT_MAPPER))
+                .addCallAdapterFactory(Java8CallAdapterFactory.create())
+                .withClientOptions((s, clientOptionsBuilder) -> {
+                    clientOptionsBuilder.defaultMaxResponseLength(Long.MAX_VALUE);
+                    clientOptionsBuilder.defaultResponseTimeout(Duration.of(30, ChronoUnit.SECONDS));
+                    return clientOptionsBuilder;
+                })
+                .build()
+                .create(Service.class);
+
+        final ResponseBody responseBody = downloadService.largeStream().get();
+        try (BufferedInputStream bufferedInputStream = new BufferedInputStream(responseBody.byteStream())) {
+            long sum = 0;
+            int read;
+            while ((read = bufferedInputStream.read(new byte[4096])) != -1) {
+                sum += read;
+            }
+            assertThat(sum).isEqualTo(1024 * 1024 * 10L);
+        }
+    }
+}

--- a/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/BlockingCallSubscriberTest.java
+++ b/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/BlockingCallSubscriberTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 LINE Corporation
+ * Copyright 2018 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -41,7 +41,7 @@ import okhttp3.Callback;
 import okhttp3.Request;
 import okhttp3.Response;
 
-public class ArmeriaCallSubscriberTest {
+public class BlockingCallSubscriberTest {
 
     private static class ManualMockCallback implements Callback {
         private int callbackCallingCount;
@@ -79,7 +79,7 @@ public class ArmeriaCallSubscriberTest {
         when(armeriaCall.tryFinish()).thenReturn(true);
 
         final ManualMockCallback callback = new ManualMockCallback();
-        final ArmeriaCallSubscriber subscriber = new ArmeriaCallSubscriber(
+        final BlockingCallSubscriber subscriber = new BlockingCallSubscriber(
                 armeriaCall, callback, new Request.Builder().url("http://foo.com").build());
         subscriber.onSubscribe(subscription);
         subscriber.onNext(HttpHeaders.of(200));
@@ -96,7 +96,7 @@ public class ArmeriaCallSubscriberTest {
         when(armeriaCall.tryFinish()).thenReturn(true);
 
         final ManualMockCallback callback = new ManualMockCallback();
-        final ArmeriaCallSubscriber subscriber = new ArmeriaCallSubscriber(
+        final BlockingCallSubscriber subscriber = new BlockingCallSubscriber(
                 armeriaCall, callback, new Request.Builder().url("http://bar.com").build());
         subscriber.onSubscribe(subscription);
         subscriber.onNext(HttpHeaders.of(100));
@@ -118,7 +118,7 @@ public class ArmeriaCallSubscriberTest {
         when(armeriaCall.isCanceled()).thenReturn(false, false, true);
 
         final ManualMockCallback callback = new ManualMockCallback();
-        final ArmeriaCallSubscriber subscriber = new ArmeriaCallSubscriber(
+        final BlockingCallSubscriber subscriber = new BlockingCallSubscriber(
                 armeriaCall, callback, new Request.Builder().url("http://foo.com").build());
         subscriber.onSubscribe(subscription);
         subscriber.onNext(HttpHeaders.of(200));
@@ -127,6 +127,6 @@ public class ArmeriaCallSubscriberTest {
 
         verify(subscription).request(Long.MAX_VALUE);
         assertThat(callback.callbackCallingCount).isEqualTo(1);
-        assertThat(callback.exception.getMessage()).isEqualTo("Canceled");
+        assertThat(callback.exception.getMessage()).isEqualTo("cancelled");
     }
 }

--- a/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/StreamingCallSubscriberTest.java
+++ b/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/StreamingCallSubscriberTest.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client.retrofit2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+
+import javax.annotation.Nullable;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.reactivestreams.Subscription;
+
+import com.google.common.util.concurrent.MoreExecutors;
+
+import com.linecorp.armeria.client.retrofit2.ArmeriaCallFactory.ArmeriaCall;
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.MediaType;
+
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.Request;
+import okhttp3.Response;
+
+public class StreamingCallSubscriberTest {
+
+    private static class ManualMockCallback implements Callback {
+        private int callbackCallingCount;
+        @Nullable
+        private Response response;
+        @Nullable
+        private IOException exception;
+
+        @Override
+        public void onFailure(Call call, IOException e) {
+            callbackCallingCount++;
+            exception = e;
+        }
+
+        @Override
+        public void onResponse(Call call, Response response) throws IOException {
+            callbackCallingCount++;
+            this.response = response;
+        }
+    }
+
+    @Rule
+    public final MockitoRule mockingRule = MockitoJUnit.rule();
+
+    @Mock
+    @Nullable
+    ArmeriaCall armeriaCall;
+
+    @Mock
+    @Nullable
+    Subscription subscription;
+
+    @Test
+    public void completeNormally() throws Exception {
+        when(armeriaCall.tryFinish()).thenReturn(true);
+
+        final ManualMockCallback callback = new ManualMockCallback();
+        final StreamingCallSubscriber subscriber = new StreamingCallSubscriber(
+                armeriaCall, callback, new Request.Builder().url("http://foo.com").build(),
+                MoreExecutors.directExecutor());
+        subscriber.onSubscribe(subscription);
+        subscriber.onNext(HttpHeaders.of(200));
+        subscriber.onNext(HttpData.ofUtf8("{\"name\":\"foo\"}"));
+        subscriber.onComplete();
+
+        verify(subscription, times(2)).request(1L);
+        await().untilAsserted(() -> assertThat(callback.callbackCallingCount).isEqualTo(1));
+        await().untilAsserted(
+                () -> assertThat(callback.response.body().string()).isEqualTo("{\"name\":\"foo\"}"));
+    }
+
+    @Test
+    public void splitHeaders() throws Exception {
+        when(armeriaCall.tryFinish()).thenReturn(true);
+
+        final ManualMockCallback callback = new ManualMockCallback();
+        final StreamingCallSubscriber subscriber = new StreamingCallSubscriber(
+                armeriaCall, callback, new Request.Builder().url("http://bar.com").build(),
+                MoreExecutors.directExecutor());
+        subscriber.onSubscribe(subscription);
+        subscriber.onNext(HttpHeaders.of(100));
+        subscriber.onNext(HttpHeaders.of(200));
+        subscriber.onNext(HttpHeaders.of(HttpHeaderNames.CONTENT_TYPE, MediaType.PLAIN_TEXT_UTF_8.toString()));
+        subscriber.onNext(HttpData.ofUtf8("bar"));
+        subscriber.onComplete();
+
+        verify(subscription, times(4)).request(1L);
+
+        await().untilAsserted(() -> assertThat(callback.callbackCallingCount).isEqualTo(1));
+        await().untilAsserted(() -> assertThat(callback.response.header("content-type"))
+                .isEqualToIgnoringCase("text/plain; charset=utf-8"));
+        await().untilAsserted(() -> assertThat(callback.response.body().string()).isEqualTo("bar"));
+    }
+
+    @Test
+    public void cancel() throws Exception {
+        when(armeriaCall.tryFinish()).thenReturn(false);
+        when(armeriaCall.isCanceled()).thenReturn(false, false, true);
+
+        final ManualMockCallback callback = new ManualMockCallback();
+        final StreamingCallSubscriber subscriber = new StreamingCallSubscriber(
+                armeriaCall, callback, new Request.Builder().url("http://foo.com").build(),
+                MoreExecutors.directExecutor());
+        subscriber.onSubscribe(subscription);
+        subscriber.onNext(HttpHeaders.of(200));
+        subscriber.onNext(HttpData.ofUtf8("{\"name\":\"foo\"}"));
+        subscriber.onComplete();
+
+        verify(subscription, times(2)).request(1L);
+
+        await().untilAsserted(() -> assertThat(callback.callbackCallingCount).isEqualTo(1));
+        await().untilAsserted(() -> assertThat(callback.exception.getMessage()).isEqualTo("cancelled"));
+    }
+
+    @Test
+    public void cancel_duringReadingData() throws Exception {
+        when(armeriaCall.tryFinish()).thenReturn(false);
+        when(armeriaCall.isCanceled()).thenReturn(false, false, false, true);
+
+        final ManualMockCallback callback = new ManualMockCallback();
+        final StreamingCallSubscriber subscriber = new StreamingCallSubscriber(
+                armeriaCall, callback, new Request.Builder().url("http://foo.com").build(),
+                MoreExecutors.directExecutor());
+        subscriber.onSubscribe(subscription);
+        subscriber.onNext(HttpHeaders.of(200));
+        subscriber.onNext(HttpData.ofUtf8("{\"name\":"));
+        subscriber.onNext(HttpData.ofUtf8("\"foo\"}"));
+        subscriber.onComplete();
+
+        verify(subscription, times(2)).request(1L);
+
+        await().untilAsserted(() -> assertThat(callback.callbackCallingCount).isEqualTo(1));
+        await().untilAsserted(() -> assertThat(callback.exception).isNull());
+        await().untilAsserted(
+                () -> assertThatThrownBy(() -> callback.response.body().string()).hasMessage("closed"));
+    }
+
+    @Test
+    public void exception_beforeReceivingHttpData() throws Exception {
+        when(armeriaCall.tryFinish()).thenReturn(true);
+        when(armeriaCall.isCanceled()).thenReturn(false);
+
+        final ManualMockCallback callback = new ManualMockCallback();
+        final StreamingCallSubscriber subscriber = new StreamingCallSubscriber(
+                armeriaCall, callback, new Request.Builder().url("http://foo.com").build(),
+                MoreExecutors.directExecutor());
+        subscriber.onSubscribe(subscription);
+        subscriber.onNext(HttpHeaders.of(200));
+        subscriber.onError(new IOException("foo"));
+
+        verify(subscription, times(2)).request(1L);
+        await().untilAsserted(() -> assertThat(callback.callbackCallingCount).isEqualTo(1));
+        assertThat(callback.exception).hasMessage("foo");
+    }
+
+    @Test
+    public void exception_afterReceivingHttpData() throws Exception {
+        when(armeriaCall.tryFinish()).thenReturn(true);
+        when(armeriaCall.isCanceled()).thenReturn(false);
+
+        final ManualMockCallback callback = new ManualMockCallback();
+        final StreamingCallSubscriber subscriber = new StreamingCallSubscriber(
+                armeriaCall, callback, new Request.Builder().url("http://foo.com").build(),
+                MoreExecutors.directExecutor());
+        subscriber.onSubscribe(subscription);
+        subscriber.onNext(HttpHeaders.of(200));
+        subscriber.onNext(HttpData.ofUtf8("{\"name\":"));
+        subscriber.onError(new IOException("foo"));
+
+        verify(subscription, times(2)).request(1L);
+
+        await().untilAsserted(() -> assertThat(callback.callbackCallingCount).isEqualTo(1));
+        await().untilAsserted(() -> assertThat(callback.exception).isNull());
+        assertThatThrownBy(() -> callback.response.body().string()).hasMessageEndingWith("foo");
+    }
+}


### PR DESCRIPTION
Current implementation will buffer all data and call callback when complete.
So it's not suitable for downloading large files.

This PR will make subscriber requests data one by one from response.　And
because `SourceBuffer#read` and `Subscriber#onNext` are using same thread, we need to
using CommonPools to run `SourceBuffer#read` to avoiding deadlock.