### PR TITLE
Add Copy and Clear buttons to docs client

### DIFF
--- a/docs-client/src/containers/MethodPage/index.tsx
+++ b/docs-client/src/containers/MethodPage/index.tsx
@@ -15,9 +15,12 @@
  */
 
 import Button from '@material-ui/core/Button';
+import ContentCopyIcon from '@material-ui/icons/ContentCopy';
+import DeleteSweepIcon from '@material-ui/icons/DeleteSweep';
 import Checkbox from '@material-ui/core/Checkbox';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Grid from '@material-ui/core/Grid';
+import IconButton from '@material-ui/core/IconButton';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
@@ -27,6 +30,7 @@ import TableCell from '@material-ui/core/TableCell';
 import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
 import TextField from '@material-ui/core/TextField';
+import Tooltip from '@material-ui/core/Tooltip';
 import Typography from '@material-ui/core/Typography';
 import jsonMinify from 'jsonminify';
 import React, { ChangeEvent } from 'react';
@@ -186,11 +190,11 @@ export default class MethodPage extends React.PureComponent<Props, State> {
         {TRANSPORTS.getDebugTransport(method) && (
           <Section>
             <Typography variant="body1" paragraph />
-            <Typography variant="title" paragraph>
-              Debug
-            </Typography>
             <Grid container spacing={16}>
               <Grid item xs={12} sm={6}>
+                <Typography variant="title" paragraph>
+                  Debug
+                </Typography>
                 <TextField
                   multiline
                   fullWidth
@@ -240,6 +244,20 @@ export default class MethodPage extends React.PureComponent<Props, State> {
                 </Button>
               </Grid>
               <Grid item xs={12} sm={6}>
+                <Tooltip title="Copy response">
+                  <IconButton
+                      onClick={this.onCopy}
+                    >
+                    <ContentCopyIcon />
+                  </IconButton>
+                </Tooltip>
+                <Tooltip title="Clear response">
+                  <IconButton
+                      onClick={this.onDelete}
+                    >
+                    <DeleteSweepIcon />
+                  </IconButton>
+                </Tooltip>
                 <SyntaxHighlighter
                   language="json"
                   style={githubGist}
@@ -276,6 +294,23 @@ export default class MethodPage extends React.PureComponent<Props, State> {
   private onEditHttpHeadersClick = () => {
     this.setState({
       additionalHeadersOpen: !this.state.additionalHeadersOpen,
+    });
+  };
+
+  private onCopy = () => {
+    const response = this.state.debugResponse;
+    const textArea = document.createElement('textarea');
+    textArea.value = response;
+    document.body.appendChild(textArea);
+    textArea.focus();
+    textArea.select();
+    document.execCommand('copy');
+    document.body.removeChild(textArea);
+  };
+
+  private onDelete = () => {
+    this.setState({
+      debugResponse: ``,
     });
   };
 

--- a/docs-client/src/containers/MethodPage/index.tsx
+++ b/docs-client/src/containers/MethodPage/index.tsx
@@ -250,7 +250,7 @@ export default class MethodPage extends React.PureComponent<Props, State> {
                   </IconButton>
                 </Tooltip>
                 <Tooltip title="Clear response">
-                  <IconButton onClick={this.onDelete}>
+                  <IconButton onClick={this.onClear}>
                     <DeleteSweepIcon />
                   </IconButton>
                 </Tooltip>
@@ -305,9 +305,9 @@ export default class MethodPage extends React.PureComponent<Props, State> {
     document.body.removeChild(textArea);
   };
 
-  private onDelete = () => {
+  private onClear = () => {
     this.setState({
-      debugResponse: ``,
+      debugResponse:  '',
     });
   };
 

--- a/docs-client/src/containers/MethodPage/index.tsx
+++ b/docs-client/src/containers/MethodPage/index.tsx
@@ -296,6 +296,7 @@ export default class MethodPage extends React.PureComponent<Props, State> {
   private onCopy = () => {
     const response = this.state.debugResponse;
     const textArea = document.createElement('textarea');
+    textArea.style.opacity = '0.0';
     textArea.value = response;
     document.body.appendChild(textArea);
     textArea.focus();

--- a/docs-client/src/containers/MethodPage/index.tsx
+++ b/docs-client/src/containers/MethodPage/index.tsx
@@ -15,8 +15,6 @@
  */
 
 import Button from '@material-ui/core/Button';
-import ContentCopyIcon from '@material-ui/icons/ContentCopy';
-import DeleteSweepIcon from '@material-ui/icons/DeleteSweep';
 import Checkbox from '@material-ui/core/Checkbox';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Grid from '@material-ui/core/Grid';
@@ -32,6 +30,8 @@ import TableRow from '@material-ui/core/TableRow';
 import TextField from '@material-ui/core/TextField';
 import Tooltip from '@material-ui/core/Tooltip';
 import Typography from '@material-ui/core/Typography';
+import ContentCopyIcon from '@material-ui/icons/ContentCopy';
+import DeleteSweepIcon from '@material-ui/icons/DeleteSweep';
 import jsonMinify from 'jsonminify';
 import React, { ChangeEvent } from 'react';
 import { RouteComponentProps } from 'react-router-dom';
@@ -245,16 +245,12 @@ export default class MethodPage extends React.PureComponent<Props, State> {
               </Grid>
               <Grid item xs={12} sm={6}>
                 <Tooltip title="Copy response">
-                  <IconButton
-                      onClick={this.onCopy}
-                    >
+                  <IconButton onClick={this.onCopy}>
                     <ContentCopyIcon />
                   </IconButton>
                 </Tooltip>
                 <Tooltip title="Clear response">
-                  <IconButton
-                      onClick={this.onDelete}
-                    >
+                  <IconButton onClick={this.onDelete}>
                     <DeleteSweepIcon />
                   </IconButton>
                 </Tooltip>

--- a/docs-client/src/containers/MethodPage/index.tsx
+++ b/docs-client/src/containers/MethodPage/index.tsx
@@ -307,7 +307,7 @@ export default class MethodPage extends React.PureComponent<Props, State> {
 
   private onClear = () => {
     this.setState({
-      debugResponse:  '',
+      debugResponse: '',
     });
   };
 


### PR DESCRIPTION
Please consider this PR as a feature request.

I added two buttons above the response section of the method page. They are the same level as Debug title, so should not comsume additional space.

<img width="1410" alt="screen shot 2018-08-06 at 15 24 08" src="https://user-images.githubusercontent.com/1726272/43700462-a688a45c-998d-11e8-8237-fb8b09c78966.png">

### Copy

Copies whole response text to the clipboard.

While using Armeria docs-client I often deal with big responses and it is often difficult to select and copy the whole response. This is where `Copy` button will be useful.

### Clear

Clears the response text.

Sometimes when I make the same request the second time it is hard to understand if I still see result of the last one or it is new one but the response is the same. In this case I reload the page to make the second request.

#### Compatibility

[execCommand](https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand) on the temp textarea is used to put text to the clipboard. It seems to be most common solution and supported by all popular browsers.

<img width="1136" alt="screen shot 2018-08-06 at 15 40 11" src="https://user-images.githubusercontent.com/1726272/43700918-5a99fd6e-998f-11e8-8989-5cd0ad859d23.png">