### PR TITLE
Prevent cyclic call in CircuitBreakerListener

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ConnectionPoolListenerAdapter.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ConnectionPoolListenerAdapter.java
@@ -22,8 +22,8 @@ import com.linecorp.armeria.common.SessionProtocol;
 import io.netty.util.AttributeMap;
 
 /**
- * A skeletal {@link ConnectionPoolListener} implementation to minimize the effort to implement this interface.
- * Extend this class to implement only a few of the provided handler methods.
+ * A skeletal {@link ConnectionPoolListener} implementation in order for a user to implement only the methods
+ * what he or she really needs.
  */
 public class ConnectionPoolListenerAdapter implements ConnectionPoolListener {
 

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerListener.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerListener.java
@@ -24,15 +24,45 @@ public interface CircuitBreakerListener {
     /**
      * Invoked when the circuit state is changed.
      */
-    void onStateChanged(CircuitBreaker circuitBreaker, CircuitState state) throws Exception;
+    void onStateChanged(String circuitBreakerName, CircuitState state) throws Exception;
+
+    /**
+     * Invoked when the circuit state is changed.
+     *
+     * @deprecated Use {@link #onStateChanged(String, CircuitState)}.
+     */
+    @Deprecated
+    default void onStateChanged(CircuitBreaker circuitBreaker, CircuitState state) throws Exception {
+        onStateChanged(circuitBreaker.name(), state);
+    }
 
     /**
      * Invoked when the circuit breaker's internal {@link EventCount} is updated.
      */
-    void onEventCountUpdated(CircuitBreaker circuitBreaker, EventCount eventCount) throws Exception;
+    void onEventCountUpdated(String circuitBreakerName, EventCount eventCount) throws Exception;
+
+    /**
+     * Invoked when the circuit breaker's internal {@link EventCount} is updated.
+     *
+     * @deprecated Use {@link #onEventCountUpdated(String, EventCount)}.
+     */
+    @Deprecated
+    default void onEventCountUpdated(CircuitBreaker circuitBreaker, EventCount eventCount) throws Exception {
+        onEventCountUpdated(circuitBreaker.name(), eventCount);
+    }
 
     /**
      * Invoked when the circuit breaker rejects a request.
      */
-    void onRequestRejected(CircuitBreaker circuitBreaker) throws Exception;
+    void onRequestRejected(String circuitBreakerName) throws Exception;
+
+    /**
+     * Invoked when the circuit breaker rejects a request.
+     *
+     * @deprecated Use {@link #onRequestRejected(String)}.
+     */
+    @Deprecated
+    default void onRequestRejected(CircuitBreaker circuitBreaker) throws Exception {
+        onRequestRejected(circuitBreaker.name());
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerListenerAdapter.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerListenerAdapter.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.circuitbreaker;
+
+/**
+ * A skeletal {@link CircuitBreakerListener} implementation to minimize the effort to implement this interface.
+ * Extend this class to implement only few of the provided listener methods.
+ */
+public class CircuitBreakerListenerAdapter implements CircuitBreakerListener {
+
+    @Override
+    public void onStateChanged(CircuitBreaker circuitBreaker, CircuitState state) throws Exception {}
+
+    @Override
+    public void onEventCountUpdated(CircuitBreaker circuitBreaker, EventCount eventCount) throws Exception {}
+
+    @Override
+    public void onRequestRejected(CircuitBreaker circuitBreaker) throws Exception {}
+}

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerListenerAdapter.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerListenerAdapter.java
@@ -23,11 +23,11 @@ package com.linecorp.armeria.client.circuitbreaker;
 public class CircuitBreakerListenerAdapter implements CircuitBreakerListener {
 
     @Override
-    public void onStateChanged(CircuitBreaker circuitBreaker, CircuitState state) throws Exception {}
+    public void onStateChanged(String circuitBreakerName, CircuitState state) throws Exception {}
 
     @Override
-    public void onEventCountUpdated(CircuitBreaker circuitBreaker, EventCount eventCount) throws Exception {}
+    public void onEventCountUpdated(String circuitBreakerName, EventCount eventCount) throws Exception {}
 
     @Override
-    public void onRequestRejected(CircuitBreaker circuitBreaker) throws Exception {}
+    public void onRequestRejected(String circuitBreakerName) throws Exception {}
 }

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerListenerAdapter.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerListenerAdapter.java
@@ -17,8 +17,8 @@
 package com.linecorp.armeria.client.circuitbreaker;
 
 /**
- * A skeletal {@link CircuitBreakerListener} implementation to minimize the effort to implement this interface.
- * Extend this class to implement only few of the provided listener methods.
+ * A skeletal {@link CircuitBreakerListener} implementation in order for a user to implement only the methods
+ * what he or she really needs.
  */
 public class CircuitBreakerListenerAdapter implements CircuitBreakerListener {
 

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/MetricCollectingCircuitBreakerListener.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/MetricCollectingCircuitBreakerListener.java
@@ -77,22 +77,22 @@ public final class MetricCollectingCircuitBreakerListener implements CircuitBrea
     }
 
     @Override
-    public void onStateChanged(CircuitBreaker circuitBreaker, CircuitState state) {
-        metricsOf(circuitBreaker).onStateChanged(state);
+    public void onStateChanged(String circuitBreakerName, CircuitState state) {
+        metricsOf(circuitBreakerName).onStateChanged(state);
     }
 
     @Override
-    public void onEventCountUpdated(CircuitBreaker circuitBreaker, EventCount eventCount) {
-        metricsOf(circuitBreaker).onCountUpdated(eventCount);
+    public void onEventCountUpdated(String circuitBreakerName, EventCount eventCount) {
+        metricsOf(circuitBreakerName).onCountUpdated(eventCount);
     }
 
     @Override
-    public void onRequestRejected(CircuitBreaker circuitBreaker) {
-        metricsOf(circuitBreaker).onRequestRejected();
+    public void onRequestRejected(String circuitBreakerName) {
+        metricsOf(circuitBreakerName).onRequestRejected();
     }
 
-    private CircuitBreakerMetrics metricsOf(CircuitBreaker circuitBreaker) {
-        final MeterIdPrefix idPrefix = new MeterIdPrefix(name, "name", circuitBreaker.name());
+    private CircuitBreakerMetrics metricsOf(String circuitBreakerName) {
+        final MeterIdPrefix idPrefix = new MeterIdPrefix(name, "name", circuitBreakerName);
         return MicrometerUtil.register(registry, idPrefix,
                                        CircuitBreakerMetrics.class,
                                        CircuitBreakerMetrics::new);

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/NonBlockingCircuitBreaker.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/NonBlockingCircuitBreaker.java
@@ -180,22 +180,20 @@ final class NonBlockingCircuitBreaker implements CircuitBreaker {
             } catch (Throwable t) {
                 logger.warn("An error occurred when notifying a StateChanged event", t);
             }
-            try {
-                listener.onEventCountUpdated(this, EventCount.ZERO);
-            } catch (Throwable t) {
-                logger.warn("An error occurred when notifying an EventCountUpdated event", t);
-            }
+            notifyCountUpdated(listener, EventCount.ZERO);
         });
     }
 
     private void notifyCountUpdated(EventCount count) {
-        config.listeners().forEach(listener -> {
-            try {
-                listener.onEventCountUpdated(this, count);
-            } catch (Throwable t) {
-                logger.warn("An error occurred when notifying an EventCountUpdated event", t);
-            }
-        });
+        config.listeners().forEach(listener -> notifyCountUpdated(listener, count));
+    }
+
+    private void notifyCountUpdated(CircuitBreakerListener listener, EventCount count) {
+        try {
+            listener.onEventCountUpdated(this, count);
+        } catch (Throwable t) {
+            logger.warn("An error occurred when notifying an EventCountUpdated event", t);
+        }
     }
 
     private void notifyRequestRejected() {

--- a/core/src/main/java/com/linecorp/armeria/server/ServerListenerAdapter.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerListenerAdapter.java
@@ -17,8 +17,8 @@
 package com.linecorp.armeria.server;
 
 /**
- * A skeletal {@link ServerListener} implementation to minimize the effort to implement this interface.
- * Extend this class to implement only few of the provided listener methods.
+ * A skeletal {@link ServerListener} implementation in order for a user to implement only the methods
+ * what he or she really needs.
  */
 public class ServerListenerAdapter implements ServerListener {
     @Override

--- a/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerHttpClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerHttpClientTest.java
@@ -148,7 +148,7 @@ public class CircuitBreakerHttpClientTest {
                 .counterSlidingWindow(counterSlidingWindow)
                 .counterUpdateInterval(counterUpdateInterval)
                 .ticker(ticker)
-                .listener(new NoopCircuitBreakerListener() {
+                .listener(new CircuitBreakerListenerAdapter() {
                     @Override
                     public void onEventCountUpdated(CircuitBreaker circuitBreaker, EventCount eventCount)
                             throws Exception {
@@ -205,18 +205,5 @@ public class CircuitBreakerHttpClientTest {
      */
     private static CircuitBreakerStrategy strategy() {
         return (ctx, cause) -> CompletableFuture.completedFuture(cause == null);
-    }
-
-    private static class NoopCircuitBreakerListener implements CircuitBreakerListener {
-
-        @Override
-        public void onStateChanged(CircuitBreaker circuitBreaker, CircuitState state) throws Exception {}
-
-        @Override
-        public void onEventCountUpdated(CircuitBreaker circuitBreaker,
-                                        EventCount eventCount) throws Exception {}
-
-        @Override
-        public void onRequestRejected(CircuitBreaker circuitBreaker) throws Exception {}
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerHttpClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerHttpClientTest.java
@@ -150,7 +150,7 @@ public class CircuitBreakerHttpClientTest {
                 .ticker(ticker)
                 .listener(new CircuitBreakerListenerAdapter() {
                     @Override
-                    public void onEventCountUpdated(CircuitBreaker circuitBreaker, EventCount eventCount)
+                    public void onEventCountUpdated(String circuitBreakerName, EventCount eventCount)
                             throws Exception {
                         ticker.advance(Duration.ofMillis(1).toNanos());
                     }

--- a/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerHttpClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerHttpClientTest.java
@@ -122,21 +122,20 @@ public class CircuitBreakerHttpClientTest {
     }
 
     @Test
-    public void strategyWithoutContent() throws Exception {
+    public void strategyWithoutContent() {
         final CircuitBreakerStrategy strategy = CircuitBreakerStrategy.onServerErrorStatus();
         circuitBreakerIsOpenOnServerError(new CircuitBreakerHttpClientBuilder(strategy));
     }
 
     @Test
-    public void strategyWithContent() throws Exception {
+    public void strategyWithContent() {
         final CircuitBreakerStrategyWithContent<HttpResponse> strategy =
                 (ctx, response) -> response.aggregate().handle(
                         (msg, unused1) -> msg.status().codeClass() != HttpStatusClass.SERVER_ERROR);
         circuitBreakerIsOpenOnServerError(new CircuitBreakerHttpClientBuilder(strategy));
     }
 
-    private static void circuitBreakerIsOpenOnServerError(CircuitBreakerHttpClientBuilder builder)
-            throws Exception {
+    private static void circuitBreakerIsOpenOnServerError(CircuitBreakerHttpClientBuilder builder) {
         final FakeTicker ticker = new FakeTicker();
         final int minimumRequestThreshold = 2;
         final Duration circuitOpenWindow = Duration.ofSeconds(60);
@@ -149,27 +148,28 @@ public class CircuitBreakerHttpClientTest {
                 .counterSlidingWindow(counterSlidingWindow)
                 .counterUpdateInterval(counterUpdateInterval)
                 .ticker(ticker)
+                .listener(new NoopCircuitBreakerListener() {
+                    @Override
+                    public void onEventCountUpdated(CircuitBreaker circuitBreaker, EventCount eventCount)
+                            throws Exception {
+                        ticker.advance(Duration.ofMillis(1).toNanos());
+                    }
+                })
                 .build();
-
-        @SuppressWarnings("unchecked")
-        final Client<HttpRequest, HttpResponse> delegate = mock(Client.class);
-        when(delegate.execute(any(), any())).thenReturn(HttpResponse.of(503))
-                                            .thenReturn(HttpResponse.of(503))
-                                            .thenReturn(HttpResponse.of(503))
-                                            .thenReturn(HttpResponse.of(503));
 
         final CircuitBreakerMapping mapping = (ctx, req) -> circuitBreaker;
         final HttpClient client = new HttpClientBuilder(server.uri("/"))
                 .decorator(builder.circuitBreakerMapping(mapping).newDecorator())
                 .build();
 
+        ticker.advance(Duration.ofMillis(1).toNanos());
         // CLOSED
         for (int i = 0; i < minimumRequestThreshold + 1; i++) {
             // Need to call execute() one more to change the state of the circuit breaker.
-
+            final long currentTime = ticker.read();
             assertThat(client.get("/unavailable").aggregate().join().headers().status())
                     .isSameAs(HttpStatus.SERVICE_UNAVAILABLE);
-            ticker.advance(Duration.ofMillis(1).toNanos());
+            await().until(() -> currentTime != ticker.read());
         }
 
         await().untilAsserted(() -> assertThat(circuitBreaker.canRequest()).isFalse());
@@ -205,5 +205,18 @@ public class CircuitBreakerHttpClientTest {
      */
     private static CircuitBreakerStrategy strategy() {
         return (ctx, cause) -> CompletableFuture.completedFuture(cause == null);
+    }
+
+    private static class NoopCircuitBreakerListener implements CircuitBreakerListener {
+
+        @Override
+        public void onStateChanged(CircuitBreaker circuitBreaker, CircuitState state) throws Exception {}
+
+        @Override
+        public void onEventCountUpdated(CircuitBreaker circuitBreaker,
+                                        EventCount eventCount) throws Exception {}
+
+        @Override
+        public void onRequestRejected(CircuitBreaker circuitBreaker) throws Exception {}
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/MetricCollectingCircuitBreakerListenerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/MetricCollectingCircuitBreakerListenerTest.java
@@ -36,7 +36,7 @@ public class MetricCollectingCircuitBreakerListenerTest {
         final CircuitBreaker cb = new CircuitBreakerBuilder("bar").build();
 
         // Trigger the first event so that the metric group is registered.
-        l.onEventCountUpdated(cb, new EventCount(1, 2));
+        l.onEventCountUpdated(cb.name(), new EventCount(1, 2));
 
         assertThat(MoreMeters.measureAll(registry))
                 .containsEntry("foo.requests#value{name=bar,result=success}", 1.0)
@@ -47,22 +47,22 @@ public class MetricCollectingCircuitBreakerListenerTest {
                 .containsEntry("foo.rejectedRequests#count{name=bar}", 0.0);
 
         // Transit to CLOSED.
-        l.onStateChanged(cb, CircuitState.CLOSED);
+        l.onStateChanged(cb.name(), CircuitState.CLOSED);
         assertThat(MoreMeters.measureAll(registry))
                 .containsEntry("foo.transitions#count{name=bar,state=CLOSED}", 1.0);
 
         // Transit to OPEN.
-        l.onStateChanged(cb, CircuitState.OPEN);
+        l.onStateChanged(cb.name(), CircuitState.OPEN);
         assertThat(MoreMeters.measureAll(registry))
                 .containsEntry("foo.transitions#count{name=bar,state=OPEN}", 1.0);
 
         // Transit to HALF_OPEN.
-        l.onStateChanged(cb, CircuitState.HALF_OPEN);
+        l.onStateChanged(cb.name(), CircuitState.HALF_OPEN);
         assertThat(MoreMeters.measureAll(registry))
                 .containsEntry("foo.transitions#count{name=bar,state=HALF_OPEN}", 1.0);
 
         // Reject a request.
-        l.onRequestRejected(cb);
+        l.onRequestRejected(cb.name());
         assertThat(MoreMeters.measureAll(registry))
                 .containsEntry("foo.rejectedRequests#count{name=bar}", 1.0);
     }


### PR DESCRIPTION
Motivation:
The methods in `CircuitBreakerListener` are invoked with the `CircuitBreaker` instance. In our default implementation of `CircuitBreaker` which is `NonBlockingCircuitBreaker`, `canRequest()` calls `CircuitBreakerListener.onRequestRejected()` internally. So if `canRequest()` is called inside `onRequestRejected()`, it makes cycle, so we should prevent it.

Modifications:
- Make all methods in `CircuitBreakerListener` deprecated, and add methods which take the circuit breaker name as an argument.
- Fix flaky test in CircuitBreakerHttpClientTest
- Add CircuitBreakerListenerAdapter

Result:
- Less cycle
- Less flaky
- Fix #1443 