### PR TITLE
Make javax.validation compileOnly

### DIFF
--- a/spring/boot-autoconfigure/build.gradle
+++ b/spring/boot-autoconfigure/build.gradle
@@ -7,11 +7,10 @@ dependencies {
     compile 'io.micrometer:micrometer-registry-prometheus'
     compile 'io.dropwizard.metrics:metrics-json'
     compile 'javax.inject:javax.inject'
-    compile 'javax.validation:validation-api'
+    compileOnly 'javax.validation:validation-api'
     compile 'org.springframework.boot:spring-boot-starter'
     compile 'org.springframework.boot:spring-boot-starter-actuator'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
     testCompile 'org.springframework.boot:spring-boot-starter-test'
-    testCompile 'org.hibernate.validator:hibernate-validator'
 }

--- a/spring/boot-webflux-autoconfigure/build.gradle
+++ b/spring/boot-webflux-autoconfigure/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     compile 'io.micrometer:micrometer-registry-prometheus'
     compile 'io.dropwizard.metrics:metrics-json'
     compile 'javax.inject:javax.inject'
-    compile 'javax.validation:validation-api'
+    compileOnly 'javax.validation:validation-api'
     compile 'org.springframework.boot:spring-boot-starter-actuator'
     compile 'org.springframework.boot:spring-boot-starter-webflux'
 
@@ -23,7 +23,6 @@ dependencies {
 
     testCompile "io.projectreactor:reactor-test"
     testCompile 'org.springframework.boot:spring-boot-starter-test'
-    testCompile 'org.hibernate.validator:hibernate-validator'
 }
 
 // Copy common files from boot-autoconfigure module to gen-src directory in order to use them as a source set.

--- a/spring/boot1-autoconfigure/build.gradle
+++ b/spring/boot1-autoconfigure/build.gradle
@@ -8,12 +8,11 @@ dependencies {
     compile 'io.micrometer:micrometer-registry-prometheus'
     compile 'io.dropwizard.metrics:metrics-json'
     compile 'javax.inject:javax.inject'
-    compile 'javax.validation:validation-api'
+    compileOnly 'javax.validation:validation-api'
     compile 'org.springframework.boot:spring-boot-starter:1.5.18.RELEASE'
     compileOnly 'org.springframework.boot:spring-boot-configuration-processor:1.5.18.RELEASE'
 
     testCompile 'org.springframework.boot:spring-boot-starter-test:1.5.18.RELEASE'
-    testCompile 'org.hibernate.validator:hibernate-validator'
 }
 
 // Use the sources from ':spring:boot-autoconfigure'.


### PR DESCRIPTION
Currently, users either need to provide `hibernate-validator` or exclude `javax.validation` when using `armeria-spring` because spring boot checks for the presence of the latter on the classpath and then requires something like the former. I think most users will have the dependencies if they want validation automatically without armeria enforcing it as a required dependency. Of course, exclusion is always an option too so maybe it's not a big deal. Thoughts?

Came up in https://github.com/openzipkin/zipkin/pull/2348