### PR TITLE
Allow configuring HTTP2 SETTINGS frame.

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -154,6 +154,25 @@ public final class Flags {
     private static final boolean DEFAULT_USE_HTTP2_PREFACE = getBoolean("defaultUseHttp2Preface", true);
     private static final boolean DEFAULT_USE_HTTP1_PIPELINING = getBoolean("defaultUseHttp1Pipelining", false);
 
+    private static final int DEFAULT_DEFAULT_HTTP2_INITIAL_WINDOW_SIZE = 1048576; // 1MiB
+    private static final int DEFAULT_HTTP2_INITIAL_WINDOW_SIZE =
+            getInt("defaultHttp2InitialWindowSize",
+                   DEFAULT_DEFAULT_HTTP2_INITIAL_WINDOW_SIZE,
+                   value -> value > 0);
+
+    private static final int DEFAULT_DEFAULT_HTTP2_MAX_STREAMS_PER_CONNECTION = Integer.MAX_VALUE;
+    private static final int DEFAULT_HTTP2_MAX_STREAMS_PER_CONNECTION =
+            getInt("defaultHttp2MaxStreamsPerConnection",
+                   DEFAULT_DEFAULT_HTTP2_MAX_STREAMS_PER_CONNECTION,
+                   value -> value > 0);
+
+    // from Netty default maxHeaderSize
+    private static final int DEFAULT_DEFAULT_HTTP2_MAX_HEADER_LIST_SIZE = 8192;
+    private static final int DEFAULT_HTTP2_MAX_HEADER_LIST_SIZE =
+            getInt("defaultHttp2MaxHeaderListSize",
+                   DEFAULT_DEFAULT_HTTP2_MAX_HEADER_LIST_SIZE,
+                   value -> value > 0);
+
     private static final String DEFAULT_DEFAULT_BACKOFF_SPEC =
             "exponential=200:10000,jitter=0.2";
     private static final String DEFAULT_BACKOFF_SPEC =
@@ -456,6 +475,18 @@ public final class Flags {
      */
     public static boolean defaultUseHttp1Pipelining() {
         return DEFAULT_USE_HTTP1_PIPELINING;
+    }
+
+    public static int defaultHttp2InitialWindowSize() {
+        return DEFAULT_HTTP2_INITIAL_WINDOW_SIZE;
+    }
+
+    public static int defaultHttp2MaxStreamsPerConnection() {
+        return DEFAULT_HTTP2_MAX_STREAMS_PER_CONNECTION;
+    }
+
+    public static int defaultHttp2MaxHeaderListSize() {
+        return DEFAULT_HTTP2_MAX_HEADER_LIST_SIZE;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -42,6 +42,7 @@ import com.linecorp.armeria.client.retry.RetryingHttpClient;
 import com.linecorp.armeria.client.retry.RetryingRpcClient;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.server.PathMappingContext;
+import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.ServiceConfig;
 import com.linecorp.armeria.server.annotation.ExceptionHandler;
 import com.linecorp.armeria.server.annotation.ExceptionVerbosity;
@@ -154,7 +155,7 @@ public final class Flags {
     private static final boolean DEFAULT_USE_HTTP2_PREFACE = getBoolean("defaultUseHttp2Preface", true);
     private static final boolean DEFAULT_USE_HTTP1_PIPELINING = getBoolean("defaultUseHttp1Pipelining", false);
 
-    private static final int DEFAULT_DEFAULT_HTTP2_INITIAL_WINDOW_SIZE = 1048576; // 1MiB
+    private static final int DEFAULT_DEFAULT_HTTP2_INITIAL_WINDOW_SIZE = 1024 * 1024; // 1MiB
     private static final int DEFAULT_HTTP2_INITIAL_WINDOW_SIZE =
             getInt("defaultHttp2InitialWindowSize",
                    DEFAULT_DEFAULT_HTTP2_INITIAL_WINDOW_SIZE,
@@ -447,8 +448,8 @@ public final class Flags {
      * so that their lengths never exceed it.
      * Note that this value has effect only if a user did not specify it.
      *
-     * <p>This default value of this flag is {@value #DEFAULT_DEFAULT_MAX_HTTP1_CHUNK_SIZE}.
-     * Specify theb {@code -Dcom.linecorp.armeria.defaultMaxHttp1ChunkSize=<integer>} JVM option
+     * <p>The default value of this flag is {@value #DEFAULT_DEFAULT_MAX_HTTP1_CHUNK_SIZE}.
+     * Specify the {@code -Dcom.linecorp.armeria.defaultMaxHttp1ChunkSize=<integer>} JVM option
      * to override the default value.
      */
     public static int defaultMaxHttp1ChunkSize() {
@@ -477,14 +478,38 @@ public final class Flags {
         return DEFAULT_USE_HTTP1_PIPELINING;
     }
 
+    /**
+     * Returns the default value of the {@link ServerBuilder#http2InitialWindowSize(int)} option.
+     * Note that this value has effect only if a user did not specify it.
+     *
+     * <p>The default value of this flag is {@value #DEFAULT_DEFAULT_HTTP2_INITIAL_WINDOW_SIZE}.
+     * Specify the {@code -Dcom.linecorp.armeria.defaultHttp2InitialWindowSize=<integer>} JVM option
+     * to override the default value.
+     */
     public static int defaultHttp2InitialWindowSize() {
         return DEFAULT_HTTP2_INITIAL_WINDOW_SIZE;
     }
 
+    /**
+     * Returns the default value of the {@link ServerBuilder#http2MaxStreamsPerConnection(int)} option.
+     * Note that this value has effect only if a user did not specify it.
+     *
+     * <p>The default value of this flag is {@value #DEFAULT_DEFAULT_HTTP2_MAX_STREAMS_PER_CONNECTION}.
+     * Specify the {@code -Dcom.linecorp.armeria.defaultHttp2MaxStreamsPerConnection=<integer>} JVM option
+     * to override the default value.
+     */
     public static int defaultHttp2MaxStreamsPerConnection() {
         return DEFAULT_HTTP2_MAX_STREAMS_PER_CONNECTION;
     }
 
+    /**
+     * Returns the default value of the {@link ServerBuilder#http2MaxHeaderListSize(int)} option.
+     * Note that this value has effect only if a user did not specify it.
+     *
+     * <p>The default value of this flag is {@value #DEFAULT_DEFAULT_HTTP2_MAX_HEADER_LIST_SIZE}.
+     * Specify the {@code -Dcom.linecorp.armeria.defaultHttp2MaxHeaderListSize=<integer>} JVM option
+     * to override the default value.
+     */
     public static int defaultHttp2MaxHeaderListSize() {
         return DEFAULT_HTTP2_MAX_HEADER_LIST_SIZE;
     }

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
@@ -184,8 +184,13 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
         final Http2ConnectionEncoder encoder = new DefaultHttp2ConnectionEncoder(conn, writer);
         final Http2ConnectionDecoder decoder = new DefaultHttp2ConnectionDecoder(conn, encoder, reader);
 
+        final Http2Settings settings = new Http2Settings();
+        settings.initialWindowSize(config.http2InitialWindowSize());
+        settings.maxConcurrentStreams(config.http2MaxStreamsPerConnection());
+        settings.maxHeaderListSize(config.http2MaxHeaderListSize());
+
         final Http2ConnectionHandler handler =
-                new Http2ServerConnectionHandler(decoder, encoder, new Http2Settings());
+                new Http2ServerConnectionHandler(decoder, encoder, settings);
 
         // Setup post build options
         final Http2RequestDecoder listener =

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -499,8 +499,8 @@ public final class ServerBuilder {
     }
 
     /**
-     * Sets the initial HTTP/2 flow control window size. Larger values can stream warmup time at
-     * the expense of being easier to overload the server. Defaults to
+     * Sets the initial HTTP/2 flow control window size. Larger values can lower stream warmup time
+     * at the expense of being easier to overload the server. Defaults to
      * {@link Flags#defaultHttp2InitialWindowSize()}.
      */
     public ServerBuilder http2InitialWindowSize(int windowSize) {
@@ -521,7 +521,7 @@ public final class ServerBuilder {
 
     /**
      * Sets the maximum size of headers that can be received. Defaults to
-     * {@link Flags#defaultHttp2MaxHeaderListSize()} ()}.
+     * {@link Flags#defaultHttp2MaxHeaderListSize()}.
      */
     public ServerBuilder http2MaxHeaderListSize(int headerListSize) {
         this.http2MaxHeaderListSize = validateNonNegative(headerListSize, "headerListSize");

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -152,6 +152,9 @@ public final class ServerBuilder {
     private int maxHttp1InitialLineLength = Flags.defaultMaxHttp1InitialLineLength();
     private int maxHttp1HeaderSize = Flags.defaultMaxHttp1HeaderSize();
     private int maxHttp1ChunkSize = Flags.defaultMaxHttp1ChunkSize();
+    private int http2InitialWindowSize = Flags.defaultHttp2InitialWindowSize();
+    private int http2MaxStreamsPerConnection = Flags.defaultHttp2MaxStreamsPerConnection();
+    private int http2MaxHeaderListSize = Flags.defaultHttp2MaxHeaderListSize();
     private int proxyProtocolMaxTlvSize = PROXY_PROTOCOL_DEFAULT_MAX_TLV_SIZE;
     private Duration gracefulShutdownQuietPeriod = DEFAULT_GRACEFUL_SHUTDOWN_QUIET_PERIOD;
     private Duration gracefulShutdownTimeout = DEFAULT_GRACEFUL_SHUTDOWN_TIMEOUT;
@@ -492,6 +495,36 @@ public final class ServerBuilder {
      */
     public ServerBuilder maxHttp1ChunkSize(int maxHttp1ChunkSize) {
         this.maxHttp1ChunkSize = validateNonNegative(maxHttp1ChunkSize, "maxHttp1ChunkSize");
+        return this;
+    }
+
+    /**
+     * Sets the initial HTTP/2 flow control window size. Larger values can stream warmup time at
+     * the expense of being easier to overload the server. Defaults to
+     * {@link Flags#defaultHttp2InitialWindowSize()}.
+     */
+    public ServerBuilder http2InitialWindowSize(int windowSize) {
+        this.http2InitialWindowSize = validateNonNegative(windowSize, "windowSize");
+        return this;
+    }
+
+    /**
+     * Sets the max concurrent streams per HTTP/2 connection. Unset means there is no limit on
+     * the number of concurrent streams. Note, this differs from {@link #maxNumConnections()},
+     * which is the maximum number of HTTP/2 connections themselves, not the streams that are
+     * multiplexed over each.
+     */
+    public ServerBuilder http2MaxStreamsPerConnection(int maxStreams) {
+        this.http2MaxStreamsPerConnection = validateNonNegative(maxStreams, "maxStreams");
+        return this;
+    }
+
+    /**
+     * Sets the maximum size of headers that can be received. Defaults to
+     * {@link Flags#defaultHttp2MaxHeaderListSize()} ()}.
+     */
+    public ServerBuilder http2MaxHeaderListSize(int headerListSize) {
+        this.http2MaxHeaderListSize = validateNonNegative(headerListSize, "headerListSize");
         return this;
     }
 
@@ -1081,6 +1114,7 @@ public final class ServerBuilder {
                 workerGroup, shutdownWorkerGroupOnStop, startStopExecutor, maxNumConnections,
                 idleTimeoutMillis, defaultRequestTimeoutMillis, defaultMaxRequestLength,
                 maxHttp1InitialLineLength, maxHttp1HeaderSize, maxHttp1ChunkSize,
+                http2InitialWindowSize, http2MaxStreamsPerConnection, http2MaxHeaderListSize,
                 gracefulShutdownQuietPeriod, gracefulShutdownTimeout, blockingTaskExecutor,
                 meterRegistry, serviceLoggerPrefix, accessLogWriter, shutdownAccessLogWriterOnStop,
                 proxyProtocolMaxTlvSize, channelOptions, childChannelOptions), sslContexts);

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -509,8 +509,8 @@ public final class ServerBuilder {
     }
 
     /**
-     * Sets the max concurrent streams per HTTP/2 connection. Unset means there is no limit on
-     * the number of concurrent streams. Note, this differs from {@link #maxNumConnections()},
+     * Sets the maximum number of concurrent streams per HTTP/2 connection. Unset means there is
+     * no limit on the number of concurrent streams. Note, this differs from {@link #maxNumConnections()},
      * which is the maximum number of HTTP/2 connections themselves, not the streams that are
      * multiplexed over each.
      */

--- a/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
@@ -68,6 +68,9 @@ public final class ServerConfig {
     private final int defaultMaxHttp1InitialLineLength;
     private final int defaultMaxHttp1HeaderSize;
     private final int defaultMaxHttp1ChunkSize;
+    private final int http2InitialWindowSize;
+    private final int http2MaxStreamsPerConnection;
+    private final int http2MaxHeaderListSize;
 
     private final Duration gracefulShutdownQuietPeriod;
     private final Duration gracefulShutdownTimeout;
@@ -96,11 +99,15 @@ public final class ServerConfig {
             int maxNumConnections, long idleTimeoutMillis,
             long defaultRequestTimeoutMillis, long defaultMaxRequestLength,
             int defaultMaxHttp1InitialLineLength, int defaultMaxHttp1HeaderSize, int defaultMaxHttp1ChunkSize,
+            int http2InitialWindowSize, int http2MaxStreamsPerConnection, int http2MaxHeaderListSize,
             Duration gracefulShutdownQuietPeriod, Duration gracefulShutdownTimeout,
             Executor blockingTaskExecutor, MeterRegistry meterRegistry, String serviceLoggerPrefix,
             AccessLogWriter accessLogWriter, boolean shutdownAccessLogWriterOnStop, int proxyProtocolMaxTlvSize,
             Map<ChannelOption<?>, Object> channelOptions,
             Map<ChannelOption<?>, Object> childChannelOptions) {
+        this.http2InitialWindowSize = http2InitialWindowSize;
+        this.http2MaxStreamsPerConnection = http2MaxStreamsPerConnection;
+        this.http2MaxHeaderListSize = http2MaxHeaderListSize;
 
         requireNonNull(ports, "ports");
         requireNonNull(defaultVirtualHost, "defaultVirtualHost");
@@ -428,6 +435,27 @@ public final class ServerConfig {
      */
     public int defaultMaxHttp1ChunkSize() {
         return defaultMaxHttp1ChunkSize;
+    }
+
+    /**
+     * Returns the initial HTTP/2 flow control window size.
+     */
+    public int http2InitialWindowSize() {
+        return http2InitialWindowSize;
+    }
+
+    /**
+     * Returns the max concurrent streams per HTTP/2 connection.
+     */
+    public int http2MaxStreamsPerConnection() {
+        return http2MaxStreamsPerConnection;
+    }
+
+    /**
+     * Returns the maximum size of headers that can be received.
+     */
+    public int http2MaxHeaderListSize() {
+        return http2MaxHeaderListSize;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
@@ -445,7 +445,7 @@ public final class ServerConfig {
     }
 
     /**
-     * Returns the max concurrent streams per HTTP/2 connection.
+     * Returns the maximum number of concurrent streams per HTTP/2 connection.
      */
     public int http2MaxStreamsPerConnection() {
         return http2MaxStreamsPerConnection;


### PR DESCRIPTION
I didn't find any real difference in my usual benchmark, but doesn't hurt to have knobs. The defaults change though

- Initial window size is 1MB instead of HTTP/2 default of 64K
- Max header size is 8K, just like our default HTTP/1 max

I just followed gRPC upstream but it'd be fine to change these defaults too.

Fixes #1241 