### PR TITLE
Remove deprecated methods in CircuitBreakerListener

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerListener.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerListener.java
@@ -27,42 +27,12 @@ public interface CircuitBreakerListener {
     void onStateChanged(String circuitBreakerName, CircuitState state) throws Exception;
 
     /**
-     * Invoked when the circuit state is changed.
-     *
-     * @deprecated Use {@link #onStateChanged(String, CircuitState)}.
-     */
-    @Deprecated
-    default void onStateChanged(CircuitBreaker circuitBreaker, CircuitState state) throws Exception {
-        onStateChanged(circuitBreaker.name(), state);
-    }
-
-    /**
      * Invoked when the circuit breaker's internal {@link EventCount} is updated.
      */
     void onEventCountUpdated(String circuitBreakerName, EventCount eventCount) throws Exception;
 
     /**
-     * Invoked when the circuit breaker's internal {@link EventCount} is updated.
-     *
-     * @deprecated Use {@link #onEventCountUpdated(String, EventCount)}.
-     */
-    @Deprecated
-    default void onEventCountUpdated(CircuitBreaker circuitBreaker, EventCount eventCount) throws Exception {
-        onEventCountUpdated(circuitBreaker.name(), eventCount);
-    }
-
-    /**
      * Invoked when the circuit breaker rejects a request.
      */
     void onRequestRejected(String circuitBreakerName) throws Exception;
-
-    /**
-     * Invoked when the circuit breaker rejects a request.
-     *
-     * @deprecated Use {@link #onRequestRejected(String)}.
-     */
-    @Deprecated
-    default void onRequestRejected(CircuitBreaker circuitBreaker) throws Exception {
-        onRequestRejected(circuitBreaker.name());
-    }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/NonBlockingCircuitBreaker.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/NonBlockingCircuitBreaker.java
@@ -176,7 +176,7 @@ final class NonBlockingCircuitBreaker implements CircuitBreaker {
     private void notifyStateChanged(CircuitState circuitState) {
         config.listeners().forEach(listener -> {
             try {
-                listener.onStateChanged(this, circuitState);
+                listener.onStateChanged(name(), circuitState);
             } catch (Throwable t) {
                 logger.warn("An error occurred when notifying a StateChanged event", t);
             }
@@ -190,7 +190,7 @@ final class NonBlockingCircuitBreaker implements CircuitBreaker {
 
     private void notifyCountUpdated(CircuitBreakerListener listener, EventCount count) {
         try {
-            listener.onEventCountUpdated(this, count);
+            listener.onEventCountUpdated(name(), count);
         } catch (Throwable t) {
             logger.warn("An error occurred when notifying an EventCountUpdated event", t);
         }
@@ -199,7 +199,7 @@ final class NonBlockingCircuitBreaker implements CircuitBreaker {
     private void notifyRequestRejected() {
         config.listeners().forEach(listener -> {
             try {
-                listener.onRequestRejected(this);
+                listener.onRequestRejected(name());
             } catch (Throwable t) {
                 logger.warn("An error occurred when notifying a RequestRejected event", t);
             }

--- a/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/NonBlockingCircuitBreakerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/NonBlockingCircuitBreakerTest.java
@@ -190,10 +190,11 @@ public class NonBlockingCircuitBreakerTest {
         reset(listener);
 
         final NonBlockingCircuitBreaker cb = create(4, 0.5);
+        final String name = cb.name();
 
         // Notify initial state
-        verify(listener, times(1)).onEventCountUpdated(cb, EventCount.ZERO);
-        verify(listener, times(1)).onStateChanged(cb, CircuitState.CLOSED);
+        verify(listener, times(1)).onEventCountUpdated(name, EventCount.ZERO);
+        verify(listener, times(1)).onStateChanged(name, CircuitState.CLOSED);
         reset(listener);
 
         cb.onFailure();
@@ -201,7 +202,7 @@ public class NonBlockingCircuitBreakerTest {
         cb.onFailure();
 
         // Notify updated event count
-        verify(listener, times(1)).onEventCountUpdated(cb, new EventCount(0, 1));
+        verify(listener, times(1)).onEventCountUpdated(name, new EventCount(0, 1));
         reset(listener);
 
         // Notify circuit tripped
@@ -211,14 +212,14 @@ public class NonBlockingCircuitBreakerTest {
         ticker.advance(counterUpdateInterval.toNanos());
         cb.onFailure();
 
-        verify(listener, times(1)).onEventCountUpdated(cb, EventCount.ZERO);
-        verify(listener, times(1)).onStateChanged(cb, CircuitState.OPEN);
+        verify(listener, times(1)).onEventCountUpdated(name, EventCount.ZERO);
+        verify(listener, times(1)).onStateChanged(name, CircuitState.OPEN);
         reset(listener);
 
         // Notify request rejected
 
         cb.canRequest();
-        verify(listener, times(1)).onRequestRejected(cb);
+        verify(listener, times(1)).onRequestRejected(name);
 
         ticker.advance(circuitOpenWindow.toNanos());
 
@@ -226,15 +227,15 @@ public class NonBlockingCircuitBreakerTest {
 
         cb.canRequest();
 
-        verify(listener, times(1)).onEventCountUpdated(cb, EventCount.ZERO);
-        verify(listener, times(1)).onStateChanged(cb, CircuitState.HALF_OPEN);
+        verify(listener, times(1)).onEventCountUpdated(name, EventCount.ZERO);
+        verify(listener, times(1)).onStateChanged(name, CircuitState.HALF_OPEN);
         reset(listener);
 
         // Notify circuit closed
 
         cb.onSuccess();
 
-        verify(listener, times(1)).onEventCountUpdated(cb, EventCount.ZERO);
-        verify(listener, times(1)).onStateChanged(cb, CircuitState.CLOSED);
+        verify(listener, times(1)).onEventCountUpdated(name, EventCount.ZERO);
+        verify(listener, times(1)).onStateChanged(name, CircuitState.CLOSED);
     }
 }


### PR DESCRIPTION
Motivation
I made the methods in `CircuitBreakerListener` deprecated and add methods whose first parameter
is the `circuitBreakerName` to prevent another breaking change.
But it was not a good idea because I had to add new methods in `CircuitBreakerListener` so I cannot
avoid making breaking change anyway.

Modification
- Remove the deprecated methods

Result
- Neat APIs