### PR TITLE
Prohibit adding a suppressed exception to singleton exceptions

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClosedClientFactoryException.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClosedClientFactoryException.java
@@ -16,11 +16,6 @@
 
 package com.linecorp.armeria.client;
 
-import javax.annotation.Nullable;
-
-import com.linecorp.armeria.common.Flags;
-import com.linecorp.armeria.common.util.Exceptions;
-
 /**
  * A {@link RuntimeException} raised when a {@link Client} is executing and the {@link ClientFactory} which the
  * {@link Client} is using is closed.
@@ -32,20 +27,12 @@ public final class ClosedClientFactoryException extends IllegalStateException {
 
     private static final long serialVersionUID = 6865054624299408503L;
 
-    private static final ClosedClientFactoryException INSTANCE =
-            Exceptions.clearTrace(new ClosedClientFactoryException(null));
-
     /**
-     * Returns a {@link ClosedClientFactoryException} which may be a singleton or a new instance, depending on
-     * whether {@linkplain Flags#verboseExceptions() the verbose exception mode} is enabled.
+     * Returns a new {@link ClosedClientFactoryException}.
      */
     public static ClosedClientFactoryException get() {
-        return Flags.verboseExceptions() ? new ClosedClientFactoryException() : INSTANCE;
+        return new ClosedClientFactoryException();
     }
 
     private ClosedClientFactoryException() {}
