### PR TITLE
Support Spring validation on annotated HTTP services

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/AnnotatedHttpServiceFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AnnotatedHttpServiceFactory.java
@@ -23,17 +23,26 @@ import static com.linecorp.armeria.internal.ArmeriaHttpUtil.concatPaths;
 import static com.linecorp.armeria.server.AbstractPathMapping.ensureAbsolutePath;
 import static com.linecorp.armeria.server.AnnotatedValueResolver.toRequestObjectResolvers;
 import static java.util.Objects.requireNonNull;
+import static org.reflections.ReflectionUtils.getAllAnnotations;
+import static org.reflections.ReflectionUtils.getAllMethods;
+import static org.reflections.ReflectionUtils.getConstructors;
+import static org.reflections.ReflectionUtils.getMethods;
+import static org.reflections.ReflectionUtils.withModifier;
+import static org.reflections.ReflectionUtils.withName;
+import static org.reflections.ReflectionUtils.withParametersCount;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -50,6 +59,7 @@ import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableList.Builder;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 
 import com.linecorp.armeria.common.HttpMethod;
@@ -70,6 +80,7 @@ import com.linecorp.armeria.server.annotation.Decorators;
 import com.linecorp.armeria.server.annotation.Delete;
 import com.linecorp.armeria.server.annotation.ExceptionHandler;
 import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
+import com.linecorp.armeria.server.annotation.ExceptionHandlers;
 import com.linecorp.armeria.server.annotation.Get;
 import com.linecorp.armeria.server.annotation.Head;
 import com.linecorp.armeria.server.annotation.JacksonResponseConverterFunction;
@@ -85,9 +96,11 @@ import com.linecorp.armeria.server.annotation.ProducesGroup;
 import com.linecorp.armeria.server.annotation.Put;
 import com.linecorp.armeria.server.annotation.RequestConverter;
 import com.linecorp.armeria.server.annotation.RequestConverterFunction;
+import com.linecorp.armeria.server.annotation.RequestConverters;
 import com.linecorp.armeria.server.annotation.RequestObject;
 import com.linecorp.armeria.server.annotation.ResponseConverter;
 import com.linecorp.armeria.server.annotation.ResponseConverterFunction;
+import com.linecorp.armeria.server.annotation.ResponseConverters;
 import com.linecorp.armeria.server.annotation.StringResponseConverterFunction;
 import com.linecorp.armeria.server.annotation.Trace;
 
