### PR TITLE
Generate config metadata for Spring

### DIFF
--- a/spring/boot-autoconfigure/build.gradle
+++ b/spring/boot-autoconfigure/build.gradle
@@ -10,6 +10,7 @@ dependencies {
     compile 'javax.validation:validation-api'
     compile 'org.springframework.boot:spring-boot-starter'
     compile 'org.springframework.boot:spring-boot-starter-actuator'
+    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
     testCompile 'org.springframework.boot:spring-boot-starter-test'
     testCompile 'org.hibernate.validator:hibernate-validator'

--- a/spring/boot1-autoconfigure/build.gradle
+++ b/spring/boot1-autoconfigure/build.gradle
@@ -10,6 +10,7 @@ dependencies {
     compile 'javax.inject:javax.inject'
     compile 'javax.validation:validation-api'
     compile 'org.springframework.boot:spring-boot-starter:1.5.15.RELEASE'
+    compileOnly 'org.springframework.boot:spring-boot-configuration-processor:1.5.15.RELEASE'
 
     testCompile 'org.springframework.boot:spring-boot-starter-test:1.5.15.RELEASE'
     testCompile 'org.hibernate.validator:hibernate-validator'


### PR DESCRIPTION
If metadata is generated, we can use code completion and code jump feature in IntelliJ.
I think that is helpful.

---

# As-Is

![](https://i.gyazo.com/0e450e5ef6243e56a2c6ce67776c36d8.png)

# To-Be

Unfortunately, the `ports` property defined with List doesn't seem to be complemented.

![](https://i.gyazo.com/c354200c5a19359f2531c5a2eded3a5b.png)

---

Official documentation of Spring Boot:
- [Spring 1.5.x](https://docs.spring.io/spring-boot/docs/1.5.15.RELEASE/reference/html/configuration-metadata.html#configuration-metadata-annotation-processor)
- [Spring 2.0.x](https://docs.spring.io/spring-boot/docs/2.0.4.RELEASE/reference/html/configuration-metadata.html#configuration-metadata-annotation-processor)