### PR TITLE
Avoid using CompletableFuture.whenCompleteAsync()

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/Http2ResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http2ResponseDecoder.java
@@ -71,7 +71,7 @@ final class Http2ResponseDecoder extends HttpResponseDecoder implements Http2Con
         final HttpResponseWrapper resWrapper =
                 super.addResponse(id, req, res, logBuilder, responseTimeoutMillis, maxContentLength);
 
-        resWrapper.completionFuture().whenCompleteAsync((unused, cause) -> {
+        resWrapper.completionFuture().handleAsync((unused, cause) -> {
             // Cancel timeout future and abort the request if it exists.
             resWrapper.onSubscriptionCancelled();
 
@@ -94,6 +94,8 @@ final class Http2ResponseDecoder extends HttpResponseDecoder implements Http2Con
                     }
                 }
             }
+
+            return null;
         }, channel().eventLoop());
         return resWrapper;
     }

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClient.java
@@ -17,7 +17,6 @@
 package com.linecorp.armeria.client.circuitbreaker;
 
 import static com.google.common.base.Preconditions.checkState;
-import static com.linecorp.armeria.common.util.Functions.voidFunction;
 import static java.util.Objects.requireNonNull;
 
 import java.util.concurrent.CompletionStage;
@@ -131,15 +130,17 @@ public abstract class CircuitBreakerClient<I extends Request, O extends Response
      */
     protected static void reportSuccessOrFailure(CircuitBreaker circuitBreaker,
                                                  CompletionStage<Boolean> future) {
-        future.handle(voidFunction((success, unused) -> {
+        future.handle((success, unused) -> {
             if (success != null) {
                 if (success) {
                     circuitBreaker.onSuccess();
                 } else {
                     circuitBreaker.onFailure();
                 }
+            } else {
+                // Ignore, because 'null' means the user does not want to count as a success nor failure.
             }
-            // If the success is null, the user does not want to count as a success nor failure. So ignore it.
-        })).exceptionally(CompletionActions::log);
+            return null;
+        }).exceptionally(CompletionActions::log);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
@@ -17,7 +17,6 @@ package com.linecorp.armeria.client.endpoint.healthcheck;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
-import static com.linecorp.armeria.common.util.Functions.voidFunction;
 import static java.util.Objects.requireNonNull;
 
 import java.time.Duration;
@@ -92,7 +91,7 @@ public abstract class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
                               .map(connection -> connection.healthChecker.isHealthy(connection.endpoint()))
                               .collect(toImmutableList()),
                 t -> false);
