### PR TITLE
Marshall Status.cause between server and client for more structured e…

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/common/grpc/StatusCauseException.java
+++ b/grpc/src/main/java/com/linecorp/armeria/common/grpc/StatusCauseException.java
@@ -20,12 +20,9 @@ import static java.util.Objects.requireNonNull;
 
 import com.google.common.base.Strings;
 
-import com.linecorp.armeria.grpc.StackTraceElementProto;
-import com.linecorp.armeria.grpc.ThrowableProto;
-
 /**
  * A {@link RuntimeException} reconstructed from debug information in a failed gRPC
- * response containing information about the cause of the exception at the server
+ * response, containing information about the cause of the exception at the server
  * side.
  */
 public final class StatusCauseException extends RuntimeException {
@@ -37,10 +34,10 @@ public final class StatusCauseException extends RuntimeException {
      * Constructs a {@link StatusCauseException} from the information in the {@link ThrowableProto}.
      */
     public StatusCauseException(ThrowableProto proto) {
-        super(requireNonNull(proto, "proto").getExceptionClassName() + ": " + proto.getMessage());
+        super(requireNonNull(proto, "proto").getOriginalClassName() + ": " + proto.getOriginalMessage());
 
-        this.className = proto.getExceptionClassName();
-        this.originalMessage = proto.getMessage();
+        this.className = proto.getOriginalClassName();
+        this.originalMessage = proto.getOriginalMessage();
 
         if (proto.getStackTraceCount() > 0) {
             setStackTrace(proto.getStackTraceList().stream()
@@ -56,7 +53,7 @@ public final class StatusCauseException extends RuntimeException {
     /**
      * Returns the class name of the original exception in the server.
      */
-    public String getClassName() {
+    public String getOriginalClassName() {
         return className;
     }
 

--- a/grpc/src/main/java/com/linecorp/armeria/common/grpc/StatusCauseException.java
+++ b/grpc/src/main/java/com/linecorp/armeria/common/grpc/StatusCauseException.java
@@ -27,7 +27,7 @@ import com.google.common.base.Strings;
  */
 public final class StatusCauseException extends RuntimeException {
 
-    private final String className;
+    private final String originalClassName;
     private final String originalMessage;
 
     /**
@@ -36,7 +36,7 @@ public final class StatusCauseException extends RuntimeException {
     public StatusCauseException(ThrowableProto proto) {
         super(requireNonNull(proto, "proto").getOriginalClassName() + ": " + proto.getOriginalMessage());
 
-        this.className = proto.getOriginalClassName();
+        this.originalClassName = proto.getOriginalClassName();
         this.originalMessage = proto.getOriginalMessage();
 
         if (proto.getStackTraceCount() > 0) {
@@ -54,7 +54,7 @@ public final class StatusCauseException extends RuntimeException {
      * Returns the class name of the original exception in the server.
      */
     public String getOriginalClassName() {
-        return className;
+        return originalClassName;
     }
 
     /**

--- a/grpc/src/main/java/com/linecorp/armeria/common/grpc/StatusCauseException.java
+++ b/grpc/src/main/java/com/linecorp/armeria/common/grpc/StatusCauseException.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.grpc;
+
+import static java.util.Objects.requireNonNull;
+
+import com.google.common.base.Strings;
+
+import com.linecorp.armeria.common.util.Exceptions;
+import com.linecorp.armeria.grpc.StackTraceElementProto;
+import com.linecorp.armeria.grpc.ThrowableProto;
+
+/**
+ * A {@link RuntimeException} reconstructed from debug information in a failed gRPC
+ * response containing information about the cause of the exception at the server
+ * side.
+ */
+public class StatusCauseException extends RuntimeException {
+
+    private final String className;
+    private final String originalMessage;
+
+    /**
+     * Constructs a {@link StatusCauseException} from the information in the {@link ThrowableProto}.
+     */
+    public StatusCauseException(ThrowableProto proto) {
+        super(requireNonNull(proto, "proto").getExceptionClassName() + ": " + proto.getMessage());
+
+        this.className = proto.getExceptionClassName();
+        this.originalMessage = proto.getMessage();
+
+        if (proto.getStackTraceCount() > 0) {
+            setStackTrace(proto.getStackTraceList().stream()
+                               .map(StatusCauseException::deserializeStackTraceElement)
+                               .toArray(StackTraceElement[]::new));
+        } else {
+            Exceptions.clearTrace(this);
+        }
+
+        if (proto.hasCause()) {
+            initCause(new StatusCauseException(proto.getCause()));
+        }
+    }
+
+    /**
+     * Returns the class name of the original exception in the server.
+     */
+    public String getClassName() {
+        return className;
+    }
+
+    /**
+     * Returns the message attached to the original exception in the server.
+     */
+    public String getOriginalMessage() {
+        return originalMessage;
+    }
+
+    private static StackTraceElement deserializeStackTraceElement(StackTraceElementProto proto) {
+        return new StackTraceElement(
+                proto.getClassName(),
+                proto.getMethodName(),
+                Strings.emptyToNull(proto.getFileName()),
+                proto.getLineNumber());
+    }
+}

--- a/grpc/src/main/java/com/linecorp/armeria/common/grpc/StatusCauseException.java
+++ b/grpc/src/main/java/com/linecorp/armeria/common/grpc/StatusCauseException.java
@@ -20,7 +20,6 @@ import static java.util.Objects.requireNonNull;
 
 import com.google.common.base.Strings;
 
-import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.grpc.StackTraceElementProto;
 import com.linecorp.armeria.grpc.ThrowableProto;
 
@@ -29,7 +28,7 @@ import com.linecorp.armeria.grpc.ThrowableProto;
  * response containing information about the cause of the exception at the server
  * side.
  */
-public class StatusCauseException extends RuntimeException {
+public final class StatusCauseException extends RuntimeException {
 
     private final String className;
     private final String originalMessage;
@@ -47,8 +46,6 @@ public class StatusCauseException extends RuntimeException {
             setStackTrace(proto.getStackTraceList().stream()
                                .map(StatusCauseException::deserializeStackTraceElement)
                                .toArray(StackTraceElement[]::new));
-        } else {
-            Exceptions.clearTrace(this);
         }
 
         if (proto.hasCause()) {
@@ -76,5 +73,11 @@ public class StatusCauseException extends RuntimeException {
                 proto.getMethodName(),
                 Strings.emptyToNull(proto.getFileName()),
                 proto.getLineNumber());
+    }
+
+    @Override
+    public Throwable fillInStackTrace() {
+        // We set the stack trace based on ThrowableProto so don't need to fill it automatically.
+        return this;
     }
 }

--- a/grpc/src/main/java/com/linecorp/armeria/internal/grpc/GrpcHeaderNames.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/grpc/GrpcHeaderNames.java
@@ -17,7 +17,7 @@
 package com.linecorp.armeria.internal.grpc;
 
 import com.linecorp.armeria.common.HttpHeaderNames;
-import com.linecorp.armeria.grpc.ThrowableProto;
+import com.linecorp.armeria.common.grpc.ThrowableProto;
 
 import io.grpc.protobuf.ProtoUtils;
 import io.netty.util.AsciiString;
@@ -34,7 +34,8 @@ public final class GrpcHeaderNames {
 
     public static final AsciiString GRPC_TIMEOUT = HttpHeaderNames.of("grpc-timeout");
 
-    public static final AsciiString ARMERIA_GRPC_THROWABLE =
+    // Header name is armeria.grpc.ThrowableProto-bin
+    public static final AsciiString ARMERIA_GRPC_THROWABLEPROTO_BIN =
             HttpHeaderNames.of(ProtoUtils.keyForProto(ThrowableProto.getDefaultInstance()).name());
 
     private GrpcHeaderNames() {}

--- a/grpc/src/main/java/com/linecorp/armeria/internal/grpc/GrpcHeaderNames.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/grpc/GrpcHeaderNames.java
@@ -17,7 +17,9 @@
 package com.linecorp.armeria.internal.grpc;
 
 import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.grpc.ThrowableProto;
 
+import io.grpc.protobuf.ProtoUtils;
 import io.netty.util.AsciiString;
 
 public final class GrpcHeaderNames {
@@ -31,6 +33,9 @@ public final class GrpcHeaderNames {
     public static final AsciiString GRPC_ACCEPT_ENCODING = HttpHeaderNames.of("grpc-accept-encoding");
 
     public static final AsciiString GRPC_TIMEOUT = HttpHeaderNames.of("grpc-timeout");
+
+    public static final AsciiString ARMERIA_GRPC_THROWABLE =
+            HttpHeaderNames.of(ProtoUtils.keyForProto(ThrowableProto.getDefaultInstance()).name());
 
     private GrpcHeaderNames() {}
 }

--- a/grpc/src/main/java/com/linecorp/armeria/internal/grpc/GrpcStatus.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/grpc/GrpcStatus.java
@@ -173,10 +173,10 @@ public final class GrpcStatus {
      * returning to a client.
      */
     public static ThrowableProto serializeThrowable(Throwable t) {
-        ThrowableProto.Builder builder = ThrowableProto.newBuilder();
+        final ThrowableProto.Builder builder = ThrowableProto.newBuilder();
 
         if (t instanceof StatusCauseException) {
-            StatusCauseException statusCause = (StatusCauseException) t;
+            final StatusCauseException statusCause = (StatusCauseException) t;
             builder.setExceptionClassName(statusCause.getClassName());
             builder.setMessage(statusCause.getOriginalMessage());
         } else {
@@ -195,7 +195,7 @@ public final class GrpcStatus {
     }
 
     private static StackTraceElementProto serializeStackTraceElement(StackTraceElement element) {
-        StackTraceElementProto.Builder builder = StackTraceElementProto.newBuilder()
+        final StackTraceElementProto.Builder builder = StackTraceElementProto.newBuilder()
                 .setClassName(element.getClassName())
                 .setMethodName(element.getMethodName())
                 .setLineNumber(element.getLineNumber());

--- a/grpc/src/main/java/com/linecorp/armeria/internal/grpc/GrpcStatus.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/grpc/GrpcStatus.java
@@ -41,9 +41,9 @@ import com.google.common.base.Strings;
 
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.TimeoutException;
+import com.linecorp.armeria.common.grpc.StackTraceElementProto;
 import com.linecorp.armeria.common.grpc.StatusCauseException;
-import com.linecorp.armeria.grpc.StackTraceElementProto;
-import com.linecorp.armeria.grpc.ThrowableProto;
+import com.linecorp.armeria.common.grpc.ThrowableProto;
 
 import io.grpc.Status;
 import io.grpc.Status.Code;
@@ -177,11 +177,11 @@ public final class GrpcStatus {
 
         if (t instanceof StatusCauseException) {
             final StatusCauseException statusCause = (StatusCauseException) t;
-            builder.setExceptionClassName(statusCause.getClassName());
-            builder.setMessage(statusCause.getOriginalMessage());
+            builder.setOriginalClassName(statusCause.getOriginalClassName());
+            builder.setOriginalMessage(statusCause.getOriginalMessage());
         } else {
-            builder.setExceptionClassName(t.getClass().getCanonicalName());
-            builder.setMessage(Strings.nullToEmpty(t.getMessage()));
+            builder.setOriginalClassName(t.getClass().getCanonicalName());
+            builder.setOriginalMessage(Strings.nullToEmpty(t.getMessage()));
         }
 
         for (StackTraceElement element : t.getStackTrace()) {

--- a/grpc/src/main/java/com/linecorp/armeria/internal/grpc/GrpcStatus.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/grpc/GrpcStatus.java
@@ -37,8 +37,13 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.nio.channels.ClosedChannelException;
 
+import com.google.common.base.Strings;
+
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.TimeoutException;
+import com.linecorp.armeria.common.grpc.StatusCauseException;
+import com.linecorp.armeria.grpc.StackTraceElementProto;
+import com.linecorp.armeria.grpc.ThrowableProto;
 
 import io.grpc.Status;
 import io.grpc.Status.Code;
@@ -161,6 +166,43 @@ public final class GrpcStatus {
             default:
                 return Status.Code.UNKNOWN;
         }
+    }
+
+    /**
+     * Fills the information from the {@link Throwable} into a {@link ThrowableProto} for
+     * returning to a client.
+     */
+    public static ThrowableProto serializeThrowable(Throwable t) {
+        ThrowableProto.Builder builder = ThrowableProto.newBuilder();
+
+        if (t instanceof StatusCauseException) {
+            StatusCauseException statusCause = (StatusCauseException) t;
+            builder.setExceptionClassName(statusCause.getClassName());
+            builder.setMessage(statusCause.getOriginalMessage());
+        } else {
+            builder.setExceptionClassName(t.getClass().getCanonicalName());
+            builder.setMessage(Strings.nullToEmpty(t.getMessage()));
+        }
+
+        for (StackTraceElement element : t.getStackTrace()) {
+            builder.addStackTrace(serializeStackTraceElement(element));
+        }
+
+        if (t.getCause() != null) {
+            builder.setCause(serializeThrowable(t.getCause()));
+        }
+        return builder.build();
+    }
+
+    private static StackTraceElementProto serializeStackTraceElement(StackTraceElement element) {
+        StackTraceElementProto.Builder builder = StackTraceElementProto.newBuilder()
+                .setClassName(element.getClassName())
+                .setMethodName(element.getMethodName())
+                .setLineNumber(element.getLineNumber());
+        if (element.getFileName() != null) {
+            builder.setFileName(element.getFileName());
+        }
+        return builder.build();
     }
 
     private GrpcStatus() {}

--- a/grpc/src/main/java/com/linecorp/armeria/internal/grpc/HttpStreamReader.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/grpc/HttpStreamReader.java
@@ -37,7 +37,7 @@ import com.linecorp.armeria.common.HttpObject;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.HttpStatusClass;
 import com.linecorp.armeria.common.grpc.StatusCauseException;
-import com.linecorp.armeria.grpc.ThrowableProto;
+import com.linecorp.armeria.common.grpc.ThrowableProto;
 
 import io.grpc.Decompressor;
 import io.grpc.DecompressorRegistry;
@@ -140,7 +140,7 @@ public class HttpStreamReader implements Subscriber<HttpObject>, BiFunction<Void
                 if (grpcMessage != null) {
                     status = status.withDescription(StatusMessageEscaper.unescape(grpcMessage));
                 }
-                final String grpcThrowable = headers.get(GrpcHeaderNames.ARMERIA_GRPC_THROWABLE);
+                final String grpcThrowable = headers.get(GrpcHeaderNames.ARMERIA_GRPC_THROWABLEPROTO_BIN);
                 if (grpcThrowable != null) {
                     status = addCause(status, grpcThrowable);
                 }

--- a/grpc/src/main/java/com/linecorp/armeria/internal/grpc/HttpStreamReader.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/grpc/HttpStreamReader.java
@@ -18,20 +18,26 @@ package com.linecorp.armeria.internal.grpc;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Base64;
 import java.util.function.BiFunction;
 
 import javax.annotation.Nullable;
 
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.protobuf.InvalidProtocolBufferException;
 
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpObject;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.HttpStatusClass;
+import com.linecorp.armeria.common.grpc.StatusCauseException;
+import com.linecorp.armeria.grpc.ThrowableProto;
 
 import io.grpc.Decompressor;
 import io.grpc.DecompressorRegistry;
@@ -41,6 +47,8 @@ import io.grpc.Status;
  * A {@link Subscriber} to read HTTP messages and pass to gRPC business logic.
  */
 public class HttpStreamReader implements Subscriber<HttpObject>, BiFunction<Void, Throwable, Void> {
+
+    private static final Logger logger = LoggerFactory.getLogger(HttpStreamReader.class);
 
     private final DecompressorRegistry decompressorRegistry;
     private final TransportStatusListener transportStatusListener;
@@ -132,6 +140,10 @@ public class HttpStreamReader implements Subscriber<HttpObject>, BiFunction<Void
                 if (grpcMessage != null) {
                     status = status.withDescription(StatusMessageEscaper.unescape(grpcMessage));
                 }
+                final String grpcThrowable = headers.get(GrpcHeaderNames.ARMERIA_GRPC_THROWABLE);
+                if (grpcThrowable != null) {
+                    status = addCause(status, grpcThrowable);
+                }
                 transportStatusListener.transportReportStatus(status);
                 return;
             }
@@ -211,5 +223,23 @@ public class HttpStreamReader implements Subscriber<HttpObject>, BiFunction<Void
         if (deframer.isStalled()) {
             subscription.request(1);
         }
+    }
+
+    private static Status addCause(Status status, String serializedThrowableProto) {
+        final byte[] decoded;
+        try {
+            decoded = Base64.getDecoder().decode(serializedThrowableProto);
+        } catch (IllegalArgumentException e) {
+            logger.warn("Invalid Base64 in status cause proto, ignoring.", e);
+            return status;
+        }
+        final ThrowableProto grpcThrowableProto;
+        try {
+            grpcThrowableProto = ThrowableProto.parseFrom(decoded);
+        } catch (InvalidProtocolBufferException e) {
+            logger.warn("Invalid serialized status cause proto, ignoring.", e);
+            return status;
+        }
+        return status.withCause(new StatusCauseException(grpcThrowableProto));
     }
 }

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
@@ -24,6 +24,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
@@ -49,14 +50,15 @@ import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
 import com.linecorp.armeria.common.logging.RequestLogAvailability;
-import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.common.util.SafeCloseable;
+import com.linecorp.armeria.grpc.ThrowableProto;
 import com.linecorp.armeria.internal.grpc.ArmeriaMessageDeframer;
 import com.linecorp.armeria.internal.grpc.ArmeriaMessageDeframer.ByteBufOrStream;
 import com.linecorp.armeria.internal.grpc.ArmeriaMessageFramer;
 import com.linecorp.armeria.internal.grpc.GrpcHeaderNames;
 import com.linecorp.armeria.internal.grpc.GrpcLogUtil;
 import com.linecorp.armeria.internal.grpc.GrpcMessageMarshaller;
+import com.linecorp.armeria.internal.grpc.GrpcStatus;
 import com.linecorp.armeria.internal.grpc.HttpStreamReader;
 import com.linecorp.armeria.internal.grpc.StatusMessageEscaper;
 import com.linecorp.armeria.internal.grpc.TransportStatusListener;
@@ -477,29 +479,16 @@ class ArmeriaServerCall<I, O> extends ServerCall<I, O>
         }
         trailers.add(GrpcHeaderNames.GRPC_STATUS, Integer.toString(status.getCode().value()));
 
-        final String description = statusToDescription(status);
-        if (description != null) {
-            trailers.add(GrpcHeaderNames.GRPC_MESSAGE, StatusMessageEscaper.escape(description));
+        if (status.getDescription() != null) {
+            trailers.add(GrpcHeaderNames.GRPC_MESSAGE, StatusMessageEscaper.escape(status.getDescription()));
+        }
+        if (Flags.verboseResponses() && status.getCause() != null) {
+            ThrowableProto proto = GrpcStatus.serializeThrowable(status.getCause());
+            trailers.add(GrpcHeaderNames.ARMERIA_GRPC_THROWABLE,
+                         Base64.getEncoder().encodeToString(proto.toByteArray()));
         }
 
         return trailers;
-    }
-
-    @Nullable
-    private static String statusToDescription(Status status) {
-        final String description = status.getDescription();
-        if (Flags.verboseResponses()) {
-            final Throwable cause = status.getCause();
-            if (cause != null) {
-                final String trace = Exceptions.traceText(cause);
-                if (Strings.isNullOrEmpty(description)) {
-                    return "Caused by: " + trace;
-                } else {
-                    return description + "\nCaused by: " + trace;
-                }
-            }
-        }
-        return description;
     }
 
     HttpStreamReader messageReader() {

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
@@ -49,9 +49,9 @@ import com.linecorp.armeria.common.HttpResponseWriter;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
+import com.linecorp.armeria.common.grpc.ThrowableProto;
 import com.linecorp.armeria.common.logging.RequestLogAvailability;
 import com.linecorp.armeria.common.util.SafeCloseable;
-import com.linecorp.armeria.grpc.ThrowableProto;
 import com.linecorp.armeria.internal.grpc.ArmeriaMessageDeframer;
 import com.linecorp.armeria.internal.grpc.ArmeriaMessageDeframer.ByteBufOrStream;
 import com.linecorp.armeria.internal.grpc.ArmeriaMessageFramer;
@@ -484,7 +484,7 @@ class ArmeriaServerCall<I, O> extends ServerCall<I, O>
         }
         if (Flags.verboseResponses() && status.getCause() != null) {
             final ThrowableProto proto = GrpcStatus.serializeThrowable(status.getCause());
-            trailers.add(GrpcHeaderNames.ARMERIA_GRPC_THROWABLE,
+            trailers.add(GrpcHeaderNames.ARMERIA_GRPC_THROWABLEPROTO_BIN,
                          Base64.getEncoder().encodeToString(proto.toByteArray()));
         }
 

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
@@ -483,7 +483,7 @@ class ArmeriaServerCall<I, O> extends ServerCall<I, O>
             trailers.add(GrpcHeaderNames.GRPC_MESSAGE, StatusMessageEscaper.escape(status.getDescription()));
         }
         if (Flags.verboseResponses() && status.getCause() != null) {
-            ThrowableProto proto = GrpcStatus.serializeThrowable(status.getCause());
+            final ThrowableProto proto = GrpcStatus.serializeThrowable(status.getCause());
             trailers.add(GrpcHeaderNames.ARMERIA_GRPC_THROWABLE,
                          Base64.getEncoder().encodeToString(proto.toByteArray()));
         }

--- a/grpc/src/main/proto/com/linecorp/armeria/grpc/debug.proto
+++ b/grpc/src/main/proto/com/linecorp/armeria/grpc/debug.proto
@@ -1,0 +1,63 @@
+// Copyright 2018 LINE Corporation
+//
+// LINE Corporation licenses this file to you under the Apache License,
+// version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at:
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+// Messages used for transporting debug information between server and client.
+
+syntax = "proto3";
+
+package armeria.grpc;
+
+option java_package = "com.linecorp.armeria.grpc";
+option java_multiple_files = true;
+
+// An element in a stack trace, based on the Java type of the same name.
+//
+// See: https://docs.oracle.com/javase/8/docs/api/java/lang/StackTraceElement.html
+message StackTraceElementProto {
+    // The fully qualified name of the class containing the execution point
+    // represented by the stack trace element.
+    string class_name = 1;
+
+    // The name of the method containing the execution point represented by the
+    // stack trace element
+    string method_name = 2;
+
+    // The name of the file containing the execution point represented by the
+    // stack trace element, or null if this information is unavailable.
+    string file_name = 3;
+
+    // The line number of the source line containing the execution point represented
+    // by this stack trace element, or a negative number if this information is
+    // unavailable.
+    int32 line_number = 4;
+}
+
+// An exception that was thrown by some code, based on the Java type of the same name.
+//
+// See: https://docs.oracle.com/javase/7/docs/api/java/lang/Throwable.html
+message ThrowableProto {
+    // The name of the class of the exception that was actually thrown. Downstream readers
+    // of this message may or may not have the actual class available to initialize, so
+    // this is just used to prefix the message of a generic exception type.
+    string exception_class_name = 1;
+
+    // The message of this throwable. Not filled if there is no message.
+    string message = 2;
+
+    // The stack trace of this Throwable.
+    repeated StackTraceElementProto stack_trace = 3;
+
+    // The cause of this Throwable. Not filled if there is no cause.
+    ThrowableProto cause = 4;
+}

--- a/grpc/src/main/proto/com/linecorp/armeria/grpc/debug.proto
+++ b/grpc/src/main/proto/com/linecorp/armeria/grpc/debug.proto
@@ -18,12 +18,12 @@ syntax = "proto3";
 
 package armeria.grpc;
 
-option java_package = "com.linecorp.armeria.grpc";
+option java_package = "com.linecorp.armeria.common.grpc";
 option java_multiple_files = true;
 
 // An element in a stack trace, based on the Java type of the same name.
 //
-// See: https://docs.oracle.com/javase/11/docs/api/java/lang/StackTraceElement.html
+// See: https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/StackTraceElement.html
 message StackTraceElementProto {
     // The fully qualified name of the class containing the execution point
     // represented by the stack trace element.
@@ -45,15 +45,15 @@ message StackTraceElementProto {
 
 // An exception that was thrown by some code, based on the Java type of the same name.
 //
-// See: https://docs.oracle.com/javase/11/docs/api/java/lang/Throwable.html
+// See: https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Throwable.html
 message ThrowableProto {
     // The name of the class of the exception that was actually thrown. Downstream readers
     // of this message may or may not have the actual class available to initialize, so
     // this is just used to prefix the message of a generic exception type.
-    string exception_class_name = 1;
+    string original_class_name = 1;
 
     // The message of this throwable. Not filled if there is no message.
-    string message = 2;
+    string original_message = 2;
 
     // The stack trace of this Throwable.
     repeated StackTraceElementProto stack_trace = 3;

--- a/grpc/src/main/proto/com/linecorp/armeria/grpc/debug.proto
+++ b/grpc/src/main/proto/com/linecorp/armeria/grpc/debug.proto
@@ -23,7 +23,7 @@ option java_multiple_files = true;
 
 // An element in a stack trace, based on the Java type of the same name.
 //
-// See: https://docs.oracle.com/javase/8/docs/api/java/lang/StackTraceElement.html
+// See: https://docs.oracle.com/javase/11/docs/api/java/lang/StackTraceElement.html
 message StackTraceElementProto {
     // The fully qualified name of the class containing the execution point
     // represented by the stack trace element.
@@ -45,7 +45,7 @@ message StackTraceElementProto {
 
 // An exception that was thrown by some code, based on the Java type of the same name.
 //
-// See: https://docs.oracle.com/javase/7/docs/api/java/lang/Throwable.html
+// See: https://docs.oracle.com/javase/11/docs/api/java/lang/Throwable.html
 message ThrowableProto {
     // The name of the class of the exception that was actually thrown. Downstream readers
     // of this message may or may not have the actual class available to initialize, so

--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcMetricsIntegrationTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcMetricsIntegrationTest.java
@@ -66,15 +66,15 @@ public class GrpcMetricsIntegrationTest {
     private static final MeterRegistry registry = PrometheusMeterRegistries.newRegistry();
 
     private static class TestServiceImpl extends TestServiceImplBase {
-            @Override
-            public void unaryCall(SimpleRequest request, StreamObserver<SimpleResponse> responseObserver) {
-                if ("world".equals(request.getPayload().getBody().toStringUtf8())) {
-                    responseObserver.onNext(SimpleResponse.getDefaultInstance());
-                    responseObserver.onCompleted();
-                    return;
-                }
-                responseObserver.onError(new IllegalArgumentException("bad argument"));
+        @Override
+        public void unaryCall(SimpleRequest request, StreamObserver<SimpleResponse> responseObserver) {
+            if ("world".equals(request.getPayload().getBody().toStringUtf8())) {
+                responseObserver.onNext(SimpleResponse.getDefaultInstance());
+                responseObserver.onCompleted();
+                return;
             }
+            responseObserver.onError(new IllegalArgumentException("bad argument"));
+        }
 
         @Override
         public void unaryCall2(SimpleRequest request, StreamObserver<SimpleResponse> responseObserver) {

--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcMetricsIntegrationTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcMetricsIntegrationTest.java
@@ -39,7 +39,6 @@ import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.ClientFactoryBuilder;
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.client.metric.MetricCollectingClient;
-import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.SerializationFormat;
@@ -67,15 +66,15 @@ public class GrpcMetricsIntegrationTest {
     private static final MeterRegistry registry = PrometheusMeterRegistries.newRegistry();
 
     private static class TestServiceImpl extends TestServiceImplBase {
-        @Override
-        public void unaryCall(SimpleRequest request, StreamObserver<SimpleResponse> responseObserver) {
-            if ("world".equals(request.getPayload().getBody().toStringUtf8())) {
-                responseObserver.onNext(SimpleResponse.getDefaultInstance());
-                responseObserver.onCompleted();
-                return;
+            @Override
+            public void unaryCall(SimpleRequest request, StreamObserver<SimpleResponse> responseObserver) {
+                if ("world".equals(request.getPayload().getBody().toStringUtf8())) {
+                    responseObserver.onNext(SimpleResponse.getDefaultInstance());
+                    responseObserver.onCompleted();
+                    return;
+                }
+                responseObserver.onError(new IllegalArgumentException("bad argument"));
             }
-            responseObserver.onError(new IllegalArgumentException("bad argument"));
-        }
 
         @Override
         public void unaryCall2(SimpleRequest request, StreamObserver<SimpleResponse> responseObserver) {
@@ -167,14 +166,7 @@ public class GrpcMetricsIntegrationTest {
         assertThat(findServerMeter("UnaryCall2", "responseLength", COUNT, "httpStatus", "200")).contains(4.0);
         assertThat(findServerMeter("UnaryCall2", "responseLength", COUNT, "httpStatus", "500")).contains(3.0);
         assertThat(findServerMeter("UnaryCall2", "responseLength", TOTAL, "httpStatus", "200")).contains(0.0);
-        assertThat(findServerMeter("UnaryCall2", "responseLength", TOTAL, "httpStatus", "500"))
-                .hasValueSatisfying(value -> {
-                    if (Flags.verboseResponses()) {
-                        assertThat(value).isGreaterThan(225.0); // As larger as the stack trace
-                    } else {
-                        assertThat(value).isEqualTo(225.0);
-                    }
-                });
+        assertThat(findServerMeter("UnaryCall2", "responseLength", TOTAL, "httpStatus", "500")).contains(225.0);
     }
 
     private static Optional<Double> findServerMeter(

--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcStatusCauseTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcStatusCauseTest.java
@@ -87,7 +87,7 @@ public class GrpcStatusCauseTest {
                     assertThat(t.getCause()).isInstanceOfSatisfying(
                             StatusCauseException.class,
                             cause -> {
-                                assertThat(cause.getClassName())
+                                assertThat(cause.getOriginalClassName())
                                         .isEqualTo("java.lang.IllegalStateException");
                                 assertThat(cause.getOriginalMessage()).isEqualTo("Exception 1");
                                 assertThat(cause.getMessage())

--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcStatusCauseTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcStatusCauseTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.it.grpc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import com.linecorp.armeria.client.Clients;
+import com.linecorp.armeria.common.Flags;
+import com.linecorp.armeria.common.grpc.StatusCauseException;
+import com.linecorp.armeria.common.util.Exceptions;
+import com.linecorp.armeria.grpc.testing.Messages.SimpleRequest;
+import com.linecorp.armeria.grpc.testing.Messages.SimpleResponse;
+import com.linecorp.armeria.grpc.testing.TestServiceGrpc.TestServiceBlockingStub;
+import com.linecorp.armeria.grpc.testing.TestServiceGrpc.TestServiceImplBase;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.grpc.GrpcServiceBuilder;
+import com.linecorp.armeria.testing.server.ServerRule;
+
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.StreamObserver;
+
+public class GrpcStatusCauseTest {
+
+    private static class TestServiceImpl extends TestServiceImplBase {
+        @Override
+        public void unaryCall(SimpleRequest request, StreamObserver<SimpleResponse> responseObserver) {
+            IllegalStateException e1 = new IllegalStateException("Exception 1");
+            IllegalArgumentException e2 = new IllegalArgumentException();
+            AssertionError e3 = new AssertionError("Exception 3");
+            Exceptions.clearTrace(e3);
+            RuntimeException e4 = new RuntimeException("Exception 4");
+
+            e1.initCause(e2);
+            e2.initCause(e3);
+            e3.initCause(e4);
+
+            Status status = Status.ABORTED.withCause(e1);
+            responseObserver.onError(status.asRuntimeException());
+        }
+    }
+
+    @ClassRule
+    public static final ServerRule server = new ServerRule() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.serviceUnder("/", new GrpcServiceBuilder()
+                    .addService(new TestServiceImpl())
+                    .build());
+        }
+    };
+
+    private TestServiceBlockingStub stub;
+
+    @Before
+    public void setUp() {
+        stub = Clients.newClient("gproto+" + server.httpUri("/"), TestServiceBlockingStub.class);
+    }
+
+    @Test
+    public void normal() {
+        if (!Flags.verboseExceptions()) {
+            // This test doesn't do anything if verbose exceptions aren't enabled.
+            return;
+        }
+        assertThatThrownBy(() -> stub.unaryCall(SimpleRequest.getDefaultInstance()))
+                .isInstanceOfSatisfying(StatusRuntimeException.class, t -> {
+                    assertThat(t.getCause()).isInstanceOfSatisfying(
+                            StatusCauseException.class,
+                            cause -> {
+                                assertThat(cause.getClassName())
+                                        .isEqualTo("java.lang.IllegalStateException");
+                                assertThat(cause.getOriginalMessage()).isEqualTo("Exception 1");
+                                assertThat(cause.getMessage())
+                                        .isEqualTo("java.lang.IllegalStateException: Exception 1");
+                                assertThat(cause.getStackTrace()).isNotEmpty();
+                                assertThat(cause.getStackTrace()[0].getClassName()).contains("TestServiceImpl");
+                                assertThat(cause.getStackTrace()[0].getMethodName()).isEqualTo("unaryCall");
+                                assertThat(cause.getStackTrace()[0].getFileName())
+                                        .isEqualTo("GrpcStatusCauseTest.java");
+                                assertThat(cause.getStackTrace()[0].getLineNumber()).isPositive();
+                            }
+                    );
+                    assertThat(t.getCause().getCause()).isInstanceOfSatisfying(
+                            StatusCauseException.class,
+                            cause -> {
+                                assertThat(cause.getMessage())
+                                        .isEqualTo("java.lang.IllegalArgumentException: ");
+                                assertThat(cause.getOriginalMessage()).isEmpty();
+                            }
+                    );
+                    assertThat(t.getCause().getCause().getCause()).isInstanceOfSatisfying(
+                            StatusCauseException.class,
+                            cause -> {
+                                assertThat(cause.getMessage())
+                                        .isEqualTo("java.lang.AssertionError: Exception 3");
+                                assertThat(cause.getStackTrace()).isEmpty();
+                            }
+                    );
+                    assertThat(t.getCause().getCause().getCause().getCause()).isInstanceOfSatisfying(
+                            StatusCauseException.class,
+                            cause -> {
+                                assertThat(cause.getMessage())
+                                        .isEqualTo("java.lang.RuntimeException: Exception 4");
+                                assertThat(cause.getCause()).isNull();
+                            }
+                    );
+                });
+    }
+}

--- a/site/src/sphinx/client-grpc.rst
+++ b/site/src/sphinx/client-grpc.rst
@@ -160,10 +160,11 @@ to gather metrics. Please also refer to :api:`ClientBuilder` for more configurat
 Exception propagation
 ======================
 
-If you have enabled ``Flags.verboseResponses()`` in the server being accessed, then any exception during
-processing in the server will be returned to the client as a :api:`StatusCauseException` attached to the
-normal gRPC ``Status``. This can be used for programmatic access to the exception that happened in the
-server. In this example, the server always fails with ``throw new IllegalStateException("Failed!");``
+If you have enabled ``Flags.verboseResponses()`` in the server being accessed by specifying
+``-Dcom.linecorp.armeria.verboseResponses=true`` system property, then any exception during processing
+in the server will be returned to the client as a :api:`StatusCauseException` attached to the normal gRPC
+``Status``. This can be used for programmatic access to the exception that happened in the server. In this
+example, the server always fails with ``throw new IllegalStateException("Failed!");``
 
 .. code-block:: java
 
@@ -182,12 +183,19 @@ server. In this example, the server always fails with ``throw new IllegalStateEx
     } catch (StatusRuntimeException e) {
         if (e.getCause() instanceof StatusCauseException) {
             StatusCauseException cause = (StatusCauseException) e.getCause();
-            // The name of the class of the exception in the server can be accessed.
-            assert cause.getClassName() == "java.lang.IllegalStateException";
-            // The exception's message is a combination of both this class name and original message.
-            assert cause.getMessage() == "java.lang.IllegalStateException: Failed!";
+            // The name of the class of the exception and its message in the server can be accessed.
+            assert cause.getOriginalClassName().equals("java.lang.IllegalStateException");
+            assert cause.getOriginalMessage().equals("Failed!");
+
+            // The exception's message is a combination of both the class name and original message.
+            assert cause.getMessage().equals("java.lang.IllegalStateException: Failed!");
+
             // The exception's stack trace is that which occurred when the server threw the exception.
             cause.printStackTrace();
+
+            // Logging frameworks, as used by e.g., LoggingClient, will print the stack trace if configured
+            // to do so.
+
             // Now you know exactly where to look in the server to figure out what may have gone wrong.
         }
     }

--- a/site/src/sphinx/client-grpc.rst
+++ b/site/src/sphinx/client-grpc.rst
@@ -158,7 +158,7 @@ requests and responses. You might be interested in decorating a client using oth
 to gather metrics. Please also refer to :api:`ClientBuilder` for more configuration options.
 
 Exception propagation
-======================
+=====================
 
 If you have enabled ``Flags.verboseResponses()`` in the server being accessed by specifying
 ``-Dcom.linecorp.armeria.verboseResponses=true`` system property, then any exception during processing

--- a/site/src/sphinx/client-grpc.rst
+++ b/site/src/sphinx/client-grpc.rst
@@ -157,6 +157,42 @@ As you might have noticed already, we decorated the client using :api:`LoggingCl
 requests and responses. You might be interested in decorating a client using other decorators, for example
 to gather metrics. Please also refer to :api:`ClientBuilder` for more configuration options.
 
+Exception propagation
+======================
+
+If you have enabled ``Flags.verboseResponses()`` in the server being accessed, then any exception during
+processing in the server will be returned to the client as a :api:`StatusCauseException` attached to the
+normal gRPC ``Status``. This can be used for programmatic access to the exception that happened in the
+server. In this example, the server always fails with ``throw new IllegalStateException("Failed!");``
+
+.. code-block:: java
+
+    import com.linecorp.armeria.client.Clients;
+    import com.linecorp.armeria.common.grpc.StatusCauseException;
+
+    import io.grpc.StatusRuntimeException;
+
+    HelloServiceBlockingStub helloService = Clients.newClient(
+            "gproto+http://127.0.0.1:8080/",
+            HelloServiceBlockingStub.class); // or HelloServiceFutureStub.class or HelloServiceStub.class
+
+    HelloRequest request = HelloRequest.newBuilder().setName("Armerian World").build();
+    try {
+        HelloReply reply = helloService.hello(request);
+    } catch (StatusRuntimeException e) {
+        if (e.getCause() instanceof StatusCauseException) {
+            StatusCauseException cause = (StatusCauseException) e.getCause();
+            // The name of the class of the exception in the server can be accessed.
+            assert cause.getClassName() == "java.lang.IllegalStateException";
+            // The exception's message is a combination of both this class name and original message.
+            assert cause.getMessage() == "java.lang.IllegalStateException: Failed!";
+            // The exception's stack trace is that which occurred when the server threw the exception.
+            cause.printStackTrace();
+            // Now you know exactly where to look in the server to figure out what may have gone wrong.
+        }
+    }
+
+
 See also
 --------
 

--- a/site/src/sphinx/server-grpc.rst
+++ b/site/src/sphinx/server-grpc.rst
@@ -203,7 +203,8 @@ entire service implementation in ``RequestContext.current().blockingTaskExecutor
 Exception propagation
 ======================
 
-It can be very useful to enable ``Flags.verboseResponses()` in your server, which will automatically return
+It can be very useful to enable ``Flags.verboseResponses()`` in your server by specifying the
+``-Dcom.linecorp.armeria.verboseResponses=true`` system property, which will automatically return
 information about an exception thrown in the server to gRPC clients. Armeria clients will automatically
 convert it back into an exception for structured logging, etc. This response will include information about
 the actual source code in the server - make sure it is safe to send such potentially sensitive information

--- a/site/src/sphinx/server-grpc.rst
+++ b/site/src/sphinx/server-grpc.rst
@@ -200,6 +200,16 @@ entire service implementation in ``RequestContext.current().blockingTaskExecutor
         }
     }
 
+Exception propagation
+======================
+
+It can be very useful to enable ``Flags.verboseResponses()` in your server, which will automatically return
+information about an exception thrown in the server to gRPC clients. Armeria clients will automatically
+convert it back into an exception for structured logging, etc. This response will include information about
+the actual source code in the server - make sure it is safe to send such potentially sensitive information
+to all your clients before enabling this flag!
+
+See more details at :ref:`client-grpc`.
 
 See also
 --------

--- a/site/src/sphinx/server-grpc.rst
+++ b/site/src/sphinx/server-grpc.rst
@@ -201,7 +201,7 @@ entire service implementation in ``RequestContext.current().blockingTaskExecutor
     }
 
 Exception propagation
-======================
+=====================
 
 It can be very useful to enable ``Flags.verboseResponses()`` in your server by specifying the
 ``-Dcom.linecorp.armeria.verboseResponses=true`` system property, which will automatically return


### PR DESCRIPTION
…rror handling.

Currently, when `verboseResponses` is enabled we serialize an exception's stack trace into the gRPC message, which is similar to the `message` of a `Throwable`. This allows the stack trace to be logged, e.g. by `LoggingClient` which is useful, but it could be even more useful if we provided better programmatic access to the stack trace.

This PR defines a proto which models the information found in an exception, including message, stack trace, and cause. Serializing this information allows the client to reconstruct almost all of the exception - the class itself is not used since the client may not have it or it may be difficult to instantiate it with reflection, so instead `StatusCauseException` provides information about the original class in its message and programmatically. Now, instead of the server's exception stack trace being logged as part of an exception's message, it is logged as part of an exception's cause, which gives more freedom to logging frameworks too.

The proto itself is serialized using gRPC's standard conventions for including proto in trailers, by using a key suffixed by `-bin` (handled by ProtoUtils) and a base64-encoded value. Non-armeria clients shouldn't have a huge trouble accessing the information in this proto if they need to.

Fixes #1471 