### PR TITLE
Fix a bug where RequestLog is not complete under certain circumstances

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
@@ -190,7 +190,6 @@ abstract class HttpResponseDecoder {
         public boolean tryWrite(HttpObject o) {
             if (o instanceof HttpHeaders) {
                 // NB: It's safe to call logBuilder.start() multiple times.
-                //     See AbstractMessageLog.start() for more information.
                 logBuilder.startResponse();
                 final HttpHeaders headers = (HttpHeaders) o;
                 final HttpStatus status = headers.status();

--- a/core/src/main/java/com/linecorp/armeria/client/UserClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/UserClient.java
@@ -17,7 +17,7 @@
 package com.linecorp.armeria.client;
 
 import java.net.URI;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 
 import javax.annotation.Nullable;
 
@@ -26,6 +26,7 @@ import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.logging.RequestLogAvailability;
+import com.linecorp.armeria.common.logging.RequestLogBuilder;
 import com.linecorp.armeria.common.util.ReleasableHolder;
 import com.linecorp.armeria.common.util.SafeCloseable;
 
@@ -118,12 +119,12 @@ public abstract class UserClient<I extends Request, O extends Response> implemen
      * @param query the query part of the {@link Request} URI
      * @param fragment the fragment part of the {@link Request} URI
      * @param req the {@link Request}
-     * @param fallback the fallback response {@link Function} to use when
+     * @param fallback the fallback response {@link BiFunction} to use when
      *                 {@link Client#execute(ClientRequestContext, Request)} of {@link #delegate()} throws
      *                 an exception instead of returning an error response
      */
     protected final O execute(HttpMethod method, String path, @Nullable String query, @Nullable String fragment,
-                              I req, Function<Throwable, O> fallback) {
+                              I req, BiFunction<ClientRequestContext, Throwable, O> fallback) {
         return execute(null, method, path, query, fragment, req, fallback);
     }
 
@@ -136,12 +137,12 @@ public abstract class UserClient<I extends Request, O extends Response> implemen
      * @param query the query part of the {@link Request} URI
      * @param fragment the fragment part of the {@link Request} URI
      * @param req the {@link Request}
-     * @param fallback the fallback response {@link Function} to use when
+     * @param fallback the fallback response {@link BiFunction} to use when
      *                 {@link Client#execute(ClientRequestContext, Request)} of {@link #delegate()} throws
      */
     protected final O execute(@Nullable EventLoop eventLoop,
                               HttpMethod method, String path, @Nullable String query, @Nullable String fragment,
-                              I req, Function<Throwable, O> fallback) {
+                              I req, BiFunction<ClientRequestContext, Throwable, O> fallback) {
 
         final ClientRequestContext ctx;
         if (eventLoop == null) {
@@ -158,8 +159,14 @@ public abstract class UserClient<I extends Request, O extends Response> implemen
         try (SafeCloseable ignored = ctx.push()) {
             return delegate().execute(ctx, req);
         } catch (Throwable cause) {
-            ctx.logBuilder().endResponse(cause);
-            return fallback.apply(cause);
+            final O fallbackRes = fallback.apply(ctx, cause);
+            final RequestLogBuilder logBuilder = ctx.logBuilder();
+            if (!ctx.log().isAvailable(RequestLogAvailability.REQUEST_START)) {
+                // An exception is raised even before sending a request, so end the request with the exception.
+                logBuilder.endRequest(cause);
+            }
+            logBuilder.endResponse(cause);
+            return fallbackRes;
         }
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientWithRequestLogTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientWithRequestLogTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+
+import java.net.ConnectException;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.logging.RequestLog;
+import com.linecorp.armeria.common.logging.RequestLogAvailability;
+import com.linecorp.armeria.testing.internal.AnticipatedException;
+
+public class HttpClientWithRequestLogTest {
+
+    private static final String LOCAL_HOST = "http://127.0.0.1/";
+
+    private static final AtomicReference<Throwable> requestCauseHolder = new AtomicReference<>();
+    private static final AtomicReference<Throwable> responseCauseHolder = new AtomicReference<>();
+
+    @Before
+    public void setUp() {
+        requestCauseHolder.set(null);
+        responseCauseHolder.set(null);
+    }
+
+    @Test
+    public void exceptionRaisedInDecorator() {
+        final HttpClient client = new HttpClientBuilder(LOCAL_HOST)
+                .decorator((delegate, ctx, req1) -> {
+                    throw new AnticipatedException();
+                })
+                .decorator(new ExceptionHoldingDecorator())
+                .build();
+
+        final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/");
+        assertThatThrownBy(() -> client.execute(req).aggregate().get())
+                .hasCauseExactlyInstanceOf(AnticipatedException.class);
+
+        // If the RequestLog has requestCause and responseCause, the RequestLog is complete.
+        // The RequestLog should be complete so that ReleasableHolder#release() is called in UserClient
+        // to decrease the active request count of EventLoop.
+        await().untilAsserted(() -> assertThat(
+                requestCauseHolder.get()).isExactlyInstanceOf(AnticipatedException.class));
+        await().untilAsserted(() -> assertThat(
+                responseCauseHolder.get()).isExactlyInstanceOf(AnticipatedException.class));
+        await().untilAsserted(() -> assertThat(req.isComplete()).isTrue());
+    }
+
+    @Test
+    public void invalidPath() {
+        final HttpClient client = new HttpClientBuilder(LOCAL_HOST)
+                .decorator((delegate, ctx, req) -> {
+                    req.headers().path("/%");
+                    return delegate.execute(ctx, req);
+                })
+                .decorator(new ExceptionHoldingDecorator())
+                .build();
+
+        final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/");
+        assertThatThrownBy(() -> client.execute(req).aggregate().get())
+                .hasCauseExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("invalid path");
+
+        await().untilAsserted(() -> assertThat(
+                requestCauseHolder.get()).isExactlyInstanceOf(IllegalArgumentException.class));
+        await().untilAsserted(() -> assertThat(
+                responseCauseHolder.get()).isExactlyInstanceOf(IllegalArgumentException.class));
+        await().untilAsserted(() -> assertThat(req.isComplete()).isTrue());
+    }
+
+    @Test
+    public void unresolvedUri() {
+        final HttpClient client = new HttpClientBuilder("http://unresolved.armeria.com").decorator(
+                new ExceptionHoldingDecorator()).build();
+        final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/");
+        assertThatThrownBy(() -> client.execute(req).aggregate().get()).isInstanceOf(Exception.class);
+
+        await().untilAsserted(() -> assertThat(requestCauseHolder.get()).isNotNull());
+        await().untilAsserted(() -> assertThat(responseCauseHolder.get()).isNotNull());
+        await().untilAsserted(() -> assertThat(req.isComplete()).isTrue());
+    }
+
+    @Test
+    public void connectionError() {
+        // According to rfc7805, TCP port number 1 is not used so a connection error always happens.
+        final HttpClient client = new HttpClientBuilder("http://127.0.0.1:1")
+                .decorator(new ExceptionHoldingDecorator()).build();
+        final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/");
+        assertThatThrownBy(() -> client.execute(req).aggregate().get())
+                .hasCauseInstanceOf(ConnectException.class);
+
+        await().untilAsserted(() -> assertThat(
+                requestCauseHolder.get()).hasCauseInstanceOf(ConnectException.class));
+        await().untilAsserted(() -> assertThat(
+                responseCauseHolder.get()).hasCauseInstanceOf(ConnectException.class));
+        await().untilAsserted(() -> assertThat(req.isComplete()).isTrue());
+    }
+
+    private static class ExceptionHoldingDecorator
+            implements DecoratingClientFunction<HttpRequest, HttpResponse> {
+
+        @Override
+        public HttpResponse execute(Client<HttpRequest, HttpResponse> delegate, ClientRequestContext ctx,
+                                    HttpRequest req) throws Exception {
+            final RequestLog requestLog = ctx.log();
+            requestLog.addListener(log -> requestCauseHolder.set(log.requestCause()),
+                                   RequestLogAvailability.REQUEST_END);
+            requestLog.addListener(log -> responseCauseHolder.set(log.responseCause()),
+                                   RequestLogAvailability.RESPONSE_END);
+            return delegate.execute(ctx, req);
+        }
+    }
+}

--- a/thrift/src/main/java/com/linecorp/armeria/client/thrift/DefaultTHttpClient.java
+++ b/thrift/src/main/java/com/linecorp/armeria/client/thrift/DefaultTHttpClient.java
@@ -66,6 +66,7 @@ final class DefaultTHttpClient extends UserClient<RpcRequest, RpcResponse> imple
         pathAndQuery.storeInCache(path);
 
         final RpcRequest call = RpcRequest.of(serviceType, method, args);
-        return execute(HttpMethod.POST, pathAndQuery.path(), null, serviceName, call, DefaultRpcResponse::new);
+        return execute(HttpMethod.POST, pathAndQuery.path(), null, serviceName, call,
+                       (ctx, cause) -> new DefaultRpcResponse(cause));
     }
 }


### PR DESCRIPTION
Motivation:
The `RequestLog` should be complete because the active request count of an `EventLoop`
is decreased when the `ReqeustLog` is complete.
However, if an exception is raised even before sending an `HttpRequest` by specifying
invalid URI, failing to resolve URI, etc, the `RequestLog` is not complete.

Modifications:
- Fix to complete `RequestLog`
- Fix to abort the `HttpRuest`

Result:

- Less bugs