### PR TITLE
Make more HTTP/2 settings configurable and make them consistent

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientFactory.java
@@ -75,12 +75,13 @@ final class HttpClientFactory extends AbstractClientFactory {
     private final boolean shutdownWorkerGroupOnClose;
     private final Bootstrap baseBootstrap;
     private final Consumer<? super SslContextBuilder> sslContextCustomizer;
-    private final int initialHttp2ConnectionWindowSize;
-    private final int initialHttp2StreamWindowSize;
+    private final int http2InitialConnectionWindowSize;
+    private final int http2InitialStreamWindowSize;
     private final int http2MaxFrameSize;
-    private final int maxHttp1InitialLineLength;
-    private final int maxHttp1HeaderSize;
-    private final int maxHttp1ChunkSize;
+    private final long http2MaxHeaderListSize;
+    private final int http1MaxInitialLineLength;
+    private final int http1MaxHeaderSize;
+    private final int http1MaxChunkSize;
     private final long idleTimeoutMillis;
     private final boolean useHttp2Preface;
     private final boolean useHttp1Pipelining;
@@ -101,9 +102,9 @@ final class HttpClientFactory extends AbstractClientFactory {
             Consumer<? super SslContextBuilder> sslContextCustomizer,
             Function<? super EventLoopGroup,
                     ? extends AddressResolverGroup<? extends InetSocketAddress>> addressResolverGroupFactory,
-            int initialHttp2ConnectionWindowSize, int initialHttp2StreamWindowSize, int http2MaxFrameSize,
-            int maxHttp1InitialLineLength, int maxHttp1HeaderSize, int maxHttp1ChunkSize,
-            long idleTimeoutMillis, boolean useHttp2Preface, boolean useHttp1Pipelining,
+            int http2InitialConnectionWindowSize, int http2InitialStreamWindowSize, int http2MaxFrameSize,
+            long http2MaxHeaderListSize, int http1MaxInitialLineLength, int http1MaxHeaderSize,
+            int http1MaxChunkSize, long idleTimeoutMillis, boolean useHttp2Preface, boolean useHttp1Pipelining,
             KeyedChannelPoolHandler<? super PoolKey> connectionPoolListener, MeterRegistry meterRegistry) {
 
         @SuppressWarnings("unchecked")
@@ -124,12 +125,13 @@ final class HttpClientFactory extends AbstractClientFactory {
         this.shutdownWorkerGroupOnClose = shutdownWorkerGroupOnClose;
         this.baseBootstrap = baseBootstrap;
         this.sslContextCustomizer = sslContextCustomizer;
-        this.initialHttp2ConnectionWindowSize = initialHttp2ConnectionWindowSize;
-        this.initialHttp2StreamWindowSize = initialHttp2StreamWindowSize;
+        this.http2InitialConnectionWindowSize = http2InitialConnectionWindowSize;
+        this.http2InitialStreamWindowSize = http2InitialStreamWindowSize;
         this.http2MaxFrameSize = http2MaxFrameSize;
-        this.maxHttp1InitialLineLength = maxHttp1InitialLineLength;
-        this.maxHttp1HeaderSize = maxHttp1HeaderSize;
-        this.maxHttp1ChunkSize = maxHttp1ChunkSize;
+        this.http2MaxHeaderListSize = http2MaxHeaderListSize;
+        this.http1MaxInitialLineLength = http1MaxInitialLineLength;
+        this.http1MaxHeaderSize = http1MaxHeaderSize;
+        this.http1MaxChunkSize = http1MaxChunkSize;
         this.idleTimeoutMillis = idleTimeoutMillis;
         this.useHttp2Preface = useHttp2Preface;
         this.useHttp1Pipelining = useHttp1Pipelining;
@@ -152,28 +154,32 @@ final class HttpClientFactory extends AbstractClientFactory {
         return sslContextCustomizer;
     }
 
-    int initialHttp2ConnectionWindowSize() {
-        return initialHttp2ConnectionWindowSize;
+    int http2InitialConnectionWindowSize() {
+        return http2InitialConnectionWindowSize;
     }
 
-    int initialHttp2StreamWindowSize() {
-        return initialHttp2StreamWindowSize;
+    int http2InitialStreamWindowSize() {
+        return http2InitialStreamWindowSize;
     }
 
     int http2MaxFrameSize() {
         return http2MaxFrameSize;
     }
 
-    int maxHttp1InitialLineLength() {
-        return maxHttp1InitialLineLength;
+    long http2MaxHeaderListSize() {
+        return http2MaxHeaderListSize;
     }
 
-    int maxHttp1HeaderSize() {
-        return maxHttp1HeaderSize;
+    int http1MaxInitialLineLength() {
+        return http1MaxInitialLineLength;
     }
 
-    int maxHttp1ChunkSize() {
-        return maxHttp1ChunkSize;
+    int http1MaxHeaderSize() {
+        return http1MaxHeaderSize;
+    }
+
+    int http1MaxChunkSize() {
+        return http1MaxChunkSize;
     }
 
     long idleTimeoutMillis() {

--- a/core/src/test/java/com/linecorp/armeria/client/Http2GoAwayTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/Http2GoAwayTest.java
@@ -42,6 +42,7 @@ import com.linecorp.armeria.testing.common.EventLoopRule;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http2.Http2CodecUtil;
 import io.netty.handler.codec.http2.Http2FrameTypes;
 
 public class Http2GoAwayTest {
@@ -58,10 +59,7 @@ public class Http2GoAwayTest {
     @Test
     public void streamEndsBeforeGoAway() throws Exception {
         try (ServerSocket ss = new ServerSocket(0);
-             ClientFactory clientFactory = new ClientFactoryBuilder()
-                     .useHttp2Preface(true)
-                     .workerGroup(eventLoop.get(), false)
-                     .build()) {
+             ClientFactory clientFactory = newClientFactory()) {
 
             final int port = ss.getLocalPort();
 
@@ -107,9 +105,7 @@ public class Http2GoAwayTest {
     @Test
     public void streamEndsAfterGoAway() throws Exception {
         try (ServerSocket ss = new ServerSocket(0);
-             ClientFactory clientFactory = new ClientFactoryBuilder()
-                     .workerGroup(eventLoop.get(), false)
-                     .useHttp2Preface(true).build()) {
+             ClientFactory clientFactory = newClientFactory()) {
 
             final int port = ss.getLocalPort();
 
@@ -156,10 +152,7 @@ public class Http2GoAwayTest {
     @Test
     public void streamGreaterThanLastStreamId() throws Exception {
         try (ServerSocket ss = new ServerSocket(0);
-             ClientFactory clientFactory = new ClientFactoryBuilder()
-                     .useHttp2Preface(true)
-                     .workerGroup(eventLoop.get(), false)
-                     .build()) {
+             ClientFactory clientFactory = newClientFactory()) {
 
             final int port = ss.getLocalPort();
 
@@ -211,6 +204,16 @@ public class Http2GoAwayTest {
                 assertThat(in.read()).isEqualTo(-1);
             }
         }
+    }
+
+    private static ClientFactory newClientFactory() {
+        return new ClientFactoryBuilder()
+                .useHttp2Preface(true)
+                // Set the window size to the HTTP/2 default values to simplify the traffic.
+                .http2InitialConnectionWindowSize(Http2CodecUtil.DEFAULT_WINDOW_SIZE)
+                .http2InitialStreamWindowSize(Http2CodecUtil.DEFAULT_WINDOW_SIZE)
+                .workerGroup(eventLoop.get(), false)
+                .build();
     }
 
     private static void handleInitialExchange(InputStream in, BufferedOutputStream out) throws IOException {


### PR DESCRIPTION
- Made sure both client and server have the following HTTP/2 settings
  - Connection-level initial window size
  - Stream-level initial window size
  - Max frame size
  - Max header list size
- Reordered the fields and methods related with HTTP settings so that
  HTTP/2 settings come right before HTTP/1 settings.
- (breaking) Made the protocol-related property names consistent so that
  they all start with protocol name first, e.g.
  - `maxHttp1ChunkSize` -> `http1MaxChunkSize`
  - `initialHttp2ConnectionWindowSize` -> `http2InitialConnectionWindowSize`
- Renamed `ServerBuilder.http2InitialWindowSize` to `http2InitialStreamWindowSize`
- Added `ServerBuilder.http2InitialConnectionWindowSize` and implemented
  connection-level initial window size update in `HttpServerHandler`.
- Improve/fix validation of HTTP/2-related properties
- Change the type of `http2MaxStreamsPerConnection` and `http2MaxHeaderListSize`
  to `long` because its maximum value is `0xFFFFFFFFL`
- (breaking) Removed `default` prefix for HTTP/1-related properties because
  they should've not been named so from the beginning.
- Miscellaneous:
  - Fixed a race between `Http2RequestDecoder` and `HttpServerHandler`
    trying to write an error response, causing HTTP/2 violation.
    - Reproduced by `HttpServerTest.testTooLargeContentToNonExistentService()`
      which makes `Http2RequestDecoder` and `HttpServerHandler` send
      `413 Entity Too Large` and `404 Not Found`.