### PR TITLE
Add README for benchmarks / Add async-profiler support

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -21,8 +21,10 @@ A collection of JMH benchmarks which may be useful for measuring Armeria perform
 - `-Pjmh.profilers=<spec>`
   - The profiler settings. Profiler disabled if unspecified.
     - `jmh.extras.Async:asyncProfilerDir=...;flameGraphDir=...`
-- `-Pjmh.threads=<integer>` - The number of threads. JMH default if unspecified.
-- `-Pjmh.verbose` - Increases the verbosity of JMH to `EXTRA`.
+- `-Pjmh.threads=<integer>`
+  - The number of threads. JMH default if unspecified.
+- `-Pjmh.verbose`
+  - Increases the verbosity of JMH to `EXTRA`.
 - `-Pjmh.jvmargs=<jvm options>`
   - Additional JVM options.
 - `-Pjmh.forcegc=<true|false>`
@@ -57,6 +59,6 @@ $ ./gradlew :benchmarks:jmh \
 
 ## Notes
 
-- Do not forgot to wrap `-Pjmh.params` and `-Pjmh.profilers` option with double quotes, because otherwise your
+- Do not forget to wrap `-Pjmh.params` and `-Pjmh.profilers` option with double quotes, because otherwise your
   shell will interpret `;` as the end of the command.
 - See [sbt-jmh documentation](https://github.com/ktoso/sbt-jmh#using-async-profiler) for more profiler options.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,62 @@
+# JMH benchmarks
+
+A collection of JMH benchmarks which may be useful for measuring Armeria performance.
+
+## Options
+
+- `-Pjmh.include=<pattern>`
+  - The benchmarks to run. All benchmarks if unspecified.
+    - `DownstreamSimpleBenchmark`
+    - `DownstreamSimpleBenchmark.emptyNonBlocking`
+- `-Pjmh.params=<spec>`
+  - The benchmark parameters. Uses the parameters specified in the benchmark code if unspecified.
+    - `clientType=NORMAL`
+    - `num=10,100;flowControl=false`
+- `-Pjmh.fork=<integer>`
+  - The number of forks. `1` if unspecified.
+- `-Pjmh.iterations=<integer>`
+  - The number of iterations. JMH default if unspecified.
+- `-Pjmh.warmupIterations`
+  - The number of iterations. Uses the value of `jmh.iterations` if unspecified.
+- `-Pjmh.profilers=<spec>`
+  - The profiler settings. Profiler disabled if unspecified.
+    - `jmh.extras.Async:asyncProfilerDir=...;flameGraphDir=...`
+- `-Pjmh.threads=<integer>` - The number of threads. JMH default if unspecified.
+- `-Pjmh.verbose` - Increases the verbosity of JMH to `EXTRA`.
+- `-Pjmh.jvmargs=<jvm options>`
+  - Additional JVM options.
+- `-Pjmh.forcegc=<true|false>`
+  - Whether to force JVM garbage collection. `false` if unspecified.
+
+## Retrieving flame graph using async-profiler
+
+Allow running `perf` as a normal user:
+
+```
+# echo 1 > /proc/sys/kernel/perf_event_paranoid
+# echo 0 > /proc/sys/kernel/kptr_restrict
+```
+
+Install [async-profiler](https://github.com/jvm-profiling-tools/async-profiler) and
+[FlameGraph](https://github.com/brendangregg/FlameGraph):
+
+```
+$ cd "$HOME"
+$ git clone https://github.com/jvm-profiling-tools/async-profiler.git
+$ git clone https://github.com/brendangregg/FlameGraph.git
+$ cd async-profiler
+$ make
+```
+
+When running a benchmark, specify `-Pjmh.profilers` option:
+
+```
+$ ./gradlew :benchmarks:jmh \
+  "-Pjmh.profilers=jmh.extras.Async:asyncProfilerDir=$HOME/async-profiler;flameGraphDir=$HOME/FlameGraph"
+```
+
+## Notes
+
+- Do not forgot to wrap `-Pjmh.params` and `-Pjmh.profilers` option with double quotes, because otherwise your
+  shell will interpret `;` as the end of the command.
+- See [sbt-jmh documentation](https://github.com/ktoso/sbt-jmh#using-async-profiler) for more profiler options.

--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -23,29 +23,16 @@ dependencies {
 
     compile 'com.squareup.retrofit2:adapter-java8'
     compile 'com.squareup.retrofit2:converter-jackson'
+
+    jmh 'pl.project13.scala:sbt-jmh-extras'
 }
 
 jmh {
-    if (jmhInclude) {
-        include = jmhInclude
-    }
-
-    if (rootProject.hasProperty('jmh.forceGC')) {
-        forceGC = 'true'.equals(rootProject.findProperty('jmh.forceGC'))
-    } else {
-        forceGC = true
-    }
-
-
     duplicateClassesStrategy = DuplicatesStrategy.EXCLUDE
     jmhVersion = managedVersions['org.openjdk.jmh:jmh-core']
 
-    if (rootProject.hasProperty('jmh.params')) {
-        benchmarkParameters = [:]
-        rootProject.findProperty('jmh.params').split(';').each {
-            def parts = it.split('=')
-            benchmarkParameters[parts[0]] = parts[1].tokenize(',')
-        }
+    if (jmhInclude) {
+        include = jmhInclude
     }
 
     if (rootProject.hasProperty('jmh.fork')) {
@@ -54,25 +41,43 @@ jmh {
         fork = 1
     }
 
-    if (rootProject.hasProperty('jmh.jvmargs')) {
-        jvmArgsAppend = String.valueOf(rootProject.findProperty('jmh.jvmargs')).split(' ').toList()
-    }
-
     if (rootProject.hasProperty('jmh.iterations')) {
         iterations = Integer.parseInt(String.valueOf(rootProject.findProperty('jmh.iterations')))
     }
+
     if (rootProject.hasProperty('jmh.warmupIterations')) {
         warmupIterations = Integer.parseInt(String.valueOf(rootProject.findProperty('jmh.warmupIterations')))
     } else {
         warmupIterations = iterations
     }
+
     if (rootProject.hasProperty('jmh.profilers')) {
         profilers = String.valueOf(rootProject.findProperty('jmh.profilers')).split(',')
     }
+
     if (rootProject.hasProperty('jmh.threads')) {
         threads = Integer.parseInt(String.valueOf(rootProject.findProperty('jmh.threads')))
     }
+
     if (rootProject.hasProperty('jmh.verbose')) {
         verbosity = 'EXTRA'
+    }
+
+    if (rootProject.hasProperty('jmh.jvmargs')) {
+        jvmArgsAppend = String.valueOf(rootProject.findProperty('jmh.jvmargs')).split(' ').toList()
+    }
+
+    if (rootProject.hasProperty('jmh.forceGC')) {
+        forceGC = 'true'.equals(rootProject.findProperty('jmh.forceGC'))
+    } else {
+        forceGC = true
+    }
+
+    if (rootProject.hasProperty('jmh.params')) {
+        benchmarkParameters = [:]
+        rootProject.findProperty('jmh.params').split(';').each {
+            def parts = it.split('=')
+            benchmarkParameters[parts[0]] = parts[1].tokenize(',')
+        }
     }
 }

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -386,3 +386,6 @@ org.springframework.boot:
   spring-boot-starter-web: { version: *SPRING_BOOT_VERSION }
   spring-boot-configuration-processor: { version: *SPRING_BOOT_VERSION }
   spring-boot-gradle-plugin: { version: *SPRING_BOOT_VERSION }
+
+pl.project13.scala:
+  sbt-jmh-extras: { version: 0.3.4 }


### PR DESCRIPTION
Motivation:

- We have various non-standard properties that allows a user to specify
  JMH options, but they are barely documented.
- @ktoso wrote `sbt-jmh-extras` which provides JMH profiler
  implementations based on async-profiler and JFR.
  - https://github.com/ktoso/sbt-jmh
  - https://github.com/jvm-profiling-tools/async-profiler

Modifications:

- Add `README.md`
- Add `sbt-jmh-extras` to the JMH class path
- Reorganize the build script a little bit

Result:

- A user can run and customize the benchmarks easilyy.
- A user can generate a flame graph using async-profiler.