### PR TITLE
Allow users to set additional trailers using ServiceRequestContext.

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
@@ -94,7 +94,7 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
     private volatile HttpHeaders additionalResponseHeaders; // set only via additionalResponseHeadersUpdater
     @Nullable
     @SuppressWarnings("unused")
-    private volatile HttpHeaders additionalResponseTrailers; // set only via additionalResponseHeadersUpdater
+    private volatile HttpHeaders additionalResponseTrailers; // set only via additionalResponseTrailersUpdater
 
     @Nullable
     private String strVal;

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
@@ -24,6 +24,7 @@ import java.time.Duration;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -57,6 +58,14 @@ import io.netty.util.Attribute;
  */
 public class DefaultServiceRequestContext extends NonWrappingRequestContext implements ServiceRequestContext {
 
+    private static final AtomicReferenceFieldUpdater<DefaultServiceRequestContext, HttpHeaders>
+            additionalResponseHeadersUpdater = AtomicReferenceFieldUpdater.newUpdater(
+            DefaultServiceRequestContext.class, HttpHeaders.class, "additionalResponseHeaders");
+
+    private static final AtomicReferenceFieldUpdater<DefaultServiceRequestContext, HttpHeaders>
+            additionalResponseTrailersUpdater = AtomicReferenceFieldUpdater.newUpdater(
+            DefaultServiceRequestContext.class, HttpHeaders.class, "additionalResponseTrailers");
+
     private final Channel ch;
     private final ServiceConfig cfg;
     private final PathMappingContext pathMappingContext;
@@ -81,7 +90,11 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
     @Nullable
     private volatile RequestTimeoutChangeListener requestTimeoutChangeListener;
     @Nullable
-    private volatile HttpHeaders additionalResponseHeaders;
+    @SuppressWarnings("unused")
+    private volatile HttpHeaders additionalResponseHeaders; // set only via additionalResponseHeadersUpdater
+    @Nullable
+    @SuppressWarnings("unused")
+    private volatile HttpHeaders additionalResponseTrailers; // set only via additionalResponseHeadersUpdater
 
     @Nullable
     private String strVal;
@@ -167,6 +180,11 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
             ctx.setAdditionalResponseHeaders(additionalHeaders);
         }
 
+        final HttpHeaders additionalTrailers = additionalResponseTrailers();
+        if (!additionalTrailers.isEmpty()) {
+            ctx.setAdditionalResponseTrailers(additionalTrailers);
+        }
+
         for (final Iterator<Attribute<?>> i = attrs(); i.hasNext();/* noop */) {
             ctx.addAttr(i.next());
         }
@@ -177,10 +195,31 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
         final HttpHeaders additionalResponseHeaders = this.additionalResponseHeaders;
         if (additionalResponseHeaders == null) {
             final HttpHeaders newHeaders = new DefaultHttpHeaders();
-            this.additionalResponseHeaders = newHeaders;
-            return newHeaders;
+            if (additionalResponseHeadersUpdater.compareAndSet(this, null, newHeaders)) {
+                return newHeaders;
+            } else {
+                final HttpHeaders additionalResponseHeadersSetByOtherThread = this.additionalResponseHeaders;
+                assert additionalResponseHeadersSetByOtherThread != null;
+                return additionalResponseHeadersSetByOtherThread;
+            }
         } else {
             return additionalResponseHeaders;
+        }
+    }
+
+    private HttpHeaders createAdditionalTrailersIfAbsent() {
+        final HttpHeaders additionalResponseTrailers = this.additionalResponseTrailers;
+        if (additionalResponseTrailers == null) {
+            final HttpHeaders newTrailers = new DefaultHttpHeaders();
+            if (additionalResponseTrailersUpdater.compareAndSet(this, null, newTrailers)) {
+                return newTrailers;
+            } else {
+                final HttpHeaders additionalResponseTrailersSetByOtherThread = this.additionalResponseTrailers;
+                assert additionalResponseTrailersSetByOtherThread != null;
+                return additionalResponseTrailersSetByOtherThread;
+            }
+        } else {
+            return additionalResponseTrailers;
         }
     }
 
