### PR TITLE
Don't return empty string when prettifying empty object.

### DIFF
--- a/docs-client/src/lib/json-prettify.ts
+++ b/docs-client/src/lib/json-prettify.ts
@@ -43,6 +43,10 @@ function doPrettify(ch: string, indentation: number): [string, number] {
 
 // A modified version of JSON.minify() by Kyle Simpson that prettifies a JSON string without fully parsing it.
 export default function prettify(json: string) {
+  if (json === '{}') {
+    return json;
+  }
+
   const tokenizer = /"|\n|\r/g;
   const new_str = [];
   let in_string = false;


### PR DESCRIPTION
While migrating `prettify` to typescript, I may have changed something so it prettifies `{}` as ``, though I can't see what might cause it. This tweaks it so it'll ignore `{}` which is pretty enough as is.

Found while looking at #1313