### PR TITLE
Add `AccessLogWriter` and deprecate StructuredLog and its related classes

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -31,7 +31,6 @@ import java.util.EnumSet;
 import java.util.IdentityHashMap;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
@@ -69,6 +68,7 @@ import com.linecorp.armeria.internal.Http1ObjectEncoder;
 import com.linecorp.armeria.internal.Http2ObjectEncoder;
 import com.linecorp.armeria.internal.HttpObjectEncoder;
 import com.linecorp.armeria.internal.PathAndQuery;
+import com.linecorp.armeria.server.logging.AccessLogWriter;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.netty.buffer.Unpooled;
@@ -168,7 +168,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
     private boolean isReading;
     private boolean handledLastRequest;
 
-    private final Consumer<RequestLog> accessLogWriter;
+    private final AccessLogWriter accessLogWriter;
     private final IdentityHashMap<HttpResponse, Boolean> unfinishedResponses;
 
     HttpServerHandler(ServerConfig config,
@@ -585,7 +585,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
                 // Respect the first specified cause.
                 logBuilder.endResponse(firstNonNull(cause, f.cause()));
             }
-            reqCtx.log().addListener(accessLogWriter::accept, RequestLogAvailability.COMPLETE);
+            reqCtx.log().addListener(accessLogWriter::log, RequestLogAvailability.COMPLETE);
         });
         return future;
     }

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -35,7 +35,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executor;
-import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -52,11 +51,10 @@ import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.SessionProtocol;
-import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
 import com.linecorp.armeria.server.annotation.RequestConverterFunction;
 import com.linecorp.armeria.server.annotation.ResponseConverterFunction;
