### PR TITLE
Add EventLoopRule and EventLoopGroupRule

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/ChannelUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/ChannelUtil.java
@@ -24,8 +24,27 @@ import com.google.common.collect.ImmutableList;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.epoll.EpollEventLoopGroup;
 
 public final class ChannelUtil {
+
+    private static final Class<? extends EventLoopGroup> EPOLL_EVENT_LOOP_CLASS;
+
+    static {
+        try {
+            //noinspection unchecked
+            EPOLL_EVENT_LOOP_CLASS = (Class<? extends EventLoopGroup>)
+                    Class.forName("io.netty.channel.epoll.EpollEventLoop", false,
+                                  EpollEventLoopGroup.class.getClassLoader());
+        } catch (Exception e) {
+            throw new IllegalStateException("failed to locate EpollEventLoop class", e);
+        }
+    }
+
+    public static Class<? extends EventLoopGroup> epollEventLoopClass() {
+        return EPOLL_EVENT_LOOP_CLASS;
+    }
 
     public static CompletableFuture<Void> close(Iterable<? extends Channel> channels) {
         final List<Channel> channelsCopy = ImmutableList.copyOf(channels);

--- a/core/src/test/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingHttpClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingHttpClientTest.java
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.concurrent.TimeUnit;
 
-import org.junit.AfterClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import com.linecorp.armeria.client.Client;
@@ -37,18 +37,12 @@ import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpResponseWriter;
 import com.linecorp.armeria.common.stream.NoopSubscriber;
-
-import io.netty.channel.DefaultEventLoop;
-import io.netty.channel.EventLoop;
+import com.linecorp.armeria.testing.common.EventLoopRule;
 
 public class ConcurrencyLimitingHttpClientTest {
 
-    private static final EventLoop eventLoop = new DefaultEventLoop();
-
-    @AfterClass
-    public static void destroy() {
-        eventLoop.shutdownGracefully();
-    }
+    @ClassRule
+    public static final EventLoopRule eventLoop = new EventLoopRule();
 
     /**
      * Tests the request pattern  that does not exceed maxConcurrency.
@@ -231,7 +225,7 @@ public class ConcurrencyLimitingHttpClientTest {
 
     private static ClientRequestContext newContext() {
         final ClientRequestContext ctx = mock(ClientRequestContext.class);
-        when(ctx.eventLoop()).thenReturn(eventLoop);
+        when(ctx.eventLoop()).thenReturn(eventLoop.get());
         return ctx;
     }
 
@@ -247,6 +241,6 @@ public class ConcurrencyLimitingHttpClientTest {
     }
 
     private static void waitForEventLoop() {
-        eventLoop.submit(() -> { /* no-op */ }).syncUninterruptibly();
+        eventLoop.get().submit(() -> { /* no-op */ }).syncUninterruptibly();
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/common/stream/AbstractStreamMessageAndWriterTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/AbstractStreamMessageAndWriterTest.java
@@ -60,7 +60,7 @@ public abstract class AbstractStreamMessageAndWriterTest extends AbstractStreamM
         // Repeat to increase the chance of reproduction.
         for (int i = 0; i < 8192; i++) {
             final StreamMessageAndWriter<Integer> stream = newStreamWriter(TEN_INTEGERS);
-            eventLoop().execute(stream::close);
+            eventLoop.get().execute(stream::close);
             stream.subscribe(new Subscriber<Object>() {
                 @Override
                 public void onSubscribe(Subscription s) {
@@ -82,7 +82,7 @@ public abstract class AbstractStreamMessageAndWriterTest extends AbstractStreamM
                 public void onComplete() {
                     queue.add("onComplete");
                 }
-            }, eventLoop());
+            }, eventLoop.get());
 
             assertThat(queue.poll(5, TimeUnit.SECONDS)).isEqualTo("onSubscribe");
             assertThat(queue.poll(5, TimeUnit.SECONDS)).isEqualTo("onComplete");

--- a/core/src/test/java/com/linecorp/armeria/server/auth/AuthorizerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/auth/AuthorizerTest.java
@@ -34,34 +34,29 @@ import javax.annotation.Nullable;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import com.linecorp.armeria.server.ServiceRequestContext;
-
-import io.netty.channel.DefaultEventLoop;
-import io.netty.channel.EventLoop;
+import com.linecorp.armeria.testing.common.EventLoopRule;
 
 public class AuthorizerTest {
 
-    @Nullable
-    private static EventLoop eventLoop;
+    @ClassRule
+    public static final EventLoopRule eventLoop = new EventLoopRule();
+
     @Nullable
     private static ServiceRequestContext serviceCtx;
 
     @BeforeClass
-    public static void setEventLoop() {
-        eventLoop = new DefaultEventLoop();
+    public static void setServiceContext() {
         serviceCtx = mock(ServiceRequestContext.class);
-        when(serviceCtx.contextAwareEventLoop()).thenReturn(eventLoop);
+        when(serviceCtx.contextAwareEventLoop()).thenReturn(eventLoop.get());
     }
 
     @AfterClass
-    public static void clearEventLoop() {
+    public static void clearServiceContext() {
         serviceCtx = null;
-        if (eventLoop != null) {
-            eventLoop.shutdownGracefully();
-            eventLoop = null;
-        }
     }
 
     @Test

--- a/testing/src/main/java/com/linecorp/armeria/testing/common/AbstractEventLoopGroupRule.java
+++ b/testing/src/main/java/com/linecorp/armeria/testing/common/AbstractEventLoopGroupRule.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright 2018 LINE Corporation
+ *
+ *  LINE Corporation licenses this file to you under the Apache License,
+ *  version 2.0 (the "License"); you may not use this file except in compliance
+ *  with the License. You may obtain a copy of the License at:
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations
+ *  under the License.
+ */
+package com.linecorp.armeria.testing.common;
+
+import org.junit.rules.ExternalResource;
+import org.junit.rules.TestRule;
+
+import com.linecorp.armeria.common.util.EventLoopGroups;
+
+import io.netty.channel.EventLoopGroup;
+
+abstract class AbstractEventLoopGroupRule extends ExternalResource {
+
+    private final EventLoopGroup group;
+
+    AbstractEventLoopGroupRule(int numThreads, String threadNamePrefix, boolean useDaemonThreads) {
+        group = EventLoopGroups.newEventLoopGroup(numThreads, threadNamePrefix, useDaemonThreads);
+    }
+
+    EventLoopGroup group() {
+        return group;
+    }
+
+    /**
+     * Shuts down all threads created by this {@link TestRule} asynchronously.
+     * Call {@code rule.get().shutdownGracefully().sync()} if you want to wait for complete termination.
+     */
+    @Override
+    protected void after() {
+        group.shutdownGracefully();
+    }
+}

--- a/testing/src/main/java/com/linecorp/armeria/testing/common/EventLoopGroupRule.java
+++ b/testing/src/main/java/com/linecorp/armeria/testing/common/EventLoopGroupRule.java
@@ -1,0 +1,90 @@
+/*
+ *  Copyright 2018 LINE Corporation
+ *
+ *  LINE Corporation licenses this file to you under the Apache License,
+ *  version 2.0 (the "License"); you may not use this file except in compliance
+ *  with the License. You may obtain a copy of the License at:
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations
+ *  under the License.
+ */
+package com.linecorp.armeria.testing.common;
+
+import org.junit.rules.TestRule;
+
+import io.netty.channel.EventLoopGroup;
+
+/**
+ * A {@link TestRule} that provides an {@link EventLoopGroup}. For example:
+ *
+ * <pre>{@code
+ * > public class MyTest {
+ * >     @ClassRule
+ * >     public static final EventLoopGroupRule eventLoopGroup = new EventLoopGroupRule(4);
+ * >
+ * >     @Test
+ * >     public void test() {
+ * >         ClientFactory f = new ClientFactoryBuilder()
+ * >                 .workerGroup(eventLoopGroup.get())
+ * >                 .build();
+ * >         ...
+ * >     }
+ * > }
+ * }</pre>
+ *
+ * @see EventLoopRule
+ */
+public class EventLoopGroupRule extends AbstractEventLoopGroupRule {
+
+    /**
+     * Creates a new {@link TestRule} that provides an {@link EventLoopGroup}.
+     *
+     * @param numThreads the number of event loop threads
+     */
+    public EventLoopGroupRule(int numThreads) {
+        this(numThreads, false);
+    }
+
+    /**
+     * Creates a new {@link TestRule} that provides an {@link EventLoopGroup}.
+     *
+     * @param numThreads the number of event loop threads
+     * @param useDaemonThreads whether to create daemon threads or not
+     */
+    public EventLoopGroupRule(int numThreads, boolean useDaemonThreads) {
+        this(numThreads, "armeria-testing-eventloop", useDaemonThreads);
+    }
+
+    /**
+     * Creates a new {@link TestRule} that provides an {@link EventLoopGroup}.
+     *
+     * @param numThreads the number of event loop threads
+     * @param threadNamePrefix the prefix of thread names
+     */
+    public EventLoopGroupRule(int numThreads, String threadNamePrefix) {
+        this(numThreads, threadNamePrefix, false);
+    }
+
+    /**
+     * Creates a new {@link TestRule} that provides an {@link EventLoopGroup}.
+     *
+     * @param numThreads the number of event loop threads
+     * @param threadNamePrefix the prefix of thread names
+     * @param useDaemonThreads whether to create daemon threads or not
+     */
+    public EventLoopGroupRule(int numThreads, String threadNamePrefix, boolean useDaemonThreads) {
+        super(numThreads, threadNamePrefix, useDaemonThreads);
+    }
+
+    /**
+     * Returns the {@link EventLoopGroup}.
+     */
+    public EventLoopGroup get() {
+        return group();
+    }
+}

--- a/testing/src/main/java/com/linecorp/armeria/testing/common/EventLoopRule.java
+++ b/testing/src/main/java/com/linecorp/armeria/testing/common/EventLoopRule.java
@@ -1,0 +1,83 @@
+/*
+ *  Copyright 2018 LINE Corporation
+ *
+ *  LINE Corporation licenses this file to you under the Apache License,
+ *  version 2.0 (the "License"); you may not use this file except in compliance
+ *  with the License. You may obtain a copy of the License at:
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations
+ *  under the License.
+ */
+package com.linecorp.armeria.testing.common;
+
+import org.junit.rules.TestRule;
+
+import io.netty.channel.EventLoop;
+import io.netty.channel.EventLoopGroup;
+
+/**
+ * A {@link TestRule} that provides an {@link EventLoopGroup}. For example:
+ *
+ * <pre>{@code
+ * > public class MyTest {
+ * >     @ClassRule
+ * >     public static final EventLoopRule eventLoop = new EventLoopRule();
+ * >
+ * >     @Test
+ * >     public void test() {
+ * >         eventLoop.get().execute(() -> System.out.println("Hello!"));
+ * >     }
+ * > }
+ * }</pre>
+ *
+ * @see EventLoopGroupRule
+ */
+public class EventLoopRule extends AbstractEventLoopGroupRule {
+
+    /**
+     * Creates a new {@link TestRule} that provides an {@link EventLoop}.
+     */
+    public EventLoopRule() {
+        this(false);
+    }
+
+    /**
+     * Creates a new {@link TestRule} that provides an {@link EventLoop}.
+     *
+     * @param useDaemonThreads whether to create daemon threads or not
+     */
+    public EventLoopRule(boolean useDaemonThreads) {
+        this("armeria-testing-eventloop", useDaemonThreads);
+    }
+
+    /**
+     * Creates a new {@link TestRule} that provides an {@link EventLoop}.
+     *
+     * @param threadNamePrefix the prefix of thread names
+     */
+    public EventLoopRule(String threadNamePrefix) {
+        this(threadNamePrefix, false);
+    }
+
+    /**
+     * Creates a new {@link TestRule} that provides an {@link EventLoop}.
+     *
+     * @param threadNamePrefix the prefix of thread names
+     * @param useDaemonThreads whether to create daemon threads or not
+     */
+    public EventLoopRule(String threadNamePrefix, boolean useDaemonThreads) {
+        super(1, threadNamePrefix, useDaemonThreads);
+    }
+
+    /**
+     * Returns the {@link EventLoop}.
+     */
+    public EventLoop get() {
+        return group().next();
+    }
+}

--- a/testing/src/main/java/com/linecorp/armeria/testing/common/package-info.java
+++ b/testing/src/main/java/com/linecorp/armeria/testing/common/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 LINE Corporation
+ * Copyright 2018 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -14,14 +14,10 @@
  * under the License.
  */
 
-package com.linecorp.armeria.common.stream;
+/**
+ * Common testing utilities.
+ */
+@NonNullByDefault
+package com.linecorp.armeria.testing.common;
 
-import java.util.List;
-
-public class EventLoopStreamMessageTest extends AbstractStreamMessageAndWriterTest {
-
-    @Override
-    <T> StreamMessageAndWriter<T> newStreamWriter(List<T> unused) {
-        return new EventLoopStreamMessage<>(eventLoop.get());
-    }
-}
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftServiceTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftServiceTest.java
@@ -32,7 +32,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
 
 import javax.annotation.Nonnull;
@@ -41,9 +40,8 @@ import org.apache.thrift.TApplicationException;
 import org.apache.thrift.protocol.TProtocol;
 import org.apache.thrift.transport.TMemoryBuffer;
 import org.apache.thrift.transport.TMemoryInputTransport;
-import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -71,10 +69,9 @@ import com.linecorp.armeria.service.test.thrift.main.Name;
 import com.linecorp.armeria.service.test.thrift.main.NameService;
 import com.linecorp.armeria.service.test.thrift.main.NameSortService;
 import com.linecorp.armeria.service.test.thrift.main.OnewayHelloService;
+import com.linecorp.armeria.testing.common.EventLoopRule;
 
 import io.netty.buffer.ByteBufAllocator;
-import io.netty.channel.DefaultEventLoop;
-import io.netty.channel.EventLoop;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 
 /**
@@ -112,7 +109,8 @@ public class ThriftServiceTest {
     private static final String BAR = "bar";
     private static final String BAZ = "baz";
 
-    private static EventLoop eventLoop;
+    @ClassRule
+    public static final EventLoopRule eventLoop = new EventLoopRule();
 
     @Parameters(name = "{0}")
     public static Collection<SerializationFormat> parameters() throws Exception {
@@ -131,16 +129,6 @@ public class ThriftServiceTest {
 
     public ThriftServiceTest(SerializationFormat defaultSerializationFormat) {
         this.defaultSerializationFormat = defaultSerializationFormat;
-    }
-
-    @BeforeClass
-    public static void setupLoop() {
-        eventLoop = new DefaultEventLoop(Executors.newSingleThreadExecutor());
-    }
-
-    @AfterClass
-    public static void closeLoop() {
-        eventLoop.shutdownGracefully();
     }
 
     @Before
@@ -648,7 +636,7 @@ public class ThriftServiceTest {
 
         final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
         when(ctx.alloc()).thenReturn(ByteBufAllocator.DEFAULT);
-        when(ctx.eventLoop()).thenReturn(eventLoop);
+        when(ctx.eventLoop()).thenReturn(eventLoop.get());
         final DefaultRequestLog reqLogBuilder = new DefaultRequestLog(ctx);
 
         when(ctx.blockingTaskExecutor()).thenReturn(ImmediateEventExecutor.INSTANCE);


### PR DESCRIPTION
Motivation:

It would be useful to have JUnit `TestRule`s for Netty `EventLoop` and
`EventLoopGroup`.

Modifications:

- Add `EventLoopRule` and `EventLoopGroupRule`
- Update our tests to leverate the rule.
- Fix a bug where `TransportType` rejects `EpollEventLoop`

Result:

- Easier to prepare an event loop in a test case