### PR TITLE
Fix endpoint group health check metrics register different tag problem.

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupMetrics.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupMetrics.java
@@ -88,12 +88,9 @@ class HealthCheckedEndpointGroupMetrics implements MeterBinder {
                 healthMap.put(endpoint, healthy);
                 final List<Tag> tags = new ArrayList<>(2);
                 tags.add(Tag.of("authority", endpoint.authority()));
-                if (endpoint.hasIpAddr()) {
-                    final String address = endpoint.ipAddr();
-                    assert address != null;
-                    tags.add(Tag.of("ip", address));
-                }
-
+                final String ipAddr = endpoint.hasIpAddr() ? endpoint.ipAddr() : "";
+                assert ipAddr != null;
+                tags.add(Tag.of("ip", ipAddr));
                 registry.gauge(idPrefix.name(), idPrefix.tags(tags),
                                this, unused -> healthMap.get(endpoint) ? 1 : 0);
             });


### PR DESCRIPTION
Sometime we may have some endpoint groups using ip, some not. But
MeterRegistry doesn't allow us to create label with different tags. So
we need to set blank to ip tag if there is no ip addr.