### PR TITLE
Correct documentation on GrpcService's Protobuf-JSON support

### DIFF
--- a/site/src/sphinx/server-grpc.rst
+++ b/site/src/sphinx/server-grpc.rst
@@ -161,6 +161,7 @@ can be used.
     ...
     sb.service(new GrpcServiceBuilder().addService(new MyHelloService())
                                        .enableUnframedRequests(true)
+                                       // Needed to support JSON in addition to binary
                                        .supportedSerializationFormats(GrpcSerializationFormats.PROTO,
                                                                       GrpcSerializationFormats.JSON)
                                        .build());

--- a/site/src/sphinx/server-grpc.rst
+++ b/site/src/sphinx/server-grpc.rst
@@ -161,14 +161,16 @@ can be used.
     ...
     sb.service(new GrpcServiceBuilder().addService(new MyHelloService())
                                        .enableUnframedRequests(true)
+                                       .supportedSerializationFormats(GrpcSerializationFormats.PROTO,
+                                                                      GrpcSerializationFormats.JSON)
                                        .build());
     ...
     Server server = sb.build();
     server.start();
 
 This service's unary methods can be accessed from any HTTP client at e.g., URL ``/grpc.hello.HelloService/Hello``
-with Content-Type ``application/protobuf`` for binary protobuf POST body or ``application/json`` for JSON POST
-body.
+with Content-Type ``application/protobuf`` for binary protobuf POST body or ``application/json; charset=utf-8``
+for JSON POST body.
 
 Blocking service implementation
 -------------------------------


### PR DESCRIPTION
I tried to set up my server to accept gRPC unframed requests by following the instructions of the page "Running a gRPC service", but it didn't work.

The description of "Unframed requests" in the page seems to need the following two corrections.

*  In the example code, `GrpcSerializationFormats.JSON` must be given to `GrpcServiceBuilder.supportedSerializationFormats()`, because [the default formats are only `PROTO` and `PROTO_WEB`](https://github.com/line/armeria/blob/master/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java#L53-L54).
* Content-Type must be `application/json; charset=utf-8`, not simply `application/json`, since [`UnframedGrpcService` requires `MediaType.JSON_UTF_8`](https://github.com/line/armeria/blob/master/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcService.java#L132).