### PR TITLE
Add StartStopSupport

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -43,6 +43,7 @@ sourceSets {
 
 // Run HttpServerStreamingTest separately with memory constraint.
 tasks.test.exclude '**/HttpServerStreamingTest**'
+tasks.shadedTest.exclude '**/HttpServerStreamingTest**'
 task testStreaming(type: Test,
                    group: 'Verification',
                    description: 'Runs the streaming tests.') {

--- a/core/src/main/java/com/linecorp/armeria/common/util/StartStopSupport.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/StartStopSupport.java
@@ -1,0 +1,355 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common.util;
+
+import static com.spotify.futures.CompletableFutures.exceptionallyCompletedFuture;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.function.Function;
+
+import javax.annotation.Nullable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Provides asynchronous start-stop life cycle support.
+ *
+ * @param <V> the type of the startup result. Use {@link Void} if unused.
+ * @param <L> the type of the life cycle event listener. Use {@link Void} if unused.
+ */
+public abstract class StartStopSupport<V, L> implements AutoCloseable {
+
+    private static final Logger logger = LoggerFactory.getLogger(StartStopSupport.class);
+
+    enum State {
+        STARTING,
+        STARTED,
+        STOPPING,
+        STOPPED
+    }
+
+    private final Executor executor;
+    private final List<L> listeners = new CopyOnWriteArrayList<>();
+    private volatile State state = State.STOPPED;
+    /**
+     * The value is {@code V}-typed when STARTING/STARTED and {@link Void}-typed when STOPPING/STOPPED.
+     */
+    private CompletableFuture<?> future = completedFuture(null);
+
+    /**
+     * Creates a new instance.
+     *
+     * @param executor the {@link Executor} which will be used for invoking the extension points of this class:
+     *                 <ul>
+     *                   <li>{@link #doStart()}</li>
+     *                   <li>{@link #doStop()}</li>
+     *                   <li>{@link #rollbackFailed(Throwable)}</li>
+     *                   <li>{@link #notificationFailed(Object, Throwable)}</li>
+     *                   <li>All listener notifications</li>
+     *                 </ul>
+     *                 .. except {@link #closeFailed(Throwable)} which is invoked at the caller thread.
+     */
+    protected StartStopSupport(Executor executor) {
+        this.executor = requireNonNull(executor, "executor");
+    }
+
+    /**
+     * Adds the specified {@code listener}, so that it is notified when the state of this
+     * {@link StartStopSupport} changes.
+     */
+    public final void addListener(L listener) {
+        listeners.add(requireNonNull(listener, "listener"));
+    }
+
+    /**
+     * Removes the specified {@code listener}, so that it is not notified anymore.
+     */
+    public final boolean removeListener(L listener) {
+        return listeners.remove(requireNonNull(listener, "listener"));
+    }
+
+    /**
+     * Begins the startup procedure by calling {@link #doStart()}, ensuring that neither {@link #doStart()}
+     * nor {@link #doStop()} is invoked concurrently. When the startup fails, {@link #stop()} will be
+     * invoked automatically to roll back the side effect caused by {@link #start(boolean)} and any exceptions
+     * that occurred during the rollback will be reported to {@link #rollbackFailed(Throwable)}.
+     *
+     * @param failIfStarted whether to fail the returned {@link CompletableFuture} with
+     *                      an {@link IllegalStateException} when the startup procedure is already
+     *                      in progress or done
+     */
+    public final synchronized CompletableFuture<V> start(boolean failIfStarted) {
+        switch (state) {
+            case STARTING:
+            case STARTED:
+                if (failIfStarted) {
+                    return exceptionallyCompletedFuture(
+                            new IllegalStateException("must be stopped to start; currently " + state));
+                } else {
+                    @SuppressWarnings("unchecked")
+                    final CompletableFuture<V> castFuture = (CompletableFuture<V>) future;
+                    return castFuture;
+                }
+            case STOPPING:
+                // A user called start() to restart, but not stopped completely yet.
+                // Try again once stopped.
+                return future.exceptionally(unused -> null)
+                             .thenComposeAsync(unused -> start(failIfStarted), executor);
+        }
+
+        // Attempt to start.
+        final CompletableFuture<V> startFuture = new CompletableFuture<>();
+        try {
+            executor.execute(() -> {
+                try {
+                    assert state == State.STOPPED;
+                    enter(State.STARTING, null);
+                    final CompletionStage<V> f = doStart();
+                    if (f == null) {
+                        throw new IllegalStateException("doStart() returned null.");
+                    }
+
+                    f.whenComplete((result, cause) -> {
+                        if (cause != null) {
+                            startFuture.completeExceptionally(cause);
+                        } else {
+                            startFuture.complete(result);
+                        }
+                    });
+                } catch (Exception e) {
+                    startFuture.completeExceptionally(e);
+                }
+            });
+        } catch (Exception e) {
+            return exceptionallyCompletedFuture(e);
+        }
+
+        final CompletableFuture<V> future = startFuture.handleAsync((result, cause) -> {
+            if (cause != null) {
+                // Failed to start. Stop and complete with the start failure cause.
+                final CompletableFuture<Void> rollbackFuture = stop(true).exceptionally(stopCause -> {
+                    rollbackFailed(Exceptions.peel(stopCause));
+                    return null;
+                });
+
+                return rollbackFuture.<V>thenCompose(unused -> exceptionallyCompletedFuture(cause));
+            } else {
+                enter(State.STARTED, result);
+                return completedFuture(result);
+            }
+        }, executor).thenCompose(Function.identity());
+
+        this.future = future;
+        return future;
+    }
+
+    /**
+     * Begins the shutdown procedure by calling {@link #doStop()}, ensuring that neither {@link #doStart()} nor
+     * {@link #doStop()} is invoked concurrently.
+     */
+    public final CompletableFuture<Void> stop() {
+        return stop(false);
+    }
+
+    private synchronized CompletableFuture<Void> stop(boolean rollback) {
+        switch (state) {
+            case STARTING:
+                if (!rollback) {
+                    // Try again once started.
+                    return future.exceptionally(unused -> null) // Ignore the exception.
+                                 .thenComposeAsync(unused -> stop(), executor);
+                } else {
+                    break;
+                }
+            case STOPPING:
+            case STOPPED:
+                @SuppressWarnings("unchecked")
+                final CompletableFuture<Void> castFuture = (CompletableFuture<Void>) future;
+                return castFuture;
+        }
+
+        final CompletableFuture<Void> stopFuture = new CompletableFuture<>();
+        try {
+            executor.execute(() -> {
+                try {
+                    assert state == State.STARTED || rollback;
+                    enter(State.STOPPING, null);
+
+                    final CompletionStage<Void> f = doStop();
+                    if (f == null) {
+                        throw new IllegalStateException("doStop() returned null.");
+                    }
+
+                    f.whenComplete((unused, cause) -> {
+                        if (cause != null) {
+                            stopFuture.completeExceptionally(cause);
+                        } else {
+                            stopFuture.complete(null);
+                        }
+                    });
+                } catch (Exception e) {
+                    stopFuture.completeExceptionally(e);
+                }
+            });
+        } catch (Exception e) {
+            return exceptionallyCompletedFuture(e);
+        }
+
+        final CompletableFuture<Void> future = stopFuture.whenCompleteAsync(
+                (unused1, unused2) -> enter(State.STOPPED, null), executor);
+        this.future = future;
+        return future;
+    }
+
+    /**
+     * A synchronous version of {@link #stop()}. Exceptions occurred during shutdown are reported to
+     * {@link #closeFailed(Throwable)}.
+     */
+    @Override
+    public final void close() {
+        final CompletableFuture<Void> f;
+        synchronized (this) {
+            if (state == State.STOPPED) {
+                return;
+            }
+            f = stop();
+        }
+
+        boolean interrupted = false;
+        for (;;) {
+            try {
+                f.get();
+                break;
+            } catch (InterruptedException ignored) {
+                interrupted = true;
+            } catch (ExecutionException e) {
+                closeFailed(Exceptions.peel(e));
+                break;
+            }
+        }
+
+        if (interrupted) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private void enter(State state, @Nullable V value) {
+        synchronized (this) {
+            assert this.state != state : "transition to the same state: " + state;
+            this.state = state;
+        }
+
+        for (L l : listeners) {
+            try {
+                switch (state) {
+                    case STARTING:
+                        notifyStarting(l);
+                        break;
+                    case STARTED:
+                        notifyStarted(l, value);
+                        break;
+                    case STOPPING:
+                        notifyStopping(l);
+                        break;
+                    case STOPPED:
+                        notifyStopped(l);
+                        break;
+                    default:
+                        throw new Error("unknown state: " + state);
+                }
+            } catch (Exception cause) {
+                notificationFailed(l, cause);
+            }
+        }
+    }
+
+    /**
+     * Invoked by {@link #start(boolean)} to perform the actual startup.
+     */
+    protected abstract CompletionStage<V> doStart() throws Exception;
+
+    /**
+     * Invoked by {@link #stop()} to perform the actual startup, or indirectly by {@link #start(boolean)} when
+     * startup failed.
+     */
+    protected abstract CompletionStage<Void> doStop() throws Exception;
+
+    /**
+     * Invoked when the startup procedure begins.
+     *
+     * @param listener the listener
+     */
+    protected void notifyStarting(L listener) throws Exception {}
+
+    /**
+     * Invoked when the startup procedure is finished.
+     *
+     * @param listener the listener
+     */
+    protected void notifyStarted(L listener, @Nullable V value) throws Exception {}
+
+    /**
+     * Invoked when the shutdown procedure begins.
+     *
+     * @param listener the listener
+     */
+    protected void notifyStopping(L listener) throws Exception {}
+
+    /**
+     * Invoked when the shutdown procedure is finished.
+     *
+     * @param listener the listener
+     */
+    protected void notifyStopped(L listener) throws Exception {}
+
+    /**
+     * Invoked when failed to stop during the rollback after startup failure.
+     */
+    protected void rollbackFailed(Throwable cause) {
+        logStopFailure(cause);
+    }
+
+    /**
+     * Invoked when an event listener raises an exception.
+     */
+    protected void notificationFailed(L listener, Throwable cause) {
+        logger.warn("Failed to notify a listener: {}", listener, cause);
+    }
+
+    /**
+     * Invoked when failed to stop in {@link #close()}.
+     */
+    protected void closeFailed(Throwable cause) {
+        logStopFailure(cause);
+    }
+
+    private static void logStopFailure(Throwable cause) {
+        logger.warn("Failed to stop: {}", cause.getMessage(), cause);
+    }
+
+    @Override
+    public String toString() {
+        return state.name();
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/Server.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Server.java
@@ -16,7 +16,6 @@
 
 package com.linecorp.armeria.server;
 
-import static com.linecorp.armeria.common.util.Functions.voidFunction;
 import static java.util.Objects.requireNonNull;
 
 import java.net.InetSocketAddress;
@@ -26,9 +25,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
@@ -36,8 +34,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
@@ -52,8 +48,8 @@ import com.google.common.collect.ImmutableSet;
 
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.metric.MeterIdPrefix;
-import com.linecorp.armeria.common.util.CompletionActions;
 import com.linecorp.armeria.common.util.EventLoopGroups;
+import com.linecorp.armeria.common.util.StartStopSupport;
 import com.linecorp.armeria.internal.ChannelUtil;
 import com.linecorp.armeria.internal.ConnectionLimitingHandler;
 import com.linecorp.armeria.internal.PathAndQuery;
@@ -87,13 +83,11 @@ public final class Server implements AutoCloseable {
     @Nullable
     private final DomainNameMapping<SslContext> sslContexts;
 
-    private final StateManager stateManager = new StateManager();
+    private final StartStopSupport<Void, ServerListener> startStop = new ServerStartStopSupport();
     private final Set<Channel> serverChannels = Collections.newSetFromMap(new ConcurrentHashMap<>());
     private final Map<InetSocketAddress, ServerPort> activePorts = new ConcurrentHashMap<>();
     private final Map<InetSocketAddress, ServerPort> unmodifiableActivePorts =
             Collections.unmodifiableMap(activePorts);
-
-    private final List<ServerListener> listeners = new CopyOnWriteArrayList<>();
 
     private final ConnectionLimitingHandler connectionLimitingHandler;
 
@@ -200,7 +194,7 @@ public final class Server implements AutoCloseable {
      * }</pre>
      */
     public void addListener(ServerListener listener) {
-        listeners.add(requireNonNull(listener, "listener"));
+        startStop.addListener(requireNonNull(listener, "listener"));
     }
 
     /**
@@ -208,15 +202,7 @@ public final class Server implements AutoCloseable {
      * anymore when the state of this {@link Server} changes.
      */
     public boolean removeListener(ServerListener listener) {
-        return listeners.remove(requireNonNull(listener, "listener"));
-    }
-
-    private void setupServerMetrics() {
-        final MeterRegistry meterRegistry = config().meterRegistry();
-        meterRegistry.gauge("armeria.server.pendingResponses", gracefulShutdownSupport,
-                            GracefulShutdownSupport::pendingResponses);
-        meterRegistry.gauge("armeria.server.connections", connectionLimitingHandler,
-                            ConnectionLimitingHandler::numConnections);
+        return startStop.removeListener(requireNonNull(listener, "listener"));
     }
 
     /**
@@ -231,72 +217,7 @@ public final class Server implements AutoCloseable {
      * }</pre>
      */
     public CompletableFuture<Void> start() {
-        final CompletableFuture<Void> future = new CompletableFuture<>();
-        start(future);
-        return future;
-    }
-
-    private void start(CompletableFuture<Void> future) {
-        final State state = stateManager.state();
-        switch (state.type) {
-        case STOPPING:
-            // A user called start() to restart the server, but the server is not stopped completely.
-            // Try again after stopping.
-            state.future.handleAsync(voidFunction((ret, cause) -> start(future)),
-                                     GlobalEventExecutor.INSTANCE)
-                        .exceptionally(CompletionActions::log);
-            return;
-        }
-
-        if (!stateManager.enterStarting(future, this::stop0)) {
-            return;
-        }
-
-        try {
-            // Initialize the server sockets asynchronously.
-            final List<ServerPort> ports = config().ports();
-            final AtomicInteger remainingPorts = new AtomicInteger(ports.size());
-            if (config().gracefulShutdownQuietPeriod().isZero()) {
-                gracefulShutdownSupport = GracefulShutdownSupport.disabled();
-            } else {
-                gracefulShutdownSupport =
-                        GracefulShutdownSupport.create(config().gracefulShutdownQuietPeriod(),
-                                                       config().blockingTaskExecutor());
-            }
-
-            for (final ServerPort p: ports) {
-                start(p).addListener(new ServerPortStartListener(remainingPorts, future, p));
-            }
-        } catch (Throwable t) {
-            completeFutureExceptionally(future, t);
-        }
-        setupServerMetrics();
-    }
-
-    private ChannelFuture start(ServerPort port) {
-        final ServerBootstrap b = new ServerBootstrap();
-        serverBootstrap = b;
-        config.channelOptions().forEach((k, v) -> {
-            @SuppressWarnings("unchecked")
-            final ChannelOption<Object> castOption = (ChannelOption<Object>) k;
-            b.option(castOption, v);
-        });
-        config.childChannelOptions().forEach((k, v) -> {
-            @SuppressWarnings("unchecked")
-            final ChannelOption<Object> castOption = (ChannelOption<Object>) k;
-            b.childOption(castOption, v);
-        });
-
-        b.group(EventLoopGroups.newEventLoopGroup(1, r -> {
-            final FastThreadLocalThread thread = new FastThreadLocalThread(r, bossThreadName(port));
-            thread.setDaemon(false);
-            return thread;
-        }), config.workerGroup());
-        b.channel(TransportType.detectTransportType().serverChannelClass());
-        b.handler(connectionLimitingHandler);
-        b.childHandler(new HttpServerPipelineConfigurator(config, port, sslContexts, gracefulShutdownSupport));
-
-        return b.bind(port.localAddress());
+        return startStop.start(true);
     }
 
     /**
@@ -309,45 +230,7 @@ public final class Server implements AutoCloseable {
      * }</pre>
      */
     public CompletableFuture<Void> stop() {
-        final CompletableFuture<Void> future = new CompletableFuture<>();
-        stop(future);
-        // Make sure all channel services will be GC'd even if a user forgot to dereference a Server
-        serverBootstrap = null;
-        return future;
-    }
-
-    private void stop(CompletableFuture<Void> future) {
-        for (;;) {
-            final State state = stateManager.state();
-            switch (state.type) {
-            case STOPPED:
-                completeFuture(future);
-                return;
-            case STOPPING:
-                state.future.handle(voidFunction((ret, cause) -> {
-                    if (cause == null) {
-                        completeFuture(future);
-                    } else {
-                        completeFutureExceptionally(future, cause);
-                    }
-                })).exceptionally(CompletionActions::log);
-                return;
-            case STARTED:
-                if (!stateManager.enterStopping(state, future)) {
-                    // Someone else changed the state meanwhile; try again.
-                    continue;
-                }
-
-                stop0(future);
-                return;
-            case STARTING:
-                // Wait until the start process is finished, and then try again.
-                state.future.handleAsync(voidFunction((ret, cause) -> stop(future)),
-                                         GlobalEventExecutor.INSTANCE)
-                            .exceptionally(CompletionActions::log);
-                return;
-            }
-        }
+        return startStop.stop();
     }
 
     /**
@@ -360,118 +243,12 @@ public final class Server implements AutoCloseable {
         return config().workerGroup().next();
     }
 
-    private void stop0(CompletableFuture<Void> future) {
-        assert future != null;
-
-        final GracefulShutdownSupport gracefulShutdownSupport = this.gracefulShutdownSupport;
-        if (gracefulShutdownSupport.completedQuietPeriod()) {
-            stop1(future, null);
-            return;
-        }
-
-        // Create a single-use thread dedicated for monitoring graceful shutdown status.
-        final ScheduledExecutorService gracefulShutdownExecutor = Executors.newSingleThreadScheduledExecutor(
-                r -> new Thread(r, "armeria-shutdown-0x" + Integer.toHexString(hashCode())));
-
-        // Check every 100 ms for the server to have completed processing requests.
-        final ScheduledFuture<?> quietPeriodFuture = gracefulShutdownExecutor.scheduleAtFixedRate(() -> {
-            if (gracefulShutdownSupport.completedQuietPeriod()) {
-                stop1(future, gracefulShutdownExecutor);
-            }
-        }, 0, 100, TimeUnit.MILLISECONDS);
-
-        // Make sure the event loop stops after the timeout, regardless of what
-        // the GracefulShutdownSupport says.
-        try {
-            gracefulShutdownExecutor.schedule(() -> {
-                quietPeriodFuture.cancel(false);
-                stop1(future, gracefulShutdownExecutor);
-            }, config.gracefulShutdownTimeout().toMillis(), TimeUnit.MILLISECONDS);
-        } catch (RejectedExecutionException e) {
-            // Can be rejected if quiet period is complete already.
-        }
-    }
-
-    /**
-     * Closes all channels and terminates all event loops.
-     * <ol>
-     *   <li>Closes all server channels so that we don't accept any more incoming connections.</li>
-     *   <li>Closes all accepted channels.</li>
-     *   <li>Shuts down the worker group if necessary.</li>
-     *   <li>Shuts down the boss groups.</li>
-     * </ol>
-     * Note that we terminate the boss groups lastly so that the JVM does not terminate itself
-     * even if other threads are daemon, because boss group threads are always non-daemon.
-     */
-    private void stop1(CompletableFuture<Void> future, @Nullable ExecutorService gracefulShutdownExecutor) {
-        // Graceful shutdown is over. Terminate the temporary executor we created at stop0(future).
-        if (gracefulShutdownExecutor != null) {
-            gracefulShutdownExecutor.shutdownNow();
-        }
-
-        // Close all server sockets.
-        final Set<Channel> serverChannels = ImmutableSet.copyOf(this.serverChannels);
-        ChannelUtil.close(serverChannels).whenComplete((unused1, unused2) -> {
-            // All server ports have been closed.
-            primaryActivePort = null;
-            activePorts.clear();
-
-            // Close all accepted sockets.
-            ChannelUtil.close(connectionLimitingHandler.children()).whenComplete((unused3, unused4) -> {
-                // Shut down the worker group if necessary.
-                final Future<?> workerShutdownFuture;
-                if (config.shutdownWorkerGroupOnStop()) {
-                    workerShutdownFuture = config.workerGroup().shutdownGracefully();
-                } else {
-                    workerShutdownFuture = ImmediateEventExecutor.INSTANCE.newSucceededFuture(null);
-                }
-
-                workerShutdownFuture.addListener(unused5 -> {
-                    // Shut down all boss groups and wait until they are terminated.
-                    final AtomicInteger remainingBossGroups = new AtomicInteger(serverChannels.size());
-                    serverChannels.forEach(ch -> {
-                        final EventLoopGroup bossGroup = ch.eventLoop().parent();
-                        bossGroup.shutdownGracefully();
-                        bossGroup.terminationFuture().addListener(unused6 -> {
-                            if (remainingBossGroups.decrementAndGet() != 0) {
-                                // There are more boss groups to terminate.
-                                return;
-                            }
-
-                            // Boss groups have been terminated completely.
-                            // TODO(trustin): Add shutdownBlockingTaskExecutorOnStop
-                            // TODO(trustin): Count the pending blocking tasks and wait until it becomes zero.
-                            stateManager.enter(State.STOPPED);
-                            completeFuture(future);
-                        });
-                    });
-                });
-            });
-        });
-    }
-
     /**
      * A shortcut to {@link #stop() stop().get()}.
      */
     @Override
     public void close() {
-        final CompletableFuture<Void> f = stop();
-        boolean interrupted = false;
-        for (;;) {
-            try {
-                f.get();
-                break;
-            } catch (InterruptedException ignored) {
-                interrupted = true;
-            } catch (ExecutionException e) {
-                logger.warn("Failed to stop a server", e);
-                break;
-            }
-        }
-
-        if (interrupted) {
-            Thread.currentThread().interrupt();
-        }
+        startStop.close();
     }
 
     /**
@@ -486,144 +263,203 @@ public final class Server implements AutoCloseable {
         return MoreObjects.toStringHelper(this)
                           .add("config", config())
                           .add("activePorts", activePorts())
-                          .add("state", stateManager.state())
+                          .add("state", startStop)
                           .toString();
     }
 
-    enum StateType {
-        STARTING,
-        STARTED,
-        STOPPING,
-        STOPPED
-    }
+    private final class ServerStartStopSupport extends StartStopSupport<Void, ServerListener> {
 
-    static final class State {
-        static final State STARTED = new State(StateType.STARTED, null);
-        static final State STOPPED = new State(StateType.STOPPED, null);
-
-        final StateType type;
-        @Nullable
-        final CompletableFuture<Void> future;
-
-        State(StateType type, @Nullable CompletableFuture<Void> future) {
-            this.type = type;
-            this.future = future;
+        ServerStartStopSupport() {
+            super(GlobalEventExecutor.INSTANCE);
         }
 
         @Override
-        public String toString() {
-            return "(" + type + ", " + future + ')';
-        }
-    }
-
-    private final class StateManager {
-
-        private final AtomicReference<State> ref = new AtomicReference<>(State.STOPPED);
-
-        State state() {
-            return ref.get();
-        }
-
-        void enter(State state) {
-            assert state.type != StateType.STARTING; // must be set via setStarting()
-            assert state.type != StateType.STOPPING; // must be set via setStopping()
-
-            final State oldState = ref.getAndSet(state);
-            notifyState(oldState, state);
-        }
-
-        boolean enterStarting(CompletableFuture<Void> future, Consumer<CompletableFuture<Void>> rollbackTask) {
-            final State startingState = new State(StateType.STARTING, future);
-            if (!ref.compareAndSet(State.STOPPED, startingState)) {
-                completeFutureExceptionally(
-                        future,
-                        new IllegalStateException("must be stopped to start: " + this));
-                return false;
+        protected CompletionStage<Void> doStart() throws Exception {
+            final CompletableFuture<Void> future = new CompletableFuture<>();
+            // Initialize the server sockets asynchronously.
+            final List<ServerPort> ports = config().ports();
+            final AtomicInteger remainingPorts = new AtomicInteger(ports.size());
+            if (config().gracefulShutdownQuietPeriod().isZero()) {
+                gracefulShutdownSupport = GracefulShutdownSupport.disabled();
+            } else {
+                gracefulShutdownSupport =
+                        GracefulShutdownSupport.create(config().gracefulShutdownQuietPeriod(),
+                                                       config().blockingTaskExecutor());
             }
 
-            // Note that we added the listener only ..
-            // - after the compareAndSet() above so that the listener is invoked only when state transition
-            //   actually occurred.
-            // - before notifyState() below so that the listener is invoked when listener notification fails.
-
-            future.handle(voidFunction((ret, cause) -> {
-                if (cause == null) {
-                    enter(State.STARTED);
-                } else {
-                    rollbackTask.accept(stateManager.enterStopping(new CompletableFuture<>()));
-                }
-            })).exceptionally(CompletionActions::log);
-
-            if (!notifyState(State.STOPPED, startingState)) {
-                completeFutureExceptionally(
-                        future,
-                        new IllegalStateException("failed to notify all server listeners"));
-                return false;
+            for (final ServerPort p: ports) {
+                doStart(p).addListener(new ServerPortStartListener(remainingPorts, future, p));
             }
 
-            return true;
-        }
-
-        CompletableFuture<Void> enterStopping(CompletableFuture<Void> future) {
-            final State update = new State(StateType.STOPPING, future);
-            final State oldState = ref.getAndSet(update);
-
-            notifyState(oldState, update);
+            setupServerMetrics();
             return future;
         }
 
-        boolean enterStopping(@Nullable State expect, CompletableFuture<Void> future) {
-            final State update = new State(StateType.STOPPING, future);
-            final State oldState;
-            if (expect != null) {
-                if (!ref.compareAndSet(expect, update)) {
-                    return false;
-                }
-                oldState = expect;
-            } else {
-                oldState = ref.getAndSet(update);
-            }
+        private ChannelFuture doStart(ServerPort port) {
+            final ServerBootstrap b = new ServerBootstrap();
+            serverBootstrap = b;
+            config.channelOptions().forEach((k, v) -> {
+                @SuppressWarnings("unchecked")
+                final ChannelOption<Object> castOption = (ChannelOption<Object>) k;
+                b.option(castOption, v);
+            });
+            config.childChannelOptions().forEach((k, v) -> {
+                @SuppressWarnings("unchecked")
+                final ChannelOption<Object> castOption = (ChannelOption<Object>) k;
+                b.childOption(castOption, v);
+            });
 
-            notifyState(oldState, update);
-            return true;
+            b.group(EventLoopGroups.newEventLoopGroup(1, r -> {
+                final FastThreadLocalThread thread = new FastThreadLocalThread(r, bossThreadName(port));
+                thread.setDaemon(false);
+                return thread;
+            }), config.workerGroup());
+            b.channel(TransportType.detectTransportType().serverChannelClass());
+            b.handler(connectionLimitingHandler);
+            b.childHandler(new HttpServerPipelineConfigurator(config, port, sslContexts,
+                                                              gracefulShutdownSupport));
+
+            return b.bind(port.localAddress());
         }
 
-        private boolean notifyState(State oldState, State state) {
-            if (oldState.type == state.type) {
-                return true;
-            }
-
-            boolean success = true;
-            for (ServerListener l : listeners) {
-                try {
-                    switch (state.type) {
-                        case STARTING:
-                            l.serverStarting(Server.this);
-                            break;
-                        case STARTED:
-                            l.serverStarted(Server.this);
-                            break;
-                        case STOPPING:
-                            l.serverStopping(Server.this);
-                            break;
-                        case STOPPED:
-                            l.serverStopped(Server.this);
-                            break;
-                        default:
-                            throw new Error("unknown state type " + state.type);
-                    }
-                } catch (Throwable t) {
-                    success = false;
-                    logger.warn("Failed to notify a server listener: {}", l, t);
-                }
-            }
-
-            return success;
+        private void setupServerMetrics() {
+            final MeterRegistry meterRegistry = config().meterRegistry();
+            meterRegistry.gauge("armeria.server.pendingResponses", gracefulShutdownSupport,
+                                GracefulShutdownSupport::pendingResponses);
+            meterRegistry.gauge("armeria.server.connections", connectionLimitingHandler,
+                                ConnectionLimitingHandler::numConnections);
         }
 
         @Override
-        public String toString() {
-            return ref.toString();
+        protected CompletionStage<Void> doStop() throws Exception {
+            final CompletableFuture<Void> future = new CompletableFuture<>();
+            final GracefulShutdownSupport gracefulShutdownSupport = Server.this.gracefulShutdownSupport;
+            if (gracefulShutdownSupport.completedQuietPeriod()) {
+                doStop(future, null);
+                return future;
+            }
+
+            // Create a single-use thread dedicated for monitoring graceful shutdown status.
+            final ScheduledExecutorService gracefulShutdownExecutor =
+                    Executors.newSingleThreadScheduledExecutor(
+                            r -> new Thread(r, "armeria-shutdown-0x" + Integer.toHexString(hashCode())));
+
+            // Check every 100 ms for the server to have completed processing requests.
+            final ScheduledFuture<?> quietPeriodFuture = gracefulShutdownExecutor.scheduleAtFixedRate(() -> {
+                if (gracefulShutdownSupport.completedQuietPeriod()) {
+                    doStop(future, gracefulShutdownExecutor);
+                }
+            }, 0, 100, TimeUnit.MILLISECONDS);
+
+            // Make sure the event loop stops after the timeout, regardless of what
+            // the GracefulShutdownSupport says.
+            try {
+                gracefulShutdownExecutor.schedule(() -> {
+                    quietPeriodFuture.cancel(false);
+                    doStop(future, gracefulShutdownExecutor);
+                }, config.gracefulShutdownTimeout().toMillis(), TimeUnit.MILLISECONDS);
+            } catch (RejectedExecutionException e) {
+                // Can be rejected if quiet period is complete already.
+            }
+
+            return future;
+        }
+
+        /**
+         * Closes all channels and terminates all event loops.
+         * <ol>
+         *   <li>Closes all server channels so that we don't accept any more incoming connections.</li>
+         *   <li>Closes all accepted channels.</li>
+         *   <li>Shuts down the worker group if necessary.</li>
+         *   <li>Shuts down the boss groups.</li>
+         * </ol>
+         * Note that we terminate the boss groups lastly so that the JVM does not terminate itself
+         * even if other threads are daemon, because boss group threads are always non-daemon.
+         */
+        private void doStop(CompletableFuture<Void> future,
+                            @Nullable ExecutorService gracefulShutdownExecutor) {
+            // Graceful shutdown is over. Terminate the temporary executor we created at stop0(future).
+            if (gracefulShutdownExecutor != null) {
+                gracefulShutdownExecutor.shutdownNow();
+            }
+
+            // Close all server sockets.
+            final Set<Channel> serverChannels = ImmutableSet.copyOf(Server.this.serverChannels);
+            ChannelUtil.close(serverChannels).whenComplete((unused1, unused2) -> {
+                // All server ports have been closed.
+                primaryActivePort = null;
+                activePorts.clear();
+
+                // Close all accepted sockets.
+                ChannelUtil.close(connectionLimitingHandler.children()).whenComplete((unused3, unused4) -> {
+                    // Shut down the worker group if necessary.
+                    final Future<?> workerShutdownFuture;
+                    if (config.shutdownWorkerGroupOnStop()) {
+                        workerShutdownFuture = config.workerGroup().shutdownGracefully();
+                    } else {
+                        workerShutdownFuture = ImmediateEventExecutor.INSTANCE.newSucceededFuture(null);
+                    }
+
+                    workerShutdownFuture.addListener(unused5 -> {
+                        // Shut down all boss groups and wait until they are terminated.
+                        final AtomicInteger remainingBossGroups = new AtomicInteger(serverChannels.size());
+                        serverChannels.forEach(ch -> {
+                            final EventLoopGroup bossGroup = ch.eventLoop().parent();
+                            bossGroup.shutdownGracefully();
+                            bossGroup.terminationFuture().addListener(unused6 -> {
+                                if (remainingBossGroups.decrementAndGet() != 0) {
+                                    // There are more boss groups to terminate.
+                                    return;
+                                }
+
+                                // Boss groups have been terminated completely.
+                                // TODO(trustin): Add shutdownBlockingTaskExecutorOnStop
+                                // TODO(trustin): Count the pending blocking tasks and wait until it goes zero.
+                                future.complete(null);
+                            });
+                        });
+                    });
+                });
+            });
+        }
+
+        @Override
+        protected void notifyStarting(ServerListener listener) throws Exception {
+            listener.serverStarting(Server.this);
+        }
+
+        @Override
+        protected void notifyStarted(ServerListener listener, @Nullable Void value) throws Exception {
+            listener.serverStarted(Server.this);
+        }
+
+        @Override
+        protected void notifyStopping(ServerListener listener) throws Exception {
+            listener.serverStopping(Server.this);
+        }
+
+        @Override
+        protected void notifyStopped(ServerListener listener) throws Exception {
+            listener.serverStopped(Server.this);
+        }
+
+        @Override
+        protected void rollbackFailed(Throwable cause) {
+            logStopFailure(cause);
+        }
+
+        @Override
+        protected void notificationFailed(ServerListener listener, Throwable cause) {
+            logger.warn("Failed to notify a server listener: {}", listener, cause);
+        }
+
+        @Override
+        protected void closeFailed(Throwable cause) {
+            logStopFailure(cause);
+        }
+
+        private void logStopFailure(Throwable cause) {
+            logger.warn("Failed to stop a server: {}", cause.getMessage(), cause);
         }
     }
 
@@ -681,10 +517,10 @@ public final class Server implements AutoCloseable {
                 }
 
                 if (remainingPorts.decrementAndGet() == 0) {
-                    completeFuture(startFuture);
+                    startFuture.complete(null);
                 }
             } else {
-                completeFutureExceptionally(startFuture, f.cause());
+                startFuture.completeExceptionally(f.cause());
             }
         }
     }
@@ -701,21 +537,5 @@ public final class Server implements AutoCloseable {
                                          .map(SessionProtocol::uriText)
                                          .collect(Collectors.joining("+"));
         return "armeria-boss-" + protocolNames + '-' + localHostName + ':' + localAddr.getPort();
-    }
-
-    private static void completeFuture(CompletableFuture<Void> future) {
-        if (GlobalEventExecutor.INSTANCE.inEventLoop()) {
-            future.complete(null);
-        } else {
-            GlobalEventExecutor.INSTANCE.execute(() -> future.complete(null));
-        }
-    }
-
-    private static void completeFutureExceptionally(CompletableFuture<Void> future, Throwable cause) {
-        if (GlobalEventExecutor.INSTANCE.inEventLoop()) {
-            future.completeExceptionally(cause);
-        } else {
-            GlobalEventExecutor.INSTANCE.execute(() -> future.completeExceptionally(cause));
-        }
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/docs/DocStringExtractor.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/DocStringExtractor.java
@@ -65,7 +65,7 @@ public abstract class DocStringExtractor {
     private Map<String, String> getAllDocStrings0(ClassLoader classLoader) {
         final Configuration configuration = new ConfigurationBuilder()
                 .filterInputsBy(new FilterBuilder().includePackage(path))
-                .setUrls(ClasspathHelper.forPackage(path))
+                .setUrls(ClasspathHelper.forPackage(path, classLoader))
                 .addClassLoader(classLoader)
                 .setScanners(new ResourcesScanner());
         if (configuration.getUrls() == null || configuration.getUrls().isEmpty()) {

--- a/core/src/test/java/com/linecorp/armeria/common/util/StartStopSupportTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/util/StartStopSupportTest.java
@@ -1,0 +1,568 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.EventListener;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.DisableOnDebug;
+import org.junit.rules.TestRule;
+import org.junit.rules.Timeout;
+
+import com.google.common.base.Stopwatch;
+
+import com.linecorp.armeria.testing.common.EventLoopRule;
+import com.linecorp.armeria.testing.internal.AnticipatedException;
+
+import io.netty.util.concurrent.FutureListener;
+
+public class StartStopSupportTest {
+
+    private static final String THREAD_NAME_PREFIX = StartStopSupportTest.class.getSimpleName();
+
+    @ClassRule
+    public static final EventLoopRule rule = new EventLoopRule(THREAD_NAME_PREFIX);
+
+    @Rule
+    public TestRule globalTimeout = new DisableOnDebug(new Timeout(10, TimeUnit.SECONDS));
+
+    @Test
+    public void simpleStartStop() throws Throwable {
+        final Callable<String> startTask = SpiedCallable.of("foo");
+        final ThrowingCallable stopTask = mock(ThrowingCallable.class);
+        final StartStop startStop = new StartStop(startTask, stopTask);
+
+        assertThat(startStop.toString()).isEqualTo("STOPPED");
+        assertThat(startStop.start(true).join()).isEqualTo("foo");
+        assertThat(startStop.toString()).isEqualTo("STARTED");
+        verify(startTask, times(1)).call();
+        verify(stopTask, never()).call();
+
+        assertThat(startStop.stop().join()).isNull();
+        assertThat(startStop.toString()).isEqualTo("STOPPED");
+        verify(startTask, times(1)).call();
+        verify(stopTask, times(1)).call();
+    }
+
+    @Test
+    public void startingWhileStarting() {
+        final CountDownLatch startLatch = new CountDownLatch(2);
+        final StartStop startStop = new StartStop(() -> {
+            // Signal the main thread that it entered the STARTING state.
+            startLatch.countDown();
+            startLatch.await();
+            return "bar";
+        }, () -> {});
+
+        // Enter the STARTING state.
+        final CompletableFuture<String> startFuture = startStop.start(true);
+        await().until(() -> startLatch.getCount() == 1);
+        assertThat(startStop.toString()).isEqualTo("STARTING");
+
+        // If 'failIfStarted' is true, start() will fail.
+        assertThatThrownBy(() -> startStop.start(true).join())
+                .isInstanceOf(CompletionException.class)
+                .hasCauseInstanceOf(IllegalStateException.class);
+
+        // If 'failIfStarted' is false, start() will return the previous future.
+        assertThat(startStop.start(false)).isSameAs(startFuture);
+
+        // Finish the startup procedure.
+        startLatch.countDown();
+        assertThat(startFuture.join()).isEqualTo("bar");
+    }
+
+    @Test
+    public void startingWhileStarted() {
+        final StartStop startStop = new StartStop(() -> "foo", () -> {});
+
+        // Enter the STARTED state.
+        final CompletableFuture<String> startFuture = startStop.start(true);
+        assertThat(startFuture.join()).isEqualTo("foo");
+
+        // If 'failIfStarted' is true, start() will fail.
+        assertThatThrownBy(() -> startStop.start(true).join())
+                .isInstanceOf(CompletionException.class)
+                .hasCauseInstanceOf(IllegalStateException.class);
+
+        // If 'failIfStarted' is false, start() will return the previous future.
+        assertThat(startStop.start(false)).isSameAs(startFuture);
+    }
+
+    @Test
+    public void startingWhileStopping() throws Throwable {
+        final Callable<String> startTask = SpiedCallable.of("bar");
+        final CountDownLatch stopLatch = new CountDownLatch(2);
+        final StartStop startStop = new StartStop(startTask, () -> {
+            // Signal the main thread that it entered the STOPPING state.
+            stopLatch.countDown();
+            stopLatch.await();
+        });
+
+        // Enter the STOPPING state.
+        assertThat(startStop.start(true).join()).isEqualTo("bar");
+        final CompletableFuture<Void> stopFuture = startStop.stop();
+        await().until(() -> stopLatch.getCount() == 1);
+        assertThat(startStop.toString()).isEqualTo("STOPPING");
+
+        // start() should never complete until shutdown procedure is complete.
+        clearInvocations(startTask);
+        final CompletableFuture<String> startFuture = startStop.start(true);
+        repeat(() -> {
+            verify(startTask, never()).call();
+            assertThat(startFuture).isNotDone();
+        });
+
+        // Finish the shutdown procedure, so that startup procedure follows.
+        stopLatch.countDown();
+        assertThat(stopFuture.join()).isNull();
+
+        // Now check that the startup procedure has been performed.
+        assertThat(startFuture.join()).isEqualTo("bar");
+        verify(startTask, times(1)).call();
+    }
+
+    @Test
+    public void stoppingWhileStarting() throws Throwable {
+        final ThrowingCallable stopTask = mock(ThrowingCallable.class);
+        final CountDownLatch startLatch = new CountDownLatch(2);
+        final StartStop startStop = new StartStop(() -> {
+            // Signal the main thread that it entered the STARTING state.
+            startLatch.countDown();
+            startLatch.await();
+            return "foo";
+        }, stopTask);
+
+        // Enter the STARTING state.
+        final CompletableFuture<String> startFuture = startStop.start(true);
+        await().until(() -> startLatch.getCount() == 1);
+
+        // stop() should never complete until startup procedure is complete.
+        final CompletableFuture<Void> stopFuture = startStop.stop();
+        repeat(() -> {
+            verify(stopTask, never()).call();
+            assertThat(stopFuture).isNotDone();
+        });
+
+        // Finish the startup procedure, so that shutdown procedure follows.
+        startLatch.countDown();
+        assertThat(startFuture.join()).isEqualTo("foo");
+
+        // Now check that the shutdown procedure has been performed.
+        assertThat(stopFuture.join()).isNull();
+        verify(stopTask, times(1)).call();
+    }
+
+    @Test
+    public void stoppingWhileStopping() {
+        final CountDownLatch stopLatch = new CountDownLatch(2);
+        final StartStop startStop = new StartStop(() -> "bar", () -> {
+            // Signal the main thread that it entered the STOPPING state.
+            stopLatch.countDown();
+            stopLatch.await();
+        });
+
+        // Enter the STOPPING state.
+        assertThat(startStop.start(true).join()).isEqualTo("bar");
+        final CompletableFuture<Void> stopFuture = startStop.stop();
+        await().until(() -> stopLatch.getCount() == 1);
+
+        // stop() will return the previous future.
+        assertThat(startStop.stop()).isSameAs(stopFuture);
+
+        // Finish the shutdown procedure.
+        stopLatch.countDown();
+        assertThat(stopFuture.join()).isNull();
+    }
+
+    @Test
+    public void stoppingWhileStopped() {
+        final StartStop startStop = new StartStop(() -> "foo", () -> {});
+
+        // Enter the STOPPED state.
+        assertThat(startStop.start(true).join()).isEqualTo("foo");
+        final CompletableFuture<Void> stopFuture = startStop.stop();
+        assertThat(stopFuture.join()).isNull();
+
+        // stop() will return the previous future.
+        assertThat(startStop.stop()).isSameAs(stopFuture);
+    }
+
+    @Test
+    public void rollback() throws Throwable {
+        final ThrowingCallable stopTask = mock(ThrowingCallable.class);
+        final Exception exception = new AnticipatedException();
+        final StartStop startStop = new StartStop(() -> {
+            throw exception;
+        }, stopTask);
+
+        assertThatThrownBy(() -> startStop.start(true).join())
+                .isInstanceOf(CompletionException.class)
+                .hasCause(exception);
+        verify(stopTask, times(1)).call();
+    }
+
+    @Test
+    public void rollbackFailure() throws Throwable {
+        final Exception startException = new AnticipatedException();
+        final Exception stopException = new AnticipatedException();
+        final StartStop startStop = spy(new StartStop(() -> {
+            throw startException;
+        }, () -> {
+            throw stopException;
+        }));
+
+        assertThatThrownBy(() -> startStop.start(true).join())
+                .isInstanceOf(CompletionException.class)
+                .hasCause(startException);
+
+        verify(startStop, times(1)).rollbackFailed(stopException);
+    }
+
+    @Test
+    public void listenerNotifications() {
+        final CountDownLatch startLatch = new CountDownLatch(1);
+        final CountDownLatch stopLatch = new CountDownLatch(1);
+        final EventListener listener = mock(EventListener.class);
+        final StartStop startStop = spy(new StartStop(() -> {
+            startLatch.await();
+            return "bar";
+        }, stopLatch::await));
+        startStop.addListener(listener);
+
+        final CompletableFuture<String> startFuture = startStop.start(true);
+        await().untilAsserted(() -> {
+            verify(startStop, times(1)).notifyStarting(listener);
+            verify(startStop, never()).notifyStarted(listener, "bar");
+            verify(startStop, never()).notifyStopping(listener);
+            verify(startStop, never()).notifyStopped(listener);
+            assertThat(startFuture).isNotDone();
+        });
+
+        startLatch.countDown();
+        await().untilAsserted(() -> {
+            verify(startStop, times(1)).notifyStarting(listener);
+            verify(startStop, times(1)).notifyStarted(listener, "bar");
+            verify(startStop, never()).notifyStopping(listener);
+            verify(startStop, never()).notifyStopped(listener);
+            assertThat(startFuture).isCompletedWithValue("bar");
+        });
+
+        final CompletableFuture<Void> stopFuture = startStop.stop();
+        await().untilAsserted(() -> {
+            verify(startStop, times(1)).notifyStarting(listener);
+            verify(startStop, times(1)).notifyStarted(listener, "bar");
+            verify(startStop, times(1)).notifyStopping(listener);
+            verify(startStop, never()).notifyStopped(listener);
+            assertThat(stopFuture).isNotDone();
+        });
+
+        stopLatch.countDown();
+        await().untilAsserted(() -> {
+            verify(startStop, times(1)).notifyStarting(listener);
+            verify(startStop, times(1)).notifyStarted(listener, "bar");
+            verify(startStop, times(1)).notifyStopping(listener);
+            verify(startStop, times(1)).notifyStopped(listener);
+            assertThat(stopFuture).isCompletedWithValue(null);
+        });
+    }
+
+    @Test
+    public void listenerNotificationFailure() throws Exception {
+        final EventListener listener = mock(EventListener.class);
+        final Exception exception = new AnticipatedException();
+        final StartStop startStop = spy(new StartStop(() -> "foo", () -> {}));
+        doThrow(exception).when(startStop).notifyStarting(any());
+
+        startStop.addListener(listener);
+        assertThat(startStop.start(true).join()).isEqualTo("foo");
+        verify(startStop).notificationFailed(listener, exception);
+    }
+
+    @Test
+    public void listenerRemoval() throws Exception {
+        final EventListener listener = mock(EventListener.class);
+        final StartStop startStop = spy(new StartStop(() -> "bar", () -> {}));
+        startStop.addListener(listener);
+        startStop.removeListener(listener);
+
+        assertThat(startStop.start(true).join()).isEqualTo("bar");
+        assertThat(startStop.stop().join()).isNull();
+
+        verify(startStop, never()).notifyStarting(listener);
+        verify(startStop, never()).notifyStarted(listener, "bar");
+        verify(startStop, never()).notifyStopping(listener);
+        verify(startStop, never()).notifyStopped(listener);
+    }
+
+    @Test
+    public void close() {
+        final StartStop startStop = new StartStop(() -> "foo", () -> {});
+        startStop.close();
+    }
+
+    @Test
+    public void closeWhileStopped() throws Throwable {
+        final Callable<String> startTask = SpiedCallable.of("bar");
+        final ThrowingCallable stopTask = mock(ThrowingCallable.class);
+        final StartStop startStop = new StartStop(startTask, stopTask);
+
+        for (int i = 0; i < 2; i++) { // Check twice to ensure idempotence.
+            startStop.close();
+            verify(startTask, never()).call();
+            verify(stopTask, never()).call();
+        }
+    }
+
+    @Test
+    public void closeWhileStarted() throws Throwable {
+        final Callable<String> startTask = SpiedCallable.of("foo");
+        final ThrowingCallable stopTask = mock(ThrowingCallable.class);
+        final StartStop startStop = new StartStop(startTask, stopTask);
+        startStop.start(true).join();
+
+        for (int i = 0; i < 2; i++) { // Check twice to ensure idempotence.
+            verify(startTask, times(1)).call();
+            startStop.close();
+            verify(stopTask, times(1)).call();
+        }
+    }
+
+    @Test
+    public void closeFailure() {
+        final Exception exception = new AnticipatedException();
+        final StartStop startStop = spy(new StartStop(() -> "bar", () -> {
+            throw exception;
+        }));
+        startStop.start(true).join();
+
+        for (int i = 0; i < 2; i++) { // Check twice to ensure idempotence.
+            startStop.close();
+            verify(startStop, times(1)).closeFailed(exception);
+        }
+    }
+
+    @Test
+    public void interruptedWhileClosing() throws Throwable {
+        final AtomicBoolean interrupted = new AtomicBoolean();
+        final CountDownLatch stopLatch = new CountDownLatch(2);
+        final StartStop startStop = new StartStop(() -> "foo", () -> {
+            // Signal the main thread that it entered the STOPPING state.
+            stopLatch.countDown();
+            stopLatch.await();
+        });
+
+        // Enter the STOPPING state.
+        assertThat(startStop.start(true).join()).isEqualTo("foo");
+        final Thread thread = new Thread(() -> {
+            startStop.close();
+            interrupted.set(Thread.currentThread().isInterrupted());
+        });
+        thread.start();
+        await().until(() -> stopLatch.getCount() == 1);
+
+        // Interrupt the thread that is blocked by close().
+        thread.interrupt();
+
+        // The interrupt should never interrupt the shutdown procedure.
+        repeat(() -> assertThat(startStop.toString()).isEqualTo("STOPPING"));
+
+        // Finish the shutdown procedure so that the close() returns.
+        stopLatch.countDown();
+
+        // Make sure the thread interruption state has been restored.
+        await().untilAsserted(() -> assertThat(interrupted).isTrue());
+    }
+
+    @Test
+    public void doStartReturnsNull() throws Exception {
+        final StartStopSupport<Void, Void> startStop = new StartStopSupport<Void, Void>(rule.get()) {
+            @Override
+            protected CompletionStage<Void> doStart() throws Exception {
+                return null;
+            }
+
+            @Override
+            protected CompletionStage<Void> doStop() throws Exception {
+                return CompletableFuture.completedFuture(null);
+            }
+        };
+
+        assertThatThrownBy(() -> startStop.start(true).join())
+                .isInstanceOf(CompletionException.class)
+                .hasCauseInstanceOf(IllegalStateException.class)
+                .satisfies(cause -> {
+                    assertThat(cause.getCause().getMessage()).contains("doStart() returned null");
+                });
+    }
+
+    @Test
+    public void doStopReturnsNull() throws Exception {
+        final StartStopSupport<String, Void> startStop = new StartStopSupport<String, Void>(rule.get()) {
+            @Override
+            protected CompletionStage<String> doStart() throws Exception {
+                return CompletableFuture.completedFuture("started");
+            }
+
+            @Override
+            protected CompletionStage<Void> doStop() throws Exception {
+                return null;
+            }
+        };
+
+        assertThat(startStop.start(true).join()).isEqualTo("started");
+        assertThatThrownBy(() -> startStop.stop().join())
+                .isInstanceOf(CompletionException.class)
+                .hasCauseInstanceOf(IllegalStateException.class)
+                .satisfies(cause -> {
+                    assertThat(cause.getCause().getMessage()).contains("doStop() returned null");
+                });
+    }
+
+    @Test
+    public void rejectingExecutor() throws Exception {
+        final Executor executor = mock(Executor.class);
+        final StartStopSupport<String, Void> startStop = new StartStopSupport<String, Void>(executor) {
+            @Override
+            protected CompletionStage<String> doStart() throws Exception {
+                return CompletableFuture.completedFuture("started");
+            }
+
+            @Override
+            protected CompletionStage<Void> doStop() throws Exception {
+                return CompletableFuture.completedFuture(null);
+            }
+        };
+
+        // Rejected when starting.
+        doThrow(new RejectedExecutionException()).when(executor).execute(any());
+        assertThatThrownBy(() -> startStop.start(true).join())
+                .isInstanceOf(CompletionException.class)
+                .hasCauseInstanceOf(RejectedExecutionException.class);
+
+        // Run the first execution so that startup succeeds.
+        doAnswer(invocation -> {
+            rule.get().execute(invocation.getArgument(0));
+            return null;
+        }).when(executor).execute(any());
+        assertThat(startStop.start(true).join()).isEqualTo("started");
+
+        // Now reject so that shutdown fails.
+        doThrow(new RejectedExecutionException()).when(executor).execute(any());
+        assertThatThrownBy(() -> startStop.stop().join())
+                .isInstanceOf(CompletionException.class)
+                .hasCauseInstanceOf(RejectedExecutionException.class);
+    }
+
+    private static class StartStop extends StartStopSupport<String, EventListener> {
+
+        private final Callable<String> startTask;
+        private final ThrowingCallable stopTask;
+
+        StartStop(Callable<String> startTask, ThrowingCallable stopTask) {
+            super(rule.get());
+            this.startTask = startTask;
+            this.stopTask = stopTask;
+        }
+
+        @Override
+        protected CompletionStage<String> doStart() throws Exception {
+            return execute(startTask);
+        }
+
+        @Override
+        protected CompletionStage<Void> doStop() throws Exception {
+            return execute(() -> {
+                try {
+                    stopTask.call();
+                } catch (Throwable cause) {
+                    Exceptions.throwUnsafely(cause);
+                }
+                return null;
+            });
+        }
+
+        private static <T> CompletionStage<T> execute(Callable<T> task) {
+            final CompletableFuture<T> future = new CompletableFuture<>();
+            rule.get().submit(task).addListener((FutureListener<T>) f -> {
+                if (f.isSuccess()) {
+                    future.complete(f.getNow());
+                } else {
+                    future.completeExceptionally(f.cause());
+                }
+            });
+            return future;
+        }
+    }
+
+    /**
+     * Keeps running the given {@code task} for a second.
+     */
+    private static void repeat(ThrowingCallable task) throws Throwable {
+        final Stopwatch stopwatch = Stopwatch.createStarted();
+        do {
+            task.call();
+            Thread.sleep(100);
+        } while (stopwatch.elapsed(TimeUnit.MILLISECONDS) < 1000);
+    }
+
+    @SuppressWarnings({
+            "checkstyle:FinalClass",
+            "ClassWithOnlyPrivateConstructors"
+    }) // Can't be final to spy on it.
+    private static class SpiedCallable implements Callable<String> {
+
+        static Callable<String> of(String value) {
+            return spy(new SpiedCallable(value));
+        }
+
+        private final String value;
+
+        private SpiedCallable(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String call() throws Exception {
+            return value;
+        }
+    }
+}

--- a/thrift/src/test/java/com/linecorp/armeria/server/thrift/AbstractThriftOverHttpTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/server/thrift/AbstractThriftOverHttpTest.java
@@ -154,7 +154,7 @@ public abstract class AbstractThriftOverHttpTest {
 
     @AfterClass
     public static void destroy() throws Exception {
-        server.stop();
+        server.stop().get();
     }
 
     @Before


### PR DESCRIPTION
Motivation:

It would be useful to provide a general construct that helps a user
implement asynchronous startup/shutdown life cycle, just like we do for
`Server.start()` and `stop()`.

Modifications:

- Add `StartStopSupport`
- Use `StartStopSupport` in `Server`
- Miscellaneous:
  - Do not run streaming tests in `:code:shadedTest`
  - Fix a bug where `DocStringExtractor` uses a wrong `ClassLoader`

Result:

- Reusability
- Slightly reduced build time
- Fixes build failures due to the test failures in `GrpcDocStringExtractorTest`
