### PR TITLE
Add a flag `com.linecorp.armeria.annotatedServiceExceptionVerbosity`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -43,6 +43,7 @@ import com.linecorp.armeria.client.retry.RetryingRpcClient;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.server.PathMappingContext;
 import com.linecorp.armeria.server.ServiceConfig;
+import com.linecorp.armeria.server.annotation.ExceptionHandler;
 import com.linecorp.armeria.server.annotation.ExceptionLoggingMode;
 
 import io.netty.channel.epoll.Epoll;
@@ -531,13 +532,20 @@ public final class Flags {
     }
 
     /**
-     * Returns the value of the {@code annotatedServiceExceptionLoggingMode} parameter which equals to
-     * one of the {@code all}, {@code unhandled} or {@code none}.
+     * Returns the value of the {@code annotatedServiceExceptionLoggingMode} parameter. It would be used to
+     * log an exception which is raised from annotated HTTP services. If it is set to
+     * {@link ExceptionLoggingMode#ALL}, all exceptions raised from annotated HTTP services are logged as
+     * {@code warn} level. If it is set to {@link ExceptionLoggingMode#UNHANDLED}, exceptions, which are
+     * not handled by {@link ExceptionHandler}s provided by a user and not well-known exceptions,
+     * would be logged as {@code warn} level. If it is set to {@link ExceptionLoggingMode#NONE},
+     * no log would be written.
      *
      * <p>The default value of this flag is {@value DEFAULT_ANNOTATED_SERVICE_EXCEPTION_LOGGING_MODE}.
      * Specify the
-     * {@code -Dcom.linecorp.armeria.annotatedServiceExceptionLoggingMode=<spec>} JVM option to override
+     * {@code -Dcom.linecorp.armeria.annotatedServiceExceptionLoggingMode=<mode>} JVM option to override
      * the default value.
+     *
+     * @see ExceptionLoggingMode
      */
     public static ExceptionLoggingMode annotatedServiceExceptionLoggingMode() {
         return ANNOTATED_SERVICE_EXCEPTION_LOGGING_MODE;

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -532,17 +532,20 @@ public final class Flags {
     }
 
     /**
-     * Returns the verbosity of exceptions logged by annotated HTTP services. If it is set to
-     * {@link ExceptionVerbosity#ALL}, all exceptions raised from annotated HTTP services are logged as
-     * {@code warn} level. If it is set to {@link ExceptionVerbosity#UNHANDLED}, exceptions, which are
-     * not handled by {@link ExceptionHandler}s provided by a user and not well-known exceptions,
-     * would be logged as {@code warn} level. If it is set to {@link ExceptionVerbosity#NONE},
-     * no log would be written.
+     * Returns the verbosity of exceptions logged by annotated HTTP services. The value of this property
+     * is one of the following:
+     * <ul>
+     *     <li>{@link ExceptionVerbosity#ALL} - logging all exceptions raised from annotated HTTP services</li>
+     *     <li>{@link ExceptionVerbosity#UNHANDLED} - logging exceptions which are not handled by
+     *     {@link ExceptionHandler}s provided by a user and are not well-known exceptions
+     *     <li>{@link ExceptionVerbosity#NONE} - no logging exceptions</li>
+     * </ul>
+     * A log message would be written at {@code WARN} level.
      *
      * <p>The default value of this flag is {@value DEFAULT_ANNOTATED_SERVICE_EXCEPTION_VERBOSITY}.
      * Specify the
-     * {@code -Dcom.linecorp.armeria.annotatedServiceExceptionVerbosity=<mode>} JVM option to override
-     * the default value.
+     * {@code -Dcom.linecorp.armeria.annotatedServiceExceptionVerbosity=<all|unhandled|none>} JVM option
+     * to override the default value.
      *
      * @see ExceptionVerbosity
      */

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -44,7 +44,7 @@ import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.server.PathMappingContext;
 import com.linecorp.armeria.server.ServiceConfig;
 import com.linecorp.armeria.server.annotation.ExceptionHandler;
-import com.linecorp.armeria.server.annotation.ExceptionLoggingMode;
+import com.linecorp.armeria.server.annotation.ExceptionVerbosity;
 
 import io.netty.channel.epoll.Epoll;
 import io.netty.handler.ssl.OpenSsl;
@@ -193,10 +193,10 @@ public final class Flags {
             CSV_SPLITTER.splitToList(getNormalized(
                     "cachedHeaders", DEFAULT_CACHED_HEADERS, CharMatcher.ascii()::matchesAllOf));
 
-    private static final String DEFAULT_ANNOTATED_SERVICE_EXCEPTION_LOGGING_MODE = "unhandled";
-    private static final ExceptionLoggingMode ANNOTATED_SERVICE_EXCEPTION_LOGGING_MODE =
-            exceptionLoggingMode("annotatedServiceExceptionLoggingMode",
-                                 DEFAULT_ANNOTATED_SERVICE_EXCEPTION_LOGGING_MODE);
+    private static final String DEFAULT_ANNOTATED_SERVICE_EXCEPTION_VERBOSITY = "unhandled";
+    private static final ExceptionVerbosity ANNOTATED_SERVICE_EXCEPTION_VERBOSITY =
+            exceptionLoggingMode("annotatedServiceExceptionVerbosity",
+                                 DEFAULT_ANNOTATED_SERVICE_EXCEPTION_VERBOSITY);
 
     static {
         if (!Epoll.isAvailable()) {
@@ -532,23 +532,22 @@ public final class Flags {
     }
 
     /**
-     * Returns the value of the {@code annotatedServiceExceptionLoggingMode} parameter. It would be used to
-     * log an exception which is raised from annotated HTTP services. If it is set to
-     * {@link ExceptionLoggingMode#ALL}, all exceptions raised from annotated HTTP services are logged as
-     * {@code warn} level. If it is set to {@link ExceptionLoggingMode#UNHANDLED}, exceptions, which are
+     * Returns the verbosity of exceptions logged by annotated HTTP services. If it is set to
+     * {@link ExceptionVerbosity#ALL}, all exceptions raised from annotated HTTP services are logged as
+     * {@code warn} level. If it is set to {@link ExceptionVerbosity#UNHANDLED}, exceptions, which are
      * not handled by {@link ExceptionHandler}s provided by a user and not well-known exceptions,
-     * would be logged as {@code warn} level. If it is set to {@link ExceptionLoggingMode#NONE},
+     * would be logged as {@code warn} level. If it is set to {@link ExceptionVerbosity#NONE},
      * no log would be written.
      *
-     * <p>The default value of this flag is {@value DEFAULT_ANNOTATED_SERVICE_EXCEPTION_LOGGING_MODE}.
+     * <p>The default value of this flag is {@value DEFAULT_ANNOTATED_SERVICE_EXCEPTION_VERBOSITY}.
      * Specify the
-     * {@code -Dcom.linecorp.armeria.annotatedServiceExceptionLoggingMode=<mode>} JVM option to override
+     * {@code -Dcom.linecorp.armeria.annotatedServiceExceptionVerbosity=<mode>} JVM option to override
      * the default value.
      *
-     * @see ExceptionLoggingMode
+     * @see ExceptionVerbosity
      */
-    public static ExceptionLoggingMode annotatedServiceExceptionLoggingMode() {
-        return ANNOTATED_SERVICE_EXCEPTION_LOGGING_MODE;
+    public static ExceptionVerbosity annotatedServiceExceptionVerbosity() {
+        return ANNOTATED_SERVICE_EXCEPTION_VERBOSITY;
     }
 
     private static Optional<String> caffeineSpec(String name, String defaultValue) {
@@ -566,11 +565,11 @@ public final class Flags {
                                   : Optional.of(spec);
     }
 
-    private static ExceptionLoggingMode exceptionLoggingMode(String name, String defaultValue) {
+    private static ExceptionVerbosity exceptionLoggingMode(String name, String defaultValue) {
         final String mode = getNormalized(name, defaultValue,
-                                          value -> Arrays.stream(ExceptionLoggingMode.values())
+                                          value -> Arrays.stream(ExceptionVerbosity.values())
                                                          .anyMatch(v -> v.name().equalsIgnoreCase(value)));
-        return ExceptionLoggingMode.valueOf(mode.toUpperCase());
+        return ExceptionVerbosity.valueOf(mode.toUpperCase());
     }
 
     private static boolean getBoolean(String name, boolean defaultValue) {

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.common;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.IntPredicate;
@@ -42,6 +43,7 @@ import com.linecorp.armeria.client.retry.RetryingRpcClient;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.server.PathMappingContext;
 import com.linecorp.armeria.server.ServiceConfig;
+import com.linecorp.armeria.server.annotation.ExceptionLoggingMode;
 
 import io.netty.channel.epoll.Epoll;
 import io.netty.handler.ssl.OpenSsl;
@@ -189,6 +191,11 @@ public final class Flags {
     private static final List<String> CACHED_HEADERS =
             CSV_SPLITTER.splitToList(getNormalized(
                     "cachedHeaders", DEFAULT_CACHED_HEADERS, CharMatcher.ascii()::matchesAllOf));
+
+    private static final String DEFAULT_ANNOTATED_SERVICE_EXCEPTION_LOGGING_MODE = "unhandled";
+    private static final ExceptionLoggingMode ANNOTATED_SERVICE_EXCEPTION_LOGGING_MODE =
+            exceptionLoggingMode("annotatedServiceExceptionLoggingMode",
+                                 DEFAULT_ANNOTATED_SERVICE_EXCEPTION_LOGGING_MODE);
 
     static {
         if (!Epoll.isAvailable()) {
@@ -523,6 +530,19 @@ public final class Flags {
         return COMPOSITE_SERVICE_CACHE_SPEC;
     }
 
+    /**
+     * Returns the value of the {@code annotatedServiceExceptionLoggingMode} parameter which equals to
+     * one of the {@code all}, {@code unhandled} or {@code none}.
+     *
+     * <p>The default value of this flag is {@value DEFAULT_ANNOTATED_SERVICE_EXCEPTION_LOGGING_MODE}.
+     * Specify the
+     * {@code -Dcom.linecorp.armeria.annotatedServiceExceptionLoggingMode=<spec>} JVM option to override
+     * the default value.
+     */
+    public static ExceptionLoggingMode annotatedServiceExceptionLoggingMode() {
+        return ANNOTATED_SERVICE_EXCEPTION_LOGGING_MODE;
+    }
+
     private static Optional<String> caffeineSpec(String name, String defaultValue) {
         final String spec = get(name, defaultValue, value -> {
             try {
@@ -536,6 +556,13 @@ public final class Flags {
         });
         return "off".equals(spec) ? Optional.empty()
                                   : Optional.of(spec);
+    }
+
+    private static ExceptionLoggingMode exceptionLoggingMode(String name, String defaultValue) {
+        final String mode = getNormalized(name, defaultValue,
+                                          value -> Arrays.stream(ExceptionLoggingMode.values())
+                                                         .anyMatch(v -> v.name().equalsIgnoreCase(value)));
+        return ExceptionLoggingMode.valueOf(mode.toUpperCase());
     }
 
     private static boolean getBoolean(String name, boolean defaultValue) {

--- a/core/src/main/java/com/linecorp/armeria/server/AnnotatedHttpService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AnnotatedHttpService.java
@@ -52,7 +52,7 @@ import com.linecorp.armeria.internal.PublisherToHttpResponseConverter;
 import com.linecorp.armeria.server.AnnotatedValueResolver.AggregationStrategy;
 import com.linecorp.armeria.server.AnnotatedValueResolver.ResolverContext;
 import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
-import com.linecorp.armeria.server.annotation.ExceptionLoggingMode;
+import com.linecorp.armeria.server.annotation.ExceptionVerbosity;
 import com.linecorp.armeria.server.annotation.Path;
 import com.linecorp.armeria.server.annotation.ResponseConverterFunction;
 import com.linecorp.armeria.server.annotation.ResponseConverterFunctionProvider;
@@ -253,7 +253,7 @@ final class AnnotatedHttpService implements HttpService {
     private HttpResponse convertException(RequestContext ctx, HttpRequest req, Throwable cause) {
         final Throwable peeledCause = Exceptions.peel(cause);
 
-        if (Flags.annotatedServiceExceptionLoggingMode() == ExceptionLoggingMode.ALL &&
+        if (Flags.annotatedServiceExceptionVerbosity() == ExceptionVerbosity.ALL &&
             logger.isWarnEnabled()) {
             logger.warn("An exception from a class '{}' and its method '{}':",
                         object.getClass().getSimpleName(), method.getName(), peeledCause);

--- a/core/src/main/java/com/linecorp/armeria/server/AnnotatedHttpServiceFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AnnotatedHttpServiceFactory.java
@@ -52,7 +52,6 @@ import com.google.common.collect.ImmutableList.Builder;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 
-import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
@@ -71,7 +70,6 @@ import com.linecorp.armeria.server.annotation.Decorators;
 import com.linecorp.armeria.server.annotation.Delete;
 import com.linecorp.armeria.server.annotation.ExceptionHandler;
 import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
-import com.linecorp.armeria.server.annotation.ExceptionLoggingMode;
 import com.linecorp.armeria.server.annotation.Get;
 import com.linecorp.armeria.server.annotation.Head;
 import com.linecorp.armeria.server.annotation.JacksonResponseConverterFunction;
@@ -99,8 +97,6 @@ import com.linecorp.armeria.server.annotation.Trace;
 final class AnnotatedHttpServiceFactory {
     private static final Logger logger = LoggerFactory.getLogger(AnnotatedHttpServiceFactory.class);
 
-    private static final ExceptionLoggingMode exceptionLoggingMode =
-            Flags.annotatedServiceExceptionLoggingMode();
     /**
      * An instance map for reusing converters, exception handlers and decorators.
      */
@@ -260,8 +256,7 @@ final class AnnotatedHttpServiceFactory {
                         "They would not be automatically injected: " + missing);
         }
         return new AnnotatedHttpServiceElement(pathMapping,
-                                               new AnnotatedHttpService(object, method, resolvers, eh, res,
-                                                                        exceptionLoggingMode),
+                                               new AnnotatedHttpService(object, method, resolvers, eh, res),
                                                decorator(method, clazz));
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/DefaultExceptionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/DefaultExceptionHandler.java
@@ -41,8 +41,6 @@ import com.linecorp.armeria.server.HttpStatusException;
 final class DefaultExceptionHandler implements ExceptionHandlerFunction {
     private static final Logger logger = LoggerFactory.getLogger(DefaultExceptionHandler.class);
 
-    private final ExceptionLoggingMode exceptionLoggingMode = Flags.annotatedServiceExceptionLoggingMode();
-
     @Override
     public HttpResponse handleException(RequestContext ctx, HttpRequest req, Throwable cause) {
         if (cause instanceof IllegalArgumentException) {
@@ -57,7 +55,7 @@ final class DefaultExceptionHandler implements ExceptionHandlerFunction {
             return ((HttpResponseException) cause).httpResponse();
         }
 
-        if (exceptionLoggingMode == ExceptionLoggingMode.UNHANDLED &&
+        if (Flags.annotatedServiceExceptionVerbosity() == ExceptionVerbosity.UNHANDLED &&
             logger.isWarnEnabled()) {
             logger.warn("No exception handler exists for the cause. {} is handling it.",
                         DefaultExceptionHandler.class.getName(), cause);

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/DefaultExceptionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/DefaultExceptionHandler.java
@@ -59,9 +59,8 @@ final class DefaultExceptionHandler implements ExceptionHandlerFunction {
 
         if (exceptionLoggingMode == ExceptionLoggingMode.UNHANDLED &&
             logger.isWarnEnabled()) {
-            logger.warn("No exception handler exists for the cause. " +
-                        DefaultExceptionHandler.class.getName() + " is handling it.",
-                        cause);
+            logger.warn("No exception handler exists for the cause. {} is handling it.",
+                        DefaultExceptionHandler.class.getName(), cause);
         }
 
         return HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR);

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/DefaultExceptionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/DefaultExceptionHandler.java
@@ -19,23 +19,51 @@ package com.linecorp.armeria.server.annotation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.server.HttpResponseException;
+import com.linecorp.armeria.server.HttpStatusException;
 
 /**
- * A default exception handler function. It returns an {@link HttpResponse} with
- * {@code 500 Internal Server Error} status code.
+ * A default exception handler is used when a user does not specify exception handlers
+ * by {@link ExceptionHandler} annotation. It returns:
+ * <ul>
+ *     <li>an {@link HttpResponse} with {@code 400 Bad Request} status code when the cause is an
+ *     {@link IllegalArgumentException}, or</li>
+ *     <li>an {@link HttpResponse} with the status code that an {@link HttpStatusException} holds, or</li>
+ *     <li>an {@link HttpResponse} that an {@link HttpResponseException} holds, or</li>
+ *     <li>an {@link HttpResponse} with {@code 500 Internal Server Error}.</li>
+ * </ul>
  */
 final class DefaultExceptionHandler implements ExceptionHandlerFunction {
     private static final Logger logger = LoggerFactory.getLogger(DefaultExceptionHandler.class);
 
+    private final ExceptionLoggingMode exceptionLoggingMode = Flags.annotatedServiceExceptionLoggingMode();
+
     @Override
     public HttpResponse handleException(RequestContext ctx, HttpRequest req, Throwable cause) {
-        logger.warn("No exception handler exists for the cause. " +
-                    DefaultExceptionHandler.class.getName() + " is handling it.",
-                    cause);
+        if (cause instanceof IllegalArgumentException) {
+            return HttpResponse.of(HttpStatus.BAD_REQUEST);
+        }
+
+        if (cause instanceof HttpStatusException) {
+            return HttpResponse.of(((HttpStatusException) cause).httpStatus());
+        }
+
+        if (cause instanceof HttpResponseException) {
+            return ((HttpResponseException) cause).httpResponse();
+        }
+
+        if (exceptionLoggingMode == ExceptionLoggingMode.UNHANDLED &&
+            logger.isWarnEnabled()) {
+            logger.warn("No exception handler exists for the cause. " +
+                        DefaultExceptionHandler.class.getName() + " is handling it.",
+                        cause);
+        }
+
         return HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/ExceptionHandlerFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/ExceptionHandlerFunction.java
@@ -30,8 +30,7 @@ import com.linecorp.armeria.internal.FallthroughException;
 public interface ExceptionHandlerFunction {
 
     /**
-     * A default exception handler function. It returns an {@link HttpResponse} with
-     * {@code 500 Internal Server Error} status code.
+     * A default exception handler function.
      */
     ExceptionHandlerFunction DEFAULT = new DefaultExceptionHandler();
 

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/ExceptionLoggingMode.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/ExceptionLoggingMode.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.annotation;
+
+import com.linecorp.armeria.server.HttpResponseException;
+import com.linecorp.armeria.server.HttpStatusException;
+
+/**
+ * A logging mode when handling an exception from the annotated HTTP services.
+ */
+public enum ExceptionLoggingMode {
+    /**
+     * Log all exceptions.
+     */
+    ALL,
+    /**
+     * Log exceptions which are not handled by any {@link ExceptionHandler} specified by a user.
+     * However, the following exceptions would not be logged because they are from the well-known cause.
+     * <ul>
+     *     <li>{@link IllegalArgumentException}</li>
+     *     <li>{@link HttpStatusException}</li>
+     *     <li>{@link HttpResponseException}</li>
+     * </ul>
+     */
+    UNHANDLED,
+    /**
+     * Do not log any exceptions.
+     */
+    NONE
+}

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/ExceptionVerbosity.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/ExceptionVerbosity.java
@@ -19,9 +19,9 @@ import com.linecorp.armeria.server.HttpResponseException;
 import com.linecorp.armeria.server.HttpStatusException;
 
 /**
- * A logging mode when handling an exception from the annotated HTTP services.
+ * The verbosity of exceptions logged by annotated HTTP services.
  */
-public enum ExceptionLoggingMode {
+public enum ExceptionVerbosity {
     /**
      * Log all exceptions.
      */


### PR DESCRIPTION
Motivation:
A user may want to know why his or her annotated service returns 400 or 500 status code from the log files.

Modifications:
- Add a flag `com.linecorp.armeria.annotatedServiceExceptionVerbosity`
- Add `ExceptionVerbosity` enum to control logging

Result:
A user can get every exception when adding `com.linecorp.armeria.annotatedServiceExceptionVerbosity=all` to the system properties.