### PR TITLE
Do not treat a class as automatically-convertible bean if it has a me…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/AnnotatedValueResolver.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AnnotatedValueResolver.java
@@ -209,8 +209,8 @@ final class AnnotatedValueResolver {
             throw new NoAnnotatedParameterException(constructorOrMethod.toGenericString());
         }
         if (list.size() != parameters.length) {
-            throw new IllegalArgumentException("Unsupported parameter exists: " +
-                                               constructorOrMethod.toGenericString());
+            throw new NoAnnotatedParameterException("Unsupported parameter exists: " +
+                                                    constructorOrMethod.toGenericString());
         }
         return list;
     }


### PR DESCRIPTION
…mber which is not injectable

Motivation:
The server cannot be started if there is a parameter when there is a parameter unable to be injected on a constructor or method of a bean specified as `@RequestObject`. This behavior makes a user confused when he or she adds a member variable of one of the automatically-injectable types, such as `HttpRequest` and `RequestContext`, to his or her class which is not an automatically-convertiable class. We need to skip checking the class for this case because the class may be converted by one of the user-defined request converters.

Modifications:
- Throw `NoAnnotatedParameterException` instead of `IllegalArgumentException` when there is a parameter unable to be injected on a constructor or method of a bean specified as `@RequestObject`.