### PR TITLE
Overall cleanup of HTTP/2 handlers / Do not send GOAWAY to a closed connection

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
@@ -48,7 +48,6 @@ import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.logging.RequestLogBuilder;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.internal.Http1ClientCodec;
-import com.linecorp.armeria.internal.Http2GoAwayListener;
 import com.linecorp.armeria.internal.ReadSuppressingHandler;
 import com.linecorp.armeria.internal.TrafficLoggingHandler;
 
@@ -632,15 +631,13 @@ final class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
     private Http2ClientConnectionHandler newHttp2ConnectionHandler(Channel ch) {
         final boolean validateHeaders = false;
         final Http2Connection conn = new DefaultHttp2Connection(false);
-        conn.addListener(new Http2GoAwayListener(ch));
-
         final Http2FrameReader reader = new DefaultHttp2FrameReader(validateHeaders);
         final Http2FrameWriter writer = new DefaultHttp2FrameWriter();
 
         final Http2ConnectionEncoder encoder = new DefaultHttp2ConnectionEncoder(conn, writer);
         final Http2ConnectionDecoder decoder = new DefaultHttp2ConnectionDecoder(conn, encoder, reader);
 
-        return new Http2ClientConnectionHandler(clientFactory, ch, decoder, encoder, http2Settings());
+        return new Http2ClientConnectionHandler(decoder, encoder, http2Settings(), ch, clientFactory);
     }
 
     private Http2Settings http2Settings() {

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
@@ -38,7 +38,6 @@ import com.google.common.collect.Iterables;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.internal.Http1ObjectEncoder;
-import com.linecorp.armeria.internal.Http2GoAwayListener;
 import com.linecorp.armeria.internal.ReadSuppressingHandler;
 import com.linecorp.armeria.internal.TrafficLoggingHandler;
 
@@ -176,8 +175,6 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
     private Http2ConnectionHandler newHttp2ConnectionHandler(ChannelPipeline pipeline) {
 
         final Http2Connection conn = new DefaultHttp2Connection(true);
-        conn.addListener(new Http2GoAwayListener(pipeline.channel()));
-
         final Http2FrameReader reader = new DefaultHttp2FrameReader(true);
         final Http2FrameWriter writer = new DefaultHttp2FrameWriter();
 
@@ -185,7 +182,7 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
         final Http2ConnectionDecoder decoder = new DefaultHttp2ConnectionDecoder(conn, encoder, reader);
 
         return new Http2ServerConnectionHandler(
-                config, pipeline.channel(), gracefulShutdownSupport, decoder, encoder, http2Settings());
+                decoder, encoder, http2Settings(), pipeline.channel(), config, gracefulShutdownSupport);
     }
 
     private Http2Settings http2Settings() {

--- a/testing-internal/src/main/resources/logback-test.xml
+++ b/testing-internal/src/main/resources/logback-test.xml
@@ -31,7 +31,7 @@
   <logger name="com.linecorp.armeria" level="DEBUG" />
   <logger name="com.linecorp.armeria.logging.traffic.server" level="OFF" />
   <logger name="com.linecorp.armeria.logging.traffic.client" level="OFF" />
-  <logger name="com.linecorp.armeria.internal.Http2GoAwayListener" level="INFO" />
+  <logger name="com.linecorp.armeria.internal.Http2GoAwayHandler" level="INFO" />
   <logger name="armeria" level="DEBUG" />
   <logger name="loggerTest" level="ALL" additivity="false">
     <appender-ref ref="NOP" />


### PR DESCRIPTION
Motivation:

- We currently add 2 `Http2Connection.Listener`s, `Http2GoAwayListener`
  and `Http2(Request|Response)Decoder`. We could add only a single
  listener so that Netty does not waste time to notify the events which
  is uninteresting to `Http2GoAwayListener`.
- We handle GOAWAY frames in more than one place, which is not great for
  readability.
- Netty invokes `onGoAwaySent()` callback even if the connection has
  been closed already and thus a GOAWAY frame is never sent. This makes
  `Http2GoAwayListener` log a false-positive message at WARN level.

Modifications

- Renamed `Http2GoAwayListener` to `Http2GoAwayHandler`.
- `Http2GoAwayHandler` is not an `Http2ConnectionAdapter` anymore.
- Moved all GOAWAY-related code to `Http2GoAwayHandler`.
- Clean-up
  - Reordered some constructor parameters so that the parameters of superclass
    appears first.
  - Removed `Http2Connection` from parameter list if there is
    `Http2ConnectionEncoder` in the parameter list, because
    `Http2Connection` can be retrieved via `Http2ConnectionEncoder.connection()`.
  - Cleaned up the code that injects verbose debug data into
    `Http2Exception`.
- Miscellaneous:
  - Fixed a bug where HTTP/2 graceful shutdown timeout it set to 0 when
    Armeria idle timeout is disabled.

Result:

- Fewer number of `Http2Connection.Listener`s
- Less scattered code
- Less noisy log messages