@@ -357,11 +396,48 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
     @Override
     public boolean removeAdditionalResponseHeader(AsciiString name) {
         requireNonNull(name, "name");
-        final HttpHeaders additionalResponseHeaders = this.additionalResponseHeaders;
-        if (additionalResponseHeaders == null) {
-            return false;
+        return createAdditionalHeadersIfAbsent().remove(name);
+    }
+
+    @Override
+    public HttpHeaders additionalResponseTrailers() {
+        final HttpHeaders additionalResponseTrailers = this.additionalResponseTrailers;
+        if (additionalResponseTrailers == null) {
+            return HttpHeaders.EMPTY_HEADERS;
         }
-        return additionalResponseHeaders.remove(name);
+        return additionalResponseTrailers.asImmutable();
+    }
+
+    @Override
+    public void setAdditionalResponseTrailer(AsciiString name, String value) {
+        requireNonNull(name, "name");
+        requireNonNull(value, "value");
+        createAdditionalTrailersIfAbsent().set(name, value);
+    }
+
+    @Override
+    public void setAdditionalResponseTrailers(Headers<? extends AsciiString, ? extends String, ?> headers) {
+        requireNonNull(headers, "headers");
+        createAdditionalTrailersIfAbsent().set(headers);
+    }
+
+    @Override
+    public void addAdditionalResponseTrailer(AsciiString name, String value) {
+        requireNonNull(name, "name");
+        requireNonNull(value, "value");
+        createAdditionalTrailersIfAbsent().add(name, value);
+    }
+
+    @Override
+    public void addAdditionalResponseTrailers(Headers<? extends AsciiString, ? extends String, ?> headers) {
+        requireNonNull(headers, "headers");
+        createAdditionalTrailersIfAbsent().add(headers);
+    }
+
+    @Override
+    public boolean removeAdditionalResponseTrailer(AsciiString name) {
+        requireNonNull(name, "name");
+        return createAdditionalTrailersIfAbsent().remove(name);
     }
 
     @Nullable

--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
@@ -173,16 +173,7 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject>, RequestTim
                 }
 
                 final HttpHeaders additionalHeaders = reqCtx.additionalResponseHeaders();
-                if (!additionalHeaders.isEmpty()) {
-                    if (headers.isImmutable()) {
-                        // All headers are already validated.
-                        final HttpHeaders temp = headers;
-                        headers = new DefaultHttpHeaders(false, temp.size() + additionalHeaders.size());
-                        headers.set(temp);
-                        o = headers;
-                    }
-                    headers.setAllIfAbsent(additionalHeaders);
-                }
+                o = fillAdditionalHeaders(headers, additionalHeaders);
 
                 logBuilder().responseHeaders(headers);
 
@@ -215,6 +206,8 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject>, RequestTim
                                 "published a trailing HttpHeaders with status: " + o +
                                 " (service: " + service() + ')');
                     }
+                    final HttpHeaders additionalTrailers = reqCtx.additionalResponseTrailers();
+                    o = fillAdditionalHeaders(trailingHeaders, additionalTrailers);
 
                     // Trailing headers always end the stream even if not explicitly set.
                     endOfStream = true;
@@ -226,6 +219,14 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject>, RequestTim
                 return;
         }
 
+        if (endOfStream && !(o instanceof HttpHeaders)) {
+            final HttpHeaders additionalTrailers = reqCtx.additionalResponseTrailers();
+            if (!additionalTrailers.isEmpty()) {
+                write(o, false);
+
+                o = additionalTrailers;
+            }
+        }
         write(o, endOfStream);
     }
 
@@ -277,7 +278,12 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject>, RequestTim
         }
 
         if (state != State.DONE) {
-            write(HttpData.EMPTY_DATA, true);
+            final HttpHeaders additionalTrailers = reqCtx.additionalResponseTrailers();
+            if (!additionalTrailers.isEmpty()) {
+                write(additionalTrailers, true);
+            } else {
+                write(HttpData.EMPTY_DATA, true);
+            }
         }
     }
 
