### PR TITLE
Add AsyncMethodCallbacks which bridges the gap between CompletionStage and AsyncMethodCallback

### DIFF
--- a/thrift/src/main/java/com/linecorp/armeria/common/thrift/AsyncMethodCallbacks.java
+++ b/thrift/src/main/java/com/linecorp/armeria/common/thrift/AsyncMethodCallbacks.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common.thrift;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
+import java.util.function.BiConsumer;
+
+import org.apache.thrift.async.AsyncMethodCallback;
+
+import com.linecorp.armeria.common.util.CompletionActions;
+
+/**
+ * A utility class that bridges the gap between {@link CompletionStage} and {@link AsyncMethodCallback}.
+ */
+public final class AsyncMethodCallbacks {
+
+    /**
+     * Adds a callback that transfers the outcome of the specified {@link CompletionStage} to the specified
+     * {@link AsyncMethodCallback}.
+     *
+     * <pre>{@code
+     * > public class MyThriftService implements ThriftService.AsyncIface {
+     * >     @Override
+     * >     public void myServiceMethod(AsyncMethodCallback<MyResult> callback) {
+     * >         final CompletableFuture<MyResult> future = ...;
+     * >         AsyncMethodCallbacks.transfer(future, callback);
+     * >     }
+     * > }
+     * }</pre>
+     */
+    public static <T> void transfer(CompletionStage<T> src, AsyncMethodCallback<? super T> dest) {
+        requireNonNull(src, "src");
+        src.whenComplete(callback(dest));
+    }
+
+    /**
+     * Adds a callback that transfers the outcome of the specified {@link CompletionStage} to the specified
+     * {@link AsyncMethodCallback}. The callback methods of {@link AsyncMethodCallback} will be invoked by
+     * the default asynchronous execution facility of the {@link CompletionStage}.
+     *
+     * <pre>{@code
+     * > public class MyThriftService implements ThriftService.AsyncIface {
+     * >     @Override
+     * >     public void myServiceMethod(AsyncMethodCallback<MyResult> callback) {
+     * >         final CompletableFuture<MyResult> future = ...;
+     * >         AsyncMethodCallbacks.transferAsync(future, callback);
+     * >     }
+     * > }
+     * }</pre>
+     */
+    public static <T> void transferAsync(CompletionStage<T> src, AsyncMethodCallback<? super T> dest) {
+        requireNonNull(src, "src");
+        src.whenCompleteAsync(callback(dest));
+    }
+
+    /**
+     * Adds a callback that transfers the outcome of the specified {@link CompletionStage} to the specified
+     * {@link AsyncMethodCallback}. The callback methods of {@link AsyncMethodCallback} will be invoked by
+     * the specified {@link Executor}.
+     *
+     * <pre>{@code
+     * > public class MyThriftService implements ThriftService.AsyncIface {
+     * >     @Override
+     * >     public void myServiceMethod(AsyncMethodCallback<MyResult> callback) {
+     * >         final CompletableFuture<MyResult> future = ...;
+     * >         AsyncMethodCallbacks.transferAsync(future, callback, executor);
+     * >     }
+     * > }
+     * }</pre>
+     */
+    public static <T> void transferAsync(
+            CompletionStage<T> src, AsyncMethodCallback<? super T> dest, Executor executor) {
+
+        requireNonNull(src, "src");
+        requireNonNull(executor, "executor");
+        src.whenCompleteAsync(callback(dest), executor);
+    }
+
+    /**
+     * Invokes {@link AsyncMethodCallback#onError(Exception)}. If the specified {@code cause} is not an
+     * {@link Exception}, it will be wrapped with a {@link CompletionException}.
+     */
+    public static void invokeOnError(AsyncMethodCallback<?> callback, Throwable cause) {
+        requireNonNull(callback, "callback");
+        requireNonNull(cause, "cause");
+        if (cause instanceof Exception) {
+            callback.onError((Exception) cause);
+        } else {
+            callback.onError(new CompletionException(cause.toString(), cause));
+        }
+    }
+
+    private static <T> BiConsumer<T, Throwable> callback(AsyncMethodCallback<? super T> dest) {
+        requireNonNull(dest, "dest");
+        return (res, cause) -> {
+            try {
+                if (cause != null) {
+                    invokeOnError(dest, cause);
+                } else {
+                    dest.onComplete(res);
+                }
+            } catch (Exception e) {
+                CompletionActions.log(e);
+            }
+        };
+    }
+
+    private AsyncMethodCallbacks() {}
+}

