### PR TITLE
Determine a client address from Forwarded, X-Forwarded-For headers an…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/HttpHeaderNames.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpHeaderNames.java
@@ -224,6 +224,10 @@ public final class HttpHeaderNames {
      */
     public static final AsciiString EXPIRES = AsciiString.cached("expires");
     /**
+     * {@code "forwarded"}.
+     */
+    public static final AsciiString FORWARDED = AsciiString.cached("forwarded");
+    /**
      * {@code "from"}.
      */
     public static final AsciiString FROM = AsciiString.cached("from");
@@ -409,6 +413,10 @@ public final class HttpHeaderNames {
      * {@code "www-authenticate"}.
      */
     public static final AsciiString WWW_AUTHENTICATE = AsciiString.cached("www-authenticate");
+    /**
+     * {@code "x-forwarded-for"}.
+     */
+    public static final AsciiString X_FORWARDED_FOR = AsciiString.cached("x-forwarded-for");
     /**
      * {@code "x-frame-options"}.
      */

--- a/core/src/main/java/com/linecorp/armeria/server/ClientAddressSource.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ClientAddressSource.java
@@ -20,7 +20,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import java.util.List;
 
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.common.HttpHeaderNames;
@@ -32,7 +31,8 @@ import io.netty.util.AsciiString;
  * to provide a client address:
  * <ul>
  *     <li>an HTTP header, such as {@code Forwarded} and {@code X-Forwarded-For} header</li>
- *     <li>the source address of a PROXY protocol header</li>
+ *     <li>the source address specified in a
+ *     <a href="https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt">PROXY protocol</a> message</li>
  * </ul>
  */
 public final class ClientAddressSource {
@@ -49,26 +49,18 @@ public final class ClientAddressSource {
                              ofProxyProtocol());
 
     /**
-     * Returns a {@link ClientAddressSource} of the specified {@code header} which will be used to determine
-     * a client address from a request.
+     * Returns a {@link ClientAddressSource} which indicates the value of the specified {@code header}
+     * in a request will be used to determine a client address.
      */
-    public static ClientAddressSource ofHeader(AsciiString header) {
-        checkArgument(header != null && !header.isEmpty(), "empty header");
-        return new ClientAddressSource(header);
+    public static ClientAddressSource ofHeader(CharSequence header) {
+        checkArgument(header != null && header.length() > 0, "empty header");
+        return new ClientAddressSource(AsciiString.of(header));
     }
 
     /**
-     * Returns a {@link ClientAddressSource} of the specified {@code header} which will be used to determine
-     * a client address from a request.
-     */
-    public static ClientAddressSource ofHeader(String header) {
-        checkArgument(!Strings.isNullOrEmpty(header), "empty header");
-        return new ClientAddressSource(AsciiString.cached(header));
-    }
-
-    /**
-     * Returns a {@link ClientAddressSource} of a PROXY protocol which indicates a {@link ProxiedAddresses}
-     * will be used to determine a client address if a request has came via PROXY protocol.
+     * Returns the {@link ClientAddressSource} which indicates the source address specified in
+     * a <a href="https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt">PROXY protocol</a> message
+     * will be used to determine a client address.
      */
     public static ClientAddressSource ofProxyProtocol() {
         return PROXY_PROTOCOL;
@@ -77,8 +69,8 @@ public final class ClientAddressSource {
     /**
      * Returns {@code true} if the specified {@code source} is for a PROXY protocol.
      */
-    static boolean isProxyProtocol(ClientAddressSource source) {
-        return source == PROXY_PROTOCOL;
+    boolean isProxyProtocol() {
+        return this == PROXY_PROTOCOL;
     }
 
     private final AsciiString header;

--- a/core/src/main/java/com/linecorp/armeria/server/ClientAddressSource.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ClientAddressSource.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.util.List;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.common.HttpHeaderNames;
+
+import io.netty.util.AsciiString;
+
+/**
+ * A source which is used to get a client address. Currently there are two sources which are available
+ * to provide a client address:
+ * <ul>
+ *     <li>an HTTP header, such as {@code Forwarded} and {@code X-Forwarded-For} header</li>
+ *     <li>the source address of a PROXY protocol header</li>
+ * </ul>
+ */
+public final class ClientAddressSource {
+
+    private static final ClientAddressSource PROXY_PROTOCOL =
+            new ClientAddressSource(AsciiString.of("PROXY_PROTOCOL"));
+
+    /**
+     * A default list of {@link ClientAddressSource}s.
+     */
+    static final List<ClientAddressSource> DEFAULT_SOURCES =
+            ImmutableList.of(ofHeader(HttpHeaderNames.FORWARDED),
+                             ofHeader(HttpHeaderNames.X_FORWARDED_FOR),
+                             ofProxyProtocol());
+
+    /**
+     * Returns a {@link ClientAddressSource} of the specified {@code header} which will be used to determine
+     * a client address from a request.
+     */
+    public static ClientAddressSource ofHeader(AsciiString header) {
+        checkArgument(header != null && !header.isEmpty(), "empty header");
+        return new ClientAddressSource(header);
+    }
+
+    /**
+     * Returns a {@link ClientAddressSource} of the specified {@code header} which will be used to determine
+     * a client address from a request.
+     */
+    public static ClientAddressSource ofHeader(String header) {
+        checkArgument(!Strings.isNullOrEmpty(header), "empty header");
+        return new ClientAddressSource(AsciiString.cached(header));
+    }
+
+    /**
+     * Returns a {@link ClientAddressSource} of a PROXY protocol which indicates a {@link ProxiedAddresses}
+     * will be used to determine a client address if a request has came via PROXY protocol.
+     */
+    public static ClientAddressSource ofProxyProtocol() {
+        return PROXY_PROTOCOL;
+    }
+
+    /**
+     * Returns {@code true} if the specified {@code source} is for a PROXY protocol.
+     */
+    static boolean isProxyProtocol(ClientAddressSource source) {
+        return source == PROXY_PROTOCOL;
+    }
+
+    private final AsciiString header;
+
+    private ClientAddressSource(AsciiString header) {
+        this.header = header;
+    }
+
+    AsciiString header() {
+        return header;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("header", header)
+                          .toString();
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/ClientAddressSource.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ClientAddressSource.java
@@ -66,21 +66,25 @@ public final class ClientAddressSource {
         return PROXY_PROTOCOL;
     }
 
-    /**
-     * Returns {@code true} if the specified {@code source} is for a PROXY protocol.
-     */
-    boolean isProxyProtocol() {
-        return this == PROXY_PROTOCOL;
-    }
-
     private final AsciiString header;
 
     private ClientAddressSource(AsciiString header) {
         this.header = header;
     }
 
+    /**
+     * Returns the name of an HTTP header. The value of the header in a request will be used to determine
+     * a client address.
+     */
     AsciiString header() {
         return header;
+    }
+
+    /**
+     * Returns {@code true} if the specified {@code source} is for a PROXY protocol.
+     */
+    boolean isProxyProtocol() {
+        return this == PROXY_PROTOCOL;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
@@ -100,7 +100,7 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
      * @param request the request associated with this context
      * @param sslSession the {@link SSLSession} for this invocation if it is over TLS
      * @param proxiedAddresses source and destination addresses retrieved from PROXY protocol header
-     * @param clientAddress the address of a client who initiates the request
+     * @param clientAddress the address of a client who initiated the request
      */
     public DefaultServiceRequestContext(
             ServiceConfig cfg, Channel ch, MeterRegistry meterRegistry, SessionProtocol sessionProtocol,

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.server;
 
 import static java.util.Objects.requireNonNull;
 
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.time.Duration;
@@ -66,6 +67,7 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
 
     @Nullable
     private final ProxiedAddresses proxiedAddresses;
+    private final InetAddress clientAddress;
 
     private final DefaultRequestLog log;
     private final Logger logger;
@@ -89,16 +91,22 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
     /**
      * Creates a new instance.
      *
+     * @param cfg the {@link ServiceConfig}
      * @param ch the {@link Channel} that handles the invocation
      * @param meterRegistry the {@link MeterRegistry} that collects various stats
      * @param sessionProtocol the {@link SessionProtocol} of the invocation
+     * @param pathMappingContext the parameters which is used when finding a matched {@link PathMapping}
+     * @param pathMappingResult the result of finding a matched {@link PathMapping}
      * @param request the request associated with this context
      * @param sslSession the {@link SSLSession} for this invocation if it is over TLS
+     * @param proxiedAddresses source and destination addresses retrieved from PROXY protocol header
+     * @param clientAddress the address of a client who initiates the request
      */
     public DefaultServiceRequestContext(
             ServiceConfig cfg, Channel ch, MeterRegistry meterRegistry, SessionProtocol sessionProtocol,
             PathMappingContext pathMappingContext, PathMappingResult pathMappingResult, Request request,
-            @Nullable SSLSession sslSession, @Nullable ProxiedAddresses proxiedAddresses) {
+            @Nullable SSLSession sslSession, @Nullable ProxiedAddresses proxiedAddresses,
+            InetAddress clientAddress) {
 
         super(meterRegistry, sessionProtocol,
               requireNonNull(pathMappingContext, "pathMappingContext").method(), pathMappingContext.path(),
@@ -111,6 +119,7 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
         this.pathMappingResult = pathMappingResult;
         this.sslSession = sslSession;
         this.proxiedAddresses = proxiedAddresses;
+        this.clientAddress = requireNonNull(clientAddress, "clientAddress");
 
         log = new DefaultRequestLog(this);
         log.startRequest(ch, sessionProtocol);
@@ -152,6 +161,11 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
     }
 
     @Override
+    public InetAddress clientAddress() {
+        return clientAddress;
+    }
+
+    @Override
     public ServiceRequestContext newDerivedContext() {
         return newDerivedContext(request());
     }
@@ -160,7 +174,7 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
     public ServiceRequestContext newDerivedContext(Request request) {
         final DefaultServiceRequestContext ctx = new DefaultServiceRequestContext(
                 cfg, ch, meterRegistry(), sessionProtocol(), pathMappingContext,
-                pathMappingResult, request, sslSession(), proxiedAddresses());
+                pathMappingResult, request, sslSession(), proxiedAddresses(), clientAddress);
 
         final HttpHeaders additionalHeaders = additionalResponseHeaders();
         if (!additionalHeaders.isEmpty()) {
@@ -414,6 +428,12 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
         final boolean hasChannel = ch != null;
         if (hasChannel) {
             buf.append(ch);
+
+            final InetAddress remote = ((InetSocketAddress) remoteAddress()).getAddress();
+            final InetAddress client = clientAddress();
+            if (remote != null && !remote.equals(client)) {
+                buf.append("[C:").append(client.getHostAddress()).append(']');
+            }
         }
 
         buf.append('[')

--- a/core/src/main/java/com/linecorp/armeria/server/HttpHeaderUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpHeaderUtil.java
@@ -15,8 +15,6 @@
  */
 package com.linecorp.armeria.server;
 
-import static com.linecorp.armeria.server.ClientAddressSource.isProxyProtocol;
-
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
@@ -60,7 +58,7 @@ final class HttpHeaderUtil {
      *
      * @param headers the HTTP headers which were received from the client
      * @param clientAddressSources a list of {@link ClientAddressSource}s which are used to determine
-     *                             an address of a client who initiated a request
+     *                             where to look for the client address, in the order of preference
      * @param proxiedAddresses source and destination addresses retrieved from PROXY protocol header
      * @param remoteAddress a remote endpoint of a channel
      * @param filter the filter which evaluates an {@link InetAddress} can be used as a client address
@@ -74,7 +72,7 @@ final class HttpHeaderUtil {
                                               Predicate<InetAddress> filter) {
         for (final ClientAddressSource source : clientAddressSources) {
             final InetAddress addr;
-            if (isProxyProtocol(source)) {
+            if (source.isProxyProtocol()) {
                 if (proxiedAddresses != null) {
                     addr = ((InetSocketAddress) proxiedAddresses.sourceAddress()).getAddress();
                     if (filter.test(addr)) {
@@ -129,7 +127,7 @@ final class HttpHeaderUtil {
         if (firstChar == '_' ||
             (firstChar == 'u' && "unknown".equals(address))) {
             // To early return when the address is not an IP address.
-            // - a obfuscated identifier which must start with '_'
+            // - an obfuscated identifier which must start with '_'
             //   - https://tools.ietf.org/html/rfc7239#section-6.3
             // - the "unknown" identifier
             return null;

--- a/core/src/main/java/com/linecorp/armeria/server/HttpHeaderUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpHeaderUtil.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import javax.annotation.Nullable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.CharMatcher;
+import com.google.common.base.Splitter;
+import com.google.common.base.Splitter.MapSplitter;
+import com.google.common.base.Strings;
+
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpHeaders;
+
+import io.netty.util.AsciiString;
+import io.netty.util.NetUtil;
+
+/**
+ * A utility class which provides useful methods for handling HTTP headers.
+ */
+final class HttpHeaderUtil {
+    private static final Logger logger = LoggerFactory.getLogger(HttpHeaderUtil.class);
+
+    private static final Splitter CSV_SPLITTER = Splitter.on(',').omitEmptyStrings();
+    private static final MapSplitter TOKEN_SPLITTER =
+            Splitter.on(';').omitEmptyStrings().withKeyValueSeparator('=');
+    private static final CharMatcher QUOTED_STRING_TRIMMER = CharMatcher.is('"');
+
+    @VisibleForTesting
+    static final Function<String, String> FORWARDED_CONVERTER = value -> TOKEN_SPLITTER.split(value).get("for");
+
+    /**
+     * Returns an {@link InetAddress} of a client who initiates a request.
+     *
+     * @param headers the HTTP headers which is received from the client
+     * @param candidateHeaderNames a list of the HTTP header names that may contain a client address
+     * @param proxiedAddresses source and destination addresses retrieved from PROXY protocol header
+     * @param remoteAddress a remote endpoint of a channel
+     * @param filter the filter which evaluates an {@link InetAddress} can be used as a client address
+     * @see <a href="https://tools.ietf.org/html/rfc7239">Forwarded HTTP Extension</a>
+     * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For">X-Forwarded-For</a>
+     */
+    static InetAddress determineClientAddress(HttpHeaders headers,
+                                              List<AsciiString> candidateHeaderNames,
+                                              @Nullable ProxiedAddresses proxiedAddresses,
+                                              InetSocketAddress remoteAddress,
+                                              Predicate<InetAddress> filter) {
+        for (final AsciiString name : candidateHeaderNames) {
+            final InetAddress addr;
+            if (name.equals(HttpHeaderNames.FORWARDED)) {
+                addr = getFirstValidAddress(
+                        headers.get(HttpHeaderNames.FORWARDED), FORWARDED_CONVERTER, filter);
+            } else {
+                addr = getFirstValidAddress(headers.get(name), Function.identity(), filter);
+            }
+            if (addr != null) {
+                return addr;
+            }
+        }
+
+        if (proxiedAddresses != null) {
+            final InetSocketAddress source = proxiedAddresses.sourceAddress();
+            final InetAddress addr = tryResolveInetAddress(source, false);
+            if (addr != null) {
+                return addr;
+            }
+
+            logger.debug("Failed to resolve hostname: {}", source.getHostName());
+        }
+
+        // Return the remote address as unresolved. A user may handle it later.
+        final InetAddress addr = tryResolveInetAddress(remoteAddress, true);
+        assert addr != null;
+        return addr;
+    }
+
+    /**
+     * Returns an {@link InetAddress} which was tried to resolve. It can be a unresolved one.
+     */
+    static InetAddress tryResolveInetAddress(InetSocketAddress addr) {
+        final InetAddress res = tryResolveInetAddress(addr, true);
+        assert res != null;
+        return res;
+    }
+
+    @Nullable
+    private static InetAddress tryResolveInetAddress(InetSocketAddress addr, boolean stayUnresolvedIfFailed) {
+        if (!addr.isUnresolved()) {
+            return addr.getAddress();
+        }
+        try {
+            return InetAddress.getByAddress(NetUtil.createByteArrayFromIpAddressString(addr.getHostName()));
+        } catch (UnknownHostException e) {
+            return stayUnresolvedIfFailed ? addr.getAddress() : null;
+        }
+    }
+
+    @VisibleForTesting
+    @Nullable
+    static InetAddress getFirstValidAddress(String headerValue,
+                                            Function<String, String> valueConverter,
+                                            Predicate<InetAddress> filter) {
+        if (Strings.isNullOrEmpty(headerValue)) {
+            return null;
+        }
+        for (String value : CSV_SPLITTER.split(headerValue)) {
+            final String v = valueConverter.apply(value);
+            if (Strings.isNullOrEmpty(v)) {
+                continue;
+            }
+            try {
+                final InetAddress addr = createInetAddress(v);
+                if (filter.test(addr)) {
+                    return addr;
+                }
+            } catch (UnknownHostException e) {
+                logger.debug("Failed to resolve hostname: {}", v, e);
+            }
+        }
+        return null;
+    }
+
+    private static InetAddress createInetAddress(String address) throws UnknownHostException {
+        // Remote quotes. e.g. "[2001:db8:cafe::17]:4711" => [2001:db8:cafe::17]:4711
+        final String addr = address.charAt(0) == '"' ? QUOTED_STRING_TRIMMER.trimFrom(address)
+                                                     : address;
+
+        if (NetUtil.isValidIpV4Address(addr) || NetUtil.isValidIpV6Address(addr)) {
+            return InetAddress.getByAddress(NetUtil.createByteArrayFromIpAddressString(addr));
+        }
+
+        if (addr.charAt(0) == '[') {
+            final int delim = addr.indexOf(']');
+            if (delim < 0) {
+                throw new UnknownHostException("Invalid IPv6 address format: " + addr);
+            }
+            // Remove the port part. e.g. [2001:db8:cafe::17]:4711 => [2001:db8:cafe::17]
+            final String withoutPort = addr.substring(0, delim + 1);
+            if (NetUtil.isValidIpV6Address(withoutPort)) {
+                return InetAddress.getByAddress(NetUtil.createByteArrayFromIpAddressString(withoutPort));
+            } else {
+                return InetAddress.getByName(withoutPort);
+            }
+        }
+
+        final int delim = addr.indexOf(':');
+        if (delim >= 0) {
+            // Remove the port part. e.g. 192.168.1.1:4711 => 192.168.1.1
+            final String withoutPort = addr.substring(0, delim);
+            if (NetUtil.isValidIpV4Address(withoutPort)) {
+                return InetAddress.getByAddress(NetUtil.createByteArrayFromIpAddressString(withoutPort));
+            } else {
+                return InetAddress.getByName(withoutPort);
+            }
+        }
+
+        // Try to lookup the host name.
+        return InetAddress.getByName(addr);
+    }
+
+    private HttpHeaderUtil() {}
+}

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -376,14 +376,14 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
         final ServiceConfig serviceCfg = mapped.value();
         final Service<HttpRequest, HttpResponse> service = serviceCfg.service();
         final Channel channel = ctx.channel();
-        final InetSocketAddress remote = (InetSocketAddress) channel.remoteAddress();
+        final InetAddress remoteAddress = ((InetSocketAddress) channel.remoteAddress()).getAddress();
 
         final InetAddress clientAddress;
-        if (config.clientAddressTrustedProxyFilter().test(remote)) {
-            clientAddress = determineClientAddress(headers, config.clientAddressHeaders(), proxiedAddresses,
-                                                   remote, config.clientAddressFilter());
+        if (config.clientAddressTrustedProxyFilter().test(remoteAddress)) {
+            clientAddress = determineClientAddress(headers, config.clientAddressSources(), proxiedAddresses,
+                                                   remoteAddress, config.clientAddressFilter());
         } else {
-            clientAddress = remote.getAddress();
+            clientAddress = remoteAddress;
         }
 
         final DefaultServiceRequestContext reqCtx = new DefaultServiceRequestContext(

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -23,7 +23,6 @@ import static com.linecorp.armeria.common.SessionProtocol.H1C;
 import static com.linecorp.armeria.common.SessionProtocol.H2;
 import static com.linecorp.armeria.common.SessionProtocol.H2C;
 import static com.linecorp.armeria.server.HttpHeaderUtil.determineClientAddress;
-import static com.linecorp.armeria.server.HttpHeaderUtil.tryResolveInetAddress;
 import static io.netty.handler.codec.http2.Http2CodecUtil.DEFAULT_WINDOW_SIZE;
 import static java.util.Objects.requireNonNull;
 
@@ -384,7 +383,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
             clientAddress = determineClientAddress(headers, config.clientAddressHeaders(), proxiedAddresses,
                                                    remote, config.clientAddressFilter());
         } else {
-            clientAddress = tryResolveInetAddress(remote);
+            clientAddress = remote.getAddress();
         }
 
         final DefaultServiceRequestContext reqCtx = new DefaultServiceRequestContext(

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -22,9 +22,12 @@ import static com.linecorp.armeria.common.SessionProtocol.H1;
 import static com.linecorp.armeria.common.SessionProtocol.H1C;
 import static com.linecorp.armeria.common.SessionProtocol.H2;
 import static com.linecorp.armeria.common.SessionProtocol.H2C;
+import static com.linecorp.armeria.server.HttpHeaderUtil.determineClientAddress;
+import static com.linecorp.armeria.server.HttpHeaderUtil.tryResolveInetAddress;
 import static io.netty.handler.codec.http2.Http2CodecUtil.DEFAULT_WINDOW_SIZE;
 import static java.util.Objects.requireNonNull;
 
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -373,11 +376,21 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
         final PathMappingResult mappingResult = mapped.mappingResult();
         final ServiceConfig serviceCfg = mapped.value();
         final Service<HttpRequest, HttpResponse> service = serviceCfg.service();
-
         final Channel channel = ctx.channel();
+        final InetSocketAddress remote = (InetSocketAddress) channel.remoteAddress();
+
+        final InetAddress clientAddress;
+        if (config.clientAddressTrustedProxyFilter().test(remote)) {
+            clientAddress = determineClientAddress(headers, config.clientAddressHeaders(), proxiedAddresses,
+                                                   remote, config.clientAddressFilter());
+        } else {
+            clientAddress = tryResolveInetAddress(remote);
+        }
+
         final DefaultServiceRequestContext reqCtx = new DefaultServiceRequestContext(
                 serviceCfg, channel, serviceCfg.server().meterRegistry(),
-                protocol, mappingCtx, mappingResult, req, getSSLSession(channel), proxiedAddresses);
+                protocol, mappingCtx, mappingResult, req, getSSLSession(channel),
+                proxiedAddresses, clientAddress);
 
         try (SafeCloseable ignored = reqCtx.push()) {
             final RequestLogBuilder logBuilder = reqCtx.logBuilder();

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
@@ -21,6 +21,7 @@ import static com.linecorp.armeria.common.SessionProtocol.HTTPS;
 import static com.linecorp.armeria.common.SessionProtocol.PROXY;
 import static java.util.Objects.requireNonNull;
 
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.EnumSet;
 import java.util.Iterator;
@@ -77,6 +78,7 @@ import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.util.AsciiString;
 import io.netty.util.DomainNameMapping;
+import io.netty.util.NetUtil;
 
 /**
  * Configures Netty {@link ChannelPipeline} to serve HTTP/1 and 2 requests.
@@ -332,9 +334,13 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
                              proxiedCandidates);
             }
             final ChannelPipeline p = ctx.pipeline();
-            final ProxiedAddresses proxiedAddresses = ProxiedAddresses.of(
-                    InetSocketAddress.createUnresolved(msg.sourceAddress(), msg.sourcePort()),
-                    InetSocketAddress.createUnresolved(msg.destinationAddress(), msg.destinationPort()));
+            final InetAddress src = InetAddress.getByAddress(
+                    NetUtil.createByteArrayFromIpAddressString(msg.sourceAddress()));
+            final InetAddress dst = InetAddress.getByAddress(
+                    NetUtil.createByteArrayFromIpAddressString(msg.destinationAddress()));
+            final ProxiedAddresses proxiedAddresses =
+                    ProxiedAddresses.of(new InetSocketAddress(src, msg.sourcePort()),
+                                        new InetSocketAddress(dst, msg.destinationPort()));
             configurePipeline(p, proxiedCandidates, proxiedAddresses);
             p.remove(this);
         }

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -176,7 +176,7 @@ public final class ServerBuilder {
     private boolean shutdownAccessLogWriterOnStop = true;
     private List<AsciiString> clientAddressHeaders =
             ImmutableList.of(HttpHeaderNames.FORWARDED, HttpHeaderNames.X_FORWARDED_FOR);
-    private Predicate<InetSocketAddress> clientAddressTrustedProxyFilter = remoteAddress -> true;
+    private Predicate<InetSocketAddress> clientAddressTrustedProxyFilter = remoteAddress -> false;
     private Predicate<InetAddress> clientAddressFilter = address -> true;
 
     @Nullable
@@ -1102,7 +1102,16 @@ public final class ServerBuilder {
     /**
      * Sets a list of HTTP headers which are used to determine a client address of a request.
      */
-    public ServerBuilder clientAddressHeaders(List<AsciiString> clientAddressHeaders) {
+    public ServerBuilder clientAddressHeaders(AsciiString... clientAddressHeaders) {
+        this.clientAddressHeaders = ImmutableList.copyOf(
+                requireNonNull(clientAddressHeaders, "clientAddressHeaders"));
+        return this;
+    }
+
+    /**
+     * Sets a list of HTTP headers which are used to determine a client address of a request.
+     */
+    public ServerBuilder clientAddressHeaders(Iterable<AsciiString> clientAddressHeaders) {
         this.clientAddressHeaders = ImmutableList.copyOf(
                 requireNonNull(clientAddressHeaders, "clientAddressHeaders"));
         return this;

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -1097,9 +1097,9 @@ public final class ServerBuilder {
     }
 
     /**
-     * Sets a list of {@link ClientAddressSource}s which are used to determine a client address of a request.
-     * {@code Forwarded} header, {@code X-Forwarded-For} header and the source address of a PROXY protocol
-     * header will be used by default.
+     * Sets a list of {@link ClientAddressSource}s which are used to determine where to look for the
+     * client address, in the order of preference. {@code Forwarded} header, {@code X-Forwarded-For} header
+     * and the source address of a PROXY protocol header will be used by default.
      */
     public ServerBuilder clientAddressSources(ClientAddressSource... clientAddressSources) {
         this.clientAddressSources = ImmutableList.copyOf(
@@ -1108,9 +1108,9 @@ public final class ServerBuilder {
     }
 
     /**
-     * Sets a list of {@link ClientAddressSource}s which are used to determine a client address of a request.
-     * {@code Forwarded} header, {@code X-Forwarded-For} header and the source address of a PROXY protocol
-     * header will be used by default.
+     * Sets a list of {@link ClientAddressSource}s which are used to determine where to look for the
+     * client address, in the order of preference. {@code Forwarded} header, {@code X-Forwarded-For} header
+     * and the source address of a PROXY protocol header will be used by default.
      */
     public ServerBuilder clientAddressSources(Iterable<ClientAddressSource> clientAddressSources) {
         this.clientAddressSources = ImmutableList.copyOf(

--- a/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
@@ -556,7 +556,8 @@ public final class ServerConfig {
     }
 
     /**
-     * Returns a list of {@link ClientAddressSource}s which are used to determine a client address of a request.
+     * Returns a list of {@link ClientAddressSource}s which are used to determine where to look for
+     * the client address, in the order of preference.
      */
     public List<ClientAddressSource> clientAddressSources() {
         return clientAddressSources;

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.server;
 
+import java.net.InetAddress;
 import java.net.SocketAddress;
 import java.time.Duration;
 import java.util.Map;
@@ -58,6 +59,11 @@ public interface ServiceRequestContext extends RequestContext {
     @Nonnull
     @Override
     <A extends SocketAddress> A localAddress();
+
+    /**
+     * Returns the address who initiates this request.
+     */
+    InetAddress clientAddress();
 
     @Override
     ServiceRequestContext newDerivedContext();

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
@@ -61,7 +61,7 @@ public interface ServiceRequestContext extends RequestContext {
     <A extends SocketAddress> A localAddress();
 
     /**
-     * Returns the address who initiates this request.
+     * Returns the address who initiated this request.
      */
     InetAddress clientAddress();
 

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
@@ -17,6 +17,7 @@
 package com.linecorp.armeria.server;
 
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.time.Duration;
 import java.util.Map;
@@ -63,7 +64,10 @@ public interface ServiceRequestContext extends RequestContext {
     /**
      * Returns the address of the client who initiated this request.
      */
-    InetAddress clientAddress();
+    default InetAddress clientAddress() {
+        final InetSocketAddress remoteAddress = remoteAddress();
+        return remoteAddress.getAddress();
+    }
 
     @Override
     ServiceRequestContext newDerivedContext();

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
@@ -61,7 +61,7 @@ public interface ServiceRequestContext extends RequestContext {
     <A extends SocketAddress> A localAddress();
 
     /**
-     * Returns the address who initiated this request.
+     * Returns the address of the client who initiated this request.
      */
     InetAddress clientAddress();
 

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.server;
 
+import java.net.InetAddress;
 import java.net.SocketAddress;
 import java.time.Duration;
 import java.util.Map;
@@ -59,6 +60,11 @@ public class ServiceRequestContextWrapper
     @Override
     public <A extends SocketAddress> A localAddress() {
         return delegate().localAddress();
+    }
+
+    @Override
+    public InetAddress clientAddress() {
+        return delegate().clientAddress();
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/logging/AccessLogComponent.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/AccessLogComponent.java
@@ -43,6 +43,7 @@ import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.util.Exceptions;
+import com.linecorp.armeria.server.ServiceRequestContext;
 
 import io.netty.util.AsciiString;
 import io.netty.util.Attribute;
@@ -76,7 +77,11 @@ interface AccessLogComponent {
     }
 
     static AccessLogComponent ofPredefinedCommon(AccessLogType type) {
-        return new CommonComponent(type, type == AccessLogType.REQUEST_LINE, null);
+        return ofPredefinedCommon(type, null);
+    }
+
+    static AccessLogComponent ofPredefinedCommon(AccessLogType type, @Nullable String variable) {
+        return new CommonComponent(type, type == AccessLogType.REQUEST_LINE, null, variable);
     }
 
     static AccessLogComponent ofQuotedRequestHeader(AsciiString headerName) {
@@ -222,6 +227,8 @@ interface AccessLogComponent {
 
         static boolean isSupported(AccessLogType type) {
             switch (type) {
+                case LOCAL_IP_ADDRESS:
+                case REMOTE_IP_ADDRESS:
                 case REMOTE_HOST:
                 case RFC931:
                 case AUTHENTICATED_USER:
@@ -235,20 +242,39 @@ interface AccessLogComponent {
         }
 
         private final AccessLogType type;
+        @Nullable
+        private final String variable;
 
         CommonComponent(AccessLogType type, boolean addQuote,
-                        @Nullable Function<HttpHeaders, Boolean> condition) {
+                        @Nullable Function<HttpHeaders, Boolean> condition,
+                        @Nullable String variable) {
             super(condition, addQuote);
             checkArgument(isSupported(requireNonNull(type, "type")),
                           "Type '" + type + "' is not acceptable by " +
                           CommonComponent.class.getName());
             this.type = type;
+            this.variable = variable;
         }
 
         @Nullable
         @Override
         public Object getMessage0(RequestLog log) {
             switch (type) {
+                case LOCAL_IP_ADDRESS:
+                    final InetSocketAddress local = log.context().localAddress();
+                    return local == null || local.isUnresolved() ? null : local.getAddress().getHostAddress();
+
+                case REMOTE_IP_ADDRESS:
+                    if ("c".equals(variable)) {
+                        // %{c}a means the remote address of the underlying channel.
+                        final InetSocketAddress remote = log.context().remoteAddress();
+                        return remote == null || remote.isUnresolved() ? null
+                                                                       : remote.getAddress().getHostAddress();
+                    } else {
+                        // %a means the client address who initiates a request.
+                        final ServiceRequestContext ctx = (ServiceRequestContext) log.context();
+                        return ctx.clientAddress().getHostAddress();
+                    }
                 case REMOTE_HOST:
                     final SocketAddress ra = log.context().remoteAddress();
                     return ra instanceof InetSocketAddress ? ((InetSocketAddress) ra).getHostString() : null;

--- a/core/src/main/java/com/linecorp/armeria/server/logging/AccessLogComponent.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/AccessLogComponent.java
@@ -271,7 +271,7 @@ interface AccessLogComponent {
                         return remote == null || remote.isUnresolved() ? null
                                                                        : remote.getAddress().getHostAddress();
                     } else {
-                        // %a means the client address who initiates a request.
+                        // %a means the client address who initiated a request.
                         final ServiceRequestContext ctx = (ServiceRequestContext) log.context();
                         return ctx.clientAddress().getHostAddress();
                     }

--- a/core/src/main/java/com/linecorp/armeria/server/logging/AccessLogFormats.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/AccessLogFormats.java
@@ -213,7 +213,7 @@ final class AccessLogFormats {
             return new TimestampComponent(addQuote, variable);
         }
         if (CommonComponent.isSupported(type)) {
-            return new CommonComponent(type, addQuote, condition);
+            return new CommonComponent(type, addQuote, condition, variable);
         }
         if (HttpHeaderComponent.isSupported(type)) {
             assert variable != null;

--- a/core/src/main/java/com/linecorp/armeria/server/logging/AccessLogType.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/AccessLogType.java
@@ -48,6 +48,17 @@ import io.netty.util.AttributeMap;
  */
 enum AccessLogType {
     /**
+     * {@code "%A"} - the local IP address.
+     */
+    LOCAL_IP_ADDRESS('A', false, NO),
+
+    /**
+     * {@code "%a"} - the remote IP address. The underlying client IP of the connection is available in the
+     * {@code "%{c}a"} format string.
+     */
+    REMOTE_IP_ADDRESS('a', false, OPTIONAL),
+
+    /**
      * {@code "%h"} - the remote hostname or IP address if DNS hostname lookup is not available.
      */
     REMOTE_HOST('h', false, NO),

--- a/core/src/main/java/com/linecorp/armeria/server/logging/AccessLogType.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/AccessLogType.java
@@ -53,8 +53,8 @@ enum AccessLogType {
     LOCAL_IP_ADDRESS('A', false, NO),
 
     /**
-     * {@code "%a"} - the remote IP address. The underlying client IP of the connection is available in the
-     * {@code "%{c}a"} format string.
+     * {@code "%a"} - the client IP address who initiated a request. Use {@code "%{c}a"} format string to get
+     * a remote IP address where the channel is connected to.
      */
     REMOTE_IP_ADDRESS('a', false, OPTIONAL),
 

--- a/core/src/main/java/com/linecorp/armeria/server/logging/AccessLogType.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/AccessLogType.java
@@ -51,69 +51,57 @@ enum AccessLogType {
      * {@code "%A"} - the local IP address.
      */
     LOCAL_IP_ADDRESS('A', false, NO),
-
     /**
-     * {@code "%a"} - the client IP address who initiated a request. Use {@code "%{c}a"} format string to get
-     * a remote IP address where the channel is connected to.
+     * {@code "%a"} - the IP address of the client who initiated a request. Use {@code "%{c}a"} format string
+     * to get the remote IP address where the channel is connected to, which may yield a different value
+     * when there is an intermediary proxy server.
      */
     REMOTE_IP_ADDRESS('a', false, OPTIONAL),
-
     /**
      * {@code "%h"} - the remote hostname or IP address if DNS hostname lookup is not available.
      */
     REMOTE_HOST('h', false, NO),
-
     /**
      * {@code "%l"} - the remote logname of the user.
      */
     RFC931('l', false, NO),
-
     /**
      * {@code "%u"} - the name of the authenticated remote user.
      */
     AUTHENTICATED_USER('u', false, NO),
-
     /**
      * {@code "%t"} - the date, time and time zone that the request was received.
      */
     REQUEST_TIMESTAMP('t', false, OPTIONAL),
-
     /**
      * {@code "%r"} - the request line from the client.
      */
     REQUEST_LINE('r', true, NO),
-
     /**
      * {@code "%s"} - the HTTP status code returned to the client.
      */
     RESPONSE_STATUS_CODE('s', false, NO),
-
     /**
      * {@code "%b"} - the size of the object returned to the client, measured in bytes.
      */
     RESPONSE_LENGTH('b', true, NO),
-
     /**
      * {@code "%{HEADER_NAME}i"} - the name of HTTP request header.
      */
     REQUEST_HEADER('i', true, YES),
-
     /**
      * {@code "%{HEADER_NAME}o"} - the name of HTTP response header.
      */
     RESPONSE_HEADER('o', true, YES),
-
     /**
      * {@code "%{ATTRIBUTE_NAME}j"} - the attribute name of the {@link AttributeMap} of the
      * {@link RequestContext}.
      */
     ATTRIBUTE('j', true, YES),
-
     /**
      * {@code "%{REQUEST_LOG_NAME}L"} - the name of the attributes in the {@link RequestLog}.
      */
     REQUEST_LOG('L', true, YES),
-
     /**
      * A plain text which would be written to access log message.
      */

--- a/core/src/test/java/com/linecorp/armeria/server/DefaultServiceRequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/DefaultServiceRequestContextTest.java
@@ -19,8 +19,6 @@ package com.linecorp.armeria.server;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-import java.net.UnknownHostException;
-
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableList;
@@ -42,7 +40,7 @@ import io.netty.util.NetUtil;
 public class DefaultServiceRequestContextTest {
 
     @Test
-    public void deriveContext() throws UnknownHostException {
+    public void deriveContext() {
         final VirtualHost virtualHost = virtualHost();
         final DefaultPathMappingContext mappingCtx = new DefaultPathMappingContext(
                 virtualHost, "example.com", HttpMethod.GET, "/hello", null, MediaType.JSON_UTF_8,

--- a/core/src/test/java/com/linecorp/armeria/server/DefaultServiceRequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/DefaultServiceRequestContextTest.java
@@ -19,7 +19,6 @@ package com.linecorp.armeria.server;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-import java.net.InetAddress;
 import java.net.UnknownHostException;
 
 import org.junit.Test;
@@ -38,6 +37,7 @@ import com.linecorp.armeria.common.metric.NoopMeterRegistry;
 import io.netty.channel.Channel;
 import io.netty.util.AsciiString;
 import io.netty.util.AttributeKey;
+import io.netty.util.NetUtil;
 
 public class DefaultServiceRequestContextTest {
 
@@ -52,7 +52,7 @@ public class DefaultServiceRequestContextTest {
                 virtualHost.serviceConfigs().get(0), mock(Channel.class), NoopMeterRegistry.get(),
                 SessionProtocol.H2,
                 mappingCtx, PathMappingResult.of("/foo"),
-                mock(Request.class), null, null, InetAddress.getByName("127.0.0.1"));
+                mock(Request.class), null, null, NetUtil.LOCALHOST4);
 
         setAdditionalHeaders(originalCtx);
 

--- a/core/src/test/java/com/linecorp/armeria/server/DefaultServiceRequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/DefaultServiceRequestContextTest.java
@@ -19,6 +19,9 @@ package com.linecorp.armeria.server;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableList;
@@ -39,7 +42,7 @@ import io.netty.util.AttributeKey;
 public class DefaultServiceRequestContextTest {
 
     @Test
-    public void deriveContext() {
+    public void deriveContext() throws UnknownHostException {
         final VirtualHost virtualHost = virtualHost();
         final DefaultPathMappingContext mappingCtx = new DefaultPathMappingContext(
                 virtualHost, "example.com", HttpMethod.GET, "/hello", null, MediaType.JSON_UTF_8,
@@ -49,7 +52,7 @@ public class DefaultServiceRequestContextTest {
                 virtualHost.serviceConfigs().get(0), mock(Channel.class), NoopMeterRegistry.get(),
                 SessionProtocol.H2,
                 mappingCtx, PathMappingResult.of("/foo"),
-                mock(Request.class), null, null);
+                mock(Request.class), null, null, InetAddress.getByName("127.0.0.1"));
 
         setAdditionalHeaders(originalCtx);
 

--- a/core/src/test/java/com/linecorp/armeria/server/HttpHeaderUtilTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpHeaderUtilTest.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import javax.annotation.Nullable;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpHeaders;
+
+import io.netty.util.AsciiString;
+
+public class HttpHeaderUtilTest {
+
+    private static final ImmutableList<AsciiString> CANDIDATES =
+            ImmutableList.of(HttpHeaderNames.FORWARDED, HttpHeaderNames.X_FORWARDED_FOR);
+    private static final Predicate<InetAddress> ACCEPT_ANY = addr -> true;
+
+    @Test
+    public void getAddress_Forwarded() throws UnknownHostException {
+        // IPv4
+        assertThat(forwarded("for=192.0.2.60;proto=http;by=203.0.113.43,for=192.0.2.61"))
+                .isEqualTo(InetAddress.getByName("192.0.2.60"));
+
+        // IPv4 with a port number
+        assertThat(forwarded("for=192.0.2.60:4711;proto=http;by=203.0.113.43,for=192.0.2.61"))
+                .isEqualTo(InetAddress.getByName("192.0.2.60"));
+
+        // IPv6
+        assertThat(forwarded("for=\"[2001:db8:cafe::17]\";proto=http;by=203.0.113.43,for=192.0.2.61"))
+                .isEqualTo(InetAddress.getByName("2001:db8:cafe::17"));
+
+        // IPv6 with a port number
+        assertThat(forwarded("for=\"[2001:db8:cafe::17]:4711\";proto=http;by=203.0.113.43,for=192.0.2.61"))
+                .isEqualTo(InetAddress.getByName("2001:db8:cafe::17"));
+
+        // No "for" parameter in the first value.
+        assertThat(forwarded("proto=http," +
+                             "for=\"[2001:db8:cafe::17]:4711\";proto=http;by=203.0.113.43,for=192.0.2.61"))
+                .isEqualTo(InetAddress.getByName("2001:db8:cafe::17"));
+
+        // The format of the first value is invalid.
+        assertThat(forwarded("for=\"[2001:db8:cafe::," +
+                             "for=\"[2001:db8:cafe::17]:4711\";proto=http;by=203.0.113.43,for=192.0.2.61"))
+                .isEqualTo(InetAddress.getByName("2001:db8:cafe::17"));
+
+        // Localhost
+        assertThat(forwarded("for=localhost;proto=http;by=203.0.113.43,for=192.0.2.61"))
+                .isEqualTo(InetAddress.getByName("localhost"));
+
+        // Resolved by DNS
+        assertThat(forwarded("for=github.com;proto=http;by=203.0.113.43,for=192.0.2.61"))
+                .isIn(InetAddress.getAllByName("github.com"));
+    }
+
+    @Nullable
+    private static InetAddress forwarded(String value) {
+        return HttpHeaderUtil.getFirstValidAddress(value, HttpHeaderUtil.FORWARDED_CONVERTER, ACCEPT_ANY);
+    }
+
+    @Test
+    public void getAddress_X_Forwarded_For() throws UnknownHostException {
+        // IPv4
+        assertThat(xForwardedFor("192.0.2.60,192.0.2.61,192.0.2.62"))
+                .isEqualTo(InetAddress.getByName("192.0.2.60"));
+
+        // IPv4 with a port number
+        assertThat(xForwardedFor("192.0.2.60:4711,192.0.2.61:4711,192.0.2.62:4711"))
+                .isEqualTo(InetAddress.getByName("192.0.2.60"));
+
+        // IPv6
+        assertThat(xForwardedFor("[2001:db8:cafe::17],[2001:db8:cafe::18],[2001:db8:cafe::19]"))
+                .isEqualTo(InetAddress.getByName("2001:db8:cafe::17"));
+
+        // IPv6 with a port number
+        assertThat(xForwardedFor("\"[2001:db8:cafe::17]:4711\",[2001:db8:cafe::18]:4711"))
+                .isEqualTo(InetAddress.getByName("2001:db8:cafe::17"));
+
+        // The format of the first value is invalid.
+        assertThat(xForwardedFor("[2001:db8:cafe::,[2001:db8:cafe::17]:4711,[2001:db8:cafe::18]:4711"))
+                .isEqualTo(InetAddress.getByName("2001:db8:cafe::17"));
+
+        // Localhost
+        assertThat(xForwardedFor("localhost,[2001:db8:cafe::17]:4711,[2001:db8:cafe::18]:4711"))
+                .isEqualTo(InetAddress.getByName("localhost"));
+
+        // Resolved by DNS
+        assertThat(xForwardedFor("github.com,[2001:db8:cafe::17]:4711,[2001:db8:cafe::18]:4711"))
+                .isIn(InetAddress.getAllByName("github.com"));
+    }
+
+    @Nullable
+    private static InetAddress xForwardedFor(String value) {
+        return HttpHeaderUtil.getFirstValidAddress(value, Function.identity(), ACCEPT_ANY);
+    }
+
+    @Test
+    public void testFilter_Forwarded() throws UnknownHostException {
+        // The first address which is not one of site local addresses
+        assertThat(HttpHeaderUtil.getFirstValidAddress(
+                "for=10.0.0.1,for=\"[2001:db8:cafe::17]:4711\";proto=http;by=203.0.113.43",
+                HttpHeaderUtil.FORWARDED_CONVERTER, addr -> !addr.isSiteLocalAddress()))
+                .isEqualTo(InetAddress.getByName("2001:db8:cafe::17"));
+
+        // The first address which is one of site local addresses
+        assertThat(HttpHeaderUtil.getFirstValidAddress(
+                "for=10.0.0.1,for=\"[2001:db8:cafe::17]:4711\";proto=http;by=203.0.113.43",
+                HttpHeaderUtil.FORWARDED_CONVERTER, InetAddress::isSiteLocalAddress))
+                .isEqualTo(InetAddress.getByName("10.0.0.1"));
+
+        // The first IPv6 address
+        assertThat(HttpHeaderUtil.getFirstValidAddress(
+                "for=10.0.0.1,for=\"[2001:db8:cafe::17]:4711\";proto=http;by=203.0.113.43",
+                HttpHeaderUtil.FORWARDED_CONVERTER, addr -> addr instanceof Inet6Address))
+                .isEqualTo(InetAddress.getByName("2001:db8:cafe::17"));
+
+        // The first address which is not a loopback
+        assertThat(HttpHeaderUtil.getFirstValidAddress(
+                "for=localhost",
+                HttpHeaderUtil.FORWARDED_CONVERTER, addr -> !addr.isLoopbackAddress()))
+                .isNull();
+    }
+
+    @Test
+    public void testFilter_X_Forwarded_For() throws UnknownHostException {
+        // The first address which is not one of site local addresses
+        assertThat(HttpHeaderUtil.getFirstValidAddress(
+                "10.0.0.1,8.8.8.8",
+                Function.identity(), addr -> !addr.isSiteLocalAddress()))
+                .isEqualTo(InetAddress.getByName("8.8.8.8"));
+
+        // The first address which is one of site local addresses
+        assertThat(HttpHeaderUtil.getFirstValidAddress(
+                "8.8.8.8,10.0.0.1",
+                Function.identity(), InetAddress::isSiteLocalAddress))
+                .isEqualTo(InetAddress.getByName("10.0.0.1"));
+
+        // The first IPv6 address
+        assertThat(HttpHeaderUtil.getFirstValidAddress(
+                "10.0.0.1,[2001:db8:cafe::17]:4711",
+                Function.identity(), addr -> addr instanceof Inet6Address))
+                .isEqualTo(InetAddress.getByName("[2001:db8:cafe::17]"));
+
+        // The first address which is not a loopback
+        assertThat(HttpHeaderUtil.getFirstValidAddress(
+                "localhost",
+                Function.identity(), addr -> !addr.isLoopbackAddress()))
+                .isNull();
+    }
+
+    @Test
+    public void testClientAddress() throws UnknownHostException {
+        final InetSocketAddress remoteAddr = new InetSocketAddress(5000);
+
+        // The first address in Forwarded header.
+        assertThat(HttpHeaderUtil.determineClientAddress(
+                HttpHeaders.of(HttpHeaderNames.FORWARDED, "for=10.0.0.1,for=10.0.0.2",
+                               HttpHeaderNames.X_FORWARDED_FOR, "10.1.0.1,10.1.0.2"),
+                CANDIDATES, null, remoteAddr, ACCEPT_ANY))
+                .isEqualTo(InetAddress.getByName("10.0.0.1"));
+        assertThat(HttpHeaderUtil.determineClientAddress(
+                HttpHeaders.of(HttpHeaderNames.FORWARDED, "for=10.0.0.1,for=10.0.0.2"),
+                CANDIDATES, null, remoteAddr, ACCEPT_ANY))
+                .isEqualTo(InetAddress.getByName("10.0.0.1"));
+
+        // Get a client address from a custom header.
+        assertThat(HttpHeaderUtil.determineClientAddress(
+                HttpHeaders.of(HttpHeaderNames.FORWARDED, "for=10.0.0.1,for=10.0.0.2",
+                               HttpHeaderNames.X_FORWARDED_FOR, "10.1.0.1,10.1.0.2",
+                               AsciiString.of("x-real-ip"), "10.2.0.1,10.2.0.2"),
+                ImmutableList.of(AsciiString.of("x-real-ip"),
+                                 HttpHeaderNames.FORWARDED,
+                                 HttpHeaderNames.X_FORWARDED_FOR),
+                null, remoteAddr, ACCEPT_ANY))
+                .isEqualTo(InetAddress.getByName("10.2.0.1"));
+
+        // The first address in X-Forwarded-For header.
+        assertThat(HttpHeaderUtil.determineClientAddress(
+                HttpHeaders.of(HttpHeaderNames.X_FORWARDED_FOR, "10.1.0.1,10.1.0.2"),
+                CANDIDATES, null, remoteAddr, ACCEPT_ANY))
+                .isEqualTo(InetAddress.getByName("10.1.0.1"));
+        assertThat(HttpHeaderUtil.determineClientAddress(
+                HttpHeaders.of(HttpHeaderNames.FORWARDED, "for=10.0.0.1,for=10.0.0.2",
+                               HttpHeaderNames.X_FORWARDED_FOR, "10.1.0.1,10.1.0.2"),
+                ImmutableList.of(HttpHeaderNames.X_FORWARDED_FOR),
+                null, remoteAddr, ACCEPT_ANY))
+                .isEqualTo(InetAddress.getByName("10.1.0.1"));
+
+        // Source address of the proxied addresses.
+        assertThat(HttpHeaderUtil.determineClientAddress(
+                HttpHeaders.of(), CANDIDATES,
+                ProxiedAddresses.of(new InetSocketAddress("10.2.0.1", 50001),
+                                    new InetSocketAddress("10.2.0.2", 50002)),
+                remoteAddr, ACCEPT_ANY))
+                .isEqualTo(InetAddress.getByName("10.2.0.1"));
+
+        // Remote address of the channel.
+        assertThat(HttpHeaderUtil.determineClientAddress(
+                HttpHeaders.of(), CANDIDATES, null, remoteAddr, ACCEPT_ANY))
+                .isEqualTo(remoteAddr.getAddress());
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/HttpHeaderUtilTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpHeaderUtilTest.java
@@ -69,13 +69,13 @@ public class HttpHeaderUtilTest {
                              "for=\"[2001:db8:cafe::17]:4711\";proto=http;by=203.0.113.43,for=192.0.2.61"))
                 .isEqualTo(InetAddress.getByName("2001:db8:cafe::17"));
 
-        // Localhost
-        assertThat(forwarded("for=localhost;proto=http;by=203.0.113.43,for=192.0.2.61"))
-                .isEqualTo(InetAddress.getByName("localhost"));
+        // A obfuscated identifier
+        assertThat(forwarded("for=_superhost;proto=http;by=203.0.113.43,for=192.0.2.61"))
+                .isEqualTo(InetAddress.getByName("192.0.2.61"));
 
-        // Resolved by DNS
-        assertThat(forwarded("for=github.com;proto=http;by=203.0.113.43,for=192.0.2.61"))
-                .isIn(InetAddress.getAllByName("github.com"));
+        // The unknown identifier
+        assertThat(forwarded("for=unknown;proto=http;by=203.0.113.43,for=192.0.2.61"))
+                .isIn(InetAddress.getAllByName("192.0.2.61"));
     }
 
     @Nullable
@@ -105,13 +105,15 @@ public class HttpHeaderUtilTest {
         assertThat(xForwardedFor("[2001:db8:cafe::,[2001:db8:cafe::17]:4711,[2001:db8:cafe::18]:4711"))
                 .isEqualTo(InetAddress.getByName("2001:db8:cafe::17"));
 
-        // Localhost
-        assertThat(xForwardedFor("localhost,[2001:db8:cafe::17]:4711,[2001:db8:cafe::18]:4711"))
-                .isEqualTo(InetAddress.getByName("localhost"));
+        // The following cases are not a part of X-Forwarded-For specifications, but the first element is
+        // definitely not valid.
+        // A obfuscated identifier
+        assertThat(xForwardedFor("_superhost,[2001:db8:cafe::17]:4711,[2001:db8:cafe::18]:4711"))
+                .isEqualTo(InetAddress.getByName("2001:db8:cafe::17"));
 
-        // Resolved by DNS
-        assertThat(xForwardedFor("github.com,[2001:db8:cafe::17]:4711,[2001:db8:cafe::18]:4711"))
-                .isIn(InetAddress.getAllByName("github.com"));
+        // The unknown identifier
+        assertThat(xForwardedFor("unknown,[2001:db8:cafe::17]:4711,[2001:db8:cafe::18]:4711"))
+                .isIn(InetAddress.getAllByName("2001:db8:cafe::17"));
     }
 
     @Nullable

--- a/logback/src/main/java/com/linecorp/armeria/common/logback/BuiltInProperties.java
+++ b/logback/src/main/java/com/linecorp/armeria/common/logback/BuiltInProperties.java
@@ -15,6 +15,7 @@
  */
 package com.linecorp.armeria.common.logback;
 
+import static com.linecorp.armeria.common.logback.BuiltInProperty.CLIENT_IP;
 import static com.linecorp.armeria.common.logback.BuiltInProperty.LOCAL_HOST;
 import static com.linecorp.armeria.common.logback.BuiltInProperty.LOCAL_IP;
 import static com.linecorp.armeria.common.logback.BuiltInProperty.LOCAL_PORT;
@@ -33,7 +34,7 @@ final class BuiltInProperties {
     private static final BuiltInProperty[] allValues = BuiltInProperty.values();
 
     private static final long MASK_ADDRESSES =
-            mask(REMOTE_HOST, REMOTE_IP, REMOTE_PORT, LOCAL_HOST, LOCAL_IP, LOCAL_PORT);
+            mask(REMOTE_HOST, REMOTE_IP, REMOTE_PORT, LOCAL_HOST, LOCAL_IP, LOCAL_PORT, CLIENT_IP);
     private static final long MASK_RPC = mask(REQ_RPC_METHOD, REQ_RPC_PARAMS, RES_RPC_RESULT);
     private static final long MASK_SSL = mask(TLS_SESSION_ID, TLS_CIPHER, TLS_PROTO);
 

--- a/logback/src/main/java/com/linecorp/armeria/common/logback/BuiltInProperty.java
+++ b/logback/src/main/java/com/linecorp/armeria/common/logback/BuiltInProperty.java
@@ -62,6 +62,11 @@ public enum BuiltInProperty {
      */
     LOCAL_PORT("local.port"),
     /**
+     * {@code "client.ip"} - the IP address who initiated a request. Unavailable if the connection is not
+     * established yet.
+     */
+    CLIENT_IP("client.ip"),
+    /**
      * {@code "scheme"} - the scheme of the request, represented by {@link Scheme#uriText()}.
      * e.g. {@code "tbinary+h2"}
      */

--- a/logback/src/main/java/com/linecorp/armeria/common/logback/RequestContextExporter.java
+++ b/logback/src/main/java/com/linecorp/armeria/common/logback/RequestContextExporter.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.common.logback;
 
+import static com.linecorp.armeria.common.logback.BuiltInProperty.CLIENT_IP;
 import static com.linecorp.armeria.common.logback.BuiltInProperty.ELAPSED_NANOS;
 import static com.linecorp.armeria.common.logback.BuiltInProperty.LOCAL_HOST;
 import static com.linecorp.armeria.common.logback.BuiltInProperty.LOCAL_IP;
@@ -39,6 +40,7 @@ import static com.linecorp.armeria.common.logback.BuiltInProperty.TLS_CIPHER;
 import static com.linecorp.armeria.common.logback.BuiltInProperty.TLS_PROTO;
 import static com.linecorp.armeria.common.logback.BuiltInProperty.TLS_SESSION_ID;
 
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.Map;
 import java.util.Set;
@@ -170,6 +172,8 @@ final class RequestContextExporter {
     private void exportAddresses(Map<String, String> out, RequestContext ctx) {
         final InetSocketAddress raddr = ctx.remoteAddress();
         final InetSocketAddress laddr = ctx.localAddress();
+        final InetAddress caddr =
+                ctx instanceof ServiceRequestContext ? ((ServiceRequestContext) ctx).clientAddress() : null;
 
         if (raddr != null) {
             if (builtIns.contains(REMOTE_HOST)) {
@@ -192,6 +196,12 @@ final class RequestContextExporter {
             }
             if (builtIns.contains(LOCAL_PORT)) {
                 out.put(LOCAL_PORT.mdcKey, String.valueOf(laddr.getPort()));
+            }
+        }
+
+        if (caddr != null) {
+            if (builtIns.contains(CLIENT_IP)) {
+                out.put(CLIENT_IP.mdcKey, caddr.getHostAddress());
             }
         }
     }

--- a/logback/src/test/java/com/linecorp/armeria/common/logback/RequestContextExportingAppenderTest.java
+++ b/logback/src/test/java/com/linecorp/armeria/common/logback/RequestContextExportingAppenderTest.java
@@ -276,6 +276,7 @@ public class RequestContextExportingAppenderTest {
                            .containsEntry("remote.host", "client.com")
                            .containsEntry("remote.ip", "1.2.3.4")
                            .containsEntry("remote.port", "5678")
+                           .containsEntry("client.ip", "9.10.11.12")
                            .containsEntry("req.direction", "INBOUND")
                            .containsEntry("req.authority", "server.com:8080")
                            .containsEntry("req.method", "GET")
@@ -285,7 +286,7 @@ public class RequestContextExportingAppenderTest {
                            .containsEntry("tls.session_id", "0101020305080d15")
                            .containsEntry("tls.proto", "TLSv1.2")
                            .containsEntry("tls.cipher", "some-cipher")
-                           .hasSize(15);
+                           .hasSize(16);
         }
     }
 
@@ -312,6 +313,7 @@ public class RequestContextExportingAppenderTest {
                            .containsEntry("remote.host", "client.com")
                            .containsEntry("remote.ip", "1.2.3.4")
                            .containsEntry("remote.port", "5678")
+                           .containsEntry("client.ip", "9.10.11.12")
                            .containsEntry("req.direction", "INBOUND")
                            .containsEntry("req.authority", "?")
                            .containsEntry("req.method", "GET")
@@ -325,7 +327,7 @@ public class RequestContextExportingAppenderTest {
                            .containsEntry("tls.proto", "TLSv1.2")
                            .containsEntry("tls.cipher", "some-cipher")
                            .containsKey("elapsed_nanos")
-                           .hasSize(19);
+                           .hasSize(20);
         }
     }
 
@@ -364,6 +366,7 @@ public class RequestContextExportingAppenderTest {
                            .containsEntry("remote.host", "client.com")
                            .containsEntry("remote.ip", "1.2.3.4")
                            .containsEntry("remote.port", "5678")
+                           .containsEntry("client.ip", "9.10.11.12")
                            .containsEntry("req.direction", "INBOUND")
                            .containsEntry("req.authority", "server.com:8080")
                            .containsEntry("req.method", "GET")
@@ -383,7 +386,7 @@ public class RequestContextExportingAppenderTest {
                            .containsEntry("tls.cipher", "some-cipher")
                            .containsEntry("attrs.my_attr", "some-attr")
                            .containsKey("elapsed_nanos")
-                           .hasSize(25);
+                           .hasSize(26);
         }
     }
 
@@ -425,7 +428,7 @@ public class RequestContextExportingAppenderTest {
         final ServiceRequestContext ctx = new DefaultServiceRequestContext(
                 serviceConfig, ch, NoopMeterRegistry.get(), SessionProtocol.H2, mappingCtx,
                 PathMappingResult.of(path, query), req, newSslSession(), null,
-                InetAddress.getByName("127.0.0.1"));
+                InetAddress.getByName("9.10.11.12"));
 
         ctx.attr(MY_ATTR).set(new CustomValue("some-attr"));
         return ctx;

--- a/logback/src/test/java/com/linecorp/armeria/common/logback/RequestContextExportingAppenderTest.java
+++ b/logback/src/test/java/com/linecorp/armeria/common/logback/RequestContextExportingAppenderTest.java
@@ -424,7 +424,8 @@ public class RequestContextExportingAppenderTest {
 
         final ServiceRequestContext ctx = new DefaultServiceRequestContext(
                 serviceConfig, ch, NoopMeterRegistry.get(), SessionProtocol.H2, mappingCtx,
-                PathMappingResult.of(path, query), req, newSslSession(), null);
+                PathMappingResult.of(path, query), req, newSslSession(), null,
+                InetAddress.getByName("127.0.0.1"));
 
         ctx.attr(MY_ATTR).set(new CustomValue("some-attr"));
         return ctx;

--- a/site/src/sphinx/server-access-log.rst
+++ b/site/src/sphinx/server-access-log.rst
@@ -122,9 +122,11 @@ Tokens for the log format are listed in the following table.
 +===========================+===================+====================================================+
 | ``%A``                    | No                | the local IP address                               |
 +---------------------------+-------------------+----------------------------------------------------+
-| ``%a``                    | No                | the client IP address who initiated a request.     |
-|                           |                   | Use ``%{c}a`` format string to get a remote IP     |
-|                           |                   | address where the channel is connected to.         |
+| ``%a``                    | No                | the IP address of the client who initiated a       |
+|                           |                   | request. Use ``%{c}a`` format string to get the    |
+|                           |                   | remote IP address where the channel is connected   |
+|                           |                   | to, which may yield a different value when there   |
+|                           |                   | is an intermediary proxy server.                   |
 +---------------------------+-------------------+----------------------------------------------------+
 | ``%h``                    | No                | the remote hostname or IP address if DNS           |
 |                           |                   | hostname lookup is not available                   |

--- a/site/src/sphinx/server-access-log.rst
+++ b/site/src/sphinx/server-access-log.rst
@@ -122,9 +122,9 @@ Tokens for the log format are listed in the following table.
 +===========================+===================+====================================================+
 | ``%A``                    | No                | the local IP address                               |
 +---------------------------+-------------------+----------------------------------------------------+
-| ``%A``                    | No                | the remote IP address. The underlying client IP of |
-|                           |                   | the connection is available in the ``%{c}a``       |
-|                           |                   | format string.                                     |
+| ``%a``                    | No                | the client IP address who initiated a request.     |
+|                           |                   | Use ``%{c}a`` format string to get a remote IP     |
+|                           |                   | address where the channel is connected to.         |
 +---------------------------+-------------------+----------------------------------------------------+
 | ``%h``                    | No                | the remote hostname or IP address if DNS           |
 |                           |                   | hostname lookup is not available                   |

--- a/site/src/sphinx/server-access-log.rst
+++ b/site/src/sphinx/server-access-log.rst
@@ -120,6 +120,12 @@ Tokens for the log format are listed in the following table.
 +---------------------------+-------------------+----------------------------------------------------+
 | Tokens                    | Condition support | Description                                        |
 +===========================+===================+====================================================+
+| ``%A``                    | No                | the local IP address                               |
++---------------------------+-------------------+----------------------------------------------------+
+| ``%A``                    | No                | the remote IP address. The underlying client IP of |
+|                           |                   | the connection is available in the ``%{c}a``       |
+|                           |                   | format string.                                     |
++---------------------------+-------------------+----------------------------------------------------+
 | ``%h``                    | No                | the remote hostname or IP address if DNS           |
 |                           |                   | hostname lookup is not available                   |
 +---------------------------+-------------------+----------------------------------------------------+


### PR DESCRIPTION
…d PROXY protocol

Modifications:
- Add `InetAddress clientAddress()` method to `ServiceRequestContext` interface.
- Can specify HTTP header names which are used to determine a client address.
- Can specify a remote address filter that evaluates whether a remote endpoint is trusted. Only the requests from the trust endpoint will be used to determine the client address.
- Add `Predicate<InetAddress>` to filter out the `InetAddress` that a user is not interested in.
- Add `server/HttpHeaderUtil` to provide a method which determines a client address from a request.
- Add `[C:x.x.x.x]` to `DefaultServiceRequestContext#toString` if the `#clientAddress`  is different from `#remoteAddress`.
- Add more tokens for access log format:
  - `%a`: client IP address of a request
  - `%{c}a`: remote IP address of the channel
  - `%A`: local IP address of the channel

Result:
- Closes #1077 