### PR TITLE
Completes stopFuture immediately if Server does not start server serverChannels yet

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/Server.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Server.java
@@ -397,6 +397,12 @@ public final class Server implements AutoCloseable {
                     }
 
                     workerShutdownFuture.addListener(unused5 -> {
+                        // If starts to shutdown before initializing serverChannels, completes the future
+                        // immediately.
+                        if (serverChannels.size() == 0) {
+                            future.complete(null);
+                            return;
+                        }
                         // Shut down all boss groups and wait until they are terminated.
                         final AtomicInteger remainingBossGroups = new AtomicInteger(serverChannels.size());
                         serverChannels.forEach(ch -> {

--- a/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
@@ -23,7 +23,6 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
-import java.net.BindException;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -317,8 +316,7 @@ public class ServerTest {
                 .service("/", (ctx, res) -> HttpResponse.of(""))
                 .build();
         assertThatThrownBy(() -> duplicatedPortServer.start().join())
-                .hasCauseInstanceOf(BindException.class)
-                .hasMessageContaining("Address already in use");
+                .hasCauseInstanceOf(IOException.class);
     }
 
     private static void testSimple(

--- a/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
@@ -16,12 +16,14 @@
 package com.linecorp.armeria.server;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.fail;
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
+import java.net.BindException;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -306,6 +308,17 @@ public class ServerTest {
     @Test
     public void testUnsupportedMethod() throws Exception {
         testSimple("WHOA / HTTP/1.1", "HTTP/1.1 405 Method Not Allowed");
+    }
+
+    @Test
+    public void duplicatedPort() {
+        Server duplicatedPortServer = new ServerBuilder()
+                .http(server.httpPort())
+                .service("/", (ctx, res) -> HttpResponse.of(""))
+                .build();
+        assertThatThrownBy(() -> duplicatedPortServer.start().join())
+                .hasCauseInstanceOf(BindException.class)
+                .hasMessageContaining("Address already in use");
     }
 
     private static void testSimple(


### PR DESCRIPTION
Motivations:
- When a server starts multiple times, it fails to start later one but
  start/stopFuture for later one will be stuck since there is no chance to
  complete the future.

Modifications:
- Completes a stopFuture immediately if Server does not start server serverChannels yet
- Shutdown server correctly even if fails to startup