### PR TITLE
Revert 'null' to 'Function.identity()' which was fixed by #1478

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceElement.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceElement.java
@@ -20,8 +20,6 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.function.Function;
 
-import javax.annotation.Nullable;
-
 import com.google.common.base.MoreObjects;
 
 import com.linecorp.armeria.common.HttpRequest;
@@ -43,11 +41,11 @@ public final class AnnotatedHttpServiceElement {
 
     AnnotatedHttpServiceElement(PathMapping pathMapping,
                                 AnnotatedHttpService service,
-                                @Nullable Function<Service<HttpRequest, HttpResponse>,
+                                Function<Service<HttpRequest, HttpResponse>,
                                         ? extends Service<HttpRequest, HttpResponse>> decorator) {
         this.pathMapping = requireNonNull(pathMapping, "pathMapping");
         this.service = requireNonNull(service, "service");
-        this.decorator = decorator;
+        this.decorator = requireNonNull(decorator, "decorator");
     }
 
     /**
@@ -68,7 +66,6 @@ public final class AnnotatedHttpServiceElement {
      * Returns the decorator of the {@link AnnotatedHttpService} which will be evaluated at service
      * registration time.
      */
-    @Nullable
     public Function<Service<HttpRequest, HttpResponse>,
             ? extends Service<HttpRequest, HttpResponse>> decorator() {
         return decorator;

--- a/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceFactory.java
@@ -516,18 +516,16 @@ public final class AnnotatedHttpServiceFactory {
      * Returns a decorator chain which is specified by {@link Decorator} annotations and user-defined
      * decorator annotations.
      */
-    @Nullable
     private static Function<Service<HttpRequest, HttpResponse>,
             ? extends Service<HttpRequest, HttpResponse>> decorator(Method method, Class<?> clazz) {
 
         final List<DecoratorAndOrder> decorators = collectDecorators(clazz, method);
 
         Function<Service<HttpRequest, HttpResponse>,
-                ? extends Service<HttpRequest, HttpResponse>> decorator = null;
+                ? extends Service<HttpRequest, HttpResponse>> decorator = Function.identity();
         for (int i = decorators.size() - 1; i >= 0; i--) {
             final DecoratorAndOrder d = decorators.get(i);
-            decorator = decorator == null ? d.decorator()
-                                          : decorator.andThen(d.decorator());
+            decorator = decorator.andThen(d.decorator());
         }
         return decorator;
     }

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -904,8 +904,8 @@ public final class ServerBuilder {
     public ServerBuilder annotatedService(Object service,
                                           Object... exceptionHandlersAndConverters) {
         return annotatedService("/", service, Function.identity(),
-                                requireNonNull(exceptionHandlersAndConverters,
-                                               "exceptionHandlersAndConverters"));
+                                ImmutableList.copyOf(requireNonNull(exceptionHandlersAndConverters,
+                                                                    "exceptionHandlersAndConverters")));
     }
 
     /**
@@ -920,8 +920,8 @@ public final class ServerBuilder {
                                                   ? extends Service<HttpRequest, HttpResponse>> decorator,
                                           Object... exceptionHandlersAndConverters) {
         return annotatedService("/", service, decorator,
-                                requireNonNull(exceptionHandlersAndConverters,
-                                               "exceptionHandlersAndConverters"));
+                                ImmutableList.copyOf(requireNonNull(exceptionHandlersAndConverters,
+                                                                    "exceptionHandlersAndConverters")));
     }
 
     /**
@@ -941,8 +941,8 @@ public final class ServerBuilder {
     public ServerBuilder annotatedService(String pathPrefix, Object service,
                                           Object... exceptionHandlersAndConverters) {
         return annotatedService(pathPrefix, service, Function.identity(),
-                                requireNonNull(exceptionHandlersAndConverters,
-                                               "exceptionHandlersAndConverters"));
+                                ImmutableList.copyOf(requireNonNull(exceptionHandlersAndConverters,
+                                                                    "exceptionHandlersAndConverters")));
     }
 
     /**
@@ -970,9 +970,25 @@ public final class ServerBuilder {
      *                                       {@link ResponseConverterFunction}
      */
     public ServerBuilder annotatedService(String pathPrefix, Object service,
+                                          Iterable<?> exceptionHandlersAndConverters) {
+        return annotatedService(pathPrefix, service, Function.identity(), exceptionHandlersAndConverters);
+    }
+
+    /**
+     * Binds the specified annotated service object under the specified path prefix.
+     *
+     * @param exceptionHandlersAndConverters an iterable object of {@link ExceptionHandlerFunction},
+     *                                       {@link RequestConverterFunction} and/or
+     *                                       {@link ResponseConverterFunction}
+     */
+    public ServerBuilder annotatedService(String pathPrefix, Object service,
                                           Function<Service<HttpRequest, HttpResponse>,
                                                   ? extends Service<HttpRequest, HttpResponse>> decorator,
                                           Iterable<?> exceptionHandlersAndConverters) {
+        requireNonNull(pathPrefix, "pathPrefix");
+        requireNonNull(service, "service");
+        requireNonNull(decorator, "decorator");
+        requireNonNull(exceptionHandlersAndConverters, "exceptionHandlersAndConverters");
 
         defaultVirtualHostBuilderUpdated();
         defaultVirtualHostBuilder.annotatedService(pathPrefix, service, decorator,

--- a/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/internal/spring/ArmeriaConfigurationUtilTest.java
+++ b/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/internal/spring/ArmeriaConfigurationUtilTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.internal.spring;
+
+import static com.linecorp.armeria.internal.spring.ArmeriaConfigurationUtil.configureAnnotatedHttpServices;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import java.util.function.Function;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.internal.annotation.AnnotatedHttpService;
+import com.linecorp.armeria.server.AbstractHttpService;
+import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.Service;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.annotation.Get;
+import com.linecorp.armeria.spring.AnnotatedServiceRegistrationBean;
+import com.linecorp.armeria.spring.MeterIdPrefixFunctionFactory;
+
+public class ArmeriaConfigurationUtilTest {
+
+    @Test
+    public void makesSureDecoratorsAreConfigured() {
+        final Function<Service<HttpRequest, HttpResponse>,
+                ? extends Service<HttpRequest, HttpResponse>> decorator = spy(new IdentityFunction());
+        final AnnotatedServiceRegistrationBean bean = new AnnotatedServiceRegistrationBean()
+                .setServiceName("test")
+                .setService(new SimpleService())
+                .setDecorators(decorator);
+
+        final ServerBuilder sb1 = new ServerBuilder();
+        configureAnnotatedHttpServices(sb1, ImmutableList.of(bean), MeterIdPrefixFunctionFactory.DEFAULT);
+        verify(decorator).apply(any());
+        assertThat(service(sb1)).isNotInstanceOf(AnnotatedHttpService.class)
+                                .satisfies(s -> assertThat(s.getClass().getName())
+                                        .endsWith("$ExceptionFilteredHttpResponseDecorator"));
+
+        reset(decorator);
+
+        final ServerBuilder sb2 = new ServerBuilder();
+        configureAnnotatedHttpServices(sb2, ImmutableList.of(bean), null);
+        verify(decorator).apply(any());
+        assertThat(service(sb2)).isInstanceOf(AnnotatedHttpService.class);
+    }
+
+    @Test
+    public void makesSureDecoratedServiceIsAdded() {
+        final Function<Service<HttpRequest, HttpResponse>,
+                ? extends Service<HttpRequest, HttpResponse>> decorator = spy(new DecoratingFunction());
+        final AnnotatedServiceRegistrationBean bean = new AnnotatedServiceRegistrationBean()
+                .setServiceName("test")
+                .setService(new SimpleService())
+                .setDecorators(decorator);
+
+        final ServerBuilder sb = new ServerBuilder();
+        configureAnnotatedHttpServices(sb, ImmutableList.of(bean), null);
+        verify(decorator).apply(any());
+        assertThat(service(sb)).isNotInstanceOf(AnnotatedHttpService.class)
+                               .satisfies(s -> assertThat(s.getClass().getName())
+                                       .endsWith("$ExceptionFilteredHttpResponseDecorator"));
+    }
+
+    private static Service<?, ?> service(ServerBuilder sb) {
+        final Server server = sb.build();
+        return server.config().defaultVirtualHost().serviceConfigs().get(0).service();
+    }
+
+    /**
+     * A decorator function which is the same as {@link #identity()} but is not a final class.
+     */
+    static class IdentityFunction
+            implements Function<Service<HttpRequest, HttpResponse>, Service<HttpRequest, HttpResponse>> {
+        @Override
+        public Service<HttpRequest, HttpResponse> apply(Service<HttpRequest, HttpResponse> delegate) {
+            return delegate;
+        }
+    }
+
+    /**
+     * A simple decorating function.
+     */
+    static class DecoratingFunction
+            implements Function<Service<HttpRequest, HttpResponse>, Service<HttpRequest, HttpResponse>> {
+        @Override
+        public Service<HttpRequest, HttpResponse> apply(Service<HttpRequest, HttpResponse> delegate) {
+            return new AbstractHttpService() {
+                @Override
+                protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+                    return HttpResponse.of(HttpStatus.NO_CONTENT);
+                }
+            };
+        }
+    }
+
+    /**
+     * A simple annotated HTTP service.
+     */
+    static class SimpleService {
+        @Get("/")
+        public String root() {
+            return "Hello, world!";
+        }
+    }
+}


### PR DESCRIPTION
Motivation:
It was unnecessary because we are comparing the original service instance with decorators-applied service instance when deciding to add an exception handling decorator.

Modifications:
- Revert `null` to `Function.identity()` in `AbstractVirtualHostBuilder`.
- Add a test case for `ArmeriaConfigurationUtil#configureAnnotatedHttpServices`. (related to #1497)