### PR TITLE
Make gRPC downstream / upstream more consistent by disabling somewhat time-con…

### DIFF
--- a/benchmarks/src/jmh/java/com/linecorp/armeria/grpc/downstream/DownstreamSimpleBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/grpc/downstream/DownstreamSimpleBenchmark.java
@@ -16,11 +16,14 @@
 
 package com.linecorp.armeria.grpc.downstream;
 
+import java.time.Duration;
+
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 
 import com.linecorp.armeria.client.Clients;
+import com.linecorp.armeria.common.metric.NoopMeterRegistry;
 import com.linecorp.armeria.grpc.GithubServiceGrpc.GithubServiceBlockingStub;
 import com.linecorp.armeria.grpc.GithubServiceGrpc.GithubServiceFutureStub;
 import com.linecorp.armeria.grpc.shared.GithubApiService;
@@ -61,6 +64,8 @@ public class DownstreamSimpleBenchmark extends SimpleBenchmarkBase {
     protected void setUp() throws Exception {
         server = new ServerBuilder()
                 .serviceUnder("/", new GrpcServiceBuilder().addService(new GithubApiService()).build())
+                .defaultRequestTimeout(Duration.ZERO)
+                .meterRegistry(NoopMeterRegistry.get())
                 .build();
         server.start().join();
         final String url = "gproto+http://127.0.0.1:" + port() + '/';


### PR DESCRIPTION
…suming request timeout + metrics.

After
```
Benchmark                                           (clientType)   Mode  Cnt      Score     Error  Units
c.l.a.g.downstream.DownstreamSimpleBenchmark.empty        OKHTTP  thrpt    5  19214.558 ± 114.257  ops/s
c.l.a.g.upstream.UpstreamSimpleBenchmark.empty            OKHTTP  thrpt    5  23600.588 ± 385.477  ops/s
```

Before
```
Benchmark                                           (clientType)   Mode  Cnt      Score     Error  Units
c.l.a.g.downstream.DownstreamSimpleBenchmark.empty        OKHTTP  thrpt    5  18231.400 ± 729.205  ops/s
c.l.a.g.upstream.UpstreamSimpleBenchmark.empty            OKHTTP  thrpt    5  23053.297 ± 384.082  ops/s
```