### PR TITLE
Reduce memory copies in `Http2ResponseDecoder` and gRPC

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/Http2ResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http2ResponseDecoder.java
@@ -27,12 +27,12 @@ import org.slf4j.LoggerFactory;
 
 import com.linecorp.armeria.common.ClosedSessionException;
 import com.linecorp.armeria.common.ContentTooLargeException;
-import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.logging.RequestLogBuilder;
 import com.linecorp.armeria.internal.ArmeriaHttpUtil;
 import com.linecorp.armeria.internal.Http2GoAwayHandler;
+import com.linecorp.armeria.unsafe.ByteBufHttpData;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
@@ -230,7 +230,7 @@ final class Http2ResponseDecoder extends HttpResponseDecoder implements Http2Con
             // If this tryWrite() returns false, it means the response stream has been closed due to
             // disconnection or by the response consumer. We do not need to handle such cases here because
             // it will be notified to the response consumer anyway.
-            res.tryWrite(HttpData.of(data));
+            res.tryWrite(new ByteBufHttpData(data.retain(), endOfStream));
         } catch (Throwable t) {
             res.close(t);
             throw connectionError(INTERNAL_ERROR, t, "failed to consume a DATA frame");

--- a/grpc/src/main/java/com/linecorp/armeria/internal/grpc/ArmeriaMessageDeframer.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/grpc/ArmeriaMessageDeframer.java
@@ -53,7 +53,9 @@ import static java.util.Objects.requireNonNull;
 import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayDeque;
 import java.util.Objects;
+import java.util.Queue;
 
 import javax.annotation.Nullable;
 
@@ -69,7 +71,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.ByteBufHolder;
 import io.netty.buffer.ByteBufInputStream;
-import io.netty.buffer.CompositeByteBuf;
+import io.netty.buffer.Unpooled;
 
 /**
  * A deframer of messages transported in the gRPC wire format. See
@@ -177,7 +179,8 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
     private boolean endOfStream;
 
     @Nullable
-    private CompositeByteBuf unprocessed;
+    private Queue<ByteBuf> unprocessed;
+    private int unprocessedBytes;
 
     private long pendingDeliveries;
     private boolean deliveryStalled = true;
@@ -191,7 +194,7 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
         this.maxMessageSizeBytes = maxMessageSizeBytes;
         this.alloc = requireNonNull(alloc, "alloc");
 
-        unprocessed = alloc.compositeBuffer();
+        unprocessed = new ArrayDeque<>();
     }
 
     /**
@@ -236,16 +239,17 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
 
         startedDeframing = true;
 
-        if (!data.isEmpty()) {
+        final int dataLength = data.length();
+        if (dataLength != 0) {
             final ByteBuf buf;
             if (data instanceof ByteBufHolder) {
                 buf = ((ByteBufHolder) data).content();
             } else {
-                buf = alloc.buffer(data.length());
-                buf.writeBytes(data.array(), data.offset(), data.length());
+                buf = Unpooled.wrappedBuffer(data.array(), data.offset(), dataLength);
             }
             assert unprocessed != null;
-            unprocessed.addComponent(true, buf);
+            unprocessed.add(buf);
+            unprocessedBytes += dataLength;
         }
 
         // Indicate that all of the data for this stream has been received.
@@ -261,7 +265,7 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
     public void close() {
         try {
             if (unprocessed != null) {
-                unprocessed.release();
+                unprocessed.forEach(ByteBuf::release);
             }
         } finally {
             unprocessed = null;
@@ -330,7 +334,7 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
 
             if (endOfStream && stalled) {
                 assert unprocessed != null;
-                final boolean havePartialMessage = unprocessed.isReadable();
+                final boolean havePartialMessage = !unprocessed.isEmpty();
                 if (!havePartialMessage) {
                     listener.endOfStream();
                     deliveryStalled = false;
@@ -349,7 +353,7 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
     }
 
     private boolean hasRequiredBytes() {
-        return unprocessed.readableBytes() >= requiredLength;
+        return unprocessedBytes >= requiredLength;
     }
 
     /**
@@ -358,7 +362,9 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
      */
     private void readHeader() {
         assert unprocessed != null;
-        final int type = unprocessed.readUnsignedByte();
+
+        final long header = readHeaderAsLong();
+        final int type = (int) (header >>> 32);
         if ((type & RESERVED_MASK) != 0) {
             throw Status.INTERNAL.withDescription(
                     DEBUG_STRING + ": Frame header malformed: reserved bits not zero")
@@ -367,7 +373,7 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
         compressedFlag = (type & COMPRESSED_FLAG_MASK) != 0;
 
         // Update the required length to include the length of the frame.
-        requiredLength = unprocessed.readInt();
+        requiredLength = (int) header;
         if (requiredLength < 0 || requiredLength > maxMessageSizeBytes) {
             throw Status.RESOURCE_EXHAUSTED.withDescription(
                     String.format("%s: Frame size %d exceeds maximum: %d. ",
@@ -377,6 +383,42 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
 
         // Continue reading the frame body.
         state = State.BODY;
+    }
+
+    private long readHeaderAsLong() {
+        unprocessedBytes -= HEADER_LENGTH;
+        assert unprocessed != null;
+        final ByteBuf firstBuf = unprocessed.peek();
+        assert firstBuf != null;
+        final int firstBufLen = firstBuf.readableBytes();
+
+        if (firstBufLen >= HEADER_LENGTH) {
+            final long header = (firstBuf.readUnsignedInt() << 8) | firstBuf.readUnsignedByte();
+            if (firstBufLen == HEADER_LENGTH) {
+                unprocessed.remove().release();
+            }
+            return header;
+        }
+
+        return readHeaderAsLongSlowPath();
+    }
+
+    private long readHeaderAsLongSlowPath() {
+        assert unprocessed != null;
+
+        long header = 0;
+        int readBytes = 0;
+        do {
+            final ByteBuf buf = unprocessed.peek();
+            assert buf != null;
+            header <<= 8;
+            header |=  buf.readUnsignedByte();
+            if (!buf.isReadable()) {
+                unprocessed.remove().release();
+            }
+            readBytes++;
+        } while (readBytes < HEADER_LENGTH);
+        return header;
     }
 
     /**
@@ -394,10 +436,51 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
     }
 
     private ByteBuf readBytes(int length) {
+        if (length == 0) {
+            return Unpooled.EMPTY_BUFFER;
+        }
+
+        unprocessedBytes -= length;
         assert unprocessed != null;
-        final ByteBuf buf = unprocessed.readBytes(length);
-        unprocessed.discardReadComponents();
-        return buf;
+        final ByteBuf firstBuf = unprocessed.peek();
+        assert firstBuf != null;
+        final int firstBufLen = firstBuf.readableBytes();
+
+        if (firstBufLen == length) {
+            unprocessed.remove();
+            return firstBuf;
+        }
+
+        if (firstBufLen > length) {
+            return firstBuf.readRetainedSlice(length);
+        }
+
+        return readBytesMerged(length);
+    }
+
+    private ByteBuf readBytesMerged(int length) {
+        assert unprocessed != null;
+
+        final ByteBuf merged = alloc.buffer(length);
+        for (;;) {
+            final ByteBuf buf = unprocessed.peek();
+            assert buf != null;
+
+            final int bufLen = buf.readableBytes();
+            final int remaining = merged.writableBytes();
+
+            if (bufLen <= remaining) {
+                merged.writeBytes(buf, bufLen);
+                unprocessed.remove().release();
+
+                if (bufLen == remaining) {
+                    return merged;
+                }
+            } else {
+                merged.writeBytes(buf, remaining);
+                return merged;
+            }
+        }
     }
 
     private static ByteBufOrStream getUncompressedBody(ByteBuf buf) {

--- a/grpc/src/main/java/com/linecorp/armeria/internal/grpc/ArmeriaMessageDeframer.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/grpc/ArmeriaMessageDeframer.java
@@ -387,11 +387,11 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
         assert unprocessed != null;
         final ByteBuf firstBuf = unprocessed.peek();
         assert firstBuf != null;
-        final int type = firstBuf.readUnsignedByte();
+        final int value = firstBuf.readUnsignedByte();
         if (!firstBuf.isReadable()) {
             unprocessed.remove().release();
         }
-        return type;
+        return value;
     }
 
     private int readInt() {

--- a/grpc/src/main/java/com/linecorp/armeria/internal/grpc/ArmeriaMessageDeframer.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/grpc/ArmeriaMessageDeframer.java
@@ -412,7 +412,7 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
             final ByteBuf buf = unprocessed.peek();
             assert buf != null;
             header <<= 8;
-            header |=  buf.readUnsignedByte();
+            header |= buf.readUnsignedByte();
             if (!buf.isReadable()) {
                 unprocessed.remove().release();
             }
@@ -470,7 +470,7 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
             final int remaining = merged.writableBytes();
 
             if (bufLen <= remaining) {
-                merged.writeBytes(buf, bufLen);
+                merged.writeBytes(buf);
                 unprocessed.remove().release();
 
                 if (bufLen == remaining) {

--- a/grpc/src/main/java/com/linecorp/armeria/internal/grpc/ArmeriaMessageDeframer.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/grpc/ArmeriaMessageDeframer.java
@@ -394,7 +394,7 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
 
         if (firstBufLen >= HEADER_LENGTH) {
             final long header = (firstBuf.readUnsignedInt() << 8) | firstBuf.readUnsignedByte();
-            if (firstBufLen == HEADER_LENGTH) {
+            if (!firstBuf.isReadable()) {
                 unprocessed.remove().release();
             }
             return header;

--- a/grpc/src/main/java/com/linecorp/armeria/internal/grpc/GrpcMessageMarshaller.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/grpc/GrpcMessageMarshaller.java
@@ -170,15 +170,15 @@ public class GrpcMessageMarshaller<I, O> {
 
     private ByteBuf serializeProto(Message message) throws IOException {
         if (GrpcSerializationFormats.isProto(serializationFormat)) {
-            int serializedSize = message.getSerializedSize();
+            final int serializedSize = message.getSerializedSize();
             if (serializedSize == 0) {
                 return Unpooled.EMPTY_BUFFER;
             }
             final ByteBuf buf = alloc.buffer(serializedSize);
             boolean success = false;
             try {
-                message.writeTo(CodedOutputStream.newInstance(buf.nioBuffer(0, buf.writableBytes())));
-                buf.writerIndex(buf.capacity());
+                message.writeTo(CodedOutputStream.newInstance(buf.nioBuffer(0, serializedSize)));
+                buf.writerIndex(serializedSize);
                 success = true;
             } finally {
                 if (!success) {


### PR DESCRIPTION
Motivation:

We perform unnecessary memory copies while handling a gRPC request.

Modifications:

- Use `ByteBufHttpData` instead of `HttpData.of()` in
  `Http2ResponseDecoder`
- Use a queue of `ByteBuf`s instead of `CompositeByteBuf` for deframing
  in `ArmeriaMessageDeframer`, because the buffers we get from
  `CompositeByteBuf` is often copied or wrapped with indirection.
- Use `CompositeByteBuf` to prepend a frame header if the frame is
  larger than 128 bytes

Result:

Higher performance.

Before:

    Benchmark                     (wrapBuffer)   Mode  Cnt   Score   Error  Units
    LargePayloadBenchmark.normal         false  thrpt  100  35.266 ± 0.191  ops/s
    LargePayloadBenchmark.normal          true  thrpt  100  40.839 ± 0.228  ops/s

After:

    Benchmark                     (wrapBuffer)   Mode  Cnt    Score   Error  Units
    LargePayloadBenchmark.normal         false  thrpt  100   95.581 ± 0.700  ops/s
    LargePayloadBenchmark.normal          true  thrpt  100  117.076 ± 0.806  ops/s
