### PR TITLE
Make Armeria(Client|Server)Configurator extend Spring's Ordered inter…

### DIFF
--- a/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaServerConfigurator.java
+++ b/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaServerConfigurator.java
@@ -15,6 +15,11 @@
  */
 package com.linecorp.armeria.spring;
 
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.AnnotationAwareOrderComparator;
+import org.springframework.core.annotation.Order;
+
 import com.linecorp.armeria.server.ServerBuilder;
 
 /**
@@ -23,9 +28,25 @@ import com.linecorp.armeria.server.ServerBuilder;
  * to use convenience beans like {@link ThriftServiceRegistrationBean}.
  */
 @FunctionalInterface
-public interface ArmeriaServerConfigurator {
+public interface ArmeriaServerConfigurator extends Ordered {
     /**
      * Configures the server using the specified {@link ServerBuilder}.
      */
     void configure(ServerBuilder serverBuilder);
+
+    /**
+     * Returns the evaluation order of this configurator. A user can specify the order with an {@link Order}
+     * annotation when defining a bean with a {@link Bean} annotation.
+     *
+     * <p>Note that the default value of the {@link Order} annotation is {@link Ordered#LOWEST_PRECEDENCE}
+     * which equals to {@link Integer#MAX_VALUE}, but it is overridden to {@code 0} by this default method.
+     *
+     * @see Ordered#LOWEST_PRECEDENCE
+     * @see Ordered#HIGHEST_PRECEDENCE
+     * @see AnnotationAwareOrderComparator
+     */
+    @Override
+    default int getOrder() {
+        return 0;
+    }
 }

--- a/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaServerConfiguratorTest.java
+++ b/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaServerConfiguratorTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.spring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.linecorp.armeria.server.ServerBuilder;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+public class ArmeriaServerConfiguratorTest {
+
+    @Configuration
+    static class TestConfiguration {
+        @Bean
+        @Order(1)
+        static ArmeriaServerConfigurator configurator1() {
+            return new TestArmeriaServerConfigurator("order:1");
+        }
+
+        @Bean
+        @Order(-1)
+        static ArmeriaServerConfigurator configurator2() {
+            return new TestArmeriaServerConfigurator("order:-1");
+        }
+
+        @Bean
+        static ArmeriaServerConfigurator configurator3() {
+            return new TestArmeriaServerConfigurator("order:0");
+        }
+
+        private static class TestArmeriaServerConfigurator implements ArmeriaServerConfigurator {
+            private final String name;
+
+            TestArmeriaServerConfigurator(String name) {
+                this.name = name;
+            }
+
+            @Override
+            public void configure(ServerBuilder serverBuilder) {}
+
+            @Override
+            public String toString() {
+                return name;
+            }
+        }
+    }
+
+    @Inject
+    List<ArmeriaServerConfigurator> configurators;
+
+    @Test
+    public void ordering() {
+        // We cannot check ArmeriaServerConfigurator#getOrder here because we didn't override it
+        // so it always returns 0.
+        assertThat(configurators.get(0).toString()).isEqualTo("order:-1");
+        assertThat(configurators.get(1).toString()).isEqualTo("order:0");
+        assertThat(configurators.get(2).toString()).isEqualTo("order:1");
+    }
+}

--- a/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaClientAutoConfiguration.java
+++ b/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaClientAutoConfiguration.java
@@ -15,7 +15,7 @@
  */
 package com.linecorp.armeria.spring.web.reactive;
 
-import java.util.Optional;
+import java.util.List;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -38,15 +38,14 @@ import org.springframework.web.reactive.function.client.WebClient.Builder;
 public class ArmeriaClientAutoConfiguration {
 
     /**
-     * Returns a {@link ClientHttpConnector} which is customized by an
-     * {@link ArmeriaClientConfigurator}.
+     * Returns a {@link ClientHttpConnector} which is configured by a list of
+     * {@link ArmeriaClientConfigurator}s.
      */
     @Bean
     public ClientHttpConnector clientHttpConnector(
-            Optional<ArmeriaClientConfigurator> customizer,
+            List<ArmeriaClientConfigurator> customizer,
             DataBufferFactoryWrapper<?> factoryWrapper) {
-        return customizer.map(c -> new ArmeriaClientHttpConnector(c, factoryWrapper))
-                         .orElseGet(() -> new ArmeriaClientHttpConnector(factoryWrapper));
+        return new ArmeriaClientHttpConnector(customizer, factoryWrapper);
     }
 
     /**

--- a/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaClientConfigurator.java
+++ b/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaClientConfigurator.java
@@ -15,15 +15,36 @@
  */
 package com.linecorp.armeria.spring.web.reactive;
 
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.AnnotationAwareOrderComparator;
+import org.springframework.core.annotation.Order;
+
 import com.linecorp.armeria.client.HttpClientBuilder;
 
 /**
- * A customizer to customize an {@link HttpClientBuilder} for an {@link ArmeriaClientHttpConnector}.
+ * A configurator to configure an {@link HttpClientBuilder} for an {@link ArmeriaClientHttpConnector}.
  */
 @FunctionalInterface
-public interface ArmeriaClientConfigurator {
+public interface ArmeriaClientConfigurator extends Ordered {
     /**
      * Configures the client using the specified {@link HttpClientBuilder}.
      */
-    void customize(HttpClientBuilder builder);
+    void configure(HttpClientBuilder builder);
+
+    /**
+     * Returns the evaluation order of this configurator. A user can specify the order with an {@link Order}
+     * annotation when defining a bean with a {@link Bean} annotation.
+     *
+     * <p>Note that the default value of the {@link Order} annotation is {@link Ordered#LOWEST_PRECEDENCE}
+     * which equals to {@link Integer#MAX_VALUE}, but it is overridden to {@code 0} by this default method.
+     *
+     * @see Ordered#LOWEST_PRECEDENCE
+     * @see Ordered#HIGHEST_PRECEDENCE
+     * @see AnnotationAwareOrderComparator
+     */
+    @Override
+    default int getOrder() {
+        return 0;
+    }
 }

--- a/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaClientConfigurator.java
+++ b/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaClientConfigurator.java
@@ -33,16 +33,6 @@ public interface ArmeriaClientConfigurator extends Ordered {
     void configure(HttpClientBuilder builder);
 
     /**
-     * Configures the client using the specified {@link HttpClientBuilder}.
-     *
-     * @deprecated Use {@link #configure(HttpClientBuilder)}.
-     */
-    @Deprecated
-    default void customize(HttpClientBuilder builder) {
-        configure(builder);
-    }
-
-    /**
      * Returns the evaluation order of this configurator. A user can specify the order with an {@link Order}
      * annotation when defining a bean with a {@link Bean} annotation.
      *

--- a/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaClientConfigurator.java
+++ b/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaClientConfigurator.java
@@ -33,6 +33,16 @@ public interface ArmeriaClientConfigurator extends Ordered {
     void configure(HttpClientBuilder builder);
 
     /**
+     * Configures the client using the specified {@link HttpClientBuilder}.
+     *
+     * @deprecated Use {@link #configure(HttpClientBuilder)}.
+     */
+    @Deprecated
+    default void customize(HttpClientBuilder builder) {
+        configure(builder);
+    }
+
+    /**
      * Returns the evaluation order of this configurator. A user can specify the order with an {@link Order}
      * annotation when defining a bean with a {@link Bean} annotation.
      *

--- a/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaClientHttpConnector.java
+++ b/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaClientHttpConnector.java
@@ -19,6 +19,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 import java.net.URI;
+import java.util.List;
 import java.util.function.Function;
 
 import org.springframework.core.io.buffer.DataBuffer;
@@ -28,6 +29,7 @@ import org.springframework.http.client.reactive.ClientHttpRequest;
 import org.springframework.http.client.reactive.ClientHttpResponse;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.client.HttpClientBuilder;
@@ -40,52 +42,37 @@ import reactor.core.publisher.Mono;
  */
 public final class ArmeriaClientHttpConnector implements ClientHttpConnector {
 
-    /**
-     * A default {@link ArmeriaClientConfigurator} which does nothing.
-     */
-    private static final ArmeriaClientConfigurator IDENTITY = b -> { /* noop */ };
-
-    private final ArmeriaClientConfigurator customizer;
+    private final List<ArmeriaClientConfigurator> configurators;
     private final DataBufferFactoryWrapper<?> factoryWrapper;
 
     /**
-     * Creates an {@link ArmeriaClientHttpConnector} with the default
-     * {@link ArmeriaClientConfigurator} and {@link DataBufferFactoryWrapper}.
+     * Creates an {@link ArmeriaClientHttpConnector} with the default {@link ArmeriaClientConfigurator} and
+     * {@link DataBufferFactoryWrapper}.
      */
     public ArmeriaClientHttpConnector() {
-        this(IDENTITY, DataBufferFactoryWrapper.DEFAULT);
+        this(ImmutableList.of(), DataBufferFactoryWrapper.DEFAULT);
     }
 
     /**
      * Creates an {@link ArmeriaClientHttpConnector} with the specified
      * {@link ArmeriaClientConfigurator} and the default {@link DataBufferFactoryWrapper}.
      *
-     * @param customizer the customizer to be used to build an {@link HttpClient}
+     * @param configurator the configurator to be used to build an {@link HttpClient}
      */
-    public ArmeriaClientHttpConnector(ArmeriaClientConfigurator customizer) {
-        this(customizer, DataBufferFactoryWrapper.DEFAULT);
-    }
-
-    /**
-     * Creates an {@link ArmeriaClientHttpConnector} with the specified {@link DataBufferFactoryWrapper}
-     * and the default {@link ArmeriaClientConfigurator}.
-     *
-     * @param factoryWrapper the factory wrapper to be used to create a {@link DataBuffer}
-     */
-    public ArmeriaClientHttpConnector(DataBufferFactoryWrapper<?> factoryWrapper) {
-        this(IDENTITY, factoryWrapper);
+    public ArmeriaClientHttpConnector(ArmeriaClientConfigurator configurator) {
+        this(ImmutableList.of(requireNonNull(configurator, "configurator")),
+             DataBufferFactoryWrapper.DEFAULT);
     }
 
     /**
      * Creates an {@link ArmeriaClientHttpConnector}.
      *
-     * @param customizer the {@link ArmeriaClientConfigurator} to be used to build an
-     *                   {@link HttpClient}
+     * @param configurators the {@link ArmeriaClientConfigurator} to be used to build an {@link HttpClient}
      * @param factoryWrapper the factory wrapper to be used to create a {@link DataBuffer}
      */
-    public ArmeriaClientHttpConnector(ArmeriaClientConfigurator customizer,
+    public ArmeriaClientHttpConnector(List<ArmeriaClientConfigurator> configurators,
                                       DataBufferFactoryWrapper<?> factoryWrapper) {
-        this.customizer = requireNonNull(customizer, "customizer");
+        this.configurators = ImmutableList.copyOf(requireNonNull(configurators, "configurators"));
         this.factoryWrapper = requireNonNull(factoryWrapper, "factoryWrapper");
     }
 
@@ -119,7 +106,7 @@ public final class ArmeriaClientHttpConnector implements ClientHttpConnector {
 
         final URI baseUri = URI.create(Strings.isNullOrEmpty(scheme) ? authority : scheme + "://" + authority);
         final HttpClientBuilder builder = new HttpClientBuilder(baseUri);
-        customizer.customize(builder);
+        configurators.forEach(c -> c.configure(builder));
 
         final String pathAndQuery = Strings.isNullOrEmpty(query) ? path : path + '?' + query;
 

--- a/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaClientHttpConnector.java
+++ b/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaClientHttpConnector.java
@@ -67,10 +67,10 @@ public final class ArmeriaClientHttpConnector implements ClientHttpConnector {
     /**
      * Creates an {@link ArmeriaClientHttpConnector}.
      *
-     * @param configurators the {@link ArmeriaClientConfigurator} to be used to build an {@link HttpClient}
+     * @param configurators the {@link ArmeriaClientConfigurator}s to be used to build an {@link HttpClient}
      * @param factoryWrapper the factory wrapper to be used to create a {@link DataBuffer}
      */
-    public ArmeriaClientHttpConnector(List<ArmeriaClientConfigurator> configurators,
+    public ArmeriaClientHttpConnector(Iterable<ArmeriaClientConfigurator> configurators,
                                       DataBufferFactoryWrapper<?> factoryWrapper) {
         this.configurators = ImmutableList.copyOf(requireNonNull(configurators, "configurators"));
         this.factoryWrapper = requireNonNull(factoryWrapper, "factoryWrapper");

--- a/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaClientConfiguratorTest.java
+++ b/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaClientConfiguratorTest.java
@@ -29,8 +29,6 @@ import org.springframework.core.annotation.Order;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import com.linecorp.armeria.client.HttpClientBuilder;
-import com.linecorp.armeria.server.ServerBuilder;
-import com.linecorp.armeria.spring.ArmeriaServerConfigurator;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 public class ArmeriaClientConfiguratorTest {
@@ -67,18 +65,6 @@ public class ArmeriaClientConfiguratorTest {
             @Override
             public String toString() {
                 return name;
-            }
-        }
-
-        private static class ArmeriaConfigurator implements ArmeriaClientConfigurator, ArmeriaServerConfigurator {
-            @Override
-            public void configure(ServerBuilder builder) {
-
-            }
-
-            @Override
-            public void configure(HttpClientBuilder builder) {
-
             }
         }
     }

--- a/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaClientConfiguratorTest.java
+++ b/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaClientConfiguratorTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.spring.web.reactive;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.linecorp.armeria.client.HttpClientBuilder;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.spring.ArmeriaServerConfigurator;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+public class ArmeriaClientConfiguratorTest {
+
+    @Configuration
+    static class TestConfiguration {
+        @Bean
+        @Order(1)
+        static ArmeriaClientConfigurator configurator1() {
+            return new TestArmeriaClientConfigurator("order:1");
+        }
+
+        @Bean
+        @Order(-1)
+        static ArmeriaClientConfigurator configurator2() {
+            return new TestArmeriaClientConfigurator("order:-1");
+        }
+
+        @Bean
+        static ArmeriaClientConfigurator configurator3() {
+            return new TestArmeriaClientConfigurator("order:0");
+        }
+
+        private static class TestArmeriaClientConfigurator implements ArmeriaClientConfigurator {
+            private final String name;
+
+            TestArmeriaClientConfigurator(String name) {
+                this.name = name;
+            }
+
+            @Override
+            public void configure(HttpClientBuilder builder) {}
+
+            @Override
+            public String toString() {
+                return name;
+            }
+        }
+
+        private static class ArmeriaConfigurator implements ArmeriaClientConfigurator, ArmeriaServerConfigurator {
+            @Override
+            public void configure(ServerBuilder builder) {
+
+            }
+
+            @Override
+            public void configure(HttpClientBuilder builder) {
+
+            }
+        }
+    }
+
+    @Inject
+    List<ArmeriaClientConfigurator> configurators;
+
+    @Test
+    public void ordering() {
+        // We cannot check ArmeriaClientConfigurator#getOrder here because we didn't override it
+        // so it always returns 0.
+        assertThat(configurators.get(0).toString()).isEqualTo("order:-1");
+        assertThat(configurators.get(1).toString()).isEqualTo("order:0");
+        assertThat(configurators.get(2).toString()).isEqualTo("order:1");
+    }
+}


### PR DESCRIPTION
…face

Motivation:
When specifying evaluation order of the configurators using Spring's `@Order` annotation, it's definitely inconvenient if you want to make a configurator to be called at the last. Because the default value of `@Order` annotation is `Integer.MAX_VALUE` which means the lowest precedence. So it would be more convenient if we change the default order of our configurators to `0` so that a user can easily make a configurator to be called at the last by specifying `@Order(1)` or `@Order(Ordered.LOWEST_PRECEDENCE)`.

Modifications:
- Make `Armeria(Client|Server)Configurator` extend `org.springframework.core.Ordered`.
  - Implement `getOrder()` as a default method which returns `0`.
- (Breaking change) Rename `ArmeriaClientConfigurator#customize` to `configure` for consistency.
- A user can specify multiple `ArmeriaClientConfigurator` beans, like `ArmeriaServerConfigurator`.

Result:
- Closes #1533