### PR TITLE
Update dependencies

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/MediaType.java
+++ b/core/src/main/java/com/linecorp/armeria/common/MediaType.java
@@ -92,7 +92,7 @@ import com.google.common.collect.Multimaps;
 @JsonDeserialize(using = MediaTypeJsonDeserializer.class)
 public final class MediaType {
 
-    // Forked from Guava at abd0906f6ed288671b75aa6f828a6ba904fe4477 (24.0)
+    // Forked from Guava at 59ca61a255620bf7e5f55f991c74e8b61e99d765 (26.0)
 
     private static final String CHARSET_ATTRIBUTE = "charset";
     private static final ImmutableListMultimap<String, String> UTF_8_CONSTANT_PARAMETERS =
@@ -106,6 +106,7 @@ public final class MediaType {
                     .and(CharMatcher.noneOf("()<>@,;:\\\"/[]?="));
 
     private static final CharMatcher QUOTED_TEXT_MATCHER = ascii().and(CharMatcher.noneOf("\"\\\r"));
+
     /*
      * This matches the same characters as linear-white-space from RFC 822, but we make no effort to
      * enforce any particular rules with regards to line folding as stated in the class docs.
@@ -167,6 +168,7 @@ public final class MediaType {
     public static final MediaType HTML_UTF_8 = createConstantUtf8(TEXT_TYPE, "html");
     public static final MediaType I_CALENDAR_UTF_8 = createConstantUtf8(TEXT_TYPE, "calendar");
     public static final MediaType PLAIN_TEXT_UTF_8 = createConstantUtf8(TEXT_TYPE, "plain");
+
     /**
      * <a href="http://www.rfc-editor.org/rfc/rfc4329.txt">RFC 4329</a> declares {@link
      * #JAVASCRIPT_UTF_8 application/javascript} to be the correct media type for JavaScript, but this
@@ -181,12 +183,14 @@ public final class MediaType {
 
     public static final MediaType VCARD_UTF_8 = createConstantUtf8(TEXT_TYPE, "vcard");
     public static final MediaType WML_UTF_8 = createConstantUtf8(TEXT_TYPE, "vnd.wap.wml");
+
     /**
      * As described in <a href="http://www.ietf.org/rfc/rfc3023.txt">RFC 3023</a>, this constant
      * ({@code text/xml}) is used for XML documents that are "readable by casual users." {@link
      * #APPLICATION_XML_UTF_8} is provided for documents that are intended for applications.
      */
     public static final MediaType XML_UTF_8 = createConstantUtf8(TEXT_TYPE, "xml");
+
     /**
      * As described in <a href="https://w3c.github.io/webvtt/#iana-text-vtt">the VTT spec</a>, this is
      * used for Web Video Text Tracks (WebVTT) files, used with the HTML5 track element.
@@ -195,6 +199,7 @@ public final class MediaType {
 
     /* image types */
     public static final MediaType BMP = createConstant(IMAGE_TYPE, "bmp");
+
     /**
      * The media type for the <a href="http://en.wikipedia.org/wiki/Camera_Image_File_Format">Canon
      * Image File Format</a> ({@code crw} files), a widely-used "raw image" format for cameras. It is
@@ -208,6 +213,7 @@ public final class MediaType {
     public static final MediaType ICO = createConstant(IMAGE_TYPE, "vnd.microsoft.icon");
     public static final MediaType JPEG = createConstant(IMAGE_TYPE, "jpeg");
     public static final MediaType PNG = createConstant(IMAGE_TYPE, "png");
+
     /**
      * The media type for the Photoshop File Format ({@code psd} files) as defined by <a
      * href="http://www.iana.org/assignments/media-types/image/vnd.adobe.photoshop">IANA</a>, and
@@ -234,6 +240,12 @@ public final class MediaType {
     public static final MediaType MPEG_AUDIO = createConstant(AUDIO_TYPE, "mpeg");
     public static final MediaType OGG_AUDIO = createConstant(AUDIO_TYPE, "ogg");
     public static final MediaType WEBM_AUDIO = createConstant(AUDIO_TYPE, "webm");
+
+    /**
+     * Media type for L16 audio, as defined by <a href="https://tools.ietf.org/html/rfc2586">RFC
+     * 2586</a>.
+     */
+    public static final MediaType L16_AUDIO = createConstant(AUDIO_TYPE, "l16");
 
     /**
      * Media type for L24 audio, as defined by <a href="https://tools.ietf.org/html/rfc3190">RFC
@@ -343,6 +355,7 @@ public final class MediaType {
      * </a> with the IANA.
      */
     public static final MediaType EOT = createConstant(APPLICATION_TYPE, "vnd.ms-fontobject");
+
     /**
      * As described in the <a href="http://idpf.org/epub">International Digital Publishing Forum</a>
      * EPUB is the distribution and interchange format standard for digital publications and
@@ -354,12 +367,14 @@ public final class MediaType {
 
     public static final MediaType FORM_DATA =
             createConstant(APPLICATION_TYPE, "x-www-form-urlencoded");
+
     /**
      * As described in <a href="https://www.rsa.com/rsalabs/node.asp?id=2138">PKCS #12: Personal
      * Information Exchange Syntax Standard</a>, PKCS #12 defines an archive file format for storing
      * many cryptography objects as a single file.
      */
     public static final MediaType KEY_ARCHIVE = createConstant(APPLICATION_TYPE, "pkcs12");
+
     /**
      * This is a non-standard media type, but is commonly used in serving hosted binary files as it is
      * <a href="http://code.google.com/p/browsersec/wiki/Part2#Survey_of_content_sniffing_behaviors">
@@ -371,6 +386,13 @@ public final class MediaType {
     public static final MediaType APPLICATION_BINARY = createConstant(APPLICATION_TYPE, "binary");
 
     public static final MediaType GZIP = createConstant(APPLICATION_TYPE, "x-gzip");
+
+    /**
+     * Media type for the <a href="https://tools.ietf.org/html/draft-kelly-json-hal-08#section-3">JSON
+     * Hypertext Application Language (HAL) documents</a>.
+     */
+    public static final MediaType HAL_JSON = createConstant(APPLICATION_TYPE, "hal+json");
+
     /**
      * <a href="http://www.rfc-editor.org/rfc/rfc4329.txt">RFC 4329</a> declares this to be the
      * correct media type for JavaScript, but {@link #TEXT_JAVASCRIPT_UTF_8 text/javascript} may be
@@ -381,12 +403,14 @@ public final class MediaType {
 
     public static final MediaType JSON_UTF_8 = createConstantUtf8(APPLICATION_TYPE, "json");
     public static final MediaType JSON = createConstant(APPLICATION_TYPE, "json");
+
     /**
      * As described in <a href="https://www.ietf.org/rfc/rfc6902.txt">RFC 6902</a>, this constant
      * ({@code application/json-patch+json}) is used for expressing a sequence of operations to apply
      * to a JavaScript Object Notation(JSON) document.
      */
     public static final MediaType JSON_PATCH = createConstant(APPLICATION_TYPE, "json-patch+json");
+
     /**
      * Media type for the <a href="http://www.w3.org/TR/appmanifest/">Manifest for a web
      * application</a>.

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -41,14 +41,14 @@ com.github.jengelman.gradle.plugins:
   shadow: { version: '2.0.3' }
 
 com.google.api:
-  gax-grpc: { version: '1.29.0' }
+  gax-grpc: { version: '1.30.0' }
 
 com.google.code.findbugs:
   jsr305: { version: '3.0.2' }
 
 com.google.guava:
   guava:
-    version: &GUAVA_VERSION '25.1-jre'
+    version: &GUAVA_VERSION '26.0-jre'
     exclusions:
     - com.google.errorprone:error_prone_annotations
     - com.google.j2objc:j2objc-annotations
@@ -161,7 +161,7 @@ io.prometheus:
 
 io.reactivex.rxjava2:
   rxjava:
-    version: '2.1.17'
+    version: '2.2.0'
     javadocs:
     - http://reactivex.io/RxJava/2.x/javadoc/
 
@@ -280,7 +280,7 @@ org.bouncycastle:
       to: com.linecorp.armeria.internal.shaded.bouncycastle
 
 org.checkerframework:
-  checker-compat-qual: { version: '2.5.3' }
+  checker-compat-qual: { version: '2.5.4' }
 
 org.curioswitch.curiostack:
   protobuf-jackson: { version: '0.2.1' }


### PR DESCRIPTION
- Guava 25.1 -> 26.0
  - Ported the changes in `MediaType`
- RxJava 2.1.17 -> 2.2.0
- Build time only
  - gax-grpc 1.29.0 -> 1.30.0
  - checker-compat-qual 2.5.3 -> 2.5.4