--- a/thrift/src/test/java/com/linecorp/armeria/common/thrift/AsyncMethodCallbacksTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/common/thrift/AsyncMethodCallbacksTest.java
@@ -17,7 +17,6 @@ package com.linecorp.armeria.common.thrift;
 
 import static com.spotify.futures.CompletableFutures.exceptionallyCompletedFuture;
 import static java.util.concurrent.CompletableFuture.completedFuture;
-import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.isA;
@@ -27,8 +26,6 @@ import static org.mockito.Mockito.only;
 import static org.mockito.Mockito.verify;
 
 import java.util.concurrent.CompletionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 import org.apache.thrift.async.AsyncMethodCallback;
 import org.junit.Test;
@@ -74,32 +71,5 @@ public class AsyncMethodCallbacksTest {
         doThrow(new AnticipatedException()).when(callback).onComplete(any());
         AsyncMethodCallbacks.transfer(completedFuture("foo"), callback);
         verify(callback, only()).onComplete("foo");
-    }
-
-    @Test
-    public void transferAsync_ExecutorUnspecified() {
-        @SuppressWarnings("unchecked")
-        final AsyncMethodCallback<String> callback = mock(AsyncMethodCallback.class);
-        AsyncMethodCallbacks.transferAsync(completedFuture("foo"), callback);
-
-        await().untilAsserted(() -> {
-            verify(callback, only()).onComplete("foo");
-        });
-    }
-
-    @Test
-    public void transferAsync_ExecutorSpecified() throws Exception {
-        final ExecutorService executor = Executors.newSingleThreadExecutor();
-        try {
-            @SuppressWarnings("unchecked")
-            final AsyncMethodCallback<String> callback = mock(AsyncMethodCallback.class);
-            AsyncMethodCallbacks.transferAsync(completedFuture("foo"), callback, executor);
-
-            await().untilAsserted(() -> {
-                verify(callback, only()).onComplete("foo");
-            });
-        } finally {
-            executor.shutdownNow();
-        }
     }
 }

