### PR TITLE
Apply collapse to side menu

### DIFF
--- a/docs-client/src/containers/App/index.tsx
+++ b/docs-client/src/containers/App/index.tsx
@@ -91,10 +91,10 @@ const styles = (theme: Theme) =>
 interface State {
   mobileDrawerOpen: boolean;
   specification?: Specification;
-  servicesState: boolean;
-  enumsState: boolean;
-  structsState: boolean;
-  exceptionsState: boolean;
+  servicesOpen: boolean;
+  enumsOpen: boolean;
+  structsOpen: boolean;
+  exceptionsOpen: boolean;
 }
 
 type Props = WithStyles<typeof styles> & RouteComponentProps<{}>;
@@ -121,9 +121,9 @@ function AppDrawer({
             <ListItemText disableTypography>
               <Typography variant="headline">Services</Typography>
             </ListItemText>
-            {state.servicesState ? <ExpandLess /> : <ExpandMore />}
+            {state.servicesOpen ? <ExpandLess /> : <ExpandMore />}
           </ListItem>
-          <Collapse in={state.servicesState} timeout="auto" unmountOnExit>
+          <Collapse in={state.servicesOpen} timeout="auto" unmountOnExit>
             {specification.getServices().map((service) => (
               <div key={service.name}>
                 <ListSubheader className={classes.methodHeader}>
@@ -161,9 +161,9 @@ function AppDrawer({
             <ListItemText disableTypography>
               <Typography variant="headline">Enums</Typography>
             </ListItemText>
-            {state.enumsState ? <ExpandLess /> : <ExpandMore />}
+            {state.enumsOpen ? <ExpandLess /> : <ExpandMore />}
           </ListItem>
-          <Collapse in={state.enumsState} timeout="auto" unmountOnExit>
+          <Collapse in={state.enumsOpen} timeout="auto" unmountOnExit>
             {specification.getEnums().map((enm) => (
               <ListItem
                 dense
@@ -190,9 +190,9 @@ function AppDrawer({
             <ListItemText disableTypography>
               <Typography variant="headline">Structs</Typography>
             </ListItemText>
-            {state.structsState ? <ExpandLess /> : <ExpandMore />}
+            {state.structsOpen ? <ExpandLess /> : <ExpandMore />}
           </ListItem>
-          <Collapse in={state.structsState} timeout="auto" unmountOnExit>
+          <Collapse in={state.structsOpen} timeout="auto" unmountOnExit>
             {specification.getStructs().map((struct) => (
               <ListItem
                 dense
@@ -219,9 +219,9 @@ function AppDrawer({
             <ListItemText disableTypography>
               <Typography variant="headline">Exceptions</Typography>
             </ListItemText>
-            {state.exceptionsState ? <ExpandLess /> : <ExpandMore />}
+            {state.exceptionsOpen ? <ExpandLess /> : <ExpandMore />}
           </ListItem>
-          <Collapse in={state.exceptionsState} timeout="auto" unmountOnExit>
+          <Collapse in={state.exceptionsOpen} timeout="auto" unmountOnExit>
             {specification.getExceptions().map((struct) => (
               <ListItem
                 dense
@@ -250,10 +250,10 @@ class App extends React.PureComponent<Props, State> {
   public state: State = {
     mobileDrawerOpen: false,
     specification: undefined,
-    servicesState: true,
-    enumsState: true,
-    structsState: true,
-    exceptionsState: true,
+    servicesOpen: true,
+    enumsOpen: true,
+    structsOpen: true,
+    exceptionsOpen: true,
   };
 
   public componentWillMount() {
@@ -316,9 +316,7 @@ class App extends React.PureComponent<Props, State> {
               specification={specification}
               navigateTo={(url: string) => this.navigateTo(url)}
               state={this.state}
-              handleCollapse={(itemName: string) =>
-                this.handleCollapse(itemName)
-              }
+              handleCollapse={this.handleCollapse}
             />
           </Drawer>
         </Hidden>
@@ -395,26 +393,26 @@ class App extends React.PureComponent<Props, State> {
     });
   };
 
-  private handleCollapse(itemName: string) {
+  private handleCollapse = (itemName: string) => {
     switch (itemName) {
       case 'services':
         this.setState({
-          servicesState: !this.state.servicesState,
+          servicesOpen: !this.state.servicesOpen,
         });
         break;
       case 'enums':
         this.setState({
-          enumsState: !this.state.enumsState,
+          enumsOpen: !this.state.enumsOpen,
         });
         break;
       case 'structs':
         this.setState({
-          structsState: !this.state.structsState,
+          structsOpen: !this.state.structsOpen,
         });
         break;
       case 'exceptions':
         this.setState({
-          exceptionsState: !this.state.exceptionsState,
+          exceptionsOpen: !this.state.exceptionsOpen,
         });
         break;
     }

--- a/docs-client/src/containers/App/index.tsx
+++ b/docs-client/src/containers/App/index.tsx
@@ -102,7 +102,10 @@ type Props = WithStyles<typeof styles> & RouteComponentProps<{}>;
 interface AppDrawerProps extends WithStyles<typeof styles> {
   specification: Specification;
   navigateTo: (url: string) => void;
-  state: State;
+  servicesOpen: boolean;
+  enumsOpen: boolean;
+  structsOpen: boolean;
+  exceptionsOpen: boolean;
   handleCollapse: (itemName: string) => void;
 }
 
@@ -110,7 +113,10 @@ function AppDrawer({
   classes,
   navigateTo,
   specification,
-  state,
+  servicesOpen,
+  enumsOpen,
+  structsOpen,
+  exceptionsOpen,
   handleCollapse,
 }: AppDrawerProps) {
   return (
@@ -121,9 +127,9 @@ function AppDrawer({
             <ListItemText disableTypography>
               <Typography variant="headline">Services</Typography>
             </ListItemText>
-            {state.servicesOpen ? <ExpandLess /> : <ExpandMore />}
+            {servicesOpen ? <ExpandLess /> : <ExpandMore />}
           </ListItem>
-          <Collapse in={state.servicesOpen} timeout="auto" unmountOnExit>
+          <Collapse in={servicesOpen} timeout="auto">
             {specification.getServices().map((service) => (
               <div key={service.name}>
                 <ListSubheader className={classes.methodHeader}>
@@ -161,9 +167,9 @@ function AppDrawer({
             <ListItemText disableTypography>
               <Typography variant="headline">Enums</Typography>
             </ListItemText>
-            {state.enumsOpen ? <ExpandLess /> : <ExpandMore />}
+            {enumsOpen ? <ExpandLess /> : <ExpandMore />}
           </ListItem>
-          <Collapse in={state.enumsOpen} timeout="auto" unmountOnExit>
+          <Collapse in={enumsOpen} timeout="auto">
             {specification.getEnums().map((enm) => (
               <ListItem
                 dense
@@ -190,9 +196,9 @@ function AppDrawer({
             <ListItemText disableTypography>
               <Typography variant="headline">Structs</Typography>
             </ListItemText>
-            {state.structsOpen ? <ExpandLess /> : <ExpandMore />}
+            {structsOpen ? <ExpandLess /> : <ExpandMore />}
           </ListItem>
-          <Collapse in={state.structsOpen} timeout="auto" unmountOnExit>
+          <Collapse in={structsOpen} timeout="auto">
             {specification.getStructs().map((struct) => (
               <ListItem
                 dense
@@ -219,9 +225,9 @@ function AppDrawer({
             <ListItemText disableTypography>
               <Typography variant="headline">Exceptions</Typography>
             </ListItemText>
-            {state.exceptionsOpen ? <ExpandLess /> : <ExpandMore />}
+            {exceptionsOpen ? <ExpandLess /> : <ExpandMore />}
           </ListItem>
-          <Collapse in={state.exceptionsOpen} timeout="auto" unmountOnExit>
+          <Collapse in={exceptionsOpen} timeout="auto">
             {specification.getExceptions().map((struct) => (
               <ListItem
                 dense
@@ -315,7 +321,10 @@ class App extends React.PureComponent<Props, State> {
               classes={classes}
               specification={specification}
               navigateTo={this.navigateTo}
-              state={this.state}
+              servicesOpen={this.state.servicesOpen}
+              enumsOpen={this.state.enumsOpen}
+              structsOpen={this.state.structsOpen}
+              exceptionsOpen={this.state.exceptionsOpen}
               handleCollapse={this.handleCollapse}
             />
           </Drawer>
@@ -334,7 +343,10 @@ class App extends React.PureComponent<Props, State> {
               classes={classes}
               specification={specification}
               navigateTo={this.navigateTo}
-              state={this.state}
+              servicesOpen={this.state.servicesOpen}
+              enumsOpen={this.state.enumsOpen}
+              structsOpen={this.state.structsOpen}
+              exceptionsOpen={this.state.exceptionsOpen}
               handleCollapse={this.handleCollapse}
             />
           </Drawer>

--- a/docs-client/src/containers/App/index.tsx
+++ b/docs-client/src/containers/App/index.tsx
@@ -15,6 +15,7 @@
  */
 
 import AppBar from '@material-ui/core/AppBar';
+import Collapse from '@material-ui/core/Collapse';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import Drawer from '@material-ui/core/Drawer';
 import Hidden from '@material-ui/core/Hidden';
@@ -31,6 +32,8 @@ import {
 } from '@material-ui/core/styles';
 import Toolbar from '@material-ui/core/Toolbar';
 import Typography from '@material-ui/core/Typography';
+import ExpandLess from '@material-ui/icons/ExpandLess';
+import ExpandMore from '@material-ui/icons/ExpandMore';
 import MenuIcon from '@material-ui/icons/Menu';
 import React from 'react';
 import Helmet from 'react-helmet';
@@ -88,6 +91,10 @@ const styles = (theme: Theme) =>
 interface State {
   mobileDrawerOpen: boolean;
   specification?: Specification;
+  servicesState: boolean;
+  enumsState: boolean;
+  structsState: boolean;
+  exceptionsState: boolean;
 }
 
 type Props = WithStyles<typeof styles> & RouteComponentProps<{}>;
@@ -95,120 +102,144 @@ type Props = WithStyles<typeof styles> & RouteComponentProps<{}>;
 interface AppDrawerProps extends WithStyles<typeof styles> {
   specification: Specification;
   navigateTo: (url: string) => void;
+  state: State;
+  handleCollapse: (itemName: string) => void;
 }
 
-function AppDrawer({ classes, navigateTo, specification }: AppDrawerProps) {
+function AppDrawer({
+  classes,
+  navigateTo,
+  specification,
+  state,
+  handleCollapse,
+}: AppDrawerProps) {
   return (
     <List component="nav">
       {specification.getServices().length > 0 && (
         <>
-          <ListItem>
+          <ListItem button onClick={() => handleCollapse('services')}>
             <ListItemText disableTypography>
               <Typography variant="headline">Services</Typography>
             </ListItemText>
+            {state.servicesState ? <ExpandLess /> : <ExpandMore />}
           </ListItem>
-          {specification.getServices().map((service) => (
-            <div key={service.name}>
-              <ListSubheader className={classes.methodHeader}>
-                <Typography variant="subheading">
-                  <code>{simpleName(service.name)}</code>
-                </Typography>
-              </ListSubheader>
-              {service.methods.map((method) => (
-                <ListItem
-                  key={`${service.name}/${method.name}`}
-                  button
-                  onClick={() =>
-                    navigateTo(`/methods/${service.name}/${method.name}`)
-                  }
-                >
-                  <ListItemText
-                    inset
-                    primaryTypographyProps={{
-                      variant: 'body1',
-                    }}
+          <Collapse in={state.servicesState} timeout="auto" unmountOnExit>
+            {specification.getServices().map((service) => (
+              <div key={service.name}>
+                <ListSubheader className={classes.methodHeader}>
+                  <Typography variant="subheading">
+                    <code>{simpleName(service.name)}</code>
+                  </Typography>
+                </ListSubheader>
+                {service.methods.map((method) => (
+                  <ListItem
+                    dense
+                    key={`${service.name}/${method.name}`}
+                    button
+                    onClick={() =>
+                      navigateTo(`/methods/${service.name}/${method.name}`)
+                    }
                   >
-                    <code>{method.name}()</code>
-                  </ListItemText>
-                </ListItem>
-              ))}
-            </div>
-          ))}
+                    <ListItemText
+                      inset
+                      primaryTypographyProps={{
+                        variant: 'body1',
+                      }}
+                    >
+                      <code>{method.name}()</code>
+                    </ListItemText>
+                  </ListItem>
+                ))}
+              </div>
+            ))}
+          </Collapse>
         </>
       )}
       {specification.getEnums().length > 0 && (
         <>
-          <ListItem>
+          <ListItem button onClick={() => handleCollapse('enums')}>
             <ListItemText disableTypography>
               <Typography variant="headline">Enums</Typography>
             </ListItemText>
+            {state.enumsState ? <ExpandLess /> : <ExpandMore />}
           </ListItem>
-          {specification.getEnums().map((enm) => (
-            <ListItem
-              key={enm.name}
-              button
-              onClick={() => navigateTo(`/enums/${enm.name}`)}
-            >
-              <ListItemText
-                inset
-                primaryTypographyProps={{
-                  variant: 'body1',
-                }}
+          <Collapse in={state.enumsState} timeout="auto" unmountOnExit>
+            {specification.getEnums().map((enm) => (
+              <ListItem
+                dense
+                key={enm.name}
+                button
+                onClick={() => navigateTo(`/enums/${enm.name}`)}
               >
-                <code>{simpleName(enm.name)}</code>
-              </ListItemText>
-            </ListItem>
-          ))}
+                <ListItemText
+                  inset
+                  primaryTypographyProps={{
+                    variant: 'body1',
+                  }}
+                >
+                  <code>{simpleName(enm.name)}</code>
+                </ListItemText>
+              </ListItem>
+            ))}
+          </Collapse>
         </>
       )}
       {specification.getStructs().length > 0 && (
         <>
-          <ListItem>
+          <ListItem button onClick={() => handleCollapse('structs')}>
             <ListItemText disableTypography>
               <Typography variant="headline">Structs</Typography>
             </ListItemText>
+            {state.structsState ? <ExpandLess /> : <ExpandMore />}
           </ListItem>
-          {specification.getStructs().map((struct) => (
-            <ListItem
-              key={struct.name}
-              button
-              onClick={() => navigateTo(`/structs/${struct.name}`)}
-            >
-              <ListItemText
-                inset
-                primaryTypographyProps={{
-                  variant: 'body1',
-                }}
+          <Collapse in={state.structsState} timeout="auto" unmountOnExit>
+            {specification.getStructs().map((struct) => (
+              <ListItem
+                dense
+                key={struct.name}
+                button
+                onClick={() => navigateTo(`/structs/${struct.name}`)}
               >
-                <code>{simpleName(struct.name)}</code>
-              </ListItemText>
-            </ListItem>
-          ))}
+                <ListItemText
+                  inset
+                  primaryTypographyProps={{
+                    variant: 'body1',
+                  }}
+                >
+                  <code>{simpleName(struct.name)}</code>
+                </ListItemText>
+              </ListItem>
+            ))}
+          </Collapse>
         </>
       )}
       {specification.getExceptions().length > 0 && (
         <>
-          <ListItem>
+          <ListItem button onClick={() => handleCollapse('exceptions')}>
             <ListItemText disableTypography>
               <Typography variant="headline">Exceptions</Typography>
             </ListItemText>
+            {state.exceptionsState ? <ExpandLess /> : <ExpandMore />}
           </ListItem>
-          {specification.getExceptions().map((struct) => (
-            <ListItem
-              key={struct.name}
-              button
-              onClick={() => navigateTo(`/structs/${struct.name}`)}
-            >
-              <ListItemText
-                inset
-                primaryTypographyProps={{
-                  variant: 'body1',
-                }}
+          <Collapse in={state.exceptionsState} timeout="auto" unmountOnExit>
+            {specification.getExceptions().map((struct) => (
+              <ListItem
+                dense
+                key={struct.name}
+                button
+                onClick={() => navigateTo(`/structs/${struct.name}`)}
               >
-                <code>{simpleName(struct.name)}</code>
-              </ListItemText>
-            </ListItem>
-          ))}
+                <ListItemText
+                  inset
+                  primaryTypographyProps={{
+                    variant: 'body1',
+                  }}
+                >
+                  <code>{simpleName(struct.name)}</code>
+                </ListItemText>
+              </ListItem>
+            ))}
+          </Collapse>
         </>
       )}
     </List>
@@ -219,6 +250,10 @@ class App extends React.PureComponent<Props, State> {
   public state: State = {
     mobileDrawerOpen: false,
     specification: undefined,
+    servicesState: true,
+    enumsState: true,
+    structsState: true,
+    exceptionsState: true,
   };
 
   public componentWillMount() {
@@ -280,6 +315,10 @@ class App extends React.PureComponent<Props, State> {
               classes={classes}
               specification={specification}
               navigateTo={(url: string) => this.navigateTo(url)}
+              state={this.state}
+              handleCollapse={(itemName: string) =>
+                this.handleCollapse(itemName)
+              }
             />
           </Drawer>
         </Hidden>
@@ -297,6 +336,10 @@ class App extends React.PureComponent<Props, State> {
               classes={classes}
               specification={specification}
               navigateTo={(url: string) => this.navigateTo(url)}
+              state={this.state}
+              handleCollapse={(itemName: string) =>
+                this.handleCollapse(itemName)
+              }
             />
           </Drawer>
         </Hidden>
@@ -351,6 +394,31 @@ class App extends React.PureComponent<Props, State> {
       mobileDrawerOpen: !this.state.mobileDrawerOpen,
     });
   };
+
+  private handleCollapse(itemName: string) {
+    switch (itemName) {
+      case 'services':
+        this.setState({
+          servicesState: !this.state.servicesState,
+        });
+        break;
+      case 'enums':
+        this.setState({
+          enumsState: !this.state.enumsState,
+        });
+        break;
+      case 'structs':
+        this.setState({
+          structsState: !this.state.structsState,
+        });
+        break;
+      case 'exceptions':
+        this.setState({
+          exceptionsState: !this.state.exceptionsState,
+        });
+        break;
+    }
+  }
 }
 
 export default hot(module)(withRouter(withStyles(styles)(App)));

--- a/docs-client/src/containers/App/index.tsx
+++ b/docs-client/src/containers/App/index.tsx
@@ -314,7 +314,7 @@ class App extends React.PureComponent<Props, State> {
             <AppDrawer
               classes={classes}
               specification={specification}
-              navigateTo={(url: string) => this.navigateTo(url)}
+              navigateTo={this.navigateTo}
               state={this.state}
               handleCollapse={this.handleCollapse}
             />
@@ -333,11 +333,9 @@ class App extends React.PureComponent<Props, State> {
             <AppDrawer
               classes={classes}
               specification={specification}
-              navigateTo={(url: string) => this.navigateTo(url)}
+              navigateTo={this.navigateTo}
               state={this.state}
-              handleCollapse={(itemName: string) =>
-                this.handleCollapse(itemName)
-              }
+              handleCollapse={this.handleCollapse}
             />
           </Drawer>
         </Hidden>
@@ -367,7 +365,7 @@ class App extends React.PureComponent<Props, State> {
     );
   }
 
-  private navigateTo(to: string) {
+  private navigateTo = (to: string) => {
     const params = new URLSearchParams(this.props.location.search);
     params.delete('args');
     const url = params.has('http_headers_sticky')
@@ -377,7 +375,7 @@ class App extends React.PureComponent<Props, State> {
     this.setState({
       mobileDrawerOpen: false,
     });
-  }
+  };
 
   private fetchSpecification = async () => {
     const httpResponse = await fetch('specification.json');
@@ -416,7 +414,7 @@ class App extends React.PureComponent<Props, State> {
         });
         break;
     }
-  }
+  };
 }
 
 export default hot(module)(withRouter(withStyles(styles)(App)));


### PR DESCRIPTION
This PR is to add the collapse feature to side menu which will be useful for developers when having a large list of `services` `enums` `structs` `exceptions`.
There are mainly three changes:
- Collapse feature for `services` `enums` `structs` `exceptions` sidemenu.
- Add `dense` to each `ListItem` which changed `padding-top` and `padding-down` from `12px` to `8px`

### Before (Apply `dense`)
![sidemenu-dense](https://user-images.githubusercontent.com/5969716/44635806-16ccf000-a9e3-11e8-913d-778f89b9ef46.jpeg)
### After (Apply `dense`)
![sidemenu-dense-new](https://user-images.githubusercontent.com/5969716/44635819-2b10ed00-a9e3-11e8-9b65-a3184cdd9e9f.jpeg)

### Collapse Feature
- All ListItems expand
![sidemenu-new](https://user-images.githubusercontent.com/5969716/44635864-64e1f380-a9e3-11e8-8a98-8324d9374a79.jpeg)
- Click first Item
![sidemenu-new1](https://user-images.githubusercontent.com/5969716/44635868-690e1100-a9e3-11e8-8a8d-941312684420.jpeg) 