### PR TITLE
Handle GOAWAY frames correctly

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClosedClientFactoryException.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClosedClientFactoryException.java
@@ -32,7 +32,7 @@ public final class ClosedClientFactoryException extends RuntimeException {
 
     /**
      * Returns a {@link ClosedClientFactoryException} which may be a singleton or a new instance, depending on
-     * whether {@link Flags#verboseExceptions() the verbose exception mode} is enabled.
+     * whether {@linkplain Flags#verboseExceptions() the verbose exception mode} is enabled.
      */
     public static ClosedClientFactoryException get() {
         return Flags.verboseExceptions() ? new ClosedClientFactoryException() : INSTANCE;

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientFactory.java
@@ -271,6 +271,10 @@ final class HttpClientFactory extends AbstractClientFactory {
         }
     }
 
+    boolean isClosing() {
+        return connectionPoolListener.closed;
+    }
+
     @Override
     public void close() {
         connectionPoolListener.setClosed();

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
@@ -640,19 +640,11 @@ final class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
         final Http2ConnectionEncoder encoder = new DefaultHttp2ConnectionEncoder(conn, writer);
         final Http2ConnectionDecoder decoder = new DefaultHttp2ConnectionDecoder(conn, encoder, reader);
 
-        final Http2Settings http2Settings = http2Settings();
-
-        final Http2ResponseDecoder listener = new Http2ResponseDecoder(conn, ch, encoder);
-        final Http2ClientConnectionHandler handler =
-                new Http2ClientConnectionHandler(decoder, encoder, http2Settings, listener);
-        // Setup post build options
-        handler.gracefulShutdownTimeoutMillis(clientFactory.idleTimeoutMillis());
-
-        return handler;
+        return new Http2ClientConnectionHandler(clientFactory, ch, decoder, encoder, http2Settings());
     }
 
     private Http2Settings http2Settings() {
-        final Http2Settings http2Settings = new Http2Settings();
+        final Http2Settings http2Settings = Http2Settings.defaultSettings();
         if (clientFactory.initialHttp2StreamWindowSize() != DEFAULT_WINDOW_SIZE) {
             http2Settings.initialWindowSize(clientFactory.initialHttp2StreamWindowSize());
         }

--- a/core/src/main/java/com/linecorp/armeria/client/ResponseTimeoutException.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ResponseTimeoutException.java
@@ -32,7 +32,7 @@ public final class ResponseTimeoutException extends TimeoutException {
 
     /**
      * Returns a {@link ResponseTimeoutException} which may be a singleton or a new instance, depending on
-     * whether {@link Flags#verboseExceptions() the verbose exception mode} is enabled.
+     * whether {@linkplain Flags#verboseExceptions() the verbose exception mode} is enabled.
      */
     public static ResponseTimeoutException get() {
         return Flags.verboseExceptions() ? new ResponseTimeoutException() : INSTANCE;

--- a/core/src/main/java/com/linecorp/armeria/client/UnprocessedRequestException.java
+++ b/core/src/main/java/com/linecorp/armeria/client/UnprocessedRequestException.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import com.linecorp.armeria.common.Flags;
+import com.linecorp.armeria.common.util.Exceptions;
+
+/**
+ * A {@link RuntimeException} raised when it is certain that a request has not been handled by a server and
+ * thus can be retried safely. This exception is usually raised when a server sent an HTTP/2 GOAWAY frame with
+ * the {@code lastStreamId} less than the stream ID of the request.
+ *
+ * @see <a href="https://httpwg.org/specs/rfc7540.html#GOAWAY">Section 6.8, RFC7540</a>
+ */
+public final class UnprocessedRequestException extends RuntimeException {
+
+    private static final long serialVersionUID = 4679512839715213302L;
+
+    private static final UnprocessedRequestException INSTANCE =
+            Exceptions.clearTrace(new UnprocessedRequestException());
+
+    /**
+     * Returns a {@link UnprocessedRequestException} which may be a singleton or a new instance, depending on
+     * whether {@linkplain Flags#verboseExceptions() the verbose exception mode} is enabled.
+     */
+    public static UnprocessedRequestException get() {
+        return Flags.verboseExceptions() ? new UnprocessedRequestException() : INSTANCE;
+    }
+
+    /**
+     * Creates a new instance.
+     */
+    private UnprocessedRequestException() {}
+}

--- a/core/src/main/java/com/linecorp/armeria/client/WriteTimeoutException.java
+++ b/core/src/main/java/com/linecorp/armeria/client/WriteTimeoutException.java
@@ -31,7 +31,7 @@ public final class WriteTimeoutException extends TimeoutException {
 
     /**
      * Returns a {@link WriteTimeoutException} which may be a singleton or a new instance, depending on
-     * whether {@link Flags#verboseExceptions() the verbose exception mode} is enabled.
+     * whether {@linkplain Flags#verboseExceptions() the verbose exception mode} is enabled.
      */
     public static WriteTimeoutException get() {
         return Flags.verboseExceptions() ? new WriteTimeoutException() : INSTANCE;

--- a/core/src/main/java/com/linecorp/armeria/client/pool/DefaultKeyedChannelPool.java
+++ b/core/src/main/java/com/linecorp/armeria/client/pool/DefaultKeyedChannelPool.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.CountDownLatch;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -37,6 +38,7 @@ import com.linecorp.armeria.common.util.Exceptions;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.EventLoop;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
@@ -308,13 +310,13 @@ public class DefaultKeyedChannelPool<K> implements KeyedChannelPool<K> {
             // While we'd prefer to block until the pool is actually closed, we cannot block for the channels to
             // close if it was called from the event loop or we would deadlock. In practice, it's rare to call
             // close from an event loop thread, and not a main thread.
-            doClose(false);
+            doCloseAsync();
         } else {
-            eventLoop.submit(() -> doClose(true)).syncUninterruptibly();
+            doCloseSync();
         }
     }
 
-    private void doClose(boolean blocking) {
+    private void doCloseAsync() {
         closed = true;
 
         if (allChannels.isEmpty()) {
@@ -323,16 +325,46 @@ public class DefaultKeyedChannelPool<K> implements KeyedChannelPool<K> {
 
         final List<ChannelFuture> closeFutures = new ArrayList<>(allChannels.size());
         for (Channel ch : allChannels) {
-            if (ch.isOpen()) {
-                // NB: Do not call close() here, because it will trigger the closeFuture listener
-                //     which mutates allChannels.
-                closeFutures.add(ch.closeFuture());
-            }
+            // NB: Do not call close() here, because it will trigger the closeFuture listener
+            //     which mutates allChannels.
+            closeFutures.add(ch.closeFuture());
         }
 
         closeFutures.forEach(f -> f.channel().close());
-        if (blocking) {
-            closeFutures.forEach(ChannelFuture::syncUninterruptibly);
+    }
+
+    private void doCloseSync() {
+        closed = true;
+        if (allChannels.isEmpty()) {
+            return;
+        }
+        final CountDownLatch outerLatch = eventLoop.submit(() -> {
+            final int numChannels = allChannels.size();
+            final CountDownLatch latch = new CountDownLatch(numChannels);
+            if (numChannels == 0) {
+                return latch;
+            }
+            final List<ChannelFuture> closeFutures = new ArrayList<>(numChannels);
+            for (Channel ch : allChannels) {
+                // NB: Do not call close() here, because it will trigger the closeFuture listener
+                //     which mutates allChannels.
+                final ChannelFuture f = ch.closeFuture();
+                closeFutures.add(f);
+                f.addListener((ChannelFutureListener) future -> latch.countDown());
+            }
+            closeFutures.forEach(f -> f.channel().close());
+            return latch;
+        }).syncUninterruptibly().getNow();
+        boolean interrupted = false;
+        while (outerLatch.getCount() != 0) {
+            try {
+                outerLatch.await();
+            } catch (InterruptedException e) {
+                interrupted = true;
+            }
+        }
+        if (interrupted) {
+            Thread.currentThread().interrupt();
         }
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/ClosedSessionException.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ClosedSessionException.java
@@ -28,7 +28,7 @@ public final class ClosedSessionException extends RuntimeException {
 
     /**
      * Returns a {@link ClosedSessionException} which may be a singleton or a new instance, depending on
-     * whether {@link Flags#verboseExceptions() the verbose exception mode} is enabled.
+     * whether {@linkplain Flags#verboseExceptions() the verbose exception mode} is enabled.
      */
     public static ClosedSessionException get() {
         return Flags.verboseExceptions() ? new ClosedSessionException() : INSTANCE;

--- a/core/src/main/java/com/linecorp/armeria/common/ContentTooLargeException.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ContentTooLargeException.java
@@ -30,7 +30,7 @@ public final class ContentTooLargeException extends RuntimeException {
 
     /**
      * Returns a {@link ContentTooLargeException} which may be a singleton or a new instance, depending on
-     * whether {@link Flags#verboseExceptions() the verbose exception mode} is enabled.
+     * whether {@linkplain Flags#verboseExceptions() the verbose exception mode} is enabled.
      */
     public static ContentTooLargeException get() {
         return Flags.verboseExceptions() ? new ContentTooLargeException() : INSTANCE;

--- a/core/src/main/java/com/linecorp/armeria/common/stream/AbortedStreamException.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AbortedStreamException.java
@@ -34,7 +34,7 @@ public final class AbortedStreamException extends RuntimeException {
 
     /**
      * Returns a {@link AbortedStreamException} which may be a singleton or a new instance, depending on
-     * whether {@link Flags#verboseExceptions() the verbose exception mode} is enabled.
+     * whether {@linkplain Flags#verboseExceptions() the verbose exception mode} is enabled.
      */
     public static AbortedStreamException get() {
         return Flags.verboseExceptions() ? new AbortedStreamException() : INSTANCE;

--- a/core/src/main/java/com/linecorp/armeria/common/stream/CancelledSubscriptionException.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/CancelledSubscriptionException.java
@@ -35,7 +35,7 @@ public final class CancelledSubscriptionException extends RuntimeException {
 
     /**
      * Returns a {@link CancelledSubscriptionException} which may be a singleton or a new instance, depending
-     * on whether {@link Flags#verboseExceptions() the verbose exception mode} is enabled.
+     * on whether {@linkplain Flags#verboseExceptions() the verbose exception mode} is enabled.
      */
     public static CancelledSubscriptionException get() {
         return Flags.verboseExceptions() ? new CancelledSubscriptionException() : INSTANCE;

--- a/core/src/main/java/com/linecorp/armeria/common/stream/ClosedPublisherException.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/ClosedPublisherException.java
@@ -32,7 +32,7 @@ public final class ClosedPublisherException extends RuntimeException {
 
     /**
      * Returns a {@link ClosedPublisherException} which may be a singleton or a new instance, depending on
-     * whether {@link Flags#verboseExceptions() the verbose exception mode} is enabled.
+     * whether {@linkplain Flags#verboseExceptions() the verbose exception mode} is enabled.
      */
     public static ClosedPublisherException get() {
         return Flags.verboseExceptions() ? new ClosedPublisherException() : INSTANCE;

--- a/core/src/main/java/com/linecorp/armeria/internal/Http2GoAwayListener.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/Http2GoAwayListener.java
@@ -52,9 +52,11 @@ public class Http2GoAwayListener extends Http2ConnectionAdapter {
         onGoAway("Received", lastStreamId, errorCode, debugData);
 
         // Send a GOAWAY back to the peer and close the connection gracefully if we did not send GOAWAY yet.
-        // This will make sure that the connection is always closed after receiving GOAWAY,
-        // because otherwise we have to wait until the peer who sent GOAWAY to us closes the connection.
+        // This makes sure that the connection is closed eventually once we receive GOAWAY.
         if (!goAwaySent) {
+            // This does not close the connection immediately but sends a GOAWAY frame.
+            // The connection will be closed when all streams are closed.
+            // See AbstractHttp2ConnectionHandler.close().
             ch.close();
         }
     }

--- a/core/src/main/java/com/linecorp/armeria/server/RequestTimeoutException.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RequestTimeoutException.java
@@ -32,7 +32,7 @@ public final class RequestTimeoutException extends TimeoutException {
 
     /**
      * Returns a {@link RequestTimeoutException} which may be a singleton or a new instance, depending on
-     * whether {@link Flags#verboseExceptions() the verbose exception mode} is enabled.
+     * whether {@linkplain Flags#verboseExceptions() the verbose exception mode} is enabled.
      */
     public static RequestTimeoutException get() {
         return Flags.verboseExceptions() ? new RequestTimeoutException() : INSTANCE;

--- a/core/src/test/java/com/linecorp/armeria/client/Http2GoAwayTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/Http2GoAwayTest.java
@@ -246,11 +246,10 @@ public class Http2GoAwayTest {
     }
 
     private static ByteBuf readFrame(InputStream in) throws IOException {
-        // Read a GOAWAY frame.
-        final byte[] goAwayFrameBuf = readBytes(in, 9);
-        final int payloadLength = payloadLength(goAwayFrameBuf);
+        final byte[] frameBuf = readBytes(in, 9);
+        final int payloadLength = payloadLength(frameBuf);
         final ByteBuf buffer = Unpooled.buffer(9 + payloadLength);
-        buffer.writeBytes(goAwayFrameBuf);
+        buffer.writeBytes(frameBuf);
         buffer.writeBytes(in, payloadLength);
         return buffer;
     }

--- a/core/src/test/java/com/linecorp/armeria/client/Http2GoAwayTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/Http2GoAwayTest.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client;
+
+import static io.netty.handler.codec.http2.Http2CodecUtil.connectionPrefaceBuf;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.DisableOnDebug;
+import org.junit.rules.TestRule;
+import org.junit.rules.Timeout;
+
+import com.google.common.io.ByteStreams;
+
+import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.testing.common.EventLoopRule;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http2.Http2FrameTypes;
+
+public class Http2GoAwayTest {
+
+    @ClassRule
+    public static final EventLoopRule eventLoop = new EventLoopRule();
+
+    @Rule
+    public TestRule globalTimeout = new DisableOnDebug(new Timeout(10, TimeUnit.SECONDS));
+
+    /**
+     * Server sends a GOAWAY frame after finishing all streams.
+     */
+    @Test
+    public void streamEndsBeforeGoAway() throws Exception {
+        try (ServerSocket ss = new ServerSocket(0);
+             ClientFactory clientFactory = new ClientFactoryBuilder()
+                     .useHttp2Preface(true)
+                     .workerGroup(eventLoop.get(), false)
+                     .build()) {
+
+            final int port = ss.getLocalPort();
+
+            final HttpClient client = HttpClient.of(clientFactory, "h2c://127.0.0.1:" + port);
+            final CompletableFuture<AggregatedHttpMessage> future = client.get("/").aggregate();
+
+            try (Socket s = ss.accept()) {
+
+                final InputStream in = s.getInputStream();
+                final BufferedOutputStream bos = new BufferedOutputStream(s.getOutputStream());
+                handleInitialExchange(in, bos);
+
+                // Read a HEADERS frame.
+                assertThat(readFrame(in).getByte(3)).isEqualTo(Http2FrameTypes.HEADERS);
+
+                // Send a HEADERS frame to finish the response followed by a GOAWAY frame.
+                bos.write(new byte[] {
+                        0x00, 0x00, 0x06, 0x01, 0x25, 0x00, 0x00, 0x00, 0x03,
+                        0x00, 0x00, 0x00, 0x00, 0x0f, (byte) 0x88
+                });
+                bos.write(new byte[] {
+                        0x00, 0x00, 0x08, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00,
+                        0x00, 0x00, 0x00, 0x03, // lastStreamId = 3
+                        0x00, 0x00, 0x00, 0x00  // errorCode = 0
+                });
+                bos.flush();
+
+                // Read a GOAWAY frame.
+                assertThat(readFrame(in).getByte(3)).isEqualTo(Http2FrameTypes.GO_AWAY);
+
+                // Request should not fail.
+                future.join();
+
+                // The connection should be closed by the client because there is no pending request.
+                assertThat(in.read()).isEqualTo(-1);
+            }
+        }
+    }
+
+    /**
+     * Server sends GOAWAY before finishing all streams.
+     */
+    @Test
+    public void streamEndsAfterGoAway() throws Exception {
+        try (ServerSocket ss = new ServerSocket(0);
+             ClientFactory clientFactory = new ClientFactoryBuilder()
+                     .workerGroup(eventLoop.get(), false)
+                     .useHttp2Preface(true).build()) {
+
+            final int port = ss.getLocalPort();
+
+            final HttpClient client = HttpClient.of(clientFactory, "h2c://127.0.0.1:" + port);
+            final CompletableFuture<AggregatedHttpMessage> future = client.get("/").aggregate();
+
+            try (Socket s = ss.accept()) {
+
+                final InputStream in = s.getInputStream();
+                final BufferedOutputStream bos = new BufferedOutputStream(s.getOutputStream());
+                handleInitialExchange(in, bos);
+
+                // Read a HEADERS frame.
+                assertThat(readFrame(in).getByte(3)).isEqualTo(Http2FrameTypes.HEADERS);
+
+                // Send a GOAWAY frame first followed by a HEADERS frame.
+                bos.write(new byte[] {
+                        0x00, 0x00, 0x08, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00,
+                        0x00, 0x00, 0x00, 0x03, // lastStreamId = 3
+                        0x00, 0x00, 0x00, 0x00  // errorCode = 0
+                });
+                bos.write(new byte[] {
+                        0x00, 0x00, 0x06, 0x01, 0x25, 0x00, 0x00, 0x00, 0x03,
+                        0x00, 0x00, 0x00, 0x00, 0x0f, (byte) 0x88
+                });
+                bos.flush();
+
+                // Read a GOAWAY frame.
+                assertThat(readFrame(in).getByte(3)).isEqualTo(Http2FrameTypes.GO_AWAY);
+
+                // Request should not fail.
+                future.join();
+
+                // The connection should be closed by the client because there is no pending request.
+                assertThat(in.read()).isEqualTo(-1);
+            }
+        }
+    }
+
+    /**
+     * Client sends two requests whose streamIds are 3 and 5 respectively. Server sends a GOAWAY frame
+     * whose lastStreamId is 3. The request with streamId 5 should fail.
+     */
+    @Test
+    public void streamGreaterThanLastStreamId() throws Exception {
+        try (ServerSocket ss = new ServerSocket(0);
+             ClientFactory clientFactory = new ClientFactoryBuilder()
+                     .useHttp2Preface(true)
+                     .workerGroup(eventLoop.get(), false)
+                     .build()) {
+
+            final int port = ss.getLocalPort();
+
+            final HttpClient client = HttpClient.of(clientFactory, "h2c://127.0.0.1:" + port);
+            final CompletableFuture<AggregatedHttpMessage> future1 = client.get("/").aggregate();
+            try (Socket s = ss.accept()) {
+
+                final InputStream in = s.getInputStream();
+                final BufferedOutputStream bos = new BufferedOutputStream(s.getOutputStream());
+                handleInitialExchange(in, bos);
+
+                // Read a HEADERS frame.
+                assertThat(readFrame(in).getByte(3)).isEqualTo(Http2FrameTypes.HEADERS);
+
+                // Send the second request.
+                final CompletableFuture<AggregatedHttpMessage> future2 = client.get("/").aggregate();
+
+                // Read a HEADERS frame for the second request.
+                assertThat(readFrame(in).getByte(3)).isEqualTo(Http2FrameTypes.HEADERS);
+
+                // Send a GOAWAY frame.
+                bos.write(new byte[] {
+                        0x00, 0x00, 0x08, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00,
+                        0x00, 0x00, 0x00, 0x03, // lastStreamId = 3
+                        0x00, 0x00, 0x00, 0x00  // errorCode = 0
+                });
+                bos.flush();
+
+                // The second request should fail with UnprocessedRequestException.
+                assertThatThrownBy(future2::join).isInstanceOf(CompletionException.class)
+                                                 .hasCauseInstanceOf(UnprocessedRequestException.class);
+                // The first request should not fail.
+                assertThat(future1).isNotDone();
+
+                // Read a GOAWAY frame.
+                assertThat(readFrame(in).getByte(3)).isEqualTo(Http2FrameTypes.GO_AWAY);
+
+                // Send a HEADERS frame for the first request.
+                bos.write(new byte[] {
+                        0x00, 0x00, 0x06, 0x01, 0x25, 0x00, 0x00, 0x00, 0x03,
+                        0x00, 0x00, 0x00, 0x00, 0x0f, (byte) 0x88
+                });
+                bos.flush();
+
+                // Request should not fail.
+                future1.join();
+
+                // The connection should be closed by the client because there is no pending request.
+                assertThat(in.read()).isEqualTo(-1);
+            }
+        }
+    }
+
+    private static void handleInitialExchange(InputStream in, BufferedOutputStream out) throws IOException {
+        // Read the connection preface and discard it.
+        readBytes(in, connectionPrefaceBuf().readableBytes());
+
+        // Read a SETTINGS frame.
+        assertThat(readFrame(in).getByte(3)).isEqualTo(Http2FrameTypes.SETTINGS);
+
+        // Send a SETTINGS frame and the ack for the received SETTINGS frame.
+        sendEmptySettingsAndAckFrame(out);
+
+        // Read a SETTINGS ack frame.
+        assertThat(readFrame(in).getByte(3)).isEqualTo(Http2FrameTypes.SETTINGS);
+    }
+
+    private static byte[] readBytes(InputStream in, int length) throws IOException {
+        final byte[] buf = new byte[length];
+        ByteStreams.readFully(in, buf);
+        return buf;
+    }
+
+    private static void sendEmptySettingsAndAckFrame(BufferedOutputStream bos) throws IOException {
+        // Send an empty SETTINGS frame.
+        bos.write(new byte[] { 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00 });
+        // Send a SETTINGS_ACK frame.
+        bos.write(new byte[] { 0x00, 0x00, 0x00, 0x04, 0x01, 0x00, 0x00, 0x00, 0x00 });
+        bos.flush();
+    }
+
+    private static int payloadLength(byte[] buf) {
+        return (buf[0] & 0xff) << 16 | (buf[1] & 0xff) << 8 | (buf[2] & 0xff);
+    }
+
+    private static ByteBuf readFrame(InputStream in) throws IOException {
+        // Read a GOAWAY frame.
+        final byte[] goAwayFrameBuf = readBytes(in, 9);
+        final int payloadLength = payloadLength(goAwayFrameBuf);
+        final ByteBuf buffer = Unpooled.buffer(9 + payloadLength);
+        buffer.writeBytes(goAwayFrameBuf);
+        buffer.writeBytes(in, payloadLength);
+        return buffer;
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/internal/ConnectionLimitingHandlerIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/ConnectionLimitingHandlerIntegrationTest.java
@@ -19,6 +19,7 @@ package com.linecorp.armeria.internal;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
+import static org.junit.Assume.assumeTrue;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -49,6 +50,9 @@ public class ConnectionLimitingHandlerIntegrationTest {
 
     @Test
     public void testExceedMaxNumConnections() throws Exception {
+        // Known to fail on WSL (Windows Subsystem for Linux)
+        assumeTrue(System.getenv("WSLENV") == null);
+
         try (Socket s1 = newSocketAndTest()) {
             assertThat(server.server().numConnections()).isEqualTo(1);
 

--- a/core/src/test/java/com/linecorp/armeria/server/GracefulShutdownSupportTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/GracefulShutdownSupportTest.java
@@ -71,10 +71,20 @@ public class GracefulShutdownSupportTest {
 
     @Test
     public void testDisabled() {
-        final GracefulShutdownSupport support = GracefulShutdownSupport.disabled();
+        final GracefulShutdownSupport support = GracefulShutdownSupport.createDisabled();
+        assertThat(support.isShuttingDown()).isFalse();
         assertThat(support.completedQuietPeriod()).isTrue();
+        assertThat(support.isShuttingDown()).isTrue();
         support.inc();
         assertThat(support.completedQuietPeriod()).isTrue();
+    }
+
+    @Test
+    public void testIsShutdown() {
+        // completedQuietPeriod() must make isShuttingDown() start to return true.
+        assertThat(support.isShuttingDown()).isFalse();
+        support.completedQuietPeriod();
+        assertThat(support.isShuttingDown()).isTrue();
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
@@ -19,6 +19,7 @@ import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -317,6 +318,9 @@ public class ServerTest {
 
     @Test
     public void duplicatedPort() {
+        // Known to fail on WSL (Windows Subsystem for Linux)
+        assumeTrue(System.getenv("WSLENV") == null);
+
         final Server duplicatedPortServer = new ServerBuilder()
                 .http(server.httpPort())
                 .service("/", (ctx, res) -> HttpResponse.of(""))

--- a/grpc/src/main/java/com/linecorp/armeria/internal/grpc/GrpcStatus.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/grpc/GrpcStatus.java
@@ -37,8 +37,8 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.nio.channels.ClosedChannelException;
 
-import com.linecorp.armeria.client.ResponseTimeoutException;
 import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.TimeoutException;
 
 import io.grpc.Status;
 import io.grpc.Status.Code;
@@ -78,7 +78,7 @@ public final class GrpcStatus {
         if (t instanceof Http2Exception) {
             return Status.INTERNAL.withCause(t);
         }
-        if (t instanceof ResponseTimeoutException) {
+        if (t instanceof TimeoutException) {
             return Status.DEADLINE_EXCEEDED.withCause(t);
         }
         return s;

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
@@ -76,6 +76,7 @@ import io.grpc.MethodDescriptor;
 import io.grpc.MethodDescriptor.MethodType;
 import io.grpc.ServerCall;
 import io.grpc.Status;
+import io.grpc.StatusException;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.util.AsciiString;
@@ -442,7 +443,13 @@ class ArmeriaServerCall<I, O> extends ServerCall<I, O>
                 }
                 // Transport error, not business logic error, so reset the stream.
                 if (!closeCalled) {
-                    res.close(newStatus.asException());
+                    final StatusException statusException = newStatus.asException();
+                    final Throwable cause = statusException.getCause();
+                    if (cause != null) {
+                        res.close(cause);
+                    } else {
+                        res.abort();
+                    }
                 }
             }
         }


### PR DESCRIPTION
Motivation:

Armeria always disconnects the connection immediately when it receives a
GOAWAY frame, which is a violation of HTTP/2 specification.

See https://httpwg.org/specs/rfc7540.html#GOAWAY

Modifications:

- `AbstractHttp2ConnectionHandler` does not close the connections
  immediately on a GOAWAY frame anymore.
  - It still closes the connections immediately during
    `ClientFactory.close()` and `Server.stop()`.
    - Added `HttpClientFactory.isClosing()`
    - Added `GracefulShutdownSupport.isShuttingDown()`
  - It still closes the connections immediately if the error code of the
    GOAWAY frame is not NO_ERROR.
    - Updated `Http2(Request|Response)Decoder` to store the error code
      of the received GOAWAY frame.
- `Http2ResponseDecoder` does not send a redundant RST_STREAM frame for
  the requests with higher stream ID than `lastStreamId`.
- `Http2ResponseDecoder` closes `HttpResponse` with a new exception
  called `UnprocessedRequestException` to indicate that the request can
  be retried safely, because the request had a higher stream ID than
  `lastStreamId`.
  - Updated `HttpStatusBasedCircuitBreakerStrategy` to ignore an
    `UnprocessedRequestException`.
  - Added `RetryStrategy.onUnprocessed()`
- Miscellaneous:
  - Use `@linkplain` instead of `@link` where applicable.
  - Instantiate and configure `Http2(Request|Response)Decoder` inside
    `Http2(Server|Client)ConnectionHandler`.
  - Use `Http2Settings.defaultSettings()` instead of `new
    Http2Settings()` if possible.
  - Fixed an unexpected `BlockingOperationException` during
    `DefaultKeyedChannelPool.close()`.
  - Do not include stack trace information in the `GOAWAY` frames sent
    by Armeria, respecting `Flags.verboseResponses()`.
  - Made `Http2ObjectEncoder` easier to understand.
  - Made `GracefulShutdownSupport` package-local because it is not meant
    to be part of public API.
  - Replaced `HttpServerHandler.unfinishedRequests` and `unfinishedResponses`
    with a single `IdentityHashMap`.
  - Cleaned up `Http2ClientSettingsTest`
  - Skip some tests on WSL (Windows Subsystem for Linux)
  - gRPC services yield `CANCELLED` status rather than `UNKNOWN` when a
    client sends too large message now.

Result:

- GOAWAY frames are handled correctly.
- A user can choose to retry the request with higher stream ID than the
  `lastStreamId`.