### PR TITLE
Make armeria support retrofit 2.5

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -92,7 +92,7 @@ com.spotify:
 
 com.squareup.retrofit2:
   retrofit:
-    version: &RETROFIT2_VERSION '2.4.0'
+    version: &RETROFIT2_VERSION '2.5.0'
     javadocs:
     - https://square.github.io/retrofit/2.x/retrofit/
   adapter-java8: { version: *RETROFIT2_VERSION }

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/ArmeriaCallFactory.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/ArmeriaCallFactory.java
@@ -46,6 +46,7 @@ import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
 import okio.Buffer;
+import okio.Timeout;
 
 /**
  * A {@link Factory} that creates a {@link Call} instance for {@link HttpClient}.
@@ -226,6 +227,11 @@ final class ArmeriaCallFactory implements Factory {
         @Override
         public boolean isCanceled() {
             return executionState == ExecutionState.CANCELED;
+        }
+
+        @Override
+        public Timeout timeout() {
+            return Timeout.NONE;
         }
 
         boolean tryFinish() {


### PR DESCRIPTION
* Timeout.deadlineNanoTime is similar to ClientRequestContext.responseTimeoutMillis, but client-side timeout is not runtime-adjustable in Armeria, unlike Timeout API does.
* There's nothing in Armeria that matches the contract of Timeout.timeoutNanos.

Until we can support them, perhaps we could use Timeout.NONE