-
-    private ClosedClientFactoryException(@Nullable Throwable cause) {
-        super(cause);
-    }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/ResponseTimeoutException.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ResponseTimeoutException.java
@@ -35,6 +35,6 @@ public final class ResponseTimeoutException extends TimeoutException {
     }
 
     private ResponseTimeoutException() {
-        super((Throwable) null);
+        super(null, null, false, false);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/UnprocessedRequestException.java
+++ b/core/src/main/java/com/linecorp/armeria/client/UnprocessedRequestException.java
@@ -16,10 +16,7 @@
 
 package com.linecorp.armeria.client;
 
-import javax.annotation.Nullable;
-
 import com.linecorp.armeria.common.Flags;
-import com.linecorp.armeria.common.util.Exceptions;
 
 /**
  * A {@link RuntimeException} raised when it is certain that a request has not been handled by a server and
@@ -32,8 +29,7 @@ public final class UnprocessedRequestException extends RuntimeException {
 
     private static final long serialVersionUID = 4679512839715213302L;
 
-    private static final UnprocessedRequestException INSTANCE =
-            Exceptions.clearTrace(new UnprocessedRequestException(null));
+    private static final UnprocessedRequestException INSTANCE = new UnprocessedRequestException(false);
 
     /**
      * Returns a {@link UnprocessedRequestException} which may be a singleton or a new instance, depending on
@@ -45,7 +41,7 @@ public final class UnprocessedRequestException extends RuntimeException {
 
     private UnprocessedRequestException() {}
 
-    private UnprocessedRequestException(@Nullable Throwable cause) {
-        super(cause);
+    private UnprocessedRequestException(@SuppressWarnings("unused") boolean dummy) {
+        super(null, null, false, false);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/WriteTimeoutException.java
+++ b/core/src/main/java/com/linecorp/armeria/client/WriteTimeoutException.java
@@ -35,6 +35,6 @@ public final class WriteTimeoutException extends TimeoutException {
     }
 
     private WriteTimeoutException() {
-        super((Throwable) null);
+        super(null, null, false, false);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
@@ -31,10 +31,8 @@ import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.SimpleDecoratingClient;
-import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
-import com.linecorp.armeria.common.util.Exceptions;
 
 import io.netty.util.AttributeKey;
 import io.netty.util.concurrent.ScheduledFuture;
@@ -49,9 +47,6 @@ public abstract class RetryingClient<I extends Request, O extends Response>
         extends SimpleDecoratingClient<I, O> {
 
     private static final Logger logger = LoggerFactory.getLogger(RetryingClient.class);
-
-    private static final IllegalStateException CLOSED_CHANNEL_FACTORY_EXCEPTION = Exceptions.clearTrace(
-            new IllegalStateException(ClientFactory.class.getSimpleName() + " has been closed.", null));
 
     private static final AttributeKey<State> STATE =
             AttributeKey.valueOf(RetryingClient.class, "STATE");
@@ -159,20 +154,13 @@ public abstract class RetryingClient<I extends Request, O extends Response>
                 scheduledFuture.addListener(future -> {
                     if (future.isCancelled()) {
                         // future is cancelled when the client factory is closed.
-                        actionOnException.accept(closedChannelFactoryException());
+                        actionOnException.accept(new IllegalStateException(
+                                ClientFactory.class.getSimpleName() + " has been closed."));
                     }
                 });
             }
         } catch (Throwable t) {
             actionOnException.accept(t);
-        }
-    }
-
-    private static IllegalStateException closedChannelFactoryException() {
-        if (Flags.verboseExceptions()) {
-            return new IllegalStateException(CLOSED_CHANNEL_FACTORY_EXCEPTION.getMessage());
-        } else {
-            return CLOSED_CHANNEL_FACTORY_EXCEPTION;
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/AbstractRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AbstractRequestContext.java
@@ -26,7 +26,6 @@ import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.common.util.SafeCloseable;
 
 import io.netty.channel.ChannelFutureListener;
@@ -40,9 +39,6 @@ import io.netty.util.concurrent.Promise;
  * A skeletal {@link RequestContext} implementation.
  */
 public abstract class AbstractRequestContext implements RequestContext {
-
-    private static final CancellationException CANCELLATION_EXCEPTION =
-            Exceptions.clearTrace(new CancellationException());
 
     private boolean timedOut;
 

--- a/core/src/main/java/com/linecorp/armeria/common/ClosedSessionException.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ClosedSessionException.java
@@ -15,10 +15,6 @@
  */
 package com.linecorp.armeria.common;
 
-import javax.annotation.Nullable;
-
-import com.linecorp.armeria.common.util.Exceptions;
-
 /**
  * A {@link RuntimeException} raised when the connection to the remote peer has been closed unexpectedly.
  */
@@ -26,8 +22,7 @@ public final class ClosedSessionException extends RuntimeException {
 
     private static final long serialVersionUID = -78487475521731580L;
 
-    private static final ClosedSessionException INSTANCE =
-            Exceptions.clearTrace(new ClosedSessionException(null));
+    private static final ClosedSessionException INSTANCE = new ClosedSessionException(false);
 
     /**
      * Returns a {@link ClosedSessionException} which may be a singleton or a new instance, depending on
@@ -39,7 +34,7 @@ public final class ClosedSessionException extends RuntimeException {
 
     private ClosedSessionException() {}
 
-    private ClosedSessionException(@Nullable Throwable cause) {
-        super(cause);
+    private ClosedSessionException(@SuppressWarnings("unused") boolean dummy) {
+        super(null, null, false, false);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/ContentTooLargeException.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ContentTooLargeException.java
@@ -16,10 +16,6 @@
 
 package com.linecorp.armeria.common;
 
-import javax.annotation.Nullable;
-
-import com.linecorp.armeria.common.util.Exceptions;
-
 /**
  * A {@link RuntimeException} raised when the length of request or response content exceeds its limit.
  */
@@ -27,8 +23,7 @@ public final class ContentTooLargeException extends RuntimeException {
 
     private static final long serialVersionUID = 4901614315474105954L;
 
-    private static final ContentTooLargeException INSTANCE =
-            Exceptions.clearTrace(new ContentTooLargeException(null));
+    private static final ContentTooLargeException INSTANCE = new ContentTooLargeException(false);
 
     /**
      * Returns a {@link ContentTooLargeException} which may be a singleton or a new instance, depending on
@@ -40,7 +35,7 @@ public final class ContentTooLargeException extends RuntimeException {
 
     private ContentTooLargeException() {}
 
-    private ContentTooLargeException(@Nullable Throwable cause) {
-        super(cause);
+    private ContentTooLargeException(@SuppressWarnings("unused") boolean dummy) {
+        super(null, null, false, false);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultRpcResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultRpcResponse.java
@@ -26,14 +26,10 @@ import javax.annotation.Nullable;
 
 import com.google.common.base.MoreObjects;
 
-import com.linecorp.armeria.common.util.Exceptions;
-
 /**
  * Default {@link RpcResponse} implementation.
  */
 public class DefaultRpcResponse extends CompletableFuture<Object> implements RpcResponse {
-
-    private static final CancellationException CANCELLED = Exceptions.clearTrace(new CancellationException());
 
     private static final AtomicReferenceFieldUpdater<DefaultRpcResponse, Throwable> causeUpdater =
             AtomicReferenceFieldUpdater.newUpdater(DefaultRpcResponse.class, Throwable.class, "cause");
@@ -85,7 +81,8 @@ public class DefaultRpcResponse extends CompletableFuture<Object> implements Rpc
 
     @Override
     public boolean cancel(boolean mayInterruptIfRunning) {
-        return completeExceptionally(CANCELLED) || isCancelled();
+        final boolean updated = !isDone() && completeExceptionally(new CancellationException());
+        return updated || isCancelled();
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/stream/AbortedStreamException.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AbortedStreamException.java
@@ -16,12 +16,9 @@
 
 package com.linecorp.armeria.common.stream;
 
-import javax.annotation.Nullable;
-
 import org.reactivestreams.Subscriber;
 
 import com.linecorp.armeria.common.Flags;
-import com.linecorp.armeria.common.util.Exceptions;
 
 /**
  * A {@link RuntimeException} that is raised to signal a {@link Subscriber} that the {@link StreamMessage}
@@ -31,8 +28,7 @@ public final class AbortedStreamException extends RuntimeException {
 
     private static final long serialVersionUID = -5271590540551141199L;
 
-    private static final AbortedStreamException INSTANCE =
-            Exceptions.clearTrace(new AbortedStreamException(null));
+    static final AbortedStreamException INSTANCE = new AbortedStreamException(false);
 
     /**
      * Returns a {@link AbortedStreamException} which may be a singleton or a new instance, depending on
@@ -44,7 +40,7 @@ public final class AbortedStreamException extends RuntimeException {
 
     private AbortedStreamException() {}
 
-    private AbortedStreamException(@Nullable Throwable cause) {
-        super(cause);
+    private AbortedStreamException(@SuppressWarnings("unused") boolean dummy) {
+        super(null, null, false, false);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessage.java
@@ -29,9 +29,7 @@ import org.reactivestreams.Subscription;
 import com.google.common.base.MoreObjects;
 
 import com.linecorp.armeria.common.CommonPools;
-import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.RequestContext;
-import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.internal.PooledObjects;
 
 import io.netty.util.ReferenceCountUtil;
@@ -40,22 +38,8 @@ import io.netty.util.concurrent.EventExecutor;
 abstract class AbstractStreamMessage<T> implements StreamMessage<T> {
 
     static final CloseEvent SUCCESSFUL_CLOSE = new CloseEvent(null);
-    static final CloseEvent CANCELLED_CLOSE = new CloseEvent(
-            Exceptions.clearTrace(CancelledSubscriptionException.get()));
-    static final CloseEvent ABORTED_CLOSE = new CloseEvent(
-            Exceptions.clearTrace(AbortedStreamException.get()));
-
-    static {
-        // Prevent setting a cause for singleton exceptions.
-        if (Flags.verboseExceptions()) {
-            assert CANCELLED_CLOSE.cause != null;
-            CANCELLED_CLOSE.cause.initCause(null);
-            assert ABORTED_CLOSE.cause != null;
-            ABORTED_CLOSE.cause.initCause(null);
-        } else {
-            // The singleton exceptions already has its cause assigned to null if verboseExceptions is false.
-        }
-    }
+    static final CloseEvent CANCELLED_CLOSE = new CloseEvent(CancelledSubscriptionException.INSTANCE);
+    static final CloseEvent ABORTED_CLOSE = new CloseEvent(AbortedStreamException.INSTANCE);
 
     private final CompletableFuture<Void> completionFuture = new CompletableFuture<>();
 

--- a/core/src/main/java/com/linecorp/armeria/common/stream/CancelledSubscriptionException.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/CancelledSubscriptionException.java
@@ -16,13 +16,10 @@
 
 package com.linecorp.armeria.common.stream;
 
-import javax.annotation.Nullable;
-
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
 import com.linecorp.armeria.common.Flags;
-import com.linecorp.armeria.common.util.Exceptions;
 
 /**
  * A {@link RuntimeException} that is raised to notify {@link StreamMessage#completionFuture()} when a
@@ -32,8 +29,7 @@ public final class CancelledSubscriptionException extends RuntimeException {
 
     private static final long serialVersionUID = -7815958463104921571L;
 
-    private static final CancelledSubscriptionException INSTANCE =
-            Exceptions.clearTrace(new CancelledSubscriptionException(null));
+    static final CancelledSubscriptionException INSTANCE = new CancelledSubscriptionException(false);
 
     /**
      * Returns a {@link CancelledSubscriptionException} which may be a singleton or a new instance, depending
@@ -45,7 +41,7 @@ public final class CancelledSubscriptionException extends RuntimeException {
 
     private CancelledSubscriptionException() {}
 
-    private CancelledSubscriptionException(@Nullable Throwable cause) {
-        super(cause);
+    private CancelledSubscriptionException(@SuppressWarnings("unused") boolean dummy) {
+        super(null, null, false, false);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/ClosedPublisherException.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/ClosedPublisherException.java
@@ -16,10 +16,7 @@
 
 package com.linecorp.armeria.common.stream;
 
-import javax.annotation.Nullable;
-
 import com.linecorp.armeria.common.Flags;
-import com.linecorp.armeria.common.util.Exceptions;
 
 /**
  * A {@link RuntimeException} that is raised when a {@link StreamWriter} attempts to write an object to a
@@ -29,8 +26,7 @@ public final class ClosedPublisherException extends RuntimeException {
 
     private static final long serialVersionUID = -7665826869012452735L;
 
-    private static final ClosedPublisherException INSTANCE =
-            Exceptions.clearTrace(new ClosedPublisherException(null));
+    private static final ClosedPublisherException INSTANCE = new ClosedPublisherException(false);
 
     /**
      * Returns a {@link ClosedPublisherException} which may be a singleton or a new instance, depending on
@@ -42,7 +38,7 @@ public final class ClosedPublisherException extends RuntimeException {
 
     private ClosedPublisherException() {}
 
-    private ClosedPublisherException(@Nullable Throwable cause) {
-        super(cause);
+    private ClosedPublisherException(@SuppressWarnings("unused") boolean dummy) {
+        super(null, null, false, false);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/HttpStatusException.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpStatusException.java
@@ -17,14 +17,8 @@ package com.linecorp.armeria.server;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
-import javax.annotation.Nullable;
-
 import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.HttpStatus;
-import com.linecorp.armeria.common.util.Exceptions;
 
 /**
  * A {@link RuntimeException} that is raised to send a simplistic HTTP response with minimal content
@@ -34,13 +28,28 @@ import com.linecorp.armeria.common.util.Exceptions;
  */
 public final class HttpStatusException extends RuntimeException {
 
-    private static final Map<Integer, HttpStatusException> EXCEPTIONS = new ConcurrentHashMap<>();
+    private static final HttpStatusException[] EXCEPTIONS = new HttpStatusException[1000];
+
+    static {
+        for (int i = 0; i < EXCEPTIONS.length; i++) {
+            EXCEPTIONS[i] = new HttpStatusException(HttpStatus.valueOf(i), false);
+        }
+    }
 
     /**
      * Returns a new {@link HttpStatusException} instance with the specified HTTP status code.
      */
     public static HttpStatusException of(int statusCode) {
-        return of(HttpStatus.valueOf(statusCode));
+        if (statusCode < 0 || statusCode >= 1000) {
+            final HttpStatus status = HttpStatus.valueOf(statusCode);
+            if (Flags.verboseExceptions()) {
+                return new HttpStatusException(status);
+            } else {
+                return new HttpStatusException(status, false);
+            }
+        } else {
+            return EXCEPTIONS[statusCode];
+        }
     }
 
     /**
@@ -48,13 +57,7 @@ public final class HttpStatusException extends RuntimeException {
      */
     public static HttpStatusException of(HttpStatus httpStatus) {
         requireNonNull(httpStatus, "httpStatus");
-        if (Flags.verboseExceptions()) {
-            return new HttpStatusException(httpStatus);
-        } else {
-            final int statusCode = httpStatus.code();
-            return EXCEPTIONS.computeIfAbsent(statusCode, code ->
-                    Exceptions.clearTrace(new HttpStatusException(HttpStatus.valueOf(code), null)));
-        }
+        return of(httpStatus.code());
     }
 
     private static final long serialVersionUID = 3341744805097308847L;
@@ -70,10 +73,10 @@ public final class HttpStatusException extends RuntimeException {
     }
 
     /**
-     * Creates a new instance with the specified {@link HttpStatus} and {@code cause}.
+     * Creates a new singleton instance with the specified {@link HttpStatus}.
      */
-    private HttpStatusException(HttpStatus httpStatus, @Nullable Throwable cause) {
-        super(requireNonNull(httpStatus, "httpStatus").toString(), cause);
+    private HttpStatusException(HttpStatus httpStatus, @SuppressWarnings("unused") boolean dummy) {
+        super(requireNonNull(httpStatus, "httpStatus").toString(), null, false, false);
         this.httpStatus = httpStatus;
     }
 
@@ -83,13 +86,5 @@ public final class HttpStatusException extends RuntimeException {
      */
     public HttpStatus httpStatus() {
         return httpStatus;
-    }
-
-    @Override
-    public Throwable fillInStackTrace() {
-        if (Flags.verboseExceptions()) {
-            return super.fillInStackTrace();
-        }
-        return this;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/RequestTimeoutException.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RequestTimeoutException.java
@@ -35,6 +35,6 @@ public final class RequestTimeoutException extends TimeoutException {
     }
 
     private RequestTimeoutException() {
-        super((Throwable) null);
+        super(null, null, false, false);
     }
 }


### PR DESCRIPTION
Motivation:

We prohibited `initCause()` on singleton exceptions in 10d90f5 but we
did not prohibit `addSuppressed()` which also mutates the state of the
singleton exceptions.

Modifications:

- Use `Throwable(String,Throwable,boolean,boolean)` constructor for
  singleton exceptions.
- Made the exceptions that extend `IllegalStateException` non-singleton,
  because there's no way to disable `addSuppressed()` in `IllegalStateException`.
  As a result, the following exceptions are no more singletons:
  - `ClosedClientFactoryException`
  - `CancellationException` instantiated by `DefaultRpcResponse`
- Miscellaneous:
  - Improved the lookup logic of `HttpStatus` and `HttpStatusException`.

Result:

- Singleton remains singleton.
- Better `HttpStatus` and `HttpStatusException` lookup performance.