### PR TITLE
Provide a way to stream an individual file

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/HttpMessageAggregator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpMessageAggregator.java
@@ -57,14 +57,14 @@ abstract class HttpMessageAggregator implements Subscriber<HttpObject>, BiFuncti
     }
 
     /**
-     * Handled by {@link #accept(Void, Throwable)} instead,
+     * Handled by {@link #apply(Void, Throwable)} instead,
      * because this method is not invoked on cancellation and timeout.
      */
     @Override
     public final void onError(Throwable throwable) {}
 
     /**
-     * Handled by {@link #accept(Void, Throwable)} instead,
+     * Handled by {@link #apply(Void, Throwable)} instead,
      * because this method is not invoked on cancellation and timeout.
      */
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
@@ -368,7 +368,7 @@ public interface HttpRequest extends Request, StreamMessage<HttpObject> {
      * Aggregates this request. The returned {@link CompletableFuture} will be notified when the content and
      * the trailing headers of the request is received fully. {@link AggregatedHttpMessage#content()} will
      * return a pooled object, and the caller must ensure to release it. If you don't know what this means,
-     * use {@link HttpResponse#aggregate()}.
+     * use {@link #aggregate()}.
      */
     default CompletableFuture<AggregatedHttpMessage> aggregateWithPooledObjects(ByteBufAllocator alloc) {
         requireNonNull(alloc, "alloc");
@@ -383,7 +383,7 @@ public interface HttpRequest extends Request, StreamMessage<HttpObject> {
      * Aggregates this request. The returned {@link CompletableFuture} will be notified when the content and
      * the trailing headers of the request is received fully. {@link AggregatedHttpMessage#content()} will
      * return a pooled object, and the caller must ensure to release it. If you don't know what this means,
-     * use {@link HttpResponse#aggregate()}.
+     * use {@link #aggregate()}.
      */
     default CompletableFuture<AggregatedHttpMessage> aggregateWithPooledObjects(
             EventExecutor executor, ByteBufAllocator alloc) {

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -380,7 +380,7 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
      * Aggregates this response. The returned {@link CompletableFuture} will be notified when the content and
      * the trailing headers of the response are received fully. {@link AggregatedHttpMessage#content()} will
      * return a pooled object, and the caller must ensure to release it. If you don't know what this means,
-     * use {@link HttpResponse#aggregate()}.
+     * use {@link #aggregate()}.
      */
     default CompletableFuture<AggregatedHttpMessage> aggregateWithPooledObjects(ByteBufAllocator alloc) {
         requireNonNull(alloc, "alloc");
@@ -395,7 +395,7 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
      * Aggregates this response. The returned {@link CompletableFuture} will be notified when the content and
      * the trailing headers of the request is received fully. {@link AggregatedHttpMessage#content()} will
      * return a pooled object, and the caller must ensure to release it. If you don't know what this means,
-     * use {@link HttpResponse#aggregate()}.
+     * use {@link #aggregate()}.
      */
     default CompletableFuture<AggregatedHttpMessage> aggregateWithPooledObjects(
             EventExecutor executor, ByteBufAllocator alloc) {

--- a/core/src/main/java/com/linecorp/armeria/internal/Http1ObjectEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/Http1ObjectEncoder.java
@@ -202,8 +202,7 @@ public final class Http1ObjectEncoder extends HttpObjectEncoder {
             final io.netty.handler.codec.http.HttpHeaders outHeaders = res.headers();
             convert(streamId, headers, outHeaders, false);
 
-            if (informational) {
-                // 1xx responses does not have the 'content-length' header.
+            if (ArmeriaHttpUtil.isContentAlwaysEmpty(status)) {
                 outHeaders.remove(HttpHeaderNames.CONTENT_LENGTH);
             } else if (!headers.contains(HttpHeaderNames.CONTENT_LENGTH)) {
                 // NB: Set the 'content-length' only when not set rather than always setting to 0.

--- a/core/src/main/java/com/linecorp/armeria/server/docs/DocService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/DocService.java
@@ -325,7 +325,7 @@ public class DocService extends AbstractCompositeService<HttpRequest, HttpRespon
 
         @Override
         public HttpFile get(String path, Clock clock,
-                            @Nullable MediaType contentType, @Nullable String contentEncoding) {
+                            @Nullable String contentEncoding) {
             return file;
         }
 

--- a/core/src/main/java/com/linecorp/armeria/server/docs/DocService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/DocService.java
@@ -23,6 +23,7 @@ import static com.linecorp.armeria.server.composition.CompositeServiceEntry.ofCa
 import static com.linecorp.armeria.server.composition.CompositeServiceEntry.ofExact;
 import static java.util.Objects.requireNonNull;
 
+import java.time.Clock;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -323,7 +324,8 @@ public class DocService extends AbstractCompositeService<HttpRequest, HttpRespon
         private volatile HttpFile file = HttpFile.nonExistent();
 
         @Override
-        public HttpFile get(String path, @Nullable MediaType contentType, @Nullable String contentEncoding) {
+        public HttpFile get(String path, Clock clock,
+                            @Nullable MediaType contentType, @Nullable String contentEncoding) {
             return file;
         }
 

--- a/core/src/main/java/com/linecorp/armeria/server/file/AbstractHttpFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/AbstractHttpFile.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.file;
+
+import static java.util.Objects.requireNonNull;
+
+import java.io.IOException;
+import java.util.concurrent.Executor;
+import java.util.function.BiFunction;
+
+import javax.annotation.Nullable;
+
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+
+import io.netty.buffer.ByteBufAllocator;
+
+/**
+ * A skeletal {@link HttpFile} implementation.
+ */
+public abstract class AbstractHttpFile implements HttpFile {
+
+    @Nullable
+    private final MediaType contentType;
+    private final boolean dateEnabled;
+    private final boolean lastModifiedEnabled;
+    @Nullable
+    private final BiFunction<String, HttpFileAttributes, String> entityTagFunction;
+    private final HttpHeaders headers;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param contentType the {@link MediaType} of the file which will be used as the {@code "content-type"}
+     *                    header value. {@code null} to disable setting the {@code "content-type"} header.
+     * @param dateEnabled whether to set the {@code "date"} header automatically
+     * @param lastModifiedEnabled whether to add the {@code "last-modified"} header automatically
+     * @param entityTagFunction the {@link BiFunction} that generates an entity tag from the file's attributes.
+     *                          {@code null} to disable setting the {@code "etag"} header.
+     * @param headers the additional headers to set
+     */
+    protected AbstractHttpFile(@Nullable MediaType contentType,
+                               boolean dateEnabled,
+                               boolean lastModifiedEnabled,
+                               @Nullable BiFunction<String, HttpFileAttributes, String> entityTagFunction,
+                               HttpHeaders headers) {
+
+        this.dateEnabled = dateEnabled;
+        this.lastModifiedEnabled = lastModifiedEnabled;
+        this.contentType = contentType;
+        this.entityTagFunction = entityTagFunction;
+        this.headers = requireNonNull(headers, "headers").asImmutable();
+    }
+
+    /**
+     * Returns the {@link String} representation of the file path or URI, which is given to the
+     * {@code entityTagFunction} specified in
+     * {@linkplain #AbstractHttpFile(MediaType, boolean, boolean, BiFunction, HttpHeaders) the constructor}.
+     */
+    protected abstract String pathOrUri();
+
+    /**
+     * Returns whether to add the {@code "date"} header automatically.
+     */
+    protected final boolean isDateEnabled() {
+        return dateEnabled;
+    }
+
+    /**
+     * Returns whether to add the {@code "last-modified"} header automatically.
+     */
+    protected final boolean isLastModifiedEnabled() {
+        return lastModifiedEnabled;
+    }
+
+    /**
+     * Returns the {@link MediaType} of the file, which will be used for setting the {@code "content-type"}
+     * header.
+     *
+     * @return the {@link MediaType} of the file, or {@code null} if the {@code "content-type"} header will not
+     *         be set automatically.
+     */
+    @Nullable
+    protected final MediaType contentType() {
+        return contentType;
+    }
+
+    /**
+     * Returns the immutable additional {@link HttpHeaders} which will be set when building an
+     * {@link HttpResponse}.
+     */
+    protected final HttpHeaders headers() {
+        return headers;
+    }
+
+    /**
+     * Generates an entity tag of the file with the given attributes using the {@code entityTagFunction}
+     * which was specified with
+     * {@linkplain #AbstractHttpFile(MediaType, boolean, boolean, BiFunction, HttpHeaders) the constructor}.
+     *
+     * @return the entity tag or {@code null} if {@code entityTagFunction} is {@code null}.
+     */
+    @Nullable
+    protected final String generateEntityTag(HttpFileAttributes attrs) {
+        requireNonNull(attrs, "attrs");
+        return entityTagFunction != null ? entityTagFunction.apply(pathOrUri(), attrs) : null;
+    }
+
+    @Nullable
+    @Override
+    public HttpHeaders readHeaders() throws IOException {
+        return readHeaders(readAttributes());
+    }
+
+    @Nullable
+    private HttpHeaders readHeaders(@Nullable HttpFileAttributes attrs) throws IOException {
+        if (attrs == null) {
+            return null;
+        }
+
+        // TODO(trustin): Cache the headers (sans the'date' header') if attrs did not change.
+        final long length = attrs.length();
+        final String etag = generateEntityTag(attrs);
+
+        final HttpHeaders headers = HttpHeaders.of(HttpHeaderNames.STATUS, HttpStatus.OK.codeAsText(),
+                                                   HttpHeaderNames.CONTENT_LENGTH, Long.toString(length));
+        if (contentType != null) {
+            headers.set(HttpHeaderNames.CONTENT_TYPE, contentType.toString());
+        }
+        if (dateEnabled) {
+            headers.setTimeMillis(HttpHeaderNames.DATE, System.currentTimeMillis());
+        }
+        if (lastModifiedEnabled) {
+            headers.setTimeMillis(HttpHeaderNames.LAST_MODIFIED, attrs.lastModifiedMillis());
+        }
+        if (etag != null) {
+            headers.set(HttpHeaderNames.ETAG, '\"' + etag + '\"');
+        }
+        if (!this.headers.isEmpty()) {
+            headers.setAll(this.headers);
+        }
+        return headers;
+    }
+
+    @Override
+    public final HttpResponse read(Executor fileReadExecutor, ByteBufAllocator alloc) {
+        try {
+            final HttpFileAttributes attrs = readAttributes();
+            final HttpHeaders headers = readHeaders(attrs);
+            if (headers == null) {
+                return null;
+            }
+
+            final long length = attrs.length();
+            if (length == 0) {
+                // No need to stream an empty file.
+                return HttpResponse.of(headers);
+            }
+
+            return doRead(headers, length, fileReadExecutor, alloc);
+        } catch (Exception e) {
+            return HttpResponse.ofFailure(e);
+        }
+    }
+
+    /**
+     * Returns a new {@link HttpResponse} which streams the content of the file which follows the specified
+     * {@link HttpHeaders}.
+     *
+     * @param headers the {@link HttpHeaders} of the response
+     * @param length the content length. The returned {@link HttpResponse} must stream only as many bytes as
+     *               this value.
+     * @param fileReadExecutor the {@link Executor} which should be used for performing a blocking file I/O
+     * @param alloc the {@link ByteBufAllocator} which should be used for allocating an input buffer
+     *
+     * @return the {@link HttpResponse}, or {@code null} if the file does not exist.
+     * @throws IOException if failed to open the file. Note that an I/O error which occurred during content
+     *                     streaming will be notified via the returned {@link HttpResponse}'s error
+     *                     notification mechanism.
+     */
+    @Nullable
+    protected abstract HttpResponse doRead(HttpHeaders headers, long length,
+                                           Executor fileReadExecutor,
+                                           ByteBufAllocator alloc) throws IOException;
+}

--- a/core/src/main/java/com/linecorp/armeria/server/file/AbstractHttpFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/AbstractHttpFile.java
@@ -241,11 +241,9 @@ public abstract class AbstractHttpFile implements HttpFile {
             final HttpHeaders reqHeaders = req.headers();
             final String etag = generateEntityTag(attrs);
             final String ifNoneMatch = reqHeaders.get(HttpHeaderNames.IF_NONE_MATCH);
-            if (etag != null) {
-                if (ifNoneMatch != null) {
-                    if ("*".equals(ifNoneMatch) || entityTagMatches(etag, ifNoneMatch)) {
-                        return newNotModified(attrs, etag);
-                    }
+            if (etag != null && ifNoneMatch != null) {
+                if ("*".equals(ifNoneMatch) || entityTagMatches(etag, ifNoneMatch)) {
+                    return newNotModified(attrs, etag);
                 }
             }
 
@@ -256,7 +254,7 @@ public abstract class AbstractHttpFile implements HttpFile {
                     if (ifModifiedSince != null) {
                         // HTTP-date does not have subsecond-precision; add 999ms to it.
                         final long ifModifiedSinceMillis = LongMath.saturatedAdd(ifModifiedSince, 999);
-                        if (attrs.lastModifiedMillis() < ifModifiedSinceMillis) {
+                        if (attrs.lastModifiedMillis() <= ifModifiedSinceMillis) {
                             return newNotModified(attrs, etag);
                         }
                     }

--- a/core/src/main/java/com/linecorp/armeria/server/file/AbstractHttpFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/AbstractHttpFile.java
@@ -234,6 +234,9 @@ public abstract class AbstractHttpFile implements HttpFile {
                 return HttpResponse.of(HttpStatus.NOT_FOUND);
             }
 
+            // See https://tools.ietf.org/html/rfc7232#section-6 for more information
+            // about how conditional requests are handled.
+
             // Handle 'if-none-match' header.
             final HttpHeaders reqHeaders = req.headers();
             final String etag = generateEntityTag(attrs);
@@ -246,7 +249,7 @@ public abstract class AbstractHttpFile implements HttpFile {
                 }
             }
 
-            // Handle 'if-modified-since' header, only if 'if-none-match' exists.
+            // Handle 'if-modified-since' header, only if 'if-none-match' does not exist.
             if (ifNoneMatch == null) {
                 try {
                     final Long ifModifiedSince = reqHeaders.getTimeMillis(HttpHeaderNames.IF_MODIFIED_SINCE);

--- a/core/src/main/java/com/linecorp/armeria/server/file/AbstractHttpFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/AbstractHttpFile.java
@@ -154,11 +154,11 @@ public abstract class AbstractHttpFile implements HttpFile {
         // TODO(trustin): Cache the headers (sans the 'date' header') if attrs did not change.
         final String etag = generateEntityTag(attrs);
         final HttpHeaders headers = HttpHeaders.of(HttpStatus.OK);
+        headers.set(HttpHeaderNames.CONTENT_LENGTH, Long.toString(attrs.length()));
         return addCommonHeaders(headers, attrs, etag);
     }
 
     private HttpHeaders addCommonHeaders(HttpHeaders headers, HttpFileAttributes attrs, @Nullable String etag) {
-        headers.set(HttpHeaderNames.CONTENT_LENGTH, Long.toString(attrs.length()));
         if (contentType != null) {
             headers.set(HttpHeaderNames.CONTENT_TYPE, contentType.toString());
         }

--- a/core/src/main/java/com/linecorp/armeria/server/file/AbstractHttpFileBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/AbstractHttpFileBuilder.java
@@ -17,6 +17,7 @@ package com.linecorp.armeria.server.file;
 
 import static java.util.Objects.requireNonNull;
 
+import java.time.Clock;
 import java.util.function.BiFunction;
 
 import javax.annotation.Nullable;
@@ -35,6 +36,7 @@ import io.netty.util.AsciiString;
  */
 public abstract class AbstractHttpFileBuilder<B extends AbstractHttpFileBuilder<B>> {
 
+    private Clock clock = Clock.systemUTC();
     private boolean dateEnabled = true;
     private boolean lastModifiedEnabled = true;
     private boolean contentTypeAutoDetectionEnabled = true;
@@ -49,6 +51,22 @@ public abstract class AbstractHttpFileBuilder<B extends AbstractHttpFileBuilder<
     @SuppressWarnings("unchecked")
     protected final B self() {
         return (B) this;
+    }
+
+    /**
+     * Returns the {@link Clock} that provides the current date and time.
+     */
+    protected final Clock clock() {
+        return clock;
+    }
+
+    /**
+     * Sets the {@link Clock} that provides the current date and time. By default, {@link Clock#systemUTC()}
+     * is used.
+     */
+    public final B clock(Clock clock) {
+        this.clock = requireNonNull(clock, "clock");
+        return self();
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/file/AbstractHttpFileBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/AbstractHttpFileBuilder.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.file;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.function.BiFunction;
+
+import javax.annotation.Nullable;
+
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpResponse;
+
+import io.netty.handler.codec.Headers;
+import io.netty.util.AsciiString;
+
+/**
+ * A skeletal builder class which helps easier implementation of an {@link HttpFile} builder.
+ *
+ * @param <B> the type of {@code this}
+ */
+public abstract class AbstractHttpFileBuilder<B extends AbstractHttpFileBuilder<B>> {
+
+    private boolean dateEnabled = true;
+    private boolean lastModifiedEnabled = true;
+    private boolean contentTypeAutoDetectionEnabled = true;
+    @Nullable
+    private BiFunction<String, HttpFileAttributes, String> entityTagFunction = DefaultEntityTagFunction.get();
+    @Nullable
+    private HttpHeaders headers;
+
+    /**
+     * Returns {@code this}.
+     */
+    @SuppressWarnings("unchecked")
+    protected final B self() {
+        return (B) this;
+    }
+
+    /**
+     * Returns whether to set the {@code "date"} header automatically.
+     */
+    protected final boolean isDateEnabled() {
+        return dateEnabled;
+    }
+
+    /**
+     * Sets whether to set the {@code "date"} header automatically. By default, the {@code "date"} header is
+     * set automatically.
+     */
+    public final B date(boolean dateEnabled) {
+        this.dateEnabled = dateEnabled;
+        return self();
+    }
+
+    /**
+     * Returns whether to set the {@code "last-modified"} header automatically.
+     */
+    protected final boolean isLastModifiedEnabled() {
+        return lastModifiedEnabled;
+    }
+
+    /**
+     * Sets whether to set the {@code "last-modified"} header automatically. By default,
+     * the {@code "last-modified"} is set automatically.
+     */
+    public final B lastModified(boolean lastModifiedEnabled) {
+        this.lastModifiedEnabled = lastModifiedEnabled;
+        return self();
+    }
+
+    /**
+     * Sets whether to set the {@code "content-type"} header automatically based on the extension of the file.
+     */
+    protected final boolean isContentTypeAutoDetectionEnabled() {
+        return contentTypeAutoDetectionEnabled;
+    }
+
+    /**
+     * Sets whether to set the {@code "content-type"} header automatically based on the extension of the file.
+     * By default, the {@code "content-type"} header is set automatically.
+     */
+    public final B autoDetectedContentType(boolean contentTypeAutoDetectionEnabled) {
+        this.contentTypeAutoDetectionEnabled = contentTypeAutoDetectionEnabled;
+        return self();
+    }
+
+    /**
+     * Returns the function which generates the entity tag that's used for setting the {@code "etag"} header
+     * automatically.
+     *
+     * @return the etag function, or {@code null} if the {@code "etag"} header is not set automatically.
+     */
+    @Nullable
+    protected final BiFunction<String, HttpFileAttributes, String> entityTagFunction() {
+        return entityTagFunction;
+    }
+
+    /**
+     * Sets whether to set the {@code "etag"} header automatically based on the path and attributes of the
+     * file. By default, the {@code "etag"} header is set automatically. Use {@link #entityTag(BiFunction)} to
+     * customize how an entity tag is generated.
+     */
+    public final B entityTag(boolean enabled) {
+        entityTagFunction = enabled ? DefaultEntityTagFunction.get() : null;
+        return self();
+    }
+
+    /**
+     * Sets the function which generates the entity tag that's used for setting the {@code "etag"} header
+     * automatically.
+     *
+     * @param entityTagFunction the entity tag function that generates the entity tag, or {@code null}
+     *                          to disable setting the {@code "etag"} header.
+     */
+    public final B entityTag(BiFunction<String, HttpFileAttributes, String> entityTagFunction) {
+        this.entityTagFunction = requireNonNull(entityTagFunction, "entityTagFunction");
+        return self();
+    }
+
+    /**
+     * Returns the immutable additional {@link HttpHeaders} which will be set when building an
+     * {@link HttpResponse}.
+     */
+    protected final HttpHeaders headers() {
+        return headers != null ? headers.asImmutable() : HttpHeaders.EMPTY_HEADERS;
+    }
+
+    private HttpHeaders getOrCreateHeaders() {
+        if (headers == null) {
+            headers = HttpHeaders.of();
+        }
+        return headers;
+    }
+
+    /**
+     * Adds the specified HTTP header.
+     */
+    public final B addHeader(CharSequence name, Object value) {
+        requireNonNull(name, "name");
+        requireNonNull(value, "value");
+        getOrCreateHeaders().addObject(HttpHeaderNames.of(name), value);
+        return self();
+    }
+
+    /**
+     * Adds the specified HTTP headers.
+     */
+    public final B addHeaders(Headers<AsciiString, String, ?> headers) {
+        requireNonNull(headers, "headers");
+        getOrCreateHeaders().add(headers);
+        return self();
+    }
+
+    /**
+     * Sets the specified HTTP header.
+     */
+    public final B setHeader(CharSequence name, Object value) {
+        requireNonNull(name, "name");
+        requireNonNull(value, "value");
+        getOrCreateHeaders().setObject(HttpHeaderNames.of(name), value);
+        return self();
+    }
+
+    /**
+     * Sets the specified HTTP headers.
+     */
+    public final B setHeaders(Headers<AsciiString, String, ?> headers) {
+        requireNonNull(headers, "headers");
+        getOrCreateHeaders().setAll(headers);
+        return self();
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/file/AggregatedHttpFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/AggregatedHttpFile.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.file;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+import javax.annotation.Nullable;
+
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpHeaders;
+
+import io.netty.buffer.ByteBufAllocator;
+
+/**
+ * An immutable variant of {@link HttpFile} which has its attributes and content readily available.
+ * Unlike {@link HttpFile}, an {@link AggregatedHttpFile} does not raise an {@link IOException} for
+ * <ul>
+ *   <li>{@link #readAttributes()}</li>
+ *   <li>{@link #readHeaders()}</li>
+ *   <li>{@link #read(Executor, ByteBufAllocator)}</li>
+ *   <li>{@link #aggregate(Executor)}</li>
+ *   <li>{@link #aggregateWithPooledObjects(Executor, ByteBufAllocator)}</li>
+ * </ul>
+ * It also has an additional method {@link #content()} which gives you an immediate access to the file's
+ * content.
+ */
+public interface AggregatedHttpFile extends HttpFile {
+
+    /**
+     * Returns the attributes of the file.
+     *
+     * @return the attributes, or {@code null} if the file does not exist.
+     */
+    @Nullable
+    @Override
+    HttpFileAttributes readAttributes();
+
+    /**
+     * Returns the attributes of this file as {@link HttpHeaders}, which could be useful for building
+     * a response for a {@code HEAD} request.
+     *
+     * @return the headers, or {@code null} if the file does not exist.
+     */
+    @Nullable
+    @Override
+    HttpHeaders readHeaders();
+
+    /**
+     * Returns the content of the file.
+     *
+     * @return the content, or {@code null} if the file does not exist.
+     */
+    @Nullable
+    HttpData content();
+
+    @Override
+    default CompletableFuture<AggregatedHttpFile> aggregate(Executor fileReadExecutor) {
+        return CompletableFuture.completedFuture(this);
+    }
+
+    @Override
+    default CompletableFuture<AggregatedHttpFile> aggregateWithPooledObjects(Executor fileReadExecutor,
+                                                                             ByteBufAllocator alloc) {
+        return CompletableFuture.completedFuture(this);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/file/CachingHttpFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/CachingHttpFile.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.file;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+import javax.annotation.Nullable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.spotify.futures.CompletableFutures;
+
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.util.Exceptions;
+import com.linecorp.armeria.server.HttpService;
+
+import io.netty.buffer.ByteBufAllocator;
+
+final class CachingHttpFile implements HttpFile {
+
+    private static final Logger logger = LoggerFactory.getLogger(CachingHttpFile.class);
+
+    private final HttpFile file;
+    private final int maxCachingLength;
+    @Nullable
+    private volatile AggregatedHttpFile cachedFile;
+
+    CachingHttpFile(HttpFile file, int maxCachingLength) {
+        this.file = file;
+        this.maxCachingLength = maxCachingLength;
+    }
+
+    @Nullable
+    @Override
+    public HttpFileAttributes readAttributes() throws IOException {
+        return file.readAttributes();
+    }
+
+    @Nullable
+    @Override
+    public HttpHeaders readHeaders() throws IOException {
+        return file.readHeaders();
+    }
+
+    @Nullable
+    @Override
+    public HttpResponse read(Executor fileReadExecutor, ByteBufAllocator alloc) {
+        try {
+            final HttpFile file = getFile();
+            return file != null ? file.read(fileReadExecutor, alloc) : null;
+        } catch (Exception e) {
+            return HttpResponse.ofFailure(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<AggregatedHttpFile> aggregate(Executor fileReadExecutor) {
+        try {
+            final HttpFile file = getFile();
+            return file != null ? file.aggregate(fileReadExecutor)
+                                : CompletableFuture.completedFuture(HttpFile.nonExistent());
+        } catch (Exception e) {
+            return CompletableFutures.exceptionallyCompletedFuture(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<AggregatedHttpFile> aggregateWithPooledObjects(Executor fileReadExecutor,
+                                                                            ByteBufAllocator alloc) {
+        try {
+            final HttpFile file = getFile();
+            return file != null ? file.aggregateWithPooledObjects(fileReadExecutor, alloc)
+                                : CompletableFuture.completedFuture(HttpFile.nonExistent());
+        } catch (Exception e) {
+            return CompletableFutures.exceptionallyCompletedFuture(e);
+        }
+    }
+
+    @Override
+    public HttpService asService() {
+        return (ctx, req) -> {
+            final HttpFile file = MoreObjects.firstNonNull(getFile(), HttpFile.nonExistent());
+            return file.asService().serve(ctx, req);
+        };
+    }
+
+    @Nullable
+    private HttpFile getFile() throws IOException {
+        final HttpFileAttributes uncachedAttrs = file.readAttributes();
+        if (uncachedAttrs == null) {
+            // Non-existent file. Invalidate the cache just in case it existed before.
+            cachedFile = null;
+            return null;
+        }
+
+        if (uncachedAttrs.length() > maxCachingLength) {
+            // Invalidate the cache just in case the file was small previously.
+            cachedFile = null;
+            return file;
+        }
+
+        final AggregatedHttpFile cachedFile = this.cachedFile;
+        if (cachedFile == null) {
+            // Cache miss. Add a new entry to the cache.
+            return cache();
+        }
+
+        final HttpFileAttributes cachedAttrs = cachedFile.readAttributes();
+        assert cachedAttrs != null;
+        if (cachedAttrs.equals(uncachedAttrs)) {
+            // Cache hit, and the cached file is up-to-date.
+            return cachedFile;
+        }
+
+        // Cache hit, but the cached file is out of date. Replace the old entry from the cache.
+        this.cachedFile = null;
+        return cache();
+    }
+
+    private HttpFile cache() {
+        // TODO(trustin): We assume here that the file being read is small enough that it will not block
+        //                an event loop for a long time. Revisit if the assumption turns out to be false.
+        AggregatedHttpFile cachedFile = null;
+        try {
+            this.cachedFile = cachedFile = file.aggregate(MoreExecutors.directExecutor()).get();
+        } catch (Exception e) {
+            this.cachedFile = null;
+            logger.warn("Failed to cache a file: {}", file, Exceptions.peel(e));
+        }
+
+        return MoreObjects.firstNonNull(cachedFile, file);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("file", file)
+                          .add("maxCachingLength", maxCachingLength)
+                          .add("cachedFile", cachedFile)
+                          .toString();
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/file/ClassPathHttpFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/ClassPathHttpFile.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.net.URLConnection;
+import java.time.Clock;
 import java.util.function.BiFunction;
 
 import javax.annotation.Nullable;
@@ -37,13 +38,13 @@ final class ClassPathHttpFile extends StreamingHttpFile<InputStream> {
 
     ClassPathHttpFile(URL url,
                       boolean contentTypeAutoDetectionEnabled,
+                      Clock clock,
                       boolean dateEnabled,
                       boolean lastModifiedEnabled,
                       @Nullable BiFunction<String, HttpFileAttributes, String> entityTagFunction,
                       HttpHeaders headers) {
         super(contentTypeAutoDetectionEnabled ? MimeTypeUtil.guessFromPath(url.toString()) : null,
-              dateEnabled, lastModifiedEnabled,
-              entityTagFunction, headers);
+              clock, dateEnabled, lastModifiedEnabled, entityTagFunction, headers);
         this.url = url;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/file/ClassPathHttpFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/ClassPathHttpFile.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.file;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.function.BiFunction;
+
+import javax.annotation.Nullable;
+
+import com.google.common.base.MoreObjects;
+
+import com.linecorp.armeria.common.HttpHeaders;
+
+import io.netty.buffer.ByteBuf;
+
+final class ClassPathHttpFile extends StreamingHttpFile<InputStream> {
+
+    private final URL url;
+    @Nullable
+    private HttpFileAttributes attrs;
+
+    ClassPathHttpFile(URL url,
+                      boolean contentTypeAutoDetectionEnabled,
+                      boolean dateEnabled,
+                      boolean lastModifiedEnabled,
+                      @Nullable BiFunction<String, HttpFileAttributes, String> entityTagFunction,
+                      HttpHeaders headers) {
+        super(contentTypeAutoDetectionEnabled ? MimeTypeUtil.guessFromPath(url.toString()) : null,
+              dateEnabled, lastModifiedEnabled,
+              entityTagFunction, headers);
+        this.url = url;
+    }
+
+    @Override
+    protected String pathOrUri() {
+        return url.toString();
+    }
+
+    @Override
+    public HttpFileAttributes readAttributes() throws IOException {
+        if (attrs == null) {
+            final URLConnection conn = url.openConnection();
+            final long length = conn.getContentLengthLong();
+            final long lastModifiedMillis = conn.getLastModified();
+            attrs = new HttpFileAttributes(length, lastModifiedMillis);
+        }
+        return attrs;
+    }
+
+    @Override
+    protected InputStream newStream() throws IOException {
+        return url.openStream();
+    }
+
+    @Override
+    protected int read(InputStream src, ByteBuf dst) throws IOException {
+        return dst.writeBytes(src, dst.writableBytes());
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).omitNullValues()
+                          .add("url", url)
+                          .add("contentType", contentType())
+                          .add("dateEnabled", isDateEnabled())
+                          .add("lastModifiedEnabled", isLastModifiedEnabled())
+                          .add("headers", headers())
+                          .toString();
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/file/ClassPathHttpVfs.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/ClassPathHttpVfs.java
@@ -18,15 +18,9 @@ package com.linecorp.armeria.server.file;
 
 import static java.util.Objects.requireNonNull;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URISyntaxException;
-import java.net.URL;
-
 import javax.annotation.Nullable;
 
-import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.MediaType;
 
 final class ClassPathHttpVfs extends AbstractHttpVfs {
 
@@ -52,56 +46,14 @@ final class ClassPathHttpVfs extends AbstractHttpVfs {
     }
 
     @Override
-    public Entry get(String path, @Nullable String contentEncoding) {
+    public HttpFile get(String path, @Nullable MediaType contentType, @Nullable String contentEncoding) {
         final String resourcePath = rootDir.isEmpty() ? path.substring(1) : rootDir + path;
-        final URL url = classLoader.getResource(resourcePath);
-        if (url == null || url.getPath().endsWith("/")) {
-            return Entry.NONE;
-        }
-
-        final Entry entry;
-        // Convert to a real file if possible.
-        if ("file".equals(url.getProtocol())) {
-            File f;
-            try {
-                f = new File(url.toURI());
-            } catch (URISyntaxException ignored) {
-                f = new File(url.getPath());
-            }
-
-            entry = new FileSystemHttpVfs.FileSystemEntry(f, path, contentEncoding);
-        } else {
-            entry = new ClassPathEntry(url, path, contentEncoding);
-        }
-
-        return entry;
+        final HttpFileBuilder builder = HttpFileBuilder.ofResource(classLoader, resourcePath);
+        return FileSystemHttpVfs.build(builder, contentType, contentEncoding);
     }
 
     @Override
     public String meterTag() {
         return "classpath:" + rootDir;
-    }
-
-    static final class ClassPathEntry extends AbstractEntry {
-
-        private final URL url;
-        private final long lastModifiedMillis = System.currentTimeMillis();
-
-        ClassPathEntry(URL url, String path, @Nullable String contentEncoding) {
-            super(path, contentEncoding);
-            this.url = url;
-        }
-
-        @Override
-        public long lastModifiedMillis() {
-            return lastModifiedMillis;
-        }
-
-        @Override
-        public HttpData readContent() throws IOException {
-            try (InputStream in = url.openStream()) {
-                return readContent(in);
-            }
-        }
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/file/ClassPathHttpVfs.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/ClassPathHttpVfs.java
@@ -13,10 +13,11 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package com.linecorp.armeria.server.file;
 
 import static java.util.Objects.requireNonNull;
+
+import java.time.Clock;
 
 import javax.annotation.Nullable;
 
@@ -46,10 +47,11 @@ final class ClassPathHttpVfs extends AbstractHttpVfs {
     }
 
     @Override
-    public HttpFile get(String path, @Nullable MediaType contentType, @Nullable String contentEncoding) {
+    public HttpFile get(String path, Clock clock,
+                        @Nullable MediaType contentType, @Nullable String contentEncoding) {
         final String resourcePath = rootDir.isEmpty() ? path.substring(1) : rootDir + path;
         final HttpFileBuilder builder = HttpFileBuilder.ofResource(classLoader, resourcePath);
-        return FileSystemHttpVfs.build(builder, contentType, contentEncoding);
+        return FileSystemHttpVfs.build(builder, clock, contentType, contentEncoding);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/file/ClassPathHttpVfs.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/ClassPathHttpVfs.java
@@ -21,8 +21,6 @@ import java.time.Clock;
 
 import javax.annotation.Nullable;
 
-import com.linecorp.armeria.common.MediaType;
-
 final class ClassPathHttpVfs extends AbstractHttpVfs {
 
     private final ClassLoader classLoader;
@@ -48,10 +46,10 @@ final class ClassPathHttpVfs extends AbstractHttpVfs {
 
     @Override
     public HttpFile get(String path, Clock clock,
-                        @Nullable MediaType contentType, @Nullable String contentEncoding) {
+                        @Nullable String contentEncoding) {
         final String resourcePath = rootDir.isEmpty() ? path.substring(1) : rootDir + path;
         final HttpFileBuilder builder = HttpFileBuilder.ofResource(classLoader, resourcePath);
-        return FileSystemHttpVfs.build(builder, clock, contentType, contentEncoding);
+        return FileSystemHttpVfs.build(builder, clock, path, contentEncoding);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/file/DefaultEntityTagFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/DefaultEntityTagFunction.java
@@ -15,6 +15,8 @@
  */
 package com.linecorp.armeria.server.file;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.function.BiFunction;
 
 import com.google.common.io.BaseEncoding;
@@ -33,6 +35,9 @@ final class DefaultEntityTagFunction implements BiFunction<String, HttpFileAttri
 
     @Override
     public String apply(String pathOrUri, HttpFileAttributes attrs) {
+        requireNonNull(pathOrUri, "pathOrUri");
+        requireNonNull(attrs, "attrs");
+
         final byte[] data = new byte[4 + 8 + 8];
         final long hashCode = pathOrUri.hashCode() & 0xFFFFFFFFL;
         final long length = attrs.length();

--- a/core/src/main/java/com/linecorp/armeria/server/file/DefaultEntityTagFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/DefaultEntityTagFunction.java
@@ -1,0 +1,67 @@
+package com.linecorp.armeria.server.file;
+
+import java.util.function.BiFunction;
+
+import com.google.common.io.BaseEncoding;
+
+final class DefaultEntityTagFunction implements BiFunction<String, HttpFileAttributes, String> {
+
+    private static final BaseEncoding etagEncoding = BaseEncoding.base64().omitPadding();
+
+    private static final DefaultEntityTagFunction INSTANCE = new DefaultEntityTagFunction();
+
+    static DefaultEntityTagFunction get() {
+        return INSTANCE;
+    }
+
+    private DefaultEntityTagFunction() {}
+
+    @Override
+    public String apply(String pathOrUri, HttpFileAttributes attrs) {
+        final byte[] data = new byte[4 + 8 + 8];
+        final long hashCode = pathOrUri.hashCode() & 0xFFFFFFFFL;
+        final long length = attrs.length();
+        final long lastModifiedMillis = attrs.lastModifiedMillis();
+
+        int offset = 0;
+        offset = appendInt(data, offset, hashCode);
+        offset = appendLong(data, offset, length);
+        offset = appendLong(data, offset, lastModifiedMillis);
+
+        return offset != 0 ? etagEncoding.encode(data, 0, offset) : "-";
+    }
+
+    /**
+     * Appends a 64-bit integer without its leading zero bytes.
+     */
+    private static int appendLong(byte[] data, int offset, long value) {
+        offset = appendByte(data, offset, value >>> 56);
+        offset = appendByte(data, offset, value >>> 48);
+        offset = appendByte(data, offset, value >>> 40);
+        offset = appendByte(data, offset, value >>> 32);
+        offset = appendInt(data, offset, value);
+        return offset;
+    }
+
+    /**
+     * Appends a 32-bit integer without its leading zero bytes.
+     */
+    private static int appendInt(byte[] data, int offset, long value) {
+        offset = appendByte(data, offset, value >>> 24);
+        offset = appendByte(data, offset, value >>> 16);
+        offset = appendByte(data, offset, value >>> 8);
+        offset = appendByte(data, offset, value);
+        return offset;
+    }
+
+    /**
+     * Appends a byte if it's not a leading zero.
+     */
+    private static int appendByte(byte[] dst, int offset, long value) {
+        if (value == 0) {
+            return offset;
+        }
+        dst[offset] = (byte) value;
+        return offset + 1;
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/file/DefaultEntityTagFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/DefaultEntityTagFunction.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package com.linecorp.armeria.server.file;
 
 import java.util.function.BiFunction;

--- a/core/src/main/java/com/linecorp/armeria/server/file/FileSystemHttpFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/FileSystemHttpFile.java
@@ -23,6 +23,7 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.time.Clock;
 import java.util.function.BiFunction;
 
 import javax.annotation.Nullable;
@@ -39,13 +40,13 @@ final class FileSystemHttpFile extends StreamingHttpFile<ByteChannel> {
 
     FileSystemHttpFile(Path path,
                        boolean contentTypeAutoDetectionEnabled,
+                       Clock clock,
                        boolean dateEnabled,
                        boolean lastModifiedEnabled,
                        @Nullable BiFunction<String, HttpFileAttributes, String> entityTagFunction,
                        HttpHeaders headers) {
         super(contentTypeAutoDetectionEnabled ? MimeTypeUtil.guessFromPath(path.toString()) : null,
-              dateEnabled, lastModifiedEnabled,
-              entityTagFunction, headers);
+              clock, dateEnabled, lastModifiedEnabled, entityTagFunction, headers);
         this.path = path;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/file/FileSystemHttpFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/FileSystemHttpFile.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.file;
+
+import java.io.IOException;
+import java.nio.channels.ByteChannel;
+import java.nio.channels.ScatteringByteChannel;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.function.BiFunction;
+
+import javax.annotation.Nullable;
+
+import com.google.common.base.MoreObjects;
+
+import com.linecorp.armeria.common.HttpHeaders;
+
+import io.netty.buffer.ByteBuf;
+
+final class FileSystemHttpFile extends StreamingHttpFile<ByteChannel> {
+
+    private final Path path;
+
+    FileSystemHttpFile(Path path,
+                       boolean contentTypeAutoDetectionEnabled,
+                       boolean dateEnabled,
+                       boolean lastModifiedEnabled,
+                       @Nullable BiFunction<String, HttpFileAttributes, String> entityTagFunction,
+                       HttpHeaders headers) {
+        super(contentTypeAutoDetectionEnabled ? MimeTypeUtil.guessFromPath(path.toString()) : null,
+              dateEnabled, lastModifiedEnabled,
+              entityTagFunction, headers);
+        this.path = path;
+    }
+
+    @Override
+    protected String pathOrUri() {
+        return path.toString();
+    }
+
+    @Override
+    public HttpFileAttributes readAttributes() throws IOException {
+        if (!Files.exists(path)) {
+            return null;
+        }
+
+        try {
+            final BasicFileAttributes attrs = Files.readAttributes(path, BasicFileAttributes.class);
+            if (attrs.isRegularFile()) {
+                return new HttpFileAttributes(attrs.size(), attrs.lastModifiedTime().toMillis());
+            }
+        } catch (NoSuchFileException e) {
+            // Non-existent file.
+        }
+
+        return null;
+    }
+
+    @Override
+    protected ByteChannel newStream() throws IOException {
+        try {
+            return Files.newByteChannel(path, StandardOpenOption.READ);
+        } catch (NoSuchFileException e) {
+            return null;
+        }
+    }
+
+    @Override
+    protected int read(ByteChannel src, ByteBuf dst) throws IOException {
+        if (src instanceof ScatteringByteChannel) {
+            return dst.writeBytes((ScatteringByteChannel) src, dst.writableBytes());
+        }
+
+        final int readBytes = src.read(dst.nioBuffer(dst.writerIndex(), dst.writableBytes()));
+        if (readBytes > 0) {
+            dst.writerIndex(dst.writerIndex() + readBytes);
+        }
+        return readBytes;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).omitNullValues()
+                          .add("path", path)
+                          .add("contentType", contentType())
+                          .add("dateEnabled", isDateEnabled())
+                          .add("lastModifiedEnabled", isLastModifiedEnabled())
+                          .add("headers", headers())
+                          .toString();
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/file/FileSystemHttpVfs.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/FileSystemHttpVfs.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Clock;
 
 import javax.annotation.Nullable;
 
@@ -42,20 +43,23 @@ final class FileSystemHttpVfs extends AbstractHttpVfs {
     }
 
     @Override
-    public HttpFile get(String path, @Nullable MediaType contentType, @Nullable String contentEncoding) {
+    public HttpFile get(String path, Clock clock,
+                        @Nullable MediaType contentType, @Nullable String contentEncoding) {
         // Replace '/' with the platform dependent file separator if necessary.
         if (FILE_SEPARATOR_IS_NOT_SLASH) {
             path = path.replace(File.separatorChar, '/');
         }
 
         final HttpFileBuilder builder = HttpFileBuilder.of(Paths.get(rootDir + path));
-        return build(builder, contentType, contentEncoding);
+        return build(builder, clock, contentType, contentEncoding);
     }
 
     static HttpFile build(HttpFileBuilder builder,
+                          Clock clock,
                           @Nullable MediaType contentType,
                           @Nullable String contentEncoding) {
         builder.autoDetectedContentType(false);
+        builder.clock(clock);
         if (contentType != null) {
             builder.setHeader(HttpHeaderNames.CONTENT_TYPE, contentType);
         }

--- a/core/src/main/java/com/linecorp/armeria/server/file/FileSystemHttpVfs.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/FileSystemHttpVfs.java
@@ -19,15 +19,14 @@ package com.linecorp.armeria.server.file;
 import static java.util.Objects.requireNonNull;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import javax.annotation.Nullable;
 
-import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.MediaType;
 
 final class FileSystemHttpVfs extends AbstractHttpVfs {
 
@@ -43,49 +42,31 @@ final class FileSystemHttpVfs extends AbstractHttpVfs {
     }
 
     @Override
-    public Entry get(String path, @Nullable String contentEncoding) {
+    public HttpFile get(String path, @Nullable MediaType contentType, @Nullable String contentEncoding) {
         // Replace '/' with the platform dependent file separator if necessary.
         if (FILE_SEPARATOR_IS_NOT_SLASH) {
             path = path.replace(File.separatorChar, '/');
         }
 
-        final File f = new File(rootDir + path);
-        if (!f.isFile() || !f.canRead()) {
-            return Entry.NONE;
-        }
+        final HttpFileBuilder builder = HttpFileBuilder.of(Paths.get(rootDir + path));
+        return build(builder, contentType, contentEncoding);
+    }
 
-        return new FileSystemEntry(f, path, contentEncoding);
+    static HttpFile build(HttpFileBuilder builder,
+                          @Nullable MediaType contentType,
+                          @Nullable String contentEncoding) {
+        builder.autoDetectedContentType(false);
+        if (contentType != null) {
+            builder.setHeader(HttpHeaderNames.CONTENT_TYPE, contentType);
+        }
+        if (contentEncoding != null) {
+            builder.setHeader(HttpHeaderNames.CONTENT_ENCODING, contentEncoding);
+        }
+        return builder.build();
     }
 
     @Override
     public String meterTag() {
         return "file:" + rootDir;
-    }
-
-    static final class FileSystemEntry extends AbstractEntry {
-
-        private final File file;
-
-        FileSystemEntry(File file, String path, @Nullable String contentEncoding) {
-            super(path, contentEncoding);
-            this.file = file;
-        }
-
-        @Override
-        public long lastModifiedMillis() {
-            return file.lastModified();
-        }
-
-        @Override
-        public HttpData readContent() throws IOException {
-            final long fileLength = file.length();
-            if (fileLength > Integer.MAX_VALUE) {
-                throw new IOException("file too large: " + file + " (" + fileLength + " bytes)");
-            }
-
-            try (InputStream in = new FileInputStream(file)) {
-                return readContent(in, (int) fileLength);
-            }
-        }
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/file/FileSystemHttpVfs.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/FileSystemHttpVfs.java
@@ -44,28 +44,32 @@ final class FileSystemHttpVfs extends AbstractHttpVfs {
 
     @Override
     public HttpFile get(String path, Clock clock,
-                        @Nullable MediaType contentType, @Nullable String contentEncoding) {
+                        @Nullable String contentEncoding) {
         // Replace '/' with the platform dependent file separator if necessary.
         if (FILE_SEPARATOR_IS_NOT_SLASH) {
             path = path.replace(File.separatorChar, '/');
         }
 
         final HttpFileBuilder builder = HttpFileBuilder.of(Paths.get(rootDir + path));
-        return build(builder, clock, contentType, contentEncoding);
+        return build(builder, clock, path, contentEncoding);
     }
 
     static HttpFile build(HttpFileBuilder builder,
                           Clock clock,
-                          @Nullable MediaType contentType,
+                          String pathOrUri,
                           @Nullable String contentEncoding) {
+
         builder.autoDetectedContentType(false);
         builder.clock(clock);
+
+        final MediaType contentType = MimeTypeUtil.guessFromPath(pathOrUri, contentEncoding);
         if (contentType != null) {
             builder.setHeader(HttpHeaderNames.CONTENT_TYPE, contentType);
         }
         if (contentEncoding != null) {
             builder.setHeader(HttpHeaderNames.CONTENT_ENCODING, contentEncoding);
         }
+
         return builder.build();
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/file/HttpDataFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/HttpDataFile.java
@@ -16,6 +16,7 @@
 package com.linecorp.armeria.server.file;
 
 import java.io.IOException;
+import java.time.Clock;
 import java.util.Date;
 import java.util.concurrent.Executor;
 import java.util.function.BiFunction;
@@ -40,23 +41,25 @@ final class HttpDataFile extends AbstractHttpFile implements AggregatedHttpFile 
     private final HttpFileAttributes attrs;
 
     HttpDataFile(HttpData content,
+                 Clock clock,
                  long lastModifiedMillis,
                  boolean dateEnabled,
                  boolean lastModifiedEnabled,
                  @Nullable BiFunction<String, HttpFileAttributes, String> entityTagFunction,
                  HttpHeaders headers) {
-        this(content, null, new HttpFileAttributes(content.length(), lastModifiedMillis),
+        this(content, null, clock, new HttpFileAttributes(content.length(), lastModifiedMillis),
              dateEnabled, lastModifiedEnabled, entityTagFunction, headers);
     }
 
     private HttpDataFile(HttpData content,
                          @Nullable MediaType contentType,
+                         Clock clock,
                          HttpFileAttributes attrs,
                          boolean dateEnabled,
                          boolean lastModifiedEnabled,
                          @Nullable BiFunction<String, HttpFileAttributes, String> entityTagFunction,
                          HttpHeaders headers) {
-        super(contentType, dateEnabled, lastModifiedEnabled, entityTagFunction, headers);
+        super(contentType, clock, dateEnabled, lastModifiedEnabled, entityTagFunction, headers);
         this.content = content;
         this.attrs = attrs;
     }

--- a/core/src/main/java/com/linecorp/armeria/server/file/HttpDataFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/HttpDataFile.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.file;
+
+import java.io.IOException;
+import java.util.Date;
+import java.util.concurrent.Executor;
+import java.util.function.BiFunction;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import com.google.common.base.MoreObjects;
+
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.MediaType;
+
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.ByteBufHolder;
+import io.netty.handler.codec.DateFormatter;
+
+final class HttpDataFile extends AbstractHttpFile implements AggregatedHttpFile {
+
+    private final HttpData content;
+    private final HttpFileAttributes attrs;
+
+    HttpDataFile(HttpData content,
+                 long lastModifiedMillis,
+                 boolean dateEnabled,
+                 boolean lastModifiedEnabled,
+                 @Nullable BiFunction<String, HttpFileAttributes, String> entityTagFunction,
+                 HttpHeaders headers) {
+        this(content, null, new HttpFileAttributes(content.length(), lastModifiedMillis),
+             dateEnabled, lastModifiedEnabled, entityTagFunction, headers);
+    }
+
+    private HttpDataFile(HttpData content,
+                         @Nullable MediaType contentType,
+                         HttpFileAttributes attrs,
+                         boolean dateEnabled,
+                         boolean lastModifiedEnabled,
+                         @Nullable BiFunction<String, HttpFileAttributes, String> entityTagFunction,
+                         HttpHeaders headers) {
+        super(contentType, dateEnabled, lastModifiedEnabled, entityTagFunction, headers);
+        this.content = content;
+        this.attrs = attrs;
+    }
+
+    @Override
+    protected String pathOrUri() {
+        return "";
+    }
+
+    @Override
+    public HttpFileAttributes readAttributes() {
+        return attrs;
+    }
+
+    @Override
+    public HttpHeaders readHeaders() {
+        try {
+            return super.readHeaders();
+        } catch (IOException e) {
+            throw new Error(e); // Never reaches here.
+        }
+    }
+
+    @Override
+    protected HttpResponse doRead(HttpHeaders headers, long length,
+                                  Executor fileReadExecutor, ByteBufAllocator alloc) {
+        if (content instanceof ByteBufHolder) {
+            final ByteBufHolder holder = (ByteBufHolder) content;
+            return HttpResponse.of(headers, (HttpData) holder.retainedDuplicate());
+        } else {
+            return HttpResponse.of(headers, content);
+        }
+    }
+
+    @Nonnull
+    @Override
+    public HttpData content() {
+        return content;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).omitNullValues()
+                          .add("content", content())
+                          .add("contentType", contentType())
+                          .add("lastModified", DateFormatter.format(new Date(attrs.lastModifiedMillis())))
+                          .add("dateEnabled", isDateEnabled())
+                          .add("lastModifiedEnabled", isLastModifiedEnabled())
+                          .add("headers", headers())
+                          .toString();
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/file/HttpFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/HttpFile.java
@@ -101,7 +101,7 @@ public interface HttpFile {
 
     /**
      * Creates a new {@link HttpFile} which caches the content and attributes of the specified {@link HttpFile}.
-     * If the cache is automatically invalidated when the {@link HttpFile} is updated.
+     * The cache is automatically invalidated when the {@link HttpFile} is updated.
      *
      * @param file the {@link HttpFile} to cache
      * @param maxCachingLength the maximum allowed length of the {@link HttpFile} to cache. if the length of

--- a/core/src/main/java/com/linecorp/armeria/server/file/HttpFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/HttpFile.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.file;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+import javax.annotation.Nullable;
+
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.server.HttpService;
+
+import io.netty.buffer.ByteBufAllocator;
+
+/**
+ * A file-like HTTP resource which yields an {@link HttpResponse}.
+ * <pre>{@code
+ * HttpFile faviconFile = HttpFile.of(new File("/var/www/favicon.ico"));
+ * ServerBuilder builder = new ServerBuilder();
+ * builder.service("/favicon.ico", faviconFile.asService());
+ * Server server = builder.build();
+ * }</pre>
+ *
+ * @see HttpFileBuilder
+ */
+public interface HttpFile {
+
+    /**
+     * Creates a new {@link HttpFile} which streams the specified {@link File}.
+     */
+    static HttpFile of(File file) {
+        return HttpFileBuilder.of(file).build();
+    }
+
+    /**
+     * Creates a new {@link HttpFile} which streams the file at the specified {@link Path}.
+     */
+    static HttpFile of(Path path) {
+        return HttpFileBuilder.of(path).build();
+    }
+
+    /**
+     * Creates a new {@link AggregatedHttpFile} which streams the specified {@link HttpData}. This method is
+     * a shortcut of {@code HttpFile.of(data, System.currentTimeMillis()}.
+     */
+    static AggregatedHttpFile of(HttpData data) {
+        return (AggregatedHttpFile) HttpFileBuilder.of(data).build();
+    }
+
+    /**
+     * Creates a new {@link AggregatedHttpFile} which streams the specified {@link HttpData} with the specified
+     * {@code lastModifiedMillis}.
+     *
+     * @param data the data that provides the content of an HTTP response
+     * @param lastModifiedMillis when the {@code data} has been last modified, represented as the number of
+     *                           millisecond since the epoch
+     */
+    static AggregatedHttpFile of(HttpData data, long lastModifiedMillis) {
+        return (AggregatedHttpFile) HttpFileBuilder.of(data, lastModifiedMillis).build();
+    }
+
+    /**
+     * Creates a new {@link HttpFile} which streams the resource at the specified {@code path}. This method is
+     * a shortcut of {@code HttpFile.of(HttpFile.class.getClassLoader(), path)}.
+     */
+    static HttpFile ofResource(String path) {
+        return HttpFileBuilder.ofResource(path).build();
+    }
+
+    /**
+     * Creates a new {@link HttpFile} which streams the resource at the specified {@code path}, loaded by
+     * the specified {@link ClassLoader}.
+     *
+     * @param classLoader the {@link ClassLoader} which will load the resource at the {@code path}
+     * @param path the path to the resource
+     */
+    static HttpFile ofResource(ClassLoader classLoader, String path) {
+        return HttpFileBuilder.ofResource(classLoader, path).build();
+    }
+
+    /**
+     * Returns an {@link AggregatedHttpFile} which represents a non-existent file.
+     */
+    static AggregatedHttpFile nonExistent() {
+        return NonExistentHttpFile.INSTANCE;
+    }
+
+    /**
+     * Retrieves the attributes of this file.
+     *
+     * @return the attributes of this file, or {@code null} if the file does not exist
+     * @throws IOException if failed to retrieve the attributes of this file.
+     */
+    @Nullable
+    HttpFileAttributes readAttributes() throws IOException;
+
+    /**
+     * Reads the attributes of this file as {@link HttpHeaders}, which could be useful for building a response
+     * for a {@code HEAD} request.
+     *
+     * @return the headers, or {@code null} if the file does not exist.
+     * @throws IOException if failed to retrieve the attributes of this file.
+     */
+    @Nullable
+    HttpHeaders readHeaders() throws IOException;
+
+    /**
+     * Starts to stream this file into the returned {@link HttpResponse}.
+     *
+     * @param fileReadExecutor the {@link Executor} which will perform the read operations against the file
+     * @param alloc the {@link ByteBufAllocator} which will allocate the buffers that hold the content of
+     *              the file
+     * @return the response, or {@code null} if the file does not exist.
+     */
+    @Nullable
+    HttpResponse read(Executor fileReadExecutor, ByteBufAllocator alloc);
+
+    /**
+     * Converts this file into an {@link AggregatedHttpFile}.
+     *
+     * @param fileReadExecutor the {@link Executor} which will perform the read operations against the file
+     *
+     * @return a {@link CompletableFuture} which will complete when the aggregation process is finished, or
+     *         a {@link CompletableFuture} successfully completed with {@code this}, if this file is already
+     *         an {@link AggregatedHttpFile}.
+     */
+    CompletableFuture<AggregatedHttpFile> aggregate(Executor fileReadExecutor);
+
+    /**
+     * Converts this file into an {@link AggregatedHttpFile}. {@link AggregatedHttpFile#content()} will
+     * return a pooled object, and the caller must ensure to release it. If you don't know what this means,
+     * use {@link #aggregate(Executor)}.
+     *
+     * @param fileReadExecutor the {@link Executor} which will perform the read operations against the file
+     * @param alloc the {@link ByteBufAllocator} which will allocate the content buffer
+     *
+     * @return a {@link CompletableFuture} which will complete when the aggregation process is finished, or
+     *         a {@link CompletableFuture} successfully completed with {@code this}, if this file is already
+     *         an {@link AggregatedHttpFile}.
+     */
+    CompletableFuture<AggregatedHttpFile> aggregateWithPooledObjects(Executor fileReadExecutor,
+                                                                     ByteBufAllocator alloc);
+
+    /**
+     * Returns an {@link HttpService} which serves the file for {@code HEAD} and {@code GET} requests.
+     */
+    default HttpService asService() {
+        return (ctx, req) -> {
+            // TODO(trustin): Move the logic of HttpFileService.doGet() here.
+            switch (ctx.method()) {
+                case HEAD:
+                    final HttpHeaders headers = readHeaders();
+                    if (headers != null) {
+                        return HttpResponse.of(headers);
+                    }
+                    break;
+                case GET:
+                    final HttpResponse res = read(ctx.blockingTaskExecutor(), ctx.alloc());
+                    if (res != null) {
+                        return res;
+                    }
+                    break;
+                default:
+                    return HttpResponse.of(HttpStatus.METHOD_NOT_ALLOWED);
+            }
+
+            return HttpResponse.of(HttpStatus.NOT_FOUND);
+        };
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/file/HttpFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/HttpFile.java
@@ -15,6 +15,9 @@
  */
 package com.linecorp.armeria.server.file;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -94,6 +97,24 @@ public interface HttpFile {
      */
     static HttpFile ofResource(ClassLoader classLoader, String path) {
         return HttpFileBuilder.ofResource(classLoader, path).build();
+    }
+
+    /**
+     * Creates a new {@link HttpFile} which caches the content and attributes of the specified {@link HttpFile}.
+     * If the cache is automatically invalidated when the {@link HttpFile} is updated.
+     *
+     * @param file the {@link HttpFile} to cache
+     * @param maxCachingLength the maximum allowed length of the {@link HttpFile} to cache. if the length of
+     *                         the {@link HttpFile} exceeds this value, no caching will be performed.
+     */
+    static HttpFile ofCached(HttpFile file, int maxCachingLength) {
+        requireNonNull(file, "file");
+        checkArgument(maxCachingLength >= 0, "maxCachingLength: %s (expected: >= 0)", maxCachingLength);
+        if (maxCachingLength == 0) {
+            return file;
+        } else {
+            return new CachingHttpFile(file, maxCachingLength);
+        }
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/file/HttpFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/HttpFile.java
@@ -26,7 +26,6 @@ import javax.annotation.Nullable;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.server.HttpService;
 
 import io.netty.buffer.ByteBufAllocator;
@@ -163,27 +162,5 @@ public interface HttpFile {
     /**
      * Returns an {@link HttpService} which serves the file for {@code HEAD} and {@code GET} requests.
      */
-    default HttpService asService() {
-        return (ctx, req) -> {
-            // TODO(trustin): Move the logic of HttpFileService.doGet() here.
-            switch (ctx.method()) {
-                case HEAD:
-                    final HttpHeaders headers = readHeaders();
-                    if (headers != null) {
-                        return HttpResponse.of(headers);
-                    }
-                    break;
-                case GET:
-                    final HttpResponse res = read(ctx.blockingTaskExecutor(), ctx.alloc());
-                    if (res != null) {
-                        return res;
-                    }
-                    break;
-                default:
-                    return HttpResponse.of(HttpStatus.METHOD_NOT_ALLOWED);
-            }
-
-            return HttpResponse.of(HttpStatus.NOT_FOUND);
-        };
-    }
+    HttpService asService();
 }

--- a/core/src/main/java/com/linecorp/armeria/server/file/HttpFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/HttpFile.java
@@ -106,7 +106,7 @@ public interface HttpFile {
     /**
      * Retrieves the attributes of this file.
      *
-     * @return the attributes of this file, or {@code null} if the file does not exist
+     * @return the attributes of this file, or {@code null} if the file does not exist.
      * @throws IOException if failed to retrieve the attributes of this file.
      */
     @Nullable

--- a/core/src/main/java/com/linecorp/armeria/server/file/HttpFileAttributes.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/HttpFileAttributes.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.file;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.util.Date;
+
+import com.google.common.base.MoreObjects;
+
+import io.netty.handler.codec.DateFormatter;
+
+/**
+ * The attributes of an {@link HttpFile}.
+ *
+ * @see HttpFile#readAttributes()
+ */
+public final class HttpFileAttributes {
+
+    private final long length;
+    private final long lastModifiedMillis;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param length the length in bytes
+     * @param lastModifiedMillis the last modified time represented as the number of milliseconds
+     *                           since the epoch
+     */
+    public HttpFileAttributes(long length, long lastModifiedMillis) {
+        checkArgument(length >= 0, "length: %s (expected: >= 0)", length);
+        this.length = length;
+        this.lastModifiedMillis = lastModifiedMillis;
+    }
+
+    /**
+     * Returns the length in bytes.
+     */
+    public long length() {
+        return length;
+    }
+
+    /**
+     * Returns the last modified time represented as the number of milliseconds since the epoch.
+     */
+    public long lastModifiedMillis() {
+        return lastModifiedMillis;
+    }
+
+    @Override
+    public int hashCode() {
+        return (int) (length * 31 + lastModifiedMillis);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null || obj.getClass() != HttpFileAttributes.class) {
+            return false;
+        }
+
+        final HttpFileAttributes that = (HttpFileAttributes) obj;
+        return length == that.length && lastModifiedMillis == that.lastModifiedMillis;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("length", length)
+                          .add("lastModified", DateFormatter.format(new Date(lastModifiedMillis)))
+                          .toString();
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/file/HttpFileBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/HttpFileBuilder.java
@@ -151,7 +151,7 @@ public abstract class HttpFileBuilder extends AbstractHttpFileBuilder<HttpFileBu
 
         @Override
         public HttpFile build() {
-            return new FileSystemHttpFile(path, isContentTypeAutoDetectionEnabled(), isDateEnabled(),
+            return new FileSystemHttpFile(path, isContentTypeAutoDetectionEnabled(), clock(), isDateEnabled(),
                                           isLastModifiedEnabled(), entityTagFunction(), headers());
         }
     }
@@ -166,7 +166,7 @@ public abstract class HttpFileBuilder extends AbstractHttpFileBuilder<HttpFileBu
 
         @Override
         public HttpFile build() {
-            return new ClassPathHttpFile(url, isContentTypeAutoDetectionEnabled(), isDateEnabled(),
+            return new ClassPathHttpFile(url, isContentTypeAutoDetectionEnabled(), clock(), isDateEnabled(),
                                          isLastModifiedEnabled(), entityTagFunction(), headers());
         }
     }
@@ -190,7 +190,7 @@ public abstract class HttpFileBuilder extends AbstractHttpFileBuilder<HttpFileBu
 
         @Override
         public AggregatedHttpFile build() {
-            return new HttpDataFile(content, lastModifiedMillis,
+            return new HttpDataFile(content, clock(), lastModifiedMillis,
                                     isDateEnabled(), isLastModifiedEnabled(),
                                     entityTagFunction(), headers());
         }

--- a/core/src/main/java/com/linecorp/armeria/server/file/HttpFileBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/HttpFileBuilder.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.file;
+
+import static java.util.Objects.requireNonNull;
+
+import java.io.File;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Path;
+
+import com.linecorp.armeria.common.HttpData;
+
+/**
+ * Builds an {@link HttpFile} from a file, a classpath resource or an {@link HttpData}.
+ * <pre>{@code
+ * // Build from a file.
+ * HttpFile f = HttpFileBuilder.of(new File("/var/www/index.html"))
+ *                             .lastModified(false)
+ *                             .setHeader(HttpHeaderNames.CONTENT_LANGUAGE, "en-US")
+ *                             .build();
+ *
+ * // Build from a classpath resource.
+ * HttpFile f = HttpFileBuilder.ofResource(MyClass.class.getClassLoader(), "/foo.txt.gz")
+ *                             .setHeader(HttpHeaderNames.CONTENT_ENCODING, "gzip")
+ *                             .build();
+ *
+ * // Build from an HttpData. Can be downcast into AggregatedHttpFile.
+ * AggregatedHttpFile f = (AggregatedHttpFile)
+ *         HttpFileBuilder.of(HttpData.ofUtf8("content"), System.currentTimeMillis())
+ *                        .entityTag((pathOrUri, attrs) -> "myCustomEntityTag")
+ *                        .build();
+ * }</pre>
+ */
+public abstract class HttpFileBuilder extends AbstractHttpFileBuilder<HttpFileBuilder> {
+
+    /**
+     * Returns a new {@link HttpFileBuilder} that builds an {@link HttpFile} from the specified {@link File}.
+     */
+    public static HttpFileBuilder of(File file) {
+        return of(requireNonNull(file, "file").toPath());
+    }
+
+    /**
+     * Returns a new {@link HttpFileBuilder} that builds an {@link HttpFile} from the file at the specified
+     * {@link Path}.
+     */
+    public static HttpFileBuilder of(Path path) {
+        return new FileSystemHttpFileBuilder(path);
+    }
+
+    /**
+     * Returns a new {@link HttpFileBuilder} that builds an {@link AggregatedHttpFile} from the specified
+     * {@link HttpData}. The last modified date of the file is set to 'now'. Note that the {@link #build()}
+     * method of the returned builder will always return an {@link AggregatedHttpFile}, which guarantees
+     * a safe downcast:
+     * <pre>{@code
+     * AggregatedHttpFile f = (AggregatedHttpFile) HttpFileBuilder.of(HttpData.ofUtf8("foo")).build();
+     * }</pre>
+     */
+    public static HttpFileBuilder of(HttpData data) {
+        return of(data, System.currentTimeMillis());
+    }
+
+    /**
+     * Returns a new {@link HttpFileBuilder} that builds an {@link AggregatedHttpFile} from the specified
+     * {@link HttpData} and {@code lastModifiedMillis}. Note that the {@link #build()} method of the returned
+     * builder will always return an {@link AggregatedHttpFile}, which guarantees a safe downcast:
+     * <pre>{@code
+     * AggregatedHttpFile f = (AggregatedHttpFile) HttpFileBuilder.of(HttpData.ofUtf8("foo"), 1546923055020)
+     *                                                             .build();
+     * }</pre>
+     *
+     * @param data the content of the file
+     * @param lastModifiedMillis the last modified time represented as the number of milliseconds
+     *                           since the epoch
+     */
+    public static HttpFileBuilder of(HttpData data, long lastModifiedMillis) {
+        requireNonNull(data, "data");
+        return new HttpDataFileBuilder(data, lastModifiedMillis)
+                .autoDetectedContentType(false); // Can't auto-detect because there's no path or URI.
+    }
+
+    /**
+     * Returns a new {@link HttpFileBuilder} that builds an {@link HttpFile} from the classpath resource
+     * at the specified {@code path}. This method is a shortcut of
+     * {@code HttpFileBuilder.ofResource(HttpFile.class.getClassLoader(), path)}.
+     */
+    public static HttpFileBuilder ofResource(String path) {
+        requireNonNull(path, "path");
+        return ofResource(HttpFile.class.getClassLoader(), path);
+    }
+
+    /**
+     * Returns a new {@link HttpFileBuilder} that builds an {@link HttpFile} from the classpath resource
+     * at the specified {@code path} using the specified {@link ClassLoader}.
+     */
+    public static HttpFileBuilder ofResource(ClassLoader classLoader, String path) {
+        requireNonNull(classLoader, "classLoader");
+        requireNonNull(path, "path");
+        final URL url = classLoader.getResource(path);
+        if (url == null || url.getPath().endsWith("/")) {
+            // Non-existent resource.
+            return new NonExistentHttpFileBuilder();
+        }
+
+        // Convert to a real file if possible.
+        if ("file".equals(url.getProtocol())) {
+            File f;
+            try {
+                f = new File(url.toURI());
+            } catch (URISyntaxException ignored) {
+                f = new File(url.getPath());
+            }
+
+            return of(f);
+        }
+
+        return new ClassPathHttpFileBuilder(url);
+    }
+
+    HttpFileBuilder() {}
+
+    /**
+     * Returns a newly created {@link HttpFile} with the properties configured so far. If this builder was
+     * created with {@link #of(HttpData)} or {@link #of(HttpData, long)}, the returned instance will always be
+     * an {@link AggregatedHttpFile}.
+     */
+    public abstract HttpFile build();
+
+    private static final class FileSystemHttpFileBuilder extends HttpFileBuilder {
+
+        private final Path path;
+
+        FileSystemHttpFileBuilder(Path path) {
+            this.path = requireNonNull(path, "path");
+        }
+
+        @Override
+        public HttpFile build() {
+            return new FileSystemHttpFile(path, isContentTypeAutoDetectionEnabled(), isDateEnabled(),
+                                          isLastModifiedEnabled(), entityTagFunction(), headers());
+        }
+    }
+
+    private static final class ClassPathHttpFileBuilder extends HttpFileBuilder {
+
+        private final URL url;
+
+        ClassPathHttpFileBuilder(URL url) {
+            this.url = requireNonNull(url, "url");
+        }
+
+        @Override
+        public HttpFile build() {
+            return new ClassPathHttpFile(url, isContentTypeAutoDetectionEnabled(), isDateEnabled(),
+                                         isLastModifiedEnabled(), entityTagFunction(), headers());
+        }
+    }
+
+    private static final class NonExistentHttpFileBuilder extends HttpFileBuilder {
+        @Override
+        public HttpFile build() {
+            return HttpFile.nonExistent();
+        }
+    }
+
+    private static final class HttpDataFileBuilder extends HttpFileBuilder {
+
+        private final HttpData content;
+        private final long lastModifiedMillis;
+
+        HttpDataFileBuilder(HttpData content, long lastModifiedMillis) {
+            this.content = requireNonNull(content, "content");
+            this.lastModifiedMillis = lastModifiedMillis;
+        }
+
+        @Override
+        public AggregatedHttpFile build() {
+            return new HttpDataFile(content, lastModifiedMillis,
+                                    isDateEnabled(), isLastModifiedEnabled(),
+                                    entityTagFunction(), headers());
+        }
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/file/HttpFileService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/HttpFileService.java
@@ -18,7 +18,6 @@ package com.linecorp.armeria.server.file;
 
 import static java.util.Objects.requireNonNull;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.text.ParseException;
@@ -30,9 +29,11 @@ import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
-import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.RemovalListener;
 import com.google.common.base.Splitter;
+import com.google.common.util.concurrent.MoreExecutors;
 
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaderNames;
@@ -42,6 +43,7 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.metric.MeterIdPrefix;
+import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.internal.metric.CaffeineMetricSupport;
 import com.linecorp.armeria.server.AbstractHttpService;
 import com.linecorp.armeria.server.HttpService;
@@ -50,9 +52,9 @@ import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceConfig;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.encoding.HttpEncodingService;
-import com.linecorp.armeria.server.file.HttpVfs.Entry;
 
 import io.micrometer.core.instrument.MeterRegistry;
+import io.netty.buffer.ByteBufHolder;
 
 /**
  * An {@link HttpService} that serves static files from a file system.
@@ -103,19 +105,30 @@ public final class HttpFileService extends AbstractHttpService {
     private final HttpFileServiceConfig config;
 
     @Nullable
-    private final LoadingCache<PathAndEncoding, CachedEntry> cache;
+    private final Cache<PathAndEncoding, AggregatedHttpFile> cache;
 
     HttpFileService(HttpFileServiceConfig config) {
         this.config = requireNonNull(config, "config");
-
         if (config.maxCacheEntries() != 0) {
-            cache = Caffeine.newBuilder()
-                            .maximumSize(config.maxCacheEntries())
-                            .recordStats()
-                            .build(this::getEntryWithoutCache);
+            cache = newCache(config);
         } else {
             cache = null;
         }
+    }
+
+    private static Cache<PathAndEncoding, AggregatedHttpFile> newCache(HttpFileServiceConfig config) {
+        final Caffeine<Object, Object> b = Caffeine.newBuilder();
+        b.maximumSize(config.maxCacheEntries())
+         .recordStats()
+         .removalListener((RemovalListener<PathAndEncoding, AggregatedHttpFile>) (key, value, cause) -> {
+             if (value != null) {
+                 final HttpData content = value.content();
+                 if (content instanceof ByteBufHolder) {
+                     ((ByteBufHolder) content).release();
+                 }
+             }
+         });
+        return b.build();
     }
 
     @Override
@@ -146,12 +159,15 @@ public final class HttpFileService extends AbstractHttpService {
     }
 
     @Override
-    protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) {
-        final Entry entry = getEntry(ctx, req);
-        final long lastModifiedMillis = entry.lastModifiedMillis();
+    protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+        final HttpFile file = findFile(ctx, req);
+        if (file == null) {
+            return new404Response();
+        }
 
-        if (lastModifiedMillis == 0) {
-            return HttpResponse.of(HttpStatus.NOT_FOUND);
+        final HttpFileAttributes attrs = file.readAttributes();
+        if (attrs == null) {
+            return new404Response();
         }
 
         long ifModifiedSinceMillis = Long.MIN_VALUE;
@@ -173,6 +189,7 @@ public final class HttpFileService extends AbstractHttpService {
             ifModifiedSinceMillis += 999;
         }
 
+        final long lastModifiedMillis = attrs.lastModifiedMillis();
         if (lastModifiedMillis < ifModifiedSinceMillis) {
             return HttpResponse.of(
                     HttpHeaders.of(HttpStatus.NOT_MODIFIED)
@@ -180,34 +197,11 @@ public final class HttpFileService extends AbstractHttpService {
                                .setTimeMillis(HttpHeaderNames.LAST_MODIFIED, lastModifiedMillis));
         }
 
-        final HttpData data;
-        try {
-            data = entry.readContent();
-        } catch (FileNotFoundException ignored) {
-            return HttpResponse.of(HttpStatus.NOT_FOUND);
-        } catch (Exception e) {
-            logger.warn("{} Unexpected exception reading a file:", ctx, e);
-            return HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR);
-        }
-
-        final HttpHeaders headers =
-                HttpHeaders.of(HttpStatus.OK)
-                           .setInt(HttpHeaderNames.CONTENT_LENGTH, data.length())
-                           .setTimeMillis(HttpHeaderNames.DATE, config().clock().millis())
-                           .setTimeMillis(HttpHeaderNames.LAST_MODIFIED, lastModifiedMillis);
-        final MediaType mediaType = entry.mediaType();
-        if (mediaType != null) {
-            headers.contentType(mediaType);
-        }
-        final String contentEncoding = entry.contentEncoding();
-        if (contentEncoding != null) {
-            headers.set(HttpHeaderNames.CONTENT_ENCODING, contentEncoding);
-        }
-
-        return HttpResponse.of(headers, data);
+        return file.asService().serve(ctx, req);
     }
 
-    private Entry getEntry(ServiceRequestContext ctx, HttpRequest req) {
+    @Nullable
+    private HttpFile findFile(ServiceRequestContext ctx, HttpRequest req) throws IOException {
         final String decodedMappedPath = ctx.decodedMappedPath();
 
         final EnumSet<FileServiceContentEncoding> supportedEncodings =
@@ -228,117 +222,96 @@ public final class HttpFileService extends AbstractHttpService {
             }
         }
 
-        final Entry entry = getEntryWithSupportedEncodings(decodedMappedPath, supportedEncodings);
+        final HttpFile file = findFile(ctx, decodedMappedPath, supportedEncodings);
+        if (file != null) {
+            return file;
+        }
 
-        if (entry.lastModifiedMillis() == 0) {
-            if (decodedMappedPath.charAt(decodedMappedPath.length() - 1) == '/') {
-                // Try index.html if it was a directory access.
-                final Entry indexEntry = getEntryWithSupportedEncodings(
-                        decodedMappedPath + "index.html", supportedEncodings);
-                if (indexEntry.lastModifiedMillis() != 0) {
-                    return indexEntry;
-                }
+        if (decodedMappedPath.charAt(decodedMappedPath.length() - 1) == '/') {
+            // Try index.html if it was a directory access.
+            return findFile(ctx, decodedMappedPath + "index.html", supportedEncodings);
+        }
+
+        return null;
+    }
+
+    @Nullable
+    private HttpFile findFile(ServiceRequestContext ctx, String path,
+                              EnumSet<FileServiceContentEncoding> supportedEncodings) throws IOException {
+        final MediaType contentType = MimeTypeUtil.guessFromPath(path);
+        for (FileServiceContentEncoding encoding : supportedEncodings) {
+            final String contentEncoding = encoding.headerValue;
+            final HttpFile file = findFile(ctx, path + encoding.extension, contentType, contentEncoding);
+            if (file != null) {
+                return file;
             }
         }
 
-        return entry;
+        return findFile(ctx, path, contentType, null);
     }
 
-    private Entry getEntry(String path, @Nullable String contentEncoding) {
+    @Nullable
+    private HttpFile findFile(ServiceRequestContext ctx, String path,
+                              @Nullable MediaType contentType,
+                              @Nullable String contentEncoding) throws IOException {
+        final HttpFile uncachedFile = config.vfs().get(path, contentType, contentEncoding);
+        final HttpFileAttributes uncachedAttrs = uncachedFile.readAttributes();
         if (cache == null) {
-            return config.vfs().get(path, contentEncoding);
+            return uncachedAttrs != null ? uncachedFile : null;
         }
 
         final PathAndEncoding pathAndEncoding = new PathAndEncoding(path, contentEncoding);
-        final CachedEntry entry = cache.getIfPresent(pathAndEncoding);
-        if (entry == null) {
-            return cache.get(pathAndEncoding);
-        }
-
-        if (config.vfs().get(path, contentEncoding).lastModifiedMillis() != entry.lastModifiedMillis()) {
+        if (uncachedAttrs == null) {
+            // Non-existent file. Invalidate the cache just in case it existed before.
             cache.invalidate(pathAndEncoding);
-            return cache.get(pathAndEncoding);
+            return null;
         }
 
-        return entry;
+        final AggregatedHttpFile cachedFile = cache.getIfPresent(pathAndEncoding);
+        if (cachedFile == null) {
+            // Cache miss. Cache if small enough.
+            if (uncachedAttrs.length() <= config.maxCacheEntrySizeBytes()) {
+                return cache(ctx, pathAndEncoding, uncachedFile);
+            } else {
+                return uncachedFile;
+            }
+        }
+
+        final HttpFileAttributes cachedAttrs = cachedFile.readAttributes();
+        assert cachedAttrs != null;
+        if (cachedAttrs.equals(uncachedAttrs)) {
+            // Cache hit, and the cached file is up-to-date.
+            return cachedFile;
+        }
+
+        // Cache hit, but the cached file is out of date. Cache if small enough.
+        cache.invalidate(pathAndEncoding);
+        if (uncachedAttrs.length() <= config.maxCacheEntrySizeBytes()) {
+            return cache(ctx, pathAndEncoding, uncachedFile);
+        } else {
+            return uncachedFile;
+        }
     }
 
-    private CachedEntry getEntryWithoutCache(PathAndEncoding pathAndEncoding) {
-        return new CachedEntry(config.vfs().get(pathAndEncoding.path, pathAndEncoding.contentEncoding),
-                               config.maxCacheEntrySizeBytes());
+    private HttpFile cache(ServiceRequestContext ctx, PathAndEncoding pathAndEncoding, HttpFile file) {
+        assert cache != null;
+
+        // TODO(trustin): We assume here that the file being read is small enough that it will not block
+        //                an event loop for a long time. Revisit if the assumption turns out to be false.
+        final AggregatedHttpFile cachedFile = cache.get(pathAndEncoding, key -> {
+            try {
+                return file.aggregateWithPooledObjects(MoreExecutors.directExecutor(), ctx.alloc()).get();
+            } catch (Exception e) {
+                logger.warn("{} Failed to cache a file: {}", ctx, file, Exceptions.peel(e));
+                return null;
+            }
+        });
+
+        return cachedFile != null ? cachedFile : file;
     }
 
-    private Entry getEntryWithSupportedEncodings(String path,
-                                                 EnumSet<FileServiceContentEncoding> supportedEncodings) {
-        for (FileServiceContentEncoding encoding : supportedEncodings) {
-            final Entry entry = getEntry(path + encoding.extension, encoding.headerValue);
-            if (entry.lastModifiedMillis() != 0) {
-                return entry;
-            }
-        }
-        return getEntry(path, null);
-    }
-
-    private static final class CachedEntry implements Entry {
-
-        private final Entry entry;
-        private final int maxCacheEntrySizeBytes;
-        @Nullable
-        private HttpData cachedContent;
-        private volatile long cachedLastModifiedMillis;
-
-        CachedEntry(Entry entry, int maxCacheEntrySizeBytes) {
-            this.entry = entry;
-            this.maxCacheEntrySizeBytes = maxCacheEntrySizeBytes;
-            cachedLastModifiedMillis = entry.lastModifiedMillis();
-        }
-
-        @Override
-        public MediaType mediaType() {
-            return entry.mediaType();
-        }
-
-        @Nullable
-        @Override
-        public String contentEncoding() {
-            return entry.contentEncoding();
-        }
-
-        @Override
-        public long lastModifiedMillis() {
-            final long newLastModifiedMillis = entry.lastModifiedMillis();
-            if (newLastModifiedMillis != cachedLastModifiedMillis) {
-                cachedLastModifiedMillis = newLastModifiedMillis;
-                destroyContent();
-            }
-
-            return newLastModifiedMillis;
-        }
-
-        @Override
-        public synchronized HttpData readContent() throws IOException {
-            if (cachedContent == null) {
-                final HttpData newContent = entry.readContent();
-                if (newContent.length() > maxCacheEntrySizeBytes) {
-                    // Do not cache if the content is too large.
-                    return newContent;
-                }
-                cachedContent = newContent;
-            }
-
-            return cachedContent;
-        }
-
-        synchronized void destroyContent() {
-            if (cachedContent != null) {
-                cachedContent = null;
-            }
-        }
-
-        @Override
-        public String toString() {
-            return entry.toString();
-        }
+    private static HttpResponse new404Response() {
+        return HttpResponse.of(HttpStatus.NOT_FOUND);
     }
 
     /**
@@ -370,8 +343,7 @@ public final class HttpFileService extends AbstractHttpService {
 
         @Override
         public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
-            final Entry firstEntry = first.getEntry(ctx, req);
-            if (firstEntry.lastModifiedMillis() != 0) {
+            if (first.findFile(ctx, req) != null) {
                 return first.serve(ctx, req);
             } else {
                 return second.serve(ctx, req);

--- a/core/src/main/java/com/linecorp/armeria/server/file/HttpVfs.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/HttpVfs.java
@@ -24,8 +24,6 @@ import java.time.Clock;
 
 import javax.annotation.Nullable;
 
-import com.linecorp.armeria.common.MediaType;
-
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Tag;
 
@@ -67,14 +65,12 @@ public interface HttpVfs {
      *
      * @param path an absolute path whose component separator is {@code '/'}
      * @param clock the {@link Clock} which provides the current date and time
-     * @param contentType the desired {@code 'content-type'} header value of the file.
-     *                    {@code null} to omit the header.
      * @param contentEncoding the desired {@code 'content-encoding'} header value of the file.
      *                        {@code null} to omit the header.
      *
      * @return the {@link HttpFile} at the specified {@code path}
      */
-    HttpFile get(String path, Clock clock, @Nullable MediaType contentType, @Nullable String contentEncoding);
+    HttpFile get(String path, Clock clock, @Nullable String contentEncoding);
 
     /**
      * Returns the value of the {@code "vfs"} {@link Tag} in a {@link Meter}.

--- a/core/src/main/java/com/linecorp/armeria/server/file/HttpVfs.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/HttpVfs.java
@@ -18,16 +18,11 @@ package com.linecorp.armeria.server.file;
 
 import static java.util.Objects.requireNonNull;
 
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
 
 import javax.annotation.Nullable;
 
-import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.MediaType;
 
 import io.micrometer.core.instrument.Meter;
@@ -69,228 +64,18 @@ public interface HttpVfs {
     /**
      * Finds the file at the specified {@code path}.
      *
-     *
      * @param path an absolute path whose component separator is {@code '/'}
-     * @param contentEncoding the content encoding of the file. Will be non-null for precompressed resources
+     * @param contentType the desired {@code 'content-type'} header value of the file.
+     *                    {@code null} to omit the header.
+     * @param contentEncoding the desired {@code 'content-encoding'} header value of the file.
+     *                        {@code null} to omit the header.
      *
-     * @return the {@link Entry} of the file at the specified {@code path} if found.
-     *         {@link Entry#NONE} if not found.
+     * @return the {@link HttpFile} at the specified {@code path}
      */
-    Entry get(String path, @Nullable String contentEncoding);
+    HttpFile get(String path, @Nullable MediaType contentType, @Nullable String contentEncoding);
 
     /**
      * Returns the value of the {@code "vfs"} {@link Tag} in a {@link Meter}.
      */
     String meterTag();
-
-    /**
-     * A file entry in an {@link HttpVfs}.
-     */
-    interface Entry {
-        /**
-         * A non-existent entry.
-         */
-        Entry NONE = new Entry() {
-            @Override
-            public MediaType mediaType() {
-                throw new IllegalStateException();
-            }
-
-            @Nullable
-            @Override
-            public String contentEncoding() {
-                return null;
-            }
-
-            @Override
-            public long lastModifiedMillis() {
-                return 0;
-            }
-
-            @Override
-            public HttpData readContent() throws IOException {
-                throw new FileNotFoundException();
-            }
-
-            @Override
-            public String toString() {
-                return "none";
-            }
-        };
-
-        /**
-         * Returns the MIME type of the entry.
-         *
-         * @return {@code null} if unknown
-         */
-        @Nullable
-        MediaType mediaType();
-
-        /**
-         * The content encoding of the entry. Will be set for precompressed files.
-         *
-         * @return {@code null} if not compressed
-         */
-        @Nullable
-        String contentEncoding();
-
-        /**
-         * Returns the modification time of the entry.
-         *
-         * @return {@code 0} if the entry does not exist.
-         */
-        long lastModifiedMillis();
-
-        /**
-         * Reads the content of the entry into a new buffer.
-         */
-        HttpData readContent() throws IOException;
-    }
-
-    /**
-     * A skeletal {@link Entry} implementation.
-     */
-    abstract class AbstractEntry implements Entry {
-
-        private final String path;
-        @Nullable
-        private final MediaType mediaType;
-        @Nullable
-        private final String contentEncoding;
-
-        /**
-         * Creates a new instance with the specified {@code path}.
-         */
-        protected AbstractEntry(String path, @Nullable String contentEncoding) {
-            this(path, MimeTypeUtil.guessFromPath(path, contentEncoding != null), contentEncoding);
-        }
-
-        /**
-         * Creates a new instance with the specified {@code path} and {@code mediaType}.
-         */
-        protected AbstractEntry(String path, @Nullable MediaType mediaType, @Nullable String contentEncoding) {
-            this.path = requireNonNull(path, "path");
-            this.mediaType = mediaType;
-            this.contentEncoding = contentEncoding;
-        }
-
-        @Override
-        @Nullable
-        public MediaType mediaType() {
-            return mediaType;
-        }
-
-        @Override
-        @Nullable
-        public String contentEncoding() {
-            return contentEncoding;
-        }
-
-        @Override
-        public String toString() {
-            return path;
-        }
-
-        /**
-         * Reads the content of the entry into a new buffer.
-         * Use {@link #readContent(InputStream, int)} when the length of the stream is known.
-         */
-        protected HttpData readContent(InputStream in) throws IOException {
-            byte[] buf = new byte[Math.max(in.available(), 1024)];
-            int endOffset = 0;
-
-            for (;;) {
-                final int readBytes = in.read(buf, endOffset, buf.length - endOffset);
-                if (readBytes < 0) {
-                    break;
-                }
-
-                endOffset += readBytes;
-                if (endOffset == buf.length) {
-                    buf = Arrays.copyOf(buf, buf.length << 1);
-                }
-            }
-
-            return endOffset != 0 ? HttpData.of(buf, 0, endOffset) : HttpData.EMPTY_DATA;
-        }
-
-        /**
-         * Reads the content of the entry into a new buffer.
-         * Use {@link #readContent(InputStream)} when the length of the stream is unknown.
-         */
-        protected HttpData readContent(InputStream in, int length) throws IOException {
-
-            if (length == 0) {
-                return HttpData.EMPTY_DATA;
-            }
-
-            final byte[] buf = new byte[length];
-            int endOffset = 0;
-
-            for (;;) {
-                final int readBytes = in.read(buf, endOffset, buf.length - endOffset);
-                if (readBytes < 0) {
-                    break;
-                }
-
-                endOffset += readBytes;
-                if (endOffset == buf.length) {
-                    break;
-                }
-            }
-
-            return HttpData.of(buf, 0, endOffset);
-        }
-    }
-
-    /**
-     * An {@link Entry} whose content is backed by a byte array.
-     */
-    final class ByteArrayEntry extends AbstractEntry {
-
-        private final long lastModifiedMillis;
-        private final HttpData content;
-
-        /**
-         * Creates a new instance with the specified {@code path} and byte array.
-         */
-        public ByteArrayEntry(String path, byte[] content) {
-            this(path, content, System.currentTimeMillis());
-        }
-
-        /**
-         * Creates a new instance with the specified {@code path} and byte array.
-         */
-        public ByteArrayEntry(String path, byte[] content, long lastModifiedMillis) {
-            super(path, null);
-            this.content = HttpData.of(requireNonNull(content, "content"));
-            this.lastModifiedMillis = lastModifiedMillis;
-        }
-
-        /**
-         * Creates a new instance with the specified {@code path}, {@code mediaType} and byte array.
-         */
-        public ByteArrayEntry(String path, MediaType mediaType, byte[] content) {
-            this(path, mediaType, content, System.currentTimeMillis());
-        }
-
-        /**
-         * Creates a new instance with the specified {@code path}, {@code mediaType} and byte array.
-         */
-        public ByteArrayEntry(String path, MediaType mediaType, byte[] content, long lastModifiedMillis) {
-            super(path, mediaType, null);
-            this.content = HttpData.of(requireNonNull(content, "content"));
-            this.lastModifiedMillis = lastModifiedMillis;
-        }
-
-        @Override
-        public long lastModifiedMillis() {
-            return lastModifiedMillis;
-        }
-
-        @Override
-        public HttpData readContent() {
-            return content;
-        }
-    }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/file/HttpVfs.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/HttpVfs.java
@@ -20,6 +20,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Clock;
 
 import javax.annotation.Nullable;
 
@@ -65,6 +66,7 @@ public interface HttpVfs {
      * Finds the file at the specified {@code path}.
      *
      * @param path an absolute path whose component separator is {@code '/'}
+     * @param clock the {@link Clock} which provides the current date and time
      * @param contentType the desired {@code 'content-type'} header value of the file.
      *                    {@code null} to omit the header.
      * @param contentEncoding the desired {@code 'content-encoding'} header value of the file.
@@ -72,7 +74,7 @@ public interface HttpVfs {
      *
      * @return the {@link HttpFile} at the specified {@code path}
      */
-    HttpFile get(String path, @Nullable MediaType contentType, @Nullable String contentEncoding);
+    HttpFile get(String path, Clock clock, @Nullable MediaType contentType, @Nullable String contentEncoding);
 
     /**
      * Returns the value of the {@code "vfs"} {@link Tag} in a {@link Meter}.

--- a/core/src/main/java/com/linecorp/armeria/server/file/MimeTypeUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/MimeTypeUtil.java
@@ -99,5 +99,17 @@ final class MimeTypeUtil {
         return guessedContentType != null ? MediaType.parse(guessedContentType) : null;
     }
 
+    @Nullable
+    static MediaType guessFromPath(String path, @Nullable String contentEncoding) {
+        if (contentEncoding == null || Ascii.equalsIgnoreCase(contentEncoding, "identity")) {
+            return guessFromPath(path);
+        }
+
+        requireNonNull(path, "path");
+        // If the path is for a precompressed file, it will have an additional extension indicating the
+        // encoding, which we don't want to use when determining content type.
+        return guessFromPath(path.substring(0, path.lastIndexOf('.')));
+    }
+
     private MimeTypeUtil() {}
 }

--- a/core/src/main/java/com/linecorp/armeria/server/file/MimeTypeUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/MimeTypeUtil.java
@@ -81,13 +81,8 @@ final class MimeTypeUtil {
     }
 
     @Nullable
-    static MediaType guessFromPath(String path, boolean preCompressed) {
+    static MediaType guessFromPath(String path) {
         requireNonNull(path, "path");
-        // If the path is for a precompressed file, it will have an additional extension indicating the
-        // encoding, which we don't want to use when determining content type.
-        if (preCompressed) {
-            path = path.substring(0, path.lastIndexOf('.'));
-        }
         final int dotIdx = path.lastIndexOf('.');
         final int slashIdx = path.lastIndexOf('/');
         if (dotIdx < 0 || slashIdx > dotIdx) {

--- a/core/src/main/java/com/linecorp/armeria/server/file/NonExistentHttpFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/NonExistentHttpFile.java
@@ -22,6 +22,8 @@ import javax.annotation.Nullable;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.server.HttpService;
 
 import io.netty.buffer.ByteBufAllocator;
 
@@ -51,5 +53,18 @@ final class NonExistentHttpFile implements AggregatedHttpFile {
     @Override
     public HttpData content() {
         return null;
+    }
+
+    @Override
+    public HttpService asService() {
+        return (ctx, req) -> {
+            switch (ctx.method()) {
+                case HEAD:
+                case GET:
+                    return HttpResponse.of(HttpStatus.NOT_FOUND);
+                default:
+                    return HttpResponse.of(HttpStatus.METHOD_NOT_ALLOWED);
+            }
+        };
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/file/NonExistentHttpFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/NonExistentHttpFile.java
@@ -58,7 +58,7 @@ final class NonExistentHttpFile implements AggregatedHttpFile {
     @Override
     public HttpService asService() {
         return (ctx, req) -> {
-            switch (ctx.method()) {
+            switch (req.method()) {
                 case HEAD:
                 case GET:
                     return HttpResponse.of(HttpStatus.NOT_FOUND);

--- a/core/src/main/java/com/linecorp/armeria/server/file/NonExistentHttpFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/NonExistentHttpFile.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.file;
+
+import java.util.concurrent.Executor;
+
+import javax.annotation.Nullable;
+
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpResponse;
+
+import io.netty.buffer.ByteBufAllocator;
+
+final class NonExistentHttpFile implements AggregatedHttpFile {
+
+    static final NonExistentHttpFile INSTANCE = new NonExistentHttpFile();
+
+    private NonExistentHttpFile() {}
+
+    @Override
+    public HttpFileAttributes readAttributes() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public HttpHeaders readHeaders() {
+        return null;
+    }
+
+    @Override
+    public HttpResponse read(Executor fileReadExecutor, ByteBufAllocator alloc) {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public HttpData content() {
+        return null;
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/file/StreamingHttpFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/StreamingHttpFile.java
@@ -233,6 +233,7 @@ public abstract class StreamingHttpFile<T extends Closeable> extends AbstractHtt
             } catch (Exception e) {
                 future.completeExceptionally(e);
             } finally {
+                close(in);
                 if (!success) {
                     buf.release();
                 }

--- a/core/src/main/java/com/linecorp/armeria/server/file/StreamingHttpFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/StreamingHttpFile.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.file;
+
+import static java.util.Objects.requireNonNull;
+
+import java.io.Closeable;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.function.BiFunction;
+
+import javax.annotation.Nullable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.spotify.futures.CompletableFutures;
+
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpResponseWriter;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.unsafe.ByteBufHttpData;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.Unpooled;
+
+/**
+ * A skeletal {@link HttpFile} that simplifies the streaming of potentially large content.
+ *
+ * @param <T> the type of the stream where the file content is read from, e.g. {@link InputStream}.
+ */
+public abstract class StreamingHttpFile<T extends Closeable> extends AbstractHttpFile {
+
+    private static final Logger logger = LoggerFactory.getLogger(StreamingHttpFile.class);
+    private static final int MAX_CHUNK_SIZE = 8192;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param contentType the {@link MediaType} of the file which will be used as the {@code "content-type"}
+     *                    header value. {@code null} to disable setting the {@code "content-type"} header.
+     * @param dateEnabled whether to set the {@code "date"} header automatically
+     * @param lastModifiedEnabled whether to add the {@code "last-modified"} header automatically
+     * @param entityTagFunction the {@link BiFunction} that generates an entity tag from the file's attributes.
+     *                          {@code null} to disable setting the {@code "etag"} header.
+     * @param headers the additional headers to set
+     */
+    protected StreamingHttpFile(@Nullable MediaType contentType,
+                                boolean dateEnabled,
+                                boolean lastModifiedEnabled,
+                                @Nullable BiFunction<String, HttpFileAttributes, String> entityTagFunction,
+                                HttpHeaders headers) {
+        super(contentType, dateEnabled, lastModifiedEnabled, entityTagFunction, headers);
+    }
+
+    @Override
+    protected final HttpResponse doRead(HttpHeaders headers, long length,
+                                        Executor fileReadExecutor, ByteBufAllocator alloc) throws IOException {
+        final T in = newStream();
+        if (in == null) {
+            return null;
+        }
+
+        final HttpResponseWriter res = HttpResponse.streaming();
+        res.write(headers);
+        fileReadExecutor.execute(() -> doRead(res, in, 0, length, fileReadExecutor, alloc));
+        return res;
+    }
+
+    private void doRead(HttpResponseWriter res, T in, long offset, long end,
+                        Executor fileReadExecutor, ByteBufAllocator alloc) {
+        final int chunkSize = (int) Math.min(MAX_CHUNK_SIZE, end - offset);
+        final ByteBuf buf = alloc.buffer(chunkSize);
+        final int readBytes;
+        boolean success = false;
+        try {
+            readBytes = read(in, buf);
+            if (readBytes < 0) {
+                // Should not reach here because we only read up to the end of the stream.
+                // If reached, it may mean the stream has been truncated.
+                throw new EOFException();
+            }
+            success = true;
+        } catch (Exception e) {
+            close(res, in, e);
+            return;
+        } finally {
+            if (!success) {
+                buf.release();
+            }
+        }
+
+        final long nextOffset = offset + readBytes;
+        final boolean endOfStream = nextOffset == end;
+        if (readBytes > 0) {
+            if (!res.tryWrite(new ByteBufHttpData(buf, endOfStream))) {
+                close(in);
+                return;
+            }
+        } else {
+            buf.release();
+        }
+
+        if (endOfStream) {
+            close(res, in);
+            return;
+        }
+
+        res.onDemand(() -> {
+            try {
+                fileReadExecutor.execute(() -> doRead(res, in, nextOffset, end, fileReadExecutor, alloc));
+            } catch (Exception e) {
+                close(res, in, e);
+            }
+        });
+    }
+
+    @Override
+    public final CompletableFuture<AggregatedHttpFile> aggregate(Executor fileReadExecutor) {
+        requireNonNull(fileReadExecutor, "fileReadExecutor");
+        return doAggregate(fileReadExecutor, null);
+    }
+
+    @Override
+    public final CompletableFuture<AggregatedHttpFile> aggregateWithPooledObjects(Executor fileReadExecutor,
+                                                                                  ByteBufAllocator alloc) {
+        requireNonNull(fileReadExecutor, "fileReadExecutor");
+        requireNonNull(alloc, "alloc");
+        return doAggregate(fileReadExecutor, alloc);
+    }
+
+    private CompletableFuture<AggregatedHttpFile> doAggregate(Executor fileReadExecutor,
+                                                              @Nullable ByteBufAllocator alloc) {
+        final HttpFileAttributes attrs;
+        try {
+            attrs = readAttributes();
+        } catch (IOException e) {
+            return CompletableFutures.exceptionallyCompletedFuture(e);
+        }
+
+        if (attrs == null) {
+            return CompletableFuture.completedFuture(HttpFile.nonExistent());
+        }
+
+        if (attrs.length() > Integer.MAX_VALUE) {
+            return CompletableFutures.exceptionallyCompletedFuture(
+                    new IOException("too large to aggregate: " + attrs.length() + " bytes"));
+        }
+
+        final T in;
+        try {
+            in = newStream();
+        } catch (IOException e) {
+            return CompletableFutures.exceptionallyCompletedFuture(e);
+        }
+
+        if (in == null) {
+            return CompletableFuture.completedFuture(HttpFile.nonExistent());
+        }
+
+        final CompletableFuture<AggregatedHttpFile> future = new CompletableFuture<>();
+        fileReadExecutor.execute(() -> {
+            final int length = (int) attrs.length();
+            final byte[] array;
+            final ByteBuf buf;
+            if (alloc != null) {
+                array = null;
+                buf = alloc.buffer(length);
+            } else {
+                array = new byte[length];
+                buf = Unpooled.wrappedBuffer(array).clear();
+            }
+
+            boolean success = false;
+            try {
+                for (int offset = 0;;) {
+                    final int readBytes = read(in, buf);
+                    if (readBytes < 0) {
+                        // Should not reach here because we only read up to the end of the stream.
+                        // If reached, it may mean the stream has been truncated.
+                        throw new EOFException();
+                    }
+
+                    offset += readBytes;
+                    if (offset == length) {
+                        break;
+                    }
+                }
+
+                final HttpFileBuilder builder =
+                        HttpFileBuilder.of(array != null ? HttpData.of(array)
+                                                         : new ByteBufHttpData(buf, true),
+                                           attrs.lastModifiedMillis())
+                                       .date(isDateEnabled())
+                                       .lastModified(isLastModifiedEnabled())
+                                       .entityTag(false);
+
+                if (contentType() != null) {
+                    builder.setHeader(HttpHeaderNames.CONTENT_TYPE, contentType());
+                }
+
+                final String etag = generateEntityTag(attrs);
+                if (etag != null) {
+                    builder.setHeader(HttpHeaderNames.ETAG, '\"' + etag + '\"');
+                }
+
+                builder.setHeaders(headers());
+                success = future.complete((AggregatedHttpFile) builder.build());
+            } catch (Exception e) {
+                future.completeExceptionally(e);
+            } finally {
+                if (!success) {
+                    buf.release();
+                }
+            }
+        });
+
+        return future;
+    }
+
+    /**
+     * Opens a new stream which reads from the file.
+     *
+     * @return the new stream, or {@code null} if the file does not exist.
+     *
+     * @throws IOException if failed to open a new stream
+     */
+    @Nullable
+    protected abstract T newStream() throws IOException;
+
+    /**
+     * Reads the content of {@code src} into {@code dst}.
+     *
+     * @return the number of read bytes, or {@code -1} if reached at the end of the file
+     *
+     * @throws IOException if failed to read the content
+     */
+    protected abstract int read(T src, ByteBuf dst) throws IOException;
+
+    private void close(HttpResponseWriter res, Closeable in) {
+        close(in);
+        res.close();
+    }
+
+    private void close(HttpResponseWriter res, Closeable in, Exception cause) {
+        close(in);
+        res.close(cause);
+    }
+
+    private void close(Closeable in) {
+        try {
+            in.close();
+        } catch (Exception e) {
+            logger.warn("Failed to close a stream for: {}", this, e);
+        }
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/file/CachingHttpFileTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/file/CachingHttpFileTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.file;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+import org.junit.Test;
+
+import com.google.common.util.concurrent.MoreExecutors;
+
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.server.ServiceRequestContext;
+
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.UnpooledByteBufAllocator;
+
+public class CachingHttpFileTest {
+
+    private static final Executor executor = MoreExecutors.directExecutor();
+    private static final ByteBufAllocator alloc = UnpooledByteBufAllocator.DEFAULT;
+
+    /**
+     * Makes sure zero overhead when {@code maxCachingLength} is {@code 0}.
+     */
+    @Test
+    public void disabledCache() {
+        final HttpFile uncached = mock(HttpFile.class);
+        assertThat(HttpFile.ofCached(uncached, 0)).isSameAs(uncached);
+    }
+
+    /**
+     * Makes sure a non-existent file is handled as expected.
+     */
+    @Test
+    public void nonExistentFile() throws Exception {
+        final HttpFile cached = HttpFile.ofCached(HttpFile.nonExistent(), Integer.MAX_VALUE);
+        assertThat(cached.readAttributes()).isNull();
+        assertThat(cached.readHeaders()).isNull();
+        assertThat(cached.read(executor, alloc)).isNull();
+        assertThat(cached.aggregate(executor).join()).isSameAs(HttpFile.nonExistent());
+        assertThat(cached.aggregateWithPooledObjects(executor, alloc).join()).isSameAs(HttpFile.nonExistent());
+        assertThat(cached.asService().serve(mock(ServiceRequestContext.class),
+                                            HttpRequest.of(HttpMethod.GET, "/")).aggregate().join().status())
+                .isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    /**
+     * Makes sure a regular file is handled as expected, including proper cache invalidation.
+     */
+    @Test
+    public void existentFile() throws Exception {
+        final HttpFileAttributes attrs = new HttpFileAttributes(3, 0);
+        final HttpHeaders headers = HttpHeaders.of(200);
+        final HttpFile uncached = mock(HttpFile.class);
+        when(uncached.readAttributes()).thenReturn(attrs);
+        when(uncached.readHeaders()).thenReturn(headers);
+        when(uncached.read(any(), any())).thenAnswer(invocation -> HttpResponse.of("foo"));
+        when(uncached.aggregate(any())).thenAnswer(
+                invocation -> CompletableFuture.completedFuture(HttpFile.of(HttpData.ofUtf8("foo"), 0)));
+
+        final HttpFile cached = HttpFile.ofCached(uncached, 3);
+
+        // Ensure readAttributes() is not cached.
+        assertThat(cached.readAttributes()).isSameAs(attrs);
+        verify(uncached, times(1)).readAttributes();
+        verifyNoMoreInteractions(uncached);
+        clearInvocations(uncached);
+
+        assertThat(cached.readAttributes()).isSameAs(attrs);
+        verify(uncached, times(1)).readAttributes();
+        verifyNoMoreInteractions(uncached);
+        clearInvocations(uncached);
+
+        // Ensure readHeaders() is not cached.
+        assertThat(cached.readHeaders()).isSameAs(headers);
+        verify(uncached, times(1)).readHeaders();
+        verifyNoMoreInteractions(uncached);
+        clearInvocations(uncached);
+
+        assertThat(cached.readHeaders()).isSameAs(headers);
+        verify(uncached, times(1)).readHeaders();
+        verifyNoMoreInteractions(uncached);
+        clearInvocations(uncached);
+
+        // First read() should trigger uncached.aggregate().
+        HttpResponse res = cached.read(executor, alloc);
+        assertThat(res).isNotNull();
+        assertThat(res.aggregate().join().content().toStringUtf8()).isEqualTo("foo");
+        verify(uncached, times(1)).readAttributes();
+        verify(uncached, times(1)).aggregate(executor);
+        verifyNoMoreInteractions(uncached);
+        clearInvocations(uncached);
+
+        // Second read() should not trigger uncached.aggregate().
+        res = cached.read(executor, alloc);
+        assertThat(res).isNotNull();
+        assertThat(res.aggregate().join().content().toStringUtf8()).isEqualTo("foo");
+        verify(uncached, times(1)).readAttributes();
+        verifyNoMoreInteractions(uncached);
+        clearInvocations(uncached);
+
+        // Update the uncached file's attributes to invalidate the cache.
+        final HttpFileAttributes newAttrs = new HttpFileAttributes(3, 1);
+        when(uncached.readAttributes()).thenReturn(newAttrs);
+        when(uncached.aggregate(any())).thenAnswer(
+                invocation -> CompletableFuture.completedFuture(HttpFile.of(HttpData.ofUtf8("bar"), 1)));
+
+        // Make sure read() invalidates the cache and triggers uncached.aggregate().
+        res = cached.read(executor, alloc);
+        assertThat(res).isNotNull();
+        assertThat(res.aggregate().join().content().toStringUtf8()).isEqualTo("bar");
+        verify(uncached, times(1)).readAttributes();
+        verify(uncached, times(1)).aggregate(executor);
+        verifyNoMoreInteractions(uncached);
+        clearInvocations(uncached);
+    }
+
+    /**
+     * Makes sure a large file is not cached.
+     */
+    @Test
+    public void largeFile() throws Exception {
+        final HttpFileAttributes attrs = new HttpFileAttributes(5, 0);
+        final HttpHeaders headers = HttpHeaders.of(200);
+        final HttpResponse res = HttpResponse.of("large");
+        final CompletableFuture<AggregatedHttpFile> aggregated =
+                CompletableFuture.completedFuture(HttpFile.of(HttpData.ofUtf8("large"), 0));
+        final CompletableFuture<AggregatedHttpFile> aggregatedWithPooledObjs =
+                CompletableFuture.completedFuture(HttpFile.of(HttpData.ofUtf8("large"), 0));
+        final HttpFile uncached = mock(HttpFile.class);
+        when(uncached.readAttributes()).thenReturn(attrs);
+        when(uncached.readHeaders()).thenReturn(headers);
+        when(uncached.read(any(), any())).thenReturn(res);
+        when(uncached.aggregate(any())).thenReturn(aggregated);
+        when(uncached.aggregateWithPooledObjects(any(), any())).thenReturn(aggregatedWithPooledObjs);
+
+        final HttpFile cached = HttpFile.ofCached(uncached, 4);
+
+        // read() should be delegated to 'uncached'.
+        assertThat(cached.read(executor, alloc)).isSameAs(res);
+        verify(uncached, times(1)).readAttributes();
+        verify(uncached, times(1)).read(executor, alloc);
+        verifyNoMoreInteractions(uncached);
+        clearInvocations(uncached);
+
+        // aggregate() should be delegated to 'uncached'.
+        assertThat(cached.aggregate(executor)).isSameAs(aggregated);
+        verify(uncached, times(1)).readAttributes();
+        verify(uncached, times(1)).aggregate(executor);
+        verifyNoMoreInteractions(uncached);
+        clearInvocations(uncached);
+
+        // aggregateWithPooledObjects() should be delegated to 'uncached'.
+        assertThat(cached.aggregateWithPooledObjects(executor, alloc)).isSameAs(aggregatedWithPooledObjs);
+        verify(uncached, times(1)).readAttributes();
+        verify(uncached, times(1)).aggregateWithPooledObjects(executor, alloc);
+        verifyNoMoreInteractions(uncached);
+        clearInvocations(uncached);
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/file/DefaultEntityTagFunctionTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/file/DefaultEntityTagFunctionTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.file;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class DefaultEntityTagFunctionTest {
+    @Test
+    public void test() {
+        // Make sure all-zero input produces a non-empty tag.
+        final DefaultEntityTagFunction f = DefaultEntityTagFunction.get();
+        assertThat(f.apply("", new HttpFileAttributes(0, 0))).isEqualTo("-");
+
+        // Make sure non-leading zeros are not stripped.
+        assertThat(f.apply("", new HttpFileAttributes(0x0001000000000000L, 0x0000000000010000L)))
+                .isEqualTo("AQAAAAAAAAEAAA"); // = 01 00 00 00 00 00 00 / 01 00 00
+
+        // Test a realistic one.
+        assertThat(f.apply("/favicon.ico", new HttpFileAttributes(892, 1546933942837L)))
+                .isEqualTo("eA50LAN8AWgscro1");
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/file/HttpFileServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/file/HttpFileServiceTest.java
@@ -504,32 +504,32 @@ public class HttpFileServiceTest {
         final HttpUriRequest req1 = new HttpGet(uri);
         req1.setHeader(HttpHeaders.IF_NONE_MATCH, expectedETag);
 
-        try (CloseableHttpResponse resCached = hc.execute(req1)) {
-            assert304NotModified(resCached, expectedETag, expectedLastModified);
+        try (CloseableHttpResponse res = hc.execute(req1)) {
+            assert304NotModified(res, expectedETag, expectedLastModified);
         }
 
         // Test if the 'If-None-Match' header works as expected. (multiple etags)
         final HttpUriRequest req2 = new HttpGet(uri);
         req2.setHeader(HttpHeaders.IF_NONE_MATCH, "\"an-etag-that-never-matches\", " + expectedETag);
 
-        try (CloseableHttpResponse resCached = hc.execute(req2)) {
-            assert304NotModified(resCached, expectedETag, expectedLastModified);
+        try (CloseableHttpResponse res = hc.execute(req2)) {
+            assert304NotModified(res, expectedETag, expectedLastModified);
         }
 
         // Test if the 'If-None-Match' header works as expected. (an asterisk)
         final HttpUriRequest req3 = new HttpGet(uri);
         req3.setHeader(HttpHeaders.IF_NONE_MATCH, "*");
 
-        try (CloseableHttpResponse resCached = hc.execute(req3)) {
-            assert304NotModified(resCached, expectedETag, expectedLastModified);
+        try (CloseableHttpResponse res = hc.execute(req3)) {
+            assert304NotModified(res, expectedETag, expectedLastModified);
         }
 
         // Test if the 'If-Modified-Since' header works as expected.
         final HttpUriRequest req4 = new HttpGet(uri);
         req4.setHeader(HttpHeaders.IF_MODIFIED_SINCE, currentHttpDate());
 
-        try (CloseableHttpResponse resCached = hc.execute(req4)) {
-            assert304NotModified(resCached, expectedETag, expectedLastModified);
+        try (CloseableHttpResponse res = hc.execute(req4)) {
+            assert304NotModified(res, expectedETag, expectedLastModified);
         }
 
         // 'If-Modified-Since' should never be evaluated if 'If-None-Match' exists.
@@ -537,11 +537,10 @@ public class HttpFileServiceTest {
         req5.setHeader(HttpHeaders.IF_NONE_MATCH, "\"an-etag-that-never-matches\"");
         req5.setHeader(HttpHeaders.IF_MODIFIED_SINCE, currentHttpDate());
 
-        try (CloseableHttpResponse resCached = hc.execute(req5)) {
+        try (CloseableHttpResponse res = hc.execute(req5)) {
             // Should not receive '304 Not Modified' because the etag did not match.
-            assertStatusLine(resCached, "HTTP/1.1 200 OK");
+            assertStatusLine(res, "HTTP/1.1 200 OK");
         }
-
     }
 
     private static void assert304NotModified(

--- a/core/src/test/java/com/linecorp/armeria/server/file/HttpFileServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/file/HttpFileServiceTest.java
@@ -24,7 +24,6 @@ import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
-import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.time.Instant;
 import java.time.ZoneId;
@@ -416,8 +415,7 @@ public class HttpFileServiceTest {
 
             // Modify the file cached by the service. Update last modification time explicitly
             // so that it differs from the old value.
-            Files.write(barFile.toPath(), expectedContentB.getBytes(StandardCharsets.UTF_8),
-                        StandardOpenOption.TRUNCATE_EXISTING);
+            Files.write(barFile.toPath(), expectedContentB.getBytes(StandardCharsets.UTF_8));
             assertThat(barFile.setLastModified(barFileLastModified + 5000)).isTrue();
 
             try (CloseableHttpResponse res = hc.execute(req)) {

--- a/core/src/test/java/com/linecorp/armeria/server/file/HttpFileServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/file/HttpFileServiceTest.java
@@ -554,6 +554,9 @@ public class HttpFileServiceTest {
         // Ensure that the 'Last-Modified' header did not change.
         assertThat(headerOrNull(res, HttpHeaders.LAST_MODIFIED)).isEqualTo(expectedLastModified);
 
+        // Ensure that the 'Content-Length' header does not exist.
+        assertThat(res.containsHeader(HttpHeaders.CONTENT_LENGTH)).isFalse();
+
         // Ensure that the content does not exist.
         assertThat(res.getEntity()).isNull();
     }

--- a/core/src/test/java/com/linecorp/armeria/server/file/HttpFileServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/file/HttpFileServiceTest.java
@@ -500,7 +500,7 @@ public class HttpFileServiceTest {
                                       String expectedETag, String expectedLastModified) throws IOException {
         final String uri = newUri(path);
 
-        // Test if the 'If-None-Match' header works as expected.
+        // Test if the 'If-None-Match' header works as expected. (a single etag)
         final HttpUriRequest req1 = new HttpGet(uri);
         req1.setHeader(HttpHeaders.IF_NONE_MATCH, expectedETag);
 
@@ -508,11 +508,27 @@ public class HttpFileServiceTest {
             assert304NotModified(resCached, expectedETag, expectedLastModified);
         }
 
-        // Test if the 'If-Modified-Since' header works as expected.
+        // Test if the 'If-None-Match' header works as expected. (multiple etags)
         final HttpUriRequest req2 = new HttpGet(uri);
-        req2.setHeader(HttpHeaders.IF_MODIFIED_SINCE, currentHttpDate());
+        req2.setHeader(HttpHeaders.IF_NONE_MATCH, "\"an-etag-that-never-matches\", " + expectedETag);
 
         try (CloseableHttpResponse resCached = hc.execute(req2)) {
+            assert304NotModified(resCached, expectedETag, expectedLastModified);
+        }
+
+        // Test if the 'If-None-Match' header works as expected. (an asterisk)
+        final HttpUriRequest req3 = new HttpGet(uri);
+        req3.setHeader(HttpHeaders.IF_NONE_MATCH, "*");
+
+        try (CloseableHttpResponse resCached = hc.execute(req3)) {
+            assert304NotModified(resCached, expectedETag, expectedLastModified);
+        }
+
+        // Test if the 'If-Modified-Since' header works as expected.
+        final HttpUriRequest req4 = new HttpGet(uri);
+        req4.setHeader(HttpHeaders.IF_MODIFIED_SINCE, currentHttpDate());
+
+        try (CloseableHttpResponse resCached = hc.execute(req4)) {
             assert304NotModified(resCached, expectedETag, expectedLastModified);
         }
     }

--- a/core/src/test/java/com/linecorp/armeria/server/file/HttpFileServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/file/HttpFileServiceTest.java
@@ -531,6 +531,17 @@ public class HttpFileServiceTest {
         try (CloseableHttpResponse resCached = hc.execute(req4)) {
             assert304NotModified(resCached, expectedETag, expectedLastModified);
         }
+
+        // 'If-Modified-Since' should never be evaluated if 'If-None-Match' exists.
+        final HttpUriRequest req5 = new HttpGet(uri);
+        req5.setHeader(HttpHeaders.IF_NONE_MATCH, "\"an-etag-that-never-matches\"");
+        req5.setHeader(HttpHeaders.IF_MODIFIED_SINCE, currentHttpDate());
+
+        try (CloseableHttpResponse resCached = hc.execute(req5)) {
+            // Should not receive '304 Not Modified' because the etag did not match.
+            assertStatusLine(resCached, "HTTP/1.1 200 OK");
+        }
+
     }
 
     private static void assert304NotModified(

--- a/core/src/test/java/com/linecorp/armeria/server/file/MimeTypeUtilTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/file/MimeTypeUtilTest.java
@@ -32,6 +32,14 @@ public class MimeTypeUtilTest {
     }
 
     @Test
+    public void preCompressed() {
+        assertThat(MediaType.PNG.is(MimeTypeUtil.guessFromPath("image.png.gz", "gzip"))).isTrue();
+        assertThat(MediaType.PNG.is(MimeTypeUtil.guessFromPath("/static/image.png.br", "brotli"))).isTrue();
+        assertThat(MediaType.OCTET_STREAM.is(MimeTypeUtil.guessFromPath("image.png.gz", "identity"))).isTrue();
+        assertThat(MediaType.OCTET_STREAM.is(MimeTypeUtil.guessFromPath("image.png.gz", null))).isTrue();
+    }
+
+    @Test
     public void guessedByJdk() {
         assertThat(MediaType.ZIP.is(MimeTypeUtil.guessFromPath("bundle.zip"))).isTrue();
     }

--- a/core/src/test/java/com/linecorp/armeria/server/file/MimeTypeUtilTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/file/MimeTypeUtilTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package com.linecorp.armeria.server.file;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -26,25 +25,19 @@ public class MimeTypeUtilTest {
 
     @Test
     public void knownExtensions() {
-        assertThat(MediaType.PNG.is(MimeTypeUtil.guessFromPath("image.png", false))).isTrue();
-        assertThat(MediaType.PNG.is(MimeTypeUtil.guessFromPath("/static/image.png", false))).isTrue();
-        assertThat(MediaType.PDF.is(MimeTypeUtil.guessFromPath("document.pdf", false))).isTrue();
+        assertThat(MediaType.PNG.is(MimeTypeUtil.guessFromPath("image.png"))).isTrue();
+        assertThat(MediaType.PNG.is(MimeTypeUtil.guessFromPath("/static/image.png"))).isTrue();
+        assertThat(MediaType.PDF.is(MimeTypeUtil.guessFromPath("document.pdf"))).isTrue();
+        assertThat(MediaType.OCTET_STREAM.is(MimeTypeUtil.guessFromPath("image.png.gz"))).isTrue();
     }
 
     @Test
-    public void preCompressed() {
-        assertThat(MediaType.PNG.is(MimeTypeUtil.guessFromPath("image.png.gz", true))).isTrue();
-        assertThat(MediaType.PNG.is(MimeTypeUtil.guessFromPath("/static/image.png.br", true))).isTrue();
-        assertThat(MediaType.OCTET_STREAM.is(MimeTypeUtil.guessFromPath("image.png.gz", false))).isTrue();
+    public void guessedByJdk() {
+        assertThat(MediaType.ZIP.is(MimeTypeUtil.guessFromPath("bundle.zip"))).isTrue();
     }
 
     @Test
-    public void guessed() {
-        assertThat(MediaType.ZIP.is(MimeTypeUtil.guessFromPath("bundle.zip", false))).isTrue();
-    }
-
-    @Test
-    public void unknown() {
-        assertThat(MimeTypeUtil.guessFromPath("unknown.extension", false)).isNull();
+    public void unknownExtension() {
+        assertThat(MimeTypeUtil.guessFromPath("unknown.extension")).isNull();
     }
 }

--- a/site/src/sphinx/server-annotated-service.rst
+++ b/site/src/sphinx/server-annotated-service.rst
@@ -1,5 +1,6 @@
-.. _server-annotated-service:
 .. _Publisher: https://www.reactive-streams.org/reactive-streams-1.0.2-javadoc/org/reactivestreams/Publisher.html
+
+.. _server-annotated-service:
 
 Annotated HTTP Service
 ======================

--- a/site/src/sphinx/server-http-file.rst
+++ b/site/src/sphinx/server-http-file.rst
@@ -164,6 +164,20 @@ An :api:`HttpFile` can be configured to send different headers than the auto-fil
     fb.setHeader("x-powered-by", "Armeria");
     HttpFile f = fb.build();
 
+Caching ``HttpFile``
+--------------------
+
+Unlike :api:`HttpFileService`, :api:`HttpFile` does not cache the file content. Use ``HttpFile.ofCached()``
+to enable content caching for an existing :api:`HttpFile`:
+
+.. code-block:: java
+
+    HttpFile uncachedFile = HttpFile.of(new File("/var/lib/www/index.html"));
+    HttpFile cachedFile = HttpFile.ofCached(uncachedFile, 65536);
+
+Note that you need to specify the maximum allowed length of the cached content. In the above example, the file
+will not be cached if the length of the file exceeds 65,536 bytes.
+
 Aggregating ``HttpFile``
 ------------------------
 

--- a/site/src/sphinx/server-http-file.rst
+++ b/site/src/sphinx/server-http-file.rst
@@ -201,6 +201,10 @@ that file I/O does not occur on each retrieval, you can use the ``aggregate()`` 
     // The content of the file can now be retrieved from memory.
     HttpData content = aggregated.content();
 
+Note that an aggregated :api:`HttpFile` is not linked in any way from the :api:`HttpFile` it was aggregated
+from, which means the content and attributes of the aggregated :api:`HttpFile` does not change when the original
+:api:`HttpFile` changes. Use ``HttpFile.ofCached()`` instead if such behavior is necessary.
+
 Building ``AggregatedHttpFile`` from ``HttpData``
 -------------------------------------------------
 

--- a/site/src/sphinx/server-http-file.rst
+++ b/site/src/sphinx/server-http-file.rst
@@ -105,8 +105,8 @@ based on ``If-None-Match`` and ``If-Modified-Since`` header values.
     // Serve the favicon.ico file by converting an HttpFile into a service.
     sb.service("/favicon.ico", favicon.asService());
 
-For an instance, it is possible to to serve the same file (e.g. ``index.html``) for all requests
-under a certain path, which is useful when serving a frontend application with client-side routing.
+For instance, it is possible to to serve the same file (e.g. ``index.html``) for all requests under a certain
+path, which is useful when serving a frontend application with client-side routing.
 
 .. code-block:: java
 

--- a/site/src/sphinx/server-http-file.rst
+++ b/site/src/sphinx/server-http-file.rst
@@ -139,11 +139,11 @@ Configuring ``HttpFile``
 ------------------------
 
 An :api:`HttpFile` can be configured to send different headers than the auto-filled ones using
-:api:`HttpFileBuilder`, such as:
+:api:`HttpFileBuilder`. For example, you can:
 
-- Disabling auto-generation of ``Date``, ``Last-Modified``, ``Content-Type`` and ``ETag`` header.
-- Customizing how ``ETag`` is calculated from metadata.
-- Adding or setting additional custom HTTP headers.
+- Disable auto-generation of ``Date``, ``Last-Modified``, ``Content-Type`` and ``ETag`` header.
+- Customize how ``ETag`` is calculated from metadata.
+- Add or set additional custom HTTP headers.
 
 .. code-block:: java
 

--- a/site/src/sphinx/server-http-file.rst
+++ b/site/src/sphinx/server-http-file.rst
@@ -105,7 +105,7 @@ based on ``If-None-Match`` and ``If-Modified-Since`` header values.
     // Serve the favicon.ico file by converting an HttpFile into a service.
     sb.service("/favicon.ico", favicon.asService());
 
-For instance, it is possible to to serve the same file (e.g. ``index.html``) for all requests under a certain
+For instance, it is possible to serve the same file (e.g. ``index.html``) for all requests under a certain
 path, which is useful when serving a frontend application with client-side routing.
 
 .. code-block:: java

--- a/site/src/sphinx/server-http-file.rst
+++ b/site/src/sphinx/server-http-file.rst
@@ -65,7 +65,7 @@ Serving pre-compressed files
 
     <compressed content>
 
-If ``/index.html.gz`` does not exist but ``/index.html`` does, it would fall back to serving the uncompressed
+If ``/index.html.gz`` does not exist but ``/index.html`` does, it would fall back on serving the uncompressed
 content:
 
 .. code-block:: http
@@ -122,7 +122,6 @@ path, which is useful when serving a frontend application with client-side routi
 You can also achieve the same behavior using :ref:`server-annotated-service`:
 
 .. code-block:: java
-
 
     // Register the fallback file service.
     sb.annotatedService(new Object() {

--- a/site/src/sphinx/server-http-file.rst
+++ b/site/src/sphinx/server-http-file.rst
@@ -2,8 +2,11 @@
 
 Serving static files
 ====================
-For more information, please refer to the API documentation of :api:`HttpFileService` and
-:api:`HttpFileServiceBuilder`.
+
+Use :api:`HttpFileService` to serve static files under a certain directory. :api:`HttpFileService` supports
+``GET`` and ``HEAD`` HTTP methods and will auto-fill ``Date``, ``Last-Modified``, ``ETag`` and auto-detected
+``Content-Type`` headers for you. It is also capable of sending a ``304 Not Modified`` response based on
+``If-None-Match`` and ``If-Modified-Since`` header values.
 
 .. code-block:: java
 
@@ -14,5 +17,195 @@ For more information, please refer to the API documentation of :api:`HttpFileSer
     sb.serviceUnder("/images/",
                     HttpFileService.forFileSystem("/var/lib/www/images"));
 
-    sb.serviceUnder("/",
-                    HttpFileService.forClassPath("/com/example/files"));
+    // You can also serve the resources in the class path.
+    sb.serviceUnder("/resources",
+                    HttpFileService.forClassPath("/com/example/resources"));
+
+Adjusting static file cache
+---------------------------
+
+By default, :api:`HttpFileService` caches up to 1024 files whose length is less than or equal to
+65,536 bytes. You can customize this behavior using :api:`HttpFileServiceBuilder`.
+
+.. code-block:: java
+
+    HttpFileServiceBuilder fsb = HttpFileServiceBuilder.forFileSystem("/var/lib/www/images");
+
+    // Cache up to 4096 files.
+    fsb.maxCacheEntries(4096);
+    // Cache files whose length is less than or equal to 1 MiB.
+    fsb.maxCacheEntrySizeBytes(1048576);
+
+    HttpFileService fs = fsb.build();
+
+The cache can also be disabled by specifying ``0`` for ``maxCacheEntries()``.
+
+Serving pre-compressed files
+----------------------------
+
+:api:`HttpFileService` can be configured to serve a pre-compressed file based on the value of the
+``Accept-Encoding`` header. For example, if a client sent the following HTTP request:
+
+.. code-block:: http
+
+    GET /index.html HTTP/1.1
+    Host: example.com
+    Accept-Encoding: gzip, identity
+
+:api:`HttpFileService` could look for ``/index.html.gz`` first and send the following response with the
+``Content-Encoding: gzip`` header if it exists:
+
+.. code-block:: http
+
+    HTTP/1.1 200 OK
+    Host: example.com
+    Content-Encoding: gzip
+    Content-Type: text/html
+    ...
+
+    <compressed content>
+
+If ``/index.html.gz`` does not exist but ``/index.html`` does, it would fall back to serving the uncompressed
+content:
+
+.. code-block:: http
+
+    HTTP/1.1 200 OK
+    Host: example.com
+    Content-Type: text/html
+    ...
+
+    <uncompressed content>
+
+This behavior is enabled by calling ``serveCompressedFiles(true)`` for :api:`HttpFileServiceBuilder`.
+``.gz`` (gzip) and ``.br`` (Brotli) files are supported currently.
+
+.. code-block:: java
+
+    HttpFileServiceBuilder fsb = HttpFileServiceBuilder.forClassPath("/com/example/resources");
+    // Enable serving pre-compressed files.
+    fsb.serveCompressedFiles(true);
+    HttpFileService fs = fsb.build();
+
+Serving an individual file
+--------------------------
+
+You can also serve an individual file using :api:`HttpFile`. Like :api:`HttpFileService` does, :api:`HttpFile`
+supports ``GET`` and ``HEAD`` HTTP methods and will auto-fill ``Date``, ``Last-Modified``, ``ETag`` and
+auto-detected ``Content-Type`` headers for you. It is also capable of sending a ``304 Not Modified`` response
+based on ``If-None-Match`` and ``If-Modified-Since`` header values.
+
+.. code-block:: java
+
+    import com.linecorp.armeria.server.file.HttpFile;
+
+    HttpFile favicon = HttpFile.of(new File("/var/lib/www/favicon.ico"));
+
+    ServerBuilder sb = new ServerBuilder();
+    // Serve the favicon.ico file by converting an HttpFile into a service.
+    sb.service("/favicon.ico", favicon.asService());
+
+For an instance, it is possible to to serve the same file (e.g. ``index.html``) for all requests
+under a certain path, which is useful when serving a frontend application with client-side routing.
+
+.. code-block:: java
+
+    HttpFile index = HttpFile.of(new File("/var/lib/www/index.html"));
+
+    ServerBuilder sb = new ServerBuilder();
+    // Register the file service for assets.
+    sb.serviceUnder("/node_modules", HttpFileService.forFileSystem("/var/lib/www/node_modules"));
+    sb.serviceUnder("/static", HttpFileService.forFileSystem("/var/lib/www/static"));
+    // Register the fallback file service.
+    sb.serviceUnder("/", index.asService());
+
+You can also achieve the same behavior using :ref:`server-annotated-service`:
+
+.. code-block:: java
+
+
+    // Register the fallback file service.
+    sb.annotatedService(new Object() {
+        final HttpFile index = HttpFile.of(new File("/var/lib/www/index.html"));
+        @Get
+        @Head
+        @Path("glob:/**")
+        public HttpResponse getIndex(ServiceRequestContext ctx, HttpRequest req) {
+            return index.asService().serve(ctx, req);
+        }
+    });
+
+Configuring ``HttpFile``
+------------------------
+
+An :api:`HttpFile` can be configured to send different headers than the auto-filled ones using
+:api:`HttpFileBuilder`, such as:
+
+- Disabling auto-generation of ``Date``, ``Last-Modified``, ``Content-Type`` and ``ETag`` header.
+- Customizing how ``ETag`` is calculated from metadata.
+- Adding or setting additional custom HTTP headers.
+
+.. code-block:: java
+
+    import com.linecorp.armeria.server.file.HttpFileBuilder;
+
+    HttpFileBuilder fb = HttpFileBuilder.of(new File("/var/lib/www/index.html"));
+    // Disable the 'Date' header.
+    fb.date(false);
+    // Disable the 'Last-Modified' header.
+    fb.lastModified(false);
+    // Disable the 'ETag' header.
+    fb.entityTag(false);
+    // Disable the 'Content-Type' header.
+    fb.autoDetectContentType(false);
+    // Set the 'Content-Type' header manually.
+    fb.setHeader(HttpHeaderNames.CONTENT_TYPE, "text/html; charset=EUC-KR");
+    // Set a custom header.
+    fb.setHeader("x-powered-by", "Armeria");
+    HttpFile f = fb.build();
+
+Aggregating ``HttpFile``
+------------------------
+
+An :api:`HttpFile` usually does not store its content in memory but reads its content on demand, allowing you
+to stream a potentially very large file. If you want to ensure the content of the file is kept in memory so
+that file I/O does not occur on each retrieval, you can use the ``aggregate()`` method:
+
+.. code-block:: java
+
+    // You need to prepare an Executor which will be used for reading the file,
+    // because file I/O is often a blocking operation.
+    Executor ioExecutor = ...;
+
+    HttpFile file = HttpFile.of(new File("/var/lib/www/img/logo.png");
+    CompletableFuture<AggregatedHttpFile> future = file.aggregate(ioExecutor);
+    AggregatedHttpFile aggregated = future.join();
+
+    // Note that AggregatedHttpFile is a subtype of HttpFile.
+    assert aggregated instanceof HttpFile;
+
+    // The content of the file can now be retrieved from memory.
+    HttpData content = aggregated.content();
+
+Building ``AggregatedHttpFile`` from ``HttpData``
+-------------------------------------------------
+
+The content you need to serve is not always from an external resource but sometimes from memory, such as
+``byte[]`` or ``String``. Use ``HttpFile.of(HttpData)`` or ``HttpFileBuilder.of(HttpData)`` to build an
+``AggregatedHttpFile`` from an in-memory resource:
+
+.. code-block:: java
+
+    // Build from a byte array.
+    AggregatedHttpFile f1 = HttpFile.of(HttpData.of(new byte[] { 1, 2, 3, 4 }));
+
+    // Build from a String.
+    AggregatedHttpFile f2 = HttpFile.of(HttpData.ofUtf8("Hello, world!"));
+
+    // Build using a builder with downcast.
+    // Note: HttpFileBuilder.build() returns an AggregatedHttpFile
+    //       if HttpFileBuilder was created from an HttpData.
+    AggregatedHttpFile f3 =
+        (AggregatedHttpFile) HttpFileBuilder.of(HttpData.ofAscii("Armeria"))
+                                            .lastModified(false)
+                                            .build();


### PR DESCRIPTION
Related: #1397
Motivation:

We have `HttpFileService` but its usage is limited to serving static
files under a specific path. A user may want to serve an arbitrary
static file whose path is not necessarily mapped to request URI, e.g.
'Serve `index.html` for all requests under `/my_react_app/`.'

Modifications:

- Added `HttpFile`, `AggregatedHttpFile`, `HttpFileBuilder` and their
  related subtypes.
- (Breaking change) Changed the signature of `HttpVfs.get()`.
- (Breaking change) Replaced the usage of `HttpVfs.Entry` with `HttpFile`.
- Moved most logic of `HttpFileService` to `HttpFile` implementations.
  - `if-none-match` header is now supported.
- Updated `HttpFileServiceTest` to test both cached and uncached
  scenarious completely.
- Updated the web page about static file serving.
- Miscellaneous:
  - Fixed the broken Javadoc links in `HttpMessageAggregator`.
  - Fixed a bug where an HTTP/1 response adds redundant 'content-length: 0'
    header for status code 204, 205 and 304.

Result:

- A user can serve an individual file very easily:

      final HttpFile file = HttpFile.of(new File("/var/www/index.html"));
      final Server server = new ServerBuilder()
              .service("/index.html", file.asService());
              .build();

- Closes #1397