### PR TITLE
Fix a bug where Endpoint.toString() does not include IP address

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
@@ -505,10 +505,11 @@ public final class Endpoint implements Comparable<Endpoint> {
 
     @Override
     public String toString() {
-        final ToStringHelper helper = MoreObjects.toStringHelper(this).omitNullValues();
+        final ToStringHelper helper = MoreObjects.toStringHelper(this);
         helper.addValue(authority());
         if (!isGroup()) {
-            if (hostType == null) {
+            if (hostType == HostType.HOSTNAME_AND_IPv4 ||
+                hostType == HostType.HOSTNAME_AND_IPv6) {
                 helper.add("ipAddr", ipAddr);
             }
             helper.add("weight", weight);

--- a/core/src/test/java/com/linecorp/armeria/client/EndpointTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/EndpointTest.java
@@ -288,9 +288,15 @@ public class EndpointTest {
 
     @Test
     public void testToString() {
-        assertThat(Endpoint.of("a").toString()).isNotNull();
-        assertThat(Endpoint.of("a", 80).toString()).isNotNull();
-        assertThat(Endpoint.of("a").withIpAddr("::1").toString()).isNotNull();
+        assertThat(Endpoint.ofGroup("g").toString()).isEqualTo("Endpoint{group:g}");
+        assertThat(Endpoint.of("a").toString()).isEqualTo("Endpoint{a, weight=1000}");
+        assertThat(Endpoint.of("a", 80).toString()).isEqualTo("Endpoint{a:80, weight=1000}");
+        assertThat(Endpoint.of("a").withIpAddr("::1").toString())
+                .isEqualTo("Endpoint{a, ipAddr=::1, weight=1000}");
+
+        // ipAddr is omitted if hostname is an IP address.
+        assertThat(Endpoint.of("127.0.0.1").toString()).isEqualTo("Endpoint{127.0.0.1, weight=1000}");
+        assertThat(Endpoint.of("::1").toString()).isEqualTo("Endpoint{[::1], weight=1000}");
     }
 
     @Test


### PR DESCRIPTION
Motivation:

Endpoint.toString() should include the IP address of an endpoint if
necessary. It currently does not include it at all.

Modifications:

- Fix incorrect `if` statement.
- Update the test case.

Result:

- The string representation of an `Endpoint` now includes its IP
  address.