### PR TITLE
Do not return a connection to the pool if it's scheduled for disconnection

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/Http1ResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http1ResponseDecoder.java
@@ -202,7 +202,7 @@ final class Http1ResponseDecoder extends HttpResponseDecoder implements ChannelI
 
                             res.close();
 
-                            if (needsToDisconnect()) {
+                            if (needsToDisconnectNow()) {
                                 ctx.close();
                             }
                         }

--- a/core/src/main/java/com/linecorp/armeria/client/Http2ResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http2ResponseDecoder.java
@@ -142,11 +142,13 @@ final class Http2ResponseDecoder extends HttpResponseDecoder implements Http2Con
 
     @Override
     public void onGoAwaySent(int lastStreamId, long errorCode, ByteBuf debugData) {
+        disconnectWhenFinished();
         goAwayHandler.onGoAwaySent(channel(), lastStreamId, errorCode, debugData);
     }
 
     @Override
     public void onGoAwayReceived(int lastStreamId, long errorCode, ByteBuf debugData) {
+        disconnectWhenFinished();
         goAwayHandler.onGoAwayReceived(channel(), lastStreamId, errorCode, debugData);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/Http2ResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http2ResponseDecoder.java
@@ -135,6 +135,12 @@ final class Http2ResponseDecoder extends HttpResponseDecoder implements Http2Con
         } else {
             res.close(ClosedSessionException.get());
         }
+
+        // Send a GOAWAY frame if the connection has been scheduled for disconnection and
+        // it did not receive or send a GOAWAY frame.
+        if (needsToDisconnectNow() && !goAwayHandler.sentGoAway() && !goAwayHandler.receivedGoAway()) {
+            channel().close();
+        }
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
@@ -591,10 +591,10 @@ final class HttpChannelPool implements AutoCloseable {
         @Override
         public void release() {
             if (isHealthy(this)) {
-                // Channel turns out to be healthy, offering and releasing it.
+                // Channel turns out to be healthy. Add it back to the pool.
                 addToPool(protocol(), key, this);
             } else {
-                // Channel not healthy, just releasing it.
+                // Channel not healthy. Do not add it back to the pool.
             }
         }
     }

