### PR TITLE
Exception handlers handle an exception raised from a decorator

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/AnnotatedHttpService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AnnotatedHttpService.java
@@ -301,7 +301,7 @@ final class AnnotatedHttpService implements HttpService {
     }
 
     /**
-     * Intercepts a {@link HttpResponse} and wraps the response with an {@link ExceptionFilteredHttpResponse}
+     * Intercepts an {@link HttpResponse} and wraps the response with an {@link ExceptionFilteredHttpResponse}
      * if it is not an instance of {@link ExceptionFilteredHttpResponse}. This decorator will make an
      * {@link Exception} to be handled by {@link ExceptionHandlerFunction}s even if the exception is raised
      * from a decorator.

--- a/core/src/main/java/com/linecorp/armeria/server/AnnotatedHttpService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AnnotatedHttpService.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.ServiceLoader;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
 
 import javax.annotation.Nullable;
 
@@ -291,6 +292,42 @@ final class AnnotatedHttpService implements HttpService {
     }
 
     /**
+     * Returns a {@link Function} which produces a {@link Service} wrapped with an
+     * {@link ExceptionFilteredHttpResponseDecorator}.
+     */
+    Function<Service<HttpRequest, HttpResponse>,
+            ? extends Service<HttpRequest, HttpResponse>> exceptionHandlingDecorator() {
+        return ExceptionFilteredHttpResponseDecorator::new;
+    }
+
+    /**
+     * Intercepts a {@link HttpResponse} and wraps the response with an {@link ExceptionFilteredHttpResponse}
+     * if it is not an instance of {@link ExceptionFilteredHttpResponse}. This decorator will make an
+     * {@link Exception} to be handled by {@link ExceptionHandlerFunction}s even if the exception is raised
+     * from a decorator.
+     */
+    private class ExceptionFilteredHttpResponseDecorator
+            extends SimpleDecoratingService<HttpRequest, HttpResponse> {
+
+        ExceptionFilteredHttpResponseDecorator(Service<HttpRequest, HttpResponse> delegate) {
+            super(delegate);
+        }
+
+        @Override
+        public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+            try {
+                final HttpResponse response = delegate().serve(ctx, req);
+                if (response instanceof ExceptionFilteredHttpResponse) {
+                    return response;
+                }
+                return new ExceptionFilteredHttpResponse(ctx, req, response);
+            } catch (Exception cause) {
+                return convertException(ctx, req, cause);
+            }
+        }
+    }
+
+    /**
      * Intercepts a {@link Throwable} raised from {@link HttpResponse} and then rewrites it as an
      * {@link HttpResponseException} by {@link ExceptionHandlerFunction}.
      */
@@ -313,6 +350,10 @@ final class AnnotatedHttpService implements HttpService {
 
         @Override
         protected Throwable beforeError(Subscriber<? super HttpObject> subscriber, Throwable cause) {
+            if (cause instanceof HttpResponseException) {
+                // Do not convert again if it has been already converted.
+                return cause;
+            }
             return HttpResponseException.of(convertException(ctx, req, cause));
         }
     }

--- a/core/src/main/java/com/linecorp/armeria/server/AnnotatedHttpServiceFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AnnotatedHttpServiceFactory.java
@@ -487,6 +487,7 @@ final class AnnotatedHttpServiceFactory {
      * Returns a decorator chain which is specified by {@link Decorator} annotations and user-defined
      * decorator annotations.
      */
+    @Nullable
     private static Function<Service<HttpRequest, HttpResponse>,
             ? extends Service<HttpRequest, HttpResponse>> decorator(Method method, Class<?> clazz) {
 
@@ -499,7 +500,7 @@ final class AnnotatedHttpServiceFactory {
             decorator = decorator == null ? d.decorator()
                                           : decorator.andThen(d.decorator());
         }
-        return decorator == null ? Function.identity() : decorator;
+        return decorator;
     }
 
     /**
@@ -856,16 +857,17 @@ final class AnnotatedHttpServiceFactory {
         /**
          * A decorator of the {@link AnnotatedHttpService} which will be evaluated at service registration time.
          */
+        @Nullable
         private final Function<Service<HttpRequest, HttpResponse>,
                 ? extends Service<HttpRequest, HttpResponse>> decorator;
 
         private AnnotatedHttpServiceElement(PathMapping pathMapping,
                                             AnnotatedHttpService service,
-                                            Function<Service<HttpRequest, HttpResponse>,
+                                            @Nullable Function<Service<HttpRequest, HttpResponse>,
                                                     ? extends Service<HttpRequest, HttpResponse>> decorator) {
             this.pathMapping = requireNonNull(pathMapping, "pathMapping");
             this.service = requireNonNull(service, "service");
-            this.decorator = requireNonNull(decorator, "decorator");
+            this.decorator = decorator;
         }
 
         PathMapping pathMapping() {
@@ -876,6 +878,7 @@ final class AnnotatedHttpServiceFactory {
             return service;
         }
 
+        @Nullable
         Function<Service<HttpRequest, HttpResponse>,
                 ? extends Service<HttpRequest, HttpResponse>> decorator() {
             return decorator;
@@ -883,7 +886,7 @@ final class AnnotatedHttpServiceFactory {
 
         @Override
         public String toString() {
-            return MoreObjects.toStringHelper(this)
+            return MoreObjects.toStringHelper(this).omitNullValues()
                               .add("pathMapping", pathMapping())
                               .add("service", service())
                               .add("decorator", decorator())


### PR DESCRIPTION
Motivation:
In annotated HTTP service, a user may use both a decorator and an exception handler together for his or her service.
In this case, it would be more useful to let the exception handler handle an exception raised from the decorator.

Modifications:
- Add `ExceptionFilteredHttpResponseDecorator` to the first of a decorator chain when the chain is not empty.
  - It wraps an `HttpResponse` with `ExceptionFilteredHttpResponse` if the response is not an instance of `ExceptionFilteredHttpResponse`, in order to handle an exception raised from a decorator.
- Avoid converting `HttpResponseException` to a response, because `HttpResponseException` holds an `HttpResponse` inside.

Result:
- A user can handle exceptions in a generalized way even if any exception is raised from a decorator.
- Closes #1477