### PR TITLE
Additional description in README.md and CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,8 @@ After importing the project, import the IDE settings as well.
 - [`settings.jar`](https://raw.githubusercontent.com/line/armeria/master/settings/intellij_idea/settings.jar) -
   See [Importing settings from a JAR archive](https://www.jetbrains.com/help/idea/2016.3/exporting-and-importing-settings.html#d2016665e55).
 - Make sure to use 'LINE OSS' code style and inspection profile.
+  - Go to `Preferences` > `Editors` > `Code Style` and set `Scheme` option to `LINE OSS`
+  - Go to `Preferences` > `Editors` > `Inspections` and set `Profile` option to `LINE OSS`
 - Although optional, if you want to run Checkstyle from IDEA, install the
   [Checkstyle-IDEA plugin](https://github.com/jshiell/checkstyle-idea), import and activate
   the rule file at `settings/checkstyle/checkstyle.xml`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,8 +33,8 @@ After importing the project, import the IDE settings as well.
 - [`settings.jar`](https://raw.githubusercontent.com/line/armeria/master/settings/intellij_idea/settings.jar) -
   See [Importing settings from a JAR archive](https://www.jetbrains.com/help/idea/2016.3/exporting-and-importing-settings.html#d2016665e55).
 - Make sure to use 'LINE OSS' code style and inspection profile.
-  - Go to `Preferences` > `Editors` > `Code Style` and set `Scheme` option to `LINE OSS`
-  - Go to `Preferences` > `Editors` > `Inspections` and set `Profile` option to `LINE OSS`
+  - Go to `Preferences` > `Editors` > `Code Style` and set `Scheme` option to `LINE OSS`.
+  - Go to `Preferences` > `Editors` > `Inspections` and set `Profile` option to `LINE OSS`.
 - Although optional, if you want to run Checkstyle from IDEA, install the
   [Checkstyle-IDEA plugin](https://github.com/jshiell/checkstyle-idea), import and activate
   the rule file at `settings/checkstyle/checkstyle.xml`.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ by [LINE Corporation](https://linecorp.com/en/), who uses it in production.
 
 ## How to build
 
-We use [Gradle](https://gradle.org/) and [Java 10](https://java.oracle.com/) to build Armeria. The following command will compile Armeria and generate
+We use [Gradle](https://gradle.org/) and [Java 10 or later](https://java.oracle.com/) to build Armeria. The following command will compile Armeria and generate
 JARs and web site:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ by [LINE Corporation](https://linecorp.com/en/), who uses it in production.
 
 ## How to build
 
-We use [Gradle](https://gradle.org/) to build Armeria. The following command will compile Armeria and generate
+We use [Gradle](https://gradle.org/) and [Java 10](https://java.oracle.com/) to build Armeria. The following command will compile Armeria and generate
 JARs and web site:
 
 ```bash


### PR DESCRIPTION
When I tried to build Armeria for the first time, I failed it because I used Java 8. 
As far as I know, It requires Java 10 or later to build, so I added additional description in `README.md`
so that A user doesn't have to be confused. ( Let me know if I am wrong )

I also think that the description for IDE settings for IntelliJ is not enough. so I added it too.