### PR TITLE
Add ServerConfig.verboseResponses()

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -285,7 +285,7 @@ public final class Flags {
      * insecure. When disabled, the server responses will not expose such server-side details to the client.
      *
      * <p>This flag is disabled by default. Specify the {@code -Dcom.linecorp.armeria.verboseResponses=true}
-     * JVM option to enable it.
+     * JVM option or use {@link ServerBuilder#verboseResponses(boolean)} to enable it.
      */
     public static boolean verboseResponses() {
         return VERBOSE_RESPONSES;

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -156,6 +156,7 @@ public final class ServerBuilder {
     private long idleTimeoutMillis = Flags.defaultServerIdleTimeoutMillis();
     private long defaultRequestTimeoutMillis = Flags.defaultRequestTimeoutMillis();
     private long defaultMaxRequestLength = Flags.defaultMaxRequestLength();
+    private boolean verboseResponses = Flags.verboseResponses();
     private int http2InitialConnectionWindowSize = Flags.defaultHttp2InitialConnectionWindowSize();
     private int http2InitialStreamWindowSize = Flags.defaultHttp2InitialStreamWindowSize();
     private long http2MaxStreamsPerConnection = Flags.defaultHttp2MaxStreamsPerConnection();
@@ -471,10 +472,21 @@ public final class ServerBuilder {
      * Sets the maximum allowed length of the content decoded at the session layer.
      * e.g. the content length of an HTTP request.
      *
-     *  @param defaultMaxRequestLength the maximum allowed length. {@code 0} disables the length limit.
+     * @param defaultMaxRequestLength the maximum allowed length. {@code 0} disables the length limit.
      */
     public ServerBuilder defaultMaxRequestLength(long defaultMaxRequestLength) {
         this.defaultMaxRequestLength = validateDefaultMaxRequestLength(defaultMaxRequestLength);
+        return this;
+    }
+
+    /**
+     * Sets whether the verbose response mode is enabled. When enabled, the server responses will contain
+     * the exception type and its full stack trace, which may be useful for debugging while potentially
+     * insecure. When disabled, the server responses will not expose such server-side details to the client.
+     * The default value of this property is retrieved from {@link Flags#verboseResponses()}.
+     */
+    public ServerBuilder verboseResponses(boolean verboseResponses) {
+        this.verboseResponses = verboseResponses;
         return this;
     }
 
@@ -1218,7 +1230,7 @@ public final class ServerBuilder {
         final Server server = new Server(new ServerConfig(
                 ports, normalizeDefaultVirtualHost(defaultVirtualHost, defaultSslContext), virtualHosts,
                 workerGroup, shutdownWorkerGroupOnStop, startStopExecutor, maxNumConnections,
-                idleTimeoutMillis, defaultRequestTimeoutMillis, defaultMaxRequestLength,
+                idleTimeoutMillis, defaultRequestTimeoutMillis, defaultMaxRequestLength, verboseResponses,
                 http2InitialConnectionWindowSize, http2InitialStreamWindowSize, http2MaxStreamsPerConnection,
                 http2MaxFrameSize, http2MaxHeaderListSize,
                 http1MaxInitialLineLength, http1MaxHeaderSize, http1MaxChunkSize,
@@ -1293,8 +1305,8 @@ public final class ServerBuilder {
         return ServerConfig.toString(
                 getClass(), ports, defaultVirtualHost, virtualHosts, workerGroup, shutdownWorkerGroupOnStop,
                 maxNumConnections, idleTimeoutMillis, defaultRequestTimeoutMillis, defaultMaxRequestLength,
-                http2InitialConnectionWindowSize, http2InitialStreamWindowSize, http2MaxStreamsPerConnection,
-                http2MaxFrameSize, http2MaxHeaderListSize,
+                verboseResponses, http2InitialConnectionWindowSize, http2InitialStreamWindowSize,
+                http2MaxStreamsPerConnection, http2MaxFrameSize, http2MaxHeaderListSize,
                 http1MaxInitialLineLength, http1MaxHeaderSize, http1MaxChunkSize,
                 proxyProtocolMaxTlvSize, gracefulShutdownQuietPeriod, gracefulShutdownTimeout,
                 blockingTaskExecutor, meterRegistry, serviceLoggerPrefix,

--- a/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
@@ -69,6 +69,7 @@ public final class ServerConfig {
     private final long defaultRequestTimeoutMillis;
     private final long idleTimeoutMillis;
     private final long defaultMaxRequestLength;
+    private final boolean verboseResponses;
     private final int http2InitialConnectionWindowSize;
     private final int http2InitialStreamWindowSize;
     private final long http2MaxStreamsPerConnection;
@@ -107,7 +108,7 @@ public final class ServerConfig {
             VirtualHost defaultVirtualHost, Iterable<VirtualHost> virtualHosts,
             EventLoopGroup workerGroup, boolean shutdownWorkerGroupOnStop, Executor startStopExecutor,
             int maxNumConnections, long idleTimeoutMillis,
-            long defaultRequestTimeoutMillis, long defaultMaxRequestLength,
+            long defaultRequestTimeoutMillis, long defaultMaxRequestLength, boolean verboseResponses,
             int http2InitialConnectionWindowSize, int http2InitialStreamWindowSize,
             long http2MaxStreamsPerConnection, int http2MaxFrameSize, long http2MaxHeaderListSize,
             int http1MaxInitialLineLength, int http1MaxHeaderSize, int http1MaxChunkSize,
@@ -132,6 +133,7 @@ public final class ServerConfig {
         this.idleTimeoutMillis = validateIdleTimeoutMillis(idleTimeoutMillis);
         this.defaultRequestTimeoutMillis = validateDefaultRequestTimeoutMillis(defaultRequestTimeoutMillis);
         this.defaultMaxRequestLength = validateDefaultMaxRequestLength(defaultMaxRequestLength);
+        this.verboseResponses = verboseResponses;
         this.http2InitialConnectionWindowSize = http2InitialConnectionWindowSize;
         this.http2InitialStreamWindowSize = http2InitialStreamWindowSize;
         this.http2MaxStreamsPerConnection = http2MaxStreamsPerConnection;
@@ -436,6 +438,15 @@ public final class ServerConfig {
     }
 
     /**
+     * Returns whether the verbose response mode is enabled. When enabled, the server responses will contain
+     * the exception type and its full stack trace, which may be useful for debugging while potentially
+     * insecure. When disabled, the server responses will not expose such server-side details to the client.
+     */
+    public boolean verboseResponses() {
+        return verboseResponses;
+    }
+
+    /**
      * Returns the maximum length of an HTTP/1 response initial line.
      */
     public int http1MaxInitialLineLength() {
@@ -585,7 +596,7 @@ public final class ServerConfig {
                     getClass(), ports(), null, virtualHosts(),
                     workerGroup(), shutdownWorkerGroupOnStop(),
                     maxNumConnections(), idleTimeoutMillis(),
-                    defaultRequestTimeoutMillis(), defaultMaxRequestLength(),
+                    defaultRequestTimeoutMillis(), defaultMaxRequestLength(), verboseResponses(),
                     http2InitialConnectionWindowSize(), http2InitialStreamWindowSize(),
                     http2MaxStreamsPerConnection(), http2MaxFrameSize(), http2MaxHeaderListSize(),
                     http1MaxInitialLineLength(), http1MaxHeaderSize(), http1MaxChunkSize(),
@@ -605,7 +616,7 @@ public final class ServerConfig {
             @Nullable VirtualHost defaultVirtualHost, List<VirtualHost> virtualHosts,
             EventLoopGroup workerGroup, boolean shutdownWorkerGroupOnStop,
             int maxNumConnections, long idleTimeoutMillis, long defaultRequestTimeoutMillis,
-            long defaultMaxRequestLength, int http2InitialConnectionWindowSize,
+            long defaultMaxRequestLength, boolean verboseResponses, int http2InitialConnectionWindowSize,
             int http2InitialStreamWindowSize, long http2MaxStreamsPerConnection, int http2MaxFrameSize,
             long http2MaxHeaderListSize, long http1MaxInitialLineLength, long http1MaxHeaderSize,
             long http1MaxChunkSize, int proxyProtocolMaxTlvSize,
@@ -671,7 +682,9 @@ public final class ServerConfig {
         buf.append(defaultRequestTimeoutMillis);
         buf.append("ms, defaultMaxRequestLength: ");
         buf.append(defaultMaxRequestLength);
-        buf.append("B, http2InitialConnectionWindowSize: ");
+        buf.append("B, verboseResponses: ");
+        buf.append(verboseResponses);
+        buf.append(", http2InitialConnectionWindowSize: ");
         buf.append(http2InitialConnectionWindowSize);
         buf.append("B, http2InitialStreamWindowSize: ");
         buf.append(http2InitialStreamWindowSize);

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
@@ -40,7 +40,6 @@ import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 
 import com.linecorp.armeria.common.DefaultHttpHeaders;
-import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
@@ -466,7 +465,11 @@ class ArmeriaServerCall<I, O> extends ServerCall<I, O>
         }
     }
 
-    static HttpHeaders statusToTrailers(Status status, boolean headersSent) {
+    private HttpHeaders statusToTrailers(Status status, boolean headersSent) {
+        return statusToTrailers(ctx, status, headersSent);
+    }
+
+    static HttpHeaders statusToTrailers(ServiceRequestContext ctx, Status status, boolean headersSent) {
         final HttpHeaders trailers;
         if (headersSent) {
             // Normal trailers.
@@ -482,7 +485,7 @@ class ArmeriaServerCall<I, O> extends ServerCall<I, O>
         if (status.getDescription() != null) {
             trailers.add(GrpcHeaderNames.GRPC_MESSAGE, StatusMessageEscaper.escape(status.getDescription()));
         }
-        if (Flags.verboseResponses() && status.getCause() != null) {
+        if (ctx.server().config().verboseResponses() && status.getCause() != null) {
             final ThrowableProto proto = GrpcStatus.serializeThrowable(status.getCause());
             trailers.add(GrpcHeaderNames.ARMERIA_GRPC_THROWABLEPROTO_BIN,
                          Base64.getEncoder().encodeToString(proto.toByteArray()));

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
@@ -137,6 +137,7 @@ public final class GrpcService extends AbstractHttpService
         if (method == null) {
             return HttpResponse.of(
                     ArmeriaServerCall.statusToTrailers(
+                            ctx,
                             Status.UNIMPLEMENTED.withDescription("Method not found: " + methodName),
                             false));
         }
@@ -147,7 +148,7 @@ public final class GrpcService extends AbstractHttpService
                 final long timeout = TimeoutHeaderUtil.fromHeaderValue(timeoutHeader);
                 ctx.setRequestTimeout(Duration.ofNanos(timeout));
             } catch (IllegalArgumentException e) {
-                return HttpResponse.of(ArmeriaServerCall.statusToTrailers(Status.fromThrowable(e), false));
+                return HttpResponse.of(ArmeriaServerCall.statusToTrailers(ctx, Status.fromThrowable(e), false));
             }
         }
 

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/ArmeriaServerCallTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/ArmeriaServerCallTest.java
@@ -49,6 +49,7 @@ import com.linecorp.armeria.grpc.testing.Messages.SimpleResponse;
 import com.linecorp.armeria.grpc.testing.TestServiceGrpc;
 import com.linecorp.armeria.internal.grpc.ArmeriaMessageDeframer.ByteBufOrStream;
 import com.linecorp.armeria.internal.grpc.GrpcTestUtil;
+import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.testing.common.EventLoopRule;
 import com.linecorp.armeria.unsafe.grpc.GrpcUnsafeBufferUtil;
@@ -101,6 +102,7 @@ public class ArmeriaServerCallTest {
         when(res.completionFuture()).thenReturn(completionFuture);
         when(ctx.eventLoop()).thenReturn(eventLoop.get());
         when(ctx.contextAwareEventLoop()).thenReturn(eventLoop.get());
+        when(ctx.server()).thenReturn(new ServerBuilder().service("/", (ctx, req) -> null).build());
 
         when(ctx.alloc()).thenReturn(ByteBufAllocator.DEFAULT);
         call = new ArmeriaServerCall<>(

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceTest.java
@@ -39,6 +39,8 @@ import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.logging.DefaultRequestLog;
 import com.linecorp.armeria.grpc.testing.TestServiceGrpc.TestServiceImplBase;
 import com.linecorp.armeria.server.PathMapping;
+import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
 import io.netty.util.AsciiString;
@@ -59,6 +61,8 @@ public class GrpcServiceTest {
         grpcService = (GrpcService) new GrpcServiceBuilder()
                 .addService(mock(TestServiceImplBase.class))
                 .build();
+        final Server server = new ServerBuilder().service(grpcService).build();
+        when(ctx.server()).thenReturn(server);
         when(ctx.logBuilder()).thenReturn(new DefaultRequestLog(ctx));
     }
 

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnframedGrpcServiceTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnframedGrpcServiceTest.java
@@ -43,6 +43,7 @@ import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
 import com.linecorp.armeria.common.logging.DefaultRequestLog;
 import com.linecorp.armeria.grpc.testing.TestServiceGrpc.TestServiceImplBase;
 import com.linecorp.armeria.protobuf.EmptyProtos.Empty;
+import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.testing.common.EventLoopRule;
 
@@ -80,6 +81,7 @@ public class UnframedGrpcServiceTest {
 
     @Before
     public void setUp() {
+        when(ctx.server()).thenReturn(new ServerBuilder().service("/", (ctx, req) -> null).build());
         when(ctx.mappedPath()).thenReturn("/armeria.grpc.testing.TestService/EmptyCall");
         when(ctx.eventLoop()).thenReturn(eventLoop.get());
         when(ctx.contextAwareEventLoop()).thenReturn(eventLoop.get());

--- a/thrift/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
+++ b/thrift/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
@@ -46,7 +46,6 @@ import com.google.common.collect.Iterables;
 
 import com.linecorp.armeria.common.AggregatedHttpMessage;
 import com.linecorp.armeria.common.DefaultRpcResponse;
-import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
@@ -421,7 +420,7 @@ public final class THttpService extends AbstractHttpService {
         req.aggregateWithPooledObjects(ctx.eventLoop(), ctx.alloc()).handle((aReq, cause) -> {
             if (cause != null) {
                 final HttpResponse errorRes;
-                if (Flags.verboseResponses()) {
+                if (ctx.server().config().verboseResponses()) {
                     errorRes = HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR,
                                                MediaType.PLAIN_TEXT_UTF_8,
                                                Exceptions.traceText(cause));
@@ -507,7 +506,7 @@ public final class THttpService extends AbstractHttpService {
                 logger.debug("{} Failed to decode a {} header:", ctx, serializationFormat, e);
 
                 final HttpResponse errorRes;
-                if (Flags.verboseResponses()) {
+                if (ctx.server().config().verboseResponses()) {
                     errorRes = HttpResponse.of(HttpStatus.BAD_REQUEST, MediaType.PLAIN_TEXT_UTF_8,
                                                "Failed to decode a %s header: %s", serializationFormat,
                                                Exceptions.traceText(e));
@@ -743,7 +742,7 @@ public final class THttpService extends AbstractHttpService {
         if (cause instanceof TApplicationException) {
             appException = (TApplicationException) cause;
         } else {
-            if (Flags.verboseResponses()) {
+            if (ctx.server().config().verboseResponses()) {
                 appException = new TApplicationException(
                         TApplicationException.INTERNAL_ERROR,
                         "\n---- BEGIN server-side trace ----\n" +


### PR DESCRIPTION
Motivation:

`verboseResponse` flag could be controlled programmatically when
creating a `Server` because a user may not want to rely on a system
property.

Modifications:

- Added `verboseResponses` property to `ServerBuilder` and `ServerConfig`
- Removed the stack trace from the `debugData` field of a `GOAWAY` frame
  and logged the connection error exceptions explicitly instead for
  easier protocol violation diagnosis.
  - As a result, `GOAWAY` frame logging does not rely on `verboseResponses`
    anymore.

Result:

- Closes #1507