### PR TITLE
Fix NPE in HttpRequestSubscriber.onSubscribe()

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/Http1ResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http1ResponseDecoder.java
@@ -147,7 +147,7 @@ final class Http1ResponseDecoder extends HttpResponseDecoder implements ChannelI
                             state = State.NEED_DATA_OR_TRAILING_HEADERS;
                         }
 
-                        res.scheduleTimeout(ctx);
+                        res.scheduleTimeout(channel().eventLoop());
                         res.write(ArmeriaHttpUtil.toArmeria(nettyRes));
                     } else {
                         failWithUnexpectedMessageType(ctx, msg);

--- a/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
@@ -38,7 +38,7 @@ import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.internal.InboundTrafficController;
 
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.EventLoop;
 import io.netty.util.collection.IntObjectHashMap;
 import io.netty.util.collection.IntObjectMap;
 import io.netty.util.concurrent.ScheduledFuture;
@@ -139,7 +139,7 @@ abstract class HttpResponseDecoder {
             return delegate.completionFuture();
         }
 
-        void scheduleTimeout(ChannelHandlerContext ctx) {
+        void scheduleTimeout(EventLoop eventLoop) {
             if (responseTimeoutFuture != null || responseTimeoutMillis <= 0 || !isOpen()) {
                 // No need to schedule a response timeout if:
                 // - the timeout has been scheduled already,
@@ -148,7 +148,7 @@ abstract class HttpResponseDecoder {
                 return;
             }
 
-            responseTimeoutFuture = ctx.channel().eventLoop().schedule(
+            responseTimeoutFuture = eventLoop.schedule(
                     this, responseTimeoutMillis, TimeUnit.MILLISECONDS);
         }
 

--- a/core/src/main/java/com/linecorp/armeria/internal/Http1ObjectEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/Http1ObjectEncoder.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.internal;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.ArrayDeque;
 import java.util.Map.Entry;
@@ -32,9 +34,9 @@ import com.linecorp.armeria.common.stream.ClosedPublisherException;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
 import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
-import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.DefaultHttpContent;
@@ -78,6 +80,7 @@ public final class Http1ObjectEncoder extends HttpObjectEncoder {
      */
     private static final HttpContent EMPTY_CONTENT = new DefaultHttpContent(Unpooled.EMPTY_BUFFER);
 
+    private final Channel ch;
     private final boolean server;
     private final boolean isTls;
 
@@ -101,77 +104,78 @@ public final class Http1ObjectEncoder extends HttpObjectEncoder {
      */
     private final IntObjectMap<PendingWrites> pendingWritesMap = new IntObjectHashMap<>();
 
-    public Http1ObjectEncoder(boolean server, boolean isTls) {
+    public Http1ObjectEncoder(Channel ch, boolean server, boolean isTls) {
+        this.ch = requireNonNull(ch, "ch");
         this.server = server;
         this.isTls = isTls;
     }
 
     @Override
-    protected ChannelFuture doWriteHeaders(ChannelHandlerContext ctx, int id, int streamId,
-                                           HttpHeaders headers, boolean endStream) {
+    protected Channel channel() {
+        return ch;
+    }
+
+    @Override
+    protected ChannelFuture doWriteHeaders(int id, int streamId, HttpHeaders headers, boolean endStream) {
         if (id >= minClosedId) {
-            return ctx.newFailedFuture(ClosedSessionException.get());
+            return newClosedSessionFuture();
         }
 
         try {
-            return server ? writeServerHeaders(ctx, id, streamId, headers, endStream)
-                          : writeClientHeaders(ctx, id, streamId, headers, endStream);
+            return server ? writeServerHeaders(id, streamId, headers, endStream)
+                          : writeClientHeaders(id, streamId, headers, endStream);
         } catch (Throwable t) {
-            return ctx.newFailedFuture(t);
+            return newFailedFuture(t);
         }
     }
 
     private ChannelFuture writeServerHeaders(
-            ChannelHandlerContext ctx, int id, int streamId,
-            HttpHeaders headers, boolean endStream) throws Http2Exception {
+            int id, int streamId, HttpHeaders headers, boolean endStream) throws Http2Exception {
 
         final HttpObject converted = convertServerHeaders(streamId, headers, endStream);
         final HttpStatus status = headers.status();
         if (status == null) {
             // Trailing headers
-            final ChannelFuture f = write(ctx, id, converted, endStream);
-            ctx.flush();
+            final ChannelFuture f = write(id, converted, endStream);
+            ch.flush();
             return f;
         }
 
         if (status.codeClass() == HttpStatusClass.INFORMATIONAL) {
             // Informational status headers.
-            final ChannelFuture f = write(ctx, id, converted, false);
+            final ChannelFuture f = write(id, converted, false);
             if (endStream) {
                 // Can't end a stream with informational status in HTTP/1.
                 f.addListener(ChannelFutureListener.CLOSE);
             }
-            ctx.flush();
+            ch.flush();
             return f;
         }
 
         // Non-informational status headers.
-        return writeNonInformationalHeaders(ctx, id, converted, endStream);
+        return writeNonInformationalHeaders(id, converted, endStream);
     }
 
     private ChannelFuture writeClientHeaders(
-            ChannelHandlerContext ctx, int id, int streamId,
-            HttpHeaders headers, boolean endStream) throws Http2Exception {
+            int id, int streamId, HttpHeaders headers, boolean endStream) throws Http2Exception {
 
-        return writeNonInformationalHeaders(
-                ctx, id, convertClientHeaders(streamId, headers, endStream), endStream);
+        return writeNonInformationalHeaders(id, convertClientHeaders(streamId, headers, endStream), endStream);
     }
 
-    private ChannelFuture writeNonInformationalHeaders(
-            ChannelHandlerContext ctx, int id, HttpObject converted, boolean endStream) {
+    private ChannelFuture writeNonInformationalHeaders(int id, HttpObject converted, boolean endStream) {
 
         ChannelFuture f;
         if (converted instanceof LastHttpContent) {
             assert endStream;
-            f = write(ctx, id, converted, true);
+            f = write(id, converted, true);
         } else {
-            f = write(ctx, id, converted, false);
+            f = write(id, converted, false);
             if (endStream) {
-                f = write(ctx, id, LastHttpContent.EMPTY_LAST_CONTENT, true);
+                f = write(id, LastHttpContent.EMPTY_LAST_CONTENT, true);
             }
         }
 
-        ctx.flush();
+        ch.flush();
         return f;
     }
 
@@ -288,39 +292,36 @@ public final class Http1ObjectEncoder extends HttpObjectEncoder {
     }
 
     @Override
-    protected ChannelFuture doWriteData(
-            ChannelHandlerContext ctx, int id, int streamId, HttpData data, boolean endStream) {
-
+    protected ChannelFuture doWriteData(int id, int streamId, HttpData data, boolean endStream) {
         if (id >= minClosedId) {
             ReferenceCountUtil.safeRelease(data);
-            return ctx.newFailedFuture(ClosedSessionException.get());
+            return newClosedSessionFuture();
         }
 
         final int length = data.length();
         if (length == 0) {
             ReferenceCountUtil.safeRelease(data);
             final HttpContent content = endStream ? LastHttpContent.EMPTY_LAST_CONTENT : EMPTY_CONTENT;
-            final ChannelFuture future = write(ctx, id, content, endStream);
-            ctx.flush();
+            final ChannelFuture future = write(id, content, endStream);
+            ch.flush();
             return future;
         }
 
         try {
             if (!isTls || length <= MAX_TLS_DATA_LENGTH) {
                 // Cleartext connection or data.length() <= MAX_TLS_DATA_LENGTH
-                return doWriteUnsplitData(ctx, id, data, endStream);
+                return doWriteUnsplitData(id, data, endStream);
             } else {
                 // TLS and data.length() > MAX_TLS_DATA_LENGTH
-                return doWriteSplitData(ctx, id, data, endStream);
+                return doWriteSplitData(id, data, endStream);
             }
         } catch (Throwable t) {
-            return ctx.newFailedFuture(t);
+            return newFailedFuture(t);
         }
     }
 
-    private ChannelFuture doWriteUnsplitData(ChannelHandlerContext ctx, int id, HttpData data,
-                                             boolean endStream) {
-        final ByteBuf buf = toByteBuf(ctx, data);
+    private ChannelFuture doWriteUnsplitData(int id, HttpData data, boolean endStream) {
+        final ByteBuf buf = toByteBuf(data);
         boolean handled = false;
         try {
             final HttpContent content;
@@ -330,9 +331,9 @@ public final class Http1ObjectEncoder extends HttpObjectEncoder {
                 content = new DefaultHttpContent(buf);
             }
 
-            final ChannelFuture future = write(ctx, id, content, endStream);
+            final ChannelFuture future = write(id, content, endStream);
             handled = true;
-            ctx.flush();
+            ch.flush();
             return future;
         } finally {
             if (!handled) {
@@ -341,9 +342,7 @@ public final class Http1ObjectEncoder extends HttpObjectEncoder {
         }
     }
 
-    private ChannelFuture doWriteSplitData(
-            ChannelHandlerContext ctx, int id, HttpData data, boolean endStream) {
-
+    private ChannelFuture doWriteSplitData(int id, HttpData data, boolean endStream) {
         try {
             int offset = data.offset();
             int remaining = data.length();
@@ -351,7 +350,7 @@ public final class Http1ObjectEncoder extends HttpObjectEncoder {
             for (;;) {
                 // Ensure an HttpContent does not exceed the maximum length of a cleartext TLS record.
                 final int chunkSize = Math.min(MAX_TLS_DATA_LENGTH, remaining);
-                lastFuture = write(ctx, id, new DefaultHttpContent(dataChunk(data, offset, chunkSize)), false);
+                lastFuture = write(id, new DefaultHttpContent(dataChunk(data, offset, chunkSize)), false);
                 remaining -= chunkSize;
                 if (remaining == 0) {
                     break;
@@ -360,10 +359,10 @@ public final class Http1ObjectEncoder extends HttpObjectEncoder {
             }
 
             if (endStream) {
-                lastFuture = write(ctx, id, LastHttpContent.EMPTY_LAST_CONTENT, true);
+                lastFuture = write(id, LastHttpContent.EMPTY_LAST_CONTENT, true);
             }
 
-            ctx.flush();
+            ch.flush();
             return lastFuture;
         } finally {
             ReferenceCountUtil.safeRelease(data);
@@ -379,22 +378,22 @@ public final class Http1ObjectEncoder extends HttpObjectEncoder {
         }
     }
 
-    private ChannelFuture write(ChannelHandlerContext ctx, int id, HttpObject obj, boolean endStream) {
+    private ChannelFuture write(int id, HttpObject obj, boolean endStream) {
         if (id < currentId) {
             // Attempted to write something on a finished request/response; discard.
             // e.g. the request already timed out.
             ReferenceCountUtil.safeRelease(obj);
-            return ctx.newFailedFuture(ClosedPublisherException.get());
+            return newFailedFuture(ClosedPublisherException.get());
         }
 
         final PendingWrites currentPendingWrites = pendingWritesMap.get(id);
         if (id == currentId) {
             if (currentPendingWrites != null) {
                 pendingWritesMap.remove(id);
-                flushPendingWrites(ctx, currentPendingWrites);
+                flushPendingWrites(currentPendingWrites);
             }
 
-            final ChannelFuture future = ctx.write(obj);
+            final ChannelFuture future = ch.write(obj);
             if (endStream) {
                 currentId++;
 
@@ -405,7 +404,7 @@ public final class Http1ObjectEncoder extends HttpObjectEncoder {
                         break;
                     }
 
-                    flushPendingWrites(ctx, nextPendingWrites);
+                    flushPendingWrites(nextPendingWrites);
                     if (!nextPendingWrites.isEndOfStream()) {
                         break;
                     }
@@ -417,7 +416,7 @@ public final class Http1ObjectEncoder extends HttpObjectEncoder {
 
             return future;
         } else {
-            final ChannelPromise promise = ctx.newPromise();
+            final ChannelPromise promise = ch.newPromise();
             final Entry<HttpObject, ChannelPromise> entry = new SimpleImmutableEntry<>(obj, promise);
             final PendingWrites pendingWrites;
             if (currentPendingWrites == null) {
@@ -438,19 +437,19 @@ public final class Http1ObjectEncoder extends HttpObjectEncoder {
         }
     }
 
-    private static void flushPendingWrites(ChannelHandlerContext ctx, PendingWrites pendingWrites) {
+    private void flushPendingWrites(PendingWrites pendingWrites) {
         for (;;) {
             final Entry<HttpObject, ChannelPromise> e = pendingWrites.poll();
             if (e == null) {
                 break;
             }
 
-            ctx.write(e.getKey(), e.getValue());
+            ch.write(e.getKey(), e.getValue());
         }
     }
 
     @Override
-    protected ChannelFuture doWriteReset(ChannelHandlerContext ctx, int id, int streamId, Http2Error error) {
+    protected ChannelFuture doWriteReset(int id, int streamId, Http2Error error) {
         // NB: this.minClosedId can be overwritten more than once when 3+ pipelined requests are received
         //     and they are handled by different threads simultaneously.
         //     e.g. when the 3rd request triggers a reset and then the 2nd one triggers another.
@@ -466,7 +465,7 @@ public final class Http1ObjectEncoder extends HttpObjectEncoder {
             }
         }
 
-        final ChannelFuture f = ctx.write(Unpooled.EMPTY_BUFFER);
+        final ChannelFuture f = ch.write(Unpooled.EMPTY_BUFFER);
         if (currentId >= minClosedId) {
             f.addListener(ChannelFutureListener.CLOSE);
         }

--- a/core/src/main/java/com/linecorp/armeria/internal/HttpObjectEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/HttpObjectEncoder.java
@@ -25,7 +25,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.EventLoop;
 import io.netty.handler.codec.http2.Http2Error;
 import io.netty.util.ReferenceCountUtil;
 
@@ -36,59 +36,61 @@ public abstract class HttpObjectEncoder {
 
     private volatile boolean closed;
 
+    protected abstract Channel channel();
+
+    protected EventLoop eventLoop() {
+        return channel().eventLoop();
+    }
+
     /**
      * Writes an {@link HttpHeaders}.
      */
-    public final ChannelFuture writeHeaders(
-            ChannelHandlerContext ctx, int id, int streamId, HttpHeaders headers, boolean endStream) {
+    public final ChannelFuture writeHeaders(int id, int streamId, HttpHeaders headers, boolean endStream) {
 
-        assert ctx.channel().eventLoop().inEventLoop();
+        assert eventLoop().inEventLoop();
 
         if (closed) {
-            return newFailedFuture(ctx);
+            return newClosedSessionFuture();
         }
 
-        return doWriteHeaders(ctx, id, streamId, headers, endStream);
+        return doWriteHeaders(id, streamId, headers, endStream);
     }
 
     protected abstract ChannelFuture doWriteHeaders(
-            ChannelHandlerContext ctx, int id, int streamId, HttpHeaders headers, boolean endStream);
+            int id, int streamId, HttpHeaders headers, boolean endStream);
 
     /**
      * Writes an {@link HttpData}.
      */
-    public final ChannelFuture writeData(
-            ChannelHandlerContext ctx, int id, int streamId, HttpData data, boolean endStream) {
+    public final ChannelFuture writeData(int id, int streamId, HttpData data, boolean endStream) {
 
-        assert ctx.channel().eventLoop().inEventLoop();
+        assert eventLoop().inEventLoop();
 
         if (closed) {
             ReferenceCountUtil.safeRelease(data);
-            return newFailedFuture(ctx);
+            return newClosedSessionFuture();
         }
 
-        return doWriteData(ctx, id, streamId, data, endStream);
+        return doWriteData(id, streamId, data, endStream);
     }
 
-    protected abstract ChannelFuture doWriteData(
-            ChannelHandlerContext ctx, int id, int streamId, HttpData data, boolean endStream);
+    protected abstract ChannelFuture doWriteData(int id, int streamId, HttpData data, boolean endStream);
 
     /**
      * Resets the specified stream. If the session protocol does not support multiplexing or the connection
      * is in unrecoverable state, the connection will be closed. For example, in an HTTP/1 connection, this
      * will lead the connection to be closed immediately or after the previous requests that are not reset.
      */
-    public final ChannelFuture writeReset(ChannelHandlerContext ctx, int id, int streamId, Http2Error error) {
+    public final ChannelFuture writeReset(int id, int streamId, Http2Error error) {
 
         if (closed) {
-            return newFailedFuture(ctx);
+            return newClosedSessionFuture();
         }
 
-        return doWriteReset(ctx, id, streamId, error);
+        return doWriteReset(id, streamId, error);
     }
 
-    protected abstract ChannelFuture doWriteReset(
-            ChannelHandlerContext ctx, int id, int streamId, Http2Error error);
+    protected abstract ChannelFuture doWriteReset(int id, int streamId, Http2Error error);
 
     /**
      * Releases the resources related with this encoder and fails any unfinished writes.
@@ -104,15 +106,19 @@ public abstract class HttpObjectEncoder {
 
     protected abstract void doClose();
 
-    private static ChannelFuture newFailedFuture(ChannelHandlerContext ctx) {
-        return ctx.newFailedFuture(ClosedSessionException.get());
+    protected final ChannelFuture newClosedSessionFuture() {
+        return newFailedFuture(ClosedSessionException.get());
     }
 
-    protected static ByteBuf toByteBuf(ChannelHandlerContext ctx, HttpData data) {
+    protected final ChannelFuture newFailedFuture(Throwable cause) {
+        return channel().newFailedFuture(cause);
+    }
+
+    protected final ByteBuf toByteBuf(HttpData data) {
         if (data instanceof ByteBufHolder) {
             return ((ByteBufHolder) data).content();
         }
-        final ByteBuf buf = ctx.alloc().directBuffer(data.length(), data.length());
+        final ByteBuf buf = channel().alloc().directBuffer(data.length(), data.length());
         buf.writeBytes(data.array(), data.offset(), data.length());
         return buf;
     }

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -260,10 +260,10 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
 
         final Http2ConnectionHandler handler = ctx.pipeline().get(Http2ConnectionHandler.class);
         if (responseEncoder == null) {
-            responseEncoder = new Http2ObjectEncoder(handler.encoder());
+            responseEncoder = new Http2ObjectEncoder(ctx, handler.encoder());
         } else if (responseEncoder instanceof Http1ObjectEncoder) {
             responseEncoder.close();
-            responseEncoder = new Http2ObjectEncoder(handler.encoder());
+            responseEncoder = new Http2ObjectEncoder(ctx, handler.encoder());
         }
     }
 
@@ -566,15 +566,15 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
         logBuilder.startResponse();
         assert responseEncoder != null;
         ChannelFuture future = responseEncoder.writeHeaders(
-                ctx, req.id(), req.streamId(), res.headers(), contentAndTrailingHeadersEmpty);
+                req.id(), req.streamId(), res.headers(), contentAndTrailingHeadersEmpty);
         logBuilder.responseHeaders(res.headers());
         if (!contentAndTrailingHeadersEmpty) {
             future = responseEncoder.writeData(
-                    ctx, req.id(), req.streamId(), res.content(), trailingHeadersEmpty);
+                    req.id(), req.streamId(), res.content(), trailingHeadersEmpty);
             logBuilder.increaseResponseLength(res.content().length());
             if (!trailingHeadersEmpty) {
                 future = responseEncoder.writeHeaders(
-                        ctx, req.id(), req.streamId(), res.trailingHeaders(), true);
+                        req.id(), req.streamId(), res.trailingHeaders(), true);
             }
         }
 

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
@@ -152,7 +152,7 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
     }
 
     private void configureHttp(ChannelPipeline p, @Nullable ProxiedAddresses proxiedAddresses) {
-        final Http1ObjectEncoder responseEncoder = new Http1ObjectEncoder(true, false);
+        final Http1ObjectEncoder responseEncoder = new Http1ObjectEncoder(p.channel(), true, false);
         p.addLast(TrafficLoggingHandler.SERVER);
         p.addLast(new Http2PrefaceOrHttpHandler(responseEncoder));
         configureIdleTimeoutHandler(p);
@@ -368,13 +368,14 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
         }
 
         private void addHttpHandlers(ChannelHandlerContext ctx) {
+            final Channel ch = ctx.channel();
             final ChannelPipeline p = ctx.pipeline();
-            final Http1ObjectEncoder writer = new Http1ObjectEncoder(true, true);
+            final Http1ObjectEncoder writer = new Http1ObjectEncoder(ch, true, true);
             p.addLast(new HttpServerCodec(
                     config.defaultMaxHttp1InitialLineLength(),
                     config.defaultMaxHttp1HeaderSize(),
                     config.defaultMaxHttp1ChunkSize()));
-            p.addLast(new Http1RequestDecoder(config, ctx.channel(), SCHEME_HTTPS, writer));
+            p.addLast(new Http1RequestDecoder(config, ch, SCHEME_HTTPS, writer));
             configureIdleTimeoutHandler(p);
             p.addLast(new HttpServerHandler(config, gracefulShutdownSupport, writer,
                                             SessionProtocol.H1, proxiedAddresses));


### PR DESCRIPTION
Motivation:

`HttpRequestSubscriber` retrieves the last `ChannelHandlerContext` in a
`ChannelPipeline` using `ChannelPipeline.lastContext()`. However,
`lastContext()` may return `null` when called on a closed `Channel`.

Modifications:

- Do not use `ChannelPipeline.lastContext()`.
- Make `HttpObjectEncoder` implementations keep the non-null reference
  to `Channel` or `ChannelHandlerContext` for 1) no change of NPE and 2)
  simpler method signatures.

Result:

- NPE is gone.
- Slightly simpler encoder code.