### PR TITLE
Deprecate `ClosedClientFactoryException` and use `IllegalStateException`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClosedClientFactoryException.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClosedClientFactoryException.java
@@ -22,8 +22,11 @@ import com.linecorp.armeria.common.util.Exceptions;
 /**
  * A {@link RuntimeException} raised when a {@link Client} is executing and the {@link ClientFactory} which the
  * {@link Client} is using is closed.
+ *
+ * @deprecated {@link IllegalStateException} with a message will be raised.
  */
-public final class ClosedClientFactoryException extends RuntimeException {
+@Deprecated
+public final class ClosedClientFactoryException extends IllegalStateException {
 
     private static final long serialVersionUID = 6865054624299408503L;
 

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryingHttpClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryingHttpClientTest.java
@@ -44,7 +44,6 @@ import com.google.common.base.Stopwatch;
 import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.ClientFactoryBuilder;
 import com.linecorp.armeria.client.ClientRequestContext;
-import com.linecorp.armeria.client.ClosedClientFactoryException;
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.client.HttpClientBuilder;
 import com.linecorp.armeria.client.ResponseTimeoutException;
@@ -410,7 +409,9 @@ public class RetryingHttpClientTest {
         // The next retry will be after 8 seconds so closing the factory after 3 seconds should work.
         Executors.newSingleThreadScheduledExecutor().schedule(factory::close, 3, TimeUnit.SECONDS);
         assertThatThrownBy(() -> client.get("/service-unavailable").aggregate().join())
-                .hasCauseInstanceOf(ClosedClientFactoryException.class);
+                .hasCauseInstanceOf(IllegalStateException.class)
+                .satisfies(cause -> assertThat(cause.getCause().getMessage()).matches(
+                        "(?i).*(factory has been closed|not accepting a task).*"));
     }
 
     @Test

--- a/thrift/src/test/java/com/linecorp/armeria/it/client/retry/RetryingRpcClientTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/client/retry/RetryingRpcClientTest.java
@@ -40,7 +40,6 @@ import org.junit.Test;
 import com.linecorp.armeria.client.ClientBuilder;
 import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.ClientFactoryBuilder;
-import com.linecorp.armeria.client.ClosedClientFactoryException;
 import com.linecorp.armeria.client.retry.Backoff;
 import com.linecorp.armeria.client.retry.RetryStrategyWithContent;
 import com.linecorp.armeria.client.retry.RetryingRpcClient;
@@ -168,7 +167,9 @@ public class RetryingRpcClientTest {
         // The next retry will be after 8 seconds so closing the factory after 3 seconds should work.
         Executors.newSingleThreadScheduledExecutor().schedule(factory::close, 3, TimeUnit.SECONDS);
         assertThatThrownBy(() -> client.hello("hello"))
-                .isInstanceOf(ClosedClientFactoryException.class);
+                .isInstanceOf(IllegalStateException.class)
+                .satisfies(cause -> assertThat(cause.getMessage()).matches(
+                        "(?i).*(factory has been closed|not accepting a task).*"));
     }
 
     @Test


### PR DESCRIPTION
Motivation:

Previously at #1236, we added `ClosedClientFactoryException` which is
raised when a request in progress by `RetryingClient` is cancelled due
to the termination of `ClientFactory`. I see two issues here:

- Defining a new exception type for such an exceptional cause has
  dubious value. It is hard to expect for a user to catch
  `ClosedClientFactoryException` and handle it.
- Due to inevitable race conditions, we are already raising
  `IllegalStateException` in some places, such as the connection pool.
  Indeed, `IllegalStateException` with a message is a better choice
  here.

Modifications:

- Deprecated `ClosedClientFactoryException` and used `IllegalStateException`.
- Made `ClosedClientFactoryException` extend `IllegalStateException`.
- Updates the test cases.

Result:

- Less flakiness
- Leaner API