### PR TITLE
Update dependencies / Make sure /dev/epoll and OpenSSL are used durin…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/MediaType.java
+++ b/core/src/main/java/com/linecorp/armeria/common/MediaType.java
@@ -92,7 +92,7 @@ import com.google.common.collect.Multimaps;
 @JsonDeserialize(using = MediaTypeJsonDeserializer.class)
 public final class MediaType {
 
-    // Forked from Guava at 59ca61a255620bf7e5f55f991c74e8b61e99d765 (26.0)
+    // Forked from Guava at 9704538cd9aa8e4b783b824773cfc76290f572c2 (27.0)
 
     private static final String CHARSET_ATTRIBUTE = "charset";
     private static final ImmutableListMultimap<String, String> UTF_8_CONSTANT_PARAMETERS =
@@ -418,8 +418,21 @@ public final class MediaType {
     public static final MediaType MANIFEST_JSON_UTF_8 =
             createConstantUtf8(APPLICATION_TYPE, "manifest+json");
 
+    /**
+     * Media type for <a href="http://www.opengeospatial.org/standards/kml/">OGC KML (Keyhole Markup
+     * Language)</a>.
+     */
     public static final MediaType KML = createConstant(APPLICATION_TYPE, "vnd.google-earth.kml+xml");
+
+    /**
+     * Media type for <a href="http://www.opengeospatial.org/standards/kml/">OGC KML (Keyhole Markup
+     * Language)</a>, compressed using the ZIP format into KMZ archives.
+     */
     public static final MediaType KMZ = createConstant(APPLICATION_TYPE, "vnd.google-earth.kmz");
+
+    /**
+     * Media type for the <a href="https://tools.ietf.org/html/rfc4155">mbox database format</a>.
+     */
     public static final MediaType MBOX = createConstant(APPLICATION_TYPE, "mbox");
 
     /**
@@ -433,6 +446,12 @@ public final class MediaType {
     public static final MediaType MICROSOFT_POWERPOINT =
             createConstant(APPLICATION_TYPE, "vnd.ms-powerpoint");
     public static final MediaType MICROSOFT_WORD = createConstant(APPLICATION_TYPE, "msword");
+
+    /**
+     * Media type for WASM applications. For more information see <a
+     * href="https://webassembly.org/">the Web Assembly overview</a>.
+     */
+    public static final MediaType WASM_APPLICATION = createConstant(APPLICATION_TYPE, "wasm");
 
     /**
      * Media type for NaCl applications. For more information see <a

--- a/core/src/test/java/com/linecorp/armeria/common/FlagsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/FlagsTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeTrue;
+
+import org.junit.Test;
+
+import com.google.common.base.Ascii;
+
+import io.netty.channel.epoll.Epoll;
+import io.netty.handler.ssl.OpenSsl;
+
+public class FlagsTest {
+
+    private static final String osName = Ascii.toLowerCase(System.getProperty("os.name"));
+
+    /**
+     * Makes sure /dev/epoll is used while running tests on Linux.
+     */
+    @Test
+    public void epollAvailableOnLinux() {
+        assumeTrue(osName.startsWith("linux"));
+        assumeTrue(System.getenv("WSLENV") == null);
+        assumeFalse("false".equals(System.getProperty("com.linecorp.armeria.useEpoll")));
+
+        assertThat(Flags.useEpoll()).isTrue();
+        assertThat(Epoll.isAvailable()).isTrue();
+    }
+
+    /**
+     * Makes sure OpenSSL SSLEngine is used instead of JDK SSLEngine while running tests
+     * on Linux, Windows and OS X.
+     */
+    @Test
+    public void openSslAvailable() {
+        assumeTrue(osName.startsWith("linux") || osName.startsWith("windows") ||
+                   osName.startsWith("macosx") || osName.startsWith("osx"));
+        assumeFalse("false".equals(System.getProperty("com.linecorp.armeria.useOpenSsl")));
+
+        assertThat(Flags.useOpenSsl()).isTrue();
+        assertThat(OpenSsl.isAvailable()).isTrue();
+    }
+}

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -48,7 +48,7 @@ com.google.code.findbugs:
 
 com.google.guava:
   guava:
-    version: &GUAVA_VERSION '26.0-jre'
+    version: &GUAVA_VERSION '27.0-jre'
     exclusions:
     - com.google.errorprone:error_prone_annotations
     - com.google.j2objc:j2objc-annotations
@@ -63,6 +63,12 @@ com.google.guava:
     exclusions:
     - com.google.errorprone:error_prone_annotations
     - com.google.j2objc:j2objc-annotations
+    relocations:
+    - from: com.google.common
+      to: com.linecorp.armeria.internal.shaded.guava
+  # A transitive dependency of Guava which needs relocation as well.
+  failureaccess:
+    version: '1.0'
     relocations:
     - from: com.google.common
       to: com.linecorp.armeria.internal.shaded.guava
@@ -126,17 +132,17 @@ io.grpc:
 
 io.micrometer:
   micrometer-core:
-    version: &MICROMETER_VERSION '1.0.6'
+    version: &MICROMETER_VERSION '1.0.7'
     javadocs:
-    - https://static.javadoc.io/io.micrometer/micrometer-core/1.0.6/
+    - https://static.javadoc.io/io.micrometer/micrometer-core/1.0.7/
   micrometer-registry-prometheus:
     version: *MICROMETER_VERSION
     javadocs:
-    - https://static.javadoc.io/io.micrometer/micrometer-registry-prometheus/1.0.6/
+    - https://static.javadoc.io/io.micrometer/micrometer-registry-prometheus/1.0.7/
   micrometer-spring-legacy:
     version: *MICROMETER_VERSION
     javadocs:
-    - https://static.javadoc.io/io.micrometer/micrometer-spring-legacy/1.0.6/
+    - https://static.javadoc.io/io.micrometer/micrometer-spring-legacy/1.0.7/
     exclusions:
     - org.springframework:spring-web
     - org.springframework:spring-webmvc
@@ -174,9 +180,9 @@ io.reactivex.rxjava2:
 
 io.zipkin.brave:
   brave:
-    version: '5.4.2'
+    version: '5.4.3'
     javadocs:
-    - https://static.javadoc.io/io.zipkin.brave/brave/5.4.2/
+    - https://static.javadoc.io/io.zipkin.brave/brave/5.4.3/
 
 it.unimi.dsi:
   fastutil:
@@ -372,7 +378,7 @@ org.slf4j:
 
 org.springframework.boot:
   spring-boot-starter:
-    version: &SPRING_BOOT_VERSION '2.0.5.RELEASE'
+    version: &SPRING_BOOT_VERSION '2.0.6.RELEASE'
     javadocs:
     - https://docs.spring.io/spring/docs/current/javadoc-api/
   spring-boot-starter-actuator: { version: *SPRING_BOOT_VERSION }

--- a/spring/boot1-autoconfigure/build.gradle
+++ b/spring/boot1-autoconfigure/build.gradle
@@ -9,10 +9,10 @@ dependencies {
     compile 'io.dropwizard.metrics:metrics-json'
     compile 'javax.inject:javax.inject'
     compile 'javax.validation:validation-api'
-    compile 'org.springframework.boot:spring-boot-starter:1.5.16.RELEASE'
-    compileOnly 'org.springframework.boot:spring-boot-configuration-processor:1.5.16.RELEASE'
+    compile 'org.springframework.boot:spring-boot-starter:1.5.17.RELEASE'
+    compileOnly 'org.springframework.boot:spring-boot-configuration-processor:1.5.17.RELEASE'
 
-    testCompile 'org.springframework.boot:spring-boot-starter-test:1.5.16.RELEASE'
+    testCompile 'org.springframework.boot:spring-boot-starter-test:1.5.17.RELEASE'
     testCompile 'org.hibernate.validator:hibernate-validator'
 }
 


### PR DESCRIPTION
…g tests

- Brave 5.4.2 -> 5.4.3
- Guava 26.0 -> 27.0
- Micrometer 1.0.6 -> 1.0.7
- Spring Boot 2.0.5 -> 2.0.6, 1.5.16 -> 1.5.17
- Miscellaneous:
  - Ported the changes in Guava `MediaType`.
  - Added `FlagsTest` which makes sure `Flags.useEpoll()` and
    `useOpenSsl()` are set when expected, so that we always run our
    tests with `/dev/epoll` and OpenSSL enabled.