### PR TITLE
Allows trace scope decoration such as Log4J trace ID correlation

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -167,9 +167,9 @@ io.reactivex.rxjava2:
 
 io.zipkin.brave:
   brave:
-    version: &BRAVE_VERSION '5.1.5'
+    version: &BRAVE_VERSION '5.2.0'
     javadocs:
-    - https://static.javadoc.io/io.zipkin.brave/brave/5.1.2/
+    - https://static.javadoc.io/io.zipkin.brave/brave/5.2.0/
 
 it.unimi.dsi:
   fastutil:

--- a/zipkin/src/main/java/com/linecorp/armeria/common/tracing/RequestContextCurrentTraceContext.java
+++ b/zipkin/src/main/java/com/linecorp/armeria/common/tracing/RequestContextCurrentTraceContext.java
@@ -50,9 +50,20 @@ public final class RequestContextCurrentTraceContext extends CurrentTraceContext
      * Use this singleton when building a {@link brave.Tracing} instance for use with
      * {@link HttpTracingService} or {@link HttpTracingClient}.
      *
+     * <p>If you need to customize the context, use {@linkplain #newBuilder()} instead.
+     *
      * @see brave.Tracing.Builder#currentTraceContext(brave.propagation.CurrentTraceContext)
      */
-    public static final CurrentTraceContext INSTANCE = new RequestContextCurrentTraceContext();
+    public static final CurrentTraceContext DEFAULT = new RequestContextCurrentTraceContext(new Builder());
+
+    /**
+     * Singleton retained for backwards compatibility, but replaced by {@link #DEFAULT}.
+     *
+     * @deprecated Please use {@link #DEFAULT} or {@link #newBuilder()} to customize an instance.
+     */
+    @Deprecated
+    public static final CurrentTraceContext INSTANCE = new RequestContextCurrentTraceContext(new Builder());
+
     private static final Logger logger = LoggerFactory.getLogger(RequestContextCurrentTraceContext.class);
     private static final AttributeKey<TraceContext> TRACE_CONTEXT_KEY =
             AttributeKey.valueOf(RequestContextCurrentTraceContext.class, "TRACE_CONTEXT");
@@ -79,6 +90,27 @@ public final class RequestContextCurrentTraceContext extends CurrentTraceContext
             return "InitialRequestScope";
         }
     };
+
+    static final class Builder extends CurrentTraceContext.Builder {
+
+        @Override
+        public CurrentTraceContext build() {
+            return new RequestContextCurrentTraceContext(this);
+        }
+
+        Builder() {
+        }
+    }
+
+    /**
+     * Use this when you need customizations such as log integration via
+     * {@linkplain Builder#addScopeDecorator(ScopeDecorator)}.
+     *
+     * @see brave.Tracing.Builder#currentTraceContext(brave.propagation.CurrentTraceContext)
+     */
+    public static CurrentTraceContext.Builder newBuilder() {
+        return new Builder();
+    }
 
     /**
      * Ensures the specified {@link Tracing} uses a {@link RequestContextCurrentTraceContext}.
@@ -160,7 +192,8 @@ public final class RequestContextCurrentTraceContext extends CurrentTraceContext
         return RequestContext.mapCurrent(r -> r.attr(TRACE_CONTEXT_KEY), LogRequestContextWarningOnce.INSTANCE);
     }
 
-    private RequestContextCurrentTraceContext() {
+    private RequestContextCurrentTraceContext(Builder builder) {
+        super(builder);
     }
 
     private enum LogRequestContextWarningOnce implements Supplier<Attribute<TraceContext>> {

--- a/zipkin/src/main/java/com/linecorp/armeria/common/tracing/RequestContextCurrentTraceContext.java
+++ b/zipkin/src/main/java/com/linecorp/armeria/common/tracing/RequestContextCurrentTraceContext.java
@@ -50,7 +50,7 @@ public final class RequestContextCurrentTraceContext extends CurrentTraceContext
      * Use this singleton when building a {@link brave.Tracing} instance for use with
      * {@link HttpTracingService} or {@link HttpTracingClient}.
      *
-     * <p>If you need to customize the context, use {@linkplain #newBuilder()} instead.
+     * <p>If you need to customize the context, use {@link #newBuilder()} instead.
      *
      * @see brave.Tracing.Builder#currentTraceContext(brave.propagation.CurrentTraceContext)
      */
