### PR TITLE
Don't rewrite the user's path if it is valid since it may be escaped.

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientDelegate.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientDelegate.java
@@ -57,7 +57,7 @@ final class HttpClientDelegate implements Client<HttpRequest, HttpResponse> {
 
     @Override
     public HttpResponse execute(ClientRequestContext ctx, HttpRequest req) throws Exception {
-        if (!sanitizePath(req)) {
+        if (!isValidPath(req)) {
             req.abort();
             return HttpResponse.ofFailure(new IllegalArgumentException("invalid path: " + req.path()));
         }
@@ -169,23 +169,8 @@ final class HttpClientDelegate implements Client<HttpRequest, HttpResponse> {
         return null;
     }
 
-    private static boolean sanitizePath(HttpRequest req) {
-        final PathAndQuery pathAndQuery = PathAndQuery.parse(req.path());
-        if (pathAndQuery == null) {
-            return false;
-        }
-
-        final String path = pathAndQuery.path();
-        final String query = pathAndQuery.query();
-        final String newPathAndQuery;
-        if (query != null) {
-            newPathAndQuery = path + '?' + query;
-        } else {
-            newPathAndQuery = path;
-        }
-
-        req.path(newPathAndQuery);
-        return true;
+    private static boolean isValidPath(HttpRequest req) {
+        return PathAndQuery.parse(req.path()) != null;
     }
 
     void invoke0(Channel channel, ClientRequestContext ctx,

--- a/core/src/main/java/com/linecorp/armeria/internal/PathAndQuery.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/PathAndQuery.java
@@ -68,6 +68,12 @@ public final class PathAndQuery {
 
     /**
      * A special byte which tells {@link #encodeToPercents(Bytes, boolean)} to translate it to
+     * {@code "%2F"}.
+     */
+    private static final int ENCODED_SLASH = 0xFC;
+
+    /**
+     * A special byte which tells {@link #encodeToPercents(Bytes, boolean)} to translate it to
      * {@code "%26"}.
      */
     private static final int ENCODED_AMPERSAND = 0xFD;

--- a/core/src/main/java/com/linecorp/armeria/internal/PathAndQuery.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/PathAndQuery.java
@@ -68,12 +68,6 @@ public final class PathAndQuery {
 
     /**
      * A special byte which tells {@link #encodeToPercents(Bytes, boolean)} to translate it to
-     * {@code "%2F"}.
-     */
-    private static final int ENCODED_SLASH = 0xFC;
-
-    /**
-     * A special byte which tells {@link #encodeToPercents(Bytes, boolean)} to translate it to
      * {@code "%26"}.
      */
     private static final int ENCODED_AMPERSAND = 0xFD;

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientIntegrationTest.java
@@ -304,7 +304,8 @@ public class HttpClientIntegrationTest {
             sb.service("glob:/oneparam/**", ((ctx, req) -> {
                 // The client was able to send a request with an escaped path param. Armeria servers always
                 // decode the path so ctx.path == '/oneparam/foo/bar' here.
-                if (req.headers().path().equals("/oneparam/foo%2Fbar")) {
+                if (req.headers().path().equals("/oneparam/foo%2Fbar") &&
+                    ctx.path().equals("/oneparam/foo/bar")) {
                     return HttpResponse.of("routed");
                 }
                 return HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR);

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientIntegrationTest.java
@@ -401,25 +401,6 @@ public class HttpClientIntegrationTest {
     }
 
     /**
-     * When the request path contains double slashes, they should be replaced with single slashes.
-     */
-    @Test
-    public void testDoubleSlashSuppression() throws Exception {
-        testDoubleSlashSuppression("/double//slashes", "/double/slashes");
-        // The double slashes in the query string should not be normalized.
-        testDoubleSlashSuppression("/double//slashes?slashed//query", "/double/slashes?slashed//query");
-    }
-
-    private static void testDoubleSlashSuppression(String path, String normalizedPath) throws IOException {
-        testSocketOutput(
-                path,
-                port -> "GET " + normalizedPath + " HTTP/1.1\r\n" +
-                        "host: 127.0.0.1:" + port + "\r\n" +
-                        "user-agent: " + HttpHeaderUtil.USER_AGENT + "\r\n\r\n"
-        );
-    }
-
-    /**
      * :authority header should be overridden by ClientOption.HTTP_HEADER
      */
     @Test


### PR DESCRIPTION
Users may have a specific reason to use special escaping in a client request (it may be the contract of the server such as [here](https://cloud.google.com/storage/docs/json_api/#encoding)). While the client should make sure request paths are valid, it should not overwrite whatever escaping the user may have used.

A side effect is double slashes are sent as is instead of rewriting them to single slashes. It's conceivable that a server requires double slashes for whatever reason and the client should support it (grudgingly).

Fixes #1416 