### PR TITLE
Set RequestLog wall time in micros and use RequestLog timestamps for s…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
@@ -29,10 +29,13 @@ import static com.linecorp.armeria.common.logging.RequestLogAvailability.RESPONS
 import static com.linecorp.armeria.common.logging.RequestLogAvailability.SCHEME;
 import static java.util.Objects.requireNonNull;
 
+import java.time.Clock;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.function.Function;
 
@@ -88,14 +91,14 @@ public class DefaultRequestLog implements RequestLog, RequestLogBuilder {
     private volatile boolean requestContentDeferred;
     private volatile boolean responseContentDeferred;
 
-    private long requestStartTimeMillis;
+    private long requestStartTimeMicros;
     private long requestStartTimeNanos;
     private long requestEndTimeNanos;
     private long requestLength;
     @Nullable
     private Throwable requestCause;
 
-    private long responseStartTimeMillis;
+    private long responseStartTimeMicros;
     private long responseStartTimeNanos;
     private long responseEndTimeNanos;
     private long responseLength;
@@ -149,7 +152,7 @@ public class DefaultRequestLog implements RequestLog, RequestLogBuilder {
 
     private void propagateRequestSideLog(RequestLog child) {
         child.addListener(log -> {
-            startRequest0(log.requestStartTimeNanos(), log.requestStartTimeMillis(), log.channel(),
+            startRequest0(log.requestStartTimeNanos(), log.requestStartTimeMicros(), log.channel(),
                           log.sessionProtocol(), true);
         }, REQUEST_START);
         child.addListener(log -> serializationFormat(log.serializationFormat()), SCHEME);
@@ -177,7 +180,7 @@ public class DefaultRequestLog implements RequestLog, RequestLogBuilder {
     private void propagateResponseSideLog(RequestLog lastChild) {
         // update the available logs if the lastChild already has them
         if (lastChild.isAvailable(RESPONSE_START)) {
-            startResponse0(lastChild.responseStartTimeNanos(), lastChild.responseStartTimeMillis(), true);
+            startResponse0(lastChild.responseStartTimeNanos(), lastChild.responseStartTimeMicros(), true);
         }
 
         if (lastChild.isAvailable(RESPONSE_HEADERS)) {
@@ -193,7 +196,7 @@ public class DefaultRequestLog implements RequestLog, RequestLogBuilder {
         }
 
         lastChild.addListener(log -> startResponse0(
-                log.responseStartTimeNanos(), log.responseStartTimeMillis(), true), RESPONSE_START);
+                log.responseStartTimeNanos(), log.responseStartTimeMicros(), true), RESPONSE_START);
         lastChild.addListener(log -> responseHeaders(log.responseHeaders()), RESPONSE_HEADERS);
         lastChild.addListener(log -> responseContent(
                 log.responseContent(), log.rawResponseContent()), RESPONSE_CONTENT);
@@ -316,11 +319,10 @@ public class DefaultRequestLog implements RequestLog, RequestLogBuilder {
     }
 
     private void startRequest0(Channel channel, SessionProtocol sessionProtocol, boolean updateAvailability) {
-        startRequest0(System.nanoTime(), System.currentTimeMillis(), channel, sessionProtocol,
-                      updateAvailability);
+        startRequest0(System.nanoTime(), currentTimeMicros(), channel, sessionProtocol, updateAvailability);
     }
 
-    private void startRequest0(long requestStartTimeNanos, long requestStartTimeMillis,
+    private void startRequest0(long requestStartTimeNanos, long requestStartTimeMicros,
                                @Nullable Channel channel, SessionProtocol sessionProtocol,
                                boolean updateAvailability) {
         if (isAvailabilityAlreadyUpdated(REQUEST_START)) {
@@ -328,7 +330,7 @@ public class DefaultRequestLog implements RequestLog, RequestLogBuilder {
         }
 
         this.requestStartTimeNanos = requestStartTimeNanos;
-        this.requestStartTimeMillis = requestStartTimeMillis;
+        this.requestStartTimeMicros = requestStartTimeMicros;
         this.channel = channel;
         this.sessionProtocol = sessionProtocol;
         if (sessionProtocol.isTls()) {
@@ -344,9 +346,14 @@ public class DefaultRequestLog implements RequestLog, RequestLogBuilder {
     }
 
     @Override
-    public long requestStartTimeMillis() {
+    public long requestStartTimeMicros() {
         ensureAvailability(REQUEST_START);
-        return requestStartTimeMillis;
+        return requestStartTimeMicros;
+    }
+
+    @Override
+    public long requestStartTimeMillis() {
+        return TimeUnit.MICROSECONDS.toMillis(requestStartTimeMicros());
     }
 
     @Override
@@ -514,7 +521,7 @@ public class DefaultRequestLog implements RequestLog, RequestLogBuilder {
 
         // if the request is not started yet, call startRequest() with requestEndTimeNanos so that
         // totalRequestDuration will be 0
-        startRequest0(requestEndTimeNanos, System.currentTimeMillis(), null,
+        startRequest0(requestEndTimeNanos, currentTimeMicros(), null,
                       context().sessionProtocol(), false);
 
         this.requestEndTimeNanos = requestEndTimeNanos;
@@ -538,16 +545,21 @@ public class DefaultRequestLog implements RequestLog, RequestLogBuilder {
         }
 
         this.responseStartTimeNanos = responseStartTimeNanos;
-        this.responseStartTimeMillis = responseStartTimeMillis;
+        this.responseStartTimeMicros = responseStartTimeMillis;
         if (updateAvailability) {
             updateAvailability(RESPONSE_START);
         }
     }
 
     @Override
-    public long responseStartTimeMillis() {
+    public long responseStartTimeMicros() {
         ensureAvailability(RESPONSE_START);
-        return responseStartTimeMillis;
+        return responseStartTimeMicros;
+    }
+
+    @Override
+    public long responseStartTimeMillis() {
+        return TimeUnit.MICROSECONDS.toMillis(responseStartTimeMicros());
     }
 
     @Override
@@ -691,7 +703,7 @@ public class DefaultRequestLog implements RequestLog, RequestLogBuilder {
 
         // if the response is not started yet, call startResponse() with responseEndTimeNanos so that
         // totalResponseDuration will be 0
-        startResponse0(responseEndTimeNanos, System.currentTimeMillis(), false);
+        startResponse0(responseEndTimeNanos, currentTimeMicros(), false);
 
         this.responseEndTimeNanos = responseEndTimeNanos;
         if (this.responseCause == null) {
@@ -812,7 +824,7 @@ public class DefaultRequestLog implements RequestLog, RequestLogBuilder {
         buf.append('{');
         if (isAvailable(flags, REQUEST_START)) {
             buf.append("startTime=");
-            TextFormatter.appendEpoch(buf, requestStartTimeMillis);
+            TextFormatter.appendEpoch(buf, requestStartTimeMicros);
 
             if (isAvailable(flags, REQUEST_END)) {
                 buf.append(", length=");
@@ -869,7 +881,7 @@ public class DefaultRequestLog implements RequestLog, RequestLogBuilder {
         buf.append('{');
         if (isAvailable(flags, RESPONSE_START)) {
             buf.append("startTime=");
-            TextFormatter.appendEpoch(buf, responseStartTimeMillis);
+            TextFormatter.appendEpoch(buf, responseStartTimeMicros);
 
             if (isAvailable(flags, RESPONSE_END)) {
                 buf.append(", length=");
@@ -909,5 +921,11 @@ public class DefaultRequestLog implements RequestLog, RequestLogBuilder {
             this.listener = listener;
             this.interestedFlags = interestedFlags;
         }
+    }
+
+    // This is millisecond precision on Java 8, but it's the best we can do.
+    private static long currentTimeMicros() {
+        Instant now = Clock.systemUTC().instant();
+        return TimeUnit.SECONDS.toMicros(now.getEpochSecond()) + TimeUnit.NANOSECONDS.toMicros(now.getNano());
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
@@ -539,14 +539,14 @@ public class DefaultRequestLog implements RequestLog, RequestLogBuilder {
         startResponse0(System.nanoTime(), System.currentTimeMillis(), updateAvailability);
     }
 
-    private void startResponse0(long responseStartTimeNanos, long responseStartTimeMillis,
+    private void startResponse0(long responseStartTimeNanos, long responseStartTimeMicros,
                                 boolean updateAvailability) {
         if (isAvailabilityAlreadyUpdated(RESPONSE_START)) {
             return;
         }
 
         this.responseStartTimeNanos = responseStartTimeNanos;
-        this.responseStartTimeMicros = responseStartTimeMillis;
+        this.responseStartTimeMicros = responseStartTimeMicros;
         if (updateAvailability) {
             updateAvailability(RESPONSE_START);
         }

--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
@@ -824,7 +824,7 @@ public class DefaultRequestLog implements RequestLog, RequestLogBuilder {
         buf.append('{');
         if (isAvailable(flags, REQUEST_START)) {
             buf.append("startTime=");
-            TextFormatter.appendEpoch(buf, requestStartTimeMicros);
+            TextFormatter.appendEpoch(buf, TimeUnit.MICROSECONDS.toMillis(requestStartTimeMicros));
 
             if (isAvailable(flags, REQUEST_END)) {
                 buf.append(", length=");
@@ -881,7 +881,7 @@ public class DefaultRequestLog implements RequestLog, RequestLogBuilder {
         buf.append('{');
         if (isAvailable(flags, RESPONSE_START)) {
             buf.append("startTime=");
-            TextFormatter.appendEpoch(buf, responseStartTimeMicros);
+            TextFormatter.appendEpoch(buf, TimeUnit.MICROSECONDS.toMillis(responseStartTimeMicros));
 
             if (isAvailable(flags, RESPONSE_END)) {
                 buf.append(", length=");

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestLog.java
@@ -258,7 +258,7 @@ public interface RequestLog {
      *
      * @throws RequestLogAvailabilityException if this property is not available yet
      *
-     * @deprecated Use {@link #requestStartTimeMicros()}.
+     * @deprecated Use {@link #responseStartTimeMicros()}.
      */
     @Deprecated
     long responseStartTimeMillis();

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestLog.java
@@ -201,10 +201,7 @@ public interface RequestLog {
      * Returns the time when the processing of the request started, in millis since the epoch.
      *
      * @throws RequestLogAvailabilityException if this property is not available yet
-     *
-     * @deprecated Use {@link #requestStartTimeMicros()}.
      */
-    @Deprecated
     long requestStartTimeMillis();
 
     /**
@@ -257,10 +254,7 @@ public interface RequestLog {
      * Returns the time when the processing of the response started, in millis since the epoch.
      *
      * @throws RequestLogAvailabilityException if this property is not available yet
-     *
-     * @deprecated Use {@link #responseStartTimeMicros()}.
      */
-    @Deprecated
     long responseStartTimeMillis();
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestLog.java
@@ -191,10 +191,20 @@ public interface RequestLog {
     }
 
     /**
-     * Returns the time when the processing of the request started, in millis since the epoch.
+     * Returns the time when the processing of the request started, in micros since the epoch.
      *
      * @throws RequestLogAvailabilityException if this property is not available yet
      */
+    long requestStartTimeMicros();
+
+    /**
+     * Returns the time when the processing of the request started, in millis since the epoch.
+     *
+     * @throws RequestLogAvailabilityException if this property is not available yet
+     *
+     * @deprecated Use {@link #requestStartTimeMicros()}.
+     */
+    @Deprecated
     long requestStartTimeMillis();
 
     /**
@@ -237,10 +247,20 @@ public interface RequestLog {
     Throwable requestCause();
 
     /**
-     * Returns the time when the processing of the response started, in millis since the epoch.
+     * Returns the time when the processing of the response started, in micros since the epoch.
      *
      * @throws RequestLogAvailabilityException if this property is not available yet
      */
+    long responseStartTimeMicros();
+
+    /**
+     * Returns the time when the processing of the response started, in millis since the epoch.
+     *
+     * @throws RequestLogAvailabilityException if this property is not available yet
+     *
+     * @deprecated Use {@link #requestStartTimeMicros()}.
+     */
+    @Deprecated
     long responseStartTimeMillis();
 
     /**

--- a/core/src/test/java/com/linecorp/armeria/common/logging/DefaultRequestLogTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/logging/DefaultRequestLogTest.java
@@ -123,7 +123,7 @@ public class DefaultRequestLogTest {
         final DefaultRequestLog child = new DefaultRequestLog(ctx);
         log.addChild(child);
         child.startRequest(channel, SessionProtocol.H2C);
-        assertThat(log.requestStartTimeMillis()).isEqualTo(child.requestStartTimeMillis());
+        assertThat(log.requestStartTimeMicros()).isEqualTo(child.requestStartTimeMicros());
         assertThat(log.channel()).isSameAs(channel);
         assertThat(log.sessionProtocol()).isSameAs(SessionProtocol.H2C);
 
@@ -146,7 +146,7 @@ public class DefaultRequestLogTest {
 
         // response-side log are propagated when RequestLogBuilder.endResponseWithLastChild() is invoked
         child.startResponse();
-        assertThatThrownBy(() -> log.responseStartTimeMillis())
+        assertThatThrownBy(() -> log.responseStartTimeMicros())
                 .isExactlyInstanceOf(RequestLogAvailabilityException.class);
 
         final HttpHeaders bar = HttpHeaders.of(AsciiString.of("bar"), "bar");
@@ -155,7 +155,7 @@ public class DefaultRequestLogTest {
                 .isExactlyInstanceOf(RequestLogAvailabilityException.class);
 
         log.endResponseWithLastChild();
-        assertThat(log.responseStartTimeMillis()).isEqualTo(child.responseStartTimeMillis());
+        assertThat(log.responseStartTimeMicros()).isEqualTo(child.responseStartTimeMicros());
         assertThat(log.responseHeaders()).isSameAs(bar);
 
         final String responseContent = "baz1";

--- a/zipkin/src/main/java/com/linecorp/armeria/client/tracing/HttpTracingClient.java
+++ b/zipkin/src/main/java/com/linecorp/armeria/client/tracing/HttpTracingClient.java
@@ -99,12 +99,13 @@ public class HttpTracingClient extends SimpleDecoratingClient<HttpRequest, HttpR
 
         final String method = ctx.method().name();
         span.kind(Kind.CLIENT).name(method);
-        ctx.log().addListener(l -> SpanContextUtil.startSpan(span, l), RequestLogAvailability.REQUEST_START);
+        ctx.log().addListener(log -> SpanContextUtil.startSpan(span, log),
+                              RequestLogAvailability.REQUEST_START);
 
         // Ensure the trace context propagates to children
         ctx.onChild(RequestContextCurrentTraceContext::copy);
 
-        ctx.log().addListener(l -> finishSpan(span, l), RequestLogAvailability.COMPLETE);
+        ctx.log().addListener(log -> finishSpan(span, log), RequestLogAvailability.COMPLETE);
 
         try (SpanInScope ignored = tracer.withSpanInScope(span)) {
             return delegate().execute(ctx, req);

--- a/zipkin/src/main/java/com/linecorp/armeria/client/tracing/HttpTracingClient.java
+++ b/zipkin/src/main/java/com/linecorp/armeria/client/tracing/HttpTracingClient.java
@@ -98,12 +98,13 @@ public class HttpTracingClient extends SimpleDecoratingClient<HttpRequest, HttpR
         }
 
         final String method = ctx.method().name();
-        span.kind(Kind.CLIENT).name(method).start();
+        span.kind(Kind.CLIENT).name(method);
+        ctx.log().addListener(l -> SpanContextUtil.startSpan(span, l), RequestLogAvailability.REQUEST_START);
 
         // Ensure the trace context propagates to children
         ctx.onChild(RequestContextCurrentTraceContext::copy);
 
-        ctx.log().addListener(log -> finishSpan(span, log), RequestLogAvailability.COMPLETE);
+        ctx.log().addListener(l -> finishSpan(span, l), RequestLogAvailability.COMPLETE);
 
         try (SpanInScope ignored = tracer.withSpanInScope(span)) {
             return delegate().execute(ctx, req);

--- a/zipkin/src/main/java/com/linecorp/armeria/server/tracing/HttpTracingService.java
+++ b/zipkin/src/main/java/com/linecorp/armeria/server/tracing/HttpTracingService.java
@@ -81,12 +81,13 @@ public class HttpTracingService extends SimpleDecoratingService<HttpRequest, Htt
         }
 
         final String method = ctx.method().name();
-        span.kind(Kind.SERVER).name(method).start();
+        span.kind(Kind.SERVER).name(method);
+        ctx.log().addListener(l -> SpanContextUtil.startSpan(span, l), RequestLogAvailability.REQUEST_START);
 
         // Ensure the trace context propagates to children
         ctx.onChild(RequestContextCurrentTraceContext::copy);
 
-        ctx.log().addListener(log -> SpanContextUtil.closeSpan(span, log), RequestLogAvailability.COMPLETE);
+        ctx.log().addListener(l -> SpanContextUtil.closeSpan(span, l), RequestLogAvailability.COMPLETE);
 
         try (SpanInScope ignored = tracer.withSpanInScope(span)) {
             return delegate().serve(ctx, req);

--- a/zipkin/src/main/java/com/linecorp/armeria/server/tracing/HttpTracingService.java
+++ b/zipkin/src/main/java/com/linecorp/armeria/server/tracing/HttpTracingService.java
@@ -82,12 +82,13 @@ public class HttpTracingService extends SimpleDecoratingService<HttpRequest, Htt
 
         final String method = ctx.method().name();
         span.kind(Kind.SERVER).name(method);
-        ctx.log().addListener(l -> SpanContextUtil.startSpan(span, l), RequestLogAvailability.REQUEST_START);
+        ctx.log().addListener(log -> SpanContextUtil.startSpan(span, log),
+                              RequestLogAvailability.REQUEST_START);
 
         // Ensure the trace context propagates to children
         ctx.onChild(RequestContextCurrentTraceContext::copy);
 
-        ctx.log().addListener(l -> SpanContextUtil.closeSpan(span, l), RequestLogAvailability.COMPLETE);
+        ctx.log().addListener(log -> SpanContextUtil.closeSpan(span, log), RequestLogAvailability.COMPLETE);
 
         try (SpanInScope ignored = tracer.withSpanInScope(span)) {
             return delegate().serve(ctx, req);


### PR DESCRIPTION
…pan timing.

JDK9+ supports returning wall time with microseconds precision. We may as well use it in logging instead of millis so users can take advantage of extra precision.

I also went ahead and updated the zipkin tracing to use the new values for spans. However I'm not exactly sure if this is good or bad - I think it means time spent in decorators can't be traced as the `RequestLog` is tied to the lifecycle of `StreamMessage`, not `Service`. On the flip side, maybe that is more natural behavior and it does make adding annotations like in #1423 much simpler. Appreciate thoughts on it.

/cc @adriancole 