@@ -62,7 +62,7 @@ public final class RequestContextCurrentTraceContext extends CurrentTraceContext
      * @deprecated Please use {@link #DEFAULT} or {@link #newBuilder()} to customize an instance.
      */
     @Deprecated
-    public static final CurrentTraceContext INSTANCE = new RequestContextCurrentTraceContext(new Builder());
+    public static final CurrentTraceContext INSTANCE = DEFAULT;
 
     private static final Logger logger = LoggerFactory.getLogger(RequestContextCurrentTraceContext.class);
     private static final AttributeKey<TraceContext> TRACE_CONTEXT_KEY =

--- a/zipkin/src/test/java/com/linecorp/armeria/client/tracing/HttpTracingClientTest.java
+++ b/zipkin/src/test/java/com/linecorp/armeria/client/tracing/HttpTracingClientTest.java
@@ -81,7 +81,7 @@ public class HttpTracingClientTest {
     @Test
     public void newDecorator_shouldWorkWhenRequestContextCurrentTraceContextConfigured() {
         HttpTracingClient.newDecorator(
-                Tracing.newBuilder().currentTraceContext(RequestContextCurrentTraceContext.INSTANCE).build());
+                Tracing.newBuilder().currentTraceContext(RequestContextCurrentTraceContext.DEFAULT).build());
     }
 
     @Test(timeout = 20000)

--- a/zipkin/src/test/java/com/linecorp/armeria/common/tracing/RequestContextCurrentTraceContextTest.java
+++ b/zipkin/src/test/java/com/linecorp/armeria/common/tracing/RequestContextCurrentTraceContextTest.java
@@ -51,7 +51,7 @@ public class RequestContextCurrentTraceContextTest {
     @Mock(answer = Answers.CALLS_REAL_METHODS)
     RequestContext mockRequestContext2;
 
-    final CurrentTraceContext currentTraceContext = RequestContextCurrentTraceContext.INSTANCE;
+    final CurrentTraceContext currentTraceContext = RequestContextCurrentTraceContext.DEFAULT;
     final DefaultAttributeMap attrs1 = new DefaultAttributeMap();
     final DefaultAttributeMap attrs2 = new DefaultAttributeMap();
     final TraceContext traceContext = TraceContext.newBuilder().traceId(1).spanId(1).build();

--- a/zipkin/src/test/java/com/linecorp/armeria/it/tracing/HttpTracingIntegrationTest.java
+++ b/zipkin/src/test/java/com/linecorp/armeria/it/tracing/HttpTracingIntegrationTest.java
@@ -67,6 +67,8 @@ import com.linecorp.armeria.testing.server.ServerRule;
 
 import brave.ScopedSpan;
 import brave.Tracing;
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.StrictScopeDecorator;
 import brave.sampler.Sampler;
 import zipkin2.Span;
 import zipkin2.reporter.Reporter;
@@ -196,8 +198,12 @@ public class HttpTracingIntegrationTest {
     }
 
     private static Tracing newTracing(String name) {
+        final CurrentTraceContext currentTraceContext =
+                RequestContextCurrentTraceContext.newBuilder()
+                                                 .addScopeDecorator(StrictScopeDecorator.create())
+                                                 .build();
         return Tracing.newBuilder()
-                      .currentTraceContext(RequestContextCurrentTraceContext.INSTANCE)
+                      .currentTraceContext(currentTraceContext)
                       .localServiceName(name)
                       .spanReporter(spanReporter)
                       .sampler(Sampler.ALWAYS_SAMPLE)

--- a/zipkin/src/test/java/com/linecorp/armeria/server/tracing/HttpTracingServiceTest.java
+++ b/zipkin/src/test/java/com/linecorp/armeria/server/tracing/HttpTracingServiceTest.java
@@ -77,7 +77,7 @@ public class HttpTracingServiceTest {
     @Test
     public void newDecorator_shouldWorkWhenRequestContextCurrentTraceContextConfigured() {
         HttpTracingService.newDecorator(
-                Tracing.newBuilder().currentTraceContext(RequestContextCurrentTraceContext.INSTANCE).build());
+                Tracing.newBuilder().currentTraceContext(RequestContextCurrentTraceContext.DEFAULT).build());
     }
 
     @Test(timeout = 20000)


### PR DESCRIPTION
This allows us to do things now that we are using a custom thread local.

See https://github.com/openzipkin/brave/pull/683