### PR TITLE
Customize client options of HttpClient used in HttpHealthCheckedEndpointGroup

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroup.java
@@ -20,8 +20,10 @@ import static java.util.Objects.requireNonNull;
 import java.net.StandardProtocolFamily;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 
 import com.linecorp.armeria.client.ClientFactory;
+import com.linecorp.armeria.client.ClientOptionsBuilder;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.client.HttpClientBuilder;
@@ -73,6 +75,7 @@ public final class HttpHealthCheckedEndpointGroup extends HealthCheckedEndpointG
 
     private final SessionProtocol protocol;
     private final String healthCheckPath;
+    private final Function<? super ClientOptionsBuilder, ClientOptionsBuilder> configurator;
 
     /**
      * Creates a new {@link HttpHealthCheckedEndpointGroup} instance.
@@ -81,44 +84,48 @@ public final class HttpHealthCheckedEndpointGroup extends HealthCheckedEndpointG
                                    EndpointGroup delegate,
                                    SessionProtocol protocol,
                                    String healthCheckPath,
-                                   Duration healthCheckRetryInterval) {
+                                   Duration healthCheckRetryInterval,
+                                   Function<? super ClientOptionsBuilder, ClientOptionsBuilder> configurator) {
         super(clientFactory, delegate, healthCheckRetryInterval);
         this.protocol = requireNonNull(protocol, "protocol");
         this.healthCheckPath = requireNonNull(healthCheckPath, "healthCheckPath");
+        this.configurator = requireNonNull(configurator, "configurator");
         init();
     }
 
     @Override
     protected EndpointHealthChecker createEndpointHealthChecker(Endpoint endpoint) {
-        return new HttpEndpointHealthChecker(clientFactory(), endpoint, protocol, healthCheckPath);
+        return new HttpEndpointHealthChecker(clientFactory(), endpoint, protocol, healthCheckPath,
+                                             configurator);
     }
 
     private static final class HttpEndpointHealthChecker implements EndpointHealthChecker {
         private final HttpClient httpClient;
         private final String healthCheckPath;
 
-        private HttpEndpointHealthChecker(ClientFactory clientFactory,
-                                          Endpoint endpoint,
-                                          SessionProtocol protocol,
-                                          String healthCheckPath) {
+        private HttpEndpointHealthChecker(
+                ClientFactory clientFactory, Endpoint endpoint,
+                SessionProtocol protocol, String healthCheckPath,
+                Function<? super ClientOptionsBuilder, ClientOptionsBuilder> configurator) {
 
             final String scheme = protocol.uriText();
             final String ipAddr = endpoint.ipAddr();
+            final HttpClientBuilder builder;
             if (ipAddr == null) {
-                httpClient = HttpClient.of(clientFactory, scheme + "://" + endpoint.authority());
+                builder = new HttpClientBuilder(scheme + "://" + endpoint.authority());
             } else {
                 final int port = endpoint.port(protocol.defaultPort());
-                final HttpClientBuilder builder;
                 if (endpoint.ipFamily() == StandardProtocolFamily.INET) {
                     builder = new HttpClientBuilder(scheme + "://" + ipAddr + ':' + port);
                 } else {
                     builder = new HttpClientBuilder(scheme + "://[" + ipAddr + "]:" + port);
                 }
-
-                builder.factory(clientFactory);
                 builder.setHttpHeader(HttpHeaderNames.AUTHORITY, endpoint.authority());
-                httpClient = builder.build();
             }
+
+            httpClient = builder.factory(clientFactory)
+                                .options(configurator.apply(new ClientOptionsBuilder()).build())
+                                .build();
             this.healthCheckPath = healthCheckPath;
         }
 

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroupBuilder.java
@@ -21,9 +21,12 @@ import static com.linecorp.armeria.client.endpoint.healthcheck.HealthCheckedEndp
 import static java.util.Objects.requireNonNull;
 
 import java.time.Duration;
+import java.util.function.Function;
 
 import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.client.ClientFactory;
+import com.linecorp.armeria.client.ClientOptionsBuilder;
+import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.common.SessionProtocol;
 
@@ -38,6 +41,7 @@ public class HttpHealthCheckedEndpointGroupBuilder {
     private SessionProtocol protocol = SessionProtocol.HTTP;
     private Duration retryInterval = DEFAULT_HEALTHCHECK_RETRY_INTERVAL;
     private ClientFactory clientFactory = ClientFactory.DEFAULT;
+    private Function<? super ClientOptionsBuilder, ClientOptionsBuilder> configurator = Function.identity();
 
     /**
      * Creates a new {@link HttpHealthCheckedEndpointGroupBuilder}. Health check requests for the delegate
@@ -78,11 +82,25 @@ public class HttpHealthCheckedEndpointGroupBuilder {
     }
 
     /**
+     * Sets the {@link Function} that customizes a {@link HttpClient} for health check.
+     * <pre>{@code
+     * new HttpHealthCheckedEndpointGroupBuilder(delegate, healthCheckPath)
+     *     .withClientOptions(op -> op.defaultResponseTimeout(Duration.ofSeconds(1)))
+     *     .build();
+     * }</pre>
+     */
+    public HttpHealthCheckedEndpointGroupBuilder withClientOptions(
+            Function<? super ClientOptionsBuilder, ClientOptionsBuilder> configurator) {
+        this.configurator = requireNonNull(configurator, "configurator");
+        return this;
+    }
+
+    /**
      * Returns a newly created {@link HttpHealthCheckedEndpointGroup} based on the contents of the
      * {@link HttpHealthCheckedEndpointGroupBuilder}.
      */
     public HttpHealthCheckedEndpointGroup build() {
         return new HttpHealthCheckedEndpointGroup(clientFactory, delegate, protocol, healthCheckPath,
-                                                  retryInterval);
+                                                  retryInterval, configurator);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroupBuilder.java
@@ -82,7 +82,7 @@ public class HttpHealthCheckedEndpointGroupBuilder {
     }
 
     /**
-     * Sets the {@link Function} that customizes a {@link HttpClient} for health check.
+     * Sets the {@link Function} that customizes an {@link HttpClient} for health check.
      * <pre>{@code
      * new HttpHealthCheckedEndpointGroupBuilder(delegate, healthCheckPath)
      *     .withClientOptions(op -> op.defaultResponseTimeout(Duration.ofSeconds(1)))


### PR DESCRIPTION
Motivations:
- Currently, we use default `ClientOptions` for healthcheck `HttpClient` (15 seconds). And it causes that `HttpHealthCheckedEndpointGroup` exposes unhealthy endpoint if a target endpoint stucks.

Changes:
- Provide a `ClientOptions` customizer for healthcheck `HttpClient`