### PR TITLE
Make Armeria builds on Java 11

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -77,9 +77,11 @@ if (project.hasFlags('coverage')) {
     }
 }
 
-tasks.trimShadedJar.configure {
-    keep "class !com.linecorp.armeria.internal.shaded.**,com.linecorp.armeria.** { *; }"
-    // Do not optimize the dependencies that access some fields via sun.misc.Unsafe or reflection only.
-    keep "class com.linecorp.armeria.internal.shaded.caffeine.** { *; }"
-    keep "class com.linecorp.armeria.internal.shaded.jctools.** { *; }"
+if (tasks.findByName('trimShadedJar')) {
+    tasks.trimShadedJar.configure {
+        keep "class !com.linecorp.armeria.internal.shaded.**,com.linecorp.armeria.** { *; }"
+        // Do not optimize the dependencies that access some fields via sun.misc.Unsafe or reflection only.
+        keep "class com.linecorp.armeria.internal.shaded.caffeine.** { *; }"
+        keep "class com.linecorp.armeria.internal.shaded.jctools.** { *; }"
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,3 +23,5 @@ publishSignatureRequired=true
 # Gradle options
 org.gradle.jvmargs=-Xmx1280m
 org.gradle.configureondemand=true
+## Disable TLSv1.3 because it triggers handshake failures on some hosts we access.
+systemProp.https.protocols=TLSv1,TLSv1.1,TLSv1.2

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,11 +2,16 @@ rootProject.name = 'armeria'
 
 apply from: "${rootDir}/gradle/scripts/settings-flags.gradle"
 
+// TODO(trustin): Remove this once ProGuard 6.1 is out.
+// Do not trim for Java 11+ because ProGuard does not support Java 11 yet.
+// See: https://sourceforge.net/p/proguard/feature-requests/188/
+def trimFlag = JavaVersion.current() <= JavaVersion.VERSION_1_10 ? 'trim' : 'notrim'
+
 // Published BOM projects
 includeWithFlags ':bom',                       'bom'
 
 // Published Java projects
-includeWithFlags ':core',                       'java', 'publish', 'shade', 'trim'
+includeWithFlags ':core',                       'java', 'publish', 'shade', trimFlag
 includeWithFlags ':rxjava',                     'java', 'publish', 'relocate'
 includeWithFlags ':grpc',                       'java', 'publish', 'relocate'
 includeWithFlags ':jetty',                      'java', 'publish', 'relocate'


### PR DESCRIPTION
Motivation:

- A developer should be able to build Armeria on Java 11.

Modifications:

- Disable ProGuard if Java version is 11+.
  - Release still must be done on Java 10 to trim the shaded JAR.
- Disable TLSv1.3 so that handshake failures do not occur when
  retrieving package-list files.

Result:

- Armeria builds fine on Java 11.