### PR TITLE
Handle `%26` and `%3D` in a query string correctly

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/PathAndQuery.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/PathAndQuery.java
@@ -70,12 +70,17 @@ public final class PathAndQuery {
      * A special byte which tells {@link #encodeToPercents(Bytes, boolean)} to translate it to
      * {@code "%26"}.
      */
-    private static final int ENCODED_AMPERSAND = 0xFF;
+    private static final int ENCODED_AMPERSAND = 0xFD;
+    /**
+     * A special byte which tells {@link #encodeToPercents(Bytes, boolean)} to translate it to
+     * {@code "%3B"}.
+     */
+    private static final int ENCODED_SEMICOLON = 0xFE;
     /**
      * A special byte which tells {@link #encodeToPercents(Bytes, boolean)} to translate it to
      * {@code "%3D"}.
      */
-    private static final int ENCODED_EQUAL = 0xFE;
+    private static final int ENCODED_EQUAL = 0xFF;
 
     @Nullable
     private static final Cache<String, PathAndQuery> CACHE =
@@ -269,6 +274,12 @@ public final class PathAndQuery {
                         buf.ensure(1);
                         buf.add((byte) ENCODED_AMPERSAND);
                         wasSlash = false;
+                    } else if (decoded == ';') {
+                        // Insert a special mark 'ENCODED_SEMICOLON' so we can distinguish ';' and '%3D'
+                        // in a query string. We will encode 'ENCODED_SEMICOLON' back into '%3D' later.
+                        buf.ensure(1);
+                        buf.add((byte) ENCODED_SEMICOLON);
+                        wasSlash = false;
                     } else if (decoded == '=') {
                         // Insert a special mark 'ENCODED_EQUAL' so we can distinguish '=' and '%3D'
                         // in a query string. We will encode 'ENCODED_EQUAL' back into '%3D' later.
@@ -440,6 +451,8 @@ public final class PathAndQuery {
                 }
             } else if (b == ENCODED_AMPERSAND) {
                 buf.append("%26");
+            } else if (b == ENCODED_SEMICOLON) {
+                buf.append("%3B");
             } else if (b == ENCODED_EQUAL) {
                 buf.append("%3D");
             } else {

--- a/core/src/main/java/com/linecorp/armeria/internal/PathAndQuery.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/PathAndQuery.java
@@ -66,6 +66,17 @@ public final class PathAndQuery {
     private static final Bytes EMPTY_QUERY = new Bytes(0);
     private static final Bytes ROOT_PATH = new Bytes(new byte[] { '/' });
 
+    /**
+     * A special byte which tells {@link #encodeToPercents(Bytes, boolean)} to translate it to
+     * {@code "%26"}.
+     */
+    private static final int ENCODED_AMPERSAND = 0xFF;
+    /**
+     * A special byte which tells {@link #encodeToPercents(Bytes, boolean)} to translate it to
+     * {@code "%3D"}.
+     */
+    private static final int ENCODED_EQUAL = 0xFE;
+
     @Nullable
     private static final Cache<String, PathAndQuery> CACHE =
             Flags.parsedPathCacheSpec().map(PathAndQuery::buildCache).orElse(null);
@@ -217,15 +228,14 @@ public final class PathAndQuery {
     }
 
     @Nullable
-    private static Bytes decodePercentsAndEncodeToUtf8(String value, int start, int end,
-                                                          boolean isPath) {
+    private static Bytes decodePercentsAndEncodeToUtf8(String value, int start, int end, boolean isPath) {
         final int length = end - start;
         if (length == 0) {
             return isPath ? ROOT_PATH : EMPTY_QUERY;
         }
 
         final Bytes buf = new Bytes(Math.max(length * 3 / 2, 4));
-        int lastCP = 0;
+        boolean wasSlash = false;
         for (final CodePointIterator i = new CodePointIterator(value, start, end); i.hasNextCodePoint();) {
             final int pos = i.position();
             final int cp = i.nextCodePoint();
@@ -245,26 +255,53 @@ public final class PathAndQuery {
                 }
 
                 final int decoded = (decodeHexNibble(digit1) << 4) | decodeHexNibble(digit2);
-                if (!appendOneByte(buf, decoded, lastCP, isPath)) {
-                    return null;
+                if (isPath) {
+                    if (appendOneByte(buf, decoded, wasSlash, isPath)) {
+                        wasSlash = decoded == '/';
+                    } else {
+                        return null;
+                    }
+                } else {
+                    // If query:
+                    if (decoded == '&') {
+                        // Insert a special mark 'ENCODED_AMPERSAND' so we can distinguish '&' and '%26'
+                        // in a query string. We will encode 'ENCODED_AMPERSAND' back into '%26' later.
+                        buf.ensure(1);
+                        buf.add((byte) ENCODED_AMPERSAND);
+                        wasSlash = false;
+                    } else if (decoded == '=') {
+                        // Insert a special mark 'ENCODED_EQUAL' so we can distinguish '=' and '%3D'
+                        // in a query string. We will encode 'ENCODED_EQUAL' back into '%3D' later.
+                        buf.ensure(1);
+                        buf.add((byte) ENCODED_EQUAL);
+                        wasSlash = false;
+                    } else if (appendOneByte(buf, decoded, wasSlash, isPath)) {
+                        wasSlash = decoded == '/';
+                    } else {
+                        return null;
+                    }
                 }
+
                 i.position(hexEnd);
-                lastCP = decoded;
                 continue;
             }
 
             if (cp == '+' && !isPath) {
                 buf.ensure(1);
                 buf.add((byte) ' ');
-                lastCP = '+';
+                wasSlash = false;
                 continue;
             }
 
             if (cp <= 0x7F) {
-                if (!appendOneByte(buf, cp, lastCP, isPath)) {
+                if (!appendOneByte(buf, cp, wasSlash, isPath)) {
                     return null;
                 }
-            } else if (cp <= 0x7ff) {
+                wasSlash = cp == '/';
+                continue;
+            }
+
+            if (cp <= 0x7ff) {
                 buf.ensure(2);
                 buf.add((byte) ((cp >>> 6) | 0b110_00000));
                 buf.add((byte) (cp & 0b111111 | 0b10_000000));
@@ -300,20 +337,20 @@ public final class PathAndQuery {
                 buf.add((byte) ((cp & 0b111111) | 0b10_000000));
             }
 
-            lastCP = cp;
+            wasSlash = false;
         }
 
         return buf;
     }
 
-    private static boolean appendOneByte(Bytes buf, int cp, int lastCP, boolean isPath) {
+    private static boolean appendOneByte(Bytes buf, int cp, boolean wasSlash, boolean isPath) {
         if (cp == 0x7F || (cp >>> 5 == 0)) {
             // Reject the prohibited control characters: 0x00..0x1F and 0x7F
             return false;
         }
 
         if (cp == '/' && isPath) {
-            if (lastCP != '/') {
+            if (!wasSlash) {
                 buf.ensure(1);
                 buf.add((byte) '/');
             } else {
@@ -401,6 +438,10 @@ public final class PathAndQuery {
                 } else {
                     buf.append('+');
                 }
+            } else if (b == ENCODED_AMPERSAND) {
+                buf.append("%26");
+            } else if (b == ENCODED_EQUAL) {
+                buf.append("%3D");
             } else {
                 buf.append('%');
                 appendHexNibble(buf, b >>> 4);

--- a/core/src/test/java/com/linecorp/armeria/internal/PathAndQueryTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/PathAndQueryTest.java
@@ -189,14 +189,42 @@ public class PathAndQueryTest {
 
     @Test
     public void plus() {
-        final PathAndQuery res = PathAndQuery.parse("/+?+");
+        final PathAndQuery res = PathAndQuery.parse("/+?a+b=c+d");
         assertThat(res).isNotNull();
         assertThat(res.path()).isEqualTo("/+");
-        assertThat(res.query()).isEqualTo("+");
+        assertThat(res.query()).isEqualTo("a+b=c+d");
 
-        final PathAndQuery res2 = PathAndQuery.parse("/%2b?%2b");
+        final PathAndQuery res2 = PathAndQuery.parse("/%2b?a%2bb=c%2bd");
         assertThat(res2).isNotNull();
         assertThat(res2.path()).isEqualTo("/+");
-        assertThat(res2.query()).isEqualTo("%2B");
+        assertThat(res2.query()).isEqualTo("a%2Bb=c%2Bd");
+    }
+
+    @Test
+    public void ampersand() {
+        final PathAndQuery res = PathAndQuery.parse("/&?a=1&a=2&b=3");
+        assertThat(res).isNotNull();
+        assertThat(res.path()).isEqualTo("/&");
+        assertThat(res.query()).isEqualTo("a=1&a=2&b=3");
+
+        // '%26' in a query string should never be decoded into '&'.
+        final PathAndQuery res2 = PathAndQuery.parse("/%26?a=1%26a=2&b=3");
+        assertThat(res2).isNotNull();
+        assertThat(res2.path()).isEqualTo("/&");
+        assertThat(res2.query()).isEqualTo("a=1%26a=2&b=3");
+    }
+
+    @Test
+    public void equal() {
+        final PathAndQuery res = PathAndQuery.parse("/=?a=b=1");
+        assertThat(res).isNotNull();
+        assertThat(res.path()).isEqualTo("/=");
+        assertThat(res.query()).isEqualTo("a=b=1");
+
+        // '%26' in a query string should never be decoded into '&'.
+        final PathAndQuery res2 = PathAndQuery.parse("/%3D?a%3db=1");
+        assertThat(res2).isNotNull();
+        assertThat(res2.path()).isEqualTo("/=");
+        assertThat(res2.query()).isEqualTo("a%3Db=1");
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/internal/PathAndQueryTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/PathAndQueryTest.java
@@ -215,6 +215,20 @@ public class PathAndQueryTest {
     }
 
     @Test
+    public void semicolon() {
+        final PathAndQuery res = PathAndQuery.parse("/;?a=b;c=d");
+        assertThat(res).isNotNull();
+        assertThat(res.path()).isEqualTo("/;");
+        assertThat(res.query()).isEqualTo("a=b;c=d");
+
+        // '%26' in a query string should never be decoded into '&'.
+        final PathAndQuery res2 = PathAndQuery.parse("/%3b?a=b%3Bc=d");
+        assertThat(res2).isNotNull();
+        assertThat(res2.path()).isEqualTo("/;");
+        assertThat(res2.query()).isEqualTo("a=b%3Bc=d");
+    }
+
+    @Test
     public void equal() {
         final PathAndQuery res = PathAndQuery.parse("/=?a=b=1");
         assertThat(res).isNotNull();

--- a/core/src/test/java/com/linecorp/armeria/internal/PathAndQueryTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/PathAndQueryTest.java
@@ -221,7 +221,7 @@ public class PathAndQueryTest {
         assertThat(res.path()).isEqualTo("/;");
         assertThat(res.query()).isEqualTo("a=b;c=d");
 
-        // '%26' in a query string should never be decoded into '&'.
+        // '%3B' in a query string should never be decoded into ';'.
         final PathAndQuery res2 = PathAndQuery.parse("/%3b?a=b%3Bc=d");
         assertThat(res2).isNotNull();
         assertThat(res2.path()).isEqualTo("/;");

--- a/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/ArmeriaCallFactoryTest.java
+++ b/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/ArmeriaCallFactoryTest.java
@@ -361,6 +361,18 @@ public class ArmeriaCallFactoryTest {
 
         response = service.queryStringEncoded("Foo+Bar", 33).get();
         assertThat(response).isEqualTo(new Pojo("Foo Bar", 33));
+
+        response = service.queryString("Foo%26name%3DBar", 33).get();
+        assertThat(response).isEqualTo(new Pojo("Foo%26name%3DBar", 33));
+
+        response = service.queryString("Foo&name=Bar", 34).get();
+        assertThat(response).isEqualTo(new Pojo("Foo&name=Bar", 34));
+
+        response = service.queryStringEncoded("Foo&name=Bar", 33).get();
+        assertThat(response).isEqualTo(new Pojo("Foo&name=Bar", 33));
+
+        response = service.queryStringEncoded("Foo%26name%3DBar", 33).get();
+        assertThat(response).isEqualTo(new Pojo("Foo&name=Bar", 33));
     }
 
     @Test

--- a/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/ArmeriaCallFactoryTest.java
+++ b/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/ArmeriaCallFactoryTest.java
@@ -350,6 +350,12 @@ public class ArmeriaCallFactoryTest {
         Pojo response = service.queryString("Foo+Bar", 33).get();
         assertThat(response).isEqualTo(new Pojo("Foo+Bar", 33));
 
+        response = service.queryString("Foo&name=Bar", 34).get();
+        assertThat(response).isEqualTo(new Pojo("Foo&name=Bar", 34));
+
+        response = service.queryString("Foo;Bar", 33).get();
+        assertThat(response).isEqualTo(new Pojo("Foo;Bar", 33));
+
         response = service.queryString("Foo%2BBar", 33).get();
         assertThat(response).isEqualTo(new Pojo("Foo%2BBar", 33));
 
@@ -364,9 +370,6 @@ public class ArmeriaCallFactoryTest {
 
         response = service.queryStringEncoded("Foo+Bar", 33).get();
         assertThat(response).isEqualTo(new Pojo("Foo Bar", 33));
-
-        response = service.queryString("Foo&name=Bar", 34).get();
-        assertThat(response).isEqualTo(new Pojo("Foo&name=Bar", 34));
 
         response = service.queryStringEncoded("Foo&name=Bar", 33).get();
         assertThat(response).isEqualTo(new Pojo("Foo&name=Bar", 33));

--- a/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/ArmeriaCallFactoryTest.java
+++ b/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/ArmeriaCallFactoryTest.java
@@ -352,6 +352,9 @@ public class ArmeriaCallFactoryTest {
 
         response = service.queryString("Foo%2BBar", 33).get();
         assertThat(response).isEqualTo(new Pojo("Foo%2BBar", 33));
+
+        response = service.queryString("Foo%26name%3DBar", 33).get();
+        assertThat(response).isEqualTo(new Pojo("Foo%26name%3DBar", 33));
     }
 
     @Test
@@ -361,9 +364,6 @@ public class ArmeriaCallFactoryTest {
 
         response = service.queryStringEncoded("Foo+Bar", 33).get();
         assertThat(response).isEqualTo(new Pojo("Foo Bar", 33));
-
-        response = service.queryString("Foo%26name%3DBar", 33).get();
-        assertThat(response).isEqualTo(new Pojo("Foo%26name%3DBar", 33));
 
         response = service.queryString("Foo&name=Bar", 34).get();
         assertThat(response).isEqualTo(new Pojo("Foo&name=Bar", 34));


### PR DESCRIPTION
Motivation:

The following query string:

    a=1%26a=2

should be interpreted as a single query entry whose key is `a` and value
is `1&a=2`. However, `PathAndQuery` currently handles it as two query
entries: `a=1` and `a=2`.

It is because `PathAndQuery` decodes `%26` into `&` internally, making `%26`
indistinguishable from `&`.

Also, `%3D` in a query string should be similarly due to the case where
a query string key contains `=`: `a%3Db=1`

Modifications:

- Decode `%26` and `%3D` into a special marker character so that it is encoded
  back into `%26` and `%3D` in `PathAndQuery`
- Update test cases
  - ArmeriaCallFactory has been updated by @kojilin.

Result:

- A query parameter that contains an ampersand or an equal sign is interpreted correctly.