### PR TITLE
Reduce unnecessary event loop task queueing

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
@@ -469,7 +469,7 @@ final class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
 
                 @Override
                 public void onComplete() {}
-            });
+            }, ctx.channel().eventLoop());
 
             // NB: No need to set the response timeout because we have session creation timeout.
             responseDecoder.addResponse(0, null, res, RequestLogBuilder.NOOP, 0, UPGRADE_RESPONSE_MAX_LENGTH);

--- a/core/src/main/java/com/linecorp/armeria/client/HttpRequestSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpRequestSubscriber.java
@@ -138,7 +138,7 @@ final class HttpRequestSubscriber implements Subscriber<HttpObject>, ChannelFutu
         // NB: This must be invoked at the end of this method because otherwise the callback methods in this
         //     class can be called before the member fields (subscription and timeoutFuture) are initialized.
         //     It is because the successful write of the first headers will trigger subscription.request(1).
-        eventLoop.execute(this::writeFirstHeader);
+        writeFirstHeader();
     }
 
     private void writeFirstHeader() {
@@ -263,7 +263,7 @@ final class HttpRequestSubscriber implements Subscriber<HttpObject>, ChannelFutu
             state = State.DONE;
         }
 
-        ch.eventLoop().execute(() -> write0(o, endOfStream, flush));
+        write0(o, endOfStream, flush);
     }
 
     private void write0(HttpObject o, boolean endOfStream, boolean flush) {

--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
@@ -283,10 +283,6 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject>, RequestTim
             setDone();
         }
 
-        ctx.channel().eventLoop().execute(() -> write0(o, endOfStream));
-    }
-
-    private void write0(HttpObject o, boolean endOfStream) {
         final ChannelFuture future;
         final boolean wroteEmptyData;
         if (o instanceof HttpData) {


### PR DESCRIPTION
Motivation:

- We always specify the current event loop when subscribing to a
  user-provided `HttpRequest` or `HttpResponse`. Therefore, we do not
  really need to use `EventLoop.execute()` anywhere in
  `Http(Request|Response)Subscriber`.
- We forgot to specify the event loop when subscribing to the response
  of the HTTP/1-to-2 upgrade request. As a result, we subscribe using
  `CommonPools.workerGroup()` which is not optimal.

Modifications:

- Do not use `EventLoop.execute()` in `Http(Request|Response)Subscriber`.
  - This change triggered an issue where `412 Request Entity Too Large`
    response is not sent due to a slight change in event ordering.
- Specify corrent `EventLoop` when subscribing to HTTP/1-to-2 upgrade
  responses in `HttpClientPipelineConfigurator`.

Result:

This pull request improves the overall throughput by approximately 10%
by reducing task execution latency and garbage creation.