### PR TITLE
Revert HttpServerPipelineConfigurator TLS Hostname verification chang…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/ChannelUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/ChannelUtil.java
@@ -20,16 +20,12 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import javax.net.ssl.SSLEngine;
-import javax.net.ssl.SSLParameters;
-
 import com.google.common.collect.ImmutableList;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.epoll.EpollEventLoopGroup;
-import io.netty.handler.ssl.SslHandler;
 
 public final class ChannelUtil {
 
@@ -69,20 +65,6 @@ public final class ChannelUtil {
         }
 
         return future;
-    }
-
-    /**
-     * Configures the specified {@link SslHandler} with the common settings.
-     */
-    public static SslHandler configureSslHandler(SslHandler sslHandler) {
-        // Set endpoint identification algorithm so that JDK's default X509TrustManager implementation
-        // performs host name checks. Without this, the X509TrustManager implementation will never raise
-        // a CertificateException even if the domain name or IP address mismatches.
-        final SSLEngine engine = sslHandler.engine();
-        final SSLParameters params = engine.getSSLParameters();
-        params.setEndpointIdentificationAlgorithm("HTTPS");
-        engine.setSSLParameters(params);
-        return sslHandler;
     }
 
     private ChannelUtil() {}

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
@@ -37,7 +37,6 @@ import com.google.common.collect.Iterables;
 
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.util.Exceptions;
-import com.linecorp.armeria.internal.ChannelUtil;
 import com.linecorp.armeria.internal.Http1ObjectEncoder;
 import com.linecorp.armeria.internal.Http2GoAwayListener;
 import com.linecorp.armeria.internal.ReadSuppressingHandler;
@@ -79,7 +78,6 @@ import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.util.AsciiString;
 import io.netty.util.DomainNameMapping;
-import io.netty.util.ReferenceCountUtil;
 
 /**
  * Configures Netty {@link ChannelPipeline} to serve HTTP/1 and 2 requests.
@@ -170,7 +168,7 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
 
     private void configureHttps(ChannelPipeline p, @Nullable ProxiedAddresses proxiedAddresses) {
         assert sslContexts != null;
-        p.addLast(new HttpsSniHandler(sslContexts));
+        p.addLast(new SniHandler(sslContexts));
         p.addLast(TrafficLoggingHandler.SERVER);
         p.addLast(new Http2OrHttpHandler(proxiedAddresses));
     }
@@ -477,33 +475,6 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
         private String addAfter(ChannelPipeline p, String baseName, ChannelHandler handler) {
             p.addAfter(baseName, null, handler);
             return p.context(handler).name();
-        }
-    }
-
-    /**
-     * An {@link SniHandler} that calls {@link ChannelUtil#configureSslHandler(SslHandler)}
-     * so that an {@link SslHandler} is configured correctly.
-     */
-    private static class HttpsSniHandler extends SniHandler {
-        HttpsSniHandler(DomainNameMapping<SslContext> sslContexts) {
-            super(sslContexts);
-        }
-
-        @Override
-        protected void replaceHandler(ChannelHandlerContext ctx, String hostname, SslContext sslContext) {
-            SslHandler sslHandler = null;
-            try {
-                sslHandler = sslContext.newHandler(ctx.alloc());
-                ctx.pipeline().replace(this, SslHandler.class.getName(),
-                                       ChannelUtil.configureSslHandler(sslHandler));
-                sslHandler = null;
-            } finally {
-                // Since the SslHandler was not inserted into the pipeline,
-                // the ownership of the SSLEngine was not transferred to the SslHandler.
-                if (sslHandler != null) {
-                    ReferenceCountUtil.safeRelease(sslHandler.engine());
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
…e due to NPE.

I'm not sure if this is the correct fix but sending it anyways, feel free to close. But I guess in general servers don't verify hostname of client, since client doesn't have a hostname?

Fixes #1317 