### PR TITLE
Fix the wrong unit of response time

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
@@ -567,7 +567,7 @@ public class DefaultRequestLog implements RequestLog, RequestLogBuilder {
     }
 
     private void startResponse0(boolean updateAvailability) {
-        startResponse0(System.nanoTime(), System.currentTimeMillis(), updateAvailability);
+        startResponse0(System.nanoTime(), currentTimeMicros(), updateAvailability);
     }
 
     private void startResponse0(long responseStartTimeNanos, long responseStartTimeMicros,


### PR DESCRIPTION
Motivation
---

We get a wrong response time after upgrading 0.76.X.
Response time present 1970-01-...
```
2018-11-28 11:05:12.542|DEBUG|armeria-common-worker-nio-7-4||RequestContextAwareLogger.java:148|[id: 0x3e355099, L:/0:0:0:0:0:0:0:1:8080 - R:/0:0:0:0:0:0:0:1:63853][h1c://al01370165.local:8080/api/v1#POST] Response: {startTime=1970-01-18T20:42:50.712Z(1543370712), length=2497B, duration=292µs(292431ns), headers=[:status=200, content-type=application/x-thrift; protocol=TTEXT, content-length=2497], content=DefaultRpcResponse{Reactions(reactions:{1150267870113044227=Reaction(like:LikeResults(type:null, count:1, likeList:[Like(parentId:1150267870113044227, mid:ufe3b776fbc1d451aeb7611a6f8af473c, serialNumber:1, type:1001, createdDate:1541413760652, updatedDate:0)], hasMore:false, nextScrollId:0), liked:true, likeStats:[Counter(type:1001, count:1), Counter(type:1002, count:0), Counter(type:1003, count:0), Counter(type:1004, count:0), Counter(type:1005, count:0), Counter(type:1006, count:0)], comment:CommentResults(count:0, commentList:null, hasMore:false, nextScrollId:0), previewComments:CommentResults(count:0, commentList:null, hasMore:false, nextScrollId:0)), 1150267870113044228=Reaction(like:LikeResults(type:null, count:1, likeList:[Like(parentId:1150267870113044228, mid:ufe3b776fbc1d451aeb7611a6f8af473c, serialNumber:1, type:1001, createdDate:1540782358996, updatedDate:0)], hasMore:false, nextScrollId:0), liked:true, likeStats:[Counter(type:1001, count:1), Counter(type:1002, count:0), Counter(type:1003, count:0), Counter(type:1004, count:0), Counter(type:1005, count:0), Counter(type:1006, count:0)], comment:CommentResults(count:0, commentList:null, hasMore:false, nextScrollId:0), previewComments:CommentResults(count:0, commentList:null, hasMore:false, nextScrollId:0))})}}
```

Fix
---
Fix wrong arguement using System.currentTimeMillis()