### PR TITLE
Ensure SSLParameters.endpointIdentificationAlgorithm is 'HTTPS'

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
@@ -45,6 +45,7 @@ import com.linecorp.armeria.common.HttpObject;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.logging.RequestLogBuilder;
 import com.linecorp.armeria.common.util.Exceptions;
+import com.linecorp.armeria.internal.ChannelUtil;
 import com.linecorp.armeria.internal.Http1ClientCodec;
 import com.linecorp.armeria.internal.Http2GoAwayListener;
 import com.linecorp.armeria.internal.ReadSuppressingHandler;
@@ -209,7 +210,7 @@ final class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
         final SslHandler sslHandler = sslCtx.newHandler(ch.alloc(),
                                                         remoteAddr.getHostString(),
                                                         remoteAddr.getPort());
-        p.addLast(sslHandler);
+        p.addLast(ChannelUtil.configureSslHandler(sslHandler));
         p.addLast(TrafficLoggingHandler.CLIENT);
         p.addLast(new ChannelInboundHandlerAdapter() {
             private boolean handshakeFailed;

--- a/core/src/main/java/com/linecorp/armeria/internal/ChannelUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/ChannelUtil.java
@@ -20,12 +20,16 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLParameters;
+
 import com.google.common.collect.ImmutableList;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.epoll.EpollEventLoopGroup;
+import io.netty.handler.ssl.SslHandler;
 
 public final class ChannelUtil {
 
@@ -65,6 +69,20 @@ public final class ChannelUtil {
         }
 
         return future;
+    }
+
+    /**
+     * Configures the specified {@link SslHandler} with the common settings.
+     */
+    public static SslHandler configureSslHandler(SslHandler sslHandler) {
+        // Set endpoint identification algorithm so that JDK's default X509TrustManager implementation
+        // performs host name checks. Without this, the X509TrustManager implementation will never raise
+        // a CertificateException even if the domain name or IP address mismatches.
+        final SSLEngine engine = sslHandler.engine();
+        final SSLParameters params = engine.getSSLParameters();
+        params.setEndpointIdentificationAlgorithm("HTTPS");
+        engine.setSSLParameters(params);
+        return sslHandler;
     }
 
     private ChannelUtil() {}


### PR DESCRIPTION
Motivation:

JDK's default X509TrustManager implementation skips host name
verification entirely when SSLParameters.endpointIdentificationAlgorithm
is null or empty, which is our current default.

This can be a security threat because an IP address HTTPS request like
`https://10.0.1.2/` will never fail as long as the server gives a valid
certificate.

Modifications:

- Always set 'HTTPS' to SSLParameters.endpointIdentificationAlgorithm

Result:

- Not insecure anymore