--- a/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
@@ -216,7 +216,7 @@ final class HttpChannelPool implements AutoCloseable {
 
     private static boolean isHealthy(PooledChannel pooledChannel) {
         final Channel ch = pooledChannel.get();
-        return ch.isActive() && HttpSession.get(ch).isActive();
+        return ch.isActive() && HttpSession.get(ch).canSendRequest();
     }
 
     @Nullable
@@ -497,9 +497,6 @@ final class HttpChannelPool implements AutoCloseable {
 
             final int numChannels = allChannels.size();
             final CountDownLatch latch = new CountDownLatch(numChannels);
-            if (numChannels == 0) {
-                return latch;
-            }
             final List<ChannelFuture> closeFutures = new ArrayList<>(numChannels);
             for (Channel ch : allChannels.keySet()) {
                 // NB: Do not call close() here, because it will trigger the closeFuture listener
@@ -598,10 +595,6 @@ final class HttpChannelPool implements AutoCloseable {
                 addToPool(protocol(), key, this);
             } else {
                 // Channel not healthy, just releasing it.
-                final Channel channel = get();
-                if (channel.isActive()) {
-                    channel.close();
-                }
             }
         }
     }

--- a/core/src/main/java/com/linecorp/armeria/client/HttpRequestSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpRequestSubscriber.java
@@ -152,7 +152,7 @@ final class HttpRequestSubscriber implements Subscriber<HttpObject>, ChannelFutu
 
     private void writeFirstHeader() {
         final HttpSession session = HttpSession.get(ch);
-        if (!session.isActive()) {
+        if (!session.canSendRequest()) {
             failAndRespond(UnprocessedRequestException.get());
             return;
         }

--- a/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
@@ -116,8 +116,12 @@ abstract class HttpResponseDecoder {
         disconnectWhenFinished = true;
     }
 
-    final boolean needsToDisconnect() {
+    final boolean needsToDisconnectNow() {
         return disconnectWhenFinished && !hasUnfinishedResponses();
+    }
+
+    final boolean needsToDisconnectWhenFinished() {
+        return disconnectWhenFinished;
     }
 
     static final class HttpResponseWrapper implements StreamWriter<HttpObject>, Runnable {

--- a/core/src/main/java/com/linecorp/armeria/client/HttpSession.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpSession.java
@@ -36,7 +36,7 @@ interface HttpSession {
         }
 
         @Override
-        public boolean isActive() {
+        public boolean canSendRequest() {
             return false;
         }
 
@@ -76,7 +76,7 @@ interface HttpSession {
     @Nullable
     SessionProtocol protocol();
 
-    boolean isActive();
+    boolean canSendRequest();
 
     InboundTrafficController inboundTrafficController();
 

--- a/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
@@ -130,8 +130,9 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
     }
 
     @Override
-    public boolean isActive() {
-        return active;
+    public boolean canSendRequest() {
+        assert responseDecoder != null;
+        return active && !responseDecoder.needsToDisconnectWhenFinished();
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/internal/Http2GoAwayHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/Http2GoAwayHandler.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package com.linecorp.armeria.internal;
 
 import java.nio.charset.StandardCharsets;
@@ -35,6 +34,13 @@ public final class Http2GoAwayHandler {
 
     private boolean goAwaySent;
     private long goAwayReceived; // -1 if not received, errorCode if received.
+
+    /**
+     * Returns {@code true} if the connection has sent a GOAWAY frame.
+     */
+    public boolean sentGoAway() {
+        return goAwaySent;
+    }
 
     /**
      * Returns {@code true} if the connection has received a GOAWAY frame.

--- a/core/src/test/java/com/linecorp/armeria/client/Http1ConnectionCloseHeaderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/Http1ConnectionCloseHeaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2019 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/core/src/test/java/com/linecorp/armeria/client/Http1ConnectionCloseHeaderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/Http1ConnectionCloseHeaderTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.DisableOnDebug;
+import org.junit.rules.TestRule;
+import org.junit.rules.Timeout;
+
+/**
+ * Makes sure an HTTP/1 client closes the connection when it receives a response with
+ * a {@code "connection: close"} header.
+ */
+public class Http1ConnectionCloseHeaderTest {
+
+    @Rule
+    public TestRule globalTimeout = new DisableOnDebug(new Timeout(10, TimeUnit.SECONDS));
+
+    @Test
+    public void connectionCloseHeaderInResponse() throws Exception {
+        try (ServerSocket ss = new ServerSocket(0);) {
+            final int port = ss.getLocalPort();
+
+            final HttpClient client = HttpClient.of("h1c://127.0.0.1:" + port);
+            client.get("/").aggregate();
+
+            try (Socket s = ss.accept()) {
+                final BufferedReader in = new BufferedReader(
+                        new InputStreamReader(s.getInputStream(), StandardCharsets.US_ASCII));
+                final OutputStream out = s.getOutputStream();
+                assertThat(in.readLine()).isEqualTo("GET / HTTP/1.1");
+                assertThat(in.readLine()).startsWith("host: 127.0.0.1:");
+                assertThat(in.readLine()).startsWith("user-agent: armeria/");
+                assertThat(in.readLine()).isEmpty();
+
+                out.write(("HTTP/1.1 200 OK\r\n" +
+                           "Connection: close\r\n" +
+                           "Content-Length: 0\r\n" +
+                           "\r\n").getBytes(StandardCharsets.US_ASCII));
+
+                assertThat(in.readLine()).isNull();
+            }
+        }
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/client/Http1EmptyRequestTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/Http1EmptyRequestTest.java
@@ -25,7 +25,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.DisableOnDebug;
@@ -39,7 +38,6 @@ import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
-import com.linecorp.armeria.testing.common.EventLoopRule;
 
 /**
  * Makes sure an empty HTTP/1 request is sent with or without the {@code content-length} header
@@ -60,9 +58,6 @@ public class Http1EmptyRequestTest {
                                 new Object[] { HttpMethod.TRACE, false },
                                 new Object[] { HttpMethod.CONNECT, false });
     }
-
-    @ClassRule
-    public static final EventLoopRule eventLoop = new EventLoopRule();
 
     @Rule
     public TestRule globalTimeout = new DisableOnDebug(new Timeout(10, TimeUnit.SECONDS));

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientIdleTimeoutHandlerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientIdleTimeoutHandlerTest.java
@@ -114,7 +114,7 @@ public class HttpClientIdleTimeoutHandlerTest {
         }
 
         @Override
-        public boolean isActive() {
+        public boolean canSendRequest() {
             return true;
         }
 


### PR DESCRIPTION
Motivation:

It is currently possible to return a connection to the pool even if it's
scheduled for disconnection, e.g. a connection which received a response
with a `connection: close` header or a `GOAWAY` frame.

As a result, it is possible to acquire a connection which will be closed
very soon, causing an unexpected request failure.

Modifications:

- Renamed `HttpSession.isActive()` to `canSendRequest()` to make its
  meaning clearer.
- `HttpSession.canSendRequest()` will return `false` if disconnection
  has been scheduled, e.g. received a `connection: close` header or
  sent/received a `GOAWAY` frame.
- Renamed `HttpResponseDecoder.needsToDisconnect()` to `needsToDisconnectNow()`
  for clarity.
- Added `HttpResponseDecoder.needsToDisconnectWhenFinished()`, which is
  used to tell if the connection has been scheduled for disconnection.
- Do not close the connection immediately when returning an unhealthy
  connection, because it may be handling unfinished requests.
  - The connection will be closed anyway eventually after all unfinished
    requests are handled.
- Added `Http1ConnectionCloseHeaderTest` to ensure that Armeria client
  respects the `connection: close` header.

Result:

- Less chance of getting a bad connection from the pool.