### PR TITLE
Add a new flag: 'com.linecorp.armeria.verboseResponses'

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,8 +33,9 @@ allprojects {
     }
 
     tasks.withType(Test) {
-        // Use verbose exception reporting for easier debugging.
+        // Use verbose exception/response reporting for easier debugging.
         systemProperty 'com.linecorp.armeria.verboseExceptions', 'true'
+        systemProperty 'com.linecorp.armeria.verboseResponses', 'true'
         // Pass special system property to tell our tests that we are measuring coverage.
         if (project.hasFlags('coverage')) {
             systemProperty 'com.linecorp.armeria.testing.coverage', 'true'

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -59,7 +59,9 @@ public final class Flags {
 
     private static final int NUM_CPU_CORES = Runtime.getRuntime().availableProcessors();
 
-    private static final boolean VERBOSE_EXCEPTION = getBoolean("verboseExceptions", false);
+    private static final boolean VERBOSE_EXCEPTIONS = getBoolean("verboseExceptions", false);
+
+    private static final boolean VERBOSE_RESPONSES = getBoolean("verboseResponses", false);
 
     private static final boolean USE_EPOLL = getBoolean("useEpoll", Epoll.isAvailable(),
                                                         value -> Epoll.isAvailable() || !value);
@@ -215,7 +217,19 @@ public final class Flags {
      * JVM option to enable it.
      */
     public static boolean verboseExceptions() {
-        return VERBOSE_EXCEPTION;
+        return VERBOSE_EXCEPTIONS;
+    }
+
+    /**
+     * Returns whether the verbose response mode is enabled. When enabled, the server responses will contain
+     * the exception type and its full stack trace, which may be useful for debugging while potentially
+     * insecure. When disabled, the server responses will not expose such server-side details to the client.
+     *
+     * <p>This flag is disabled by default. Specify the {@code -Dcom.linecorp.armeria.verboseResponses=true}
+     * JVM option to enable it.
+     */
+    public static boolean verboseResponses() {
+        return VERBOSE_RESPONSES;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/util/Exceptions.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/Exceptions.java
@@ -237,6 +237,10 @@ public final class Exceptions {
 
     private Exceptions() {}
 
+    /**
+     * A variant of {@link PrintWriter} that 1) is backed by a {@link StringWriter}, 2) removes locking,
+     * 3) always uses {@code '\n'} as a line delimiter.
+     */
     private static final class StackTraceWriter extends PrintWriter {
         StackTraceWriter() {
             super(new StringWriter(512));
@@ -245,6 +249,57 @@ public final class Exceptions {
         @Override
         public String toString() {
             return out.toString();
+        }
+
+        @Override
+        public void flush() {}
+
+        @Override
+        public void close() {}
+
+        @Override
+        public void write(int c) {
+            try {
+                out.write(c);
+            } catch (IOException e) {
+                setError();
+            }
+        }
+
+        @Override
+        public void write(char[] buf, int off, int len) {
+            try {
+                out.write(buf, off, len);
+            } catch (IOException e) {
+                setError();
+            }
+        }
+
+        @Override
+        public void write(char[] buf) {
+            try {
+                out.write(buf);
+            } catch (IOException e) {
+                setError();
+            }
+        }
+
+        @Override
+        public void write(String s, int off, int len) {
+            try {
+                out.write(s, off, len);
+            } catch (IOException e) {
+                setError();
+            }
+        }
+
+        @Override
+        public void write(String s) {
+            try {
+                out.write(s);
+            } catch (IOException e) {
+                setError();
+            }
         }
 
         @Override

--- a/core/src/main/java/com/linecorp/armeria/common/util/Exceptions.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/Exceptions.java
@@ -19,6 +19,8 @@ package com.linecorp.armeria.common.util;
 import static java.util.Objects.requireNonNull;
 
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.channels.ClosedChannelException;
 import java.util.concurrent.CompletionException;
@@ -191,6 +193,7 @@ public final class Exceptions {
      *         e.g. {@code return Exceptions.throwUnsafely(...);} vs.
      *              {@code Exceptions.throwUnsafely(...); return null;}
      */
+    @SuppressWarnings("ReturnOfNull")
     public static <T> T throwUnsafely(Throwable cause) {
         doThrowUnsafely(requireNonNull(cause, "cause"));
         return null; // Never reaches here.
@@ -222,14 +225,89 @@ public final class Exceptions {
     }
 
     /**
-     * Returns the stack trace of the specified {@code exception} as a {@link String} instead.
-     *
-     * @deprecated Use {@link Throwables#getStackTraceAsString(Throwable)}.
+     * Converts the stack trace of the specified {@code exception} into a {@link String}.
+     * This method always uses {@code '\n'} as a line delimiter, unlike
+     * {@link Throwable#printStackTrace(PrintWriter)} or {@link Throwables#getStackTraceAsString(Throwable)}.
      */
-    @Deprecated
     public static String traceText(Throwable exception) {
-        return Throwables.getStackTraceAsString(exception);
+        final StackTraceWriter writer = new StackTraceWriter();
+        exception.printStackTrace(writer);
+        return writer.toString();
     }
 
     private Exceptions() {}
+
+    private static final class StackTraceWriter extends PrintWriter {
+        StackTraceWriter() {
+            super(new StringWriter(512));
+        }
+
+        @Override
+        public String toString() {
+            return out.toString();
+        }
+
+        @Override
+        public void println() {
+            try {
+                out.write('\n');
+            } catch (IOException e) {
+                setError();
+            }
+        }
+
+        @Override
+        public void println(boolean x) {
+            print(x);
+            println();
+        }
+
+        @Override
+        public void println(char x) {
+            print(x);
+            println();
+        }
+
+        @Override
+        public void println(int x) {
+            print(x);
+            println();
+        }
+
+        @Override
+        public void println(long x) {
+            print(x);
+            println();
+        }
+
+        @Override
+        public void println(float x) {
+            print(x);
+            println();
+        }
+
+        @Override
+        public void println(double x) {
+            print(x);
+            println();
+        }
+
+        @Override
+        public void println(char[] x) {
+            print(x);
+            println();
+        }
+
+        @Override
+        public void println(String x) {
+            print(x);
+            println();
+        }
+
+        @Override
+        public void println(Object x) {
+            print(x);
+            println();
+        }
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/internal/AbstractHttp2ConnectionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/AbstractHttp2ConnectionHandler.java
@@ -21,7 +21,8 @@ import static io.netty.handler.codec.http2.Http2Error.INTERNAL_ERROR;
 import javax.annotation.Nullable;
 
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Throwables;
+
+import com.linecorp.armeria.common.util.Exceptions;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
@@ -110,7 +111,7 @@ public abstract class AbstractHttp2ConnectionHandler extends Http2ConnectionHand
         buf.append(", message: ");
         buf.append(MoreObjects.firstNonNull(message, "n/a"));
         buf.append(", cause: ");
-        buf.append(cause != null ? Throwables.getStackTraceAsString(cause) : "n/a");
+        buf.append(cause != null ? Exceptions.traceText(cause) : "n/a");
 
         return buf.toString();
     }

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientIntegrationTest.java
@@ -37,7 +37,6 @@ import org.junit.Test;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
-import com.google.common.base.Throwables;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.Closeables;
 
@@ -60,6 +59,7 @@ import com.linecorp.armeria.common.HttpResponseWriter;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.util.CompletionActions;
+import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.server.AbstractHttpService;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.Service;
@@ -206,7 +206,7 @@ public class HttpClientIntegrationTest {
                         if (cause != null) {
                             return HttpResponse.of(
                                     HttpStatus.INTERNAL_SERVER_ERROR,
-                                    MediaType.PLAIN_TEXT_UTF_8, Throwables.getStackTraceAsString(cause));
+                                    MediaType.PLAIN_TEXT_UTF_8, Exceptions.traceText(cause));
                         }
 
                         return HttpResponse.of(

--- a/core/src/test/java/com/linecorp/armeria/common/stream/DeferredStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/DeferredStreamMessageTest.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
-import com.google.common.base.Throwables;
+import com.linecorp.armeria.common.util.Exceptions;
 
 import io.netty.util.concurrent.ImmediateEventExecutor;
 
@@ -172,7 +172,7 @@ public class DeferredStreamMessageTest {
 
             @Override
             public void onError(Throwable t) {
-                streamed.add("onError: " + Throwables.getStackTraceAsString(t));
+                streamed.add("onError: " + Exceptions.traceText(t));
             }
 
             @Override

--- a/core/src/test/java/com/linecorp/armeria/common/util/ExceptionsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/util/ExceptionsTest.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 public class ExceptionsTest {
 
     @Test
-    public void peelTest() {
+    public void testPeel() {
         final IllegalArgumentException originalException = new IllegalArgumentException();
 
         // There's nothing to peel.
@@ -54,5 +54,16 @@ public class ExceptionsTest {
         final ExceptionInInitializerError exceptionInInitializerError = new ExceptionInInitializerError(
                 executionException);
         assertThat(Exceptions.peel(exceptionInInitializerError)).isSameAs(originalException);
+    }
+
+    /**
+     * Should pass on both Windows and *nix because {@link Exceptions#traceText(Throwable)} is expected to
+     * always use {@code '\n'} as a line delimiter.
+     */
+    @Test
+    public void testTraceText() {
+        final String trace = Exceptions.traceText(new Exception("foo"));
+        assertThat(trace).startsWith(Exception.class.getName() + ": foo\n" +
+                                     "\tat " + ExceptionsTest.class.getName());
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerStreamingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerStreamingTest.java
@@ -42,7 +42,6 @@ import org.reactivestreams.Subscription;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.client.ClientFactory;
@@ -64,6 +63,7 @@ import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.stream.StreamWriter;
 import com.linecorp.armeria.common.util.EventLoopGroups;
+import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.internal.InboundTrafficController;
 import com.linecorp.armeria.testing.server.ServerRule;
 
@@ -322,7 +322,7 @@ public class HttpServerStreamingTest {
                             HttpResponse.of(
                                     HttpStatus.INTERNAL_SERVER_ERROR,
                                     MediaType.PLAIN_TEXT_UTF_8,
-                                    Throwables.getStackTraceAsString(cause)));
+                                    Exceptions.traceText(cause)));
                 }
 
                 @Override

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
@@ -38,7 +38,6 @@ import org.slf4j.LoggerFactory;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
-import com.google.common.base.Throwables;
 
 import com.linecorp.armeria.common.DefaultHttpHeaders;
 import com.linecorp.armeria.common.Flags;
@@ -51,6 +50,7 @@ import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
 import com.linecorp.armeria.common.logging.RequestLogAvailability;
+import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.common.util.SafeCloseable;
 import com.linecorp.armeria.internal.grpc.ArmeriaMessageDeframer;
 import com.linecorp.armeria.internal.grpc.ArmeriaMessageDeframer.ByteBufOrStream;
@@ -472,11 +472,11 @@ class ArmeriaServerCall<I, O> extends ServerCall<I, O>
         if (Flags.verboseResponses()) {
             final Throwable cause = status.getCause();
             if (cause != null) {
-                final String trace = Throwables.getStackTraceAsString(cause);
+                final String trace = Exceptions.traceText(cause);
                 if (Strings.isNullOrEmpty(description)) {
                     return "Caused by: " + trace;
                 } else {
-                    return description + System.lineSeparator() + "Caused by: " + trace;
+                    return description + "\nCaused by: " + trace;
                 }
             }
         }

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientTest.java
@@ -49,7 +49,6 @@ import org.junit.rules.TestRule;
 import org.junit.rules.Timeout;
 import org.mockito.ArgumentCaptor;
 
-import com.google.common.base.Throwables;
 import com.google.protobuf.ByteString;
 
 import com.linecorp.armeria.client.ClientBuilder;
@@ -69,6 +68,7 @@ import com.linecorp.armeria.common.RpcResponse;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.logging.RequestLogAvailability;
 import com.linecorp.armeria.common.util.EventLoopGroups;
+import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.grpc.testing.Messages.EchoStatus;
 import com.linecorp.armeria.grpc.testing.Messages.Payload;
 import com.linecorp.armeria.grpc.testing.Messages.ResponseParameters;
@@ -931,7 +931,7 @@ public class GrpcClientTest {
         final Throwable t = catchThrowable(() -> stub.streamingOutputCall(request).next());
         assertThat(t).isInstanceOf(StatusRuntimeException.class);
         assertThat(((StatusRuntimeException) t).getStatus().getCode()).isEqualTo(Code.RESOURCE_EXHAUSTED);
-        assertThat(Throwables.getStackTraceAsString(t)).contains("exceeds maximum");
+        assertThat(Exceptions.traceText(t)).contains("exceeds maximum");
 
         checkRequestLog((rpcReq, rpcRes, grpcStatus) -> {
             assertThat(rpcReq.params()).containsExactly(request);
@@ -970,7 +970,7 @@ public class GrpcClientTest {
         final Throwable t = catchThrowable(() -> stub.streamingOutputCall(request).next());
         assertThat(t).isInstanceOf(StatusRuntimeException.class);
         assertThat(((StatusRuntimeException) t).getStatus().getCode()).isEqualTo(Code.CANCELLED);
-        assertThat(Throwables.getStackTraceAsString(t)).contains("message too large");
+        assertThat(Exceptions.traceText(t)).contains("message too large");
 
         checkRequestLog((rpcReq, rpcRes, grpcStatus) -> {
             assertThat(rpcReq.params()).containsExactly(request);

--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcMetricsIntegrationTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcMetricsIntegrationTest.java
@@ -39,6 +39,7 @@ import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.ClientFactoryBuilder;
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.client.metric.MetricCollectingClient;
+import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
@@ -168,7 +169,14 @@ public class GrpcMetricsIntegrationTest {
         assertThat(findServerMeter("UnaryCall2", "responseLength", COUNT, "httpStatus", "200")).contains(4.0);
         assertThat(findServerMeter("UnaryCall2", "responseLength", COUNT, "httpStatus", "500")).contains(3.0);
         assertThat(findServerMeter("UnaryCall2", "responseLength", TOTAL, "httpStatus", "200")).contains(0.0);
-        assertThat(findServerMeter("UnaryCall2", "responseLength", TOTAL, "httpStatus", "500")).contains(225.0);
+        assertThat(findServerMeter("UnaryCall2", "responseLength", TOTAL, "httpStatus", "500"))
+                .hasValueSatisfying(value -> {
+                    if (Flags.verboseResponses()) {
+                        assertThat(value).isGreaterThan(225.0); // As larger as the stack trace
+                    } else {
+                        assertThat(value).isEqualTo(225.0);
+                    }
+                });
     }
 
     private static Optional<Double> findServerMeter(

--- a/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/ArmeriaCallFactoryTest.java
+++ b/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/ArmeriaCallFactoryTest.java
@@ -42,7 +42,6 @@ import org.junit.runners.Parameterized.Parameters;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.client.Endpoint;
@@ -53,6 +52,7 @@ import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.internal.PathAndQuery;
 import com.linecorp.armeria.server.AbstractHttpService;
 import com.linecorp.armeria.server.ServerBuilder;
@@ -232,7 +232,7 @@ public class ArmeriaCallFactoryTest {
                           if (cause != null) {
                               return HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR,
                                                      MediaType.PLAIN_TEXT_UTF_8,
-                                                     Throwables.getStackTraceAsString(cause));
+                                                     Exceptions.traceText(cause));
                           }
                           final String text = aReq.content().toStringUtf8();
                           final Pojo request;
@@ -241,7 +241,7 @@ public class ArmeriaCallFactoryTest {
                           } catch (IOException e) {
                               return HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR,
                                                      MediaType.PLAIN_TEXT_UTF_8,
-                                                     Throwables.getStackTraceAsString(e));
+                                                     Exceptions.traceText(e));
                           }
                           assertThat(request).isEqualTo(new Pojo("Cony", 26));
                           return HttpResponse.of(HttpStatus.OK);
@@ -255,7 +255,7 @@ public class ArmeriaCallFactoryTest {
                           if (cause != null) {
                               return HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR,
                                                      MediaType.PLAIN_TEXT_UTF_8,
-                                                     Throwables.getStackTraceAsString(cause));
+                                                     Exceptions.traceText(cause));
                           }
                           final Map<String, List<String>> params = new QueryStringDecoder(
                                   aReq.content().toStringUtf8(), false)
@@ -273,7 +273,7 @@ public class ArmeriaCallFactoryTest {
                           if (cause != null) {
                               return HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR,
                                                      MediaType.PLAIN_TEXT_UTF_8,
-                                                     Throwables.getStackTraceAsString(cause));
+                                                     Exceptions.traceText(cause));
                           }
                           final Map<String, List<String>> params = new QueryStringDecoder(
                                   aReq.content().toStringUtf8(), false)

--- a/thrift/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
+++ b/thrift/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
@@ -42,7 +42,6 @@ import org.apache.thrift.transport.TTransport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 
@@ -64,6 +63,7 @@ import com.linecorp.armeria.common.thrift.ThriftProtocolFactories;
 import com.linecorp.armeria.common.thrift.ThriftReply;
 import com.linecorp.armeria.common.thrift.ThriftSerializationFormats;
 import com.linecorp.armeria.common.util.CompletionActions;
+import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.common.util.SafeCloseable;
 import com.linecorp.armeria.internal.thrift.ThriftFieldAccess;
 import com.linecorp.armeria.internal.thrift.ThriftFunction;
@@ -425,7 +425,7 @@ public final class THttpService extends AbstractHttpService {
                 if (Flags.verboseResponses()) {
                     errorRes = HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR,
                                                MediaType.PLAIN_TEXT_UTF_8,
-                                               Throwables.getStackTraceAsString(cause));
+                                               Exceptions.traceText(cause));
                 } else {
                     errorRes = HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR);
                 }
@@ -510,7 +510,7 @@ public final class THttpService extends AbstractHttpService {
                 if (Flags.verboseResponses()) {
                     errorRes = HttpResponse.of(HttpStatus.BAD_REQUEST, MediaType.PLAIN_TEXT_UTF_8,
                                                "Failed to decode a %s header: %s", serializationFormat,
-                                               Throwables.getStackTraceAsString(e));
+                                               Exceptions.traceText(e));
                 } else {
                     errorRes = HttpResponse.of(HttpStatus.BAD_REQUEST, MediaType.PLAIN_TEXT_UTF_8,
                                                "Failed to decode a %s header", serializationFormat);
@@ -744,9 +744,8 @@ public final class THttpService extends AbstractHttpService {
             if (Flags.verboseResponses()) {
                 appException = new TApplicationException(
                         TApplicationException.INTERNAL_ERROR,
-                        "internal server error:" + System.lineSeparator() +
-                        "---- BEGIN server-side trace ----" + System.lineSeparator() +
-                        Throwables.getStackTraceAsString(cause) +
+                        "\n---- BEGIN server-side trace ----\n" +
+                        Exceptions.traceText(cause) +
                         "---- END server-side trace ----");
             } else {
                 appException = new TApplicationException(TApplicationException.INTERNAL_ERROR);

--- a/thrift/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
+++ b/thrift/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
@@ -422,12 +422,12 @@ public final class THttpService extends AbstractHttpService {
         req.aggregateWithPooledObjects(ctx.eventLoop(), ctx.alloc()).handle(voidFunction((aReq, cause) -> {
             if (cause != null) {
                 final HttpResponse errorRes;
-                if (!Flags.verboseResponses()) {
-                    errorRes = HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR);
-                } else {
+                if (Flags.verboseResponses()) {
                     errorRes = HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR,
                                                MediaType.PLAIN_TEXT_UTF_8,
                                                Throwables.getStackTraceAsString(cause));
+                } else {
+                    errorRes = HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR);
                 }
                 responseFuture.complete(errorRes);
                 return;
@@ -507,13 +507,13 @@ public final class THttpService extends AbstractHttpService {
                 logger.debug("{} Failed to decode a {} header:", ctx, serializationFormat, e);
 
                 final HttpResponse errorRes;
-                if (!Flags.verboseResponses()) {
-                    errorRes = HttpResponse.of(HttpStatus.BAD_REQUEST, MediaType.PLAIN_TEXT_UTF_8,
-                                               "Failed to decode a %s header", serializationFormat);
-                } else {
+                if (Flags.verboseResponses()) {
                     errorRes = HttpResponse.of(HttpStatus.BAD_REQUEST, MediaType.PLAIN_TEXT_UTF_8,
                                                "Failed to decode a %s header: %s", serializationFormat,
                                                Throwables.getStackTraceAsString(e));
+                } else {
+                    errorRes = HttpResponse.of(HttpStatus.BAD_REQUEST, MediaType.PLAIN_TEXT_UTF_8,
+                                               "Failed to decode a %s header", serializationFormat);
                 }
 
                 httpRes.complete(errorRes);
@@ -741,15 +741,15 @@ public final class THttpService extends AbstractHttpService {
         if (cause instanceof TApplicationException) {
             appException = (TApplicationException) cause;
         } else {
-            if (!Flags.verboseResponses()) {
-                appException = new TApplicationException(TApplicationException.INTERNAL_ERROR);
-            } else {
+            if (Flags.verboseResponses()) {
                 appException = new TApplicationException(
                         TApplicationException.INTERNAL_ERROR,
                         "internal server error:" + System.lineSeparator() +
                         "---- BEGIN server-side trace ----" + System.lineSeparator() +
                         Throwables.getStackTraceAsString(cause) +
                         "---- END server-side trace ----");
+            } else {
+                appException = new TApplicationException(TApplicationException.INTERNAL_ERROR);
             }
 
             // Causes are not sent over the wire but just used for RequestLog.


### PR DESCRIPTION
Motivation:

Exposing the server-side stack trace in a response can be a security
concern depending on server configuration.

Modifications:

- Add a new system property called `com.linecorp.armeria.verboseResponses`
  so that a user can go back to the previous behavior.
- Do not include stack traces in `THttpService` responses by default.
- Include stack traces in `GrpcService` responses if the flag is set.
- Miscellaneous:
  - Un-deprecate `Exceptions.traceText()` and make it always use `\n` as a line delimiter
  - Replace `Throwables.getStackTraceAsString()` and `System.lineSeparator()` with
    `Exceptions.traceText()` and `\n`
Result:

- A little bit more out-of-the-box security
- gRPC response stack traces are sent if enabled.
- Platform independent stack trace responses

@anuraaga Anything to change on gRPC side? I can make a fix here.