-        return healthCheckResults.handle(voidFunction((result, thrown) -> {
+        return healthCheckResults.handle((result, thrown) -> {
             final ImmutableList.Builder<Endpoint> newHealthyEndpoints = ImmutableList.builder();
             for (int i = 0; i < result.size(); i++) {
                 if (result.get(i)) {
@@ -100,7 +99,8 @@ public abstract class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
                 }
             }
             setEndpoints(newHealthyEndpoints.build());
-        }));
+            return null;
+        });
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingClient.java
@@ -239,9 +239,10 @@ public abstract class ConcurrencyLimitingClient<I extends Request, O extends Res
             try (SafeCloseable ignored = ctx.push()) {
                 try {
                     final O actualRes = delegate().execute(ctx, req);
-                    actualRes.completionFuture().whenCompleteAsync((unused, cause) -> {
+                    actualRes.completionFuture().handleAsync((unused, cause) -> {
                         numActiveRequests.decrementAndGet();
                         drain();
+                        return null;
                     }, ctx.eventLoop());
                     deferred.delegate(actualRes);
                 } catch (Throwable t) {

--- a/core/src/main/java/com/linecorp/armeria/common/HttpMessageAggregator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpMessageAggregator.java
@@ -19,7 +19,7 @@ package com.linecorp.armeria.common;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
 
 import javax.annotation.Nullable;
 
@@ -33,7 +33,7 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.ByteBufHolder;
 import io.netty.util.ReferenceCountUtil;
 
-abstract class HttpMessageAggregator implements Subscriber<HttpObject>, BiConsumer<Void, Throwable> {
+abstract class HttpMessageAggregator implements Subscriber<HttpObject>, BiFunction<Void, Throwable, Void> {
 
     private final CompletableFuture<AggregatedHttpMessage> future;
     private final List<HttpData> contentList = new ArrayList<>();
@@ -109,10 +109,10 @@ abstract class HttpMessageAggregator implements Subscriber<HttpObject>, BiConsum
     }
 
     @Override
-    public void accept(Void unused, Throwable cause) {
+    public Void apply(Void unused, Throwable cause) {
         if (cause != null) {
             fail(cause);
-            return;
+            return null;
         }
 
         final HttpData content;
@@ -152,6 +152,8 @@ abstract class HttpMessageAggregator implements Subscriber<HttpObject>, BiConsum
         } catch (Throwable e) {
             future.completeExceptionally(e);
         }
+
+        return null;
     }
 
     private void fail(Throwable cause) {

--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
@@ -346,7 +346,7 @@ public interface HttpRequest extends Request, StreamMessage<HttpObject> {
     default CompletableFuture<AggregatedHttpMessage> aggregate() {
         final CompletableFuture<AggregatedHttpMessage> future = new CompletableFuture<>();
         final HttpRequestAggregator aggregator = new HttpRequestAggregator(this, future, null);
-        completionFuture().whenComplete(aggregator);
+        completionFuture().handle(aggregator);
         subscribe(aggregator);
         return future;
     }
@@ -359,7 +359,7 @@ public interface HttpRequest extends Request, StreamMessage<HttpObject> {
         requireNonNull(executor, "executor");
         final CompletableFuture<AggregatedHttpMessage> future = new CompletableFuture<>();
         final HttpRequestAggregator aggregator = new HttpRequestAggregator(this, future, null);
-        completionFuture().whenCompleteAsync(aggregator, executor);
+        completionFuture().handleAsync(aggregator, executor);
         subscribe(aggregator, executor);
         return future;
     }
@@ -374,7 +374,7 @@ public interface HttpRequest extends Request, StreamMessage<HttpObject> {
         requireNonNull(alloc, "alloc");
         final CompletableFuture<AggregatedHttpMessage> future = new CompletableFuture<>();
         final HttpRequestAggregator aggregator = new HttpRequestAggregator(this, future, alloc);
-        completionFuture().whenComplete(aggregator);
+        completionFuture().handle(aggregator);
         subscribe(aggregator, true);
         return future;
     }
@@ -391,7 +391,7 @@ public interface HttpRequest extends Request, StreamMessage<HttpObject> {
         requireNonNull(alloc, "alloc");
         final CompletableFuture<AggregatedHttpMessage> future = new CompletableFuture<>();
         final HttpRequestAggregator aggregator = new HttpRequestAggregator(this, future, alloc);
-        completionFuture().whenCompleteAsync(aggregator, executor);
+        completionFuture().handleAsync(aggregator, executor);
         subscribe(aggregator, executor, true);
         return future;
     }

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -358,7 +358,7 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
     default CompletableFuture<AggregatedHttpMessage> aggregate() {
         final CompletableFuture<AggregatedHttpMessage> future = new CompletableFuture<>();
         final HttpResponseAggregator aggregator = new HttpResponseAggregator(future, null);
-        completionFuture().whenComplete(aggregator);
+        completionFuture().handle(aggregator);
         subscribe(aggregator);
         return future;
     }
@@ -370,7 +370,7 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
     default CompletableFuture<AggregatedHttpMessage> aggregate(EventExecutor executor) {
         final CompletableFuture<AggregatedHttpMessage> future = new CompletableFuture<>();
         final HttpResponseAggregator aggregator = new HttpResponseAggregator(future, null);
-        completionFuture().whenCompleteAsync(aggregator, executor);
+        completionFuture().handleAsync(aggregator, executor);
         subscribe(aggregator, executor);
         return future;
     }
@@ -385,7 +385,7 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
         requireNonNull(alloc, "alloc");
         final CompletableFuture<AggregatedHttpMessage> future = new CompletableFuture<>();
         final HttpResponseAggregator aggregator = new HttpResponseAggregator(future, alloc);
-        completionFuture().whenComplete(aggregator);
+        completionFuture().handle(aggregator);
         subscribe(aggregator, true);
         return future;
     }
@@ -402,7 +402,7 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
         requireNonNull(alloc, "alloc");
         final CompletableFuture<AggregatedHttpMessage> future = new CompletableFuture<>();
         final HttpResponseAggregator aggregator = new HttpResponseAggregator(future, alloc);
-        completionFuture().whenCompleteAsync(aggregator, executor);
+        completionFuture().handleAsync(aggregator, executor);
         subscribe(aggregator, executor, true);
         return future;
     }

--- a/core/src/main/java/com/linecorp/armeria/common/util/StartStopSupport.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/StartStopSupport.java
@@ -233,7 +233,7 @@ public abstract class StartStopSupport<V, L> implements AutoCloseable {
         }
 
         final CompletableFuture<Void> future = stopFuture.whenCompleteAsync(
-                (unused1, unused2) -> enter(State.STOPPED, null), executor);
+                (unused1, cause) -> enter(State.STOPPED, null), executor);
         this.future = future;
         return future;
     }

--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
@@ -234,7 +234,7 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject>, RequestTim
             // If timeout occurs, respond with 503 Service Unavailable.
             ((HttpResponseException) cause).httpResponse()
                                            .aggregate(ctx.executor())
-                                           .whenCompleteAsync((message, throwable) -> {
+                                           .handleAsync((message, throwable) -> {
                                                if (throwable != null) {
                                                    failAndRespond(throwable,
                                                                   INTERNAL_SERVER_ERROR_MESSAGE,
@@ -242,6 +242,7 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject>, RequestTim
                                                } else {
                                                    failAndRespond(cause, message, Http2Error.CANCEL);
                                                }
+                                               return null;
                                            }, ctx.executor());
         } else if (cause instanceof HttpStatusException) {
             failAndRespond(cause,

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaClientCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaClientCall.java
@@ -171,7 +171,7 @@ class ArmeriaClientCall<I, O> extends ClientCall<I, O>
             return;
         }
         res.subscribe(responseReader, ctx.eventLoop(), true);
-        res.completionFuture().whenCompleteAsync(responseReader, ctx.eventLoop());
+        res.completionFuture().handleAsync(responseReader, ctx.eventLoop());
     }
 
     @Override

--- a/grpc/src/main/java/com/linecorp/armeria/internal/grpc/HttpStreamReader.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/grpc/HttpStreamReader.java
@@ -18,7 +18,7 @@ package com.linecorp.armeria.internal.grpc;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
 
 import javax.annotation.Nullable;
 
@@ -40,7 +40,7 @@ import io.grpc.Status;
 /**
  * A {@link Subscriber} to read HTTP messages and pass to gRPC business logic.
  */
-public class HttpStreamReader implements Subscriber<HttpObject>, BiConsumer<Void, Throwable> {
+public class HttpStreamReader implements Subscriber<HttpObject>, BiFunction<Void, Throwable, Void> {
 
     private final DecompressorRegistry decompressorRegistry;
     private final TransportStatusListener transportStatusListener;
@@ -175,9 +175,9 @@ public class HttpStreamReader implements Subscriber<HttpObject>, BiConsumer<Void
     }
 
     @Override
-    public void accept(Void unused, Throwable cause) {
+    public Void apply(@Nullable Void unused, @Nullable Throwable cause) {
         if (cancelled) {
-            return;
+            return null;
         }
 
         if (cause == null) {
@@ -185,6 +185,8 @@ public class HttpStreamReader implements Subscriber<HttpObject>, BiConsumer<Void
         } else {
             transportStatusListener.transportReportStatus(GrpcStatus.fromThrowable(cause));
         }
+
+        return null;
     }
 
     public void cancel() {

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
@@ -160,7 +160,7 @@ public final class GrpcService extends AbstractHttpService
         if (call != null) {
             ctx.setRequestTimeoutHandler(() -> call.close(Status.DEADLINE_EXCEEDED, EMPTY_METADATA));
             req.subscribe(call.messageReader(), ctx.eventLoop(), true);
-            req.completionFuture().whenCompleteAsync(call.messageReader(), ctx.eventLoop());
+            req.completionFuture().handleAsync(call.messageReader(), ctx.eventLoop());
         }
         return res;
     }

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcService.java
@@ -200,13 +200,14 @@ class UnframedGrpcService extends SimpleDecoratingService<HttpRequest, HttpRespo
             return;
         }
 
-        grpcResponse.aggregate().whenCompleteAsync(
+        grpcResponse.aggregate().handleAsync(
                 (framedResponse, t) -> {
                     if (t != null) {
                         res.completeExceptionally(t);
                     } else {
                         deframeAndRespond(ctx, framedResponse, res);
                     }
+                    return null;
                 },
                 ctx.eventLoop());
     }

--- a/grpc/src/test/java/com/linecorp/armeria/internal/grpc/HttpStreamReaderTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/internal/grpc/HttpStreamReaderTest.java
@@ -150,7 +150,7 @@ public class HttpStreamReaderTest {
 
     @Test
     public void clientDone() {
-        reader.accept(null, null);
+        reader.apply(null, null);
         verify(deframer).deframe(HttpData.EMPTY_DATA, true);
         verify(deframer).close();
     }


### PR DESCRIPTION
Related: #1426

Motivation:

`CompletableFuture` always creates a new `CompletionException` after it
calls the callback registered with `whenCompleteAsync()`, even if there
are no dependants and the `CompletionException` will never be used.

See https://hg.openjdk.java.net/jdk/jdk11/file/1ddf9a99e4ad/src/java.base/share/classes/java/util/concurrent/CompletableFuture.java#l870
for more information.

Modifications:

- Use `CompletableFuture.handleAsync()` instead of `whenCompleteAsync()`.
- Miscellaneous:
  - Avoid using `voidFunction()` which increases the level of indirection

Result:

- Fixes #1426
- Better performance

master:

    Benchmark                        (clientType)   Mode  Cnt      Score     Error  Units
    DownstreamSimpleBenchmark.empty        NORMAL  thrpt  100  52167.567 ± 274.358  ops/s

This pull request:

    Benchmark                        (clientType)   Mode  Cnt      Score     Error  Units
    DownstreamSimpleBenchmark.empty        NORMAL  thrpt  100  58171.594 ± 365.014  ops/s