### PR TITLE
add numMaxConnections Flag

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -66,6 +66,10 @@ public final class Flags {
     private static final boolean USE_OPENSSL = getBoolean("useOpenSsl", OpenSsl.isAvailable(),
                                                           value -> OpenSsl.isAvailable() || !value);
 
+    private static final int DEFAULT_NUM_MAX_CONNECTIONS = 10000; // from Tomcat default maxConnections
+    private static final int NUM_MAX_CONNECTIONS =
+            getInt("numMaxConnections", DEFAULT_NUM_MAX_CONNECTIONS, value -> value > 0);
+
     private static final int DEFAULT_NUM_COMMON_WORKERS = NUM_CPU_CORES * 2;
     private static final int NUM_COMMON_WORKERS =
             getInt("numCommonWorkers", DEFAULT_NUM_COMMON_WORKERS, value -> value > 0);
@@ -236,6 +240,17 @@ public final class Flags {
      */
     public static boolean useOpenSsl() {
         return USE_OPENSSL;
+    }
+
+    /**
+     * Returns the default server-side maximum number of connections.
+     *
+     * <p>The default value of this flag is {@value #DEFAULT_NUM_MAX_CONNECTIONS}. Specify the
+     * {@code -Dcom.linecorp.armeria.numMaxConnections=<integer>} JVM option to override
+     * the default value.
+     */
+    public static int numMaxConnections() {
+        return NUM_MAX_CONNECTIONS;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -66,9 +66,9 @@ public final class Flags {
     private static final boolean USE_OPENSSL = getBoolean("useOpenSsl", OpenSsl.isAvailable(),
                                                           value -> OpenSsl.isAvailable() || !value);
 
-    private static final int DEFAULT_NUM_MAX_CONNECTIONS = 10000; // from Tomcat default maxConnections
-    private static final int NUM_MAX_CONNECTIONS =
-            getInt("numMaxConnections", DEFAULT_NUM_MAX_CONNECTIONS, value -> value > 0);
+    private static final int DEFAULT_MAX_NUM_CONNECTIONS = Integer.MAX_VALUE;
+    private static final int MAX_NUM_CONNECTIONS =
+            getInt("maxNumConnections", DEFAULT_MAX_NUM_CONNECTIONS, value -> value > 0);
 
     private static final int DEFAULT_NUM_COMMON_WORKERS = NUM_CPU_CORES * 2;
     private static final int NUM_COMMON_WORKERS =
@@ -245,12 +245,12 @@ public final class Flags {
     /**
      * Returns the default server-side maximum number of connections.
      *
-     * <p>The default value of this flag is {@value #DEFAULT_NUM_MAX_CONNECTIONS}. Specify the
-     * {@code -Dcom.linecorp.armeria.numMaxConnections=<integer>} JVM option to override
+     * <p>The default value of this flag is {@value #DEFAULT_MAX_NUM_CONNECTIONS}. Specify the
+     * {@code -Dcom.linecorp.armeria.maxNumConnections=<integer>} JVM option to override
      * the default value.
      */
-    public static int numMaxConnections() {
-        return NUM_MAX_CONNECTIONS;
+    public static int maxNumConnections() {
+        return MAX_NUM_CONNECTIONS;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -42,6 +42,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLException;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
@@ -144,7 +145,7 @@ public final class ServerBuilder {
     private boolean shutdownWorkerGroupOnStop;
     private final Map<ChannelOption<?>, Object> channelOptions = new Object2ObjectArrayMap<>();
     private final Map<ChannelOption<?>, Object> childChannelOptions = new Object2ObjectArrayMap<>();
-    private int maxNumConnections = Flags.numMaxConnections();
+    private int maxNumConnections = Flags.maxNumConnections();
     private long idleTimeoutMillis = Flags.defaultServerIdleTimeoutMillis();
     private long defaultRequestTimeoutMillis = Flags.defaultRequestTimeoutMillis();
     private long defaultMaxRequestLength = Flags.defaultMaxRequestLength();
@@ -398,6 +399,11 @@ public final class ServerBuilder {
     public ServerBuilder maxNumConnections(int maxNumConnections) {
         this.maxNumConnections = ServerConfig.validateMaxNumConnections(maxNumConnections);
         return this;
+    }
+
+    @VisibleForTesting
+    int maxNumConnections() {
+        return maxNumConnections;
     }
 
     /**
@@ -919,10 +925,6 @@ public final class ServerBuilder {
         requireNonNull(serverListener, "serverListener");
         serverListeners.add(serverListener);
         return this;
-    }
-
-    public int getMaxNumConnections() {
-        return maxNumConnections;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -116,9 +116,6 @@ import it.unimi.dsi.fastutil.objects.Object2ObjectArrayMap;
  */
 public final class ServerBuilder {
 
-    // Use Integer.MAX_VALUE not to limit open connections by default.
-    private static final int DEFAULT_MAX_NUM_CONNECTIONS = Integer.MAX_VALUE;
-
     // Defaults to no graceful shutdown.
     private static final Duration DEFAULT_GRACEFUL_SHUTDOWN_QUIET_PERIOD = Duration.ZERO;
     private static final Duration DEFAULT_GRACEFUL_SHUTDOWN_TIMEOUT = Duration.ZERO;
@@ -147,7 +144,7 @@ public final class ServerBuilder {
     private boolean shutdownWorkerGroupOnStop;
     private final Map<ChannelOption<?>, Object> channelOptions = new Object2ObjectArrayMap<>();
     private final Map<ChannelOption<?>, Object> childChannelOptions = new Object2ObjectArrayMap<>();
-    private int maxNumConnections = DEFAULT_MAX_NUM_CONNECTIONS;
+    private int maxNumConnections = Flags.numMaxConnections();
     private long idleTimeoutMillis = Flags.defaultServerIdleTimeoutMillis();
     private long defaultRequestTimeoutMillis = Flags.defaultRequestTimeoutMillis();
     private long defaultMaxRequestLength = Flags.defaultMaxRequestLength();
@@ -922,6 +919,10 @@ public final class ServerBuilder {
         requireNonNull(serverListener, "serverListener");
         serverListeners.add(serverListener);
         return this;
+    }
+
+    public int getMaxNumConnections() {
+        return maxNumConnections;
     }
 
     /**

--- a/core/src/test/java/com/linecorp/armeria/server/ServerBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerBuilderTest.java
@@ -15,6 +15,7 @@
  */
 package com.linecorp.armeria.server;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
@@ -27,6 +28,12 @@ public class ServerBuilderTest {
         final ServerBuilder sb = new ServerBuilder();
         sb.http(8080);
         assertDuplicatePort(() -> sb.https(8080));
+    }
+
+    @Test
+    public void numMaxConnections() {
+        final ServerBuilder sb = new ServerBuilder();
+        assertThat(sb.getMaxNumConnections()).isEqualTo(10000);
     }
 
     private static void assertDuplicatePort(ThrowingCallable callable) {

--- a/core/src/test/java/com/linecorp/armeria/server/ServerBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerBuilderTest.java
@@ -33,7 +33,7 @@ public class ServerBuilderTest {
     @Test
     public void numMaxConnections() {
         final ServerBuilder sb = new ServerBuilder();
-        assertThat(sb.getMaxNumConnections()).isEqualTo(10000);
+        assertThat(sb.maxNumConnections()).isEqualTo(Integer.MAX_VALUE);
     }
 
     private static void assertDuplicatePort(ThrowingCallable callable) {


### PR DESCRIPTION
Inspried by https://line-armeria.slack.com/archives/C1NGPBUH2/p1527204753000180 and @chokoswitch 's idea in https://github.com/curioswitch/curiostack/issues/144#issuecomment-392628889 , try to add numMaxConnections Flag. 

And set the default value as 10000 according to https://stackoverflow.com/a/25765451 
> The defaults are maxConnections=10,000 and maxThreads=200. 