### PR TITLE
Abort a response stream immediately when a client aborts the stream

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/Http1ResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http1ResponseDecoder.java
@@ -73,18 +73,13 @@ final class Http1ResponseDecoder extends HttpResponseDecoder implements ChannelI
                 super.addResponse(id, req, res, logBuilder, responseTimeoutMillis, maxContentLength);
 
         resWrapper.completionFuture().whenComplete((unused, cause) -> {
-            if (cause != null) {
-                // Ensure that the resWrapper is closed.
-                // This is needed in case the response is aborted by the client.
-                resWrapper.close(cause);
+            // Cancel timeout future and abort the request if it exists.
+            resWrapper.onSubscriptionCancelled();
 
+            if (cause != null) {
                 // Disconnect when the response has been closed with an exception because there's no way
                 // to recover from it in HTTP/1.
                 channel().close();
-            } else {
-                // Ensure that the resWrapper is closed.
-                // This is needed in case the response is aborted by the client.
-                resWrapper.close();
             }
         });
 

--- a/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
@@ -213,22 +213,22 @@ abstract class HttpResponseDecoder {
             return delegate.onDemand(task);
         }
 
+        void onSubscriptionCancelled() {
+            close(null, this::cancelAction);
+        }
+
         @Override
         public void close() {
-            close0(null, this::closeAction);
+            close(null, this::closeAction);
         }
 
         @Override
         public void close(Throwable cause) {
-            close0(cause, this::closeAction);
+            close(cause, this::closeAction);
         }
 
-        void onSubscriptionCancelled() {
-            close0(null, this::cancelAction);
-        }
-
-        private void close0(@Nullable Throwable cause,
-                            Consumer<Throwable> actionOnTimeoutCancelled) {
+        private void close(@Nullable Throwable cause,
+                           Consumer<Throwable> actionOnTimeoutCancelled) {
             if (cancelTimeout()) {
                 actionOnTimeoutCancelled.accept(cause);
             } else {

--- a/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
@@ -67,7 +67,7 @@ public class DefaultStreamMessage<T> extends AbstractStreamMessageAndWriter<T> {
     @SuppressWarnings("rawtypes")
     private static final AtomicReferenceFieldUpdater<DefaultStreamMessage, SubscriptionImpl>
             subscriptionUpdater = AtomicReferenceFieldUpdater.newUpdater(
-                    DefaultStreamMessage.class, SubscriptionImpl.class, "subscription");
+            DefaultStreamMessage.class, SubscriptionImpl.class, "subscription");
 
     @SuppressWarnings("rawtypes")
     private static final AtomicReferenceFieldUpdater<DefaultStreamMessage, State> stateUpdater =
@@ -376,9 +376,19 @@ public class DefaultStreamMessage<T> extends AbstractStreamMessageAndWriter<T> {
             throw new IllegalArgumentException("cause: " + cause + " (must use Subscription.cancel())");
         }
 
+        tryClose(cause);
+    }
+
+    /**
+     * Returns {@code true} if the state is successfully changed from {@link State#OPEN} to
+     * {@link State#CLOSED} and a close event is propagated.
+     */
+    protected final boolean tryClose(Throwable cause) {
         if (setState(State.OPEN, State.CLOSED)) {
             addObjectOrEvent(new CloseEvent(cause));
+            return true;
         }
+        return false;
     }
 
     private boolean setState(State oldState, State newState) {

--- a/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
@@ -380,8 +380,10 @@ public class DefaultStreamMessage<T> extends AbstractStreamMessageAndWriter<T> {
     }
 
     /**
-     * Returns {@code true} if the state is successfully changed from {@link State#OPEN} to
-     * {@link State#CLOSED} and a close event is propagated.
+     * Tries to close the stream with the specified {@code cause}.
+     *
+     * @return {@code true} if the stream has been closed by this method call.
+     *         {@code false} if the stream has been closed already by other party.
      */
     protected final boolean tryClose(Throwable cause) {
         if (setState(State.OPEN, State.CLOSED)) {

--- a/core/src/main/java/com/linecorp/armeria/server/Http2RequestDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http2RequestDecoder.java
@@ -27,7 +27,6 @@ import com.linecorp.armeria.common.ClosedSessionException;
 import com.linecorp.armeria.common.ContentTooLargeException;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpMethod;
-import com.linecorp.armeria.common.HttpRequestWriter;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.internal.ArmeriaHttpUtil;
@@ -251,13 +250,13 @@ final class Http2RequestDecoder extends Http2EventAdapter {
 
     @Override
     public void onRstStreamRead(ChannelHandlerContext ctx, int streamId, long errorCode) throws Http2Exception {
-        final HttpRequestWriter req = requests.get(streamId);
+        final DecodedHttpRequest req = requests.get(streamId);
         if (req == null) {
             throw connectionError(PROTOCOL_ERROR,
                                   "received a RST_STREAM frame for an unknown stream: %d", streamId);
         }
 
-        req.close(streamError(
+        req.abortResponse(streamError(
                 streamId, Http2Error.valueOf(errorCode), "received a RST_STREAM frame"));
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -420,6 +420,10 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
                 }
             }), eventLoop).exceptionally(CompletionActions::log);
 
+            // Set the response to the request in order to be able to immediately abort the response
+            // when the peer cancels the stream.
+            req.setResponse(res);
+
             assert responseEncoder != null;
             final HttpResponseSubscriber resSubscriber =
                     new HttpResponseSubscriber(ctx, responseEncoder, reqCtx, req, accessLogWriter);

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerAbortingInfiniteStreamTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerAbortingInfiniteStreamTest.java
@@ -137,6 +137,6 @@ public class HttpServerAbortingInfiniteStreamTest {
             public void onComplete() {}
         });
 
-        await().atMost(3, TimeUnit.SECONDS).untilTrue(isCompleted);
+        await().atMost(5, TimeUnit.SECONDS).untilTrue(isCompleted);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerAbortingInfiniteStreamTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerAbortingInfiniteStreamTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server;
+
+import static com.linecorp.armeria.common.SessionProtocol.H1C;
+import static com.linecorp.armeria.common.SessionProtocol.H2C;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.util.Collection;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.annotation.Nullable;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpObject;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpResponseWriter;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.testing.server.ServerRule;
+
+@RunWith(Parameterized.class)
+public class HttpServerAbortingInfiniteStreamTest {
+    private static final Logger logger = LoggerFactory.getLogger(HttpServerAbortingInfiniteStreamTest.class);
+
+    @Parameters(name = "{index}: protocol={0}")
+    public static Collection<SessionProtocol> protocols() {
+        return ImmutableList.of(H1C, H2C);
+    }
+
+    private final SessionProtocol protocol;
+    private final AtomicBoolean isCompleted = new AtomicBoolean();
+
+    public HttpServerAbortingInfiniteStreamTest(SessionProtocol protocol) {
+        this.protocol = protocol;
+    }
+
+    @Rule
+    public final ServerRule server = new ServerRule() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.service("/infinity", (ctx, req) -> {
+                // Ensure that the protocol is expected one.
+                assertThat(ctx.sessionProtocol()).isEqualTo(protocol);
+
+                final HttpResponseWriter writer = HttpResponse.streaming();
+                writer.write(HttpHeaders.of(HttpStatus.OK));
+
+                // Do not close the response writer because it returns data infinitely.
+                writer.onDemand(new Runnable() {
+                    @Override
+                    public void run() {
+                        writer.write(HttpData.ofUtf8("infinite stream"));
+                        writer.onDemand(this);
+                    }
+                });
+                writer.completionFuture().whenComplete((unused, cause) -> {
+                    // We are not expecting that this stream is successfully finished.
+                    if (cause != null) {
+                        if (isCompleted.compareAndSet(false, true)) {
+                            logger.debug("Infinite stream is completed");
+                        }
+                    }
+                });
+                return writer;
+            });
+        }
+    };
+
+    @Test
+    public void shouldCancelInfiniteStreamImmediately() {
+        final HttpClient client = HttpClient.of(server.uri(protocol, "/"));
+        final HttpResponse response = client.execute(HttpHeaders.of(HttpMethod.GET, "/infinity"));
+
+        response.subscribe(new Subscriber<HttpObject>() {
+            @Nullable
+            private Subscription subscription;
+            private int count;
+
+            @Override
+            public void onSubscribe(Subscription s) {
+                s.request(1);
+                subscription = s;
+            }
+
+            @Override
+            public void onNext(HttpObject httpObject) {
+                assert subscription != null;
+                if (++count == 10) {
+                    logger.debug("Cancel subscription: count={}", count);
+                    subscription.cancel();
+                }
+                subscription.request(1);
+            }
+
+            @Override
+            public void onError(Throwable t) {}
+
+            @Override
+            public void onComplete() {}
+        });
+
+        await().atMost(3, TimeUnit.SECONDS).untilTrue(isCompleted);
+    }
+}

--- a/testing/src/main/java/com/linecorp/armeria/testing/server/ServerRule.java
+++ b/testing/src/main/java/com/linecorp/armeria/testing/server/ServerRule.java
@@ -227,6 +227,22 @@ public abstract class ServerRule extends ExternalResource {
         // This will ensure that the server has started.
         server();
 
+        return format.uriText() + '+' + uri(protocol, path);
+    }
+
+    /**
+     * Returns the URI for the {@link Server} of the specified protocol.
+     *
+     * @throws IllegalStateException if the {@link Server} is not started or
+     *                               it did not open a port of the protocol.
+     */
+    public String uri(SessionProtocol protocol, String path) {
+        requireNonNull(protocol, "protocol");
+        requireNonNull(path, "path");
+
+        // This will ensure that the server has started.
+        server();
+
         final int port;
         if (!protocol.isTls() && hasHttp()) {
             port = httpPort();
@@ -236,7 +252,7 @@ public abstract class ServerRule extends ExternalResource {
             throw new IllegalStateException("can't find the specified port");
         }
 
-        return format.uriText() + '+' + protocol.uriText() + "://127.0.0.1:" + port + path;
+        return protocol.uriText() + "://127.0.0.1:" + port + path;
     }
 
     /**


### PR DESCRIPTION
Motivation:
When the server responds infinite streaming data, the client can aborts the stream at any time. If it does, the stream should be aborted immediately for the both side of the server and the client, but for now the stream does not be aborted until the request timeout is occurred.

Modifications:
- Client-side:
  - Call HttpResponseWrapper#onSubscriptionCancelled instead of #close when the subscription is cancelled. Calling #close with CancelledSubscriptionException raises IllegalArgumentException which is unexpected for while cancelling subscription.
- Server-side:
  - Http2RequestDecoder aborts the response stream when a RST_STREAM frame is received from the client. Before that, it closed the request with an Http2Exception, but the exception did not be propagated into the response stream. So the response stream could be completed only if the request timeout was occurred.

Result:
- The response stream can be aborted immediately for both side of the server and the client.