@@ -417,6 +423,19 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject>, RequestTim
 
     private static boolean wroteNothing(State state) {
         return state == State.NEEDS_HEADERS;
+    }
+
+    private static HttpHeaders fillAdditionalHeaders(HttpHeaders headers, HttpHeaders additionalHeaders) {
+        if (!additionalHeaders.isEmpty()) {
+            if (headers.isImmutable()) {
+                // All headers are already validated.
+                final HttpHeaders temp = headers;
+                headers = new DefaultHttpHeaders(false, temp.size() + additionalHeaders.size());
+                headers.set(temp);
+            }
+            headers.setAllIfAbsent(additionalHeaders);
+        }
+        return headers;
     }
 
     private boolean cancelTimeout() {

--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
@@ -211,6 +211,13 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject>, RequestTim
 
                     // Trailing headers always end the stream even if not explicitly set.
                     endOfStream = true;
+                } else if (endOfStream) { // Last DATA frame
+                    final HttpHeaders additionalTrailers = reqCtx.additionalResponseTrailers();
+                    if (!additionalTrailers.isEmpty()) {
+                        write(o, false);
+
+                        o = additionalTrailers;
+                    }
                 }
                 break;
             }
@@ -219,14 +226,6 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject>, RequestTim
                 return;
         }
 
-        if (endOfStream && !(o instanceof HttpHeaders)) {
-            final HttpHeaders additionalTrailers = reqCtx.additionalResponseTrailers();
-            if (!additionalTrailers.isEmpty()) {
-                write(o, false);
-
-                o = additionalTrailers;
-            }
-        }
         write(o, endOfStream);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
@@ -247,6 +247,44 @@ public interface ServiceRequestContext extends RequestContext {
     boolean removeAdditionalResponseHeader(AsciiString name);
 
     /**
+     * Returns an immutable {@link HttpHeaders} which is returned along with any other trailers when a
+     * {@link Service} completes an {@link HttpResponse}.
+     */
+    HttpHeaders additionalResponseTrailers();
+
+    /**
+     * Sets a trailer with the specified {@code name} and {@code value}. This will remove all previous values
+     * associated with the specified {@code name}.
+     * The trailer will be included when a {@link Service} completes an {@link HttpResponse}.
+     */
+    void setAdditionalResponseTrailer(AsciiString name, String value);
+
+    /**
+     * Clears the current trailer and sets the specified {@link Headers} which is included when a
+     * {@link Service} completes an {@link HttpResponse}.
+     */
+    void setAdditionalResponseTrailers(Headers<? extends AsciiString, ? extends String, ?> headers);
+
+    /**
+     * Adds a trailer with the specified {@code name} and {@code value}. The trailer will be included when
+     * a {@link Service} completes an {@link HttpResponse}.
+     */
+    void addAdditionalResponseTrailer(AsciiString name, String value);
+
+    /**
+     * Adds the specified {@link Headers} which is included when a {@link Service} completes an
+     * {@link HttpResponse}.
+     */
+    void addAdditionalResponseTrailers(Headers<? extends AsciiString, ? extends String, ?> headers);
+
+    /**
+     * Removes all trailers with the specified {@code name}.
+     *
+     * @return {@code true} if at least one entry has been removed
+     */
+    boolean removeAdditionalResponseTrailer(AsciiString name);
+
+    /**
      * Returns the proxied addresses if the current {@link Request} is received through a proxy.
      */
     @Nullable

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
@@ -187,6 +187,36 @@ public class ServiceRequestContextWrapper
         return delegate().removeAdditionalResponseHeader(name);
     }
 
