### PR TITLE
Less verbose error logging / Fix incorrect behavior when 'verboseExceptions' is set.

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/internal/Http2GoAwayHandlerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/Http2GoAwayHandlerTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.internal;
+
+import static com.linecorp.armeria.internal.Http2GoAwayHandler.isExpected;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.Test;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http2.Http2Error;
+
+public class Http2GoAwayHandlerTest {
+    @Test
+    public void testIsExpected() {
+        final ByteBuf errorFlushing = Unpooled.copiedBuffer("Error flushing", StandardCharsets.UTF_8);
+        final ByteBuf errorFlushing2 = Unpooled.copiedBuffer("Error flushing stream", StandardCharsets.UTF_8);
+        final ByteBuf other = Unpooled.copiedBuffer("Other reasons", StandardCharsets.UTF_8);
+        assertThat(isExpected(Http2Error.INTERNAL_ERROR.code(), errorFlushing)).isTrue();
+        assertThat(isExpected(Http2Error.PROTOCOL_ERROR.code(), errorFlushing)).isFalse();
+        assertThat(isExpected(Http2Error.INTERNAL_ERROR.code(), errorFlushing2)).isTrue();
+        assertThat(isExpected(Http2Error.INTERNAL_ERROR.code(), other)).isFalse();
+    }
+}


### PR DESCRIPTION
Motivation:

1)

`Exceptions.isExpected(Throwable)` should always return `false` when
`verboseExceptions` flag is set. However, it currently always returns
`true` by coding mistake.

2)

I found a few more exception messages which do not really need to be
logged at high level:

    SSLException: SSLEngine closed already
    Sent a GOAWAY frame: lastStreamId=..., errorCode=INTERNAL_ERROR(2), debugData="Error flushing"

Both errors can happen when a socket connection has been closed by a
remote peer, which should be treated in a similar manner with
'connection reset by peer' errors.

Modifications:

- Update `Exceptions.isExpected()` to always return `false` when
  `verboseExceptions` flag is set.
- Update `Exceptions.isExpected()` to return `true` for
  `SSLException: SSLEngine closed already`.
- Update `Http2GoAwayHandler` to log at DEBUG level for
  `Sent a GOAWAY frame: ... debugData="Error flushing"`.

Result:

- Fixes #1515
- `com.linecorp.armeria.verboseExceptions` flag works as expected.
- Cleaner log file with less WARN-level log messages.
