### PR TITLE
Respect MAX_CONCURRENT_STREAMS on the client side

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientDelegate.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientDelegate.java
@@ -114,7 +114,7 @@ final class HttpClientDelegate implements Client<HttpRequest, HttpResponse> {
         if (pooledChannel != null) {
             doExecute(pooledChannel, ctx, req, res);
         } else {
-            pool.acquire(protocol, key).handle((newPooledChannel, cause) -> {
+            pool.acquireLater(protocol, key).handle((newPooledChannel, cause) -> {
                 if (cause == null) {
                     doExecute(newPooledChannel, ctx, req, res);
                 } else {

--- a/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
@@ -94,6 +94,10 @@ abstract class HttpResponseDecoder {
         return responses.remove(id);
     }
 
+    final int unfinishedResponses() {
+        return responses.size();
+    }
+
     final boolean hasUnfinishedResponses() {
         return !responses.isEmpty();
     }

--- a/core/src/main/java/com/linecorp/armeria/client/HttpSession.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpSession.java
@@ -50,8 +50,8 @@ interface HttpSession {
         }
 
         @Override
-        public boolean hasUnfinishedResponses() {
-            return false;
+        public int unfinishedResponses() {
+            return 0;
         }
 
         @Override
@@ -84,7 +84,15 @@ interface HttpSession {
 
     InboundTrafficController inboundTrafficController();
 
-    boolean hasUnfinishedResponses();
+    int unfinishedResponses();
+
+    default boolean hasUnfinishedResponses() {
+        return unfinishedResponses() != 0;
+    }
+
+    default int maxUnfinishedResponses() {
+        return Integer.MAX_VALUE;
+    }
 
     boolean invoke(ClientRequestContext ctx, HttpRequest req, DecodedHttpResponse res);
 

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientIdleTimeoutHandlerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientIdleTimeoutHandlerTest.java
@@ -124,8 +124,8 @@ public class HttpClientIdleTimeoutHandlerTest {
         }
 
         @Override
-        public boolean hasUnfinishedResponses() {
-            return unfinishedResponses != 0;
+        public int unfinishedResponses() {
+            return unfinishedResponses;
         }
 
         @Override

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientMaxConcurrentStreamTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientMaxConcurrentStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 LINE Corporation
+ * Copyright 2018 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientMaxConcurrentStreamTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientMaxConcurrentStreamTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2015 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.annotation.Nullable;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.util.EventLoopGroups;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.testing.server.ServerRule;
+
+import io.netty.util.AttributeMap;
+
+/**
+ * Makes sure Armeria HTTP client respects {@code MAX_CONCURRENT_STREAMS} HTTP/2 setting.
+ */
+public class HttpClientMaxConcurrentStreamTest {
+
+    private static final String PATH = "/test";
+    private static final int MAX_CONCURRENT_STREAMS = 3;
+
+    private final Queue<CompletableFuture<HttpResponse>> responses = new ConcurrentLinkedQueue<>();
+
+    @Rule
+    public final ServerRule server = new ServerRule() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.service(PATH, (ctx, req) -> {
+                final CompletableFuture<HttpResponse> f = new CompletableFuture<>();
+                responses.add(f);
+                return HttpResponse.from(f);
+            });
+            sb.http2MaxStreamsPerConnection(MAX_CONCURRENT_STREAMS);
+        }
+    };
+
+    private final ConnectionPoolListener connectionPoolListenerWrapper = new ConnectionPoolListener() {
+        @Override
+        public void connectionOpen(SessionProtocol protocol, InetSocketAddress remoteAddr,
+                                   InetSocketAddress localAddr, AttributeMap attrs) throws Exception {
+            final ConnectionPoolListener connectionPoolListener =
+                    HttpClientMaxConcurrentStreamTest.this.connectionPoolListener;
+            if (connectionPoolListener != null) {
+                connectionPoolListener.connectionOpen(protocol, remoteAddr, localAddr, attrs);
+            }
+        }
+
+        @Override
+        public void connectionClosed(SessionProtocol protocol, InetSocketAddress remoteAddr,
+                                     InetSocketAddress localAddr, AttributeMap attrs) throws Exception {
+            final ConnectionPoolListener connectionPoolListener =
+                    HttpClientMaxConcurrentStreamTest.this.connectionPoolListener;
+            if (connectionPoolListener != null) {
+                connectionPoolListener.connectionClosed(protocol, remoteAddr, localAddr, attrs);
+            }
+        }
+    };
+
+    @Nullable
+    private ClientFactory clientFactory;
+    @Nullable
+    private volatile ConnectionPoolListener connectionPoolListener;
+
+    @Before
+    public void setUp() {
+        clientFactory = new ClientFactoryBuilder()
+                .workerGroup(EventLoopGroups.newEventLoopGroup(1), true)
+                .connectionPoolListener(connectionPoolListenerWrapper)
+                .build();
+    }
+
+    @After
+    public void tearDown() {
+        // Complete all uncompleted requests.
+        for (;;) {
+            final CompletableFuture<HttpResponse> f = responses.poll();
+            if (f == null) {
+                break;
+            }
+            f.complete(HttpResponse.of(200));
+        }
+
+        if (clientFactory != null) {
+            clientFactory.close();
+        }
+    }
+
+    @Test
+    public void shouldCreateConnectionWhenExceedsMaxConcurrentStreams() throws Exception {
+        final HttpClient client = HttpClient.of(clientFactory, server.uri(SessionProtocol.H2C, "/"));
+        final AtomicInteger opens = new AtomicInteger();
+        final AtomicInteger closes = new AtomicInteger();
+        connectionPoolListener = new ConnectionPoolListener() {
+            @Override
+            public void connectionOpen(SessionProtocol protocol, InetSocketAddress remoteAddr,
+                                       InetSocketAddress localAddr, AttributeMap attrs) throws Exception {
+                opens.incrementAndGet();
+            }
+
+            @Override
+            public void connectionClosed(SessionProtocol protocol, InetSocketAddress remoteAddr,
+                                         InetSocketAddress localAddr, AttributeMap attrs) throws Exception {
+                closes.incrementAndGet();
+            }
+        };
+
+        // Send (2 * MAX_CONCURRENT_STREAMS) requests to create 2 connections, never more and never less.
+        final List<CompletableFuture<AggregatedHttpMessage>> receivedResponses = new ArrayList<>();
+        final int NUM_CONNECTIONS = 2;
+        for (int j = 0; j < NUM_CONNECTIONS; j++) {
+            final int expectedOpens = j + 1;
+            for (int i = 0; i < MAX_CONCURRENT_STREAMS; i++) {
+                // Send a request.
+                receivedResponses.add(client.get(PATH).aggregate());
+
+                // Check the number of open and closed connections.
+                await().untilAsserted(() -> {
+                    assertThat(opens).hasValue(expectedOpens);
+                    assertThat(closes).hasValue(0);
+                });
+            }
+        }
+
+        // Complete one request so that we have a connection with (MAX_CONCURRENT_STREAM - 1) active streams.
+        responses.poll().complete(HttpResponse.of(200));
+        await().until(() -> receivedResponses.stream().anyMatch(CompletableFuture::isDone));
+
+        // Send a new request, which must not create a new connection but use an existing connection.
+        client.get(PATH);
+
+        // Wait for a while to make sure no new connection is created.
+        for (int i = 0; i < 3; i++) {
+            Thread.sleep(1000);
+            assertThat(opens).hasValue(NUM_CONNECTIONS);
+            assertThat(closes).hasValue(0);
+        }
+    }
+}


### PR DESCRIPTION
Related: #1206
Motivation:

Armeria HTTP client does not respect `MAX_CONCURRENT_STREAMS` HTTP/2
setting. As a result, it is possible for a user to create more streams
than allowed accidentally, which results it protocol violation.

Modifications:

- Do not reuse an existing HTTP/2 connection but create a new one when
  the connection already has many concurrent streams.
- Clean up acquisition logic in `HttpChannelPool`.

Result:

- Fixes #1206
- No more protocol violation