### PR TITLE
Fix flaky test where retry is made before cancelled in RetryingRpcCli…

### DIFF
--- a/thrift/src/test/java/com/linecorp/armeria/it/client/retry/RetryingRpcClientTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/client/retry/RetryingRpcClientTest.java
@@ -58,7 +58,7 @@ public class RetryingRpcClientTest {
     private static final RetryStrategy<RpcRequest, RpcResponse> retryAlways =
             (request, response) -> {
                 final CompletableFuture<Backoff> future = new CompletableFuture<>();
-                response.whenComplete((unused1, unused2) -> future.complete(Backoff.withoutDelay()));
+                response.whenComplete((unused1, unused2) -> future.complete(Backoff.fixed(500)));
                 return future;
             };
 


### PR DESCRIPTION
…entTest

Motivation:
In the test which is  `doNotRetryWhenResponseIsCancelled()`, retry shouldn't be made
because `RpcResponse` is cancelled. However the threads who are calling cancel and sending
the requests are different, the retry can happen.

Modification:
- Increase the delay for the next retry

Result:
- Fixed flaky test