### PR TITLE
Deprecate @RequestObject in favor of @RequestBean

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/AnnotatedValueResolver.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AnnotatedValueResolver.java
@@ -337,9 +337,6 @@ final class AnnotatedValueResolver {
 
         final RequestConverter requestConverter = annotatedElement.getAnnotation(RequestConverter.class);
         if (requestConverter != null) {
-            // If we are analyzing a service method, we need to deal with an element, which does not have any
-            // annotation, as a target to be converted by one of request converters.
-            //
             // A user can optionally specify @RequestConverter in order to specify a converter which
             // would be applied first, as follows:
             //
@@ -353,6 +350,8 @@ final class AnnotatedValueResolver {
 
         // No annotation but it may be converted into an object by the request converters.
         if (applyConverterForNoAnnotation) {
+            // If we are analyzing a service method, we need to deal with an element, which does not have any
+            // annotation, as a target to be converted by one of request converters.
             return Optional.of(ofRequestConverter(annotatedElement, type, converters));
         } else {
             // If we are analyzing a class to prepare a bean conversion, we don't need to analyze an element

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/RequestBean.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/RequestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 LINE Corporation
+ * Copyright 2018 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package com.linecorp.armeria.server.annotation;
 
 import java.lang.annotation.ElementType;
@@ -22,22 +21,9 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Specifies which parameter should be converted by {@link RequestConverterFunction}.
- *
- * @see RequestConverterFunction
- * @see RequestConverter
- * @deprecated No more put {@link RequestObject} on the parameter which needs to be converted by one
- *             of the {@link RequestConverterFunction}s. However, use {@link RequestBean}
- *             if a request needs to be converted into a bean.
+ * Specifies which element should be converted by a bean converter. This annotation can be put on a parameter
+ * of a constructor or method, a field, a method or a constructor.
  */
-@Deprecated
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.PARAMETER, ElementType.FIELD, ElementType.METHOD, ElementType.CONSTRUCTOR })
-public @interface RequestObject {
-
-    /**
-     * {@link RequestConverterFunction} implementation type which is used for converting the annotated
-     * parameter. The specified class must have an accessible default constructor.
-     */
-    Class<? extends RequestConverterFunction> value() default RequestConverterFunction.class;
-}
+public @interface RequestBean {}

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/RequestConverter.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/RequestConverter.java
@@ -29,11 +29,10 @@ import com.linecorp.armeria.common.AggregatedHttpMessage;
  * an object.
  *
  * @see RequestConverterFunction
- * @see RequestObject
  */
 @Repeatable(RequestConverters.class)
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.TYPE, ElementType.METHOD })
+@Target({ ElementType.TYPE, ElementType.METHOD, ElementType.PARAMETER })
 public @interface RequestConverter {
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/RequestConverterFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/RequestConverterFunction.java
@@ -27,7 +27,6 @@ import com.linecorp.armeria.server.ServiceRequestContext;
  * be specified as a value of a {@link RequestConverter} annotation.
  *
  * @see RequestConverter
- * @see RequestObject
  */
 @FunctionalInterface
 public interface RequestConverterFunction {

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/RequestObject.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/RequestObject.java
@@ -26,9 +26,9 @@ import java.lang.annotation.Target;
  *
  * @see RequestConverterFunction
  * @see RequestConverter
- * @deprecated No more putting {@link RequestObject} on the parameter which needs to be converted by one
- *             of the {@link RequestConverterFunction}s. Use {@link RequestBean} if a request needs to
- *             be converted into a bean.
+ * @deprecated There's no need to put {@link RequestObject} annotation anymore on a parameter
+ *             converted by a {@link RequestConverterFunction}. Use {@link RequestBean}
+ *             if a request needs to be converted into a bean.
  */
 @Deprecated
 @Retention(RetentionPolicy.RUNTIME)

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/RequestObject.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/RequestObject.java
@@ -26,9 +26,9 @@ import java.lang.annotation.Target;
  *
  * @see RequestConverterFunction
  * @see RequestConverter
- * @deprecated No more put {@link RequestObject} on the parameter which needs to be converted by one
- *             of the {@link RequestConverterFunction}s. However, use {@link RequestBean}
- *             if a request needs to be converted into a bean.
+ * @deprecated No more putting {@link RequestObject} on the parameter which needs to be converted by one
+ *             of the {@link RequestConverterFunction}s. Use {@link RequestBean} if a request needs to
+ *             be converted into a bean.
  */
 @Deprecated
 @Retention(RetentionPolicy.RUNTIME)

--- a/core/src/test/java/com/linecorp/armeria/server/AnnotatedBeanFactoryTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/AnnotatedBeanFactoryTest.java
@@ -20,56 +20,52 @@ import static com.linecorp.armeria.server.AnnotatedBeanFactory.register;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.util.List;
 import java.util.Set;
 
 import javax.annotation.Nullable;
 
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.server.AnnotatedBeanFactory.BeanFactoryId;
-import com.linecorp.armeria.server.AnnotatedValueResolver.RequestObjectResolver;
 import com.linecorp.armeria.server.annotation.Header;
 import com.linecorp.armeria.server.annotation.Param;
 
 public class AnnotatedBeanFactoryTest {
 
     private static final Set<String> vars = ImmutableSet.of();
-    private static final List<RequestObjectResolver> resolvers = ImmutableList.of();
 
     @Test
     public void shouldFailToRegister() {
-        assertThatThrownBy(() -> register(BadRequestBeanMoreThanOnConstructor01.class, vars, resolvers))
+        assertThatThrownBy(() -> register(BadRequestBeanMoreThanOnConstructor01.class, vars))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("too many annotated constructors");
-        assertThatThrownBy(() -> register(BadRequestBeanMoreThanOnConstructor02.class, vars, resolvers))
+        assertThatThrownBy(() -> register(BadRequestBeanMoreThanOnConstructor02.class, vars))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("too many annotated constructors");
-        assertThatThrownBy(() -> register(BadRequestBeanMoreThanOnConstructor03.class, vars, resolvers))
+        assertThatThrownBy(() -> register(BadRequestBeanMoreThanOnConstructor03.class, vars))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("too many annotated constructors");
 
         // error: annotation used in constructor param
-        assertThatThrownBy(() -> register(BadRequestBeanAnnotationInConstructorParam.class, vars, resolvers))
+        assertThatThrownBy(() -> register(BadRequestBeanAnnotationInConstructorParam.class, vars))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Both a method and parameter are annotated");
 
         // error: annotation used in method param
-        assertThatThrownBy(() -> register(BadRequestBeanAnnotationInMethodParam.class, vars, resolvers))
+        assertThatThrownBy(() -> register(BadRequestBeanAnnotationInMethodParam.class, vars))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Both a method and parameter are annotated");
 
         // error: more than one params for annotated constructor
-        assertThatThrownBy(() -> register(BadRequestBeanMoreThanOneConstructorParam.class, vars, resolvers))
+        assertThatThrownBy(() -> register(BadRequestBeanMoreThanOneConstructorParam.class, vars))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Only one parameter is allowed to an annotated method");
 
         // error: more than one params for annotated method
-        assertThatThrownBy(() -> register(BadRequestBeanMoreThanOneMethodParam.class, vars, resolvers))
+        assertThatThrownBy(() -> register(BadRequestBeanMoreThanOneMethodParam.class, vars))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Only one parameter is allowed to an annotated method");
     }
@@ -78,13 +74,13 @@ public class AnnotatedBeanFactoryTest {
     public void shouldBeRegisteredAsUnsupported() {
         BeanFactoryId id;
 
-        id = register(NotARequestBeanSomeConstructorParamWithoutAnnotation.class, vars, resolvers);
+        id = register(NotARequestBeanSomeConstructorParamWithoutAnnotation.class, vars);
         assertThat(find(id).isPresent()).isFalse();
 
-        id = register(NotARequestBeanSomeMethodParamWithoutAnnotation.class, vars, resolvers);
+        id = register(NotARequestBeanSomeMethodParamWithoutAnnotation.class, vars);
         assertThat(find(id).isPresent()).isFalse();
 
-        id = register(NotARequestBeanBecauseOfInnerClass.class, vars, resolvers);
+        id = register(NotARequestBeanBecauseOfInnerClass.class, vars);
         assertThat(find(id).isPresent()).isFalse();
     }
 

--- a/core/src/test/java/com/linecorp/armeria/server/AnnotatedHttpServiceBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/AnnotatedHttpServiceBuilderTest.java
@@ -32,7 +32,6 @@ import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.RequestContext;
-import com.linecorp.armeria.server.AnnotatedValueResolver.NoAnnotatedParameterException;
 import com.linecorp.armeria.server.annotation.ByteArrayRequestConverterFunction;
 import com.linecorp.armeria.server.annotation.Default;
 import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
@@ -207,6 +206,12 @@ public class AnnotatedHttpServiceBuilderTest {
             @Get("/test")
             public void root(@Default("a") ServiceRequestContext ctx) {}
         });
+
+        // Optional is unnecessary, but we just warn.
+        new ServerBuilder().annotatedService(new Object() {
+            @Get("/test")
+            public void root(Optional<ServiceRequestContext> ctx) {}
+        });
     }
 
     @Test
@@ -281,11 +286,6 @@ public class AnnotatedHttpServiceBuilderTest {
         assertThatThrownBy(() -> new ServerBuilder().annotatedService(new Object() {
             @Get("/test")
             public void root(@Header("name") NoDefaultConstructorList<String> name) {}
-        })).isInstanceOf(IllegalArgumentException.class);
-
-        assertThatThrownBy(() -> new ServerBuilder().annotatedService(new Object() {
-            @Get("/test")
-            public void root(Optional<ServiceRequestContext> ctx) {}
         })).isInstanceOf(IllegalArgumentException.class);
 
         assertThatThrownBy(() -> new ServerBuilder().annotatedService(new Object() {

--- a/core/src/test/java/com/linecorp/armeria/server/AnnotatedHttpServiceBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/AnnotatedHttpServiceBuilderTest.java
@@ -43,7 +43,6 @@ import com.linecorp.armeria.server.annotation.Options;
 import com.linecorp.armeria.server.annotation.Param;
 import com.linecorp.armeria.server.annotation.Path;
 import com.linecorp.armeria.server.annotation.Post;
-import com.linecorp.armeria.server.annotation.RequestObject;
 import com.linecorp.armeria.server.logging.LoggingService;
 
 public class AnnotatedHttpServiceBuilderTest {
@@ -214,19 +213,19 @@ public class AnnotatedHttpServiceBuilderTest {
     public void ofBuiltinRequestConverter() {
         new ServerBuilder().annotatedService(new Object() {
             @Get("/")
-            public void root(@RequestObject String value) {}
+            public void root(String value) {}
         });
         new ServerBuilder().annotatedService(new Object() {
             @Get("/")
-            public void root(@RequestObject byte[] value) {}
+            public void root(byte[] value) {}
         });
         new ServerBuilder().annotatedService(new Object() {
             @Get("/")
-            public void root(@RequestObject JsonNode value) {}
+            public void root(JsonNode value) {}
         });
         new ServerBuilder().annotatedService(new Object() {
             @Get("/")
-            public void root(@RequestObject HttpData value) {}
+            public void root(HttpData value) {}
         });
     }
 

--- a/core/src/test/java/com/linecorp/armeria/server/AnnotatedHttpServiceBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/AnnotatedHttpServiceBuilderTest.java
@@ -286,7 +286,7 @@ public class AnnotatedHttpServiceBuilderTest {
         assertThatThrownBy(() -> new ServerBuilder().annotatedService(new Object() {
             @Get("/test")
             public void root(Optional<ServiceRequestContext> ctx) {}
-        })).isInstanceOf(NoAnnotatedParameterException.class);
+        })).isInstanceOf(IllegalArgumentException.class);
 
         assertThatThrownBy(() -> new ServerBuilder().annotatedService(new Object() {
             @Get("/test")

--- a/core/src/test/java/com/linecorp/armeria/server/AnnotatedHttpServiceHandlersOrderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/AnnotatedHttpServiceHandlersOrderTest.java
@@ -39,7 +39,6 @@ import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
 import com.linecorp.armeria.server.annotation.Post;
 import com.linecorp.armeria.server.annotation.RequestConverter;
 import com.linecorp.armeria.server.annotation.RequestConverterFunction;
-import com.linecorp.armeria.server.annotation.RequestObject;
 import com.linecorp.armeria.server.annotation.ResponseConverter;
 import com.linecorp.armeria.server.annotation.ResponseConverterFunction;
 import com.linecorp.armeria.server.logging.LoggingService;
@@ -71,21 +70,21 @@ public class AnnotatedHttpServiceHandlersOrderTest {
         @Post("/requestConverterOrder")
         @RequestConverter(MethodLevelRequestConverter.class)
         public HttpResponse requestConverterOrder(
-                @RequestObject(ParameterLevelRequestConverter.class) JsonNode node) {
+                @RequestConverter(ParameterLevelRequestConverter.class) JsonNode node) {
             assertThat(node).isNotNull();
             return HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, HttpData.ofUtf8(node.toString()));
         }
 
         @Post("/responseConverterOrder")
         @ResponseConverter(MethodLevelResponseConverter.class)
-        public String responseConverterOrder(@RequestObject String name) {
+        public String responseConverterOrder(String name) {
             assertThat(name).isEqualTo("foo");
             return "hello " + name;
         }
 
         @Post("/exceptionHandlerOrder")
         @ExceptionHandler(MethodLevelExceptionHandler.class)
-        public HttpResponse exceptionHandlerOrder(@RequestObject String name) {
+        public HttpResponse exceptionHandlerOrder(String name) {
             assertThat(name).isEqualTo("foo");
             final AggregatedHttpMessage message = AggregatedHttpMessage.of(
                     HttpStatus.NOT_IMPLEMENTED, MediaType.PLAIN_TEXT_UTF_8, "hello " + name);

--- a/core/src/test/java/com/linecorp/armeria/server/AnnotatedHttpServiceRequestConverterTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/AnnotatedHttpServiceRequestConverterTest.java
@@ -50,9 +50,9 @@ import com.linecorp.armeria.server.annotation.Get;
 import com.linecorp.armeria.server.annotation.Header;
 import com.linecorp.armeria.server.annotation.Param;
 import com.linecorp.armeria.server.annotation.Post;
+import com.linecorp.armeria.server.annotation.RequestBean;
 import com.linecorp.armeria.server.annotation.RequestConverter;
 import com.linecorp.armeria.server.annotation.RequestConverterFunction;
-import com.linecorp.armeria.server.annotation.RequestObject;
 import com.linecorp.armeria.server.annotation.ResponseConverter;
 import com.linecorp.armeria.server.logging.LoggingService;
 import com.linecorp.armeria.testing.server.ServerRule;
@@ -77,7 +77,7 @@ public class AnnotatedHttpServiceRequestConverterTest {
     public static class MyService1 {
 
         @Post("/convert1")
-        public String convert1(@RequestObject RequestJsonObj1 obj1) {
+        public String convert1(RequestJsonObj1 obj1) {
             assertThat(obj1).isNotNull();
             return obj1.toString();
         }
@@ -86,15 +86,15 @@ public class AnnotatedHttpServiceRequestConverterTest {
         @RequestConverter(TestRequestConverter2.class)
         @RequestConverter(TestRequestConverter1A.class)
         @RequestConverter(TestRequestConverter1.class)
-        public String convert2(@RequestObject RequestJsonObj1 obj1) {
+        public String convert2(RequestJsonObj1 obj1) {
             assertThat(obj1).isNotNull();
             return obj1.toString();
         }
 
         @Post("/convert3")
-        public String convert3(@RequestObject(TestRequestConverterOptional1.class)
+        public String convert3(@RequestConverter(TestRequestConverterOptional1.class)
                                        Optional<RequestJsonObj1> obj1,
-                               @RequestObject(TestRequestConverterOptional2.class)
+                               @RequestConverter(TestRequestConverterOptional2.class)
                                        Optional<RequestJsonObj2> obj2) {
             assertThat(obj1.isPresent()).isTrue();
             assertThat(obj2.isPresent()).isTrue();
@@ -108,7 +108,7 @@ public class AnnotatedHttpServiceRequestConverterTest {
         private final ObjectMapper mapper = new ObjectMapper();
 
         @Post("/default/bean1/{userName}/{seqNum}")
-        public String defaultBean1ForPost(@RequestObject RequestBean1 bean1)
+        public String defaultBean1ForPost(@RequestBean RequestBean1 bean1)
                 throws JsonProcessingException {
             assertThat(bean1).isNotNull();
             bean1.validate();
@@ -116,7 +116,7 @@ public class AnnotatedHttpServiceRequestConverterTest {
         }
 
         @Get("/default/bean1/{userName}/{seqNum}")
-        public String defaultBean1ForGet(@RequestObject RequestBean1 bean1)
+        public String defaultBean1ForGet(@RequestBean RequestBean1 bean1)
                 throws JsonProcessingException {
             assertThat(bean1).isNotNull();
             bean1.validate();
@@ -124,7 +124,7 @@ public class AnnotatedHttpServiceRequestConverterTest {
         }
 
         @Post("/default/bean2/{userName}/{serialNo}")
-        public String defaultBean2ForPost(@RequestObject RequestBean2 bean2)
+        public String defaultBean2ForPost(@RequestBean RequestBean2 bean2)
                 throws JsonProcessingException {
             assertThat(bean2).isNotNull();
             bean2.validate();
@@ -132,7 +132,7 @@ public class AnnotatedHttpServiceRequestConverterTest {
         }
 
         @Get("/default/bean2/{userName}")
-        public String defaultBean2ForGet(@RequestObject RequestBean2 bean2)
+        public String defaultBean2ForGet(@RequestBean RequestBean2 bean2)
                 throws JsonProcessingException {
             assertThat(bean2).isNotNull();
             bean2.validate();
@@ -140,7 +140,7 @@ public class AnnotatedHttpServiceRequestConverterTest {
         }
 
         @Post("/default/bean3/{userName}/{departmentNo}")
-        public String defaultBean3ForPost(@RequestObject RequestBean3 bean3)
+        public String defaultBean3ForPost(@RequestBean RequestBean3 bean3)
                 throws JsonProcessingException {
             assertThat(bean3).isNotNull();
             bean3.validate();
@@ -148,7 +148,7 @@ public class AnnotatedHttpServiceRequestConverterTest {
         }
 
         @Get("/default/bean3/{userName}")
-        public String defaultBean3ForGet(@RequestObject RequestBean3 bean3)
+        public String defaultBean3ForGet(@RequestBean RequestBean3 bean3)
                 throws JsonProcessingException {
             assertThat(bean3).isNotNull();
             bean3.validate();
@@ -156,22 +156,22 @@ public class AnnotatedHttpServiceRequestConverterTest {
         }
 
         @Post("/default/json")
-        public String defaultJson(@RequestObject RequestJsonObj1 obj1,
-                                  @RequestObject RequestJsonObj2 obj2) {
+        public String defaultJson(RequestJsonObj1 obj1,
+                                  RequestJsonObj2 obj2) {
             assertThat(obj1).isNotNull();
             assertThat(obj2).isNotNull();
             return obj2.strVal();
         }
 
         @Post("/default/invalidJson")
-        public String invalidJson(@RequestObject JsonNode node) {
+        public String invalidJson(JsonNode node) {
             // Should never reach here because we are sending invalid JSON.
             throw new Error();
         }
 
         @Post("/default/binary")
-        public byte[] defaultBinary(@RequestObject HttpData obj1,
-                                    @RequestObject byte[] obj2) {
+        public byte[] defaultBinary(HttpData obj1,
+                                    byte[] obj2) {
             assertThat(obj1).isNotNull();
             assertThat(obj2).isNotNull();
             // Actually they have the same byte array.
@@ -180,7 +180,7 @@ public class AnnotatedHttpServiceRequestConverterTest {
         }
 
         @Post("/default/text")
-        public String defaultText(@RequestObject String obj1) {
+        public String defaultText(String obj1) {
             assertThat(obj1).isNotNull();
             return obj1;
         }
@@ -465,7 +465,7 @@ public class AnnotatedHttpServiceRequestConverterTest {
         assertThat(response.headers().status()).isEqualTo(HttpStatus.OK);
         assertThat(response.content().toStringUtf8()).isEqualTo(obj1a.toString());
 
-        // Multiple @RequestObject annotated parameters
+        // Multiple @RequestConverter annotated parameters
         response = client.post("/1/convert3", content1).aggregate().join();
         assertThat(response.headers().status()).isEqualTo(HttpStatus.OK);
         assertThat(response.content().toStringUtf8()).isEqualTo(HttpMethod.POST.name());

--- a/core/src/test/java/com/linecorp/armeria/server/AnnotatedHttpServiceRequestObjectTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/AnnotatedHttpServiceRequestObjectTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.annotation.Nullable;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.server.annotation.Get;
+import com.linecorp.armeria.server.annotation.Param;
+import com.linecorp.armeria.server.annotation.Post;
+import com.linecorp.armeria.server.annotation.RequestConverter;
+import com.linecorp.armeria.server.annotation.RequestConverterFunction;
+import com.linecorp.armeria.server.annotation.RequestObject;
+import com.linecorp.armeria.server.logging.LoggingService;
+import com.linecorp.armeria.testing.server.ServerRule;
+
+// TODO(hyangtack) This test will be removed once @RequestObject is removed.
+public class AnnotatedHttpServiceRequestObjectTest {
+
+    @ClassRule
+    public static final ServerRule rule = new ServerRule() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.annotatedService(new Service(), LoggingService.newDecorator());
+        }
+    };
+
+    private static class Service {
+        @Post("/test1")
+        public String test1(@RequestObject JsonBean bean) {
+            // Using a default JSON request converter.
+            return bean.value();
+        }
+
+        @Get("/test2/:value")
+        public String test2(@RequestObject ReqBean bean) {
+            // Using a default bean converter.
+            return bean.value();
+        }
+
+        @Get("/test3/:value")
+        public String test3(@RequestObject(MyRequestConverter.class) String value) {
+            // Using a user-defined converter.
+            return value;
+        }
+
+        @Get("/test4/:value")
+        @RequestConverter(MyRequestConverter.class)
+        public String test4(@RequestObject String value) {
+            // Using a user-defined converter.
+            return value;
+        }
+    }
+
+    private static class JsonBean {
+        private String value;
+
+        @JsonCreator
+        JsonBean(@JsonProperty("value") String value) {
+            this.value = value;
+        }
+
+        @JsonProperty
+        public String value() {
+            return value;
+        }
+    }
+
+    private static class ReqBean {
+        @Param
+        private String value;
+
+        public String value() {
+            return value;
+        }
+    }
+
+    private static class MyRequestConverter implements RequestConverterFunction {
+        @Nullable
+        @Override
+        public Object convertRequest(ServiceRequestContext ctx, AggregatedHttpMessage request,
+                                     Class<?> expectedResultType) throws Exception {
+            return ctx.pathParam("value");
+        }
+    }
+
+    @Test
+    public void testBackwardCompatibility() {
+        final HttpClient client = HttpClient.of(rule.uri("/"));
+
+        AggregatedHttpMessage response;
+        response = client.execute(HttpHeaders.of(HttpMethod.POST, "/test1")
+                                             .contentType(MediaType.JSON_UTF_8),
+                                  "{\"value\": \"json\"}").aggregate().join();
+        assertThat(response.content().toStringUtf8()).isEqualTo("json");
+
+        response = client.get("/test2/bean").aggregate().join();
+        assertThat(response.content().toStringUtf8()).isEqualTo("bean");
+
+        response = client.get("/test3/converter1").aggregate().join();
+        assertThat(response.content().toStringUtf8()).isEqualTo("converter1");
+
+        response = client.get("/test4/converter2").aggregate().join();
+        assertThat(response.content().toStringUtf8()).isEqualTo("converter2");
+    }
+}

--- a/site/src/sphinx/server-annotated-service.rst
+++ b/site/src/sphinx/server-annotated-service.rst
@@ -439,7 +439,7 @@ converter is not able to convert the request.
     }
 
 Then, you can write your service method as follows. Note that a request converter will work on the parameters
-which are neither annotated nor automatically injectable types.
+which are neither annotated nor automatically injected types.
 
 .. code-block:: java
 

--- a/site/src/sphinx/server-annotated-service.rst
+++ b/site/src/sphinx/server-annotated-service.rst
@@ -439,7 +439,7 @@ converter is not able to convert the request.
     }
 
 Then, you can write your service method as follows. Note that a request converter will work on the parameters
-which are not annotated and are not automatically injectable types.
+which are neither annotated nor automatically injectable types.
 
 .. code-block:: java
 


### PR DESCRIPTION
Motivation:
There is no reason to put `@RequestObject` for a parameter which needs to be converted into an object with a request converter, because all parameters in the annotated service method should be injectable and the others can be identified by annotations or their types. So, any parameter which does not have an annotation can be tried to be converted with a request converter. 
However, in this case, we have an ambiguity which parameter can be converted into an object with a request converter or can be converted into a bean. So we need to introduce a new annotation `@RequestBean` which indicates a parameter needs to be converted into a bean, which is used relatively less than using a request converter.

Modifications:
- Deprecate `@RequestObject`.
- Add `@RequestBean` which is used for converting a request into a bean. 
- `@RequestConverter` can be put on a parameter of an annotated service method.
- Remove `@RequestObject` from tests, except for minimal test cases for testing backward compatibility.

Result:
A user does not need to put `@RequestObject` annotation on a parameter which needs to be converted into an object with a request converter any more.