### PR TITLE
Support Tomcat 9.0.14

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -274,7 +274,7 @@ org.apache.thrift:
 
 org.apache.tomcat.embed:
   tomcat-embed-core:
-    version: &TOMCAT_VERSION '9.0.13'
+    version: &TOMCAT_VERSION '9.0.14'
     javadocs:
     - https://tomcat.apache.org/tomcat-9.0-doc/api/
   tomcat-embed-jasper: { version: *TOMCAT_VERSION }

--- a/tomcat/src/main/java/com/linecorp/armeria/server/tomcat/ConfigFileLoaderInitializer.java
+++ b/tomcat/src/main/java/com/linecorp/armeria/server/tomcat/ConfigFileLoaderInitializer.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.tomcat;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.URI;
+
+import org.apache.catalina.startup.ContextConfig;
+import org.apache.tomcat.util.file.ConfigFileLoader;
+import org.apache.tomcat.util.file.ConfigurationSource;
+
+/**
+ * Sets the dummy {@link ConfigurationSource} so that {@link ContextConfig} does not complain.
+ */
+@SuppressWarnings("unused") // Called by TomcatService.
+final class ConfigFileLoaderInitializer {
+
+    static void init() {
+        try {
+            ConfigFileLoader.getSource(); // throws IllegalStateException if source is not set.
+        } catch (Exception e) {
+            // Set only when a user did not set the source.
+            ConfigFileLoader.setSource(new ConfigurationSource() {
+                @Override
+                public Resource getResource(String name) throws IOException {
+                    throw new FileNotFoundException(name);
+                }
+
+                @Override
+                public URI getURI(String name) {
+                    throw new UnsupportedOperationException();
+                }
+            });
+        }
+    }
+
+    private ConfigFileLoaderInitializer() {}
+}

--- a/tomcat/src/main/java/com/linecorp/armeria/server/tomcat/ManagedTomcatService.java
+++ b/tomcat/src/main/java/com/linecorp/armeria/server/tomcat/ManagedTomcatService.java
@@ -61,7 +61,7 @@ final class ManagedTomcatService extends TomcatService {
     private boolean started;
 
     ManagedTomcatService(@Nullable String hostName,
-                          Function<String, Connector> connectorFactory, Consumer<Connector> postStopTask) {
+                         Function<String, Connector> connectorFactory, Consumer<Connector> postStopTask) {
         this.hostName = hostName;
         this.connectorFactory = connectorFactory;
         this.postStopTask = postStopTask;

--- a/tomcat/src/main/java/com/linecorp/armeria/server/tomcat/Tomcat90ProtocolHandler.java
+++ b/tomcat/src/main/java/com/linecorp/armeria/server/tomcat/Tomcat90ProtocolHandler.java
@@ -17,6 +17,7 @@
 package com.linecorp.armeria.server.tomcat;
 
 import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.annotation.Nullable;
@@ -57,12 +58,41 @@ public final class Tomcat90ProtocolHandler implements ProtocolHandler {
         return id;
     }
 
+    /**
+     * Accessed by {@link Connector} via reflection.
+     */
+    public int getPort() {
+       return 0;
+    }
+
     @Nullable
     @Override
     public Executor getExecutor() {
         // Doesn't seem to be used.
         return null;
     }
+
+    /**
+     * Not available in Tomcat 8.5.
+     */
+    @SuppressWarnings("override")
+    public void setExecutor(Executor executor) {}
+
+    /**
+     * Not available in Tomcat 8.5.
+     */
+    @Nullable
+    @SuppressWarnings("override")
+    public ScheduledExecutorService getUtilityExecutor() {
+        // Doesn't seem to be used.
+        return null;
+    }
+
+    /**
+     * Not available in Tomcat 8.5.
+     */
+    @SuppressWarnings("override")
+    public void setUtilityExecutor(ScheduledExecutorService utilityExecutor) {}
 
     @Override
     public void init() throws Exception {}

--- a/tomcat/src/main/java/com/linecorp/armeria/server/tomcat/TomcatService.java
+++ b/tomcat/src/main/java/com/linecorp/armeria/server/tomcat/TomcatService.java
@@ -106,6 +106,18 @@ public abstract class TomcatService implements HttpService {
                     "could not find the matching classes for Tomcat version " + ServerInfo.getServerNumber() +
                     "; using a wrong armeria-tomcat JAR?", e);
         }
+
+        if (TomcatVersion.major() >= 9) {
+            try {
+                final Class<?> initClass =
+                        Class.forName(prefix + "ConfigFileLoaderInitializer", true, classLoader);
+                MethodHandles.lookup()
+                             .findStatic(initClass, "init", MethodType.methodType(void.class))
+                             .invoke();
+            } catch (Throwable cause) {
+                logger.debug("Failed to initialize Tomcat ConfigFileLoader.source:", cause);
+            }
+        }
     }
 
     TomcatService() {}

--- a/tomcat8.0/build.gradle
+++ b/tomcat8.0/build.gradle
@@ -24,11 +24,14 @@ dependencies {
 //     will confuse IDEs such as IntelliJ IDEA.
 tasks.compileJava.source "${rootProject.projectDir}/tomcat/src/main/java"
 tasks.compileJava.exclude '**/Tomcat90*'
+tasks.compileJava.exclude '**/ConfigFileLoaderInitializer*'
 tasks.processResources.from "${rootProject.projectDir}/tomcat/src/main/resources"
 tasks.compileTestJava.source "${rootProject.projectDir}/tomcat/src/test/java"
 tasks.processTestResources.from "${rootProject.projectDir}/tomcat/src/test/resources"
 tasks.sourceJar.from "${rootProject.projectDir}/tomcat/src/main/java"
 tasks.sourceJar.from "${rootProject.projectDir}/tomcat/src/main/resources"
 tasks.sourceJar.exclude '**/Tomcat90*'
+tasks.sourceJar.exclude '**/ConfigFileLoaderInitializer*'
 tasks.javadoc.source "${rootProject.projectDir}/tomcat/src/main/java"
 tasks.javadoc.exclude '**/Tomcat90*'
+tasks.javadoc.exclude '**/ConfigFileLoaderInitializer*'

--- a/tomcat8.5/build.gradle
+++ b/tomcat8.5/build.gradle
@@ -24,9 +24,12 @@ dependencies {
 //     them added to more than one project and having a source directory with more than one output directory
 //     will confuse IDEs such as IntelliJ IDEA.
 tasks.compileJava.source "${rootProject.projectDir}/tomcat/src/main/java"
+tasks.compileJava.exclude '**/ConfigFileLoaderInitializer*'
 tasks.processResources.from "${rootProject.projectDir}/tomcat/src/main/resources"
 tasks.compileTestJava.source "${rootProject.projectDir}/tomcat/src/test/java"
 tasks.processTestResources.from "${rootProject.projectDir}/tomcat/src/test/resources"
 tasks.sourceJar.from "${rootProject.projectDir}/tomcat/src/main/java"
 tasks.sourceJar.from "${rootProject.projectDir}/tomcat/src/main/resources"
+tasks.sourceJar.exclude '**/ConfigFileLoaderInitializer*'
 tasks.javadoc.source "${rootProject.projectDir}/tomcat/src/main/java"
+tasks.javadoc.exclude '**/ConfigFileLoaderInitializer*'


### PR DESCRIPTION
- Updated Tomcat from 9.0.13 to 9.0.14
- Added `ConfigFileLoaderInitializer` which sets
  `ConfigFileLoader.source` property for Tomcat 9+
- Added the methods required to support Tomcat 9.0.14 to `Tomcat90ProtocolHandler`
