### PR TITLE
Fail with UnprocessedRequestException when writing first request head…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/HttpRequestSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpRequestSubscriber.java
@@ -144,7 +144,7 @@ final class HttpRequestSubscriber implements Subscriber<HttpObject>, ChannelFutu
     private void writeFirstHeader() {
         final HttpSession session = HttpSession.get(ch);
         if (!session.isActive()) {
-            failAndRespond(ClosedSessionException.get());
+            failAndRespond(UnprocessedRequestException.get());
             return;
         }
 


### PR DESCRIPTION
…er to an inactive session

Motivation:

`HttpRequestSubscriber` currently fails the request with
`ClosedSessionException` when it's writing the first request headers to
an inactive session. However, the request has to fail with
`UnprocessedRequestException` in this case because it is very sure that
the request was not sent at all.

Modifications:

- Fail with `UnprocessedRequestException` instead of `ClosedSessionException`

Result:

- More safely retriable requests