### PR TITLE
Add CIDR based Predicate<InetAddress>

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/misc/Inet4AddressBlock.java
+++ b/core/src/main/java/com/linecorp/armeria/server/misc/Inet4AddressBlock.java
@@ -102,7 +102,7 @@ final class Inet4AddressBlock implements Predicate<InetAddress> {
         // The first 10 bytes should be 0.
         for (int i = 0; i < 10; i++) {
             if (addr[i] != 0x00) {
-                throw new IllegalArgumentException("This IPv6 address cannot be used in IPv4 context" +
+                throw new IllegalArgumentException("This IPv6 address cannot be used in IPv4 context: " +
                                                    address.getHostAddress());
             }
         }
@@ -118,7 +118,7 @@ final class Inet4AddressBlock implements Predicate<InetAddress> {
             return new byte[] { addr[12], addr[13], addr[14], addr[15] };
         }
 
-        throw new IllegalArgumentException("This IPv6 address cannot be used in IPv4 context" +
+        throw new IllegalArgumentException("This IPv6 address cannot be used in IPv4 context: " +
                                            address.getHostAddress());
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/misc/Inet4AddressBlock.java
+++ b/core/src/main/java/com/linecorp/armeria/server/misc/Inet4AddressBlock.java
@@ -83,7 +83,7 @@ final class Inet4AddressBlock implements Predicate<InetAddress> {
     /**
      * Returns IPv4 byte representation of the specified {@link Inet6Address}.
      *
-     * @throws IllegalArgumentException if the IPv6 cannot be mapped to IPv6
+     * @throws IllegalArgumentException if the IPv6 cannot be mapped to IPv4
      */
     private static byte[] ipv6ToIpv4Address(Inet6Address address) {
         final byte[] addr = address.getAddress();

--- a/core/src/main/java/com/linecorp/armeria/server/misc/Inet6AddressBlock.java
+++ b/core/src/main/java/com/linecorp/armeria/server/misc/Inet6AddressBlock.java
@@ -85,8 +85,9 @@ final class Inet6AddressBlock implements Predicate<InetAddress> {
         final byte[] ipv6;
         if (inetAddress instanceof Inet4Address) {
             final byte[] ipv4 = inetAddress.getAddress();
-            if (ipv4[0] == 0x7F && ipv4[1] == 0x00 && ipv4[2] == 0x00 && ipv4[3] == 0x01) {
-                // Convert 127.0.0.1 to ::1.
+            if (ipv4[0] == 0x7F) {
+                // Convert 127.0.0.0/8 to ::1 because this block is assigned for use as the Internet host
+                // loopback address. See https://tools.ietf.org/html/rfc5735#section-3.
                 ipv6 = localhost;
             } else {
                 // Fill the lower 4 bytes with the IPv4 address.

--- a/core/src/main/java/com/linecorp/armeria/server/misc/Inet6AddressBlock.java
+++ b/core/src/main/java/com/linecorp/armeria/server/misc/Inet6AddressBlock.java
@@ -18,7 +18,6 @@ package com.linecorp.armeria.server.misc;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
-import java.math.BigInteger;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.net.InetAddress;
@@ -30,8 +29,11 @@ final class Inet6AddressBlock implements Predicate<InetAddress> {
 
     private final Inet6Address baseAddress;
     private final int maskBits;
-    private final BigInteger lowerBound;
-    private final BigInteger upperBound;
+
+    private final long[] lowerBound;
+    private final long[] upperBound;
+
+    private final boolean[] skipCompare = new boolean[2];
 
     Inet6AddressBlock(Inet6Address baseAddress, int maskBits) {
         this.baseAddress = requireNonNull(baseAddress, "baseAddress");
@@ -40,35 +42,37 @@ final class Inet6AddressBlock implements Predicate<InetAddress> {
         this.maskBits = maskBits;
 
         if (maskBits == 128) {
-            lowerBound = upperBound = ipv6AddressToBigInteger(baseAddress);
+            lowerBound = upperBound = ipv6AddressToLongArray(baseAddress);
         } else if (maskBits == 0) {
-            lowerBound = upperBound = BigInteger.ZERO;
+            lowerBound = upperBound = new long[] { 0, 0 };
         } else {
             // Calculate the lower and upper bounds of this address block.
             // See Inet4AddressBlock if you want to know how they are calculated.
-            final BigInteger mask = BigInteger.ONE.shiftLeft(128 - maskBits);
-            lowerBound = ipv6AddressToBigInteger(baseAddress).and(mask.negate());
-            upperBound = lowerBound.add(mask.subtract(BigInteger.ONE));
+            final long[] mask = calculateMask(maskBits);
+            lowerBound = calculateLowerBound(baseAddress, mask);
+            upperBound = calculateUpperBound(lowerBound, mask);
+
+            // If lowerBound is 0 and upperBound is 0xFFFFFFFFFFFFFFFF, skip comparing the value because
+            // it covers all values.
+            skipCompare[0] = lowerBound[0] == 0L && upperBound[0] == -1L;
+            skipCompare[1] = lowerBound[1] == 0L && upperBound[1] == -1L;
         }
     }
 
     @Override
     public boolean test(InetAddress address) {
         requireNonNull(address, "address");
-        if (maskBits == 0) {
-            return true;
-        }
         if (address instanceof Inet4Address) {
             // This block never accepts IPv6-mapped IPv4 addresses.
             return false;
         }
         if (address instanceof Inet6Address) {
-            try {
-                final BigInteger addr = ipv6AddressToBigInteger((Inet6Address) address);
-                return addr.compareTo(lowerBound) >= 0 && addr.compareTo(upperBound) <= 0;
-            } catch (Exception e) {
-                return false;
+            if (maskBits == 0) {
+                return true;
             }
+            final long[] value = ipv6AddressToLongArray((Inet6Address) address);
+            return (skipCompare[0] || (value[0] >= lowerBound[0] && value[0] <= upperBound[0])) &&
+                   (skipCompare[1] || (value[1] >= lowerBound[1] && value[1] <= upperBound[1]));
         }
         return false;
     }
@@ -78,17 +82,69 @@ final class Inet6AddressBlock implements Predicate<InetAddress> {
         return MoreObjects.toStringHelper(this)
                           .add("baseAddress", baseAddress)
                           .add("maskBits", maskBits)
-                          .add("lowerBound", "0x" + lowerBound.toString(16))
-                          .add("upperBound", "0x" + upperBound.toString(16))
+                          .add("lowerBound", "0x" + Long.toHexString(lowerBound[0]) +
+                                             ':' + Long.toHexString(lowerBound[1]))
+                          .add("upperBound", "0x" + Long.toHexString(upperBound[0]) +
+                                             ':' + Long.toHexString(upperBound[1]))
                           .toString();
     }
 
-    /**
-     * Returns the {@link BigInteger} representation of the specified {@link InetAddress}.
-     */
-    private static BigInteger ipv6AddressToBigInteger(Inet6Address inetAddress) {
-        final byte[] ipv6 = inetAddress.getAddress();
-        return ipv6[0] == -1 ? new BigInteger(1, ipv6)
-                             : new BigInteger(ipv6);
+    private static long[] ipv6AddressToLongArray(Inet6Address address) {
+        final long[] values = new long[2];
+        final byte[] bytes = address.getAddress();
+        assert bytes.length == 16;
+        for (int i = 0; i < bytes.length; i++) {
+            final int index = i / 8;
+            values[index] <<= 8;
+            values[index] |= bytes[i] & 0xFF;
+        }
+        return values;
+    }
+
+    private static long[] calculateLowerBound(Inet6Address baseAddress, long[] mask) {
+        final long[] values = ipv6AddressToLongArray(baseAddress);
+        if (mask[0] > 0L) {
+            // e.g. (-mask) = FFFF:FFFF:0000:0000:0000:0000:0000:0000 if maskBits 32
+            //                |---- Index 0 ----| |---- Index 1 ----|
+            values[0] &= -mask[0];
+            values[1] = 0L;
+        } else {
+            // Do not update values[0] because its mask bits are filled with 1.
+            // e.g. (-mask) = FFFF:FFFF:FFFF:FFFF:FFFF:0000:0000:0000 if maskBits 80
+            //                |---- Index 0 ----| |---- Index 1 ----|
+            values[1] &= -mask[1];
+        }
+        return values;
+    }
+
+    private static long[] calculateUpperBound(long[] lowerBound, long[] mask) {
+        final long[] values = new long[2];
+        if (mask[0] > 0L) {
+            // e.g. (mask-1) = 0000:0000:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF if maskBits 32
+            //                 |---- Index 0 ----| |---- Index 1 ----|
+            values[0] = lowerBound[0] + mask[0] - 1L;
+            values[1] = -1L;
+        } else {
+            // e.g. (mask-1) = 0000:0000:0000:0000:0000:FFFF:FFFF:FFFF if maskBits 80
+            //                 |---- Index 0 ----| |---- Index 1 ----|
+            values[0] = lowerBound[0];
+            values[1] = lowerBound[1] + mask[1] - 1L;
+        }
+        return values;
+    }
+
+    private static long[] calculateMask(int maskBits) {
+        final long[] mask = new long[2];
+        final int shift = 128 - maskBits;
+        if (shift < 64) {
+            // e.g. mask = 0000:0000:0000:0000:0001:0000:0000:0000 if maskBits 80
+            //             |---- Index 0 ----| |---- Index 1 ----|
+            mask[1] = 1L << shift;
+        } else {
+            // e.g. mask = 0000:0001:0000:0000:0000:0000:0000:0000 if maskBits 32
+            //             |---- Index 0 ----| |---- Index 1 ----|
+            mask[0] = 1L << shift - 64L;
+        }
+        return mask;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/misc/Inet6AddressBlock.java
+++ b/core/src/main/java/com/linecorp/armeria/server/misc/Inet6AddressBlock.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.misc;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+import java.math.BigInteger;
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.util.function.Predicate;
+
+import com.google.common.base.MoreObjects;
+
+final class Inet6AddressBlock implements Predicate<InetAddress> {
+
+    private final Inet6Address baseAddress;
+    private final int maskBits;
+    private final BigInteger lowerBound;
+    private final BigInteger upperBound;
+
+    Inet6AddressBlock(Inet6Address baseAddress, int maskBits) {
+        this.baseAddress = requireNonNull(baseAddress, "baseAddress");
+        checkArgument(maskBits >= 0 && maskBits <= 128,
+                      "maskBits: %s (expected: 0-128)", maskBits);
+        this.maskBits = maskBits;
+
+        // Calculate the lower and upper bounds of this address block.
+        // See Inet4AddressBlock if you want to know how they are calculated.
+        final BigInteger mask = BigInteger.ONE.shiftLeft(128 - maskBits);
+        lowerBound = ipv6AddressToBigInteger(baseAddress).and(mask.negate());
+        upperBound = lowerBound.add(mask.subtract(BigInteger.ONE));
+    }
+
+    @Override
+    public boolean test(InetAddress address) {
+        requireNonNull(address, "address");
+        if (maskBits == 0) {
+            return true;
+        }
+        final BigInteger addr = ipv6AddressToBigInteger(address);
+        return addr.compareTo(lowerBound) >= 0 && addr.compareTo(upperBound) <= 0;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("baseAddress", baseAddress)
+                          .add("maskBits", maskBits)
+                          .add("lowerBound", "0x" + lowerBound.toString(16))
+                          .add("upperBound", "0x" + upperBound.toString(16))
+                          .toString();
+    }
+
+    /**
+     * Returns the {@link BigInteger} representation of the specified {@link InetAddress}.
+     */
+    private static BigInteger ipv6AddressToBigInteger(InetAddress inetAddress) {
+        final byte[] ipv6;
+        if (inetAddress instanceof Inet4Address) {
+            final byte[] ipv4 = inetAddress.getAddress();
+            // Fill the lower 4 bytes with the IPv4 address.
+            ipv6 = new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ipv4[0], ipv4[1], ipv4[2], ipv4[3] };
+        } else {
+            ipv6 = inetAddress.getAddress();
+        }
+        if (ipv6[0] == -1) {
+            return new BigInteger(1, ipv6);
+        }
+        return new BigInteger(ipv6);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/misc/InetAddressPredicates.java
+++ b/core/src/main/java/com/linecorp/armeria/server/misc/InetAddressPredicates.java
@@ -25,24 +25,18 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Map;
 import java.util.function.Predicate;
-import java.util.regex.Pattern;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap.Builder;
+
+import io.netty.util.NetUtil;
 
 /**
  * A utility class which provides factory methods in order to easily create a {@link Predicate} of an
  * {@link InetAddress}.
  */
 public final class InetAddressPredicates {
-
-    /**
-     * A {@link Pattern} of a valid IP address.
-     */
-    private static final Pattern validIpV4Address =
-            Pattern.compile("^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}" +
-                            "(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$");
 
     /**
      * A {@link Splitter} for splitting an IP address.
@@ -120,7 +114,7 @@ public final class InetAddressPredicates {
     public static Predicate<InetAddress> ofCidr(InetAddress baseAddress, String subnetMask) {
         requireNonNull(baseAddress, "baseAddress");
         requireNonNull(subnetMask, "subnetMask");
-        checkArgument(validIpV4Address.matcher(subnetMask).matches(),
+        checkArgument(NetUtil.isValidIpV4Address(subnetMask),
                       "subnetMask: %s (expected: an IPv4 address string)", subnetMask);
         final int maskBits = toMaskBits(subnetMask);
         return ofCidr(baseAddress, maskBits, maskBits + 96);
@@ -151,7 +145,7 @@ public final class InetAddressPredicates {
 
         final int maskBits;
 
-        if (validIpV4Address.matcher(subnetMask).matches()) {
+        if (NetUtil.isValidIpV4Address(subnetMask)) {
             maskBits = toMaskBits(subnetMask);
             return ofCidr(baseAddress, maskBits, maskBits + 96);
         }

--- a/core/src/main/java/com/linecorp/armeria/server/misc/InetAddressPredicates.java
+++ b/core/src/main/java/com/linecorp/armeria/server/misc/InetAddressPredicates.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.misc;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Map;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableMap.Builder;
+
+/**
+ * A utility class which provides factory methods in order to easily create a {@link Predicate} of an
+ * {@link InetAddress}.
+ */
+public final class InetAddressPredicates {
+
+    /**
+     * A {@link Pattern} of a valid IP address.
+     */
+    private static final Pattern validIpV4Address =
+            Pattern.compile("^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}" +
+                            "(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$");
+
+    /**
+     * A {@link Splitter} for splitting an IP address.
+     */
+    private static final Splitter dotSplitter = Splitter.on('.').limit(4);
+
+    /**
+     * A table for converting an IP decimal value to the number of bits.
+     */
+    private static final Map<Integer, Integer> ipDecimalToMaskBits = new Builder<Integer, Integer>()
+            .put(0xFF, 8)
+            .put(0xFE, 7)
+            .put(0xFC, 6)
+            .put(0xF8, 5)
+            .put(0xF0, 4)
+            .put(0xE0, 3)
+            .put(0xC0, 2)
+            .put(0x80, 1)
+            .put(0x00, 0)
+            .build();
+
+    /**
+     * Returns a {@link Predicate} which returns {@code true} if the given {@link InetAddress} equals to
+     * the specified {@code address}.
+     *
+     * @param address the expected {@link InetAddress}
+     */
+    public static Predicate<InetAddress> ofExact(InetAddress address) {
+        requireNonNull(address, "address");
+        return address::equals;
+    }
+
+    /**
+     * Returns a {@link Predicate} which returns {@code true} if the given {@link InetAddress} equals to
+     * the specified {@code address}.
+     *
+     * @param address the expected IP address string, e.g. {@code 10.0.0.1}
+     */
+    public static Predicate<InetAddress> ofExact(String address) {
+        requireNonNull(address, "address");
+        try {
+            final InetAddress inetAddress = InetAddress.getByName(address);
+            return inetAddress::equals;
+        } catch (UnknownHostException e) {
+            throw new IllegalArgumentException("Invalid address: " + address, e);
+        }
+    }
+
+    /**
+     * Returns a {@link Predicate} which returns {@code true} if the given {@link InetAddress} is in the
+     * range of a <a href="https://tools.ietf.org/html/rfc4632">Classless Inter-domain Routing (CIDR)</a> block.
+     *
+     * @param baseAddress the base {@link InetAddress} of a CIDR notation
+     * @param maskBits the number of significant bits which describes its network portion
+     */
+    public static Predicate<InetAddress> ofCidr(InetAddress baseAddress, int maskBits) {
+        requireNonNull(baseAddress, "baseAddress");
+        checkArgument(maskBits >= 0, "maskBits: %s (expected: >= 0)", maskBits);
+        return ofCidr(baseAddress, maskBits, maskBits);
+    }
+
+    /**
+     * Returns a {@link Predicate} which returns {@code true} if the given {@link InetAddress} is in the
+     * range of a <a href="https://tools.ietf.org/html/rfc4632">Classless Inter-domain Routing (CIDR)</a> block.
+     *
+     * @param baseAddress the base {@link InetAddress} of a CIDR notation
+     * @param subnetMask the subnet mask, e.g. {@code 255.255.255.0}
+     */
+    public static Predicate<InetAddress> ofCidr(InetAddress baseAddress, String subnetMask) {
+        requireNonNull(baseAddress, "baseAddress");
+        requireNonNull(subnetMask, "subnetMask");
+        checkArgument(validIpV4Address.matcher(subnetMask).matches(),
+                      "subnetMask: %s (expected: IP v4 address string)", subnetMask);
+        final int maskBits = toMaskBits(subnetMask);
+        return ofCidr(baseAddress, maskBits, maskBits + 96);
+    }
+
+    /**
+     * Returns a {@link Predicate} which returns {@code true} if the given {@link InetAddress} is in the
+     * range of a <a href="https://tools.ietf.org/html/rfc4632">Classless Inter-domain Routing (CIDR)</a> block.
+     *
+     * @param cidr the CIDR notation of an address block, e.g. {@code 10.0.0.0/8}, {@code 192.168.1.0/24},
+     *             {@code 1080:0:0:0:8:800:200C:4100/120}
+     */
+    public static Predicate<InetAddress> ofCidr(String cidr) {
+        requireNonNull(cidr, "cidr");
+
+        final int delim = cidr.indexOf('/');
+        checkArgument(delim >= 0, "Invalid CIDR notation: %s", cidr);
+
+        final InetAddress baseAddress;
+        try {
+            baseAddress = InetAddress.getByName(cidr.substring(0, delim));
+        } catch (UnknownHostException e) {
+            throw new IllegalArgumentException("Invalid CIDR notation: " + cidr, e);
+        }
+
+        final String subnetMask = cidr.substring(delim + 1);
+        checkArgument(!subnetMask.isEmpty(), "Invalid CIDR notation: %s", cidr);
+
+        final int maskBits;
+
+        if (validIpV4Address.matcher(subnetMask).matches()) {
+            maskBits = toMaskBits(subnetMask);
+            return ofCidr(baseAddress, maskBits, maskBits + 96);
+        }
+
+        try {
+            maskBits = Integer.parseInt(subnetMask);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Invalid CIDR notation: " + cidr, e);
+        }
+        return ofCidr(baseAddress, maskBits, maskBits);
+    }
+
+    private static Predicate<InetAddress> ofCidr(InetAddress baseAddress,
+                                                 int inet4MaskBits,
+                                                 int inet6MaskBits) {
+        if (baseAddress instanceof Inet4Address) {
+            return new Inet4AddressBlock((Inet4Address) baseAddress, inet4MaskBits);
+        }
+        if (baseAddress instanceof Inet6Address) {
+            return new Inet6AddressBlock((Inet6Address) baseAddress, inet6MaskBits);
+        }
+        throw new IllegalArgumentException(
+                "Unknown baseAddress type: " + baseAddress.getClass().getName() +
+                " (expected: " + Inet4Address.class.getSimpleName() +
+                " or " + Inet6Address.class.getSimpleName() + ')');
+    }
+
+    @VisibleForTesting
+    static int toMaskBits(String subnetMask) {
+        int maskBits = 0;
+        boolean expectZero = false;
+        for (final String ipValue : dotSplitter.split(subnetMask)) {
+            final int num = Integer.parseInt(ipValue);
+            if (expectZero && num != 0) {
+                throw new IllegalArgumentException("Invalid subnet mask address: " + subnetMask);
+            }
+
+            final int bits = ipDecimalToMaskBits.getOrDefault(num, -1);
+            if (bits < 0) {
+                throw new IllegalArgumentException("Invalid subnet mask address: " + subnetMask);
+            }
+
+            maskBits += bits;
+            if (bits != 8 && !expectZero) {
+                expectZero = true;
+            }
+        }
+        return maskBits;
+    }
+
+    private InetAddressPredicates() {}
+}

--- a/core/src/main/java/com/linecorp/armeria/server/misc/package-info.java
+++ b/core/src/main/java/com/linecorp/armeria/server/misc/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Miscellaneous classes.
+ */
+@NonNullByDefault
+package com.linecorp.armeria.server.misc;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/core/src/test/java/com/linecorp/armeria/server/misc/InetAddressPredicatesTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/misc/InetAddressPredicatesTest.java
@@ -98,6 +98,16 @@ public class InetAddressPredicatesTest {
         assertThat(filter.test(InetAddress.getByName("10.1.1.255"))).isFalse();
         assertThat(filter.test(ipv6(10, 1, 1, 64))).isFalse();
         assertThat(filter.test(ipv6(10, 1, 1, 255))).isFalse();
+
+        filter = ofCidr("250.1.1.0/8");
+        assertThat(filter.test(InetAddress.getByName("250.1.1.1"))).isTrue();
+        assertThat(filter.test(InetAddress.getByName("250.255.255.255"))).isTrue();
+        assertThat(filter.test(ipv6(250, 1, 1, 1))).isTrue();
+        assertThat(filter.test(ipv6(250, 255, 255, 255))).isTrue();
+        assertThat(filter.test(InetAddress.getByName("249.1.1.1"))).isFalse();
+        assertThat(filter.test(InetAddress.getByName("249.255.255.255"))).isFalse();
+        assertThat(filter.test(ipv6(249, 1, 1, 1))).isFalse();
+        assertThat(filter.test(ipv6(249, 255, 255, 255))).isFalse();
     }
 
     @Test
@@ -166,6 +176,12 @@ public class InetAddressPredicatesTest {
         assertThat(filter.test(InetAddress.getByName("0:0:0:0:0:0:FFFF:FFFF"))).isFalse();
         assertThat(filter.test(ipv4(10, 1, 2, 1))).isFalse();
         assertThat(filter.test(ipv4(255, 255, 255, 255))).isFalse();
+
+        filter = ofCidr("F080:0:0:0:8:800:200C:4100/120");
+        assertThat(filter.test(InetAddress.getByName("F080:0:0:0:8:800:200C:4100"))).isTrue();
+        assertThat(filter.test(InetAddress.getByName("F080:0:0:0:8:800:200C:41FF"))).isTrue();
+        assertThat(filter.test(InetAddress.getByName("F080:0:0:0:8:800:200C:4200"))).isFalse();
+        assertThat(filter.test(InetAddress.getByName("F080:0:0:0:8:800:200C:FFFF"))).isFalse();
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/server/misc/InetAddressPredicatesTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/misc/InetAddressPredicatesTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.misc;
+
+import static com.linecorp.armeria.server.misc.InetAddressPredicates.ofCidr;
+import static com.linecorp.armeria.server.misc.InetAddressPredicates.ofExact;
+import static com.linecorp.armeria.server.misc.InetAddressPredicates.toMaskBits;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.List;
+import java.util.function.Predicate;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+
+public class InetAddressPredicatesTest {
+
+    @Test
+    public void exact() throws UnknownHostException {
+        final List<Predicate<InetAddress>> filters = ImmutableList.of(
+                ofExact(InetAddress.getByName("10.0.0.1")),
+                ofExact("10.0.0.1"));
+        for (final Predicate<InetAddress> filter : filters) {
+            assertThat(filter.test(InetAddress.getByName("10.0.0.1"))).isTrue();
+            assertThat(filter.test(InetAddress.getByName("10.0.0.2"))).isFalse();
+        }
+    }
+
+    @Test
+    public void inet4Cidr() throws UnknownHostException {
+        Predicate<InetAddress> filter;
+
+        filter = ofCidr("10.1.1.0/8");
+        assertThat(filter.test(InetAddress.getByName("10.0.0.0"))).isTrue();
+        assertThat(filter.test(InetAddress.getByName("10.255.255.255"))).isTrue();
+        assertThat(filter.test(InetAddress.getByName("11.1.1.1"))).isFalse();
+        assertThat(filter.test(InetAddress.getByName("255.255.255.255"))).isFalse();
+
+        filter = ofCidr("10.1.1.0/16");
+        assertThat(filter.test(InetAddress.getByName("10.1.0.0"))).isTrue();
+        assertThat(filter.test(InetAddress.getByName("10.1.255.255"))).isTrue();
+        assertThat(filter.test(InetAddress.getByName("10.2.1.1"))).isFalse();
+        assertThat(filter.test(InetAddress.getByName("10.255.255.255"))).isFalse();
+
+        filter = ofCidr("10.1.1.0/24");
+        assertThat(filter.test(InetAddress.getByName("10.1.1.0"))).isTrue();
+        assertThat(filter.test(InetAddress.getByName("10.1.1.255"))).isTrue();
+        assertThat(filter.test(InetAddress.getByName("10.1.2.1"))).isFalse();
+        assertThat(filter.test(InetAddress.getByName("10.1.255.255"))).isFalse();
+
+        filter = ofCidr("10.1.1.0/26");
+        assertThat(filter.test(InetAddress.getByName("10.1.1.0"))).isTrue();
+        assertThat(filter.test(InetAddress.getByName("10.1.1.63"))).isTrue();
+        assertThat(filter.test(InetAddress.getByName("10.1.1.64"))).isFalse();
+        assertThat(filter.test(InetAddress.getByName("10.1.1.255"))).isFalse();
+    }
+
+    @Test
+    public void inet4Cidr_withSubnetAddress() throws UnknownHostException {
+        Predicate<InetAddress> filter;
+
+        filter = ofCidr("10.1.1.0/255.0.0.0");
+        assertThat(filter.test(InetAddress.getByName("10.0.0.0"))).isTrue();
+        assertThat(filter.test(InetAddress.getByName("10.255.255.255"))).isTrue();
+        assertThat(filter.test(InetAddress.getByName("11.1.1.1"))).isFalse();
+        assertThat(filter.test(InetAddress.getByName("255.255.255.255"))).isFalse();
+
+        filter = ofCidr("10.1.1.0/255.255.0.0");
+        assertThat(filter.test(InetAddress.getByName("10.1.0.0"))).isTrue();
+        assertThat(filter.test(InetAddress.getByName("10.1.255.255"))).isTrue();
+        assertThat(filter.test(InetAddress.getByName("10.2.1.1"))).isFalse();
+        assertThat(filter.test(InetAddress.getByName("10.255.255.255"))).isFalse();
+
+        filter = ofCidr("10.1.1.0/255.255.255.0");
+        assertThat(filter.test(InetAddress.getByName("10.1.1.0"))).isTrue();
+        assertThat(filter.test(InetAddress.getByName("10.1.1.255"))).isTrue();
+        assertThat(filter.test(InetAddress.getByName("10.1.2.1"))).isFalse();
+        assertThat(filter.test(InetAddress.getByName("10.1.255.255"))).isFalse();
+
+        filter = ofCidr("10.1.1.0/255.255.255.192");
+        assertThat(filter.test(InetAddress.getByName("10.1.1.0"))).isTrue();
+        assertThat(filter.test(InetAddress.getByName("10.1.1.63"))).isTrue();
+        assertThat(filter.test(InetAddress.getByName("10.1.1.64"))).isFalse();
+        assertThat(filter.test(InetAddress.getByName("10.1.1.255"))).isFalse();
+    }
+
+    @Test
+    public void inet6Cidr() throws UnknownHostException {
+        Predicate<InetAddress> filter;
+
+        filter = ofCidr("1080:0:0:0:8:800:200C:4100/120");
+        assertThat(filter.test(InetAddress.getByName("1080:0:0:0:8:800:200C:4100"))).isTrue();
+        assertThat(filter.test(InetAddress.getByName("1080:0:0:0:8:800:200C:41FF"))).isTrue();
+        assertThat(filter.test(InetAddress.getByName("1080:0:0:0:8:800:200C:4200"))).isFalse();
+        assertThat(filter.test(InetAddress.getByName("1080:0:0:0:8:800:200C:FFFF"))).isFalse();
+
+        filter = ofCidr("1080:0:0:0:8:800:200C:4100/96");
+        assertThat(filter.test(InetAddress.getByName("1080:0:0:0:8:800:0:0"))).isTrue();
+        assertThat(filter.test(InetAddress.getByName("1080:0:0:0:8:800:FFFF:FFFF"))).isTrue();
+        assertThat(filter.test(InetAddress.getByName("1080:0:0:0:8:801:0:0"))).isFalse();
+        assertThat(filter.test(InetAddress.getByName("1080:0:0:0:8:FFFF:FFFF:FFFF"))).isFalse();
+
+        filter = ofCidr("1080:0:0:0:0:0:0:0/64");
+        assertThat(filter.test(InetAddress.getByName("1080:0:0:0:0:0:0:0"))).isTrue();
+        assertThat(filter.test(InetAddress.getByName("1080:0:0:0:FFFF:FFFF:FFFF:FFFF"))).isTrue();
+        assertThat(filter.test(InetAddress.getByName("1080:0:0:1:0:0:0:0"))).isFalse();
+        assertThat(filter.test(InetAddress.getByName("1080:0:0:FFFF:FFFF:FFFF:FFFF:FFFF"))).isFalse();
+
+        filter = ofCidr("1000:0:0:0:0:0:0:0/8");
+        assertThat(filter.test(InetAddress.getByName("1000:0:0:0:0:0:0:0"))).isTrue();
+        assertThat(filter.test(InetAddress.getByName("10FF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF"))).isTrue();
+        assertThat(filter.test(InetAddress.getByName("1100:0:0:0:0:0:0:0"))).isFalse();
+        assertThat(filter.test(InetAddress.getByName("FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF"))).isFalse();
+    }
+
+    @Test
+    public void inet6Cidr_withSubnetAddress() throws UnknownHostException {
+        Predicate<InetAddress> filter;
+
+        filter = ofCidr("1000:0:0:0:0:0:0:0/255.0.0.0");
+        assertThat(filter.test(InetAddress.getByName("1000:0:0:0:0:0:0:0"))).isTrue();
+        assertThat(filter.test(InetAddress.getByName("1000:0:0:0:0:0:0FF:FFFF"))).isTrue();
+        assertThat(filter.test(InetAddress.getByName("1000:0:0:0:0:0:FF00:0"))).isFalse();
+        assertThat(filter.test(InetAddress.getByName("1000:0:0:0:0:0:FFFF:FFFF"))).isFalse();
+
+        filter = ofCidr("1000:0:0:0:0:0:0:0/255.255.0.0");
+        assertThat(filter.test(InetAddress.getByName("1000:0:0:0:0:0:0:0"))).isTrue();
+        assertThat(filter.test(InetAddress.getByName("1000:0:0:0:0:0:0:FFFF"))).isTrue();
+        assertThat(filter.test(InetAddress.getByName("1000:0:0:0:0:0:001:0"))).isFalse();
+        assertThat(filter.test(InetAddress.getByName("1000:0:0:0:0:0:00FF:FFFF"))).isFalse();
+
+        filter = ofCidr("1000:0:0:0:0:0:0:0/255.255.255.0");
+        assertThat(filter.test(InetAddress.getByName("1000:0:0:0:0:0:0:0"))).isTrue();
+        assertThat(filter.test(InetAddress.getByName("1000:0:0:0:0:0:0:0FF"))).isTrue();
+        assertThat(filter.test(InetAddress.getByName("1000:0:0:0:0:0:0:1FF"))).isFalse();
+        assertThat(filter.test(InetAddress.getByName("1000:0:0:0:0:0:0:FFFF"))).isFalse();
+
+        filter = ofCidr("1000:0:0:0:0:0:0:0/255.255.255.192");
+        assertThat(filter.test(InetAddress.getByName("1000:0:0:0:0:0:0:0"))).isTrue();
+        assertThat(filter.test(InetAddress.getByName("1000:0:0:0:0:0:0:03F"))).isTrue();
+        assertThat(filter.test(InetAddress.getByName("1000:0:0:0:0:0:0:040"))).isFalse();
+        assertThat(filter.test(InetAddress.getByName("1000:0:0:0:0:0:0:FFFF"))).isFalse();
+    }
+
+    @Test
+    public void subnetMaskToBits() {
+        assertThat(toMaskBits("255.0.0.0")).isEqualTo(8);
+        assertThat(toMaskBits("255.255.0.0")).isEqualTo(16);
+        assertThat(toMaskBits("255.255.255.0")).isEqualTo(24);
+        assertThat(toMaskBits("255.255.255.192")).isEqualTo(26);
+        assertThat(toMaskBits("255.255.255.255")).isEqualTo(32);
+
+        assertThatThrownBy(() -> toMaskBits("255.255.0.192"))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> toMaskBits("255.193.0.0"))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> toMaskBits("255.192.192.0"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/misc/InetAddressPredicatesTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/misc/InetAddressPredicatesTest.java
@@ -177,11 +177,12 @@ public class InetAddressPredicatesTest {
         assertThat(filter.test(ipv4(10, 1, 2, 1))).isFalse();
         assertThat(filter.test(ipv4(255, 255, 255, 255))).isFalse();
 
-        filter = ofCidr("F080:0:0:0:8:800:200C:4100/120");
-        assertThat(filter.test(InetAddress.getByName("F080:0:0:0:8:800:200C:4100"))).isTrue();
-        assertThat(filter.test(InetAddress.getByName("F080:0:0:0:8:800:200C:41FF"))).isTrue();
-        assertThat(filter.test(InetAddress.getByName("F080:0:0:0:8:800:200C:4200"))).isFalse();
-        assertThat(filter.test(InetAddress.getByName("F080:0:0:0:8:800:200C:FFFF"))).isFalse();
+        filter = ofCidr("FF80:0:0:0:8:800:200C:4100/120");
+        assertThat(filter.test(InetAddress.getByName("FF80:0:0:0:8:800:200C:4100"))).isTrue();
+        assertThat(filter.test(InetAddress.getByName("FF80:0:0:0:8:800:200C:41FF"))).isTrue();
+        assertThat(filter.test(InetAddress.getByName("FF80:0:0:0:8:800:200C:4200"))).isFalse();
+        assertThat(filter.test(InetAddress.getByName("FF80:0:0:0:8:800:200C:FFFF"))).isFalse();
+        assertThat(filter.test(ipv4(10, 1, 2, 1))).isFalse();
     }
 
     @Test


### PR DESCRIPTION
Motivation:
Once #1467 is merged, we could add a utility class that provides static factory methods that creates `Predicate<InetAddress>` from a CIDR notation, such as `192.168.0.0/24`.

Modifications:
- Add `InetAddressPredicates` which provides static factory methods that return `Predicate<InetAddress>`.

Result:
- Closes #1490