### PR TITLE
Add public methods for users to determine the channel type of an even…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/util/EventLoopGroups.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/EventLoopGroups.java
@@ -23,7 +23,11 @@ import java.util.concurrent.ThreadFactory;
 
 import com.linecorp.armeria.internal.TransportType;
 
+import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.ServerChannel;
+import io.netty.channel.socket.DatagramChannel;
+import io.netty.channel.socket.SocketChannel;
 import io.netty.util.concurrent.DefaultThreadFactory;
 
 /**
@@ -91,6 +95,30 @@ public final class EventLoopGroups {
 
         final TransportType type = TransportType.detectTransportType();
         return type.newEventLoopGroup(numThreads, unused -> threadFactory);
+    }
+
+    /**
+     * Returns the {@link ServerChannel} class that is available for this {@code eventLoopGroup}, for use in
+     * configuring a custom {@link Bootstrap}.
+     */
+    public static Class<? extends ServerChannel> serverChannelClass(EventLoopGroup eventLoopGroup) {
+        return TransportType.serverChannelClass(eventLoopGroup);
+    }
+
+    /**
+     * Returns the available {@link SocketChannel} class for {@code eventLoopGroup}, for use in configuring a
+     * custom {@link Bootstrap}.
+     */
+    public static Class<? extends SocketChannel> socketChannelType(EventLoopGroup eventLoopGroup) {
+        return TransportType.socketChannelType(requireNonNull(eventLoopGroup, "eventLoopGroup"));
+    }
+
+    /**
+     * Returns the available {@link DatagramChannel} class for {@code eventLoopGroup}, for use in configuring a
+     * custom {@link Bootstrap}.
+     */
+    public static Class<? extends DatagramChannel> datagramChannelType(EventLoopGroup eventLoopGroup) {
+        return TransportType.datagramChannelType(requireNonNull(eventLoopGroup, "eventLoopGroup"));
     }
 
     private EventLoopGroups() {}

--- a/core/src/main/java/com/linecorp/armeria/common/util/EventLoopGroups.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/EventLoopGroups.java
@@ -102,7 +102,7 @@ public final class EventLoopGroups {
      * configuring a custom {@link Bootstrap}.
      */
     public static Class<? extends ServerChannel> serverChannelClass(EventLoopGroup eventLoopGroup) {
-        return TransportType.serverChannelClass(eventLoopGroup);
+        return TransportType.serverChannelClass(requireNonNull(eventLoopGroup, "eventLoopGroup"));
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/internal/TransportType.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/TransportType.java
@@ -100,6 +100,13 @@ public enum TransportType {
     }
 
     /**
+     * Returns the {@link ServerChannel} class for {@code eventLoopGroup}.
+     */
+    public static Class<? extends ServerChannel> serverChannelClass(EventLoopGroup eventLoopGroup) {
+        return find(eventLoopGroup).serverChannelClass;
+    }
+
+    /**
      * Returns the available {@link SocketChannel} class for {@code eventLoopGroup}.
      */
     public static Class<? extends SocketChannel> socketChannelType(EventLoopGroup eventLoopGroup) {

--- a/core/src/main/java/com/linecorp/armeria/internal/TransportType.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/TransportType.java
@@ -73,6 +73,13 @@ public enum TransportType {
     }
 
     /**
+     * Returns the {@link ServerChannel} class for {@code eventLoopGroup}.
+     */
+    public static Class<? extends ServerChannel> serverChannelClass(EventLoopGroup eventLoopGroup) {
+        return find(eventLoopGroup).serverChannelClass;
+    }
+
+    /**
      * Returns the {@link ServerChannel} class that is available for this transport type.
      */
     public Class<? extends ServerChannel> serverChannelClass() {
@@ -97,13 +104,6 @@ public enum TransportType {
         } else {
             return NIO;
         }
-    }
-
-    /**
-     * Returns the {@link ServerChannel} class for {@code eventLoopGroup}.
-     */
-    public static Class<? extends ServerChannel> serverChannelClass(EventLoopGroup eventLoopGroup) {
-        return find(eventLoopGroup).serverChannelClass;
     }
 
     /**


### PR DESCRIPTION
…t loop group.

This can be useful for users that want to use armeria's `CommonPools` with a custom netty pipeline, such as a raw TCP client.

Fixes #1438 