### PR TITLE
Fix NPE in HttpChannelPool

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
@@ -320,7 +320,7 @@ public final class ClientFactoryBuilder {
 
     /**
      * Sets whether to use <a href="https://en.wikipedia.org/wiki/HTTP_pipelining">HTTP pipelining</a> for
-     * HTTP/1 connections. This does not affect HTTP/2 connections. This option is enabled by default.
+     * HTTP/1 connections. This does not affect HTTP/2 connections. This option is disabled by default.
      */
     public ClientFactoryBuilder useHttp1Pipelining(boolean useHttp1Pipelining) {
         this.useHttp1Pipelining = useHttp1Pipelining;

--- a/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
@@ -454,6 +454,7 @@ final class HttpChannelPool implements AutoCloseable {
      * Adds a {@link Channel} to this pool.
      */
     private void addToPool(SessionProtocol actualProtocol, PoolKey key, PooledChannel pooledChannel) {
+        assert eventLoop.inEventLoop() : Thread.currentThread().getName();
         getOrCreatePool(actualProtocol, key).addLast(pooledChannel);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientDelegate.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientDelegate.java
@@ -215,10 +215,10 @@ final class HttpClientDelegate implements Client<HttpRequest, HttpResponse> {
                     // If pipelining is disabled, return after the response is fully received.
                     final CompletableFuture<Void> completionFuture =
                             factory.useHttp1Pipelining() ? req.completionFuture() : res.completionFuture();
-                    completionFuture.handle((ret, cause) -> {
+                    completionFuture.handleAsync((ret, cause) -> {
                         pooledChannel.release();
                         return null;
-                    });
+                    }, ctx.eventLoop());
                 } else {
                     // HTTP/2 connections do not need to get returned.
                 }


### PR DESCRIPTION
Motivation:
NPE is raised in `HttpChannelPool`. This is because the `HttpChannelPool` is designed to be accessed by just one thread, but it wasn't.
When the client uses HTTP/1 and subscribes the `HttpResponse` with another thread, it returns a connection to the `HttpChannelPool` with the different thread.

Modification:
- Fix to return the connection to the pool with the same eventloop

Result:
- Fewer NPEs