+    @Override
+    public HttpHeaders additionalResponseTrailers() {
+        return delegate().additionalResponseTrailers();
+    }
+
+    @Override
+    public void setAdditionalResponseTrailer(AsciiString name, String value) {
+        delegate().setAdditionalResponseTrailer(name, value);
+    }
+
+    @Override
+    public void setAdditionalResponseTrailers(Headers<? extends AsciiString, ? extends String, ?> headers) {
+        delegate().setAdditionalResponseTrailers(headers);
+    }
+
+    @Override
+    public void addAdditionalResponseTrailer(AsciiString name, String value) {
+        delegate().addAdditionalResponseTrailer(name, value);
+    }
+
+    @Override
+    public void addAdditionalResponseTrailers(Headers<? extends AsciiString, ? extends String, ?> headers) {
+        delegate().addAdditionalResponseTrailers(headers);
+    }
+
+    @Override
+    public boolean removeAdditionalResponseTrailer(AsciiString name) {
+        return delegate().removeAdditionalResponseTrailer(name);
+    }
+
     @Nullable
     @Override
     public ProxiedAddresses proxiedAddresses() {

--- a/core/src/test/java/com/linecorp/armeria/server/DefaultServiceRequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/DefaultServiceRequestContextTest.java
@@ -52,6 +52,7 @@ public class DefaultServiceRequestContextTest {
                 mock(Request.class), null, null);
 
         setAdditionalHeaders(originalCtx);
+        setAdditionalTrailers(originalCtx);
 
         final AttributeKey<String> foo = AttributeKey.valueOf(DefaultServiceRequestContextTest.class, "foo");
         originalCtx.attr(foo).set("foo");
@@ -73,6 +74,13 @@ public class DefaultServiceRequestContextTest {
         assertThat(derivedCtx.additionalResponseHeaders().get(AsciiString.of("my-header#3")))
                 .isEqualTo("value#3");
         assertThat(derivedCtx.additionalResponseHeaders().get(AsciiString.of("my-header#4")))
+                .isEqualTo("value#4");
+        assertThat(derivedCtx.additionalResponseTrailers().get(AsciiString.of("my-trailer#1"))).isNull();
+        assertThat(derivedCtx.additionalResponseTrailers().get(AsciiString.of("my-trailer#2")))
+                .isEqualTo("value#2");
+        assertThat(derivedCtx.additionalResponseTrailers().get(AsciiString.of("my-trailer#3")))
+                .isEqualTo("value#3");
+        assertThat(derivedCtx.additionalResponseTrailers().get(AsciiString.of("my-trailer#4")))
                 .isEqualTo("value#4");
         // the attribute is derived as well
         assertThat(derivedCtx.attr(foo).get()).isEqualTo("foo");
@@ -107,5 +115,19 @@ public class DefaultServiceRequestContextTest {
         originalCtx.addAdditionalResponseHeader(AsciiString.of("my-header#4"), "value#4");
         // Remove the first one.
         originalCtx.removeAdditionalResponseHeader(AsciiString.of("my-header#1"));
+    }
+
+    private static void setAdditionalTrailers(ServiceRequestContext originalCtx) {
+        final DefaultHttpHeaders trailers1 = new DefaultHttpHeaders();
+        trailers1.set(AsciiString.of("my-trailer#1"), "value#1");
+        originalCtx.setAdditionalResponseTrailers(trailers1);
+        originalCtx.setAdditionalResponseTrailer(AsciiString.of("my-trailer#2"), "value#2");
+
+        final DefaultHttpHeaders trailers2 = new DefaultHttpHeaders();
+        trailers2.set(AsciiString.of("my-trailer#3"), "value#3");
+        originalCtx.addAdditionalResponseTrailers(trailers2);
+        originalCtx.addAdditionalResponseTrailer(AsciiString.of("my-trailer#4"), "value#4");
+        // Remove the first one.
+        originalCtx.removeAdditionalResponseTrailer(AsciiString.of("my-trailer#1"));
     }
 }


### PR DESCRIPTION
It can be useful for RPC implementations, especially gRPC, to be able to specify additional trailers using `ServiceRequestContext`. 

This also updates `additionalResponseHeaders` manipulation to be thread-safe, which I don't think it was before. Compared to the previous implementation, `removeAdditional` always forces creation of headers but I think this is fine given usual usage of the method and makes sure it's thread-safe vs other add operations.

Fixes #1468 