### PR TITLE
Split RetryStrategy into RetryStrategy and RetryStrategyWithContent

### DIFF
--- a/benchmarks/src/jmh/java/com/linecorp/armeria/core/client/retry/WithDuplicator.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/core/client/retry/WithDuplicator.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.core.client.retry;
+
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.client.HttpClientBuilder;
+import com.linecorp.armeria.client.retry.RetryStrategyWithContent;
+import com.linecorp.armeria.client.retry.RetryingHttpClientBuilder;
+import com.linecorp.armeria.common.HttpResponse;
+
+@State(Scope.Benchmark)
+public class WithDuplicator extends RetryingHttpClientBase {
+
+    @Override
+    protected HttpClient newClient() {
+        final RetryStrategyWithContent<HttpResponse> retryStrategy =
+                (ctx, response) -> response.aggregate().handle((unused1, unused2) -> null);
+
+        return new HttpClientBuilder(baseUrl())
+                .decorator(new RetryingHttpClientBuilder(retryStrategy).newDecorator())
+                .build();
+    }
+}

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/core/client/retry/WithoutDuplicator.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/core/client/retry/WithoutDuplicator.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.core.client.retry;
+
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.client.HttpClientBuilder;
+import com.linecorp.armeria.client.retry.RetryStrategy;
+import com.linecorp.armeria.client.retry.RetryingHttpClient;
+
+@State(Scope.Benchmark)
+public class WithoutDuplicator extends RetryingHttpClientBase {
+
+    @Override
+    protected HttpClient newClient() {
+        return new HttpClientBuilder(baseUrl())
+                .decorator(RetryingHttpClient.newDecorator(RetryStrategy.never()))
+                .build();
+    }
+}

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/retrofit2/downstream/DownstreamSimpleBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/retrofit2/downstream/DownstreamSimpleBenchmark.java
@@ -33,7 +33,7 @@ import retrofit2.converter.jackson.JacksonConverterFactory;
 public class DownstreamSimpleBenchmark extends SimpleBenchmarkBase {
 
     @Override
-    protected SimpleBenchmarkClient client() {
+    protected SimpleBenchmarkClient newClient() {
         ClientFactory factory =
                 new ClientFactoryBuilder()
                         .sslContextCustomizer(ssl -> ssl.trustManager(InsecureTrustManagerFactory.INSTANCE))

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/retrofit2/upstream/UpstreamSimpleBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/retrofit2/upstream/UpstreamSimpleBenchmark.java
@@ -35,7 +35,7 @@ import retrofit2.converter.jackson.JacksonConverterFactory;
 public class UpstreamSimpleBenchmark extends SimpleBenchmarkBase {
 
     @Override
-    protected SimpleBenchmarkClient client() throws Exception {
+    protected SimpleBenchmarkClient newClient() throws Exception {
         SSLContext context = SSLContext.getInstance("TLS");
         context.init(null, InsecureTrustManagerFactory.INSTANCE.getTrustManagers(), null);
         OkHttpClient client = new OkHttpClient.Builder()

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClient.java
@@ -16,10 +16,13 @@
 
 package com.linecorp.armeria.client.circuitbreaker;
 
+import static com.google.common.base.Preconditions.checkState;
 import static com.linecorp.armeria.common.util.Functions.voidFunction;
 import static java.util.Objects.requireNonNull;
 
 import java.util.concurrent.CompletionStage;
+
+import javax.annotation.Nullable;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,7 +45,11 @@ public abstract class CircuitBreakerClient<I extends Request, O extends Response
 
     private static final Logger logger = LoggerFactory.getLogger(CircuitBreakerClient.class);
 
-    private final CircuitBreakerStrategy<O> strategy;
+    @Nullable
+    private final CircuitBreakerStrategy strategy;
+
+    @Nullable
+    private final CircuitBreakerStrategyWithContent<O> strategyWithContent;
 
     private final CircuitBreakerMapping mapping;
 
@@ -50,14 +57,48 @@ public abstract class CircuitBreakerClient<I extends Request, O extends Response
      * Creates a new instance that decorates the specified {@link Client}.
      */
     protected CircuitBreakerClient(Client<I, O> delegate, CircuitBreakerMapping mapping,
-                                   CircuitBreakerStrategy<O> strategy) {
-        super(delegate);
-        this.mapping = requireNonNull(mapping, "mapping");
-        this.strategy = requireNonNull(strategy, "strategy");
+                                   CircuitBreakerStrategy strategy) {
+        this(delegate, mapping, requireNonNull(strategy, "strategy"), null);
     }
 
-    protected final CircuitBreakerStrategy<O> strategy() {
+    /**
+     * Creates a new instance that decorates the specified {@link Client}.
+     */
+    protected CircuitBreakerClient(Client<I, O> delegate, CircuitBreakerMapping mapping,
+                                   CircuitBreakerStrategyWithContent<O> strategyWithContent) {
+        this(delegate, mapping, null, requireNonNull(strategyWithContent, "strategyWithContent"));
+    }
+
+    /**
+     * Creates a new instance that decorates the specified {@link Client}.
+     */
+    private CircuitBreakerClient(Client<I, O> delegate, CircuitBreakerMapping mapping,
+                                 @Nullable CircuitBreakerStrategy strategy,
+                                 @Nullable CircuitBreakerStrategyWithContent<O> strategyWithContent) {
+        super(delegate);
+        this.mapping = requireNonNull(mapping, "mapping");
+        this.strategy = strategy;
+        this.strategyWithContent = strategyWithContent;
+    }
+
+    /**
+     * Returns the {@link CircuitBreakerStrategy}.
+     *
+     * @throws IllegalStateException if the {@link CircuitBreakerStrategy} is not set
+     */
+    protected final CircuitBreakerStrategy strategy() {
+        checkState(strategy != null, "strategy is not set.");
         return strategy;
+    }
+
+    /**
+     * Returns the {@link CircuitBreakerStrategyWithContent}.
+     *
+     * @throws IllegalStateException if the {@link CircuitBreakerStrategyWithContent} is not set
+     */
+    protected final CircuitBreakerStrategyWithContent<O> strategyWithContent() {
+        checkState(strategyWithContent != null, "strategyWithContent is not set.");
+        return strategyWithContent;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClientBuilder.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.circuitbreaker;
+
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+import java.util.function.Function;
+
+import javax.annotation.Nullable;
+
+import com.google.common.base.MoreObjects;
+
+import com.linecorp.armeria.client.Client;
+import com.linecorp.armeria.common.Request;
+import com.linecorp.armeria.common.Response;
+
+/**
+ * Builds a new {@link CircuitBreakerClient} or its decorator function.
+ *
+ * @param <T> the type of {@link CircuitBreakerClientBuilder}
+ * @param <U> the type of the {@link Client} that this builder builds or decorates
+ * @param <I> the type of outgoing {@link Request} of the {@link Client}
+ * @param <O> the type of incoming {@link Response} of the {@link Client}
+ */
+public abstract class CircuitBreakerClientBuilder<
+        T extends CircuitBreakerClientBuilder<T, U, I, O>, U extends CircuitBreakerClient<I, O>,
+        I extends Request, O extends Response> {
+
+    @Nullable
+    private final CircuitBreakerStrategy strategy;
+
+    @Nullable
+    private final CircuitBreakerStrategyWithContent<O> strategyWithContent;
+
+    private CircuitBreakerMapping mapping = CircuitBreakerMapping.ofDefault();
+
+    /**
+     * Creates a new builder with the specified {@link CircuitBreakerStrategy}.
+     */
+    CircuitBreakerClientBuilder(CircuitBreakerStrategy strategy) {
+        this(requireNonNull(strategy, "strategy"), null);
+    }
+
+    /**
+     * Creates a new builder with the specified {@link CircuitBreakerStrategyWithContent}.
+     */
+    CircuitBreakerClientBuilder(CircuitBreakerStrategyWithContent<O> strategyWithContent) {
+        this(null, requireNonNull(strategyWithContent, "strategyWithContent"));
+    }
+
+    private CircuitBreakerClientBuilder(@Nullable CircuitBreakerStrategy strategy,
+                                        @Nullable CircuitBreakerStrategyWithContent<O> strategyWithContent) {
+        this.strategy = strategy;
+        this.strategyWithContent = strategyWithContent;
+    }
+
+    @SuppressWarnings("unchecked")
+    final T self() {
+        return (T) this;
+    }
+
+    CircuitBreakerStrategy strategy() {
+        checkState(strategy != null, "strategy is not set.");
+        return strategy;
+    }
+
+    CircuitBreakerStrategyWithContent<O> strategyWithContent() {
+        checkState(strategyWithContent != null, "strategyWithContent is not set.");
+        return strategyWithContent;
+    }
+
+    /**
+     * Sets the {@link CircuitBreakerMapping}. If unspecified, {@link CircuitBreakerMapping#ofDefault()}
+     * will be used.
+     *
+     * @return {@link T} to support method chaining.
+     */
+    public T circuitBreakerMapping(CircuitBreakerMapping mapping) {
+        this.mapping = requireNonNull(mapping, "mapping");
+        return self();
+    }
+
+    CircuitBreakerMapping circuitBreakerMapping() {
+        return mapping;
+    }
+
+    /**
+     * Returns a newly-created {@link CircuitBreakerClient} based on the properties of this builder.
+     */
+    abstract U build(Client<I, O> delegate);
+
+    /**
+     * Returns a newly-created decorator that decorates a {@link Client} with a new {@link CircuitBreakerClient}
+     * based on the properties of this builder.
+     */
+    abstract Function<Client<I, O>, U> newDecorator();
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).omitNullValues()
+                          .add("strategy", strategy)
+                          .add("strategyWithContent", strategyWithContent)
+                          .add("mapping", mapping)
+                          .toString();
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerHttpClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerHttpClientBuilder.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.circuitbreaker;
+
+import java.util.function.Function;
+
+import com.linecorp.armeria.client.Client;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+
+/**
+ * Builds a new {@link CircuitBreakerHttpClient} or its decorator function.
+ */
+public final class CircuitBreakerHttpClientBuilder extends CircuitBreakerClientBuilder<
+        CircuitBreakerHttpClientBuilder, CircuitBreakerHttpClient, HttpRequest, HttpResponse> {
+
+    private final boolean needsContentInStrategy;
+
+    /**
+     * Creates a new builder with the specified {@link CircuitBreakerStrategy}.
+     */
+    public CircuitBreakerHttpClientBuilder(CircuitBreakerStrategy strategy) {
+        super(strategy);
+        needsContentInStrategy = false;
+    }
+
+    /**
+     * Creates a new builder with the specified {@link CircuitBreakerStrategyWithContent}.
+     */
+    public CircuitBreakerHttpClientBuilder(
+            CircuitBreakerStrategyWithContent<HttpResponse> strategyWithContent) {
+        super(strategyWithContent);
+        needsContentInStrategy = true;
+    }
+
+    @Override
+    public CircuitBreakerHttpClient build(Client<HttpRequest, HttpResponse> delegate) {
+        if (needsContentInStrategy) {
+            return new CircuitBreakerHttpClient(delegate, circuitBreakerMapping(), strategyWithContent());
+        }
+
+        return new CircuitBreakerHttpClient(delegate, circuitBreakerMapping(), strategy());
+    }
+
+    @Override
+    public Function<Client<HttpRequest, HttpResponse>, CircuitBreakerHttpClient> newDecorator() {
+        return this::build;
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerMapping.java
@@ -16,7 +16,12 @@
 
 package com.linecorp.armeria.client.circuitbreaker;
 
+import static java.util.Objects.requireNonNull;
+
+import java.util.function.Function;
+
 import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.circuitbreaker.KeyedCircuitBreakerMapping.KeySelector;
 import com.linecorp.armeria.common.Request;
 
 /**
@@ -24,6 +29,43 @@ import com.linecorp.armeria.common.Request;
  */
 @FunctionalInterface
 public interface CircuitBreakerMapping {
+
+    /**
+     * Returns the default {@link CircuitBreakerMapping}.
+     */
+    static CircuitBreakerMapping ofDefault() {
+        return KeyedCircuitBreakerMapping.defaultMapping;
+    }
+
+    /**
+     * Creates a new {@link CircuitBreakerMapping} which maps {@link CircuitBreaker}s with method name.
+     *
+     * @param factory A function that takes a method name and creates a new {@link CircuitBreaker}
+     */
+    static CircuitBreakerMapping perMethod(Function<String, CircuitBreaker> factory) {
+        return new KeyedCircuitBreakerMapping<>(KeySelector.METHOD, requireNonNull(factory, "factory"));
+    }
+
+    /**
+     * Creates a new {@link CircuitBreakerMapping} which maps {@link CircuitBreaker}s with the remote host name.
+     *
+     * @param factory A function that takes a host name and creates a new {@link CircuitBreaker}
+     */
+    static CircuitBreakerMapping perHost(Function<String, CircuitBreaker> factory) {
+        return new KeyedCircuitBreakerMapping<>(KeySelector.HOST, requireNonNull(factory, "factory"));
+    }
+
+    /**
+     * Creates a new {@link CircuitBreakerMapping} which maps {@link CircuitBreaker}s with the remote host and
+     * method name.
+     *
+     * @param factory A function that takes the remote host and method name and
+     *                creates a new {@link CircuitBreaker}
+     */
+    static CircuitBreakerMapping perHostAndMethod(Function<String, CircuitBreaker> factory) {
+        return new KeyedCircuitBreakerMapping<>(KeySelector.HOST_AND_METHOD,
+                                                requireNonNull(factory, "factory"));
+    }
 
     /**
      * Returns the {@link CircuitBreaker} mapped to the given parameters.

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerRpcClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerRpcClientBuilder.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.circuitbreaker;
+
+import java.util.function.Function;
+
+import com.linecorp.armeria.client.Client;
+import com.linecorp.armeria.common.RpcRequest;
+import com.linecorp.armeria.common.RpcResponse;
+
+/**
+ * Builds a new {@link CircuitBreakerRpcClient} or its decorator function.
+ */
+public final class CircuitBreakerRpcClientBuilder extends CircuitBreakerClientBuilder<
+        CircuitBreakerRpcClientBuilder, CircuitBreakerRpcClient, RpcRequest, RpcResponse> {
+
+    /**
+     * Creates a new builder with the specified {@link CircuitBreakerStrategyWithContent}.
+     */
+    public CircuitBreakerRpcClientBuilder(CircuitBreakerStrategyWithContent<RpcResponse> strategyWithContent) {
+        super(strategyWithContent);
+    }
+
+    @Override
+    CircuitBreakerRpcClient build(Client<RpcRequest, RpcResponse> delegate) {
+        return new CircuitBreakerRpcClient(delegate, circuitBreakerMapping(), strategyWithContent());
+    }
+
+    @Override
+    Function<Client<RpcRequest, RpcResponse>, CircuitBreakerRpcClient> newDecorator() {
+        return this::build;
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerStrategyWithContent.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerStrategyWithContent.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.circuitbreaker;
+
+import java.util.concurrent.CompletionStage;
+
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.Response;
+
+/**
+ * Determines whether a {@link Response} should be reported as a success or a failure to a
+ * {@link CircuitBreaker} using the content of a {@link Response}. If you just need the {@link HttpHeaders}
+ * to make a decision, use {@link CircuitBreakerStrategy} for efficiency.
+ *
+ * @param <T> the response type
+ */
+@FunctionalInterface
+public interface CircuitBreakerStrategyWithContent<T extends Response> {
+
+    /**
+     * Returns a {@link CompletionStage} that contains {@code true}, {@code false} or
+     * {@code null} according to the specified {@link Response}.
+     * If {@code true} is returned, {@link CircuitBreaker#onSuccess()} is called so that the
+     * {@link CircuitBreaker} increases its success count and uses it to make a decision
+     * to close or open the circuit. If {@code false} is returned, it works the other way around.
+     * If {@code null} is returned, the {@link CircuitBreaker} ignores it.
+     *
+     * @param ctx the {@link ClientRequestContext} of this request
+     * @param response the {@link Response} from the server
+     */
+    CompletionStage<Boolean> shouldReportAsSuccess(ClientRequestContext ctx, T response);
+}

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/KeyedCircuitBreakerMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/KeyedCircuitBreakerMapping.java
@@ -36,6 +36,9 @@ import com.linecorp.armeria.common.RpcRequest;
  */
 public class KeyedCircuitBreakerMapping<K> implements CircuitBreakerMapping {
 
+    static final CircuitBreakerMapping defaultMapping =
+            new KeyedCircuitBreakerMapping<>(KeySelector.HOST, CircuitBreaker::of);
+
     private final ConcurrentMap<K, CircuitBreaker> mapping = new ConcurrentHashMap<>();
 
     private final KeySelector<K> keySelector;

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroup.java
@@ -48,7 +48,7 @@ public final class HttpHealthCheckedEndpointGroup extends HealthCheckedEndpointG
     /**
      * Creates a new {@link HttpHealthCheckedEndpointGroup} instance.
      *
-     * @deprecated use {@link HttpHealthCheckedEndpointGroupBuilder}
+     * @deprecated Use {@link HttpHealthCheckedEndpointGroupBuilder}.
      */
     @Deprecated
     public static HttpHealthCheckedEndpointGroup of(EndpointGroup delegate,
@@ -60,7 +60,7 @@ public final class HttpHealthCheckedEndpointGroup extends HealthCheckedEndpointG
     /**
      * Creates a new {@link HttpHealthCheckedEndpointGroup} instance.
      *
-     * @deprecated use {@link HttpHealthCheckedEndpointGroupBuilder}
+     * @deprecated Use {@link HttpHealthCheckedEndpointGroupBuilder}.
      */
     @Deprecated
     public static HttpHealthCheckedEndpointGroup of(ClientFactory clientFactory,

--- a/core/src/main/java/com/linecorp/armeria/client/retry/Backoff.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/Backoff.java
@@ -16,6 +16,7 @@
 package com.linecorp.armeria.client.retry;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.linecorp.armeria.client.retry.DefaultBackoffHolder.defaultBackoff;
 import static com.linecorp.armeria.client.retry.FixedBackoff.NO_DELAY;
 import static java.util.Objects.requireNonNull;
 
@@ -29,6 +30,14 @@ import java.util.function.Supplier;
  */
 @FunctionalInterface
 public interface Backoff {
+
+    /**
+     * Returns the default {@link Backoff}.
+     */
+    static Backoff ofDefault() {
+        return defaultBackoff;
+    }
+
     /**
      * Returns a {@link Backoff} that will never wait between attempts. In most cases, using back off
      * without delay is very dangerous. Please consider using {@link #exponential(long, long)} with

--- a/core/src/main/java/com/linecorp/armeria/client/retry/DefaultBackoffHolder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/DefaultBackoffHolder.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.retry;
+
+import com.linecorp.armeria.common.Flags;
+
+final class DefaultBackoffHolder {
+
+    static final Backoff defaultBackoff = Backoff.of(Flags.defaultBackoffSpec());
+
+    private DefaultBackoffHolder() {}
+}

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryStrategy.java
@@ -21,48 +21,53 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.BiFunction;
 
+import javax.annotation.Nullable;
+
+import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.ResponseTimeoutException;
 import com.linecorp.armeria.client.UnprocessedRequestException;
 import com.linecorp.armeria.client.circuitbreaker.FailFastException;
-import com.linecorp.armeria.common.Flags;
-import com.linecorp.armeria.common.HttpRequest;
-import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.HttpStatusClass;
-import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
 import com.linecorp.armeria.common.util.Exceptions;
 
 /**
  * Determines whether a failed request should be retried.
- * @param <I> the request type
- * @param <O> the response type
+ * If you need to determine by looking into the {@link Response}, use {@link RetryStrategyWithContent}.
  */
 @FunctionalInterface
-public interface RetryStrategy<I extends Request, O extends Response> {
+public interface RetryStrategy {
 
-    Backoff defaultBackoff = Backoff.of(Flags.defaultBackoffSpec());
+    /**
+     * The default {@link Backoff} implementation.
+     *
+     * @deprecated Use {@link Backoff#ofDefault()}.
+     */
+    @Deprecated
+    Backoff defaultBackoff = Backoff.ofDefault();
 
     /**
      * A {@link RetryStrategy} that defines a retry should not be performed.
      */
-    static <I extends Request, O extends Response> RetryStrategy<I, O> never() {
-        return (request, response) -> CompletableFuture.completedFuture(null);
+    static RetryStrategy never() {
+        return (ctx, cause) -> CompletableFuture.completedFuture(null);
     }
 
     /**
      * A {@link RetryStrategy} that retries only on {@link UnprocessedRequestException} with
-     * the {@link #defaultBackoff}..
+     * the {@link Backoff#ofDefault()}.
      */
-    static RetryStrategy<HttpRequest, HttpResponse> onUnprocessed() {
-        return onUnprocessed(defaultBackoff);
+    static RetryStrategy onUnprocessed() {
+        return onUnprocessed(Backoff.ofDefault());
     }
 
     /**
      * A {@link RetryStrategy} that retries only on {@link UnprocessedRequestException} with the specified
      * {@link Backoff}.
      */
-    static RetryStrategy<HttpRequest, HttpResponse> onUnprocessed(Backoff backoff) {
+    static RetryStrategy onUnprocessed(Backoff backoff) {
         requireNonNull(backoff, "backoff");
         return onStatus((status, thrown) -> {
             if (thrown != null && Exceptions.peel(thrown) instanceof UnprocessedRequestException) {
@@ -73,18 +78,18 @@ public interface RetryStrategy<I extends Request, O extends Response> {
     }
 
     /**
-     * Returns the {@link RetryStrategy} that retries the request with the {@link #defaultBackoff}
-     * when the response matches {@link HttpStatusClass#SERVER_ERROR} or an {@link Exception} is raised.
+     * Returns the {@link RetryStrategy} that retries the request with the {@link Backoff#ofDefault()}
+     * when the response status matches {@link HttpStatusClass#SERVER_ERROR} or an {@link Exception} is raised.
      */
-    static RetryStrategy<HttpRequest, HttpResponse> onServerErrorStatus() {
-        return onServerErrorStatus(defaultBackoff);
+    static RetryStrategy onServerErrorStatus() {
+        return onServerErrorStatus(Backoff.ofDefault());
     }
 
     /**
      * Returns the {@link RetryStrategy} that retries the request with the specified {@code backoff}
-     * when the response matches {@link HttpStatusClass#SERVER_ERROR} or an {@link Exception} is raised.
+     * when the response status matches {@link HttpStatusClass#SERVER_ERROR} or an {@link Exception} is raised.
      */
-    static RetryStrategy<HttpRequest, HttpResponse> onServerErrorStatus(Backoff backoff) {
+    static RetryStrategy onServerErrorStatus(Backoff backoff) {
         requireNonNull(backoff, "backoff");
         return onStatus((status, thrown) -> {
             if ((thrown != null && !(Exceptions.peel(thrown) instanceof FailFastException)) ||
@@ -102,7 +107,7 @@ public interface RetryStrategy<I extends Request, O extends Response> {
      * @param backoffFunction the {@link BiFunction} that returns the {@link Backoff} or {@code null}
      *                        according to the {@link HttpStatus} and {@link Throwable}
      */
-    static RetryStrategy<HttpRequest, HttpResponse> onStatus(
+    static RetryStrategy onStatus(
             BiFunction<HttpStatus, Throwable, Backoff> backoffFunction) {
         // TODO(trustin): Apply a different backoff for UnprocessedRequestException.
         return new HttpStatusBasedRetryStrategy(backoffFunction);
@@ -111,12 +116,32 @@ public interface RetryStrategy<I extends Request, O extends Response> {
     /**
      * Returns a {@link CompletionStage} that contains {@link Backoff} which will be used for retry.
      * If the condition does not match, this will return {@code null} to stop retry attempt.
-     * Note that {@link ResponseTimeoutException} is not retriable for the whole retry, but each attempt.
+     * Note that {@link ResponseTimeoutException} is not retriable for the whole retry,
+     * but only for each attempt.
+     * To retrieve the response {@link HttpHeaders}, you can use the specified {@link ClientRequestContext}:
+     *
+     * <pre>{@code
+     * CompletionStage<Backoff> shouldRetry(ClientRequestContext ctx, @Nullable Throwable cause) {
+     *     if (cause != null) {
+     *         return CompletableFuture.completedFuture(backoff);
+     *     }
+     *
+     *     HttpHeaders responseHeaders = ctx.log().responseHeaders();
+     *     if (responseHeaders.status().codeClass() == HttpStatusClass.SERVER_ERROR) {
+     *         return CompletableFuture.completedFuture(backoff);
+     *     }
+     *     ...
+     * }
+     * }</pre>
+     *
+     * @param ctx the {@link ClientRequestContext} of this request
+     * @param cause the {@link Throwable} which is raised while sending a request. {@code null} it there's no
+     *              exception.
      *
      * @see RetryingClientBuilder#responseTimeoutMillisForEachAttempt(long)
      *
      * @see <a href="https://line.github.io/armeria/advanced-retry.html#per-attempt-timeout">Per-attempt
      *      timeout</a>
      */
-    CompletionStage<Backoff> shouldRetry(I request, O response);
+    CompletionStage<Backoff> shouldRetry(ClientRequestContext ctx, @Nullable Throwable cause);
 }

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryStrategyWithContent.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryStrategyWithContent.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.retry;
+
+import java.util.concurrent.CompletionStage;
+
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.ResponseTimeoutException;
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.Response;
+
+/**
+ * Determines whether a failed request should be retried using the content of a {@link Response}.
+ * If you just need the {@link HttpHeaders} to make a decision, use {@link RetryStrategy} for efficiency.
+ *
+ * @param <T> the response type
+ */
+@FunctionalInterface
+public interface RetryStrategyWithContent<T extends Response> {
+
+    /**
+     * Returns a {@link CompletionStage} that contains {@link Backoff} which will be used for retry.
+     * If the condition does not match, this will return {@code null} to stop retry attempt.
+     * Note that {@link ResponseTimeoutException} is not retriable for the whole retry,
+     * but only for each attempt.
+     *
+     * @param ctx the {@link ClientRequestContext} of this request
+     * @param response the {@link Response} from the server
+     *
+     * @see RetryingClientBuilder#responseTimeoutMillisForEachAttempt(long)
+     *
+     * @see <a href="https://line.github.io/armeria/advanced-retry.html#per-attempt-timeout">Per-attempt
+     *      timeout</a>
+     */
+    CompletionStage<Backoff> shouldRetry(ClientRequestContext ctx, T response);
+}

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClientBuilder.java
@@ -29,11 +29,10 @@ public class RetryingRpcClientBuilder
         extends RetryingClientBuilder<RetryingRpcClientBuilder, RetryingRpcClient, RpcRequest, RpcResponse> {
 
     /**
-     * Creates a new builder with the specified retry strategy.
+     * Creates a new builder with the specified {@link RetryStrategyWithContent}.
      */
-    public RetryingRpcClientBuilder(
-            RetryStrategy<RpcRequest, RpcResponse> retryStrategy) {
-        super(retryStrategy);
+    public RetryingRpcClientBuilder(RetryStrategyWithContent<RpcResponse> retryStrategyWithContent) {
+        super(retryStrategyWithContent);
     }
 
     /**
@@ -42,7 +41,8 @@ public class RetryingRpcClientBuilder
     @Override
     public RetryingRpcClient build(Client<RpcRequest, RpcResponse> delegate) {
         return new RetryingRpcClient(
-                delegate, retryStrategy, maxTotalAttempts, responseTimeoutMillisForEachAttempt);
+                delegate, retryStrategyWithContent(), maxTotalAttempts(),
+                responseTimeoutMillisForEachAttempt());
     }
 
     /**
@@ -51,8 +51,6 @@ public class RetryingRpcClientBuilder
      */
     @Override
     public Function<Client<RpcRequest, RpcResponse>, RetryingRpcClient> newDecorator() {
-        return delegate ->
-                new RetryingRpcClient(
-                        delegate, retryStrategy, maxTotalAttempts, responseTimeoutMillisForEachAttempt);
+        return this::build;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/HttpHeaderNames.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpHeaderNames.java
@@ -254,7 +254,7 @@ public final class HttpHeaderNames {
     /**
      * {@code "keep-alive"}.
      *
-     * @deprecated Use {@link #CONNECTION} instead.
+     * @deprecated Use {@link #CONNECTION}.
      */
     @Deprecated
     public static final AsciiString KEEP_ALIVE = AsciiString.cached("keep-alive");
@@ -297,7 +297,7 @@ public final class HttpHeaderNames {
     /**
      * {@code "proxy-connection"}.
      *
-     * @deprecated Use {@link #CONNECTION} instead.
+     * @deprecated Use {@link #CONNECTION}.
      */
     @Deprecated
     public static final AsciiString PROXY_CONNECTION = AsciiString.cached("proxy-connection");

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -336,7 +336,7 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
     /**
      * Creates a new failed HTTP response.
      *
-     * @deprecated Use {@link #ofFailure(Throwable)} instead.
+     * @deprecated Use {@link #ofFailure(Throwable)}.
      */
     @Deprecated
     static HttpResponse ofFailed(Throwable cause) {

--- a/core/src/main/java/com/linecorp/armeria/common/Response.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Response.java
@@ -32,7 +32,7 @@ public interface Response {
      * 1) the response stream has been closed (the {@link StreamMessage} has been completed) or
      * 2) the result value is set (the {@link CompletionStage} has completed.)
      *
-     * @deprecated Use {@link #completionFuture()} instead.
+     * @deprecated Use {@link #completionFuture()}.
      */
     @Deprecated
     default CompletableFuture<?> closeFuture() {

--- a/core/src/main/java/com/linecorp/armeria/internal/ClientUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/ClientUtil.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.function.BiFunction;
+
+import com.linecorp.armeria.client.Client;
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.common.Request;
+import com.linecorp.armeria.common.Response;
+import com.linecorp.armeria.common.logging.RequestLogAvailability;
+import com.linecorp.armeria.common.logging.RequestLogBuilder;
+import com.linecorp.armeria.common.util.SafeCloseable;
+
+public final class ClientUtil {
+
+    public static <I extends Request, O extends Response, U extends Client<I, O>> O executeWithFallback(
+            U delegate, ClientRequestContext ctx, I req,
+            BiFunction<ClientRequestContext, Throwable, O> fallback) {
+        requireNonNull(delegate, "delegate");
+        requireNonNull(ctx, "ctx");
+        requireNonNull(req, "req");
+        requireNonNull(fallback, "fallback");
+
+        try (SafeCloseable ignored = ctx.push()) {
+            return delegate.execute(ctx, req);
+        } catch (Throwable cause) {
+            final O fallbackRes = fallback.apply(ctx, cause);
+            final RequestLogBuilder logBuilder = ctx.logBuilder();
+            if (!ctx.log().isAvailable(RequestLogAvailability.REQUEST_START)) {
+                // An exception is raised even before sending a request, so end the request with the exception.
+                logBuilder.endRequest(cause);
+            }
+            logBuilder.endResponse(cause);
+            return fallbackRes;
+        }
+    }
+
+    private ClientUtil() {}
+}

--- a/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerHttpClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerHttpClientTest.java
@@ -19,6 +19,7 @@ package com.linecorp.armeria.client.circuitbreaker;
 import static com.linecorp.armeria.common.SessionProtocol.H2C;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -26,8 +27,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import com.google.common.testing.FakeTicker;
@@ -37,11 +40,16 @@ import com.linecorp.armeria.client.ClientOptions;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.DefaultClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.client.HttpClientBuilder;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.HttpStatusClass;
 import com.linecorp.armeria.common.metric.NoopMeterRegistry;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.testing.server.ServerRule;
 
 import io.netty.channel.DefaultEventLoop;
 
@@ -54,6 +62,14 @@ public class CircuitBreakerHttpClientTest {
             Endpoint.of("dummyhost", 8080),
             HttpMethod.GET, "/", null, null, ClientOptions.DEFAULT, mock(HttpRequest.class));
 
+    @ClassRule
+    public static final ServerRule server = new ServerRule() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.service("/unavailable", (ctx, req) -> HttpResponse.of(HttpStatus.SERVICE_UNAVAILABLE));
+        }
+    };
+
     @Test
     public void testPerMethodDecorator() {
         final CircuitBreaker circuitBreaker = mock(CircuitBreaker.class);
@@ -65,7 +81,7 @@ public class CircuitBreakerHttpClientTest {
 
         final int COUNT = 2;
         failFastInvocation(CircuitBreakerHttpClient.newPerMethodDecorator(factory, strategy()),
-                           ctx.method(), COUNT);
+                           HttpMethod.GET, COUNT);
 
         verify(circuitBreaker, times(COUNT)).canRequest();
         verify(factory, times(1)).apply("GET");
@@ -82,7 +98,7 @@ public class CircuitBreakerHttpClientTest {
 
         final int COUNT = 2;
         failFastInvocation(CircuitBreakerHttpClient.newPerHostDecorator(factory, strategy()),
-                           ctx.method(), COUNT);
+                           HttpMethod.GET, COUNT);
 
         verify(circuitBreaker, times(COUNT)).canRequest();
         verify(factory, times(1)).apply("dummyhost:8080");
@@ -99,14 +115,28 @@ public class CircuitBreakerHttpClientTest {
 
         final int COUNT = 2;
         failFastInvocation(CircuitBreakerHttpClient.newPerHostAndMethodDecorator(factory, strategy()),
-                           ctx.method(), COUNT);
+                           HttpMethod.GET, COUNT);
 
         verify(circuitBreaker, times(COUNT)).canRequest();
         verify(factory, times(1)).apply("dummyhost:8080#GET");
     }
 
     @Test
-    public void circuitBreakerIsOpenOnServerError() throws Exception {
+    public void strategyWithoutContent() throws Exception {
+        final CircuitBreakerStrategy strategy = CircuitBreakerStrategy.onServerErrorStatus();
+        circuitBreakerIsOpenOnServerError(new CircuitBreakerHttpClientBuilder(strategy));
+    }
+
+    @Test
+    public void strategyWithContent() throws Exception {
+        final CircuitBreakerStrategyWithContent<HttpResponse> strategy =
+                (ctx, response) -> response.aggregate().handle(
+                        (msg, unused1) -> msg.status().codeClass() != HttpStatusClass.SERVER_ERROR);
+        circuitBreakerIsOpenOnServerError(new CircuitBreakerHttpClientBuilder(strategy));
+    }
+
+    private static void circuitBreakerIsOpenOnServerError(CircuitBreakerHttpClientBuilder builder)
+            throws Exception {
         final FakeTicker ticker = new FakeTicker();
         final int minimumRequestThreshold = 2;
         final Duration circuitOpenWindow = Duration.ofSeconds(60);
@@ -129,21 +159,23 @@ public class CircuitBreakerHttpClientTest {
                                             .thenReturn(HttpResponse.of(503));
 
         final CircuitBreakerMapping mapping = (ctx, req) -> circuitBreaker;
-        final CircuitBreakerHttpClient stub = new CircuitBreakerHttpClient(
-                delegate, mapping, CircuitBreakerStrategy.onServerErrorStatus());
+        final HttpClient client = new HttpClientBuilder(server.uri("/"))
+                .decorator(builder.circuitBreakerMapping(mapping).newDecorator())
+                .build();
 
         // CLOSED
         for (int i = 0; i < minimumRequestThreshold + 1; i++) {
             // Need to call execute() one more to change the state of the circuit breaker.
 
-            assertThat(stub.execute(ctx, mock(HttpRequest.class)).aggregate().join().headers().status())
+            assertThat(client.get("/unavailable").aggregate().join().headers().status())
                     .isSameAs(HttpStatus.SERVICE_UNAVAILABLE);
             ticker.advance(Duration.ofMillis(1).toNanos());
         }
 
+        await().untilAsserted(() -> assertThat(circuitBreaker.canRequest()).isFalse());
         // OPEN
-        assertThatThrownBy(() -> stub.execute(ctx, mock(HttpRequest.class)))
-                .isInstanceOf(FailFastException.class);
+        assertThatThrownBy(() -> client.get("/unavailable").aggregate().join())
+                .hasCauseExactlyInstanceOf(FailFastException.class);
     }
 
     private static void failFastInvocation(
@@ -171,7 +203,7 @@ public class CircuitBreakerHttpClientTest {
      * Returns a {@link CircuitBreakerStrategy} which returns {@code true} when there's
      * no {@link Exception} raised.
      */
-    private static CircuitBreakerStrategy<HttpResponse> strategy() {
-        return response -> response.aggregate().handle((res, cause) -> cause == null);
+    private static CircuitBreakerStrategy strategy() {
+        return (ctx, cause) -> CompletableFuture.completedFuture(cause == null);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerRpcClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerRpcClientTest.java
@@ -297,7 +297,7 @@ public class CircuitBreakerRpcClientTest {
      * Returns a {@link CircuitBreakerStrategy} which returns {@code true} when there's
      * no {@link Exception} raised.
      */
-    private static CircuitBreakerStrategy<RpcResponse> strategy() {
-        return response -> response.completionFuture().handle((res, cause) -> cause == null);
+    private static CircuitBreakerStrategyWithContent<RpcResponse> strategy() {
+        return (ctx, response) -> response.handle((unused, cause) -> cause == null);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryingHttpClientBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryingHttpClientBuilderTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.retry;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.Test;
+
+import com.linecorp.armeria.common.HttpResponse;
+
+public class RetryingHttpClientBuilderTest {
+
+    @Test
+    public void cannotSetContentPreviewLengthWhenRetryStrategyIsUsed() {
+        final RetryStrategy strategy = (ctx, cause) -> CompletableFuture.completedFuture(null);
+        assertThatThrownBy(() -> new RetryingHttpClientBuilder(strategy).contentPreviewLength(1024))
+                .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void contentPreviewLengthCannotBeZero() {
+        final RetryStrategyWithContent<HttpResponse> strategy =
+                (ctx, response) -> response.aggregate().handle((unused1, unused2) -> null);
+        assertThatThrownBy(() -> new RetryingHttpClientBuilder(strategy).contentPreviewLength(0))
+                .isExactlyInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/site/src/sphinx/client-retry.rst
+++ b/site/src/sphinx/client-retry.rst
@@ -25,6 +25,7 @@ You can just use the ``decorator()`` method in :api:`ClientBuilder` to build a :
     import com.linecorp.armeria.client.HttpClient;
     import com.linecorp.armeria.client.retry.RetryingHttpClient;
     import com.linecorp.armeria.client.retry.RetryStrategy;
+    import com.linecorp.armeria.common.AggregatedHttpMessage;
     import com.linecorp.armeria.common.HttpRequest;
     import com.linecorp.armeria.common.HttpResponse;
 
@@ -34,7 +35,7 @@ You can just use the ``decorator()`` method in :api:`ClientBuilder` to build a :
                        RetryingHttpClient.newDecorator(strategy))
             .build(HttpClient.class);
 
-    client.execute(...).aggregate().join();
+    final AggregatedHttpMessage res = client.execute(...).aggregate().join();
 
 or even simply,
 
@@ -47,7 +48,7 @@ or even simply,
             .decorator(RetryingHttpClient.newDecorator(strategy))
             .build();
 
-    client.execute(...).aggregate().join();
+    final AggregatedHttpMessage res = client.execute(...).aggregate().join();
 
 That's it. The client will keep attempting until it succeeds or the number of attempts exceeds the maximum
 number of total attempts. You can configure the ``maxTotalAttempts`` when making the decorator using
@@ -64,24 +65,30 @@ You can customize the ``strategy`` by implementing :api:`RetryStrategy`.
 
 .. code-block:: java
 
+    import com.linecorp.armeria.client.ClientRequestContext;
+    import com.linecorp.armeria.client.ResponseTimeoutException;
+    import com.linecorp.armeria.client.UnprocessedRequestException;
     import com.linecorp.armeria.client.retry.Backoff;
     import com.linecorp.armeria.common.HttpStatus;
 
-    new RetryStrategy<HttpRequest, HttpResponse>() {
-        final Backoff backoff = RetryStrategy.defaultBackoff;
+    new RetryStrategy() {
+        final Backoff backoff = Backoff.ofDefault();
 
         @Override
-        public CompletionStage<Backoff> shouldRetry(HttpRequest request, HttpResponse response) {
-            return response.aggregate().handle((result, cause) -> { // Do not use get() or join()!
-                if (cause != null) {
-                    if (cause instanceof ResponseTimeoutException) {
-                        return backoff;
-                    }
-                } else if (result.headers().status() == HttpStatus.CONFLICT) {
-                    return backoff;
+        public CompletionStage<Backoff> shouldRetry(ClientRequestContext ctx, @Nullable Throwable cause) {
+            if (cause != null) {
+                if (cause instanceof ResponseTimeoutException ||
+                    cause instanceof UnprocessedRequestException) {
+                    // The response timed out or the request has not been handled by the server.
+                    return CompletableFuture.completedFuture(backoff);
                 }
-                return null; // Return no backoff to stop retrying.
-            });
+            }
+
+            if (ctx.log().responseHeaders().status() == HttpStatus.CONFLICT) {
+                return CompletableFuture.completedFuture(backoff);
+            }
+
+            return CompletableFuture.completedFuture(null); // Return null to stop retrying.
         }
     };
 
@@ -98,33 +105,71 @@ This will retry when the response's status is ``409 Conflict`` or :api:`Response
     :api:`Backoff` yields a different delay based on the number of retries, such as an exponential backoff,
     it will not work as expected. We will take a close look into a :api:`Backoff` at the next section.
 
-You can return a different :api:`Backoff` according to the response.
+You can return a different :api:`Backoff` according to the response status.
 
 .. code-block:: java
 
-    import com.linecorp.armeria.client.ResponseTimeoutException;
     import com.linecorp.armeria.common.HttpStatusClass;
 
-    new RetryStrategy<HttpRequest, HttpResponse>() {
-        final Backoff backoffOnServerErrorOrTimeout = RetryStrategy.defaultBackoff;
+    new RetryStrategy() {
+        final Backoff backoffOnServerErrorOrTimeout = Backoff.ofDefault();
         final Backoff backoffOnConflict = Backoff.fixed(100);
 
         @Override
-        public CompletionStage<Backoff> shouldRetry(HttpRequest request, HttpResponse response) {
-            return response.aggregate().handle((result, cause) -> {
-                if (cause != null) {
-                    if (cause instanceof ResponseTimeoutException) {
-                        return backoffOnServerErrorOrTimeout;
-                    }
-                } else if (result.headers().status().codeClass() == HttpStatusClass.SERVER_ERROR) {
-                    return backoffOnServerErrorOrTimeout;
-                } else if (result.headers().status() == HttpStatus.CONFLICT) {
-                    return backoffOnConflict;
+        public CompletionStage<Backoff> shouldRetry(ClientRequestContext ctx, @Nullable Throwable cause) {
+            if (cause != null) {
+                if (cause instanceof ResponseTimeoutException ||
+                    cause instanceof UnprocessedRequestException) {
+                    // The response timed out or the request has not been handled by the server.
+                    return CompletableFuture.completedFuture(backoffOnServerErrorOrTimeout);
                 }
-                return null;
+            }
+
+            HttpStatus status = ctx.log().responseHeaders().status();
+            if (status.codeClass() == HttpStatusClass.SERVER_ERROR) {
+                return CompletableFuture.completedFuture(backoffOnServerErrorOrTimeout);
+            } else if (status == HttpStatus.CONFLICT) {
+                return CompletableFuture.completedFuture(backoffOnConflict);
+            }
+
+            return CompletableFuture.completedFuture(null); // Return null to stop retrying.
+        }
+    };
+
+If you need to determine whether you need to retry by looking into the response content, you should implement
+:api:`RetryStrategyWithContent` and specify it when you create an :api:`HttpClient`
+using :api:`RetryingHttpClientBuilder`:
+
+.. code-block:: java
+
+    import com.linecorp.armeria.client.retry.RetryingHttpClientBuilder;
+    import com.linecorp.armeria.client.retry.RetryStrategyWithContent;
+
+    final RetryStrategyWithContent<HttpResponse> strategy = new RetryStrategyWithContent<HttpResponse>() {
+        final Backoff backoff = Backoff.ofDefault();
+
+        @Override
+        public CompletionStage<Backoff> shouldRetry(ClientRequestContext ctx, HttpResponse response) {
+            return response.aggregate().handle((result, thrown) -> {
+                if (thrown != null) {
+                    if (thrown instanceof ResponseTimeoutException ||
+                        thrown instanceof UnprocessedRequestException) {
+                        // The response timed out or the request has not been handled by the server.
+                        return backoff;
+                    }
+                } else if ("Should I retry?".equals(result.content().toStringUtf8())) {
+                    return backoff;
+                }
+                return null; // Return null to stop retrying.
             });
         }
     };
+
+    final HttpClient client = new HttpClientBuilder(...)
+            .decorator(new RetryingHttpClientBuilder(strategy).newDecorator()) // Specify the strategy.
+            .build();
+
+    final AggregatedHttpMessage res = client.execute(...).aggregate().join();
 
 ``Backoff``
 -----------
@@ -136,7 +181,7 @@ implementations which produce the following delays out of the box:
 - Random delay, created with ``Backoff.random()``
 - Exponential delay which is multiplied on each attempt, created with ``Backoff.exponential()``
 
-Armeria provides ``RetryStrategy.defaultBackoff`` that you might use by default. It is exactly the same as:
+Armeria provides ``Backoff.ofDefault()`` that you might use by default. It is exactly the same as:
 
 .. code-block:: java
 


### PR DESCRIPTION
Motivation:
When using `RetryingHttpClient`, we use `HttpResponseDuplicator` to duplicate the `HttpResponse` in order to determine to retry or not.
However, in most cases, we just need the response headers to decide and don't need the content.
If we see the content only when we really have to, we can minimize the usage of duplicator which reduces the performance. This approach works for `CircuitBreakerHttpClient` as well.

Modifications:
- Change the method of `RetryStrategy` to `shouldRetry(RequestContext ctx, Throwable cause)`
- Add `RetryStrategyWithContent`
- Add `CircuitBreakerClientBuiler`
- Change the method of `CircuitBreakerStrategy` to `shouldReportAsSuccess(RequestContext ctx, Throwable cause)`
- Add `CircuitBreakerStrategyWithContent`
- Add a benchmark to see the difference between using `Duplicator` and without it

Result:
- Better performance
```
Benchmark                 Mode  Cnt      Score     Error  Units
WithDuplicator.empty     thrpt  100  87399.115 ± 101.651  ops/s
WithoutDuplicator.empty  thrpt  100  91787.170 ±  73.129  ops/s
```
- Close #1408

Todo:
- Change `FixedStreamMessage` duplicable
- Don't let `RetryingHttpClient` use `HttpRequestDuplicator` when the content-length is zero