### PR TITLE
More strict path validation

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/PathAndQuery.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/PathAndQuery.java
@@ -16,8 +16,10 @@
 
 package com.linecorp.armeria.internal;
 
+import static io.netty.util.internal.StringUtil.decodeHexNibble;
 import static java.util.Objects.requireNonNull;
 
+import java.util.BitSet;
 import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -28,7 +30,6 @@ import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Strings;
 
 import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.metric.MeterIdPrefix;
@@ -51,7 +52,15 @@ public final class PathAndQuery {
     private static final Pattern PROHIBITED_PATH_PATTERN =
             Pattern.compile("^/[^/]*:[^/]*/|[|<>\\\\]|/\\.\\.|\\.\\.$|\\.\\./");
 
-    private static final Pattern CONSECUTIVE_SLASHES_PATTERN = Pattern.compile("/{2,}");
+    private static final BitSet ALLOWED_CHARS = new BitSet();
+
+    static {
+        final String allowedChars =
+                "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~:/?#[]@!$&'()*+,;=";
+        for (int i = 0; i < allowedChars.length(); i++) {
+            ALLOWED_CHARS.set(allowedChars.charAt(i));
+        }
+    }
 
     @Nullable
     private static final Cache<String, PathAndQuery> CACHE =
@@ -95,8 +104,8 @@ public final class PathAndQuery {
      *         {@link String} is not an absolute path or invalid.
      */
     @Nullable
-    public static PathAndQuery parse(String rawPath) {
-        if (CACHE != null) {
+    public static PathAndQuery parse(@Nullable String rawPath) {
+        if (CACHE != null && rawPath != null) {
             final PathAndQuery parsed = CACHE.getIfPresent(rawPath);
             if (parsed != null) {
                 return parsed;
@@ -109,8 +118,8 @@ public final class PathAndQuery {
      * Stores this {@link PathAndQuery} into cache for the given raw path. This should be used by callers when
      * the parsed result was valid (e.g., when a server is able to successfully handle the parsed path).
      */
-    public void storeInCache(String rawPath) {
-        if (CACHE != null) {
+    public void storeInCache(@Nullable String rawPath) {
+        if (CACHE != null && rawPath != null) {
             CACHE.put(rawPath, this);
         }
     }
@@ -162,34 +171,35 @@ public final class PathAndQuery {
     }
 
     @Nullable
-    private static PathAndQuery splitPathAndQuery(final String pathAndQuery) {
-        final String path;
-        final String query;
+    private static PathAndQuery splitPathAndQuery(@Nullable final String pathAndQuery) {
+        final CharSequence path;
+        final CharSequence query;
 
-        if (Strings.isNullOrEmpty(pathAndQuery)) {
-            // e.g. http://example.com
-            path = "/";
-            query = null;
-        } else if (pathAndQuery.charAt(0) != '/') {
-            // Do not accept a relative path.
-            return null;
-        } else {
-            // Split by the first '?'.
-            final int queryPos = pathAndQuery.indexOf('?');
-            if (queryPos >= 0) {
-                path = pathAndQuery.substring(0, queryPos);
-                query = pathAndQuery.substring(queryPos + 1);
-            } else {
-                path = pathAndQuery;
-                query = null;
-            }
+        if (pathAndQuery == null) {
+            return new PathAndQuery("/", null);
         }
 
-        // Make sure the path and the query are encoded correctly. i.e. Do not pass poorly encoded paths
-        // and queries to services. However, do not pass the decoded paths and queries to the services,
-        // so that users have more control over the encoding.
-        if (!isValidEncoding(path) ||
-            !isValidEncoding(query)) {
+        // Split by the first '?'.
+        final int queryPos = pathAndQuery.indexOf('?');
+        if (queryPos >= 0) {
+            if ((path = decodePercentsAndEncodeToUtf8(
+                    pathAndQuery, 0, queryPos, true)) == null) {
+                return null;
+            }
+            if ((query = decodePercentsAndEncodeToUtf8(
+                    pathAndQuery, queryPos + 1, pathAndQuery.length(), false)) == null) {
+                return null;
+            }
+        } else {
+            if ((path = decodePercentsAndEncodeToUtf8(
+                    pathAndQuery, 0, pathAndQuery.length(), true)) == null) {
+                return null;
+            }
+            query = null;
+        }
+
+        if (path.charAt(0) != '/') {
+            // Do not accept a relative path.
             return null;
         }
 
@@ -198,34 +208,102 @@ public final class PathAndQuery {
             return null;
         }
 
-        // Work around the case where a client sends a path such as '/path//with///consecutive////slashes'.
-        return new PathAndQuery(CONSECUTIVE_SLASHES_PATTERN.matcher(path).replaceAll("/"), query);
+        return new PathAndQuery(encodeToPercents(path, true),
+                                query != null ? encodeToPercents(query, false) : null);
     }
 
-    @SuppressWarnings("DuplicateBooleanBranch")
-    private static boolean isValidEncoding(@Nullable String value) {
-        if (value == null) {
-            return true;
+    @Nullable
+    private static CharSequence decodePercentsAndEncodeToUtf8(String value, int start, int end,
+                                                              boolean isPath) {
+        final int length = end - start;
+        if (length == 0) {
+            return isPath ? "/" : "";
         }
 
-        final int length = value.length();
-        for (int i = 0; i < length; i++) {
-            final char ch = value.charAt(i);
-            if (ch != '%') {
+        final StringBuilder buf = new StringBuilder(length * 3 / 2);
+        int lastCP = 0;
+        for (final CodePointIterator i = new CodePointIterator(value, start, end); i.hasNextCodePoint();) {
+            final int pos = i.position();
+            final int cp = i.nextCodePoint();
+
+            if (cp == '%') {
+                final int hexEnd = pos + 3;
+                if (hexEnd > end) {
+                    // '%' or '%x' (must be followed by two hexadigits)
+                    return null;
+                }
+
+                final char digit1 = value.charAt(pos + 1);
+                final char digit2 = value.charAt(pos + 2);
+                if (!isHexadigit(digit1) || !isHexadigit(digit2)) {
+                    // The first or second digit is not hexadecimal.
+                    return null;
+                }
+
+                final int decoded = (decodeHexNibble(digit1) << 4) | decodeHexNibble(digit2);
+                if (!appendOneByte(buf, decoded, lastCP, isPath)) {
+                    return null;
+                }
+                i.position(hexEnd);
+                lastCP = decoded;
                 continue;
             }
 
-            final int end = i + 3;
-            if (end > length) {
-                // '%' or '%x' (must be followed by two hexadigits)
-                return false;
+            if (cp <= 0x7F) {
+                if (!appendOneByte(buf, cp, lastCP, isPath)) {
+                    return null;
+                }
+            } else if (cp <= 0x7ff) {
+                buf.append((char) ((cp >>> 6) | 0b110_00000));
+                buf.append((char) (cp & 0b111111 | 0b10_000000));
+            } else if (cp <= 0xffff) {
+                buf.append((char) ((cp >>> 12) | 0b1110_0000));
+                buf.append((char) (((cp >>> 6) & 0b111111) | 0b10_000000));
+                buf.append((char) ((cp & 0b111111) | 0b10_000000));
+            } else if (cp <= 0x1fffff) {
+                buf.append((char) ((cp >>> 18) | 0b11110_000));
+                buf.append((char) (((cp >>> 12) & 0b111111) | 0b10_000000));
+                buf.append((char) (((cp >>> 6) & 0b111111) | 0b10_000000));
+                buf.append((char) ((cp & 0b111111) | 0b10_000000));
+            } else if (cp <= 0x3ffffff) {
+                // A valid unicode character will never reach here, but for completeness.
+                // http://unicode.org/mail-arch/unicode-ml/Archives-Old/UML018/0330.html
+                buf.append((char) ((cp >>> 24) | 0b111110_00));
+                buf.append((char) (((cp >>> 18) & 0b111111) | 0b10_000000));
+                buf.append((char) (((cp >>> 12) & 0b111111) | 0b10_000000));
+                buf.append((char) (((cp >>> 6) & 0b111111) | 0b10_000000));
+                buf.append((char) ((cp & 0b111111) | 0b10_000000));
+            } else {
+                // A valid unicode character will never reach here, but for completeness.
+                // http://unicode.org/mail-arch/unicode-ml/Archives-Old/UML018/0330.html
+                buf.append((char) ((cp >>> 30) | 0b1111110_0));
+                buf.append((char) (((cp >>> 24) & 0b111111) | 0b10_000000));
+                buf.append((char) (((cp >>> 18) & 0b111111) | 0b10_000000));
+                buf.append((char) (((cp >>> 12) & 0b111111) | 0b10_000000));
+                buf.append((char) (((cp >>> 6) & 0b111111) | 0b10_000000));
+                buf.append((char) ((cp & 0b111111) | 0b10_000000));
             }
 
-            if (!isHexadigit(value.charAt(++i)) ||
-                !isHexadigit(value.charAt(++i))) {
-                // The first or second digit is not hexadecimal.
-                return false;
+            lastCP = cp;
+        }
+
+        return buf;
+    }
+
+    private static boolean appendOneByte(StringBuilder buf, int cp, int lastCP, boolean isPath) {
+        if (cp == 0x7F || (cp >>> 5 == 0)) {
+            // Reject the prohibited control characters: 0x00..0x1F and 0x7F
+            return false;
+        }
+
+        if (cp == '/' && isPath) {
+            if (lastCP != '/') {
+                buf.append('/');
+            } else {
+                // Remove the consecutive slashes: '/path//with///consecutive////slashes'.
             }
+        } else {
+            buf.append((char) cp);
         }
 
         return true;
@@ -235,5 +313,88 @@ public final class PathAndQuery {
         return ch >= '0' && ch <= '9' ||
                ch >= 'a' && ch <= 'f' ||
                ch >= 'A' && ch <= 'F';
+    }
+
+    private static String encodeToPercents(CharSequence value, boolean isPath) {
+        final int length = value.length();
+        boolean needsEncoding = false;
+        for (int i = 0; i < length; i++) {
+            if (!ALLOWED_CHARS.get(value.charAt(i))) {
+                needsEncoding = true;
+                break;
+            }
+        }
+
+        if (!needsEncoding) {
+            return value.toString();
+        }
+
+        final StringBuilder buf = new StringBuilder(length);
+        for (int i = 0; i < length; i++) {
+            final char b = value.charAt(i);
+            assert (b & 0xFF00) == 0; // decodePercentsAndEncodeToUtf8() makes this assertion true.
+            if (ALLOWED_CHARS.get(b)) {
+                buf.append(b);
+            } else if (b == ' ') {
+                if (isPath) {
+                    buf.append("%20");
+                } else {
+                    buf.append('+');
+                }
+            } else {
+                buf.append('%');
+                appendHexNibble(buf, b >>> 4);
+                appendHexNibble(buf, b & 0xF);
+            }
+        }
+
+        return buf.toString();
+    }
+
+    private static void appendHexNibble(StringBuilder buf, int nibble) {
+        if (nibble < 10) {
+            buf.append((char) ('0' + nibble));
+        } else {
+            buf.append((char) ('A' + nibble - 10));
+        }
+    }
+
+    private static final class CodePointIterator {
+        private final CharSequence str;
+        private final int end;
+        private int pos;
+
+        CodePointIterator(CharSequence str, int start, int end) {
+            this.str = str;
+            this.end = end;
+            pos = start;
+        }
+
+        int position() {
+            return pos;
+        }
+
+        void position(int pos) {
+            this.pos = pos;
+        }
+
+        boolean hasNextCodePoint() {
+            return pos < end;
+        }
+
+        int nextCodePoint() {
+            assert pos < end;
+
+            final char c1 = str.charAt(pos++);
+            if (Character.isHighSurrogate(c1) && pos < end) {
+                final char c2 = str.charAt(pos);
+                if (Character.isLowSurrogate(c2)) {
+                    pos++;
+                    return Character.toCodePoint(c1, c2);
+                }
+            }
+
+            return c1;
+        }
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/internal/PathAndQueryTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/PathAndQueryTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+import com.google.common.base.Ascii;
+
+public class PathAndQueryTest {
+    @Test
+    public void empty() {
+        final PathAndQuery res = PathAndQuery.parse(null);
+        assertThat(res).isNotNull();
+        assertThat(res.path()).isEqualTo("/");
+        assertThat(res.query()).isNull();
+
+        final PathAndQuery res2 = PathAndQuery.parse("");
+        assertThat(res2).isNotNull();
+        assertThat(res2.path()).isEqualTo("/");
+        assertThat(res2.query()).isNull();
+
+        final PathAndQuery res3 = PathAndQuery.parse("?");
+        assertThat(res3).isNotNull();
+        assertThat(res3.path()).isEqualTo("/");
+        assertThat(res3.query()).isEqualTo("");
+    }
+
+    @Test
+    public void relative() {
+        assertThat(PathAndQuery.parse("foo")).isNull();
+    }
+
+    @Test
+    public void doubleDots() {
+        assertThat(PathAndQuery.parse("/..")).isNull();
+        assertThat(PathAndQuery.parse("/../")).isNull();
+        assertThat(PathAndQuery.parse("/../foo")).isNull();
+        assertThat(PathAndQuery.parse("/foo/..")).isNull();
+        assertThat(PathAndQuery.parse("/foo/../")).isNull();
+        assertThat(PathAndQuery.parse("/foo/../bar")).isNull();
+
+        // Escaped
+        assertThat(PathAndQuery.parse("/.%2e")).isNull();
+        assertThat(PathAndQuery.parse("/%2E./")).isNull();
+        assertThat(PathAndQuery.parse("/foo/.%2e")).isNull();
+        assertThat(PathAndQuery.parse("/foo/%2E./")).isNull();
+    }
+
+    @Test
+    public void hexadecimal() {
+        assertThat(PathAndQuery.parse("/%")).isNull();
+        assertThat(PathAndQuery.parse("/%0")).isNull();
+        assertThat(PathAndQuery.parse("/%0X")).isNull();
+        assertThat(PathAndQuery.parse("/%X0")).isNull();
+    }
+
+    @Test
+    public void controlChars() {
+        assertThat(PathAndQuery.parse("/\0")).isNull();
+        assertThat(PathAndQuery.parse("/a\nb")).isNull();
+        assertThat(PathAndQuery.parse("/a\u007fb")).isNull();
+
+        // Escaped
+        assertThat(PathAndQuery.parse("/%00")).isNull();
+        assertThat(PathAndQuery.parse("/a%0db")).isNull();
+        assertThat(PathAndQuery.parse("/a%7fb")).isNull();
+
+        // With query string
+        assertThat(PathAndQuery.parse("/\0?c")).isNull();
+        assertThat(PathAndQuery.parse("/a\nb?c")).isNull();
+        assertThat(PathAndQuery.parse("/a\u007fb?c")).isNull();
+
+        // With query string with control chars
+        assertThat(PathAndQuery.parse("/?\0")).isNull();
+        assertThat(PathAndQuery.parse("/?a\nb")).isNull();
+        assertThat(PathAndQuery.parse("/?a\u007fb")).isNull();
+    }
+
+    @Test
+    public void percent() {
+        final PathAndQuery res = PathAndQuery.parse("/%25");
+        assertThat(res).isNotNull();
+        assertThat(res.path()).isEqualTo("/%25");
+        assertThat(res.query()).isNull();
+    }
+
+    @Test
+    public void slash() {
+        final PathAndQuery res = PathAndQuery.parse("%2F?%2F");
+        assertThat(res).isNotNull();
+        assertThat(res.path()).isEqualTo("/");
+        assertThat(res.query()).isEqualTo("/");
+    }
+
+    @Test
+    public void consecutiveSlashes() {
+        final PathAndQuery res = PathAndQuery.parse(
+                "/path//with///consecutive////slashes?/query//with///consecutive////slashes");
+        assertThat(res).isNotNull();
+        assertThat(res.path()).isEqualTo("/path/with/consecutive/slashes");
+        assertThat(res.query()).isEqualTo("/query//with///consecutive////slashes");
+
+        // Encoded slashes
+        final PathAndQuery res2 = PathAndQuery.parse(
+                "/path%2F/with/%2F/consecutive//%2F%2Fslashes?/query%2F/with/%2F/consecutive//%2F%2Fslashes");
+        assertThat(res2).isNotNull();
+        assertThat(res2.path()).isEqualTo("/path/with/consecutive/slashes");
+        assertThat(res2.query()).isEqualTo("/query//with///consecutive////slashes");
+    }
+
+    @Test
+    public void rawUnicode() {
+        // 2- and 3-byte UTF-8
+        final PathAndQuery res1 = PathAndQuery.parse("/\u00A2?\u20AC"); // ¢ and €
+        assertThat(res1).isNotNull();
+        assertThat(res1.path()).isEqualTo("/%C2%A2");
+        assertThat(res1.query()).isEqualTo("%E2%82%AC");
+
+        // 4-byte UTF-8
+        final PathAndQuery res2 = PathAndQuery.parse("/\uD800\uDF48"); // 𐍈
+        assertThat(res2).isNotNull();
+        assertThat(res2.path()).isEqualTo("/%F0%90%8D%88");
+        assertThat(res2.query()).isNull();
+
+        // 5- and 6-byte forms are only theoretically possible, so we won't test them here.
+    }
+
+    @Test
+    public void encodedUnicode() {
+        final String encodedPath = "/%ec%95%88";
+        final String encodedQuery = "%eb%85%95";
+        final PathAndQuery res = PathAndQuery.parse(encodedPath + '?' + encodedQuery);
+        assertThat(res).isNotNull();
+        assertThat(res.path()).isEqualTo(Ascii.toUpperCase(encodedPath));
+        assertThat(res.query()).isEqualTo(Ascii.toUpperCase(encodedQuery));
+    }
+
+    @Test
+    public void noEncoding() {
+        final PathAndQuery res = PathAndQuery.parse("/a?b=c");
+        assertThat(res).isNotNull();
+        assertThat(res.path()).isEqualTo("/a");
+        assertThat(res.query()).isEqualTo("b=c");
+    }
+
+    @Test
+    public void space() {
+        final PathAndQuery res = PathAndQuery.parse("/ ? ");
+        assertThat(res).isNotNull();
+        assertThat(res.path()).isEqualTo("/%20");
+        assertThat(res.query()).isEqualTo("+");
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/internal/PathAndQueryTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/PathAndQueryTest.java
@@ -124,6 +124,14 @@ public class PathAndQueryTest {
     }
 
     @Test
+    public void colon() {
+        assertThat(PathAndQuery.parse("/:")).isNull();
+        assertThat(PathAndQuery.parse("/:/")).isNull();
+        assertThat(PathAndQuery.parse("/a/:")).isNotNull();
+        assertThat(PathAndQuery.parse("/a/:/")).isNotNull();
+    }
+
+    @Test
     public void rawUnicode() {
         // 2- and 3-byte UTF-8
         final PathAndQuery res1 = PathAndQuery.parse("/\u00A2?\u20AC"); // ¢ and €

--- a/core/src/test/java/com/linecorp/armeria/internal/PathAndQueryTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/PathAndQueryTest.java
@@ -59,6 +59,14 @@ public class PathAndQueryTest {
         assertThat(PathAndQuery.parse("/%2E./")).isNull();
         assertThat(PathAndQuery.parse("/foo/.%2e")).isNull();
         assertThat(PathAndQuery.parse("/foo/%2E./")).isNull();
+
+        // Not the double dots we are looking for.
+        final PathAndQuery res = PathAndQuery.parse("/..a");
+        assertThat(res).isNotNull();
+        assertThat(res.path()).isEqualTo("/..a");
+        final PathAndQuery res2 = PathAndQuery.parse("/a..");
+        assertThat(res2).isNotNull();
+        assertThat(res2.path()).isEqualTo("/a..");
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/internal/PathAndQueryTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/PathAndQueryTest.java
@@ -164,5 +164,23 @@ public class PathAndQueryTest {
         assertThat(res).isNotNull();
         assertThat(res.path()).isEqualTo("/%20");
         assertThat(res.query()).isEqualTo("+");
+
+        final PathAndQuery res2 = PathAndQuery.parse("/%20?%20");
+        assertThat(res2).isNotNull();
+        assertThat(res2.path()).isEqualTo("/%20");
+        assertThat(res2.query()).isEqualTo("+");
+    }
+
+    @Test
+    public void plus() {
+        final PathAndQuery res = PathAndQuery.parse("/+?+");
+        assertThat(res).isNotNull();
+        assertThat(res.path()).isEqualTo("/+");
+        assertThat(res.query()).isEqualTo("+");
+
+        final PathAndQuery res2 = PathAndQuery.parse("/%2b?%2b");
+        assertThat(res2).isNotNull();
+        assertThat(res2.path()).isEqualTo("/+");
+        assertThat(res2.query()).isEqualTo("%2B");
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerPathTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerPathTest.java
@@ -83,6 +83,11 @@ public class HttpServerPathTest {
         // Should allow the asterisk character in the path
         TEST_URLS.put("/service/foo*bar4", HttpStatus.OK);
 
+        // OK as long as double dots are not used as a 'parent directory'
+        TEST_URLS.put("/..service/foobar1", HttpStatus.OK);
+        TEST_URLS.put("/service../foobar2", HttpStatus.OK);
+        TEST_URLS.put("/service/foobar3..", HttpStatus.OK);
+
         // 400 test
         TEST_URLS.put("..", HttpStatus.BAD_REQUEST);
         TEST_URLS.put(".\\", HttpStatus.BAD_REQUEST);
@@ -94,9 +99,6 @@ public class HttpServerPathTest {
         TEST_URLS.put("/service/foo<bar", HttpStatus.BAD_REQUEST);
 
         // 404 test
-        TEST_URLS.put("/..service/foobar1", HttpStatus.NOT_FOUND);
-        TEST_URLS.put("/service../foobar2", HttpStatus.NOT_FOUND);
-        TEST_URLS.put("/service/foobar3..", HttpStatus.NOT_FOUND);
         TEST_URLS.put("/gwturl#user:45/comments", HttpStatus.NOT_FOUND);
         TEST_URLS.put("/service:name/hello", HttpStatus.NOT_FOUND);
         TEST_URLS.put("/service::::name/hello", HttpStatus.NOT_FOUND);

--- a/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/ArmeriaCallFactoryTest.java
+++ b/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/ArmeriaCallFactoryTest.java
@@ -516,8 +516,9 @@ public class ArmeriaCallFactoryTest {
     public void customPath() throws Exception {
         assertThat(service.customPath("Foo", 23).get()).isEqualTo(new Pojo("Foo", 23));
         assertThat(service.customPath("Foo+Bar", 24).get()).isEqualTo(new Pojo("Foo+Bar", 24));
-        assertThat(service.customPath("Foo+Bar/Hoge", 24).get()).isEqualTo(new Pojo("Foo+Bar%2FHoge", 24));
-        assertThat(service.customPath("Foo%2BBar", 24).get()).isEqualTo(new Pojo("Foo%252BBar", 24));
+        assertThat(service.customPath("Foo+Bar/Hoge", 24).get()).isEqualTo(new Pojo("Foo+Bar/Hoge", 24));
+        assertThat(service.customPath("Foo+Bar%2fHoge", 24).get()).isEqualTo(new Pojo("Foo+Bar%252fHoge", 24));
+        assertThat(service.customPath("Foo%2bBar", 24).get()).isEqualTo(new Pojo("Foo%252bBar", 24));
     }
 
     @Test


### PR DESCRIPTION
Motivation:

- A user can send a request to an invalid URL using HttpClient:

  ```java
  HttpClient.newClient(...).get("/a\nb");
  ```

- A server accepts a path that contains control characters.
- A server does not filter out the paths with double dots when they are
  encoded, e.g. `/%2e%2e/%2e%2e/secret.txt`

Modifications:

- Reject control characters
- Decode percent-encoded characters before complex validation
- Encode a raw Unicode string to UTF-8
- Various optimizations
  - Slash deduplication while decoding
  - Percent encoding validation while decoding
- Add test cases

Result:

- Fixes #1323
- A user cannot send an invalid request with Armeria.
- Armeria filters out more potentially malicious requests.