### PR TITLE
Set endOfStream for headers based on HTTP/2 frame EOS information.

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/Http2ResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http2ResponseDecoder.java
@@ -145,7 +145,7 @@ final class Http2ResponseDecoder extends HttpResponseDecoder implements Http2Con
                                   streamId);
         }
 
-        final HttpHeaders converted = ArmeriaHttpUtil.toArmeria(headers);
+        final HttpHeaders converted = ArmeriaHttpUtil.toArmeria(headers, endOfStream);
         try {
             // If this tryWrite() returns false, it means the response stream has been closed due to
             // disconnection or by the response consumer. We do not need to handle such cases here because

--- a/core/src/main/java/com/linecorp/armeria/internal/ArmeriaHttpUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/ArmeriaHttpUtil.java
@@ -271,8 +271,8 @@ public final class ArmeriaHttpUtil {
     /**
      * Converts the specified Netty HTTP/2 into Armeria HTTP/2 headers.
      */
-    public static HttpHeaders toArmeria(Http2Headers headers) {
-        final HttpHeaders converted = new DefaultHttpHeaders(false, headers.size());
+    public static HttpHeaders toArmeria(Http2Headers headers, boolean endOfStream) {
+        final HttpHeaders converted = new DefaultHttpHeaders(false, headers.size(), endOfStream);
         StringJoiner cookieJoiner = null;
         for (Entry<CharSequence, CharSequence> e : headers) {
             final AsciiString name = AsciiString.of(e.getKey());

--- a/core/src/main/java/com/linecorp/armeria/server/Http2RequestDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http2RequestDecoder.java
@@ -106,7 +106,7 @@ final class Http2RequestDecoder extends Http2EventAdapter {
             }
 
             req = new DecodedHttpRequest(ctx.channel().eventLoop(), ++nextId, streamId,
-                                         ArmeriaHttpUtil.toArmeria(headers), true,
+                                         ArmeriaHttpUtil.toArmeria(headers, endOfStream), true,
                                          inboundTrafficController, cfg.defaultMaxRequestLength());
 
             // Close the request early when it is sure that there will be
@@ -119,7 +119,7 @@ final class Http2RequestDecoder extends Http2EventAdapter {
             ctx.fireChannelRead(req);
         } else {
             try {
-                req.write(ArmeriaHttpUtil.toArmeria(headers));
+                req.write(ArmeriaHttpUtil.toArmeria(headers, endOfStream));
             } catch (Throwable t) {
                 req.close(t);
                 throw connectionError(INTERNAL_ERROR, t, "failed to consume a HEADERS frame");

--- a/core/src/test/java/com/linecorp/armeria/internal/ArmeriaHttpUtilTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/ArmeriaHttpUtilTest.java
@@ -105,6 +105,16 @@ public class ArmeriaHttpUtilTest {
     }
 
     @Test
+    public void endOfStreamSet() {
+        final Http2Headers in = new DefaultHttp2Headers();
+        final HttpHeaders out = toArmeria(in, true);
+        assertThat(out.isEndOfStream()).isTrue();
+
+        final HttpHeaders out2 = toArmeria(in, false);
+        assertThat(out2.isEndOfStream()).isFalse();
+    }
+
+    @Test
     public void inboundCookiesMustBeMergedForHttp2() {
         final Http2Headers in = new DefaultHttp2Headers();
 
@@ -114,7 +124,7 @@ public class ArmeriaHttpUtilTest {
         in.add(HttpHeaderNames.COOKIE, "i=j");
         in.add(HttpHeaderNames.COOKIE, "k=l;");
 
-        final HttpHeaders out = toArmeria(in);
+        final HttpHeaders out = toArmeria(in, false);
 
         assertThat(out.getAll(HttpHeaderNames.COOKIE))
                 .containsExactly("a=b; c=d; e=f; g=h; i=j; k=l");

--- a/it/server/src/test/java/com/linecorp/armeria/server/http/HttpProxyIntegrationTest.java
+++ b/it/server/src/test/java/com/linecorp/armeria/server/http/HttpProxyIntegrationTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.common.DefaultHttpHeaders;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpObject;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpResponseWriter;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.logging.LoggingService;
+import com.linecorp.armeria.testing.server.ServerRule;
+
+/** Test for issues that may happen when doing simple proxying. */
+public class HttpProxyIntegrationTest {
+
+    @ClassRule
+    public static ServerRule backendServer = new ServerRule() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.service("/", ((ctx, req) -> {
+                HttpResponseWriter writer = HttpResponse.streaming();
+
+                HttpHeaders headers = HttpHeaders.of(HttpStatus.OK);
+                assertThat(headers.isEndOfStream()).isFalse();
+
+                HttpHeaders trailers = new DefaultHttpHeaders()
+                        .set(HttpHeaderNames.of("armeria-message"), "error");
+                // Armeria will automatically set endOfStream for trailers.
+                assertThat(headers.isEndOfStream()).isFalse();
+
+                writer.write(headers);
+                writer.write(trailers);
+                writer.close();
+
+                return writer;
+            }));
+
+            sb.decorator(LoggingService.newDecorator());
+        }
+    };
+
+    @ClassRule
+    public static ServerRule frontendServer = new ServerRule() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.service("/", (ctx, req) -> {
+                HttpClient client = HttpClient.of(backendServer.uri("/"));
+                return client.get("/");
+            });
+
+            sb.decorator(LoggingService.newDecorator());
+        }
+    };
+
+    @Test
+    public void proxyWithTrailers() throws Throwable {
+        HttpClient client = HttpClient.of(frontendServer.uri("/"));
+
+        AtomicBoolean headersReceived = new AtomicBoolean();
+        AtomicBoolean complete = new AtomicBoolean();
+        AtomicReference<Throwable> error = new AtomicReference<>();
+
+        client.get("/").subscribe(new Subscriber<HttpObject>() {
+            @Override
+            public void onSubscribe(Subscription s) {
+                s.request(Long.MAX_VALUE);
+            }
+
+            @Override
+            public void onNext(HttpObject obj) {
+                if (!headersReceived.get()) {
+                    headersReceived.set(true);
+                    assertThat(obj.isEndOfStream()).isFalse();
+                } else {
+                    assertThat(obj.isEndOfStream()).isTrue();
+                }
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                error.set(t);
+                complete.set(true);
+            }
+
+            @Override
+            public void onComplete() {
+                complete.set(true);
+            }
+        });
+
+        await().untilTrue(complete);
+        Throwable raisedError = error.get();
+        if (raisedError != null) {
+            throw raisedError;
+        }
+    }
+}


### PR DESCRIPTION
A simple proxy service in armeria is just essentially one line

```
(ctx, req) -> client.execute(req)
```

This should have the exact same semantics on the proxied client if it connects to the proxy or the backend, but it seems that because end-of-stream isn't set on received headers based on the HTTP/2 frame, this is not the case, and an empty data frame with EOS is inserted sometimes. We found this breaks a proxy to a gRPC backend where extra empty frames are not allowed.

The test fails before the code change and passes now.

/cc @gavinreaney