### PR TITLE
Use MIME type base64 decoder for SAML messages

### DIFF
--- a/examples/annotated-http-service/src/main/java/example/armeria/server/annotated/MessageConverterService.java
+++ b/examples/annotated-http-service/src/main/java/example/armeria/server/annotated/MessageConverterService.java
@@ -112,13 +112,13 @@ public class MessageConverterService {
      *
      * <p>If you want to specify converters for every methods in a service class, you can specify them
      * above the class definition as follows:
-     * <pre><code>
-     * {@literal @}RequestConverter(CustomRequestConverter.class)
-     * {@literal @}ResponseConverter(CustomResponseConverter.class)
-     * public class MyAnnotatedService {
-     *     ...
-     * }
-     * </code></pre>
+     * <pre>{@code
+     * > @RequestConverter(CustomRequestConverter.class)
+     * > @ResponseConverter(CustomResponseConverter.class)
+     * > public class MyAnnotatedService {
+     * >     ...
+     * > }
+     * }</pre>
      */
     @Post("/custom")
     @RequestConverter(CustomRequestConverter.class)

--- a/examples/annotated-http-service/src/main/java/example/armeria/server/annotated/MessageConverterService.java
+++ b/examples/annotated-http-service/src/main/java/example/armeria/server/annotated/MessageConverterService.java
@@ -112,13 +112,13 @@ public class MessageConverterService {
      *
      * <p>If you want to specify converters for every methods in a service class, you can specify them
      * above the class definition as follows:
-     * <pre>{@code
-     * @RequestConverter(CustomRequestConverter.class)
-     * @ResponseConverter(CustomResponseConverter.class)
+     * <pre><code>
+     * {@literal @}RequestConverter(CustomRequestConverter.class)
+     * {@literal @}ResponseConverter(CustomResponseConverter.class)
      * public class MyAnnotatedService {
      *     ...
      * }
-     * }</pre>
+     * </code></pre>
      */
     @Post("/custom")
     @RequestConverter(CustomRequestConverter.class)

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/HttpPostBindingUtil.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/HttpPostBindingUtil.java
@@ -108,7 +108,7 @@ final class HttpPostBindingUtil {
         final SamlParameters parameters = new SamlParameters(msg);
         final byte[] decoded;
         try {
-            decoded = Base64.getDecoder().decode(parameters.getFirstValue(name));
+            decoded = Base64.getMimeDecoder().decode(parameters.getFirstValue(name));
         } catch (IllegalArgumentException e) {
             throw new SamlException("failed to decode a base64 string of the parameter: " + name, e);
         }

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/HttpRedirectBindingUtil.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/HttpRedirectBindingUtil.java
@@ -154,7 +154,7 @@ final class HttpRedirectBindingUtil {
         final byte[] input = encoder.toString().substring(1).getBytes(StandardCharsets.UTF_8);
 
         try {
-            final byte[] decodedSignature = Base64.getDecoder().decode(signature);
+            final byte[] decodedSignature = Base64.getMimeDecoder().decode(signature);
             if (!XMLSigningUtil.verifyWithURI(validationCredential, sigAlg, decodedSignature, input)) {
                 throw new SamlException("failed to validate a signature");
             }
@@ -213,7 +213,7 @@ final class HttpRedirectBindingUtil {
 
         final byte[] base64decoded;
         try {
-            base64decoded = Base64.getDecoder().decode(base64Encoded);
+            base64decoded = Base64.getMimeDecoder().decode(base64Encoded);
         } catch (IllegalArgumentException e) {
             throw new SamlException("failed to decode a deflated base64 string", e);
         }

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/KeyStoreCredentialResolverBuilder.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/KeyStoreCredentialResolverBuilder.java
@@ -44,7 +44,8 @@ public final class KeyStoreCredentialResolverBuilder {
     private final ClassLoader classLoader;
 
     private String type = KeyStore.getDefaultType();
-    private String password = "";
+    @Nullable
+    private String password;
     private final Map<String, String> keyPasswords = new HashMap<>();
 
     /**
@@ -76,8 +77,8 @@ public final class KeyStoreCredentialResolverBuilder {
     /**
      * Sets a password of the {@link KeyStore}.
      */
-    public KeyStoreCredentialResolverBuilder password(String password) {
-        this.password = requireNonNull(password, "password");
+    public KeyStoreCredentialResolverBuilder password(@Nullable String password) {
+        this.password = password;
         return this;
     }
 
@@ -107,7 +108,7 @@ public final class KeyStoreCredentialResolverBuilder {
     public CredentialResolver build() throws IOException, GeneralSecurityException {
         final KeyStore ks = KeyStore.getInstance(type);
         try (InputStream is = open()) {
-            ks.load(is, password.toCharArray());
+            ks.load(is, password != null ? password.toCharArray() : null);
         }
         return new KeyStoreCredentialResolver(ks, keyPasswords);
     }

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/KeyStoreCredentialResolverBuilder.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/KeyStoreCredentialResolverBuilder.java
@@ -58,16 +58,24 @@ public final class KeyStoreCredentialResolverBuilder {
     }
 
     /**
+     * Creates a builder with the specified {@code resourcePath} and the default {@link ClassLoader}.
+     */
+    public KeyStoreCredentialResolverBuilder(String resourcePath) {
+        this(resourcePath, null);
+    }
+
+    /**
      * Creates a builder with the specified {@code resourcePath} and {@link ClassLoader}.
      */
-    public KeyStoreCredentialResolverBuilder(String resourcePath, ClassLoader classLoader) {
+    public KeyStoreCredentialResolverBuilder(String resourcePath, @Nullable ClassLoader classLoader) {
         this.resourcePath = requireNonNull(resourcePath, "path");
-        this.classLoader = requireNonNull(classLoader, "classLoader");
+        this.classLoader = classLoader;
         file = null;
     }
 
     /**
-     * Sets a type of the {@link KeyStore}.
+     * Sets a type of the {@link KeyStore}. If not set, the default value retrieved from
+     * {@link KeyStore#getDefaultType()} will be used.
      */
     public KeyStoreCredentialResolverBuilder type(String type) {
         this.type = requireNonNull(type, "type");
@@ -116,6 +124,14 @@ public final class KeyStoreCredentialResolverBuilder {
     private InputStream open() throws IOException {
         if (file != null) {
             return new FileInputStream(file);
+        }
+
+        ClassLoader classLoader = this.classLoader;
+        if (classLoader == null) {
+            classLoader = Thread.currentThread().getContextClassLoader();
+        }
+        if (classLoader == null) {
+            classLoader = getClass().getClassLoader();
         }
 
         assert classLoader != null : "classLoader";

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/KeyStoreCredentialResolverBuilder.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/KeyStoreCredentialResolverBuilder.java
@@ -68,7 +68,7 @@ public final class KeyStoreCredentialResolverBuilder {
      * Creates a builder with the specified {@code resourcePath} and {@link ClassLoader}.
      */
     public KeyStoreCredentialResolverBuilder(String resourcePath, @Nullable ClassLoader classLoader) {
-        this.resourcePath = requireNonNull(resourcePath, "path");
+        this.resourcePath = requireNonNull(resourcePath, "resourcePath");
         this.classLoader = classLoader;
         file = null;
     }


### PR DESCRIPTION
Motivation:
The `Basic` type base64 decoder rejects data that contains characters outside the base64 alphabet.
However, some identity provider produces base64 with line feed character, so we need to use
`MIME` type base64 decoder instead of the `Basic` type.

Modifications:
- Get base64 decoder by calling Base64.getMimeDecoder() instread of Base64.getDecoder().
- Improve KeyStoreCredentialResolverBuilder:
  - Able to read a keystore file from file system.
  - Able to specify keystore type.