### PR TITLE
Do not use UnpooledByteBufAllocator

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -37,7 +37,7 @@ import com.linecorp.armeria.common.logging.RequestLogBuilder;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.netty.buffer.ByteBufAllocator;
-import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.channel.Channel;
 import io.netty.channel.EventLoop;
 import io.netty.handler.codec.Headers;
@@ -333,6 +333,6 @@ public class DefaultClientRequestContext extends NonWrappingRequestContext imple
     @Override
     public ByteBufAllocator alloc() {
         final Channel channel = channel();
-        return channel != null ? channel.alloc() : UnpooledByteBufAllocator.DEFAULT;
+        return channel != null ? channel.alloc() : PooledByteBufAllocator.DEFAULT;
     }
 }


### PR DESCRIPTION
Motivation:

`DefaultClientRequestContext.alloc()` returns
`UnpooledByteBufAllocator.DEFAULT` when the current `Channel` is not
determined yet. This can lead to poor performance when a `Client` tries
to get the allocator early.

Modifications:

- Return `PooledByteBufAllocator.DEFAULT` when `Channel` is not
  determined yet.

Result:

- Better client-side gRPC performance (apx. 5% improvement)

master:

    Benchmark                        (clientType)   Mode  Cnt      Score     Error  Units
    DownstreamSimpleBenchmark.empty        NORMAL  thrpt  100  75881.642 ± 178.229  ops/s

This PR:

    Benchmark                        (clientType)   Mode  Cnt      Score     Error  Units
    DownstreamSimpleBenchmark.empty        NORMAL  thrpt  100  78863.742 ± 179.395  ops/s