### PR TITLE
Expose context-aware Executor for easier tests

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/RequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestContext.java
@@ -199,11 +199,22 @@ public interface RequestContext extends AttributeMap {
     }
 
     /**
-     * Returns an {@link EventLoop} that will make sure this {@link RequestContext} is set as the current
+     * Returns an {@link Executor} that will make sure this {@link RequestContext} is set as the current
      * context before executing any callback. This should almost always be used for executing asynchronous
      * callbacks in service code to make sure features that require the {@link RequestContext} work properly.
      * Most asynchronous libraries like {@link CompletableFuture} provide methods that accept an
      * {@link Executor} to run callbacks on.
+     */
+    default Executor contextAwareExecutor() {
+        // The implementation is the same as contextAwareEventLoop but we expose as an Executor as well given
+        // how common it is to use only as an Executor and it becomes much easier to write tests for an
+        // Executor (i.e., when(ctx.contextAwareExecutor()).thenReturn(MoreExecutors.directExecutor()));
+        return contextAwareEventLoop();
+    }
+
+    /**
+     * Returns an {@link EventLoop} that will make sure this {@link RequestContext} is set as the current
+     * context before executing any callback.
      */
     default EventLoop contextAwareEventLoop() {
         return new RequestContextAwareEventLoop(this, eventLoop());

--- a/core/src/main/java/com/linecorp/armeria/common/RequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestContext.java
@@ -186,7 +186,7 @@ public interface RequestContext extends AttributeMap {
      * Returns the {@link Executor} that is handling the current {@link Request}.
      */
     default Executor executor() {
-        // The implementation is the same as contextAwareEventLoop but we expose as an Executor as well given
+        // The implementation is the same as eventLoop but we expose as an Executor as well given
         // how much easier it is to write tests for an Executor (i.e.,
         // when(ctx.executor()).thenReturn(MoreExecutors.directExecutor()));
         return eventLoop();

--- a/core/src/main/java/com/linecorp/armeria/common/RequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestContext.java
@@ -183,6 +183,16 @@ public interface RequestContext extends AttributeMap {
     Iterator<Attribute<?>> attrs();
 
     /**
+     * Returns the {@link Executor} that is handling the current {@link Request}.
+     */
+    default Executor executor() {
+        // The implementation is the same as contextAwareEventLoop but we expose as an Executor as well given
+        // how much easier it is to write tests for an Executor (i.e.,
+        // when(ctx.executor()).thenReturn(MoreExecutors.directExecutor()));
+        return eventLoop();
+    }
+
+    /**
      * Returns the {@link EventLoop} that is handling the current {@link Request}.
      */
     EventLoop eventLoop();


### PR DESCRIPTION
It is extremely common to use the `RequestContext`-aware eventloop as just an `Executor` for callbacks (e.g., `thenApplyAsync`). Unfortunately, when writing unit tests for such code, it can be cumbersome to mock `RequestContext` because there is no direct executing event loop (an event loop with an immediate executor usually deadlocks since callbacks get blocked by the previously running item in the loop). It slows down tests to create threads and is cumbersome to shut them down.

This exposes the exact same event loop as an `Executor`. It is purely to allow easier writing of tests where it them becomes possible to just do `when(ctx.contextAwareExecutor()).thenReturn(MoreExecutors.directExecutor())` for many cases where direct execution doesn't deadlock, allowing for faster, simpler tests.