### PR TITLE
Update the outdated site document

### DIFF
--- a/site/src/sphinx/client-circuit-breaker.rst
+++ b/site/src/sphinx/client-circuit-breaker.rst
@@ -218,8 +218,8 @@ Therefore, Armeria provides various ways that let users group the range of circu
 
         // Create a CircuitBreaker with the key name
         final Function<String, CircuitBreaker> factory = key -> CircuitBreaker.of("my-cb-" + key);
-        final CircuitBreakerStrategy<HttpResponse> httpStrategy = CircuitBreakerStrategy.onServerErrorStatus();
-        final CircuitBreakerStrategy<RpcResponse> rpcStrategy =
+        final CircuitBreakerStrategy httpStrategy = CircuitBreakerStrategy.onServerErrorStatus();
+        final CircuitBreakerStrategy rpcStrategy =
                 response -> response.completionFuture().handle((res, cause) -> cause == null);
 
         // Create CircuitBreakers per host (a.com, b.com ...)


### PR DESCRIPTION
`CircuitBreakerStrategy` is not a generic interface anymore
- PR #1418 Changed `CircuitBreakerStrategy` to a non-generic interface.
- But the related document was still using generic
- See: https://github.com/line/armeria/pull/1418/files#diff-d248cc525f658e2c7a7dc11aad417ca3R49