### PR TITLE
Specialize media type matching for a single range

### DIFF
--- a/benchmarks/src/jmh/java/com/linecorp/armeria/common/MediaTypesBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/common/MediaTypesBenchmark.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * Microbenchmarks for matching media types.
+ */
+public class MediaTypesBenchmark {
+
+    private static final MediaTypeSet MEDIA_TYPES = new MediaTypeSet(
+            MediaType.create("application", "grpc"), MediaType.create("application", "grpc+proto"));
+
+    private static final MediaType GRPC_MEDIA_TYPE = MediaType.create("application", "grpc");
+
+    private static final MediaType NOT_GRPC_MEDIA_TYPE = MediaType.create("application", "json");
+
+    private static final MediaType GRPC_MEDIA_TYPE_WITH_PARAMS =
+            MediaType.parse("application/grpc; charset=utf-8; q=0.9");
+
+    private static final MediaType NOT_GRPC_MEDIA_TYPE_WITH_PARAMS =
+            MediaType.parse("application/grpc; charset=utf-8; q=0.9");
+
+    @Benchmark
+    public void simpleMatch(Blackhole bh) {
+        bh.consume(MEDIA_TYPES.match(GRPC_MEDIA_TYPE));
+    }
+
+    @Benchmark
+    public void simpleNotMatch(Blackhole bh) {
+        bh.consume(MEDIA_TYPES.match(NOT_GRPC_MEDIA_TYPE));
+    }
+
+    @Benchmark
+    public void complexMatch(Blackhole bh) {
+        bh.consume(MEDIA_TYPES.match(GRPC_MEDIA_TYPE_WITH_PARAMS));
+    }
+
+    @Benchmark
+    public void complexNotMatch(Blackhole bh) {
+        bh.consume(MEDIA_TYPES.match(NOT_GRPC_MEDIA_TYPE_WITH_PARAMS));
+    }
+
+    @Benchmark
+    public void all(Blackhole bh) {
+        // Do all matches to reduce branch predictor accuracy.
+        bh.consume(MEDIA_TYPES.match(GRPC_MEDIA_TYPE));
+        bh.consume(MEDIA_TYPES.match(NOT_GRPC_MEDIA_TYPE));
+        bh.consume(MEDIA_TYPES.match(GRPC_MEDIA_TYPE_WITH_PARAMS));
+        bh.consume(MEDIA_TYPES.match(NOT_GRPC_MEDIA_TYPE_WITH_PARAMS));
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/common/MediaTypeSet.java
+++ b/core/src/main/java/com/linecorp/armeria/common/MediaTypeSet.java
@@ -21,7 +21,6 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.AbstractSet;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -31,11 +30,12 @@ import java.util.Set;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
 
 /**
  * An immutable {@link Set} of {@link MediaType}s which provides useful methods for content negotiation.
  *
- * <p>This {@link Set} provides {@link #match(MediaType...)} and {@link #matchHeaders(CharSequence...)}
+ * <p>This {@link Set} provides {@link #match(MediaType)} and {@link #matchHeaders(CharSequence...)}
  * so that a user can find the preferred {@link MediaType} that matches the specified media ranges. For example:
  * <pre>{@code
  * MediaTypeSet set = new MediaTypeSet(MediaType.HTML_UTF_8, MediaType.PLAIN_TEXT_UTF_8);
@@ -151,14 +151,34 @@ public final class MediaTypeSet extends AbstractSet<MediaType> {
     }
 
     /**
+     * Finds the {@link MediaType} in this {@link List} that matches the specified media range.
+     *
+     * @return the {@link MediaType} that matches the specified media range.
+     *         {@link Optional#empty()} if there are no matches
+     */
+    public Optional<MediaType> match(MediaType range) {
+        requireNonNull(range, "range");
+        for (MediaType candidate : mediaTypes) {
+            if (candidate.belongsTo(range)) {
+                // With only one specified range, there is no way for candidates to have priority over each
+                // other, we just return the first match.
+                return Optional.of(candidate);
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
      * Finds the {@link MediaType} in this {@link List} that matches one of the specified media ranges.
      *
      * @return the most preferred {@link MediaType} that matches one of the specified media ranges.
      *         {@link Optional#empty()} if there are no matches or {@code ranges} does not contain
      *         any valid ranges.
      */
-    public Optional<MediaType> match(MediaType... ranges) {
-        return match(Arrays.asList(requireNonNull(ranges, "ranges")));
+    public Optional<MediaType> match(MediaType first, MediaType... rest) {
+        requireNonNull(first, "first");
+        requireNonNull(rest, "rest");
+        return match(Lists.asList(first, rest));
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/MediaTypeSet.java
+++ b/core/src/main/java/com/linecorp/armeria/common/MediaTypeSet.java
@@ -197,21 +197,21 @@ public final class MediaTypeSet extends AbstractSet<MediaType> {
         int matchNumParams = Integer.MIN_VALUE;    // higher = better
         for (MediaType range : ranges) {
             requireNonNull(range, "ranges contains null.");
+            float qValue = range.qualityFactor(Float.NEGATIVE_INFINITY);
+            final int numWildcards = range.numWildcards();
+            final int numParams;
+            if (qValue < 0) {
+                // qvalue does not exist; use the default value of 1.0.
+                qValue = 1.0f;
+                numParams = range.parameters().size();
+            } else {
+                // Do not count the qvalue.
+                numParams = range.parameters().size() - 1;
+            }
+
             for (MediaType candidate : mediaTypes) {
                 if (!candidate.belongsTo(range)) {
                     continue;
-                }
-
-                float qValue = range.qualityFactor(Float.NEGATIVE_INFINITY);
-                final int numWildcards = range.numWildcards();
-                final int numParams;
-                if (qValue < 0) {
-                    // qvalue does not exist; use the default value of 1.0.
-                    qValue = 1.0f;
-                    numParams = range.parameters().size();
-                } else {
-                    // Do not count the qvalue.
-                    numParams = range.parameters().size() - 1;
                 }
 
                 final boolean isBetter;
@@ -234,6 +234,9 @@ public final class MediaTypeSet extends AbstractSet<MediaType> {
                     matchQ = qValue;
                     matchNumWildcards = numWildcards;
                     matchNumParams = numParams;
+
+                    // Won't find another better candidate for this range.
+                    break;
                 }
             }
         }

--- a/core/src/main/java/com/linecorp/armeria/common/SerializationFormat.java
+++ b/core/src/main/java/com/linecorp/armeria/common/SerializationFormat.java
@@ -19,9 +19,9 @@ package com.linecorp.armeria.common;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.linecorp.armeria.common.MediaType.create;
-import static java.util.Arrays.asList;
 import static java.util.Objects.requireNonNull;
 
+import java.util.Arrays;
 import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.Set;
@@ -34,6 +34,7 @@ import com.google.common.collect.HashBiMap;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 
 /**
@@ -231,7 +232,7 @@ public final class SerializationFormat implements Comparable<SerializationFormat
         }
 
         for (SerializationFormat f : values()) {
-            if (f.isAccepted(ranges)) {
+            if (f.isAccepted(Arrays.asList(ranges))) {
                 return Optional.of(f);
             }
         }
@@ -290,12 +291,31 @@ public final class SerializationFormat implements Comparable<SerializationFormat
     }
 
     /**
+     * Returns whether the specified media range is accepted by any of the {@link #mediaTypes()}
+     * defined by this format.
+     */
+    public boolean isAccepted(MediaType range) {
+        requireNonNull(range, "range");
+        return mediaTypes.match(range).isPresent();
+    }
+
+    /**
      * Returns whether any of the specified media ranges is accepted by any of the {@link #mediaTypes()}
      * defined by this format.
      */
-    public boolean isAccepted(MediaType... ranges) {
+    public boolean isAccepted(MediaType first, MediaType... others) {
+        requireNonNull(first, "first");
+        requireNonNull(others, "others");
+        return isAccepted(Lists.asList(first, others));
+    }
+
+    /**
+     * Returns whether any of the specified media ranges is accepted by any of the {@link #mediaTypes()}
+     * defined by this format.
+     */
+    public boolean isAccepted(Iterable<MediaType> ranges) {
         requireNonNull(ranges, "ranges");
-        return mediaTypes.match(asList(ranges)).isPresent();
+        return mediaTypes.match(ranges).isPresent();
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/SerializationFormat.java
+++ b/core/src/main/java/com/linecorp/armeria/common/SerializationFormat.java
@@ -19,6 +19,7 @@ package com.linecorp.armeria.common;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.linecorp.armeria.common.MediaType.create;
+import static java.util.Arrays.asList;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Optional;
@@ -294,7 +295,7 @@ public final class SerializationFormat implements Comparable<SerializationFormat
      */
     public boolean isAccepted(MediaType... ranges) {
         requireNonNull(ranges, "ranges");
-        return mediaTypes.match(ranges).isPresent();
+        return mediaTypes.match(asList(ranges)).isPresent();
     }
 
     @Override

--- a/core/src/test/java/com/linecorp/armeria/common/MediaTypeSetTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/MediaTypeSetTest.java
@@ -46,6 +46,10 @@ public class MediaTypeSetTest {
         // No ranges
         assertThat(set.match(ImmutableList.of())).isEmpty();
 
+        // One match
+        assertThat(set.match(PLAIN_TEXT_UTF_8)).contains(PLAIN_TEXT_UTF_8);
+        assertThat(set.match(HTML_UTF_8)).contains(HTML_UTF_8);
+
         // More than one range
         assertThat(set.match(HTML_UTF_8.withParameter("q", "0.5"), PLAIN_TEXT_UTF_8))
                 .contains(PLAIN_TEXT_UTF_8);


### PR DESCRIPTION
While looking at code, I found this low hanging fruit. Matching media types is much simpler for a single one than multiple, so specializing the code for a single argument improves performance of matching. I found most callers to be matching against a single format (`GrpcService`, `THttpService`) so it's some free (micro-) performance.

After
```
Benchmark                             Mode  Cnt         Score          Error  Units
MediaTypesBenchmark.all              thrpt    5  10201031.774 ±   334154.181  ops/s
MediaTypesBenchmark.complexMatch     thrpt    5  28234112.782 ±  4971845.081  ops/s
MediaTypesBenchmark.complexNotMatch  thrpt    5  25309947.033 ±  2968303.292  ops/s
MediaTypesBenchmark.simpleMatch      thrpt    5  93640157.481 ± 12225237.586  ops/s
MediaTypesBenchmark.simpleNotMatch   thrpt    5  79549461.487 ± 12319334.619  ops/s
```

Before
```
Benchmark                             Mode  Cnt         Score         Error  Units
MediaTypesBenchmark.all              thrpt    5   7383325.445 ±  204680.181  ops/s
MediaTypesBenchmark.complexMatch     thrpt    5  23564626.484 ±  418400.507  ops/s
MediaTypesBenchmark.complexNotMatch  thrpt    5  21315281.225 ± 2725154.281  ops/s
MediaTypesBenchmark.simpleMatch      thrpt    5  46150165.428 ± 3222182.395  ops/s
MediaTypesBenchmark.simpleNotMatch   thrpt    5  54324601.873 ± 1090724.032  ops/s
```