### PR TITLE
Allow TAB, CR and LF in a query string

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/PathAndQuery.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/PathAndQuery.java
@@ -355,9 +355,19 @@ public final class PathAndQuery {
     }
 
     private static boolean appendOneByte(Bytes buf, int cp, boolean wasSlash, boolean isPath) {
-        if (cp == 0x7F || (cp >>> 5 == 0)) {
-            // Reject the prohibited control characters: 0x00..0x1F and 0x7F
+        if (cp == 0x7F) {
+            // Reject the control character: 0x7F
             return false;
+        }
+
+        if (cp >>> 5 == 0) {
+            // Reject the control characters: 0x00..0x1F
+            if (isPath) {
+                return false;
+            } else if (cp != 0x0A && cp != 0x0D && cp != 0x09) {
+                // .. except 0x0A (LF), 0x0D (CR) and 0x09 (TAB) because they are used in a form.
+                return false;
+            }
         }
 
         if (cp == '/' && isPath) {

--- a/core/src/test/java/com/linecorp/armeria/internal/PathAndQueryTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/PathAndQueryTest.java
@@ -85,18 +85,30 @@ public class PathAndQueryTest {
 
         // Escaped
         assertThat(PathAndQuery.parse("/%00")).isNull();
+        assertThat(PathAndQuery.parse("/a%09b")).isNull();
+        assertThat(PathAndQuery.parse("/a%0ab")).isNull();
         assertThat(PathAndQuery.parse("/a%0db")).isNull();
         assertThat(PathAndQuery.parse("/a%7fb")).isNull();
 
         // With query string
         assertThat(PathAndQuery.parse("/\0?c")).isNull();
+        assertThat(PathAndQuery.parse("/a\tb?c")).isNull();
         assertThat(PathAndQuery.parse("/a\nb?c")).isNull();
+        assertThat(PathAndQuery.parse("/a\rb?c")).isNull();
         assertThat(PathAndQuery.parse("/a\u007fb?c")).isNull();
 
         // With query string with control chars
         assertThat(PathAndQuery.parse("/?\0")).isNull();
-        assertThat(PathAndQuery.parse("/?a\nb")).isNull();
+        assertThat(PathAndQuery.parse("/?%00")).isNull();
         assertThat(PathAndQuery.parse("/?a\u007fb")).isNull();
+        assertThat(PathAndQuery.parse("/?a%7Fb")).isNull();
+        // However, 0x0A, 0x0D, 0x09 should be accepted in a query string.
+        assertThat(PathAndQuery.parse("/?a\tb").query()).isEqualTo("a%09b");
+        assertThat(PathAndQuery.parse("/?a\nb").query()).isEqualTo("a%0Ab");
+        assertThat(PathAndQuery.parse("/?a\rb").query()).isEqualTo("a%0Db");
+        assertThat(PathAndQuery.parse("/?a%09b").query()).isEqualTo("a%09b");
+        assertThat(PathAndQuery.parse("/?a%0Ab").query()).isEqualTo("a%0Ab");
+        assertThat(PathAndQuery.parse("/?a%0Db").query()).isEqualTo("a%0Db");
     }
 
     @Test


### PR DESCRIPTION
Motivation:

The validation logic in `PathAndQuery` is still too restrictive. It
should allow `%09`, `%0A` and `%0D` (TAB, LF and CR) which can be
included in a query string part, e.g. a user can enter a multi-line
text in a form.

Modifications:

- Allow TAB, CR and LF in a query string.
  - They are still unallowed in a path part.

Result:

- Innocent web form submissions are not rejected.