### PR TITLE
Allow disabling default ClientFactory shutdown hook

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactory.java
@@ -41,10 +41,10 @@ import io.netty.channel.EventLoopGroup;
  * other {@link ClientFactory} to protect itself from accidental premature termination.
  * </p><p>
  * Instead, when the current {@link ClassLoader} is {@linkplain ClassLoader#getSystemClassLoader() the system
- * class loader}, a {@link Runtime#addShutdownHook(Thread) shutdown hook} is registered so that they are
+ * class loader}, a {@linkplain Runtime#addShutdownHook(Thread) shutdown hook} is registered so that they are
  * released when the JVM exits.
  * </p><p>
- * If you are in an environment managed by a container or you desire the early termination of the default
+ * If you are in a multi-classloader environment or you desire an early/explicit termination of the default
  * {@link ClientFactory}, use {@link #closeDefault()}.
  * </p>
  */
@@ -62,6 +62,15 @@ public interface ClientFactory extends AutoCloseable {
         LoggerFactory.getLogger(ClientFactory.class).debug(
                 "Closing the default {}", ClientFactory.class.getSimpleName());
         ((DefaultClientFactory) DEFAULT).doClose();
+    }
+
+    /**
+     * Disables the {@linkplain Runtime#addShutdownHook(Thread) shutdown hook} which closes
+     * {@linkplain #DEFAULT the default <code>ClientFactory</code>}. This method is useful when you need
+     * full control over the life cycle of the default {@link ClientFactory}.
+     */
+    static void disableShutdownHook() {
+        DefaultClientFactory.disableShutdownHook0();
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientFactory.java
@@ -52,10 +52,20 @@ final class DefaultClientFactory extends AbstractClientFactory {
 
     private static final Logger logger = LoggerFactory.getLogger(DefaultClientFactory.class);
 
+    private static volatile boolean shutdownHookDisabled;
+
     static {
         if (DefaultClientFactory.class.getClassLoader() == ClassLoader.getSystemClassLoader()) {
-            Runtime.getRuntime().addShutdownHook(new Thread(ClientFactory::closeDefault));
+            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                if (!shutdownHookDisabled) {
+                    ClientFactory.closeDefault();
+                }
+            }));
         }
+    }
+
+    static void disableShutdownHook0() {
+        shutdownHookDisabled = true;
     }
 
     private final HttpClientFactory httpClientFactory;


### PR DESCRIPTION
See: #1082
Motivation:

A Spring user who uses `ClientFactory.DEFAULT` may observe the problem
where the default `ClientFactory` is closed before his/her Spring
application is fully destroyed.

Modifications:

- Added `ClientFactory.disableShutdownHook()`

Result:

- A user have full control over when the default `ClientFactory` can be
  closed.