### PR TITLE
Fix wrong assert condition in AremriaCallFactoryTest

### DIFF
--- a/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/ArmeriaCallFactoryTest.java
+++ b/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/ArmeriaCallFactoryTest.java
@@ -275,10 +275,7 @@ public class ArmeriaCallFactoryTest {
                                                      MediaType.PLAIN_TEXT_UTF_8,
                                                      Exceptions.traceText(cause));
                           }
-                          final Map<String, List<String>> params = new QueryStringDecoder(
-                                  aReq.content().toStringUtf8(), false)
-                                  .parameters();
-                          assertThat(params).isEmpty();
+                          assertThat(req.headers().contentType()).isNull();
                           return HttpResponse.of(HttpStatus.OK);
                       }));
                   }


### PR DESCRIPTION
The test should check if the content type is `null`, but it checks query.