### PR TITLE
Remove the usage of Retrofit `Java8CallAdapterFactory`

### DIFF
--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -21,7 +21,6 @@ dependencies {
     compile project(':retrofit2')
     compile project(':thrift')
 
-    compile 'com.squareup.retrofit2:adapter-java8'
     compile 'com.squareup.retrofit2:converter-jackson'
 
     jmh 'pl.project13.scala:sbt-jmh-extras'

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/retrofit2/downstream/DownstreamSimpleBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/retrofit2/downstream/DownstreamSimpleBenchmark.java
@@ -26,7 +26,6 @@ import com.linecorp.armeria.retrofit2.shared.SimpleBenchmarkBase;
 import com.linecorp.armeria.retrofit2.shared.SimpleBenchmarkClient;
 
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
-import retrofit2.adapter.java8.Java8CallAdapterFactory;
 import retrofit2.converter.jackson.JacksonConverterFactory;
 
 @State(Scope.Benchmark)
@@ -34,14 +33,13 @@ public class DownstreamSimpleBenchmark extends SimpleBenchmarkBase {
 
     @Override
     protected SimpleBenchmarkClient newClient() {
-        ClientFactory factory =
+        final ClientFactory factory =
                 new ClientFactoryBuilder()
                         .sslContextCustomizer(ssl -> ssl.trustManager(InsecureTrustManagerFactory.INSTANCE))
                         .build();
         return new ArmeriaRetrofitBuilder(factory)
                 .baseUrl(baseUrl())
                 .addConverterFactory(JacksonConverterFactory.create())
-                .addCallAdapterFactory(Java8CallAdapterFactory.create())
                 .build()
                 .create(SimpleBenchmarkClient.class);
     }

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/retrofit2/upstream/UpstreamSimpleBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/retrofit2/upstream/UpstreamSimpleBenchmark.java
@@ -28,7 +28,6 @@ import com.linecorp.armeria.retrofit2.shared.SimpleBenchmarkClient;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import okhttp3.OkHttpClient;
 import retrofit2.Retrofit;
-import retrofit2.adapter.java8.Java8CallAdapterFactory;
 import retrofit2.converter.jackson.JacksonConverterFactory;
 
 @State(Scope.Benchmark)
@@ -36,9 +35,9 @@ public class UpstreamSimpleBenchmark extends SimpleBenchmarkBase {
 
     @Override
     protected SimpleBenchmarkClient newClient() throws Exception {
-        SSLContext context = SSLContext.getInstance("TLS");
+        final SSLContext context = SSLContext.getInstance("TLS");
         context.init(null, InsecureTrustManagerFactory.INSTANCE.getTrustManagers(), null);
-        OkHttpClient client = new OkHttpClient.Builder()
+        final OkHttpClient client = new OkHttpClient.Builder()
                 .sslSocketFactory(context.getSocketFactory(),
                                   (X509TrustManager) InsecureTrustManagerFactory.INSTANCE.getTrustManagers()[0])
                 .hostnameVerifier((s, session) -> true)
@@ -48,7 +47,6 @@ public class UpstreamSimpleBenchmark extends SimpleBenchmarkBase {
                 .baseUrl(baseUrl())
                 .client(client)
                 .addConverterFactory(JacksonConverterFactory.create())
-                .addCallAdapterFactory(Java8CallAdapterFactory.create())
                 .build()
                 .create(SimpleBenchmarkClient.class);
     }

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -95,7 +95,6 @@ com.squareup.retrofit2:
     version: &RETROFIT2_VERSION '2.5.0'
     javadocs:
     - https://square.github.io/retrofit/2.x/retrofit/
-  adapter-java8: { version: *RETROFIT2_VERSION }
   converter-jackson: { version: *RETROFIT2_VERSION }
 
 gradle.plugin.net.davidecavestro:

--- a/retrofit2/build.gradle
+++ b/retrofit2/build.gradle
@@ -1,6 +1,5 @@
 dependencies {
     compile 'com.squareup.retrofit2:retrofit'
 
-    testCompile 'com.squareup.retrofit2:adapter-java8'
     testCompile 'com.squareup.retrofit2:converter-jackson'
 }

--- a/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/ArmeriaCallFactoryLargeStreamTest.java
+++ b/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/ArmeriaCallFactoryLargeStreamTest.java
@@ -39,7 +39,6 @@ import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.testing.server.ServerRule;
 
 import okhttp3.ResponseBody;
-import retrofit2.adapter.java8.Java8CallAdapterFactory;
 import retrofit2.converter.jackson.JacksonConverterFactory;
 import retrofit2.http.GET;
 import retrofit2.http.Streaming;
@@ -95,7 +94,6 @@ public class ArmeriaCallFactoryLargeStreamTest {
         final Service downloadService = new ArmeriaRetrofitBuilder()
                 .baseUrl(server.uri("/"))
                 .addConverterFactory(JacksonConverterFactory.create(OBJECT_MAPPER))
-                .addCallAdapterFactory(Java8CallAdapterFactory.create())
                 .withClientOptions((s, clientOptionsBuilder) -> {
                     clientOptionsBuilder.defaultMaxResponseLength(Long.MAX_VALUE);
                     clientOptionsBuilder.defaultResponseTimeout(Duration.of(30, ChronoUnit.SECONDS));

--- a/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/ArmeriaCallFactoryTest.java
+++ b/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/ArmeriaCallFactoryTest.java
@@ -64,7 +64,6 @@ import okhttp3.HttpUrl;
 import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Response;
-import retrofit2.adapter.java8.Java8CallAdapterFactory;
 import retrofit2.converter.jackson.JacksonConverterFactory;
 import retrofit2.http.Body;
 import retrofit2.http.Field;
@@ -312,7 +311,6 @@ public class ArmeriaCallFactoryTest {
                 .baseUrl(server.uri("/"))
                 .streaming(streaming)
                 .addConverterFactory(JacksonConverterFactory.create(OBJECT_MAPPER))
-                .addCallAdapterFactory(Java8CallAdapterFactory.create())
                 .build()
                 .create(Service.class);
     }
@@ -459,7 +457,6 @@ public class ArmeriaCallFactoryTest {
         final Service service = new ArmeriaRetrofitBuilder()
                 .baseUrl("http://group:foo/")
                 .addConverterFactory(JacksonConverterFactory.create(OBJECT_MAPPER))
-                .addCallAdapterFactory(Java8CallAdapterFactory.create())
                 .build()
                 .create(Service.class);
         final Response<Pojo> response = service.postForm("Cony", 26).get();
@@ -479,7 +476,6 @@ public class ArmeriaCallFactoryTest {
         final Service service = new ArmeriaRetrofitBuilder()
                 .baseUrl("http://group:foo/")
                 .addConverterFactory(JacksonConverterFactory.create(OBJECT_MAPPER))
-                .addCallAdapterFactory(Java8CallAdapterFactory.create())
                 .build()
                 .create(Service.class);
         final Pojo pojo = service.fullUrl("http://group_bar/pojo").get();
@@ -505,7 +501,6 @@ public class ArmeriaCallFactoryTest {
         final Service service = new ArmeriaRetrofitBuilder()
                 .baseUrl("h1c://127.0.0.1:" + server.httpPort())
                 .addConverterFactory(JacksonConverterFactory.create(OBJECT_MAPPER))
-                .addCallAdapterFactory(Java8CallAdapterFactory.create())
                 .build()
                 .create(Service.class);
         final Pojo pojo = service.pojo().get();
@@ -517,7 +512,6 @@ public class ArmeriaCallFactoryTest {
         final Service service = new ArmeriaRetrofitBuilder()
                 .baseUrl(server.uri("/nest/"))
                 .addConverterFactory(JacksonConverterFactory.create(OBJECT_MAPPER))
-                .addCallAdapterFactory(Java8CallAdapterFactory.create())
                 .build()
                 .create(Service.class);
         assertThat(service.pojoNotRoot().get()).isEqualTo(new Pojo("Leonard", 21));
@@ -552,7 +546,6 @@ public class ArmeriaCallFactoryTest {
         final Service service = new ArmeriaRetrofitBuilder()
                 .baseUrl("h1c://127.0.0.1:" + server.httpPort())
                 .addConverterFactory(JacksonConverterFactory.create(OBJECT_MAPPER))
-                .addCallAdapterFactory(Java8CallAdapterFactory.create())
                 .withClientOptions((url, optionsBuilder) -> {
                     optionsBuilder.decorator(HttpRequest.class, HttpResponse.class, (delegate, ctx, req) -> {
                         counter.incrementAndGet();

--- a/site/src/sphinx/client-retrofit.rst
+++ b/site/src/sphinx/client-retrofit.rst
@@ -25,7 +25,6 @@ you get the following benefits:
     import com.linecorp.armeria.client.HttpClient;
 
     import retrofit2.Retrofit;
-    import retrofit2.adapter.java8.Java8CallAdapterFactory;
     import retrofit2.converter.jackson.JacksonConverterFactory;
     import retrofit2.http.GET;
     import retrofit2.http.Path;
@@ -40,7 +39,6 @@ you get the following benefits:
     Retrofit retrofit = new ArmeriaRetrofitBuilder()
             .baseUrl("http://localhost:8080/")
             .addConverterFactory(JacksonConverterFactory.create())
-            .addCallAdapterFactory(Java8CallAdapterFactory.create())
             .build();
 
     MyService service = retrofit.create(MyService.class);


### PR DESCRIPTION
Motivation:

Since Retrofit 2.5, there is no need to use `Java8CallAdapterFactory`
because it's now built-in.

Modifications:

- Remove the references to `Java8CallAdapterFactory`.
- Remove `adapter-java8` from the dependencies.

Result:

- Less cruft