--- a/thrift/src/test/java/com/linecorp/armeria/common/thrift/AsyncMethodCallbacksTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/common/thrift/AsyncMethodCallbacksTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common.thrift;
+
+import static com.spotify.futures.CompletableFutures.exceptionallyCompletedFuture;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.apache.thrift.async.AsyncMethodCallback;
+import org.junit.Test;
+
+import com.linecorp.armeria.testing.internal.AnticipatedException;
+
+public class AsyncMethodCallbacksTest {
+
+    @Test
+    public void transferSuccess() {
+        @SuppressWarnings("unchecked")
+        final AsyncMethodCallback<String> callback = mock(AsyncMethodCallback.class);
+        AsyncMethodCallbacks.transfer(completedFuture("foo"), callback);
+
+        verify(callback, times(1)).onComplete("foo");
+        verify(callback, never()).onError(any());
+    }
+
+    @Test
+    public void transferFailure_Exception() {
+        @SuppressWarnings("unchecked")
+        final AsyncMethodCallback<String> callback = mock(AsyncMethodCallback.class);
+        AsyncMethodCallbacks.transfer(exceptionallyCompletedFuture(new AnticipatedException()), callback);
+
+        verify(callback, never()).onComplete(any());
+        verify(callback, times(1)).onError(isA(AnticipatedException.class));
+    }
+
+    @Test
+    public void transferFailure_Throwable() {
+        @SuppressWarnings("unchecked")
+        final AsyncMethodCallback<String> callback = mock(AsyncMethodCallback.class);
+        AsyncMethodCallbacks.transfer(exceptionallyCompletedFuture(new Throwable("foo")), callback);
+
+        verify(callback, never()).onComplete(any());
+        verify(callback, times(1)).onError(argThat(argument -> {
+            return argument instanceof CompletionException &&
+                   "foo".equals(argument.getCause().getMessage());
+        }));
+    }
+
+    @Test
+    public void transferCallbackError() {
+        @SuppressWarnings("unchecked")
+        final AsyncMethodCallback<String> callback = mock(AsyncMethodCallback.class);
+        doThrow(new AnticipatedException()).when(callback).onComplete(any());
+        AsyncMethodCallbacks.transfer(completedFuture("foo"), callback);
+    }
+
+    @Test
+    public void transferAsync_ExecutorUnspecified() {
+        @SuppressWarnings("unchecked")
+        final AsyncMethodCallback<String> callback = mock(AsyncMethodCallback.class);
+        AsyncMethodCallbacks.transferAsync(completedFuture("foo"), callback);
+
+        await().untilAsserted(() -> {
+            verify(callback, times(1)).onComplete("foo");
+            verify(callback, never()).onError(any());
+        });
+    }
+
+    @Test
+    public void transferAsync_ExecutorSpecified() throws Exception {
+        final ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            @SuppressWarnings("unchecked")
+            final AsyncMethodCallback<String> callback = mock(AsyncMethodCallback.class);
+            AsyncMethodCallbacks.transferAsync(completedFuture("foo"), callback, executor);
+
+            await().untilAsserted(() -> {
+                verify(callback, times(1)).onComplete("foo");
+                verify(callback, never()).onError(any());
+            });
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+}

--- a/thrift/src/test/java/com/linecorp/armeria/common/thrift/AsyncMethodCallbacksTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/common/thrift/AsyncMethodCallbacksTest.java
@@ -23,8 +23,7 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.only;
 import static org.mockito.Mockito.verify;
 
 import java.util.concurrent.CompletionException;
@@ -44,8 +43,7 @@ public class AsyncMethodCallbacksTest {
         final AsyncMethodCallback<String> callback = mock(AsyncMethodCallback.class);
         AsyncMethodCallbacks.transfer(completedFuture("foo"), callback);
 
-        verify(callback, times(1)).onComplete("foo");
-        verify(callback, never()).onError(any());
+        verify(callback, only()).onComplete("foo");
     }
 
     @Test
@@ -54,8 +52,7 @@ public class AsyncMethodCallbacksTest {
         final AsyncMethodCallback<String> callback = mock(AsyncMethodCallback.class);
         AsyncMethodCallbacks.transfer(exceptionallyCompletedFuture(new AnticipatedException()), callback);
 
-        verify(callback, never()).onComplete(any());
-        verify(callback, times(1)).onError(isA(AnticipatedException.class));
+        verify(callback, only()).onError(isA(AnticipatedException.class));
     }
 
     @Test
@@ -64,8 +61,7 @@ public class AsyncMethodCallbacksTest {
         final AsyncMethodCallback<String> callback = mock(AsyncMethodCallback.class);
         AsyncMethodCallbacks.transfer(exceptionallyCompletedFuture(new Throwable("foo")), callback);
 
-        verify(callback, never()).onComplete(any());
-        verify(callback, times(1)).onError(argThat(argument -> {
+        verify(callback, only()).onError(argThat(argument -> {
             return argument instanceof CompletionException &&
                    "foo".equals(argument.getCause().getMessage());
         }));
@@ -77,6 +73,7 @@ public class AsyncMethodCallbacksTest {
         final AsyncMethodCallback<String> callback = mock(AsyncMethodCallback.class);
         doThrow(new AnticipatedException()).when(callback).onComplete(any());
         AsyncMethodCallbacks.transfer(completedFuture("foo"), callback);
+        verify(callback, only()).onComplete("foo");
     }
 
     @Test
@@ -86,8 +83,7 @@ public class AsyncMethodCallbacksTest {
         AsyncMethodCallbacks.transferAsync(completedFuture("foo"), callback);
 
         await().untilAsserted(() -> {
-            verify(callback, times(1)).onComplete("foo");
-            verify(callback, never()).onError(any());
+            verify(callback, only()).onComplete("foo");
         });
     }
 
@@ -100,8 +96,7 @@ public class AsyncMethodCallbacksTest {
             AsyncMethodCallbacks.transferAsync(completedFuture("foo"), callback, executor);
 
             await().untilAsserted(() -> {
-                verify(callback, times(1)).onComplete("foo");
-                verify(callback, never()).onError(any());
+                verify(callback, only()).onComplete("foo");
             });
         } finally {
             executor.shutdownNow();


### PR DESCRIPTION
Motivation:

The following is a very common idiom when implementing an asynchronous
Thrift service:

    public void myThriftServiceMethod(AsyncMethodCallback<String> cb) {
        CompletableFuture<String> f = someAsyncOp();
        f.whenComplete((res, cause) -> {
            if (cause != null) {
                if (cause instanceof Exception) {
                    cb.onError(cause);
                } else {
                    cb.onError(new CompletionException(cause));
                }
            } else {
                cb.onComplete(res);
            }
        });
    }

We could provide some utility for this:

    public void myThriftServiceMethod(AsyncMethodCallback<String> cb) {
        AsyncMethodCallbacks.transfer(someAsyncOp(), cb);
    }

Modifications:

- Add `AsyncMethodCallbacks.transfer()` and `transferAsync()`
- Add `AsyncMethodCallbacks.invokeOnError()` for deduplication with
  `THttpClientInvocationHandler`.

Result:

- Fixes #508
- Slightly better Thrift experience