### PR TITLE
Fix a build error on Windows

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -77,6 +77,9 @@ com.google.protobuf:
   protoc: { version: '3.5.1-1' }
   protobuf-gradle-plugin: { version: '0.8.6' }
 
+com.moowork.gradle:
+  gradle-node-plugin: { version: '1.2.0' }
+
 com.puppycrawl.tools:
   checkstyle: { version: '8.11' }
 

--- a/docs-client/build.gradle
+++ b/docs-client/build.gradle
@@ -1,8 +1,43 @@
-plugins {
-    id 'com.moowork.node' version '1.2.0'
+import java.nio.file.FileVisitOption
+import java.nio.file.FileVisitResult
+import java.nio.file.Files
+import java.nio.file.SimpleFileVisitor
+
+buildscript {
+    repositories {
+        gradlePluginPortal()
+    }
+    dependencies {
+        classpath "com.moowork.gradle:gradle-node-plugin:${managedVersions['com.moowork.gradle:gradle-node-plugin']}"
+    }
 }
 
 apply plugin: 'base'
+apply plugin: 'com.moowork.node'
+
+tasks.yarn.doLast {
+    // Delete the broken symlinks so that Gradle does not fail the build.
+    // - https://github.com/gradle/gradle/issues/1365
+    // Note that this is primarily due to a bug in Yarn 1.11+:
+    // - https://github.com/yarnpkg/yarn/issues/6585
+    // - https://github.com/yarnpkg/yarn/issues/6615
+    // TODO(trustin): Remove the workaround once Yarn fixes yarnpkg/yarn#6585.
+
+    def visitor = new SimpleFileVisitor<java.nio.file.Path>() {
+        @Override
+        FileVisitResult visitFileFailed(java.nio.file.Path file, IOException exc) throws IOException {
+            logger.warn("Removing a broken symlink: ${file}")
+            Files.delete(file);
+            return FileVisitResult.CONTINUE
+        }
+    }
+
+    Files.walkFileTree(
+            project.file("${projectDir}/node_modules").toPath(),
+            [FileVisitOption.FOLLOW_LINKS] as Set,
+            Integer.MAX_VALUE,
+            visitor)
+}
 
 task buildWeb(type: YarnTask) {
     dependsOn 'yarn'


### PR DESCRIPTION
Motivation:

Yarn 1.12.1 creates a broken symlink:

- https://github.com/yarnpkg/yarn/issues/6585
- https://github.com/yarnpkg/yarn/issues/6615

Gradle fails the build on Windows when it encounters a broken symlimnk:

- https://github.com/gradle/gradle/issues/1365

Modifications:

- Delete broken symlinks after running `:docs-client:yarn`

Result:

- Gradle is happy. Build is green.