### PR TITLE
Simplify decorator builder methods

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/AbstractClientOptionsBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/AbstractClientOptionsBuilder.java
@@ -25,8 +25,12 @@ import java.util.function.Function;
 
 import com.linecorp.armeria.common.DefaultHttpHeaders;
 import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
+import com.linecorp.armeria.common.RpcRequest;
+import com.linecorp.armeria.common.RpcResponse;
 
 import io.netty.handler.codec.Headers;
 import io.netty.util.AsciiString;
@@ -104,8 +108,8 @@ class AbstractClientOptionsBuilder<B extends AbstractClientOptionsBuilder<?>> {
         final ClientOption<?> opt = optionValue.option();
         if (opt == ClientOption.DECORATION) {
             final ClientDecoration d = (ClientDecoration) optionValue.value();
-            d.entries().forEach(e -> decorator(e.requestType(), e.responseType(),
-                                               (Function) e.decorator()));
+            d.entries().forEach(e -> decoration.add0(e.requestType(), e.responseType(),
+                                                     (Function) e.decorator()));
         } else if (opt == ClientOption.HTTP_HEADERS) {
             final HttpHeaders h = (HttpHeaders) optionValue.value();
             setHttpHeaders(h);
@@ -171,7 +175,10 @@ class AbstractClientOptionsBuilder<B extends AbstractClientOptionsBuilder<?>> {
      * @param <R> the type of the {@link Client} produced by the {@code decorator}
      * @param <I> the {@link Request} type of the {@link Client} being decorated
      * @param <O> the {@link Response} type of the {@link Client} being decorated
+     *
+     * @deprecated Use {@link #decorator(Function)} or {@link #rpcDecorator(Function)}.
      */
+    @Deprecated
     public <T extends Client<I, O>, R extends Client<I, O>, I extends Request, O extends Response>
     B decorator(Class<I> requestType, Class<O> responseType, Function<T, R> decorator) {
         decoration.add(requestType, responseType, decorator);
@@ -186,10 +193,70 @@ class AbstractClientOptionsBuilder<B extends AbstractClientOptionsBuilder<?>> {
      * @param decorator the {@link DecoratingClientFunction} that intercepts an invocation
      * @param <I> the {@link Request} type of the {@link Client} being decorated
      * @param <O> the {@link Response} type of the {@link Client} being decorated
+     *
+     * @deprecated Use {@link #decorator(DecoratingClientFunction)} or
+     *             {@link #rpcDecorator(DecoratingClientFunction)}.
      */
+    @Deprecated
     public <I extends Request, O extends Response>
     B decorator(Class<I> requestType, Class<O> responseType, DecoratingClientFunction<I, O> decorator) {
         decoration.add(requestType, responseType, decorator);
+        return self();
+    }
+
+    /**
+     * Adds the specified HTTP-level {@code decorator}.
+     *
+     * @param decorator the {@link Function} that transforms a {@link Client} to another
+     * @param <T> the type of the {@link Client} being decorated
+     * @param <R> the type of the {@link Client} produced by the {@code decorator}
+     * @param <I> the {@link Request} type of the {@link Client} being decorated
+     * @param <O> the {@link Response} type of the {@link Client} being decorated
+     */
+    public <T extends Client<I, O>, R extends Client<I, O>, I extends HttpRequest, O extends HttpResponse>
+    B decorator(Function<T, R> decorator) {
+        decoration.add(decorator);
+        return self();
+    }
+
+    /**
+     * Adds the specified HTTP-level {@code decorator}.
+     *
+     * @param decorator the {@link DecoratingClientFunction} that intercepts an invocation
+     * @param <I> the {@link Request} type of the {@link Client} being decorated
+     * @param <O> the {@link Response} type of the {@link Client} being decorated
+     */
+    public <I extends HttpRequest, O extends HttpResponse>
+    B decorator(DecoratingClientFunction<I, O> decorator) {
+        decoration.add(decorator);
+        return self();
+    }
+
+    /**
+     * Adds the specified RPC-level {@code decorator}.
+     *
+     * @param decorator the {@link Function} that transforms a {@link Client} to another
+     * @param <T> the type of the {@link Client} being decorated
+     * @param <R> the type of the {@link Client} produced by the {@code decorator}
+     * @param <I> the {@link Request} type of the {@link Client} being decorated
+     * @param <O> the {@link Response} type of the {@link Client} being decorated
+     */
+    public <T extends Client<I, O>, R extends Client<I, O>, I extends RpcRequest, O extends RpcResponse>
+    B rpcDecorator(Function<T, R> decorator) {
+        decoration.addRpc(decorator);
+        return self();
+    }
+
+    /**
+     * Adds the specified RPC-level {@code decorator}.
+     *
+     * @param decorator the {@link DecoratingClientFunction} that intercepts an invocation
+     * @param <I> the {@link Request} type of the {@link Client} being decorated
+     * @param <O> the {@link Response} type of the {@link Client} being decorated
+     */
+    public <I extends RpcRequest, O extends RpcResponse>
+    B rpcDecorator(DecoratingClientFunction<I, O> decorator) {
+        decoration.addRpc(decorator);
         return self();
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/ClientDecorationBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientDecorationBuilder.java
@@ -47,10 +47,98 @@ public final class ClientDecorationBuilder {
      * @param <R> the type of the {@link Client} produced by the {@code decorator}
      * @param <I> the {@link Request} type of the {@link Client} being decorated
      * @param <O> the {@link Response} type of the {@link Client} being decorated
+     *
+     * @deprecated Use {@link #add(Function)} or {@link #addRpc(Function)}.
      */
+    @Deprecated
     public <T extends Client<I, O>, R extends Client<I, O>, I extends Request, O extends Response>
     ClientDecorationBuilder add(Class<I> requestType, Class<O> responseType, Function<T, R> decorator) {
+        return add0(requestType, responseType, decorator);
+    }
 
+    /**
+     * Adds a new {@link DecoratingClientFunction}.
+     *
+     * @param requestType the type of the {@link Request} that the {@code decorator} is interested in
+     * @param responseType the type of the {@link Response} that the {@code decorator} is interested in
+     * @param decorator the {@link DecoratingClientFunction} that intercepts an invocation
+     * @param <I> the {@link Request} type of the {@link Client} being decorated
+     * @param <O> the {@link Response} type of the {@link Client} being decorated
+     *
+     * @deprecated Use {@link #add(DecoratingClientFunction)} or {@link #addRpc(DecoratingClientFunction)}.
+     */
+    @Deprecated
+    public <I extends Request, O extends Response> ClientDecorationBuilder add(
+            Class<I> requestType, Class<O> responseType, DecoratingClientFunction<I, O> decorator) {
+        return add0(requestType, responseType, decorator);
+    }
+
+    /**
+     * Adds the specified HTTP-level {@code decorator}.
+     *
+     * @param decorator the {@link Function} that transforms a {@link Client} to another
+     * @param <T> the type of the {@link Client} being decorated
+     * @param <R> the type of the {@link Client} produced by the {@code decorator}
+     * @param <I> the {@link Request} type of the {@link Client} being decorated
+     * @param <O> the {@link Response} type of the {@link Client} being decorated
+     */
+    public <T extends Client<I, O>, R extends Client<I, O>, I extends HttpRequest, O extends HttpResponse>
+    ClientDecorationBuilder add(Function<T, R> decorator) {
+        @SuppressWarnings("unchecked")
+        final Function<Client<HttpRequest, HttpResponse>, Client<HttpRequest, HttpResponse>> cast =
+                (Function<Client<HttpRequest, HttpResponse>, Client<HttpRequest, HttpResponse>>) decorator;
+        return add0(HttpRequest.class, HttpResponse.class, cast);
+    }
+
+    /**
+     * Adds the specified HTTP-level {@code decorator}.
+     *
+     * @param decorator the {@link DecoratingClientFunction} that intercepts an invocation
+     * @param <I> the {@link Request} type of the {@link Client} being decorated
+     * @param <O> the {@link Response} type of the {@link Client} being decorated
+     */
+    public <I extends HttpRequest, O extends HttpResponse>
+    ClientDecorationBuilder add(DecoratingClientFunction<I, O> decorator) {
+        @SuppressWarnings("unchecked")
+        final DecoratingClientFunction<HttpRequest, HttpResponse> cast =
+                (DecoratingClientFunction<HttpRequest, HttpResponse>) decorator;
+        return add0(HttpRequest.class, HttpResponse.class, cast);
+    }
+
+    /**
+     * Adds the specified RPC-level {@code decorator}.
+     *
+     * @param decorator the {@link Function} that transforms a {@link Client} to another
+     * @param <T> the type of the {@link Client} being decorated
+     * @param <R> the type of the {@link Client} produced by the {@code decorator}
+     * @param <I> the {@link Request} type of the {@link Client} being decorated
+     * @param <O> the {@link Response} type of the {@link Client} being decorated
+     */
+    public <T extends Client<I, O>, R extends Client<I, O>, I extends RpcRequest, O extends RpcResponse>
+    ClientDecorationBuilder addRpc(Function<T, R> decorator) {
+        @SuppressWarnings("unchecked")
+        final Function<Client<RpcRequest, RpcResponse>, Client<RpcRequest, RpcResponse>> cast =
+                (Function<Client<RpcRequest, RpcResponse>, Client<RpcRequest, RpcResponse>>) decorator;
+        return add0(RpcRequest.class, RpcResponse.class, cast);
+    }
+
+    /**
+     * Adds the specified RPC-level {@code decorator}.
+     *
+     * @param decorator the {@link DecoratingClientFunction} that intercepts an invocation
+     * @param <I> the {@link Request} type of the {@link Client} being decorated
+     * @param <O> the {@link Response} type of the {@link Client} being decorated
+     */
+    public <I extends RpcRequest, O extends RpcResponse>
+    ClientDecorationBuilder addRpc(DecoratingClientFunction<I, O> decorator) {
+        @SuppressWarnings("unchecked")
+        final DecoratingClientFunction<RpcRequest, RpcResponse> cast =
+                (DecoratingClientFunction<RpcRequest, RpcResponse>) decorator;
+        return add0(RpcRequest.class, RpcResponse.class, cast);
+    }
+
+    <T extends Client<I, O>, R extends Client<I, O>, I extends Request, O extends Response>
+    ClientDecorationBuilder add0(Class<I> requestType, Class<O> responseType, Function<T, R> decorator) {
         requireNonNull(requestType, "requestType");
         requireNonNull(responseType, "responseType");
         requireNonNull(decorator, "decorator");
@@ -66,18 +154,8 @@ public final class ClientDecorationBuilder {
         return this;
     }
 
-    /**
-     * Adds a new {@link DecoratingClientFunction}.
-     *
-     * @param requestType the type of the {@link Request} that the {@code decorator} is interested in
-     * @param responseType the type of the {@link Response} that the {@code decorator} is interested in
-     * @param decorator the {@link DecoratingClientFunction} that intercepts an invocation
-     * @param <I> the {@link Request} type of the {@link Client} being decorated
-     * @param <O> the {@link Response} type of the {@link Client} being decorated
-     */
-    public <I extends Request, O extends Response> ClientDecorationBuilder add(
+    private <I extends Request, O extends Response> ClientDecorationBuilder add0(
             Class<I> requestType, Class<O> responseType, DecoratingClientFunction<I, O> decorator) {
-
         requireNonNull(requestType, "requestType");
         requireNonNull(responseType, "responseType");
         requireNonNull(decorator, "decorator");

--- a/core/src/main/java/com/linecorp/armeria/client/Clients.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Clients.java
@@ -204,7 +204,7 @@ public final class Clients {
      * HttpClient derivedHttpClient = Clients.newDerivedClient(httpClient, options -> {
      *     ClientOptionsBuilder builder = new ClientOptionsBuilder(options);
      *     builder.decorator(...);  // Add a decorator.
-     *     builder.httpHeader(...); // Add an HTTP header.
+     *     builder.addHttpHeader(...); // Add an HTTP header.
      *     return builder.build();
      * });
      * }</pre>

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientBuilder.java
@@ -19,12 +19,9 @@ package com.linecorp.armeria.client;
 import static java.util.Objects.requireNonNull;
 
 import java.net.URI;
-import java.util.function.Function;
 
 import com.google.common.collect.ImmutableList;
 
-import com.linecorp.armeria.common.HttpRequest;
-import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.SessionProtocol;
 
@@ -75,26 +72,6 @@ public final class HttpClientBuilder extends AbstractClientOptionsBuilder<HttpCl
     public HttpClientBuilder factory(ClientFactory factory) {
         this.factory = requireNonNull(factory, "factory");
         return this;
-    }
-
-    /**
-     * Adds the specified {@code decorator}.
-     *
-     * @param decorator the {@link Function} that transforms a {@link Client} to another
-     */
-    public HttpClientBuilder decorator(
-            Function<? extends Client<HttpRequest, HttpResponse>, ? extends Client<HttpRequest, HttpResponse>>
-                    decorator) {
-        return decorator(HttpRequest.class, HttpResponse.class, decorator);
-    }
-
-    /**
-     * Adds the specified {@code decorator}.
-     *
-     * @param decorator the {@link DecoratingClientFunction} that intercepts an invocation
-     */
-    public HttpClientBuilder decorator(DecoratingClientFunction<HttpRequest, HttpResponse> decorator) {
-        return decorator(HttpRequest.class, HttpResponse.class, decorator);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingHttpClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingHttpClient.java
@@ -31,7 +31,7 @@ import com.linecorp.armeria.common.HttpResponse;
  * <p>For example:
  * <pre>{@code
  * ClientBuilder builder = new ClientBuilder(...);
- * builder.decorator(HttpRequest.class, HttpResponse.class, ConcurrencyLimitingHttpClient.newDecorator(16));
+ * builder.decorator(ConcurrencyLimitingHttpClient.newDecorator(16));
  * client = builder.build(...);
  * }</pre>
  *

--- a/core/src/main/java/com/linecorp/armeria/client/metric/MetricCollectingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/metric/MetricCollectingClient.java
@@ -35,9 +35,7 @@ import io.micrometer.core.instrument.MeterRegistry;
  * <p>Example:
  * <pre>{@code
  * MyService.Iface client = new ClientBuilder(uri)
- *         .decorator(HttpRequest.class, HttpResponse.class,
- *                    MetricCollectingClient.newDecorator(
- *                            MeterIdPrefixFunction.ofDefault("myClient)))
+ *         .decorator(MetricCollectingClient.newDecorator(MeterIdPrefixFunction.ofDefault("myClient)))
  *         .build(MyService.Iface.class);
  * }
  * </pre>

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientTest.java
@@ -170,12 +170,12 @@ public class GrpcClientTest {
 
         blockingStub = new ClientBuilder("gproto+" + server.httpUri("/"))
                 .defaultMaxResponseLength(MAX_MESSAGE_SIZE)
-                .decorator(HttpRequest.class, HttpResponse.class, new LoggingClientBuilder().newDecorator())
-                .decorator(HttpRequest.class, HttpResponse.class, requestLogRecorder)
+                .decorator(new LoggingClientBuilder().newDecorator())
+                .decorator(requestLogRecorder)
                 .build(TestServiceBlockingStub.class);
         asyncStub = new ClientBuilder("gproto+" + server.httpUri("/"))
-                .decorator(HttpRequest.class, HttpResponse.class, new LoggingClientBuilder().newDecorator())
-                .decorator(HttpRequest.class, HttpResponse.class, requestLogRecorder)
+                .decorator(new LoggingClientBuilder().newDecorator())
+                .decorator(requestLogRecorder)
                 .build(TestServiceStub.class);
     }
 
@@ -235,7 +235,7 @@ public class GrpcClientTest {
 
         final TestServiceStub stub = new ClientBuilder("gproto+" + server.httpUri("/"))
                 .option(GrpcClientOptions.UNSAFE_WRAP_RESPONSE_BUFFERS.newValue(true))
-                .decorator(HttpRequest.class, HttpResponse.class, new LoggingClientBuilder().newDecorator())
+                .decorator(new LoggingClientBuilder().newDecorator())
                 .build(TestServiceStub.class);
 
         final BlockingQueue<Object> resultQueue = new LinkedTransferQueue<>();

--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcMetricsIntegrationTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcMetricsIntegrationTest.java
@@ -41,8 +41,6 @@ import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.client.metric.MetricCollectingClient;
 import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.HttpHeaderNames;
-import com.linecorp.armeria.common.HttpRequest;
-import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
@@ -204,9 +202,7 @@ public class GrpcMetricsIntegrationTest {
         final String uri = server.uri(GrpcSerializationFormats.PROTO, "/");
         final TestServiceBlockingStub client = new ClientBuilder(uri)
                 .factory(clientFactory)
-                .decorator(HttpRequest.class, HttpResponse.class,
-                           MetricCollectingClient.newDecorator(
-                                   MeterIdPrefixFunction.ofDefault("client")))
+                .decorator(MetricCollectingClient.newDecorator(MeterIdPrefixFunction.ofDefault("client")))
                 .build(TestServiceBlockingStub.class);
 
         final SimpleRequest request =

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
@@ -751,15 +751,14 @@ public class GrpcServiceServerTest {
         final AtomicReference<HttpHeaders> requestHeaders = new AtomicReference<>();
         final UnitTestServiceBlockingStub jsonStub =
                 new ClientBuilder(server.httpUri(GrpcSerializationFormats.JSON, "/"))
-                        .decorator(HttpRequest.class, HttpResponse.class,
-                                   client -> new SimpleDecoratingClient<HttpRequest, HttpResponse>(client) {
-                                       @Override
-                                       public HttpResponse execute(ClientRequestContext ctx, HttpRequest req)
-                                               throws Exception {
-                                           requestHeaders.set(req.headers());
-                                           return delegate().execute(ctx, req);
-                                       }
-                                   })
+                        .decorator(client -> new SimpleDecoratingClient<HttpRequest, HttpResponse>(client) {
+                            @Override
+                            public HttpResponse execute(ClientRequestContext ctx, HttpRequest req)
+                                    throws Exception {
+                                requestHeaders.set(req.headers());
+                                return delegate().execute(ctx, req);
+                            }
+                        })
                         .build(UnitTestServiceBlockingStub.class);
         final SimpleResponse response = jsonStub.staticUnaryCall(REQUEST_MESSAGE);
         assertThat(response).isEqualTo(RESPONSE_MESSAGE);

--- a/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/ArmeriaCallFactoryTest.java
+++ b/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/ArmeriaCallFactoryTest.java
@@ -547,7 +547,7 @@ public class ArmeriaCallFactoryTest {
                 .baseUrl("h1c://127.0.0.1:" + server.httpPort())
                 .addConverterFactory(JacksonConverterFactory.create(OBJECT_MAPPER))
                 .withClientOptions((url, optionsBuilder) -> {
-                    optionsBuilder.decorator(HttpRequest.class, HttpResponse.class, (delegate, ctx, req) -> {
+                    optionsBuilder.decorator((delegate, ctx, req) -> {
                         counter.incrementAndGet();
                         return delegate.execute(ctx, req);
                     });

--- a/site/src/sphinx/client-custom-http-headers.rst
+++ b/site/src/sphinx/client-custom-http-headers.rst
@@ -77,11 +77,10 @@ If you want more freedom on how you manipulate the request headers, use a decora
     ClientBuilder cb = new ClientBuilder("tbinary+http://example.com/hello");
 
     // Add a decorator that inserts the custom header.
-    cb.decorator(HttpRequest.class, HttpResponse.class,
-                 (delegate, ctx, req) -> { // See DecoratingClientFunction.
-                     req.headers().set(AUTHORIZATION, credential);
-                     return delegate.execute(ctx, req);
-                 });
+    cb.decorator((delegate, ctx, req) -> { // See DecoratingClientFunction.
+        req.headers().set(AUTHORIZATION, credential);
+        return delegate.execute(ctx, req);
+    });
 
     HelloService.Iface client = cb.build(HelloService.Iface.class);
     client.hello("authorized personnel");

--- a/site/src/sphinx/client-decorator.rst
+++ b/site/src/sphinx/client-decorator.rst
@@ -30,11 +30,10 @@ decorating client. It enables you to write a decorating client with a single lam
 
     ClientBuilder cb = new ClientBuilder(...);
     ...
-    cb.decorator(HttpRequest.class, HttpResponse.class,
-                 (delegate, ctx, req) -> {
-                     auditRequest(req);
-                     return delegate.execute(ctx, req);
-                 });
+    cb.decorator((delegate, ctx, req) -> {
+        auditRequest(req);
+        return delegate.execute(ctx, req);
+    });
 
     MyService.Iface client = cb.build(MyService.Iface.class);
 
@@ -61,8 +60,7 @@ If your decorator is expected to be reusable, it is recommended to define a new 
     ClientBuilder cb = new ClientBuilder(...);
     ...
     // Using a lambda expression:
-    cb.decorator(HttpRequest.class, HttpResponse.class,
-                 delegate -> new AuditClient(delegate));
+    cb.decorator(delegate -> new AuditClient(delegate));
 
 See also
 --------

--- a/site/src/sphinx/client-grpc.rst
+++ b/site/src/sphinx/client-grpc.rst
@@ -146,7 +146,7 @@ You can also use the builder pattern for client construction:
 
     HelloServiceBlockingStub helloService = new ClientBuilder("gproto+http://127.0.0.1:8080/")
             .defaultResponseTimeoutMillis(10000)
-            .decorator(HttpRequest.class, HttpResponse.class, LoggingClient.newDecorator())
+            .decorator(LoggingClient.newDecorator())
             .build(HelloServiceBlockingStub.class); // or HelloServiceFutureStub.class or HelloServiceStub.class
 
     HelloRequest request = HelloRequest.newBuilder().setName("Armerian World").build();

--- a/site/src/sphinx/client-retry.rst
+++ b/site/src/sphinx/client-retry.rst
@@ -32,8 +32,7 @@ You can just use the ``decorator()`` method in :api:`ClientBuilder` to build a :
 
     RetryStrategy strategy = RetryStrategy.onServerErrorStatus();
     HttpClient client = new ClientBuilder(...)
-            .decorator(HttpRequest.class, HttpResponse.class,
-                       RetryingHttpClient.newDecorator(strategy))
+            .decorator(RetryingHttpClient.newDecorator(strategy))
             .build(HttpClient.class);
 
     final AggregatedHttpMessage res = client.execute(...).aggregate().join();

--- a/site/src/sphinx/client-thrift.rst
+++ b/site/src/sphinx/client-thrift.rst
@@ -74,7 +74,7 @@ You can also use the builder pattern for client construction:
 
     HelloService.Iface helloService = new ClientBuilder("tbinary+http://127.0.0.1:8080/hello")
             .defaultResponseTimeoutMillis(10000)
-            .decorator(HttpRequest.class, HttpResponse.class, LoggingClient.newDecorator())
+            .decorator(LoggingClient.newDecorator())
             .build(HelloService.Iface.class); // or AsyncIface.class
 
     String greeting = helloService.hello("Armerian World");

--- a/thrift/src/test/java/com/linecorp/armeria/client/thrift/ThriftOverHttpClientTServletIntegrationTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/client/thrift/ThriftOverHttpClientTServletIntegrationTest.java
@@ -68,8 +68,6 @@ import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.SessionProtocolNegotiationCache;
 import com.linecorp.armeria.client.SessionProtocolNegotiationException;
 import com.linecorp.armeria.common.ClosedSessionException;
-import com.linecorp.armeria.common.RpcRequest;
-import com.linecorp.armeria.common.RpcResponse;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.logging.RequestLogAvailability;
 import com.linecorp.armeria.common.thrift.ThriftProtocolFactories;
@@ -300,12 +298,11 @@ public class ThriftOverHttpClientTServletIntegrationTest {
             String uri, AtomicReference<SessionProtocol> sessionProtocol) {
 
         return new ClientBuilder(uri)
-                .decorator(RpcRequest.class, RpcResponse.class,
-                           (delegate, ctx, req) -> {
-                               ctx.log().addListener(log -> sessionProtocol.set(log.sessionProtocol()),
-                                                     RequestLogAvailability.REQUEST_START);
-                               return delegate.execute(ctx, req);
-                           })
+                .rpcDecorator((delegate, ctx, req) -> {
+                    ctx.log().addListener(log -> sessionProtocol.set(log.sessionProtocol()),
+                                          RequestLogAvailability.REQUEST_START);
+                    return delegate.execute(ctx, req);
+                })
                 .build(HelloService.Iface.class);
     }
 

--- a/thrift/src/test/java/com/linecorp/armeria/it/metric/DropwizardMetricsIntegrationTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/metric/DropwizardMetricsIntegrationTest.java
@@ -39,8 +39,6 @@ import com.linecorp.armeria.client.ClientBuilder;
 import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.ClientFactoryBuilder;
 import com.linecorp.armeria.client.metric.MetricCollectingClient;
-import com.linecorp.armeria.common.RpcRequest;
-import com.linecorp.armeria.common.RpcResponse;
 import com.linecorp.armeria.common.metric.DropwizardMeterRegistries;
 import com.linecorp.armeria.common.metric.MeterIdPrefixFunction;
 import com.linecorp.armeria.server.ServerBuilder;
@@ -163,9 +161,8 @@ public class DropwizardMetricsIntegrationTest {
     private static void makeRequest(String name) {
         final Iface client = new ClientBuilder(server.uri(BINARY, "/helloservice"))
                 .factory(clientFactory)
-                .decorator(RpcRequest.class, RpcResponse.class,
-                           MetricCollectingClient.newDecorator(
-                                   MeterIdPrefixFunction.ofDefault("armeria.client.HelloService")))
+                .rpcDecorator(MetricCollectingClient.newDecorator(
+                        MeterIdPrefixFunction.ofDefault("armeria.client.HelloService")))
                 .build(Iface.class);
         try {
             client.hello(name);

--- a/thrift/src/test/java/com/linecorp/armeria/it/metric/PrometheusMetricsIntegrationTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/metric/PrometheusMetricsIntegrationTest.java
@@ -47,8 +47,6 @@ import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.MediaType;
-import com.linecorp.armeria.common.RpcRequest;
-import com.linecorp.armeria.common.RpcResponse;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.metric.MeterIdPrefix;
 import com.linecorp.armeria.common.metric.MeterIdPrefixFunction;
@@ -298,9 +296,8 @@ public class PrometheusMetricsIntegrationTest {
     private static void makeRequest(String path, String serviceName, String name) throws TException {
         final Iface client = new ClientBuilder(server.uri(BINARY, path))
                 .factory(clientFactory)
-                .decorator(RpcRequest.class, RpcResponse.class,
-                           MetricCollectingClient.newDecorator(
-                                   (registry, log) -> meterIdPrefix(registry, log, "client", serviceName)))
+                .rpcDecorator(MetricCollectingClient.newDecorator(
+                        (registry, log) -> meterIdPrefix(registry, log, "client", serviceName)))
                 .build(Iface.class);
         client.hello(name);
     }

--- a/thrift/src/test/java/com/linecorp/armeria/it/thrift/ThriftDynamicTimeoutTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/thrift/ThriftDynamicTimeoutTest.java
@@ -101,7 +101,7 @@ public class ThriftDynamicTimeoutTest {
     @Test
     public void testDynamicTimeout() throws Exception {
         final SleepService.Iface client = new ClientBuilder(server.uri(BINARY, "/sleep"))
-                .decorator(RpcRequest.class, RpcResponse.class, clientDecorator)
+                .rpcDecorator(clientDecorator)
                 .defaultResponseTimeout(Duration.ofSeconds(1)).build(SleepService.Iface.class);
 
         final long delay = 1500;
@@ -113,7 +113,7 @@ public class ThriftDynamicTimeoutTest {
     @Test(timeout = 10000)
     public void testDisabledTimeout() throws Exception {
         final SleepService.Iface client = new ClientBuilder(server.uri(BINARY, "/fakeSleep"))
-                .decorator(RpcRequest.class, RpcResponse.class, clientDecorator)
+                .rpcDecorator(clientDecorator)
                 .defaultResponseTimeout(Duration.ofSeconds(1)).build(SleepService.Iface.class);
 
         // This call should take very short amount of time because the fakeSleep service does not sleep.

--- a/thrift/src/test/java/com/linecorp/armeria/it/thrift/ThriftHttpHeaderTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/thrift/ThriftHttpHeaderTest.java
@@ -147,20 +147,18 @@ public class ThriftHttpHeaderTest {
     @Test
     public void httpResponseHeaderContainsFoo() throws TException {
         final Iface client = new ClientBuilder(server.uri(BINARY, "/hello"))
-                .decorator(HttpRequest.class, HttpResponse.class,
-                           (delegate, ctx, req) -> {
-                               final HttpResponse res = delegate.execute(ctx, req);
-                               return new FilteredHttpResponse(res) {
-                                   @Override
-                                   protected HttpObject filter(HttpObject obj) {
-                                       if (obj instanceof HttpHeaders) {
-                                           assertThat(((HttpHeaders) obj).get(AsciiString.of("foo")))
-                                                   .isEqualTo("bar");
-                                       }
-                                       return obj;
-                                   }
-                               };
-                           })
+                .decorator((delegate, ctx, req) -> {
+                    final HttpResponse res = delegate.execute(ctx, req);
+                    return new FilteredHttpResponse(res) {
+                        @Override
+                        protected HttpObject filter(HttpObject obj) {
+                            if (obj instanceof HttpHeaders) {
+                                assertThat(((HttpHeaders) obj).get(AsciiString.of("foo"))).isEqualTo("bar");
+                            }
+                            return obj;
+                        }
+                    };
+                })
                 .build(Iface.class);
         try (SafeCloseable ignored = Clients.withHttpHeader(AUTHORIZATION, SECRET)) {
             assertThat(client.hello("trustin")).isEqualTo("Hello, trustin!");

--- a/zipkin/src/test/java/com/linecorp/armeria/it/tracing/HttpTracingIntegrationTest.java
+++ b/zipkin/src/test/java/com/linecorp/armeria/it/tracing/HttpTracingIntegrationTest.java
@@ -174,12 +174,10 @@ public class HttpTracingIntegrationTest {
     @Before
     public void setupClients() {
         fooClient = new ClientBuilder(server.uri(BINARY, "/foo"))
-                .decorator(HttpRequest.class, HttpResponse.class,
-                           HttpTracingClient.newDecorator(newTracing("client/foo")))
+                .decorator(HttpTracingClient.newDecorator(newTracing("client/foo")))
                 .build(HelloService.Iface.class);
         zipClient = new ClientBuilder(server.uri(BINARY, "/zip"))
-                .decorator(HttpRequest.class, HttpResponse.class,
-                           HttpTracingClient.newDecorator(newTracing("client/zip")))
+                .decorator(HttpTracingClient.newDecorator(newTracing("client/zip")))
                 .build(HelloService.Iface.class);
         fooClientWithoutTracing = Clients.newClient(server.uri(BINARY, "/foo"), HelloService.Iface.class);
         barClient = newClient("/bar");
@@ -203,8 +201,7 @@ public class HttpTracingIntegrationTest {
 
     private HelloService.AsyncIface newClient(String path) {
         return new ClientBuilder(server.uri(BINARY, path))
-                .decorator(HttpRequest.class, HttpResponse.class,
-                           HttpTracingClient.newDecorator(newTracing("client" + path)))
+                .decorator(HttpTracingClient.newDecorator(newTracing("client" + path)))
                 .build(HelloService.AsyncIface.class);
     }
 


### PR DESCRIPTION
Motivation:

Practically, there are only 2 ways of adding a client decorator:

- `builder.decorator(HttpRequest.class, HttpResposne.class, ...);`
- `builder.decorator(RpcRequest.class, RpcResponse.class, ...);`

Instead of requiring a user to specify req/res types, we could just
provide two builder methods dedicated to each case.

Modifications:

- Deprecated the old `decorator()` builder methods.
- Added `decorator(Function)` and `decorator(ClientDecoratorFunction)`
  which add an HTTP-level decorator.
- Added `rpcDecorator(Function)` and `rpcDecorator(ClientDecoratorFunction)`
  which add an RPC-level decorator.
- Removed `HttpClient.decorator()` methods which became unnecessary due
  to the new `decorator()` methods in `AbstractClientOptionsBuilder`.

Result:

- Fixes #1482
- Simpler builder API
- Leaner user code