### PR TITLE
Make services in DocService collapsible

### DIFF
--- a/docs-client/build.gradle
+++ b/docs-client/build.gradle
@@ -15,7 +15,15 @@ buildscript {
 apply plugin: 'base'
 apply plugin: 'com.moowork.node'
 
+tasks.yarn.doFirst {
+    deleteBrokenSymlinks()
+}
+
 tasks.yarn.doLast {
+    deleteBrokenSymlinks()
+}
+
+def deleteBrokenSymlinks() {
     // Delete the broken symlinks so that Gradle does not fail the build.
     // - https://github.com/gradle/gradle/issues/1365
     // Note that this is primarily due to a bug in Yarn 1.11+:

--- a/docs-client/package.json
+++ b/docs-client/package.json
@@ -57,7 +57,7 @@
     "tslint-config-prettier": "^1.15.0",
     "tslint-plugin-prettier": "^2.0.1",
     "tslint-react": "^3.6.0",
-    "typescript": "^2.9.2",
+    "typescript": "^3.2.2",
     "webpack": "^4.24.0",
     "webpack-cli": "^3.1.2",
     "webpack-serve": "^2.0.2"

--- a/docs-client/package.json
+++ b/docs-client/package.json
@@ -12,6 +12,7 @@
     "@babel/polyfill": "^7.0.0",
     "@material-ui/core": "^3.3.2",
     "@material-ui/icons": "^3.0.1",
+    "immutability-helper": "^2.9.0",
     "jsonminify": "^0.4.1",
     "react": "^16.6.0",
     "react-dom": "^16.6.0",

--- a/docs-client/src/containers/App/index.tsx
+++ b/docs-client/src/containers/App/index.tsx
@@ -125,10 +125,10 @@ const styles = (theme: Theme) =>
 interface State {
   mobileDrawerOpen: boolean;
   specification?: Specification;
-  servicesOpen: boolean;
+  servicesSectionOpen: boolean;
   serviceOpens: { [key: string]: boolean };
-  enumsOpen: boolean;
-  structsOpen: boolean;
+  enumsSectionOpen: boolean;
+  structsSectionOpen: boolean;
   exceptionsOpen: boolean;
 }
 
@@ -138,10 +138,10 @@ interface AppDrawerProps extends WithStyles<typeof styles> {
   specification: Specification;
   navigateTo: (url: string) => void;
   httpMethodClass: (httpMethod: string) => string;
-  servicesOpen: boolean;
+  servicesSectionOpen: boolean;
   serviceOpens: { [key: string]: boolean };
-  enumsOpen: boolean;
-  structsOpen: boolean;
+  enumsSectionOpen: boolean;
+  structsSectionOpen: boolean;
   exceptionsOpen: boolean;
   handleCollapse: (itemName: string) => void;
   handleServiceCollapse: (serviceName: string) => void;
@@ -151,10 +151,10 @@ function AppDrawer({
   navigateTo,
   httpMethodClass,
   specification,
-  servicesOpen,
+  servicesSectionOpen,
   serviceOpens,
-  enumsOpen,
-  structsOpen,
+  enumsSectionOpen,
+  structsSectionOpen,
   exceptionsOpen,
   handleCollapse,
   handleServiceCollapse,
@@ -167,9 +167,9 @@ function AppDrawer({
             <ListItemText disableTypography>
               <Typography variant="headline">Services</Typography>
             </ListItemText>
-            {servicesOpen ? <ExpandLess /> : <ExpandMore />}
+            {servicesSectionOpen ? <ExpandLess /> : <ExpandMore />}
           </ListItem>
-          <Collapse in={servicesOpen} timeout="auto">
+          <Collapse in={servicesSectionOpen} timeout="auto">
             {specification.getServices().map((service) => (
               <div key={service.name}>
                 <ListItem
@@ -232,9 +232,9 @@ function AppDrawer({
             <ListItemText disableTypography>
               <Typography variant="headline">Enums</Typography>
             </ListItemText>
-            {enumsOpen ? <ExpandLess /> : <ExpandMore />}
+            {enumsSectionOpen ? <ExpandLess /> : <ExpandMore />}
           </ListItem>
-          <Collapse in={enumsOpen} timeout="auto">
+          <Collapse in={enumsSectionOpen} timeout="auto">
             {specification.getEnums().map((enm) => (
               <ListItem
                 dense
@@ -261,9 +261,9 @@ function AppDrawer({
             <ListItemText disableTypography>
               <Typography variant="headline">Structs</Typography>
             </ListItemText>
-            {structsOpen ? <ExpandLess /> : <ExpandMore />}
+            {structsSectionOpen ? <ExpandLess /> : <ExpandMore />}
           </ListItem>
-          <Collapse in={structsOpen} timeout="auto">
+          <Collapse in={structsSectionOpen} timeout="auto">
             {specification.getStructs().map((struct) => (
               <ListItem
                 dense
@@ -321,21 +321,15 @@ class App extends React.PureComponent<Props, State> {
   public state: State = {
     mobileDrawerOpen: false,
     specification: undefined,
-    servicesOpen: true,
+    servicesSectionOpen: true,
     serviceOpens: {},
-    enumsOpen: true,
-    structsOpen: true,
+    enumsSectionOpen: true,
+    structsSectionOpen: true,
     exceptionsOpen: true,
   };
 
   public componentWillMount() {
-    this.fetchSpecification().then((specification) => {
-      let serviceOpens = {};
-      specification.getServices().forEach((service) => {
-        serviceOpens = { ...serviceOpens, ...{ [service.name]: true } };
-      });
-      this.setState({ specification, serviceOpens });
-    });
+    this.initSpecification();
   }
 
   public render() {
@@ -394,10 +388,10 @@ class App extends React.PureComponent<Props, State> {
               specification={specification}
               navigateTo={this.navigateTo}
               httpMethodClass={this.httpMethodClass}
-              servicesOpen={this.state.servicesOpen}
+              servicesSectionOpen={this.state.servicesSectionOpen}
               serviceOpens={this.state.serviceOpens}
-              enumsOpen={this.state.enumsOpen}
-              structsOpen={this.state.structsOpen}
+              enumsSectionOpen={this.state.enumsSectionOpen}
+              structsSectionOpen={this.state.structsSectionOpen}
               exceptionsOpen={this.state.exceptionsOpen}
               handleCollapse={this.handleCollapse}
               handleServiceCollapse={this.handleServiceCollapse}
@@ -419,10 +413,10 @@ class App extends React.PureComponent<Props, State> {
               specification={specification}
               navigateTo={this.navigateTo}
               httpMethodClass={this.httpMethodClass}
-              servicesOpen={this.state.servicesOpen}
+              servicesSectionOpen={this.state.servicesSectionOpen}
               serviceOpens={this.state.serviceOpens}
-              enumsOpen={this.state.enumsOpen}
-              structsOpen={this.state.structsOpen}
+              enumsSectionOpen={this.state.enumsSectionOpen}
+              structsSectionOpen={this.state.structsSectionOpen}
               exceptionsOpen={this.state.exceptionsOpen}
               handleCollapse={this.handleCollapse}
               handleServiceCollapse={this.handleServiceCollapse}
@@ -501,10 +495,15 @@ class App extends React.PureComponent<Props, State> {
     return `${classes.httpMethodCommon} ${httpMethodClass}`;
   };
 
-  private fetchSpecification = async () => {
+  private initSpecification = async () => {
     const httpResponse = await fetch('specification.json');
     const specificationData: SpecificationData = await httpResponse.json();
-    return new Specification(specificationData);
+    const specification = new Specification(specificationData);
+    let serviceOpens = {};
+    specification.getServices().forEach((service) => {
+      serviceOpens = { ...serviceOpens, ...{ [service.name]: true } };
+    });
+    this.setState({ specification, serviceOpens });
   };
 
   private toggleMobileDrawer = () => {
@@ -517,17 +516,17 @@ class App extends React.PureComponent<Props, State> {
     switch (itemName) {
       case 'services':
         this.setState({
-          servicesOpen: !this.state.servicesOpen,
+          servicesSectionOpen: !this.state.servicesSectionOpen,
         });
         break;
       case 'enums':
         this.setState({
-          enumsOpen: !this.state.enumsOpen,
+          enumsSectionOpen: !this.state.enumsSectionOpen,
         });
         break;
       case 'structs':
         this.setState({
-          structsOpen: !this.state.structsOpen,
+          structsSectionOpen: !this.state.structsSectionOpen,
         });
         break;
       case 'exceptions':
@@ -539,9 +538,9 @@ class App extends React.PureComponent<Props, State> {
   };
 
   private handleServiceCollapse = (serviceName: string) => {
-    const serviceOpens = { ...this.state.serviceOpens };
+    const serviceOpens = this.state.serviceOpens;
     serviceOpens[serviceName] = !serviceOpens[serviceName];
-    this.setState({ serviceOpens });
+    this.forceUpdate(); // Call forceUpdate to render the service collapse.
   };
 }
 

--- a/docs-client/src/containers/App/index.tsx
+++ b/docs-client/src/containers/App/index.tsx
@@ -34,6 +34,7 @@ import Typography from '@material-ui/core/Typography';
 import ExpandLess from '@material-ui/icons/ExpandLess';
 import ExpandMore from '@material-ui/icons/ExpandMore';
 import MenuIcon from '@material-ui/icons/Menu';
+import update from 'immutability-helper';
 import React from 'react';
 import Helmet from 'react-helmet';
 import { hot } from 'react-hot-loader';
@@ -126,7 +127,7 @@ interface State {
   mobileDrawerOpen: boolean;
   specification?: Specification;
   servicesSectionOpen: boolean;
-  serviceOpens: { [key: string]: boolean };
+  openServices: { [key: string]: boolean };
   enumsSectionOpen: boolean;
   structsSectionOpen: boolean;
   exceptionsOpen: boolean;
@@ -139,7 +140,7 @@ interface AppDrawerProps extends WithStyles<typeof styles> {
   navigateTo: (url: string) => void;
   httpMethodClass: (httpMethod: string) => string;
   servicesSectionOpen: boolean;
-  serviceOpens: { [key: string]: boolean };
+  openServices: { [key: string]: boolean };
   enumsSectionOpen: boolean;
   structsSectionOpen: boolean;
   exceptionsOpen: boolean;
@@ -152,7 +153,7 @@ function AppDrawer({
   httpMethodClass,
   specification,
   servicesSectionOpen,
-  serviceOpens,
+  openServices,
   enumsSectionOpen,
   structsSectionOpen,
   exceptionsOpen,
@@ -181,9 +182,9 @@ function AppDrawer({
                       <code>{simpleName(service.name)}</code>
                     </Typography>
                   </ListItemText>
-                  {serviceOpens[service.name] ? <ExpandLess /> : <ExpandMore />}
+                  {openServices[service.name] ? <ExpandLess /> : <ExpandMore />}
                 </ListItem>
-                <Collapse in={serviceOpens[service.name]} timeout="auto">
+                <Collapse in={openServices[service.name]} timeout="auto">
                   {service.methods.map((method) => (
                     <ListItem
                       dense
@@ -322,7 +323,7 @@ class App extends React.PureComponent<Props, State> {
     mobileDrawerOpen: false,
     specification: undefined,
     servicesSectionOpen: true,
-    serviceOpens: {},
+    openServices: {},
     enumsSectionOpen: true,
     structsSectionOpen: true,
     exceptionsOpen: true,
@@ -389,7 +390,7 @@ class App extends React.PureComponent<Props, State> {
               navigateTo={this.navigateTo}
               httpMethodClass={this.httpMethodClass}
               servicesSectionOpen={this.state.servicesSectionOpen}
-              serviceOpens={this.state.serviceOpens}
+              openServices={this.state.openServices}
               enumsSectionOpen={this.state.enumsSectionOpen}
               structsSectionOpen={this.state.structsSectionOpen}
               exceptionsOpen={this.state.exceptionsOpen}
@@ -414,7 +415,7 @@ class App extends React.PureComponent<Props, State> {
               navigateTo={this.navigateTo}
               httpMethodClass={this.httpMethodClass}
               servicesSectionOpen={this.state.servicesSectionOpen}
-              serviceOpens={this.state.serviceOpens}
+              openServices={this.state.openServices}
               enumsSectionOpen={this.state.enumsSectionOpen}
               structsSectionOpen={this.state.structsSectionOpen}
               exceptionsOpen={this.state.exceptionsOpen}
@@ -499,11 +500,11 @@ class App extends React.PureComponent<Props, State> {
     const httpResponse = await fetch('specification.json');
     const specificationData: SpecificationData = await httpResponse.json();
     const specification = new Specification(specificationData);
-    let serviceOpens = {};
+    let openServices = {};
     specification.getServices().forEach((service) => {
-      serviceOpens = { ...serviceOpens, ...{ [service.name]: true } };
+      openServices = { ...openServices, ...{ [service.name]: true } };
     });
-    this.setState({ specification, serviceOpens });
+    this.setState({ specification, openServices });
   };
 
   private toggleMobileDrawer = () => {
@@ -538,9 +539,11 @@ class App extends React.PureComponent<Props, State> {
   };
 
   private handleServiceCollapse = (serviceName: string) => {
-    const serviceOpens = this.state.serviceOpens;
-    serviceOpens[serviceName] = !serviceOpens[serviceName];
-    this.forceUpdate(); // Call forceUpdate to render the service collapse.
+    this.setState({
+      openServices: update(this.state.openServices, {
+        [serviceName]: { $set: !this.state.openServices[serviceName] },
+      }),
+    });
   };
 }
 

--- a/docs-client/src/containers/App/index.tsx
+++ b/docs-client/src/containers/App/index.tsx
@@ -502,7 +502,7 @@ class App extends React.PureComponent<Props, State> {
     const specification = new Specification(specificationData);
     let openServices = {};
     specification.getServices().forEach((service) => {
-      openServices = { ...openServices, ...{ [service.name]: true } };
+      openServices = { ...openServices, [service.name]: true };
     });
     this.setState({ specification, openServices });
   };

--- a/docs-client/src/containers/MethodPage/index.tsx
+++ b/docs-client/src/containers/MethodPage/index.tsx
@@ -63,7 +63,6 @@ interface State {
   additionalQueries: string;
   endpointPathOpen: boolean;
   endpointPath: string;
-  regexPathPrefix: string;
   originalPath: string;
   additionalHeadersOpen: boolean;
   additionalHeaders: string;
@@ -87,7 +86,6 @@ export default class MethodPage extends React.PureComponent<Props, State> {
     additionalQueries: '',
     endpointPathOpen: false,
     endpointPath: '',
-    regexPathPrefix: '',
     originalPath: '',
     additionalHeadersOpen: false,
     additionalHeaders: '',
@@ -289,7 +287,6 @@ export default class MethodPage extends React.PureComponent<Props, State> {
                               placeholder={endpointPathPlaceHolder}
                               onChange={this.onEndpointPathChange.bind(
                                 this,
-                                method.endpoints[0].regexPathPrefix,
                                 method.endpoints[0].pathMapping,
                               )}
                               inputProps={{
@@ -416,12 +413,10 @@ export default class MethodPage extends React.PureComponent<Props, State> {
   };
 
   private onEndpointPathChange = (
-    regexPathPrefix: string,
     originalPath: string,
     e: ChangeEvent<HTMLInputElement>,
   ) => {
     this.setState({
-      regexPathPrefix,
       originalPath,
       endpointPath: e.target.value,
     });
@@ -712,7 +707,6 @@ export default class MethodPage extends React.PureComponent<Props, State> {
       additionalQueriesOpen: !!urlQueries,
       endpointPath: urlEndpointPath,
       endpointPathOpen: !!urlEndpointPath,
-      regexPathPrefix: '',
       originalPath: '',
       additionalHeaders:
         urlHeaders ||

--- a/docs-client/yarn.lock
+++ b/docs-client/yarn.lock
@@ -3266,6 +3266,13 @@ ignore-walk@^3.0.1:
   dependencies:
     minimatch "^3.0.4"
 
+immutability-helper@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/immutability-helper/-/immutability-helper-2.9.0.tgz#04a1c646300cd3a68aa5dc1daa7758da2ca75292"
+  integrity sha512-2LYtDuGugMLyoFV0qGvblnq39E2VVQ9m4dDktlRLVBBVV1LnUMK0rlqkbtlUjfT1UJO876OobtPlNZTEbOOYVQ==
+  dependencies:
+    invariant "^2.2.0"
+
 import-lazy@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-2.1.0.tgz#05698e3d45c88e8d7e9d92cb0584e77f096f3e43"
@@ -3337,7 +3344,7 @@ interpret@^1.1.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
   integrity sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=
 
-invariant@^2.2.1, invariant@^2.2.2, invariant@^2.2.4:
+invariant@^2.2.0, invariant@^2.2.1, invariant@^2.2.2, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
@@ -6190,10 +6197,10 @@ typeface-roboto@^0.0.54:
   resolved "https://registry.yarnpkg.com/typeface-roboto/-/typeface-roboto-0.0.54.tgz#8f02c9a18d1cfa7f49381a6ff0d21ff061f38ad2"
   integrity sha512-sOFA1FXgP0gOgBYlS6irwq6hHYA370KE3dPlgYEJHL3PJd5X8gQE0RmL79ONif6fL5JZuGDj+rtOrFeOqz5IZQ==
 
-typescript@^2.9.2:
-  version "2.9.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
-  integrity sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==
+typescript@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.2.tgz#fe8101c46aa123f8353523ebdcf5730c2ae493e5"
+  integrity sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg==
 
 ua-parser-js@^0.7.18:
   version "0.7.19"

--- a/licenses/web-licenses.txt
+++ b/licenses/web-licenses.txt
@@ -679,6 +679,32 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----
 
+The following software may be included in this product: immutability-helper. A copy of the source code may be downloaded from git+https://github.com/kolodny/immutability-helper.git. This software contains the following license and notice below:
+
+MIT License
+
+Copyright (c) 2017 Moshe Kolodny
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+-----
+
 The following software may be included in this product: indefinite-observable. A copy of the source code may be downloaded from git@github.com:material-motion/indefinite-observable-js.git. This software contains the following license and notice below:
 
 Apache License


### PR DESCRIPTION
Motivation:
When there are many services to show in `DocService`, it's not easy to see the
main content page because when the scroll goes down the main content does not follow.
So if we can collapse the services, it will me much easier to look at the main content.

Modifications:

- Make services collapsible
- Make the `AppDrawer` scrollable

Result:

- Better UI