-import com.linecorp.armeria.server.logging.AccessLogWriters;
+import com.linecorp.armeria.server.logging.AccessLogWriter;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Metrics;
@@ -160,7 +158,8 @@ public final class ServerBuilder {
     private Executor blockingTaskExecutor = CommonPools.blockingTaskExecutor();
     private MeterRegistry meterRegistry = Metrics.globalRegistry;
     private String serviceLoggerPrefix = DEFAULT_SERVICE_LOGGER_PREFIX;
-    private Consumer<RequestLog> accessLogWriter = AccessLogWriters.disabled();
+    private AccessLogWriter accessLogWriter = AccessLogWriter.disabled();
+    private boolean shutdownAccessLogWriterOnStop = true;
 
     @Nullable
     private Function<Service<HttpRequest, HttpResponse>, Service<HttpRequest, HttpResponse>> decorator;
@@ -564,21 +563,19 @@ public final class ServerBuilder {
 
     /**
      * Sets the format of this {@link Server}'s access log. The specified {@code accessLogFormat} would be
-     * parsed by {@link AccessLogWriters#custom(String)}.
+     * parsed by {@link AccessLogWriter#custom(String)}.
      */
     public ServerBuilder accessLogFormat(String accessLogFormat) {
-        accessLogWriter = AccessLogWriters.custom(requireNonNull(accessLogFormat, "accessLogFormat"));
-        return this;
+        return accessLogWriter(AccessLogWriter.custom(requireNonNull(accessLogFormat, "accessLogFormat")),
+                               true);
     }
 
     /**
-     * Sets an access log writer of this {@link Server}. {@link AccessLogWriters#disabled()} is used by default.
-     *
-     * @see AccessLogWriters to find pre-defined access log writers.
+     * Sets an access log writer of this {@link Server}. {@link AccessLogWriter#disabled()} is used by default.
      */
-    @SuppressWarnings("unchecked")
-    public ServerBuilder accessLogWriter(Consumer<? super RequestLog> accessLogWriter) {
-        this.accessLogWriter = (Consumer<RequestLog>) requireNonNull(accessLogWriter, "accessLogWriter");
+    public ServerBuilder accessLogWriter(AccessLogWriter accessLogWriter, boolean shutdownOnStop) {
+        this.accessLogWriter = requireNonNull(accessLogWriter, "accessLogWriter");
+        shutdownAccessLogWriterOnStop = shutdownOnStop;
         return this;
     }
 
@@ -1083,7 +1080,7 @@ public final class ServerBuilder {
                 idleTimeoutMillis, defaultRequestTimeoutMillis, defaultMaxRequestLength,
                 maxHttp1InitialLineLength, maxHttp1HeaderSize, maxHttp1ChunkSize,
                 gracefulShutdownQuietPeriod, gracefulShutdownTimeout, blockingTaskExecutor,
-                meterRegistry, serviceLoggerPrefix, accessLogWriter,
+                meterRegistry, serviceLoggerPrefix, accessLogWriter, shutdownAccessLogWriterOnStop,
                 proxyProtocolMaxTlvSize, channelOptions, childChannelOptions), sslContexts);
 
         serverListeners.forEach(server::addListener);
@@ -1122,8 +1119,9 @@ public final class ServerBuilder {
                 maxNumConnections, idleTimeoutMillis, defaultRequestTimeoutMillis, defaultMaxRequestLength,
                 maxHttp1InitialLineLength, maxHttp1HeaderSize, maxHttp1ChunkSize,
                 proxyProtocolMaxTlvSize, gracefulShutdownQuietPeriod, gracefulShutdownTimeout,
-                blockingTaskExecutor, meterRegistry, serviceLoggerPrefix, accessLogWriter, channelOptions,
-                childChannelOptions
+                blockingTaskExecutor, meterRegistry, serviceLoggerPrefix,
+                accessLogWriter, shutdownAccessLogWriterOnStop,
+                channelOptions, childChannelOptions
         );
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -572,6 +572,8 @@ public final class ServerBuilder {
 
     /**
      * Sets an access log writer of this {@link Server}. {@link AccessLogWriter#disabled()} is used by default.
+     *
+     * @param shutdownOnStop whether to shut down the {@link AccessLogWriter} when the {@link Server} stops
      */
     public ServerBuilder accessLogWriter(AccessLogWriter accessLogWriter, boolean shutdownOnStop) {
         this.accessLogWriter = requireNonNull(accessLogWriter, "accessLogWriter");

--- a/core/src/main/java/com/linecorp/armeria/server/logging/AccessLogWriter.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/AccessLogWriter.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.logging;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.linecorp.armeria.server.logging.AccessLogFormats.parseCustom;
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import com.linecorp.armeria.common.logging.RequestLog;
+import com.linecorp.armeria.server.Server;
+
+/**
+ * Consumes the {@link RequestLog}s produced by a {@link Server}, usually for logging purpose.
+ */
+@FunctionalInterface
+public interface AccessLogWriter {
+
+    /**
+     * Returns an access log writer with a common format.
+     */
+    static AccessLogWriter common() {
+        return requestLog -> AccessLogger.write(AccessLogFormats.COMMON, requestLog);
+    }
+
+    /**
+     * Returns an access log writer with a combined format.
+     */
+    static AccessLogWriter combined() {
+        return requestLog -> AccessLogger.write(AccessLogFormats.COMBINED, requestLog);
+    }
+
+    /**
+     * Returns disabled access log writer.
+     */
+    static AccessLogWriter disabled() {
+        return requestLog -> { /* No operation. */ };
+    }
+
+    /**
+     * Returns an access log writer with the specified {@code formatStr}.
+     */
+    static AccessLogWriter custom(String formatStr) {
+        requireNonNull(formatStr, "formatStr");
+        final List<AccessLogComponent> accessLogFormat = parseCustom(formatStr);
+        checkArgument(!accessLogFormat.isEmpty(), "Invalid access log format string: %s", formatStr);
+        return requestLog -> AccessLogger.write(accessLogFormat, requestLog);
+    }
+
+    /**
+     * Logs the specified {@link RequestLog}.
+     */
+    void log(RequestLog log) throws Exception;
+
+    /**
+     * Returns a new {@link AccessLogWriter} which combines two {@link AccessLogWriter}s.
+     */
+    default AccessLogWriter andThen(AccessLogWriter after) {
+        return new AccessLogWriter() {
+            @Override
+            public void log(RequestLog log) throws Exception {
+                try {
+                    AccessLogWriter.this.log(log);
+                } finally {
+                    after.log(log);
+                }
+            }
+
+            @Override
+            public CompletableFuture<Void> shutdown() {
+                final CompletableFuture<Void> f1;
+                final CompletableFuture<Void> f2;
+                try {
+                    f1 = AccessLogWriter.this.shutdown();
+                } finally {
+                    f2 = after.shutdown();
+                }
+                return CompletableFuture.allOf(f1, f2);
+            }
+        };
+    }
+
+    /**
+     * Shuts down this {@link AccessLogWriter}.
+     *
+     * @return the {@link CompletableFuture} which is completed
+     *         when this {@link AccessLogWriter} has been shut down.
+     */
+    default CompletableFuture<Void> shutdown() {
+        return CompletableFuture.completedFuture(null);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/logging/AccessLogWriters.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/AccessLogWriters.java
@@ -16,48 +16,40 @@
 
 package com.linecorp.armeria.server.logging;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.linecorp.armeria.server.logging.AccessLogFormats.parseCustom;
-import static java.util.Objects.requireNonNull;
-
-import java.util.List;
-import java.util.function.Consumer;
-
-import com.linecorp.armeria.common.logging.RequestLog;
-
 /**
  * Access log writers.
+ *
+ * @deprecated Use the factory methods in {@link AccessLogWriter}.
  */
+@Deprecated
 public final class AccessLogWriters {
 
     /**
      * Returns an access log writer with a common format.
      */
-    public static Consumer<RequestLog> common() {
-        return requestLog -> AccessLogger.write(AccessLogFormats.COMMON, requestLog);
+    public static AccessLogWriter common() {
+        return AccessLogWriter.common();
     }
 
     /**
      * Returns an access log writer with a combined format.
      */
-    public static Consumer<RequestLog> combined() {
-        return requestLog -> AccessLogger.write(AccessLogFormats.COMBINED, requestLog);
+    public static AccessLogWriter combined() {
+        return AccessLogWriter.combined();
     }
 
     /**
      * Returns disabled access log writer.
      */
-    public static Consumer<RequestLog> disabled() {
-        return requestLog -> { /* No operation. */ };
+    public static AccessLogWriter disabled() {
+        return AccessLogWriter.disabled();
     }
 
     /**
      * Returns an access log writer with the specified {@code formatStr}.
      */
-    public static Consumer<RequestLog> custom(String formatStr) {
-        final List<AccessLogComponent> accessLogFormat = parseCustom(requireNonNull(formatStr, "formatStr"));
-        checkArgument(!accessLogFormat.isEmpty(), "Invalid access log format string: " + formatStr);
-        return requestLog -> AccessLogger.write(accessLogFormat, requestLog);
+    public static AccessLogWriter custom(String formatStr) {
+        return AccessLogWriter.custom(formatStr);
     }
 
     private AccessLogWriters() {}

--- a/core/src/main/java/com/linecorp/armeria/server/logging/structured/StructuredLog.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/structured/StructuredLog.java
@@ -22,11 +22,15 @@ import com.google.common.base.MoreObjects;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.util.TextFormatter;
+import com.linecorp.armeria.server.logging.AccessLogWriter;
 
 /**
  * A representation and constructor of a service log which holds only very common fields that are protocol
  * agnostic.
+ *
+ * @deprecated Use {@link AccessLogWriter}.
  */
+@Deprecated
 public abstract class StructuredLog {
     private final long timestampMillis;
     private final long responseTimeNanos;

--- a/core/src/main/java/com/linecorp/armeria/server/logging/structured/StructuredLogBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/structured/StructuredLogBuilder.java
@@ -19,12 +19,16 @@ package com.linecorp.armeria.server.logging.structured;
 import javax.annotation.Nullable;
 
 import com.linecorp.armeria.common.logging.RequestLog;
+import com.linecorp.armeria.server.logging.AccessLogWriter;
 
 /**
  * An interface that a structured log constructor should implement.
  *
  * @param <L> type of the structured log representation
+ *
+ * @deprecated Use {@link AccessLogWriter}.
  */
+@Deprecated
 @FunctionalInterface
 public interface StructuredLogBuilder<L> {
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/logging/structured/StructuredLoggingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/structured/StructuredLoggingService.java
@@ -30,6 +30,7 @@ import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceConfig;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.SimpleDecoratingService;
+import com.linecorp.armeria.server.logging.AccessLogWriter;
 
 /**
  * A decorating service which provides support of structured and optionally externalized request/response
@@ -38,7 +39,10 @@ import com.linecorp.armeria.server.SimpleDecoratingService;
  * @param <I> the {@link Request} type
  * @param <O> the {@link Response} type
  * @param <L> the type of the structured log representation
+ *
+ * @deprecated Use {@link AccessLogWriter}.
  */
+@Deprecated
 public abstract class StructuredLoggingService<I extends Request, O extends Response, L>
         extends SimpleDecoratingService<I, O> {
 

--- a/kafka/src/main/java/com/linecorp/armeria/server/logging/kafka/KafkaAccessLogWriter.java
+++ b/kafka/src/main/java/com/linecorp/armeria/server/logging/kafka/KafkaAccessLogWriter.java
@@ -51,10 +51,10 @@ public final class KafkaAccessLogWriter<K, V> implements AccessLogWriter {
     /**
      * Creates a new instance.
      *
-     * @param producer a kafka {@link Producer} producer which is used to send logs to Kafka
+     * @param producer a Kafka {@link Producer} which is used to send logs to Kafka
      * @param topic the name of topic which is used to send logs
-     * @param valueExtractor a {@link Function} that extracts a {@code V}-typed record key from
-     *                       a {@link RequestLog} The {@link Function} is allowed to return {@code null}
+     * @param valueExtractor a {@link Function} that extracts a {@code V}-typed record value from
+     *                       a {@link RequestLog}. The {@link Function} is allowed to return {@code null}
      *                       to skip logging for the given {@link RequestLog}.
      */
     public KafkaAccessLogWriter(Producer<K, V> producer, String topic,
@@ -66,13 +66,13 @@ public final class KafkaAccessLogWriter<K, V> implements AccessLogWriter {
     /**
      * Creates a new instance.
      *
-     * @param producer a kafka {@link Producer} producer which is used to send logs to Kafka
+     * @param producer a Kafka {@link Producer} which is used to send logs to Kafka
      * @param topic the name of topic which is used to send logs
      * @param keyExtractor a {@link Function} that extracts a {@code K}-typed record key from
      *                     a {@link RequestLog}. The {@link Function} is allowed to return {@code null}
      *                     to leave the record key unspecified.
-     * @param valueExtractor a {@link Function} that extracts a {@code V}-typed record key from
-     *                       a {@link RequestLog} The {@link Function} is allowed to return {@code null}
+     * @param valueExtractor a {@link Function} that extracts a {@code V}-typed record value from
+     *                       a {@link RequestLog}. The {@link Function} is allowed to return {@code null}
      *                       to skip logging for the given {@link RequestLog}.
      */
     public KafkaAccessLogWriter(Producer<K, V> producer, String topic,

--- a/kafka/src/main/java/com/linecorp/armeria/server/logging/kafka/KafkaAccessLogWriter.java
+++ b/kafka/src/main/java/com/linecorp/armeria/server/logging/kafka/KafkaAccessLogWriter.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.logging.kafka;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+import java.util.function.Function;
+
+import javax.annotation.Nullable;
+
+import org.apache.kafka.clients.producer.Callback;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linecorp.armeria.common.logging.RequestLog;
+import com.linecorp.armeria.server.logging.AccessLogWriter;
+
+/**
+ * An {@link AccessLogWriter} that sends access logs to a Kafka backend.
+ *
+ * <p>This method returns immediately after the {@link Producer#send(ProducerRecord, Callback)} returns rather
+ * than waiting for returned {@link Future} completes so logs which are written and are not yet flushed can
+ * be lost if an application crashes in unclean way.
+ */
+public final class KafkaAccessLogWriter<K, V> implements AccessLogWriter {
+
+    private static final Logger logger = LoggerFactory.getLogger(KafkaAccessLogWriter.class);
+
+    private final Producer<K, V> producer;
+    private final String topic;
+    private final Function<? super RequestLog, ? extends K> keyExtractor;
+    private final Function<? super RequestLog, ? extends V> valueExtractor;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param producer a kafka {@link Producer} producer which is used to send logs to Kafka
+     * @param topic the name of topic which is used to send logs
+     * @param valueExtractor a {@link Function} that extracts a {@code V}-typed record key from
+     *                       a {@link RequestLog} The {@link Function} is allowed to return {@code null}
+     *                       to skip logging for the given {@link RequestLog}.
+     */
+    public KafkaAccessLogWriter(Producer<K, V> producer, String topic,
+                                Function<? super RequestLog, ? extends V> valueExtractor) {
+
+        this(producer, topic, null, valueExtractor,0);
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param producer a kafka {@link Producer} producer which is used to send logs to Kafka
+     * @param topic the name of topic which is used to send logs
+     * @param keyExtractor a {@link Function} that extracts a {@code K}-typed record key from
+     *                     a {@link RequestLog}. The {@link Function} is allowed to return {@code null}
+     *                     to leave the record key unspecified.
+     * @param valueExtractor a {@link Function} that extracts a {@code V}-typed record key from
+     *                       a {@link RequestLog} The {@link Function} is allowed to return {@code null}
+     *                       to skip logging for the given {@link RequestLog}.
+     */
+    public KafkaAccessLogWriter(Producer<K, V> producer, String topic,
+                                Function<? super RequestLog, ? extends K> keyExtractor,
+                                Function<? super RequestLog, ? extends V> valueExtractor) {
+        this(producer, topic, requireNonNull(keyExtractor, "keyExtractor"), valueExtractor, 0);
+    }
+
+    private KafkaAccessLogWriter(Producer<K, V> producer, String topic,
+                                 @Nullable Function<? super RequestLog, ? extends K> keyExtractor,
+                                 Function<? super RequestLog, ? extends V> valueExtractor,
+                                 @SuppressWarnings("unused") int dummy) {
+
+        this.producer = requireNonNull(producer, "producer");
+        this.topic = requireNonNull(topic, "topic");
+        this.keyExtractor = keyExtractor == null ? log -> null : keyExtractor;
+        this.valueExtractor = requireNonNull(valueExtractor, "valueExtractor");
+    }
+
+    @Override
+    public void log(RequestLog log) {
+        final V value = valueExtractor.apply(log);
+        if (value == null) {
+            return;
+        }
+
+        final K key = keyExtractor.apply(log);
+        final ProducerRecord<K, V> producerRecord = new ProducerRecord<>(topic, key, value);
+        producer.send(producerRecord, (metadata, exception) -> {
+            if (exception != null) {
+                logger.warn("Failed to send a record to Kafka: {}", producerRecord, exception);
+            }
+        });
+    }
+
+    @Override
+    public CompletableFuture<Void> shutdown() {
+        return CompletableFuture.runAsync(producer::close);
+    }
+}

--- a/kafka/src/main/java/com/linecorp/armeria/server/logging/kafka/package-info.java
+++ b/kafka/src/main/java/com/linecorp/armeria/server/logging/kafka/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 LINE Corporation
+ * Copyright 2018 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -13,10 +13,11 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+
 /**
- * Structured logging support for full request and response.
+ * Kafka backend integration support for request/response logging.
  */
 @NonNullByDefault
-package com.linecorp.armeria.server.logging.structured;
+package com.linecorp.armeria.server.logging.kafka;
 
 import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/kafka/src/main/java/com/linecorp/armeria/server/logging/structured/kafka/KafkaStructuredLoggingService.java
+++ b/kafka/src/main/java/com/linecorp/armeria/server/logging/structured/kafka/KafkaStructuredLoggingService.java
@@ -36,6 +36,7 @@ import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.server.Service;
+import com.linecorp.armeria.server.logging.kafka.KafkaAccessLogWriter;
 import com.linecorp.armeria.server.logging.structured.StructuredLogBuilder;
 import com.linecorp.armeria.server.logging.structured.StructuredLoggingService;
 
@@ -48,7 +49,10 @@ import com.linecorp.armeria.server.logging.structured.StructuredLoggingService;
  * be lost if an application crashes in unclean way.
  *
  * <p>Refer variety of {@link #newDecorator} methods to see how to enable Kafka based structured logging.
+ *
+ * @deprecated Use {@link KafkaAccessLogWriter}.
  */
+@Deprecated
 public class KafkaStructuredLoggingService<I extends Request, O extends Response, L>
         extends StructuredLoggingService<I, O, L> {
     private static final Logger logger = LoggerFactory.getLogger(KafkaStructuredLoggingService.class);

--- a/kafka/src/main/java/com/linecorp/armeria/server/logging/structured/kafka/StructuredLogJsonKafkaSerializer.java
+++ b/kafka/src/main/java/com/linecorp/armeria/server/logging/structured/kafka/StructuredLogJsonKafkaSerializer.java
@@ -29,7 +29,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 /**
  * A Kafka {@link Serializer} which serializes anything which are serializable in JSON format.
  * @param <L> the type of structured log which is being serialized
+ * @deprecated Use <a href="https://github.com/daniel-shuy/kafka-jackson-serializer">daniel-shuy/kafka-jackson-serializer</a>.
  */
+@Deprecated
 public class StructuredLogJsonKafkaSerializer<L> implements Serializer<L> {
     private final Serializer<String> stringSerializer = new StringSerializer();
     private final ObjectMapper objectMapper;

--- a/kafka/src/test/java/com/linecorp/armeria/server/logging/kafka/KafkaAccessLogWriterTest.java
+++ b/kafka/src/test/java/com/linecorp/armeria/server/logging/kafka/KafkaAccessLogWriterTest.java
@@ -41,14 +41,6 @@ public class KafkaAccessLogWriterTest {
 
     private static final String TOPIC_NAME = "topic-test";
 
-    private static final class SimpleStructuredLog {
-        private final String name;
-
-        private SimpleStructuredLog(String name) {
-            this.name = name;
-        }
-    }
-
     @Mock
     private Producer<String, String> producer;
 
@@ -69,7 +61,7 @@ public class KafkaAccessLogWriterTest {
 
         final ProducerRecord<String, String> record = captor.getValue();
         assertThat(record.key()).isNull();
-        assertThat(record.value()).isEqualTo(log);
+        assertThat(record.value()).isEqualTo("kawamuray");
     }
 
     @Test

--- a/kafka/src/test/java/com/linecorp/armeria/server/logging/kafka/KafkaAccessLogWriterTest.java
+++ b/kafka/src/test/java/com/linecorp/armeria/server/logging/kafka/KafkaAccessLogWriterTest.java
@@ -79,7 +79,8 @@ public class KafkaAccessLogWriterTest {
         when(log.decodedPath()).thenReturn("kyuto");
 
         final KafkaAccessLogWriter<String, String> service =
-                new KafkaAccessLogWriter<>(producer, TOPIC_NAME, RequestLog::decodedPath, RequestLog::authority);
+                new KafkaAccessLogWriter<>(producer, TOPIC_NAME,
+                                           RequestLog::decodedPath, RequestLog::authority);
 
         service.log(log);
 

--- a/kafka/src/test/java/com/linecorp/armeria/server/logging/kafka/KafkaAccessLogWriterTest.java
+++ b/kafka/src/test/java/com/linecorp/armeria/server/logging/kafka/KafkaAccessLogWriterTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.logging.kafka;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.internal.verification.VerificationModeFactory.times;
+
+import org.apache.kafka.clients.producer.Callback;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import com.linecorp.armeria.common.logging.RequestLog;
+
+public class KafkaAccessLogWriterTest {
+    @Rule
+    public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    private static final String TOPIC_NAME = "topic-test";
+
+    private static final class SimpleStructuredLog {
+        private final String name;
+
+        private SimpleStructuredLog(String name) {
+            this.name = name;
+        }
+    }
+
+    @Mock
+    private Producer<String, String> producer;
+
+    @Captor
+    private ArgumentCaptor<ProducerRecord<String, String>> captor;
+
+    @Test
+    public void withoutKeyExtractor() {
+        final RequestLog log = mock(RequestLog.class);
+        when(log.authority()).thenReturn("kawamuray");
+
+        final KafkaAccessLogWriter<String, String> service =
+                new KafkaAccessLogWriter<>(producer, TOPIC_NAME, RequestLog::authority);
+
+        service.log(log);
+
+        verify(producer, times(1)).send(captor.capture(), any(Callback.class));
+
+        final ProducerRecord<String, String> record = captor.getValue();
+        assertThat(record.key()).isNull();
+        assertThat(record.value()).isEqualTo(log);
+    }
+
+    @Test
+    public void withKeyExtractor() {
+        final RequestLog log = mock(RequestLog.class);
+        when(log.authority()).thenReturn("kawamuray");
+        when(log.decodedPath()).thenReturn("kyuto");
+
+        final KafkaAccessLogWriter<String, String> service =
+                new KafkaAccessLogWriter<>(producer, TOPIC_NAME, RequestLog::decodedPath, RequestLog::authority);
+
+        service.log(log);
+
+        verify(producer, times(1)).send(captor.capture(), any(Callback.class));
+
+        final ProducerRecord<String, String> record = captor.getValue();
+        assertThat(record.key()).isEqualTo("kyuto");
+        assertThat(record.value()).isEqualTo("kawamuray");
+    }
+
+    @Test
+    public void closeProducerWhenRequested() {
+        final KafkaAccessLogWriter<String, String> service =
+                new KafkaAccessLogWriter<>(producer, TOPIC_NAME, log -> "");
+
+        service.shutdown().join();
+        verify(producer, times(1)).close();
+    }
+}


### PR DESCRIPTION
Motivation:

- `StructuredLoggingService` is not capable of logging unmapped or broken
  requests.
- `StructuredLog` is of dubious value. Nobody uses it or people can just
  build his/her own.

Modifications:

- Add `AccessLogWriter` interface
  - Deprecate `AccessLogWriters` and add the same factory methods to
    `AccessLogWriter`
  - Replace the usage of `Consumer<RequestLog>` with `AccessLogWriter`
  - Add `ServerConfig.shutdownAccessLogWriterOnStop`
- Add `KafkaAccessLogWriter`
  - Deprecate `KafkaStructuredLoggingService`
- Deprecate `StructuredLogJsonKafkaSerializer`
  - Use https://github.com/daniel-shuy/kafka-jackson-serializer instead.
- Deprecate all classes under `server.logging.structured`

Result:

- Leaner API
- Can send Kafka records for unmapped or broken requests