### PR TITLE
Make HttpHeaderNames.of() accept CharSequence in lieu of String

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/AbstractClientOptionsBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/AbstractClientOptionsBuilder.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.function.Function;
 
 import com.linecorp.armeria.common.DefaultHttpHeaders;
+import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
@@ -263,10 +264,10 @@ class AbstractClientOptionsBuilder<B extends AbstractClientOptionsBuilder<?>> {
     /**
      * Adds the specified HTTP header.
      */
-    public B addHttpHeader(AsciiString name, Object value) {
+    public B addHttpHeader(CharSequence name, Object value) {
         requireNonNull(name, "name");
         requireNonNull(value, "value");
-        httpHeaders.addObject(name, value);
+        httpHeaders.addObject(HttpHeaderNames.of(name), value);
         return self();
     }
 
@@ -282,10 +283,10 @@ class AbstractClientOptionsBuilder<B extends AbstractClientOptionsBuilder<?>> {
     /**
      * Sets the specified HTTP header.
      */
-    public B setHttpHeader(AsciiString name, Object value) {
+    public B setHttpHeader(CharSequence name, Object value) {
         requireNonNull(name, "name");
         requireNonNull(value, "value");
-        httpHeaders.setObject(name, value);
+        httpHeaders.setObject(HttpHeaderNames.of(name), value);
         return self();
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/HttpHeaderUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpHeaderUtil.java
@@ -24,7 +24,7 @@ final class HttpHeaderUtil {
 
     private static final String CLIENT_ARTIFACT_ID = "armeria";
 
-    static final AsciiString USER_AGENT = AsciiString.of(createUserAgentName());
+    static final AsciiString USER_AGENT = AsciiString.cached(createUserAgentName());
 
     static String hostHeader(String host, int port, int defaultPort) {
         if (port == defaultPort) {

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/StickyEndpointSelectionStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/StickyEndpointSelectionStrategy.java
@@ -39,7 +39,7 @@ import com.linecorp.armeria.common.HttpRequest;
  *
  * <pre>{@code
  * ToLongFunction<ClientRequestContext> hasher = (ClientRequestContext ctx) -> {
- *     return ((HttpRequest) ctx.request()).headers().get(AsciiString.of("cookie")).hashCode();
+ *     return ((HttpRequest) ctx.request()).headers().get(HttpHeaderNames.COOKIE).hashCode();
  * };
  * final StickyEndpointSelectionStrategy strategy = new StickyEndpointSelectionStrategy(hasher);
  * }</pre>

--- a/core/src/main/java/com/linecorp/armeria/common/HttpHeaderNames.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpHeaderNames.java
@@ -422,10 +422,10 @@ public final class HttpHeaderNames {
      */
     public static final AsciiString X_FRAME_OPTIONS = AsciiString.cached("x-frame-options");
 
-    private static final Map<String, AsciiString> map;
+    private static final Map<CharSequence, AsciiString> map;
 
     static {
-        final ImmutableMap.Builder<String, AsciiString> builder = ImmutableMap.builder();
+        final ImmutableMap.Builder<CharSequence, AsciiString> builder = ImmutableMap.builder();
         for (Field f : HttpHeaderNames.class.getDeclaredFields()) {
             final int m = f.getModifiers();
             if (Modifier.isPublic(m) && Modifier.isStatic(m) && Modifier.isFinal(m) &&
@@ -436,6 +436,7 @@ public final class HttpHeaderNames {
                 } catch (Exception e) {
                     throw new Error(e);
                 }
+                builder.put(name, name);
                 builder.put(name.toString(), name);
             }
         }
@@ -447,10 +448,25 @@ public final class HttpHeaderNames {
      * a known header name, this method will return a pre-instantiated {@link AsciiString} to reduce
      * the allocation rate of {@link AsciiString}.
      */
-    public static AsciiString of(String name) {
-        name = Ascii.toLowerCase(requireNonNull(name, "name"));
-        final AsciiString asciiName = map.get(name);
-        return asciiName != null ? asciiName : AsciiString.cached(name);
+    public static AsciiString of(CharSequence name) {
+        if (name instanceof AsciiString) {
+            return of((AsciiString) name);
+        }
+
+        final String lowerCased = Ascii.toLowerCase(requireNonNull(name, "name"));
+        final AsciiString cached = map.get(lowerCased);
+        return cached != null ? cached : AsciiString.cached(lowerCased);
+    }
+
+    /**
+     * Lower-cases and converts the specified header name into an {@link AsciiString}. If {@code name} is
+     * a known header name, this method will return a pre-instantiated {@link AsciiString} to reduce
+     * the allocation rate of {@link AsciiString}.
+     */
+    public static AsciiString of(AsciiString name) {
+        final AsciiString lowerCased = name.toLowerCase();
+        final AsciiString cached = map.get(lowerCased);
+        return cached != null ? cached : lowerCased;
     }
 
     private HttpHeaderNames() {}

--- a/core/src/main/java/com/linecorp/armeria/internal/ArmeriaHttpUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/ArmeriaHttpUtil.java
@@ -319,7 +319,7 @@ public final class ArmeriaHttpUtil {
         final HttpHeaders converted = new DefaultHttpHeaders(false, headers.size(), endOfStream);
         StringJoiner cookieJoiner = null;
         for (Entry<CharSequence, CharSequence> e : headers) {
-            final AsciiString name = AsciiString.of(e.getKey());
+            final AsciiString name = HttpHeaderNames.of(e.getKey());
             final CharSequence value = e.getValue();
 
             // Cookies must be concatenated into a single octet string.
@@ -409,7 +409,7 @@ public final class ArmeriaHttpUtil {
         StringJoiner cookieJoiner = null;
         while (iter.hasNext()) {
             final Entry<CharSequence, CharSequence> entry = iter.next();
-            final AsciiString aName = AsciiString.of(entry.getKey()).toLowerCase();
+            final AsciiString aName = HttpHeaderNames.of(entry.getKey()).toLowerCase();
             if (HTTP_TO_HTTP2_HEADER_BLACKLIST.contains(aName) || connectionBlacklist.contains(aName)) {
                 continue;
             }
@@ -443,7 +443,7 @@ public final class ArmeriaHttpUtil {
         final CharSequenceMap result = new CharSequenceMap(arraySizeHint);
 
         while (valuesIter.hasNext()) {
-            final AsciiString lowerCased = AsciiString.of(valuesIter.next()).toLowerCase();
+            final AsciiString lowerCased = HttpHeaderNames.of(valuesIter.next()).toLowerCase();
             try {
                 int index = lowerCased.forEachByte(FIND_COMMA);
                 if (index != -1) {

--- a/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedValueResolver.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedValueResolver.java
@@ -88,7 +88,6 @@ import io.netty.handler.codec.http.HttpConstants;
 import io.netty.handler.codec.http.QueryStringDecoder;
 import io.netty.handler.codec.http.cookie.Cookie;
 import io.netty.handler.codec.http.cookie.ServerCookieDecoder;
-import io.netty.util.AsciiString;
 
 final class AnnotatedValueResolver {
     private static final Logger logger = LoggerFactory.getLogger(AnnotatedValueResolver.class);
@@ -457,7 +456,7 @@ final class AnnotatedValueResolver {
                 .supportContainer(true)
                 .description(description)
                 .resolver(resolver(
-                        ctx -> ctx.request().headers().getAll(AsciiString.of(name)),
+                        ctx -> ctx.request().headers().getAll(HttpHeaderNames.of(name)),
                         () -> "Cannot resolve a value from HTTP header: " + name))
                 .build();
     }

--- a/core/src/main/java/com/linecorp/armeria/server/ClientAddressSource.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ClientAddressSource.java
@@ -38,7 +38,7 @@ import io.netty.util.AsciiString;
 public final class ClientAddressSource {
 
     private static final ClientAddressSource PROXY_PROTOCOL =
-            new ClientAddressSource(AsciiString.of("PROXY_PROTOCOL"));
+            new ClientAddressSource(HttpHeaderNames.of("PROXY_PROTOCOL"));
 
     /**
      * A default list of {@link ClientAddressSource}s.
@@ -54,7 +54,7 @@ public final class ClientAddressSource {
      */
     public static ClientAddressSource ofHeader(CharSequence header) {
         checkArgument(header != null && header.length() > 0, "empty header");
-        return new ClientAddressSource(AsciiString.of(header));
+        return new ClientAddressSource(HttpHeaderNames.of(header));
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
@@ -90,8 +90,8 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
 
     private static final int SSL_RECORD_HEADER_LENGTH = 5;
 
-    private static final AsciiString SCHEME_HTTP = AsciiString.of("http");
-    private static final AsciiString SCHEME_HTTPS = AsciiString.of("https");
+    private static final AsciiString SCHEME_HTTP = AsciiString.cached("http");
+    private static final AsciiString SCHEME_HTTPS = AsciiString.cached("https");
 
     private static final int UPGRADE_REQUEST_MAX_LENGTH = 16384;
 

--- a/core/src/main/java/com/linecorp/armeria/server/logging/AccessLogFormats.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/AccessLogFormats.java
@@ -50,8 +50,6 @@ import com.linecorp.armeria.server.logging.AccessLogComponent.TextComponent;
 import com.linecorp.armeria.server.logging.AccessLogComponent.TimestampComponent;
 import com.linecorp.armeria.server.logging.AccessLogType.VariableRequirement;
 
-import io.netty.util.AsciiString;
-
 /**
  * Pre-defined access log formats and the utility methods for {@link AccessLogComponent}.
  */
@@ -217,7 +215,7 @@ final class AccessLogFormats {
         }
         if (HttpHeaderComponent.isSupported(type)) {
             assert variable != null;
-            return new HttpHeaderComponent(type, AsciiString.of(variable), addQuote, condition);
+            return new HttpHeaderComponent(type, HttpHeaderNames.of(variable), addQuote, condition);
         }
         if (AttributeComponent.isSupported(type)) {
             assert variable != null;

--- a/core/src/test/java/com/linecorp/armeria/client/ClientOptionsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientOptionsTest.java
@@ -22,13 +22,11 @@ import org.junit.Test;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 
-import io.netty.util.AsciiString;
-
 public class ClientOptionsTest {
 
     @Test
     public void testSetHttpHeader() {
-        final HttpHeaders httpHeader = HttpHeaders.of(AsciiString.of("x-user-defined"), "HEADER_VALUE");
+        final HttpHeaders httpHeader = HttpHeaders.of(HttpHeaderNames.of("x-user-defined"), "HEADER_VALUE");
 
         final ClientOptions options = ClientOptions.of(ClientOption.HTTP_HEADERS.newValue(httpHeader));
         assertThat(options.get(ClientOption.HTTP_HEADERS)).contains(httpHeader);

--- a/core/src/test/java/com/linecorp/armeria/client/DefaultClientRequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/DefaultClientRequestContextTest.java
@@ -22,13 +22,13 @@ import static org.mockito.Mockito.mock;
 import org.junit.Test;
 
 import com.linecorp.armeria.common.DefaultHttpHeaders;
+import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.metric.NoopMeterRegistry;
 
 import io.netty.channel.EventLoop;
-import io.netty.util.AsciiString;
 import io.netty.util.AttributeKey;
 
 public class DefaultClientRequestContextTest {
@@ -57,12 +57,12 @@ public class DefaultClientRequestContextTest {
         assertThat(derivedCtx.maxResponseLength()).isEqualTo(originalCtx.maxResponseLength());
         assertThat(derivedCtx.responseTimeoutMillis()).isEqualTo(originalCtx.responseTimeoutMillis());
         assertThat(derivedCtx.writeTimeoutMillis()).isEqualTo(originalCtx.writeTimeoutMillis());
-        assertThat(derivedCtx.additionalRequestHeaders().get(AsciiString.of("my-header#1"))).isNull();
-        assertThat(derivedCtx.additionalRequestHeaders().get(AsciiString.of("my-header#2")))
+        assertThat(derivedCtx.additionalRequestHeaders().get(HttpHeaderNames.of("my-header#1"))).isNull();
+        assertThat(derivedCtx.additionalRequestHeaders().get(HttpHeaderNames.of("my-header#2")))
                 .isEqualTo("value#2");
-        assertThat(derivedCtx.additionalRequestHeaders().get(AsciiString.of("my-header#3")))
+        assertThat(derivedCtx.additionalRequestHeaders().get(HttpHeaderNames.of("my-header#3")))
                 .isEqualTo("value#3");
-        assertThat(derivedCtx.additionalRequestHeaders().get(AsciiString.of("my-header#4")))
+        assertThat(derivedCtx.additionalRequestHeaders().get(HttpHeaderNames.of("my-header#4")))
                 .isEqualTo("value#4");
         // the attribute is derived as well
         assertThat(derivedCtx.attr(foo).get()).isEqualTo("foo");
@@ -79,15 +79,15 @@ public class DefaultClientRequestContextTest {
 
     private static void setAdditionalHeaders(ClientRequestContext originalCtx) {
         final DefaultHttpHeaders headers1 = new DefaultHttpHeaders();
-        headers1.set(AsciiString.of("my-header#1"), "value#1");
+        headers1.set(HttpHeaderNames.of("my-header#1"), "value#1");
         originalCtx.setAdditionalRequestHeaders(headers1);
-        originalCtx.setAdditionalRequestHeader(AsciiString.of("my-header#2"), "value#2");
+        originalCtx.setAdditionalRequestHeader(HttpHeaderNames.of("my-header#2"), "value#2");
 
         final DefaultHttpHeaders headers2 = new DefaultHttpHeaders();
-        headers2.set(AsciiString.of("my-header#3"), "value#3");
+        headers2.set(HttpHeaderNames.of("my-header#3"), "value#3");
         originalCtx.addAdditionalRequestHeaders(headers2);
-        originalCtx.addAdditionalRequestHeader(AsciiString.of("my-header#4"), "value#4");
+        originalCtx.addAdditionalRequestHeader(HttpHeaderNames.of("my-header#4"), "value#4");
         // Remove the first one.
-        originalCtx.removeAdditionalRequestHeader(AsciiString.of("my-header#1"));
+        originalCtx.removeAdditionalRequestHeader(HttpHeaderNames.of("my-header#1"));
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/StickyEndpointSelectionStrategyTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/StickyEndpointSelectionStrategyTest.java
@@ -28,20 +28,21 @@ import org.junit.Test;
 
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
-
-import io.netty.util.AsciiString;
 
 public class StickyEndpointSelectionStrategyTest {
 
     private static final String STICKY_HEADER_NAME = "USER_COOKIE";
 
-    final ToLongFunction<ClientRequestContext> hasher =
-            (ClientRequestContext ctx) -> ((HttpRequest) ctx.request()).headers()
-                                                                       .get(AsciiString.of(STICKY_HEADER_NAME))
-                                                                       .hashCode();
+    final ToLongFunction<ClientRequestContext> hasher = (ClientRequestContext ctx) -> {
+        return ((HttpRequest) ctx.request()).headers()
+                                            .get(HttpHeaderNames.of(STICKY_HEADER_NAME))
+                                            .hashCode();
+    };
+
     final StickyEndpointSelectionStrategy strategy = new StickyEndpointSelectionStrategy(hasher);
 
     private static final EndpointGroup STATIC_ENDPOINT_GROUP = new StaticEndpointGroup(
@@ -100,7 +101,7 @@ public class StickyEndpointSelectionStrategyTest {
     private static ClientRequestContext contextWithHeader(String k, String v) {
         final ClientRequestContext ctx = mock(ClientRequestContext.class);
         when(ctx.request()).thenReturn(HttpRequest.of(HttpHeaders.of(HttpMethod.GET, "/")
-                                                                 .set(AsciiString.of(k), v)));
+                                                                 .set(HttpHeaderNames.of(k), v)));
         return ctx;
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/common/HttpHeaderNamesTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/HttpHeaderNamesTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+import io.netty.util.AsciiString;
+
+public class HttpHeaderNamesTest {
+
+    @Test
+    public void testOfAsciiString() {
+        // Should produce a lower-cased AsciiString.
+        final AsciiString mixedCased = AsciiString.of("Foo");
+        assertThat((Object) HttpHeaderNames.of(mixedCased)).isNotSameAs(mixedCased);
+        assertThat(HttpHeaderNames.of(mixedCased).toString()).isEqualTo("foo");
+
+        // Should not produce a new instance for an AsciiString that's already lower-cased.
+        final AsciiString lowerCased = AsciiString.of("foo");
+        assertThat((Object) HttpHeaderNames.of(lowerCased)).isSameAs(lowerCased);
+
+        // Should reuse known header name instances.
+        assertThat((Object) HttpHeaderNames.of(AsciiString.of("date"))).isSameAs(HttpHeaderNames.DATE);
+    }
+
+    @Test
+    public void testOfCharSequence() {
+        // Should produce a lower-cased AsciiString.
+        assertThat((Object) HttpHeaderNames.of("Foo")).isEqualTo(AsciiString.of("foo"));
+
+        // Should reuse known header name instances.
+        assertThat((Object) HttpHeaderNames.of("date")).isSameAs(HttpHeaderNames.DATE);
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/common/HttpHeadersJsonDeserializerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/HttpHeadersJsonDeserializerTest.java
@@ -30,7 +30,7 @@ import io.netty.util.AsciiString;
 
 public class HttpHeadersJsonDeserializerTest {
 
-    private static final AsciiString NAME = AsciiString.of("a");
+    private static final AsciiString NAME = HttpHeaderNames.of("a");
 
     private static final ObjectMapper mapper = new ObjectMapper();
 

--- a/core/src/test/java/com/linecorp/armeria/common/HttpHeadersJsonSerializerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/HttpHeadersJsonSerializerTest.java
@@ -26,7 +26,7 @@ import io.netty.util.AsciiString;
 
 public class HttpHeadersJsonSerializerTest {
 
-    private static final AsciiString NAME = AsciiString.of("a");
+    private static final AsciiString NAME = HttpHeaderNames.of("a");
 
     private static final ObjectMapper mapper = new ObjectMapper();
 

--- a/core/src/test/java/com/linecorp/armeria/common/HttpHeadersTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/HttpHeadersTest.java
@@ -17,11 +17,11 @@
 package com.linecorp.armeria.common;
 
 import static com.linecorp.armeria.common.HttpHeaderNames.CONTENT_TYPE;
+import static com.linecorp.armeria.common.HttpHeaderNames.of;
 import static com.linecorp.armeria.common.MediaType.ANY_APPLICATION_TYPE;
 import static com.linecorp.armeria.common.MediaType.ANY_AUDIO_TYPE;
 import static com.linecorp.armeria.common.MediaType.ANY_TEXT_TYPE;
 import static com.linecorp.armeria.common.MediaType.ANY_TYPE;
-import static io.netty.util.AsciiString.of;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 

--- a/core/src/test/java/com/linecorp/armeria/common/logging/DefaultRequestLogTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/logging/DefaultRequestLogTest.java
@@ -27,6 +27,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
+import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpStatus;
@@ -37,7 +38,6 @@ import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.testing.internal.AnticipatedException;
 
 import io.netty.channel.Channel;
-import io.netty.util.AsciiString;
 
 public class DefaultRequestLogTest {
 
@@ -134,7 +134,7 @@ public class DefaultRequestLogTest {
         assertThat(log.requestFirstBytesTransferredTimeNanos())
                 .isEqualTo(child.requestFirstBytesTransferredTimeNanos());
 
-        final HttpHeaders foo = HttpHeaders.of(AsciiString.of("foo"), "foo");
+        final HttpHeaders foo = HttpHeaders.of(HttpHeaderNames.of("foo"), "foo");
         child.requestHeaders(foo);
         assertThat(log.requestHeaders()).isSameAs(foo);
 
@@ -157,7 +157,7 @@ public class DefaultRequestLogTest {
         assertThatThrownBy(() -> log.responseFirstBytesTransferredTimeNanos())
                 .isExactlyInstanceOf(RequestLogAvailabilityException.class);
 
-        final HttpHeaders bar = HttpHeaders.of(AsciiString.of("bar"), "bar");
+        final HttpHeaders bar = HttpHeaders.of(HttpHeaderNames.of("bar"), "bar");
         child.responseHeaders(bar);
         assertThatThrownBy(() -> log.responseHeaders())
                 .isExactlyInstanceOf(RequestLogAvailabilityException.class);

--- a/core/src/test/java/com/linecorp/armeria/internal/ArmeriaHttpUtilTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/ArmeriaHttpUtilTest.java
@@ -36,7 +36,6 @@ import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http2.DefaultHttp2Headers;
 import io.netty.handler.codec.http2.Http2Exception;
 import io.netty.handler.codec.http2.Http2Headers;
-import io.netty.util.AsciiString;
 
 public class ArmeriaHttpUtilTest {
     @Test
@@ -258,6 +257,6 @@ public class ArmeriaHttpUtilTest {
         final HttpHeaders out = new DefaultHttpHeaders();
         toArmeria(in, out);
         assertThat(out).hasSize(1);
-        assertThat(out.get(AsciiString.of("hello"))).isEqualTo("world");
+        assertThat(out.get(HttpHeaderNames.of("hello"))).isEqualTo("world");
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpDocServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpDocServiceTest.java
@@ -45,6 +45,7 @@ import com.google.common.collect.ImmutableMap;
 
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpResponse;
@@ -75,15 +76,13 @@ import com.linecorp.armeria.server.docs.MethodInfo;
 import com.linecorp.armeria.server.docs.TypeSignature;
 import com.linecorp.armeria.testing.server.ServerRule;
 
-import io.netty.util.AsciiString;
-
 public class AnnotatedHttpDocServiceTest {
 
     private static final ObjectMapper mapper = new ObjectMapper();
 
-    private static final HttpHeaders EXAMPLE_HEADERS_ALL = HttpHeaders.of(AsciiString.of("a"), "b");
-    private static final HttpHeaders EXAMPLE_HEADERS_SERVICE = HttpHeaders.of(AsciiString.of("c"), "d");
-    private static final HttpHeaders EXAMPLE_HEADERS_METHOD = HttpHeaders.of(AsciiString.of("e"), "f");
+    private static final HttpHeaders EXAMPLE_HEADERS_ALL = HttpHeaders.of(HttpHeaderNames.of("a"), "b");
+    private static final HttpHeaders EXAMPLE_HEADERS_SERVICE = HttpHeaders.of(HttpHeaderNames.of("c"), "d");
+    private static final HttpHeaders EXAMPLE_HEADERS_METHOD = HttpHeaders.of(HttpHeaderNames.of("e"), "f");
 
     @ClassRule
     public static final ServerRule server = new ServerRule() {

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceRequestConverterTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceRequestConverterTest.java
@@ -40,6 +40,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.common.AggregatedHttpMessage;
 import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpStatus;
@@ -63,8 +64,6 @@ import com.linecorp.armeria.server.annotation.RequestObject;
 import com.linecorp.armeria.server.annotation.ResponseConverter;
 import com.linecorp.armeria.server.logging.LoggingService;
 import com.linecorp.armeria.testing.server.ServerRule;
-
-import io.netty.util.AsciiString;
 
 public class AnnotatedHttpServiceRequestConverterTest {
 
@@ -611,7 +610,7 @@ public class AnnotatedHttpServiceRequestConverterTest {
         expectedRequestBean.userName = "john";
         expectedRequestBean.age = 25;
         expectedRequestBean.gender = MALE;
-        expectedRequestBean.permissions = Arrays.asList("permission1", "permission2");
+        expectedRequestBean.permissions = Arrays.asList("perm1", "perm2");
         expectedRequestBean.clientName = "TestClient";
         expectedRequestBean.seqNum = 1234L;
         expectedRequestBean.manager = true;
@@ -621,8 +620,8 @@ public class AnnotatedHttpServiceRequestConverterTest {
         // Normal Request: POST + Form Data
         final HttpData formData = HttpData.ofAscii("age=25&manager=true&gender=male");
         HttpHeaders reqHeaders = HttpHeaders.of(HttpMethod.POST, "/2/default/bean1/john/1234")
-                                            .set(AsciiString.of("x-user-permission"), "permission1,permission2")
-                                            .set(AsciiString.of("x-client-name"), "TestClient")
+                                            .set(HttpHeaderNames.of("x-user-permission"), "perm1,perm2")
+                                            .set(HttpHeaderNames.of("x-client-name"), "TestClient")
                                             .contentType(MediaType.FORM_DATA);
 
         response = client.execute(AggregatedHttpMessage.of(reqHeaders, formData)).aggregate().join();
@@ -632,8 +631,8 @@ public class AnnotatedHttpServiceRequestConverterTest {
         // Normal Request: GET + Query String
         reqHeaders = HttpHeaders.of(HttpMethod.GET,
                                     "/2/default/bean1/john/1234?age=25&manager=true&gender=MALE")
-                                .set(AsciiString.of("x-user-permission"), "permission1,permission2")
-                                .set(AsciiString.of("x-client-name"), "TestClient");
+                                .set(HttpHeaderNames.of("x-user-permission"), "perm1,perm2")
+                                .set(HttpHeaderNames.of("x-client-name"), "TestClient");
 
         response = client.execute(AggregatedHttpMessage.of(reqHeaders)).aggregate().join();
         assertThat(response.headers().status()).isEqualTo(HttpStatus.OK);
@@ -642,8 +641,8 @@ public class AnnotatedHttpServiceRequestConverterTest {
         // Bad Request: age=badParam
         reqHeaders = HttpHeaders.of(HttpMethod.GET,
                                     "/2/default/bean1/john/1234?age=badParam&manager=true&gender=male")
-                                .set(AsciiString.of("x-user-permission"), "permission1,permission2")
-                                .set(AsciiString.of("x-client-name"), "TestClient");
+                                .set(HttpHeaderNames.of("x-user-permission"), "perm1,perm2")
+                                .set(HttpHeaderNames.of("x-client-name"), "TestClient");
 
         response = client.execute(AggregatedHttpMessage.of(reqHeaders)).aggregate().join();
         assertThat(response.headers().status()).isEqualTo(HttpStatus.BAD_REQUEST);
@@ -651,8 +650,8 @@ public class AnnotatedHttpServiceRequestConverterTest {
         // Bad Request: seqNum=badParam
         reqHeaders = HttpHeaders.of(HttpMethod.GET,
                                     "/2/default/bean1/john/badParam?age=25&manager=true&gender=MALE")
-                                .set(AsciiString.of("x-user-permission"), "permission1,permission2")
-                                .set(AsciiString.of("x-client-name"), "TestClient");
+                                .set(HttpHeaderNames.of("x-user-permission"), "perm1,perm2")
+                                .set(HttpHeaderNames.of("x-client-name"), "TestClient");
 
         response = client.execute(AggregatedHttpMessage.of(reqHeaders)).aggregate().join();
         assertThat(response.headers().status()).isEqualTo(HttpStatus.BAD_REQUEST);
@@ -660,8 +659,8 @@ public class AnnotatedHttpServiceRequestConverterTest {
         // Bad Request: gender=badParam
         reqHeaders = HttpHeaders.of(HttpMethod.GET,
                                     "/2/default/bean1/john/1234?age=25&manager=true&gender=badParam")
-                                .set(AsciiString.of("x-user-permission"), "permission1,permission2")
-                                .set(AsciiString.of("x-client-name"), "TestClient");
+                                .set(HttpHeaderNames.of("x-user-permission"), "perm1,perm2")
+                                .set(HttpHeaderNames.of("x-client-name"), "TestClient");
 
         response = client.execute(AggregatedHttpMessage.of(reqHeaders)).aggregate().join();
         assertThat(response.headers().status()).isEqualTo(HttpStatus.BAD_REQUEST);
@@ -679,7 +678,7 @@ public class AnnotatedHttpServiceRequestConverterTest {
         expectedRequestBean.userName = "john";
         expectedRequestBean.age = 25;
         expectedRequestBean.gender = MALE;
-        expectedRequestBean.permissions = Arrays.asList("permission1", "permission2");
+        expectedRequestBean.permissions = Arrays.asList("perm1", "perm2");
         expectedRequestBean.clientName = "TestClient";
 
         final String expectedResponseContent = mapper.writeValueAsString(expectedRequestBean);
@@ -687,9 +686,9 @@ public class AnnotatedHttpServiceRequestConverterTest {
         // Normal Request: POST + Form Data
         final HttpData formData = HttpData.ofAscii("age=25&gender=male");
         HttpHeaders reqHeaders = HttpHeaders.of(HttpMethod.POST, "/2/default/bean2/john/98765")
-                                            .set(AsciiString.of("x-user-permission"), "permission1,permission2")
-                                            .set(AsciiString.of("x-client-name"), "TestClient")
-                                            .set(AsciiString.of("uid"), "abcd-efgh")
+                                            .set(HttpHeaderNames.of("x-user-permission"), "perm1,perm2")
+                                            .set(HttpHeaderNames.of("x-client-name"), "TestClient")
+                                            .set(HttpHeaderNames.of("uid"), "abcd-efgh")
                                             .contentType(MediaType.FORM_DATA);
 
         response = client.execute(AggregatedHttpMessage.of(reqHeaders, formData)).aggregate().join();
@@ -699,9 +698,9 @@ public class AnnotatedHttpServiceRequestConverterTest {
         // Normal Request: GET + Query String
         reqHeaders = HttpHeaders.of(HttpMethod.GET,
                                     "/2/default/bean2/john?age=25&gender=MALE&serialNo=98765")
-                                .set(AsciiString.of("x-user-permission"), "permission1,permission2")
-                                .set(AsciiString.of("x-client-name"), "TestClient")
-                                .set(AsciiString.of("uid"), "abcd-efgh");
+                                .set(HttpHeaderNames.of("x-user-permission"), "perm1,perm2")
+                                .set(HttpHeaderNames.of("x-client-name"), "TestClient")
+                                .set(HttpHeaderNames.of("uid"), "abcd-efgh");
 
         response = client.execute(AggregatedHttpMessage.of(reqHeaders)).aggregate().join();
         assertThat(response.headers().status()).isEqualTo(HttpStatus.OK);
@@ -720,7 +719,7 @@ public class AnnotatedHttpServiceRequestConverterTest {
         expectedRequestBean.userName = "john";
         expectedRequestBean.age = 25;
         expectedRequestBean.gender = MALE;
-        expectedRequestBean.permissions = Arrays.asList("permission1", "permission2");
+        expectedRequestBean.permissions = Arrays.asList("perm1", "perm2");
         expectedRequestBean.clientName = "TestClient";
 
         final String expectedResponseContent = mapper.writeValueAsString(expectedRequestBean);
@@ -728,8 +727,8 @@ public class AnnotatedHttpServiceRequestConverterTest {
         // Normal Request: POST + Form Data
         final HttpData formData = HttpData.ofAscii("age=25&gender=male");
         HttpHeaders reqHeaders = HttpHeaders.of(HttpMethod.POST, "/2/default/bean3/john/3349")
-                                            .set(AsciiString.of("x-user-permission"), "permission1,permission2")
-                                            .set(AsciiString.of("x-client-name"), "TestClient")
+                                            .set(HttpHeaderNames.of("x-user-permission"), "perm1,perm2")
+                                            .set(HttpHeaderNames.of("x-client-name"), "TestClient")
                                             .contentType(MediaType.FORM_DATA);
 
         response = client.execute(AggregatedHttpMessage.of(reqHeaders, formData)).aggregate().join();
@@ -739,8 +738,8 @@ public class AnnotatedHttpServiceRequestConverterTest {
         // Normal Request: GET + Query String
         reqHeaders = HttpHeaders.of(HttpMethod.GET,
                                     "/2/default/bean3/john?age=25&gender=MALE&departmentNo=3349")
-                                .set(AsciiString.of("x-user-permission"), "permission1,permission2")
-                                .set(AsciiString.of("x-client-name"), "TestClient");
+                                .set(HttpHeaderNames.of("x-user-permission"), "perm1,perm2")
+                                .set(HttpHeaderNames.of("x-client-name"), "TestClient");
 
         response = client.execute(AggregatedHttpMessage.of(reqHeaders)).aggregate().join();
         assertThat(response.headers().status()).isEqualTo(HttpStatus.OK);

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedValueResolverTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedValueResolverTest.java
@@ -73,8 +73,8 @@ public class AnnotatedValueResolverTest {
                                                                       "sensitive");
 
     // 'headerValues' will be returned.
-    static final Set<AsciiString> existingHttpHeaders = ImmutableSet.of(AsciiString.of("header1"),
-                                                                        AsciiString.of("header2"));
+    static final Set<AsciiString> existingHttpHeaders = ImmutableSet.of(HttpHeaderNames.of("header1"),
+                                                                        HttpHeaderNames.of("header2"));
     static final List<String> headerValues = ImmutableList.of("value1",
                                                               "value3",
                                                               "value2");
@@ -118,7 +118,7 @@ public class AnnotatedValueResolverTest {
 
     static boolean shouldHttpHeaderExist(AnnotatedValueResolver element) {
         return element.shouldExist() ||
-               existingHttpHeaders.contains(AsciiString.of(element.httpElementName()));
+               existingHttpHeaders.contains(HttpHeaderNames.of(element.httpElementName()));
     }
 
     static boolean shouldHttpParameterExist(AnnotatedValueResolver element) {

--- a/core/src/test/java/com/linecorp/armeria/server/DefaultServiceRequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/DefaultServiceRequestContextTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.common.DefaultHttpHeaders;
+import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
@@ -33,7 +34,6 @@ import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.metric.NoopMeterRegistry;
 
 import io.netty.channel.Channel;
-import io.netty.util.AsciiString;
 import io.netty.util.AttributeKey;
 import io.netty.util.NetUtil;
 
@@ -69,19 +69,19 @@ public class DefaultServiceRequestContextTest {
         assertThat(derivedCtx.path()).isEqualTo(originalCtx.path());
         assertThat(derivedCtx.maxRequestLength()).isEqualTo(originalCtx.maxRequestLength());
         assertThat(derivedCtx.requestTimeoutMillis()).isEqualTo(originalCtx.requestTimeoutMillis());
-        assertThat(derivedCtx.additionalResponseHeaders().get(AsciiString.of("my-header#1"))).isNull();
-        assertThat(derivedCtx.additionalResponseHeaders().get(AsciiString.of("my-header#2")))
+        assertThat(derivedCtx.additionalResponseHeaders().get(HttpHeaderNames.of("my-header#1"))).isNull();
+        assertThat(derivedCtx.additionalResponseHeaders().get(HttpHeaderNames.of("my-header#2")))
                 .isEqualTo("value#2");
-        assertThat(derivedCtx.additionalResponseHeaders().get(AsciiString.of("my-header#3")))
+        assertThat(derivedCtx.additionalResponseHeaders().get(HttpHeaderNames.of("my-header#3")))
                 .isEqualTo("value#3");
-        assertThat(derivedCtx.additionalResponseHeaders().get(AsciiString.of("my-header#4")))
+        assertThat(derivedCtx.additionalResponseHeaders().get(HttpHeaderNames.of("my-header#4")))
                 .isEqualTo("value#4");
-        assertThat(derivedCtx.additionalResponseTrailers().get(AsciiString.of("my-trailer#1"))).isNull();
-        assertThat(derivedCtx.additionalResponseTrailers().get(AsciiString.of("my-trailer#2")))
+        assertThat(derivedCtx.additionalResponseTrailers().get(HttpHeaderNames.of("my-trailer#1"))).isNull();
+        assertThat(derivedCtx.additionalResponseTrailers().get(HttpHeaderNames.of("my-trailer#2")))
                 .isEqualTo("value#2");
-        assertThat(derivedCtx.additionalResponseTrailers().get(AsciiString.of("my-trailer#3")))
+        assertThat(derivedCtx.additionalResponseTrailers().get(HttpHeaderNames.of("my-trailer#3")))
                 .isEqualTo("value#3");
-        assertThat(derivedCtx.additionalResponseTrailers().get(AsciiString.of("my-trailer#4")))
+        assertThat(derivedCtx.additionalResponseTrailers().get(HttpHeaderNames.of("my-trailer#4")))
                 .isEqualTo("value#4");
         // the attribute is derived as well
         assertThat(derivedCtx.attr(foo).get()).isEqualTo("foo");
@@ -106,29 +106,29 @@ public class DefaultServiceRequestContextTest {
 
     private static void setAdditionalHeaders(ServiceRequestContext originalCtx) {
         final DefaultHttpHeaders headers1 = new DefaultHttpHeaders();
-        headers1.set(AsciiString.of("my-header#1"), "value#1");
+        headers1.set(HttpHeaderNames.of("my-header#1"), "value#1");
         originalCtx.setAdditionalResponseHeaders(headers1);
-        originalCtx.setAdditionalResponseHeader(AsciiString.of("my-header#2"), "value#2");
+        originalCtx.setAdditionalResponseHeader(HttpHeaderNames.of("my-header#2"), "value#2");
 
         final DefaultHttpHeaders headers2 = new DefaultHttpHeaders();
-        headers2.set(AsciiString.of("my-header#3"), "value#3");
+        headers2.set(HttpHeaderNames.of("my-header#3"), "value#3");
         originalCtx.addAdditionalResponseHeaders(headers2);
-        originalCtx.addAdditionalResponseHeader(AsciiString.of("my-header#4"), "value#4");
+        originalCtx.addAdditionalResponseHeader(HttpHeaderNames.of("my-header#4"), "value#4");
         // Remove the first one.
-        originalCtx.removeAdditionalResponseHeader(AsciiString.of("my-header#1"));
+        originalCtx.removeAdditionalResponseHeader(HttpHeaderNames.of("my-header#1"));
     }
 
     private static void setAdditionalTrailers(ServiceRequestContext originalCtx) {
         final DefaultHttpHeaders trailers1 = new DefaultHttpHeaders();
-        trailers1.set(AsciiString.of("my-trailer#1"), "value#1");
+        trailers1.set(HttpHeaderNames.of("my-trailer#1"), "value#1");
         originalCtx.setAdditionalResponseTrailers(trailers1);
-        originalCtx.setAdditionalResponseTrailer(AsciiString.of("my-trailer#2"), "value#2");
+        originalCtx.setAdditionalResponseTrailer(HttpHeaderNames.of("my-trailer#2"), "value#2");
 
         final DefaultHttpHeaders trailers2 = new DefaultHttpHeaders();
-        trailers2.set(AsciiString.of("my-trailer#3"), "value#3");
+        trailers2.set(HttpHeaderNames.of("my-trailer#3"), "value#3");
         originalCtx.addAdditionalResponseTrailers(trailers2);
-        originalCtx.addAdditionalResponseTrailer(AsciiString.of("my-trailer#4"), "value#4");
+        originalCtx.addAdditionalResponseTrailer(HttpHeaderNames.of("my-trailer#4"), "value#4");
         // Remove the first one.
-        originalCtx.removeAdditionalResponseTrailer(AsciiString.of("my-trailer#1"));
+        originalCtx.removeAdditionalResponseTrailer(HttpHeaderNames.of("my-trailer#1"));
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/HttpHeaderUtilTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpHeaderUtilTest.java
@@ -34,8 +34,6 @@ import com.google.common.collect.ImmutableList;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 
-import io.netty.util.AsciiString;
-
 public class HttpHeaderUtilTest {
 
     private static final Predicate<InetAddress> ACCEPT_ANY = addr -> true;
@@ -193,7 +191,7 @@ public class HttpHeaderUtilTest {
         assertThat(HttpHeaderUtil.determineClientAddress(
                 HttpHeaders.of(HttpHeaderNames.FORWARDED, "for=10.0.0.1,for=10.0.0.2",
                                HttpHeaderNames.X_FORWARDED_FOR, "10.1.0.1,10.1.0.2",
-                               AsciiString.of("x-real-ip"), "10.2.0.1,10.2.0.2"),
+                               HttpHeaderNames.of("x-real-ip"), "10.2.0.1,10.2.0.2"),
                 ImmutableList.of(ofHeader("x-real-ip"),
                                  ofHeader(HttpHeaderNames.FORWARDED),
                                  ofHeader(HttpHeaderNames.X_FORWARDED_FOR)),

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerTest.java
@@ -357,8 +357,8 @@ public class HttpServerTest {
                 protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) {
                     return HttpResponse.of(
                             HttpHeaders.of(HttpStatus.OK).contentType(MediaType.PLAIN_TEXT_UTF_8)
-                                       .add(AsciiString.of("x-custom-header1"), "custom1")
-                                       .add(AsciiString.of("X-Custom-Header2"), "custom2"),
+                                       .add(HttpHeaderNames.of("x-custom-header1"), "custom1")
+                                       .add(HttpHeaderNames.of("X-Custom-Header2"), "custom2"),
                             HttpData.ofUtf8("headers"));
                 }
             }.decorate(HttpEncodingService.class));
@@ -370,21 +370,21 @@ public class HttpServerTest {
                     return HttpResponse.of(
                             HttpHeaders.of(HttpStatus.OK),
                             HttpData.ofAscii("trailers incoming!"),
-                            HttpHeaders.of(AsciiString.of("foo"), "bar"));
+                            HttpHeaders.of(HttpHeaderNames.of("foo"), "bar"));
                 }
             });
 
             sb.service("/head-headers-only", (ctx, req) -> HttpResponse.of(HttpHeaders.of(HttpStatus.OK)));
 
             sb.service("/additional-trailers-other-trailers", (ctx, req) -> {
-                ctx.addAdditionalResponseTrailer(AsciiString.of("additional-trailer"), "value2");
+                ctx.addAdditionalResponseTrailer(HttpHeaderNames.of("additional-trailer"), "value2");
                 return HttpResponse.of(HttpHeaders.of(HttpStatus.OK),
                                        HttpData.ofAscii("foobar"),
-                                       HttpHeaders.of(AsciiString.of("original-trailer"), "value1"));
+                                       HttpHeaders.of(HttpHeaderNames.of("original-trailer"), "value1"));
             });
 
             sb.service("/additional-trailers-no-other-trailers", (ctx, req) -> {
-                ctx.addAdditionalResponseTrailer(AsciiString.of("additional-trailer"), "value2");
+                ctx.addAdditionalResponseTrailer(HttpHeaderNames.of("additional-trailer"), "value2");
                 String payload = "foobar";
                 return HttpResponse.of(HttpHeaders.of(HttpStatus.OK),
                                        new DefaultHttpData(payload.getBytes(StandardCharsets.UTF_8),
@@ -392,7 +392,7 @@ public class HttpServerTest {
             });
 
             sb.service("/additional-trailers-no-eos", (ctx, req) -> {
-                ctx.addAdditionalResponseTrailer(AsciiString.of("additional-trailer"), "value2");
+                ctx.addAdditionalResponseTrailer(HttpHeaderNames.of("additional-trailer"), "value2");
                 String payload = "foobar";
                 return HttpResponse.of(HttpHeaders.of(HttpStatus.OK),
                                        new DefaultHttpData(payload.getBytes(StandardCharsets.UTF_8),
@@ -820,8 +820,8 @@ public class HttpServerTest {
                       .forEach(c -> assertTrue(Character.isLowerCase(c)));
         }
 
-        assertThat(res.headers().get(AsciiString.of("x-custom-header1"))).isEqualTo("custom1");
-        assertThat(res.headers().get(AsciiString.of("x-custom-header2"))).isEqualTo("custom2");
+        assertThat(res.headers().get(HttpHeaderNames.of("x-custom-header1"))).isEqualTo("custom1");
+        assertThat(res.headers().get(HttpHeaderNames.of("x-custom-header2"))).isEqualTo("custom2");
         assertThat(res.content().toStringUtf8()).isEqualTo("headers");
     }
 
@@ -831,7 +831,7 @@ public class HttpServerTest {
         final CompletableFuture<AggregatedHttpMessage> f = client().execute(req).aggregate();
 
         final AggregatedHttpMessage res = f.get();
-        assertThat(res.trailingHeaders().get(AsciiString.of("foo"))).isEqualTo("bar");
+        assertThat(res.trailingHeaders().get(HttpHeaderNames.of("foo"))).isEqualTo("bar");
     }
 
     @Test(timeout = 10000)
@@ -868,8 +868,8 @@ public class HttpServerTest {
         }
         HttpHeaders trailers = client().get("/additional-trailers-other-trailers")
                                        .aggregate().join().trailingHeaders();
-        assertThat(trailers.get(AsciiString.of("original-trailer"))).isEqualTo("value1");
-        assertThat(trailers.get(AsciiString.of("additional-trailer"))).isEqualTo("value2");
+        assertThat(trailers.get(HttpHeaderNames.of("original-trailer"))).isEqualTo("value1");
+        assertThat(trailers.get(HttpHeaderNames.of("additional-trailer"))).isEqualTo("value2");
     }
 
     @Test(timeout = 10000)
@@ -879,7 +879,7 @@ public class HttpServerTest {
         }
         HttpHeaders trailers = client().get("/additional-trailers-no-eos")
                                        .aggregate().join().trailingHeaders();
-        assertThat(trailers.get(AsciiString.of("additional-trailer"))).isEqualTo("value2");
+        assertThat(trailers.get(HttpHeaderNames.of("additional-trailer"))).isEqualTo("value2");
     }
 
     @Test(timeout = 10000)
@@ -889,7 +889,7 @@ public class HttpServerTest {
         }
         HttpHeaders trailers = client().get("/additional-trailers-no-other-trailers")
                                        .aggregate().join().trailingHeaders();
-        assertThat(trailers.get(AsciiString.of("additional-trailer"))).isEqualTo("value2");
+        assertThat(trailers.get(HttpHeaderNames.of("additional-trailer"))).isEqualTo("value2");
     }
 
     private HttpClient client() {

--- a/core/src/test/java/com/linecorp/armeria/server/cors/HttpServerCorsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/cors/HttpServerCorsTest.java
@@ -35,8 +35,6 @@ import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.testing.server.ServerRule;
 
-import io.netty.util.AsciiString;
-
 public class HttpServerCorsTest {
 
     private static final ClientFactory clientFactory = ClientFactory.DEFAULT;
@@ -87,7 +85,7 @@ public class HttpServerCorsTest {
 
         assertEquals(HttpStatus.OK, response.status());
         assertEquals("http://example.com", response.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN));
-        assertEquals("Hello CORS", response.headers().get(AsciiString.of("x-preflight-cors")));
+        assertEquals("Hello CORS", response.headers().get(HttpHeaderNames.of("x-preflight-cors")));
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/server/healthcheck/ManagedHttpHealthCheckServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/healthcheck/ManagedHttpHealthCheckServiceTest.java
@@ -19,7 +19,6 @@ package com.linecorp.armeria.server.healthcheck;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
-import org.apache.http.HttpHeaders;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -29,6 +28,7 @@ import org.mockito.junit.MockitoRule;
 
 import com.linecorp.armeria.common.AggregatedHttpMessage;
 import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpRequestWriter;
@@ -36,8 +36,6 @@ import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.logging.DefaultRequestLog;
 import com.linecorp.armeria.server.ServiceRequestContext;
-
-import io.netty.util.AsciiString;
 
 public class ManagedHttpHealthCheckServiceTest {
 
@@ -68,14 +66,14 @@ public class ManagedHttpHealthCheckServiceTest {
         AggregatedHttpMessage res = service.serve(context, hcTurnOffReq).aggregate().get();
 
         assertThat(res.status()).isEqualTo(HttpStatus.OK);
-        assertThat(res.headers().get(AsciiString.of(HttpHeaders.CONTENT_TYPE)))
+        assertThat(res.headers().get(HttpHeaderNames.CONTENT_TYPE))
                   .isEqualTo(MediaType.PLAIN_TEXT_UTF_8.toString());
         assertThat(res.content().toStringUtf8()).isEqualTo("Set unhealthy.");
 
         res = service.serve(context, hcReq).aggregate().get();
 
         assertThat(res.status()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
-        assertThat(res.headers().get(AsciiString.of(HttpHeaders.CONTENT_TYPE))).isEqualTo(
+        assertThat(res.headers().get(HttpHeaderNames.CONTENT_TYPE)).isEqualTo(
                 MediaType.PLAIN_TEXT_UTF_8.toString());
     }
 
@@ -84,14 +82,14 @@ public class ManagedHttpHealthCheckServiceTest {
         AggregatedHttpMessage res = service.serve(context, hcTurnOnReq).aggregate().get();
 
         assertThat(res.status()).isEqualTo(HttpStatus.OK);
-        assertThat(res.headers().get(AsciiString.of(HttpHeaders.CONTENT_TYPE))).isEqualTo(
+        assertThat(res.headers().get(HttpHeaderNames.CONTENT_TYPE)).isEqualTo(
                 MediaType.PLAIN_TEXT_UTF_8.toString());
         assertThat(res.content().toStringUtf8()).isEqualTo("Set healthy.");
 
         res = service.serve(context, hcReq).aggregate().get();
 
         assertThat(res.status()).isEqualTo(HttpStatus.OK);
-        assertThat(res.headers().get(AsciiString.of(HttpHeaders.CONTENT_TYPE))).isEqualTo(
+        assertThat(res.headers().get(HttpHeaderNames.CONTENT_TYPE)).isEqualTo(
                 MediaType.PLAIN_TEXT_UTF_8.toString());
     }
 
@@ -104,7 +102,7 @@ public class ManagedHttpHealthCheckServiceTest {
         AggregatedHttpMessage res = service.serve(context, noopRequest).aggregate().get();
 
         assertThat(res.status()).isEqualTo(HttpStatus.BAD_REQUEST);
-        assertThat(res.headers().get(AsciiString.of(HttpHeaders.CONTENT_TYPE))).isEqualTo(
+        assertThat(res.headers().get(HttpHeaderNames.CONTENT_TYPE)).isEqualTo(
                 MediaType.PLAIN_TEXT_UTF_8.toString());
         assertThat(res.content().toStringUtf8()).isEqualTo("Not supported.");
 
@@ -117,7 +115,7 @@ public class ManagedHttpHealthCheckServiceTest {
         res = service.serve(context, noopRequest).aggregate().get();
 
         assertThat(res.status()).isEqualTo(HttpStatus.BAD_REQUEST);
-        assertThat(res.headers().get(AsciiString.of(HttpHeaders.CONTENT_TYPE))).isEqualTo(
+        assertThat(res.headers().get(HttpHeaderNames.CONTENT_TYPE)).isEqualTo(
                 MediaType.PLAIN_TEXT_UTF_8.toString());
         assertThat(res.content().toStringUtf8()).isEqualTo("Not supported.");
     }

--- a/examples/annotated-http-service/src/test/java/example/armeria/server/annotated/AnnotatedHttpServiceTest.java
+++ b/examples/annotated-http-service/src/test/java/example/armeria/server/annotated/AnnotatedHttpServiceTest.java
@@ -18,8 +18,6 @@ import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.server.Server;
 
-import io.netty.util.AsciiString;
-
 public class AnnotatedHttpServiceTest {
 
     private static Server server;
@@ -72,9 +70,9 @@ public class AnnotatedHttpServiceTest {
                                                     .thatContains("MALE");
 
         final HttpHeaders headers = HttpHeaders.of(HttpMethod.GET, "/injection/header")
-                                               .add(AsciiString.of("x-armeria-text"), "armeria")
-                                               .add(AsciiString.of("x-armeria-sequence"), "1")
-                                               .add(AsciiString.of("x-armeria-sequence"), "2")
+                                               .add(HttpHeaderNames.of("x-armeria-text"), "armeria")
+                                               .add(HttpHeaderNames.of("x-armeria-sequence"), "1")
+                                               .add(HttpHeaderNames.of("x-armeria-sequence"), "2")
                                                .add(HttpHeaderNames.COOKIE, "a=1")
                                                .add(HttpHeaderNames.COOKIE, "b=1");
 

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceTest.java
@@ -43,8 +43,6 @@ import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
-import io.netty.util.AsciiString;
-
 // Tests error cases, success cases are checked in ArmeriaGrpcServiceInteropTest
 public class GrpcServiceTest {
 
@@ -112,8 +110,8 @@ public class GrpcServiceTest {
         assertThat(response.aggregate().get()).isEqualTo(AggregatedHttpMessage.of(
                 HttpHeaders.of(HttpStatus.OK)
                            .set(HttpHeaderNames.CONTENT_TYPE, "application/grpc+proto")
-                           .set(AsciiString.of("grpc-status"), "12")
-                           .set(AsciiString.of("grpc-message"),
+                           .set(HttpHeaderNames.of("grpc-status"), "12")
+                           .set(HttpHeaderNames.of("grpc-message"),
                                 "Method not found: grpc.testing.TestService/FooCall")
                            .set(HttpHeaderNames.CONTENT_LENGTH, "0"),
                 HttpData.EMPTY_DATA));

--- a/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaAutoConfigurationTest.java
+++ b/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaAutoConfigurationTest.java
@@ -43,6 +43,7 @@ import com.google.common.collect.ImmutableList;
 import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
@@ -63,8 +64,6 @@ import com.linecorp.armeria.server.thrift.THttpService;
 import com.linecorp.armeria.spring.ArmeriaAutoConfigurationTest.TestConfiguration;
 import com.linecorp.armeria.spring.test.thrift.main.HelloService;
 import com.linecorp.armeria.spring.test.thrift.main.HelloService.hello_args;
-
-import io.netty.util.AsciiString;
 
 /**
  * This uses {@link ArmeriaAutoConfiguration} for integration tests.
@@ -109,7 +108,7 @@ public class ArmeriaAutoConfigurationTest {
                     .setDecorators(ImmutableList.of(LoggingService.newDecorator()))
                     .setExampleRequests(Collections.singleton(new hello_args("nameVal")))
                     .setExampleHeaders(Collections.singleton(HttpHeaders.of(
-                            AsciiString.of("x-additional-header"), "headerVal")));
+                            HttpHeaderNames.of("x-additional-header"), "headerVal")));
         }
     }
 

--- a/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaClientHttpRequest.java
+++ b/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaClientHttpRequest.java
@@ -43,7 +43,6 @@ import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 
-import io.netty.util.AsciiString;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -79,7 +78,7 @@ final class ArmeriaClientHttpRequest extends AbstractClientHttpRequest {
     @Override
     protected void applyHeaders() {
         // Copy the HTTP headers which were specified by a user to the Armeria request.
-        getHeaders().forEach((name, values) -> headers.set(AsciiString.of(name), values));
+        getHeaders().forEach((name, values) -> headers.set(HttpHeaderNames.of(name), values));
         setDefaultRequestHeaders(headers);
     }
 

--- a/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpResponse.java
+++ b/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpResponse.java
@@ -46,7 +46,6 @@ import com.linecorp.armeria.server.ServiceRequestContext;
 import io.netty.handler.codec.http.cookie.Cookie;
 import io.netty.handler.codec.http.cookie.DefaultCookie;
 import io.netty.handler.codec.http.cookie.ServerCookieEncoder;
-import io.netty.util.AsciiString;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
@@ -122,7 +121,7 @@ final class ArmeriaServerHttpResponse extends AbstractServerHttpResponse {
 
     @Override
     protected void applyHeaders() {
-        getHeaders().forEach((name, values) -> headers.add(AsciiString.of(name), values));
+        getHeaders().forEach((name, values) -> headers.add(HttpHeaderNames.of(name), values));
     }
 
     @Override

--- a/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaClientHttpResponseTest.java
+++ b/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaClientHttpResponseTest.java
@@ -33,7 +33,6 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.stream.CancelledSubscriptionException;
 
-import io.netty.util.AsciiString;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -70,7 +69,7 @@ public class ArmeriaClientHttpResponseTest {
     @Test
     public void getCookies() {
         final HttpHeaders httpHeaders = HttpHeaders.of(HttpStatus.OK)
-                                                   .add(AsciiString.of("blahblah"), "armeria")
+                                                   .add(HttpHeaderNames.of("blahblah"), "armeria")
                                                    .add(HttpHeaderNames.SET_COOKIE, "a=1; b=2");
         final HttpResponse httpResponse = HttpResponse.of(httpHeaders);
         final ArmeriaClientHttpResponse response =

--- a/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpResponseTest.java
+++ b/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpResponseTest.java
@@ -38,7 +38,6 @@ import com.linecorp.armeria.server.ServiceRequestContext;
 
 import io.netty.handler.codec.http.cookie.ClientCookieDecoder;
 import io.netty.handler.codec.http.cookie.Cookie;
-import io.netty.util.AsciiString;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -128,7 +127,7 @@ public class ArmeriaServerHttpResponseTest {
                         final HttpHeaders headers = (HttpHeaders) o;
                         assertThat(headers.status())
                                 .isEqualTo(com.linecorp.armeria.common.HttpStatus.OK);
-                        assertThat(headers.get(AsciiString.of("Armeria"))).isEqualTo("awesome");
+                        assertThat(headers.get(HttpHeaderNames.of("Armeria"))).isEqualTo("awesome");
                         final Cookie setCookie =
                                 ClientCookieDecoder.LAX.decode(headers.get(HttpHeaderNames.SET_COOKIE));
                         assertThat(setCookie.name()).isEqualTo("a");

--- a/thrift/src/test/java/com/linecorp/armeria/client/thrift/ThriftOverHttpClientTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/client/thrift/ThriftOverHttpClientTest.java
@@ -49,6 +49,7 @@ import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.ConnectionPoolListener;
 import com.linecorp.armeria.client.logging.ConnectionPoolLoggingListener;
 import com.linecorp.armeria.client.logging.LoggingClient;
+import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
@@ -139,7 +140,7 @@ public class ThriftOverHttpClientTest {
     private static final HeaderService.AsyncIface headerServiceHandler =
             (name, resultHandler) -> {
                 final HttpRequest req = RequestContext.current().request();
-                resultHandler.onComplete(req.headers().get(AsciiString.of(name), ""));
+                resultHandler.onComplete(req.headers().get(HttpHeaderNames.of(name), ""));
             };
 
     private enum Handlers {
@@ -512,10 +513,12 @@ public class ThriftOverHttpClientTest {
         assertThat(client.header(AUTHORIZATION)).isEqualTo(NO_TOKEN);
 
         final HeaderService.Iface clientA =
-                Clients.newDerivedClient(client, newHttpHeaderOption(AsciiString.of(AUTHORIZATION), TOKEN_A));
+                Clients.newDerivedClient(client,
+                                         newHttpHeaderOption(HttpHeaderNames.of(AUTHORIZATION), TOKEN_A));
 
         final HeaderService.Iface clientB =
-                Clients.newDerivedClient(client, newHttpHeaderOption(AsciiString.of(AUTHORIZATION), TOKEN_B));
+                Clients.newDerivedClient(client,
+                                         newHttpHeaderOption(HttpHeaderNames.of(AUTHORIZATION), TOKEN_B));
 
         assertThat(clientA.header(AUTHORIZATION)).isEqualTo(TOKEN_A);
         assertThat(clientB.header(AUTHORIZATION)).isEqualTo(TOKEN_B);

--- a/thrift/src/test/java/com/linecorp/armeria/it/thrift/ThriftHttpHeaderTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/thrift/ThriftHttpHeaderTest.java
@@ -33,6 +33,7 @@ import com.linecorp.armeria.client.ClientBuilder;
 import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.common.DefaultHttpHeaders;
 import com.linecorp.armeria.common.FilteredHttpResponse;
+import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpObject;
 import com.linecorp.armeria.common.HttpRequest;
@@ -45,8 +46,6 @@ import com.linecorp.armeria.server.thrift.THttpService;
 import com.linecorp.armeria.service.test.thrift.main.HelloService;
 import com.linecorp.armeria.service.test.thrift.main.HelloService.Iface;
 import com.linecorp.armeria.testing.server.ServerRule;
-
-import io.netty.util.AsciiString;
 
 /**
  * Tests if Armeria decorators can alter the request/response timeout specified in Thrift call parameters.
@@ -71,7 +70,7 @@ public class ThriftHttpHeaderTest {
             resultHandler.onError(new Exception(errorMessage));
         }
 
-        final HttpHeaders responseHeaders = new DefaultHttpHeaders().set(AsciiString.of("foo"), "bar");
+        final HttpHeaders responseHeaders = new DefaultHttpHeaders().set(HttpHeaderNames.of("foo"), "bar");
         ctx.setAdditionalResponseHeaders(responseHeaders);
     };
 
@@ -153,7 +152,7 @@ public class ThriftHttpHeaderTest {
                         @Override
                         protected HttpObject filter(HttpObject obj) {
                             if (obj instanceof HttpHeaders) {
-                                assertThat(((HttpHeaders) obj).get(AsciiString.of("foo"))).isEqualTo("bar");
+                                assertThat(((HttpHeaders) obj).get(HttpHeaderNames.of("foo"))).isEqualTo("bar");
                             }
                             return obj;
                         }

--- a/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftDocServiceTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftDocServiceTest.java
@@ -41,6 +41,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
+import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.thrift.ThriftSerializationFormats;
@@ -58,8 +59,6 @@ import com.linecorp.armeria.service.test.thrift.main.OnewayHelloService;
 import com.linecorp.armeria.service.test.thrift.main.SleepService;
 import com.linecorp.armeria.testing.server.ServerRule;
 
-import io.netty.util.AsciiString;
-
 public class ThriftDocServiceTest {
 
     private static final HelloService.AsyncIface HELLO_SERVICE_HANDLER =
@@ -69,10 +68,10 @@ public class ThriftDocServiceTest {
             (duration, resultHandler) -> resultHandler.onComplete(duration);
 
     private static final hello_args EXAMPLE_HELLO = new hello_args("sample user");
-    private static final HttpHeaders EXAMPLE_HEADERS_ALL = HttpHeaders.of(AsciiString.of("a"), "b");
-    private static final HttpHeaders EXAMPLE_HEADERS_HELLO = HttpHeaders.of(AsciiString.of("c"), "d");
-    private static final HttpHeaders EXAMPLE_HEADERS_FOO = HttpHeaders.of(AsciiString.of("e"), "f");
-    private static final HttpHeaders EXAMPLE_HEADERS_FOO_BAR1 = HttpHeaders.of(AsciiString.of("g"), "h");
+    private static final HttpHeaders EXAMPLE_HEADERS_ALL = HttpHeaders.of(HttpHeaderNames.of("a"), "b");
+    private static final HttpHeaders EXAMPLE_HEADERS_HELLO = HttpHeaders.of(HttpHeaderNames.of("c"), "d");
+    private static final HttpHeaders EXAMPLE_HEADERS_FOO = HttpHeaders.of(HttpHeaderNames.of("e"), "f");
+    private static final HttpHeaders EXAMPLE_HEADERS_FOO_BAR1 = HttpHeaders.of(HttpHeaderNames.of("g"), "h");
 
     private static final ObjectMapper mapper = new ObjectMapper();
 

--- a/zipkin/src/main/java/com/linecorp/armeria/internal/tracing/AsciiStringKeyFactory.java
+++ b/zipkin/src/main/java/com/linecorp/armeria/internal/tracing/AsciiStringKeyFactory.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.internal.tracing;
 
+import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 
 import brave.propagation.Propagation;
@@ -30,6 +31,6 @@ public enum AsciiStringKeyFactory implements Propagation.KeyFactory<AsciiString>
 
     @Override
     public AsciiString create(String name) {
-        return AsciiString.of(name);
+        return HttpHeaderNames.of(name);
     }
 }


### PR DESCRIPTION
Motivation:

By allowing a user to specify `AsciiString` or other `CharSequence`
implementations, we can perform more HTTP header name normalization,
e.g.

    AsciiString contentType = AsciiString.of("Content-Type");
    assert HttpHeaderNames.CONTENT_TYPE != contentType;
    AsciiString normContentType = HttpHeaderNames.of(contentType);
    assert HttpHeaderNames.CONTENT_TYPE == normContentType;

Modifications:

- Change the parameter type of `HttpHeaderNames.of()` from `String` to
  `CharSequence` and add fast path for the case of `AsciiString`.
- Use `HttpHeaderNames.of()` instead of `AsciiString.of()` wherever
  possible.
- Use `AsciiString.cached()` instead of `AsciiString.of()` when the type
  of the string is actually a `String`.
- Make `ClientBuilder.add/setHttpHeader()` accept `CharSequence` as a
  header name.

Result:

- Efficiency