### PR TITLE
Rename `EventLoopGroups.serverChannelClass()` to `serverChannelType()`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/util/EventLoopGroups.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/EventLoopGroups.java
@@ -101,8 +101,19 @@ public final class EventLoopGroups {
      * Returns the {@link ServerChannel} class that is available for this {@code eventLoopGroup}, for use in
      * configuring a custom {@link Bootstrap}.
      */
+    public static Class<? extends ServerChannel> serverChannelType(EventLoopGroup eventLoopGroup) {
+        return TransportType.serverChannelType(requireNonNull(eventLoopGroup, "eventLoopGroup"));
+    }
+
+    /**
+     * Returns the {@link ServerChannel} class that is available for this {@code eventLoopGroup}, for use in
+     * configuring a custom {@link Bootstrap}.
+     *
+     * @deprecated Use {@link #serverChannelType(EventLoopGroup)}.
+     */
+    @Deprecated
     public static Class<? extends ServerChannel> serverChannelClass(EventLoopGroup eventLoopGroup) {
-        return TransportType.serverChannelClass(requireNonNull(eventLoopGroup, "eventLoopGroup"));
+        return serverChannelType(eventLoopGroup);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/internal/TransportType.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/TransportType.java
@@ -53,46 +53,23 @@ public enum TransportType {
     EPOLL(EpollServerSocketChannel.class, EpollSocketChannel.class, EpollDatagramChannel.class,
           EpollEventLoopGroup::new, EpollEventLoopGroup.class, ChannelUtil.epollEventLoopClass());
 
-    private final Class<? extends ServerChannel> serverChannelClass;
-    private final Class<? extends SocketChannel> socketChannelClass;
-    private final Class<? extends DatagramChannel> datagramClass;
+    private final Class<? extends ServerChannel> serverChannelType;
+    private final Class<? extends SocketChannel> socketChannelType;
+    private final Class<? extends DatagramChannel> datagramChannelType;
     private final Set<Class<? extends EventLoopGroup>> eventLoopGroupClasses;
     private final BiFunction<Integer, ThreadFactory, ? extends EventLoopGroup> eventLoopGroupConstructor;
 
     @SafeVarargs
-    TransportType(Class<? extends ServerChannel> serverChannelClass,
-                  Class<? extends SocketChannel> socketChannelClass,
-                  Class<? extends DatagramChannel> datagramClass,
+    TransportType(Class<? extends ServerChannel> serverChannelType,
+                  Class<? extends SocketChannel> socketChannelType,
+                  Class<? extends DatagramChannel> datagramChannelType,
                   BiFunction<Integer, ThreadFactory, ? extends EventLoopGroup> eventLoopGroupConstructor,
                   Class<? extends EventLoopGroup>... eventLoopGroupClasses) {
-        this.serverChannelClass = serverChannelClass;
-        this.socketChannelClass = socketChannelClass;
-        this.datagramClass = datagramClass;
+        this.serverChannelType = serverChannelType;
+        this.socketChannelType = socketChannelType;
+        this.datagramChannelType = datagramChannelType;
         this.eventLoopGroupClasses = ImmutableSet.copyOf(eventLoopGroupClasses);
         this.eventLoopGroupConstructor = eventLoopGroupConstructor;
-    }
-
-    /**
-     * Returns the {@link ServerChannel} class for {@code eventLoopGroup}.
-     */
-    public static Class<? extends ServerChannel> serverChannelClass(EventLoopGroup eventLoopGroup) {
-        return find(eventLoopGroup).serverChannelClass;
-    }
-
-    /**
-     * Returns the {@link ServerChannel} class that is available for this transport type.
-     */
-    public Class<? extends ServerChannel> serverChannelClass() {
-        return serverChannelClass;
-    }
-
-    /**
-     * Creates the available {@link EventLoopGroup}.
-     */
-    public EventLoopGroup newEventLoopGroup(int nThreads,
-                                            Function<TransportType, ThreadFactory> threadFactoryFactory) {
-        final ThreadFactory threadFactory = threadFactoryFactory.apply(this);
-        return eventLoopGroupConstructor.apply(nThreads, threadFactory);
     }
 
     /**
@@ -107,17 +84,31 @@ public enum TransportType {
     }
 
     /**
+     * Returns the {@link ServerChannel} class for {@code eventLoopGroup}.
+     */
+    public static Class<? extends ServerChannel> serverChannelType(EventLoopGroup eventLoopGroup) {
+        return find(eventLoopGroup).serverChannelType;
+    }
+
+    /**
+     * Returns the {@link ServerChannel} class that is available for this transport type.
+     */
+    public Class<? extends ServerChannel> serverChannelType() {
+        return serverChannelType;
+    }
+
+    /**
      * Returns the available {@link SocketChannel} class for {@code eventLoopGroup}.
      */
     public static Class<? extends SocketChannel> socketChannelType(EventLoopGroup eventLoopGroup) {
-        return find(eventLoopGroup).socketChannelClass;
+        return find(eventLoopGroup).socketChannelType;
     }
 
     /**
      * Returns the available {@link DatagramChannel} class for {@code eventLoopGroup}.
      */
     public static Class<? extends DatagramChannel> datagramChannelType(EventLoopGroup eventLoopGroup) {
-        return find(eventLoopGroup).datagramClass;
+        return find(eventLoopGroup).datagramChannelType;
     }
 
     /**
@@ -167,6 +158,15 @@ public enum TransportType {
      */
     public String lowerCasedName() {
         return Ascii.toLowerCase(name());
+    }
+
+    /**
+     * Creates the available {@link EventLoopGroup}.
+     */
+    public EventLoopGroup newEventLoopGroup(int nThreads,
+                                            Function<TransportType, ThreadFactory> threadFactoryFactory) {
+        final ThreadFactory threadFactory = threadFactoryFactory.apply(this);
+        return eventLoopGroupConstructor.apply(nThreads, threadFactory);
     }
 
     private static IllegalStateException unsupportedEventLoopType(EventLoopGroup eventLoopGroup) {

--- a/core/src/main/java/com/linecorp/armeria/server/Server.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Server.java
@@ -332,7 +332,7 @@ public final class Server implements AutoCloseable {
                 thread.setDaemon(false);
                 return thread;
             }), config.workerGroup());
-            b.channel(TransportType.detectTransportType().serverChannelClass());
+            b.channel(TransportType.detectTransportType().serverChannelType());
             b.handler(connectionLimitingHandler);
             b.childHandler(new HttpServerPipelineConfigurator(config, port, sslContexts,
                                                               gracefulShutdownSupport));


### PR DESCRIPTION
Motivation:

`EventLoopGroup.serverChannelClass()` should be renamed to
`serverChannelType()` for consistency with other methods.

Modifications:

- Added `EventLoopGroup.serverChannelType()` and deprecate
  `serverChannelClass()`.
- Renamed `TransportType.serverChannelClass()` to `serverChannelType()`.
- Reordered the methods in `TransportType`.
- Renamed field names in `TransportType` for consistency with its
  getter method names.

Result:

- Consistency