@@ -270,11 +283,14 @@ final class AnnotatedHttpServiceFactory {
      * Returns the list of {@link Path} annotated methods.
      */
     private static List<Method> requestMappingMethods(Object object) {
-        return Arrays.stream(object.getClass().getMethods())
-                     .filter(m -> m.getAnnotation(Path.class) != null ||
-                                  !httpMethodAnnotations(m).isEmpty())
-                     .sorted(Comparator.comparingInt(AnnotatedHttpServiceFactory::order))
-                     .collect(toImmutableList());
+        return getAllMethods(object.getClass(), withModifier(Modifier.PUBLIC))
+                .stream()
+                .filter(m -> getAllAnnotations(m).stream()
+                                                 .map(Annotation::annotationType)
+                                                 .anyMatch(a -> a == Path.class ||
+                                                                HTTP_METHOD_MAP.containsKey(a)))
+                .sorted(Comparator.comparingInt(AnnotatedHttpServiceFactory::order))
+                .collect(toImmutableList());
     }
 
     /**
@@ -282,7 +298,7 @@ final class AnnotatedHttpServiceFactory {
      * annotation. 0 would be returned if there is no specified {@link Order} annotation.
      */
     private static int order(Method method) {
-        final Order order = method.getAnnotation(Order.class);
+        final Order order = findAnnotation(method, Order.class).orElse(null);
         return order != null ? order.value() : 0;
     }
 
@@ -300,9 +316,10 @@ final class AnnotatedHttpServiceFactory {
      * @see Trace
      */
     private static Set<Annotation> httpMethodAnnotations(Method method) {
-        return Arrays.stream(method.getAnnotations())
-                     .filter(annotation -> HTTP_METHOD_MAP.containsKey(annotation.annotationType()))
-                     .collect(Collectors.toSet());
+        return getAllAnnotations(method)
+                .stream()
+                .filter(annotation -> HTTP_METHOD_MAP.containsKey(annotation.annotationType()))
+                .collect(Collectors.toSet());
     }
 
     /**
@@ -335,7 +352,7 @@ final class AnnotatedHttpServiceFactory {
     private static List<MediaType> consumableMediaTypes(AnnotatedElement element) {
         final List<MediaType> mediaTypes = new ArrayList<>();
 
-        for (final Annotation annotation : element.getAnnotations()) {
+        for (final Annotation annotation : getAllAnnotations(element)) {
             if (annotation instanceof ConsumesGroup) {
                 Arrays.stream(((ConsumesGroup) annotation).value())
                       .forEach(e -> addConsumableMediaType(mediaTypes, MediaType.parse(e.value())));
@@ -347,8 +364,8 @@ final class AnnotatedHttpServiceFactory {
             } else if (annotation instanceof ConsumeType) {
                 addConsumableMediaType(mediaTypes, MediaType.parse(((ConsumeType) annotation).value()));
             } else {
-                Arrays.stream(annotation.annotationType().getAnnotationsByType(Consumes.class))
-                      .forEach(e -> addConsumableMediaType(mediaTypes, MediaType.parse(e.value())));
+                findAnnotations(annotation.annotationType(), Consumes.class)
+                        .forEach(e -> addConsumableMediaType(mediaTypes, MediaType.parse(e.value())));
             }
         }
         return mediaTypes;
@@ -369,7 +386,7 @@ final class AnnotatedHttpServiceFactory {
     private static List<MediaType> producibleMediaTypes(AnnotatedElement element) {
         final List<MediaType> mediaTypes = new ArrayList<>();
 
-        for (final Annotation annotation : element.getAnnotations()) {
+        for (final Annotation annotation : getAllAnnotations(element)) {
             if (annotation instanceof ProducesGroup) {
                 Arrays.stream(((ProducesGroup) annotation).value())
                       .forEach(e -> addProducibleMediaType(mediaTypes, MediaType.parse(e.value())));
@@ -381,8 +398,8 @@ final class AnnotatedHttpServiceFactory {
             } else if (annotation instanceof ProduceType) {
                 addProducibleMediaType(mediaTypes, MediaType.parse(((ProduceType) annotation).value()));
             } else {
-                Arrays.stream(annotation.annotationType().getAnnotationsByType(Produces.class))
-                      .forEach(e -> addProducibleMediaType(mediaTypes, MediaType.parse(e.value())));
+                findAnnotations(annotation.annotationType(), Produces.class)
+                        .forEach(e -> addProducibleMediaType(mediaTypes, MediaType.parse(e.value())));
             }
         }
         return mediaTypes;
@@ -461,12 +478,8 @@ final class AnnotatedHttpServiceFactory {
      * HTTP method annotations such as {@link Get} and {@link Post}.
      */
     private static String findPattern(Method method, Set<Annotation> methodAnnotations) {
-        String pattern = null;
-
-        final Path path = method.getAnnotation(Path.class);
-        if (path != null) {
-            pattern = method.getAnnotation(Path.class).value();
-        }
+        String pattern = findAnnotation(method, Path.class).map(Path::value)
+                                                           .orElse(null);
         for (Annotation a : methodAnnotations) {
             final String p = (String) invokeValueMethod(a);
             if (DefaultValues.isUnspecified(p)) {
@@ -557,9 +570,10 @@ final class AnnotatedHttpServiceFactory {
 
             // If user-defined decorators are repeatable and they are specified more than once.
             try {
-                final Annotation[] decorators = (Annotation[]) annotation.annotationType()
-                                                                         .getMethod("value")
-                                                                         .invoke(annotation);
+                final Method method = Iterables.getFirst(getMethods(annotation.annotationType(),
+                                                                    withName("value")), null);
+                assert method != null : "No 'value' method is found from " + annotation;
+                final Annotation[] decorators = (Annotation[]) method.invoke(annotation);
                 for (final Annotation decorator : decorators) {
                     udd = userDefinedDecorator(decorator);
                     if (udd == null) {
@@ -581,7 +595,8 @@ final class AnnotatedHttpServiceFactory {
     @Nullable
     private static DecoratorAndOrder userDefinedDecorator(Annotation annotation) {
         // User-defined decorator MUST be annotated with @DecoratorFactory annotation.
-        final DecoratorFactory d = annotation.annotationType().getAnnotation(DecoratorFactory.class);
+        final DecoratorFactory d =
+                findAnnotation(annotation.annotationType(), DecoratorFactory.class).orElse(null);
         if (d == null) {
             return null;
         }
@@ -593,9 +608,13 @@ final class AnnotatedHttpServiceFactory {
         // If the annotation has "order" attribute, we can use it when sorting decorators.
         int order = 0;
         try {
-            final Object value = annotation.annotationType().getMethod("order").invoke(annotation);
-            if (value instanceof Integer) {
-                order = (Integer) value;
+            final Method method = Iterables.getFirst(getMethods(annotation.annotationType(),
+                                                                withName("order")), null);
+            if (method != null) {
+                final Object value = method.invoke(annotation);
+                if (value instanceof Integer) {
+                    order = (Integer) value;
+                }
             }
         } catch (Throwable ignore) {
             // A user-defined decorator may not have an 'order' attribute.
@@ -620,7 +639,7 @@ final class AnnotatedHttpServiceFactory {
      */
     private static Builder<ExceptionHandlerFunction> exceptionHandlers(Method targetMethod,
                                                                        Class<?> targetClass) {
-        return annotationValues(targetMethod, targetClass, ExceptionHandler.class,
+        return annotationValues(targetMethod, targetClass, ExceptionHandler.class, ExceptionHandlers.class,
                                 ExceptionHandlerFunction.class);
     }
 
@@ -629,7 +648,7 @@ final class AnnotatedHttpServiceFactory {
      */
     private static Builder<RequestConverterFunction> requestConverters(Method targetMethod,
                                                                        Class<?> targetClass) {
-        return annotationValues(targetMethod, targetClass, RequestConverter.class,
+        return annotationValues(targetMethod, targetClass, RequestConverter.class, RequestConverters.class,
                                 RequestConverterFunction.class);
     }
 
@@ -638,7 +657,7 @@ final class AnnotatedHttpServiceFactory {
      */
     private static Builder<ResponseConverterFunction> responseConverters(Method targetMethod,
                                                                          Class<?> targetClass) {
-        return annotationValues(targetMethod, targetClass, ResponseConverter.class,
+        return annotationValues(targetMethod, targetClass, ResponseConverter.class, ResponseConverters.class,
                                 ResponseConverterFunction.class);
     }
 
@@ -647,20 +666,45 @@ final class AnnotatedHttpServiceFactory {
      * {@code T}.
      */
     private static <T extends Annotation, R> Builder<R> annotationValues(
-            Method targetMethod, Class<?> targetClass, Class<T> annotationClass, Class<R> expectedType) {
+            Method targetMethod, Class<?> targetClass, Class<T> annotationClass, Class<?> repeatableClass,
+            Class<R> expectedType) {
 
         requireNonNull(annotationClass, "annotationClass");
         requireNonNull(targetMethod, "targetMethod");
         requireNonNull(targetClass, "targetClass");
 
         final Builder<R> builder = new Builder<>();
-        for (final T annotation : targetMethod.getAnnotationsByType(annotationClass)) {
-            builder.add(getInstance(annotation, expectedType));
-        }
-        for (final T annotation : targetClass.getAnnotationsByType(annotationClass)) {
-            builder.add(getInstance(annotation, expectedType));
-        }
+        annotationValues0(builder, targetMethod, annotationClass, repeatableClass, expectedType);
+        getClasses(targetClass, new Builder<>()).forEach(
+                target -> annotationValues0(builder, target, annotationClass, repeatableClass, expectedType));
         return builder;
+    }
+
+    private static <T extends Annotation, R> void annotationValues0(
+            Builder<R> builder, AnnotatedElement target, Class<T> annotationClass, Class<?> repeatableClass,
+            Class<R> expectedType) {
+        for (final Annotation annotation : target.getAnnotations()) {
+            final Class<? extends Annotation> type = annotation.annotationType();
+            if (type == annotationClass) {
+                builder.add(getInstance(annotation, expectedType));
+            } else if (type == repeatableClass) {
+                @SuppressWarnings("unchecked")
+                final T[] annotations = (T[]) invokeValueMethod(annotation);
+                Arrays.stream(annotations).forEach(a -> builder.add(getInstance(a, expectedType)));
+            }
+        }
+    }
+
+    private static List<Class<?>> getClasses(Class<?> clazz, Builder<Class<?>> builder) {
+        final Class<?> superClass = clazz.getSuperclass();
+        if (superClass == null || superClass == Object.class) {
+            builder.add(clazz);
+            return builder.build();
+        }
+
+        // Subclass first.
+        builder.add(clazz);
+        return getClasses(superClass, builder);
     }
 
     /**
@@ -673,7 +717,10 @@ final class AnnotatedHttpServiceFactory {
             final Class<? extends T> clazz = (Class<? extends T>) invokeValueMethod(annotation);
             return expectedType.cast(instanceCache.computeIfAbsent(clazz, type -> {
                 try {
-                    final Constructor<? extends T> constructor = clazz.getDeclaredConstructor();
+
+                    final Constructor<? extends T> constructor =
+                            Iterables.getFirst(getConstructors(clazz, withParametersCount(0)), null);
+                    assert constructor != null : "No default constructor is found from " + clazz.getName();
                     constructor.setAccessible(true);
                     return constructor.newInstance();
                 } catch (Exception e) {
@@ -696,7 +743,9 @@ final class AnnotatedHttpServiceFactory {
     static <T> T getInstance(Class<T> clazz) {
         return (T) instanceCache.computeIfAbsent(clazz, type -> {
             try {
-                final Constructor<? extends T> constructor = clazz.getDeclaredConstructor();
+                final Constructor<? extends T> constructor =
+                        Iterables.getFirst(getConstructors(clazz, withParametersCount(0)), null);
+                assert constructor != null : "No default constructor is found from " + clazz.getName();
                 constructor.setAccessible(true);
                 return constructor.newInstance();
             } catch (Exception e) {
@@ -711,11 +760,35 @@ final class AnnotatedHttpServiceFactory {
      */
     private static Object invokeValueMethod(Annotation a) {
         try {
-            return a.getClass().getMethod("value").invoke(a);
+            final Method method = Iterables.getFirst(getMethods(a.getClass(), withName("value")), null);
+            assert method != null : "No 'value' method is found from " + a;
+            return method.invoke(a);
         } catch (Exception e) {
             throw new IllegalStateException("An annotation @" + a.getClass().getSimpleName() +
                                             " must have a 'value' method", e);
         }
+    }
+
+    /**
+     * Returns an {@link Annotation} of the specified {@link Class}.
+     */
+    private static <T extends Annotation> Optional<T> findAnnotation(AnnotatedElement element,
+                                                                     Class<T> target) {
+        final List<T> list = findAnnotations(element, target);
+        return list.isEmpty() ? Optional.empty()
+                              : Optional.of(list.get(0));
+    }
+
+    /**
+     * Returns {@link Annotation}s of the specified {@link Class}.
+     */
+    private static <T extends Annotation> List<T> findAnnotations(AnnotatedElement element,
+                                                                  Class<T> target) {
+        return getAllAnnotations(element)
+                .stream()
+                .filter(annotation -> annotation.annotationType() == target)
+                .map(target::cast)
+                .collect(toImmutableList());
     }
 
     private AnnotatedHttpServiceFactory() {}

--- a/examples/spring-boot-webflux/src/main/java/example/springframework/boot/webflux/HelloAnnotatedService.java
+++ b/examples/spring-boot-webflux/src/main/java/example/springframework/boot/webflux/HelloAnnotatedService.java
@@ -9,6 +9,12 @@ import com.linecorp.armeria.server.annotation.ExceptionHandler;
 import com.linecorp.armeria.server.annotation.Get;
 import com.linecorp.armeria.server.annotation.Param;
 
+/**
+ * Note that this is not a Spring WebFlux-based component but an annotated HTTP service that leverages
+ * Armeria's built-in annotations.
+ *
+ * @see <a href="https://line.github.io/armeria/server-annotated-service.html">Annotated HTTP Service</a>
+ */
 @Component
 @Validated
 @ExceptionHandler(ValidationExceptionHandler.class)
@@ -21,6 +27,6 @@ public class HelloAnnotatedService {
     public String hello(
             @Size(min = 3, max = 10, message = "name should have between 3 and 10 characters")
             @Param String name) {
-        return String.format("Hello, %s! This is from Armeria annotated service!", name);
+        return String.format("Hello, %s! This message is from Armeria annotated service!", name);
     }
 }

--- a/examples/spring-boot-webflux/src/main/java/example/springframework/boot/webflux/HelloAnnotatedService.java
+++ b/examples/spring-boot-webflux/src/main/java/example/springframework/boot/webflux/HelloAnnotatedService.java
@@ -1,0 +1,26 @@
+package example.springframework.boot.webflux;
+
+import javax.validation.constraints.Size;
+
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+import com.linecorp.armeria.server.annotation.ExceptionHandler;
+import com.linecorp.armeria.server.annotation.Get;
+import com.linecorp.armeria.server.annotation.Param;
+
+@Component
+@Validated
+@ExceptionHandler(ValidationExceptionHandler.class)
+public class HelloAnnotatedService {
+
+    /**
+     * An example in order to show how to use validation framework in an annotated HTTP service.
+     */
+    @Get("/hello/{name}")
+    public String hello(
+            @Size(min = 3, max = 10, message = "name should have between 3 and 10 characters")
+            @Param String name) {
+        return String.format("Hello, %s! This is from Armeria annotated service!", name);
+    }
+}

--- a/examples/spring-boot-webflux/src/main/java/example/springframework/boot/webflux/HelloConfiguration.java
+++ b/examples/spring-boot-webflux/src/main/java/example/springframework/boot/webflux/HelloConfiguration.java
@@ -9,9 +9,11 @@ import com.linecorp.armeria.client.ClientFactoryBuilder;
 import com.linecorp.armeria.client.circuitbreaker.CircuitBreakerHttpClientBuilder;
 import com.linecorp.armeria.client.circuitbreaker.CircuitBreakerStrategy;
 import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.docs.DocService;
 import com.linecorp.armeria.server.logging.AccessLogWriter;
 import com.linecorp.armeria.server.logging.LoggingService;
+import com.linecorp.armeria.spring.AnnotatedServiceRegistrationBean;
 import com.linecorp.armeria.spring.ArmeriaServerConfigurator;
 import com.linecorp.armeria.spring.web.reactive.ArmeriaClientConfigurator;
 
@@ -72,5 +74,17 @@ public class HelloConfiguration {
             // Set a custom client factory.
             builder.factory(clientFactory);
         };
+    }
+
+    /**
+     * Returns an {@link AnnotatedServiceRegistrationBean} which will be used to add an annotated HTTP
+     * service object to a {@link ServerBuilder}. If you want to only use Spring controllers, you do not
+     * need to create this bean.
+     */
+    @Bean
+    public AnnotatedServiceRegistrationBean annotatedServiceRegistrationBean(HelloAnnotatedService service) {
+        return new AnnotatedServiceRegistrationBean().setServiceName("hello")
+                                                     .setPathPrefix("/armeria")
+                                                     .setService(service);
     }
 }

--- a/examples/spring-boot-webflux/src/main/java/example/springframework/boot/webflux/HelloConfiguration.java
+++ b/examples/spring-boot-webflux/src/main/java/example/springframework/boot/webflux/HelloConfiguration.java
@@ -9,11 +9,9 @@ import com.linecorp.armeria.client.ClientFactoryBuilder;
 import com.linecorp.armeria.client.circuitbreaker.CircuitBreakerHttpClientBuilder;
 import com.linecorp.armeria.client.circuitbreaker.CircuitBreakerStrategy;
 import com.linecorp.armeria.server.Server;
-import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.docs.DocService;
 import com.linecorp.armeria.server.logging.AccessLogWriter;
 import com.linecorp.armeria.server.logging.LoggingService;
-import com.linecorp.armeria.spring.AnnotatedServiceRegistrationBean;
 import com.linecorp.armeria.spring.ArmeriaServerConfigurator;
 import com.linecorp.armeria.spring.web.reactive.ArmeriaClientConfigurator;
 
@@ -29,7 +27,7 @@ public class HelloConfiguration {
      * A user can configure a {@link Server} by providing an {@link ArmeriaServerConfigurator} bean.
      */
     @Bean
-    public ArmeriaServerConfigurator armeriaServerConfigurator() {
+    public ArmeriaServerConfigurator armeriaServerConfigurator(HelloAnnotatedService service) {
         // Customize the server using the given ServerBuilder. For example:
         return builder -> {
             // Add DocService that enables you to send Thrift and gRPC requests from web browser.
@@ -40,6 +38,9 @@ public class HelloConfiguration {
 
             // Write access log after completing a request.
             builder.accessLogWriter(AccessLogWriter.combined(), false);
+
+            // Add an Armeria annotated HTTP service, if you want.
+            builder.annotatedService("/armeria", service);
 
             // You can also bind asynchronous RPC services such as Thrift and gRPC:
             // builder.service(THttpService.of(...));
@@ -74,17 +75,5 @@ public class HelloConfiguration {
             // Set a custom client factory.
             builder.factory(clientFactory);
         };
-    }
-
-    /**
-     * Returns an {@link AnnotatedServiceRegistrationBean} which will be used to add an annotated HTTP
-     * service object to a {@link ServerBuilder}. If you want to only use Spring controllers, you do not
-     * need to create this bean.
-     */
-    @Bean
-    public AnnotatedServiceRegistrationBean annotatedServiceRegistrationBean(HelloAnnotatedService service) {
-        return new AnnotatedServiceRegistrationBean().setServiceName("hello")
-                                                     .setPathPrefix("/armeria")
-                                                     .setService(service);
     }
 }

--- a/examples/spring-boot-webflux/src/main/java/example/springframework/boot/webflux/ValidationExceptionHandler.java
+++ b/examples/spring-boot-webflux/src/main/java/example/springframework/boot/webflux/ValidationExceptionHandler.java
@@ -28,8 +28,8 @@ public class ValidationExceptionHandler implements ExceptionHandlerFunction {
     @Override
     public HttpResponse handleException(RequestContext ctx, HttpRequest req, Throwable cause) {
         if (cause instanceof ValidationException) {
-            final HttpStatus status = HttpStatus.INTERNAL_SERVER_ERROR;
             try {
+                final HttpStatus status = HttpStatus.BAD_REQUEST;
                 return HttpResponse.of(status, MediaType.JSON_UTF_8, mapper.writeValueAsBytes(
                         new ErrorResponse(status.reasonPhrase(),
                                           cause.getMessage(),
@@ -37,7 +37,8 @@ public class ValidationExceptionHandler implements ExceptionHandlerFunction {
                                           status.code(),
                                           Instant.now().toString())));
             } catch (JsonProcessingException e) {
-                return HttpResponse.of(status, MediaType.PLAIN_TEXT_UTF_8, cause.getMessage());
+                return HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR, MediaType.PLAIN_TEXT_UTF_8,
+                                       cause.getMessage());
             }
         }
         return ExceptionHandlerFunction.fallthrough();
@@ -46,7 +47,7 @@ public class ValidationExceptionHandler implements ExceptionHandlerFunction {
     /**
      * A sample HTTP response which is sent to a client when a {@link ValidationException} is raised.
      */
-    static class ErrorResponse {
+    public static class ErrorResponse {
         private final String error;
         private final String message;
         private final String path;

--- a/examples/spring-boot-webflux/src/main/java/example/springframework/boot/webflux/ValidationExceptionHandler.java
+++ b/examples/spring-boot-webflux/src/main/java/example/springframework/boot/webflux/ValidationExceptionHandler.java
@@ -1,0 +1,94 @@
+package example.springframework.boot.webflux;
+
+import static java.util.Objects.requireNonNull;
+
+import java.time.Instant;
+
+import javax.validation.ValidationException;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
+
+/**
+ * A sample exception handler which handles a {@link ValidationException}.
+ */
+public class ValidationExceptionHandler implements ExceptionHandlerFunction {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Override
+    public HttpResponse handleException(RequestContext ctx, HttpRequest req, Throwable cause) {
+        if (cause instanceof ValidationException) {
+            final HttpStatus status = HttpStatus.INTERNAL_SERVER_ERROR;
+            try {
+                return HttpResponse.of(status, MediaType.JSON_UTF_8, mapper.writeValueAsBytes(
+                        new ErrorResponse(status.reasonPhrase(),
+                                          cause.getMessage(),
+                                          req.path(),
+                                          status.code(),
+                                          Instant.now().toString())));
+            } catch (JsonProcessingException e) {
+                return HttpResponse.of(status, MediaType.PLAIN_TEXT_UTF_8, cause.getMessage());
+            }
+        }
+        return ExceptionHandlerFunction.fallthrough();
+    }
+
+    /**
+     * A sample HTTP response which is sent to a client when a {@link ValidationException} is raised.
+     */
+    static class ErrorResponse {
+        private final String error;
+        private final String message;
+        private final String path;
+        private final int status;
+        private final String timestamp;
+
+        @JsonCreator
+        ErrorResponse(@JsonProperty("error") String error,
+                      @JsonProperty("message") String message,
+                      @JsonProperty("path") String path,
+                      @JsonProperty("status") int status,
+                      @JsonProperty("timestamp") String timestamp) {
+            this.error = requireNonNull(error, "error");
+            this.message = requireNonNull(message, "message");
+            this.path = requireNonNull(path, "path");
+            this.status = status;
+            this.timestamp = requireNonNull(timestamp, "timestamp");
+        }
+
+        @JsonProperty
+        public String error() {
+            return error;
+        }
+
+        @JsonProperty
+        public String message() {
+            return message;
+        }
+
+        @JsonProperty
+        public String path() {
+            return path;
+        }
+
+        @JsonProperty
+        public int status() {
+            return status;
+        }
+
+        @JsonProperty
+        public String timestamp() {
+            return timestamp;
+        }
+    }
+}

--- a/examples/spring-boot-webflux/src/test/java/example/springframework/boot/webflux/HelloApplicationIntegrationTest.java
+++ b/examples/spring-boot-webflux/src/test/java/example/springframework/boot/webflux/HelloApplicationIntegrationTest.java
@@ -12,6 +12,8 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 
 import com.linecorp.armeria.spring.web.reactive.ArmeriaClientHttpConnector;
 
+import example.springframework.boot.webflux.ValidationExceptionHandler.ErrorResponse;
+
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = WebEnvironment.DEFINED_PORT)
 public class HelloApplicationIntegrationTest {
@@ -31,11 +33,28 @@ public class HelloApplicationIntegrationTest {
     }
 
     @Test
-    public void getHelloWorld() {
+    public void fromSpringController() {
         client.get()
               .uri("/hello")
               .exchange()
               .expectStatus().isOk()
               .expectBody(String.class).isEqualTo("Hello, World");
+    }
+
+    @Test
+    public void fromArmeriaAnnotatedService() {
+        client.get()
+              .uri("/armeria/hello/Spring")
+              .exchange()
+              .expectStatus().isOk()
+              .expectBody(String.class)
+              .isEqualTo("Hello, Spring! This message is from Armeria annotated service!");
+
+        // Validation failure because the 'name' value is too short.
+        client.get()
+              .uri("/armeria/hello/a")
+              .exchange()
+              .expectStatus().isBadRequest()
+              .expectBody(ErrorResponse.class);
     }
 }


### PR DESCRIPTION
Motivation:
If a user uses Spring and Armeria together, he or she may want to apply Java Bean Validation framework to Armeria annotated HTTP service.

Modifications:
- Use `org.reflections.ReflectionUtils` when getting methods or constructors from a class.
- Check all super classes when getting annotations from a class.
  - `ReflectionUtils.getAllAnnotations()` returns a `HashSet` of `Annotations` which does not preserve their specified order.
- Add `HelloAnnotatedService` and related classes to `examples/spring-boo-webflux` in order to show how to use an annotated HTTP service with Spring framework.

Result:
- Closes #1473