### PR TITLE
Add `ClientRequestContextBuilder` and `ServiceRequestContextBuilder`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
@@ -55,7 +55,7 @@ public interface ClientRequestContext extends RequestContext {
     /**
      * Returns a new {@link ClientRequestContext} created from the specified {@link RpcRequest} and URI.
      * Note that it is not usually required to create a new context by yourself, because Armeria
-     * will always provide a context object for you.  However, it may be useful in some cases such as
+     * will always provide a context object for you. However, it may be useful in some cases such as
      * unit testing.
      *
      * @see ClientRequestContextBuilder

--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
@@ -16,6 +16,9 @@
 
 package com.linecorp.armeria.client;
 
+import static java.util.Objects.requireNonNull;
+
+import java.net.URI;
 import java.time.Duration;
 
 import javax.annotation.Nullable;
@@ -26,6 +29,7 @@ import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.Response;
+import com.linecorp.armeria.common.RpcRequest;
 
 import io.netty.handler.codec.Headers;
 import io.netty.util.AsciiString;
@@ -35,6 +39,42 @@ import io.netty.util.AsciiString;
  * Every client request has its own {@link ClientRequestContext} instance.
  */
 public interface ClientRequestContext extends RequestContext {
+
+    /**
+     * Returns a new {@link ClientRequestContext} created from the specified {@link HttpRequest}.
+     * Note that it is not usually required to create a new context by yourself, because Armeria
+     * will always provide a context object for you. However, it may be useful in some cases such as
+     * unit testing.
+     *
+     * @see ClientRequestContextBuilder
+     */
+    static ClientRequestContext of(HttpRequest request) {
+        return ClientRequestContextBuilder.of(request).build();
+    }
+
+    /**
+     * Returns a new {@link ClientRequestContext} created from the specified {@link RpcRequest} and URI.
+     * Note that it is not usually required to create a new context by yourself, because Armeria
+     * will always provide a context object for you.  However, it may be useful in some cases such as
+     * unit testing.
+     *
+     * @see ClientRequestContextBuilder
+     */
+    static ClientRequestContext of(RpcRequest request, String uri) {
+        return ClientRequestContextBuilder.of(request, URI.create(requireNonNull(uri, "uri"))).build();
+    }
+
+    /**
+     * Returns a new {@link ClientRequestContext} created from the specified {@link RpcRequest} and {@link URI}.
+     * Note that it is not usually required to create a new context by yourself, because Armeria
+     * will always provide a context object for you. However, it may be useful in some cases such as
+     * unit testing.
+     *
+     * @see ClientRequestContextBuilder
+     */
+    static ClientRequestContext of(RpcRequest request, URI uri) {
+        return ClientRequestContextBuilder.of(request, uri).build();
+    }
 
     @Override
     ClientRequestContext newDerivedContext();

--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextBuilder.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client;
+
+import static java.util.Objects.requireNonNull;
+
+import java.net.URI;
+
+import javax.annotation.Nullable;
+
+import com.linecorp.armeria.common.AbstractRequestContextBuilder;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.RpcRequest;
+
+/**
+ * Builds a new {@link ClientRequestContext}. Note that it is not usually required to create a new context by
+ * yourself, because Armeria will always provide a context object for you. However, it may be useful in some
+ * cases such as unit testing.
+ */
+public final class ClientRequestContextBuilder
+        extends AbstractRequestContextBuilder<ClientRequestContextBuilder> {
+
+    /**
+     * Returns a new {@link ClientRequestContextBuilder} created from the specified {@link HttpRequest}.
+     */
+    public static ClientRequestContextBuilder of(HttpRequest request) {
+        return new ClientRequestContextBuilder(request);
+    }
+
+    /**
+     * Returns a new {@link ClientRequestContextBuilder} created from the specified {@link RpcRequest} and URI.
+     */
+    public static ClientRequestContextBuilder of(RpcRequest request, String uri) {
+        return of(request, URI.create(requireNonNull(uri, "uri")));
+    }
+
+    /**
+     * Returns a new {@link ClientRequestContextBuilder} created from the specified {@link RpcRequest} and
+     * {@link URI}.
+     */
+    public static ClientRequestContextBuilder of(RpcRequest request, URI uri) {
+        return new ClientRequestContextBuilder(request, uri);
+    }
+
+    @Nullable
+    private final String fragment;
+    @Nullable
+    private Endpoint endpoint;
+    private ClientOptions options = ClientOptions.DEFAULT;
+
+    private ClientRequestContextBuilder(HttpRequest request) {
+        super(false, request);
+        fragment = null;
+    }
+
+    private ClientRequestContextBuilder(RpcRequest request, URI uri) {
+        super(false, request, uri);
+        fragment = uri.getRawFragment();
+    }
+
+    @Override
+    public ClientRequestContextBuilder method(HttpMethod method) {
+        super.method(method);
+        return this;
+    }
+
+    /**
+     * Sets the {@link Endpoint} of the request. If not set, it is auto-generated from the request authority.
+     */
+    public ClientRequestContextBuilder endpoint(Endpoint endpoint) {
+        this.endpoint = requireNonNull(endpoint, "endpoint");
+        return this;
+    }
+
+    /**
+     * Sets the {@link ClientOptions} of the client. If not set, {@link ClientOptions#DEFAULT} is used.
+     */
+    public ClientRequestContextBuilder options(ClientOptions options) {
+        this.options = requireNonNull(options, "options");
+        return this;
+    }
+
+    /**
+     * Returns a new {@link ClientRequestContext} created with the properties of this builder.
+     */
+    public ClientRequestContext build() {
+        final Endpoint endpoint;
+        if (this.endpoint != null) {
+            endpoint = this.endpoint;
+        } else {
+            endpoint = Endpoint.parse(authority());
+        }
+
+        final DefaultClientRequestContext ctx = new DefaultClientRequestContext(
+                eventLoop(), meterRegistry(), sessionProtocol(), endpoint,
+                method(), path(), query(), fragment, options, request());
+
+        if (isRequestStartTimeSet()) {
+            ctx.logBuilder().startRequest(fakeChannel(), sessionProtocol(), sslSession(),
+                                          requestStartTimeNanos(), requestStartTimeMicros());
+        } else {
+            ctx.logBuilder().startRequest(fakeChannel(), sessionProtocol(), sslSession());
+        }
+
+        if (request() instanceof HttpRequest) {
+            ctx.logBuilder().requestHeaders(((HttpRequest) request()).headers());
+        } else {
+            ctx.logBuilder().requestContent(request(), null);
+        }
+        return ctx;
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -23,6 +23,7 @@ import java.util.Iterator;
 import java.util.function.Consumer;
 
 import javax.annotation.Nullable;
+import javax.net.ssl.SSLSession;
 
 import com.linecorp.armeria.common.DefaultHttpHeaders;
 import com.linecorp.armeria.common.HttpHeaders;
@@ -176,6 +177,16 @@ public class DefaultClientRequestContext extends NonWrappingRequestContext imple
     @Override
     public EventLoop eventLoop() {
         return eventLoop;
+    }
+
+    @Nullable
+    @Override
+    public SSLSession sslSession() {
+        if (log.isAvailable(RequestLogAvailability.REQUEST_START)) {
+            return log.sslSession();
+        } else {
+            return null;
+        }
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/UnprocessedRequestException.java
+++ b/core/src/main/java/com/linecorp/armeria/client/UnprocessedRequestException.java
@@ -32,7 +32,7 @@ public final class UnprocessedRequestException extends RuntimeException {
     private static final UnprocessedRequestException INSTANCE = new UnprocessedRequestException(false);
 
     /**
-     * Returns a {@link UnprocessedRequestException} which may be a singleton or a new instance, depending on
+     * Returns an {@link UnprocessedRequestException} which may be a singleton or a new instance, depending on
      * whether {@linkplain Flags#verboseExceptions() the verbose exception mode} is enabled.
      */
     public static UnprocessedRequestException get() {

--- a/core/src/main/java/com/linecorp/armeria/common/AbstractRequestContextBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AbstractRequestContextBuilder.java
@@ -1,0 +1,684 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.net.URI;
+import java.util.concurrent.ThreadLocalRandom;
+
+import javax.annotation.Nullable;
+import javax.net.ssl.SSLSession;
+
+import com.linecorp.armeria.client.ClientRequestContextBuilder;
+import com.linecorp.armeria.common.metric.NoopMeterRegistry;
+import com.linecorp.armeria.internal.PathAndQuery;
+import com.linecorp.armeria.server.ServiceRequestContextBuilder;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelConfig;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelId;
+import io.netty.channel.ChannelMetadata;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.ChannelProgressivePromise;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.DefaultChannelId;
+import io.netty.channel.EventLoop;
+import io.netty.util.Attribute;
+import io.netty.util.AttributeKey;
+import io.netty.util.NetUtil;
+
+/**
+ * Provides the information required for building a {@link RequestContext}.
+ *
+ * @param <B> the self type.
+ * @see ServiceRequestContextBuilder
+ * @see ClientRequestContextBuilder
+ */
+public abstract class AbstractRequestContextBuilder<B extends AbstractRequestContextBuilder<B>> {
+
+    private static final String FALLBACK_AUTHORITY = "127.0.0.1";
+
+    private final boolean server;
+    private final Request request;
+    private SessionProtocol sessionProtocol;
+    private HttpMethod method;
+    private final String authority;
+    private final String path;
+    @Nullable
+    private final String query;
+
+    private MeterRegistry meterRegistry = NoopMeterRegistry.get();
+    @Nullable
+    private EventLoop eventLoop;
+    private ByteBufAllocator alloc = ByteBufAllocator.DEFAULT;
+    @Nullable
+    private InetSocketAddress remoteAddress;
+    @Nullable
+    private InetSocketAddress localAddress;
+    @Nullable
+    private SSLSession sslSession;
+    private boolean requestStartTimeSet;
+    private long requestStartTimeNanos;
+    private long requestStartTimeMicros;
+    @Nullable
+    private Channel channel;
+
+    /**
+     * Creates a new builder with the specified {@link HttpRequest}.
+     *
+     * @param server whether this builder will build a server-side context.
+     * @param request the {@link HttpRequest}.
+     */
+    protected AbstractRequestContextBuilder(boolean server, HttpRequest request) {
+        this.server = server;
+        this.request = requireNonNull(request, "request");
+        sessionProtocol = SessionProtocol.H2C;
+
+        final HttpMethod method = request.headers().method();
+        checkArgument(method != null, "request.method is not valid: %s", request);
+        this.method = method;
+        authority = firstNonNull(request.headers().authority(), FALLBACK_AUTHORITY);
+
+        final String pathAndQueryStr = request.headers().path();
+        final PathAndQuery pathAndQuery = PathAndQuery.parse(pathAndQueryStr);
+        checkArgument(pathAndQuery != null, "request.path is not valid: %s", request);
+        path = pathAndQuery.path();
+        query = pathAndQuery.query();
+    }
+
+    /**
+     * Creates a new builder with the specified {@link RpcRequest} and {@link URI}.
+     *
+     * @param server whether this builder will build a server-side context.
+     * @param request the {@link RpcRequest}.
+     * @param uri the {@link URI} of the request endpoint.
+     */
+    protected AbstractRequestContextBuilder(boolean server, RpcRequest request, URI uri) {
+        this.server = server;
+        this.request = requireNonNull(request, "request");
+        method = HttpMethod.POST;
+
+        requireNonNull(uri, "uri");
+        authority = firstNonNull(uri.getRawAuthority(), FALLBACK_AUTHORITY);
+
+        final String schemeStr = uri.getScheme();
+        if (schemeStr != null && schemeStr.indexOf('+') < 0) {
+            sessionProtocol = SessionProtocol.find(schemeStr).orElseThrow(
+                    () -> new IllegalArgumentException("uri.scheme is not valid: " + uri));
+        } else {
+            sessionProtocol =
+                    Scheme.tryParse(schemeStr)
+                          .orElseThrow(() -> new IllegalArgumentException("uri.scheme is not valid: " + uri))
+                          .sessionProtocol();
+        }
+
+        final PathAndQuery pathAndQuery;
+        if (uri.getRawQuery() != null) {
+            pathAndQuery = PathAndQuery.parse(uri.getRawPath() + '?' + uri.getRawQuery());
+        } else {
+            pathAndQuery = PathAndQuery.parse(uri.getRawPath());
+        }
+        checkArgument(pathAndQuery != null, "uri.path or uri.query is not valid: %s", uri);
+        path = pathAndQuery.path();
+        query = pathAndQuery.query();
+    }
+
+    @SuppressWarnings("unchecked")
+    private B self() {
+        return (B) this;
+    }
+
+    /**
+     * Returns the {@link MeterRegistry}.
+     */
+    protected final MeterRegistry meterRegistry() {
+        return meterRegistry;
+    }
+
+    /**
+     * Sets the {@link MeterRegistry}. If not set, {@link NoopMeterRegistry} is used.
+     */
+    public final B meterRegistry(MeterRegistry meterRegistry) {
+        this.meterRegistry = requireNonNull(meterRegistry, "meterRegistry");
+        return self();
+    }
+
+    /**
+     * Returns the {@link EventLoop} that handles the request.
+     */
+    protected final EventLoop eventLoop() {
+        if (eventLoop == null) {
+            eventLoop = CommonPools.workerGroup().next();
+        }
+        return eventLoop;
+    }
+
+    /**
+     * Sets the {@link EventLoop} that handles the request.
+     * If not set, one of the {@link CommonPools#workerGroup()} is used.
+     */
+    public final B eventLoop(EventLoop eventLoop) {
+        this.eventLoop = requireNonNull(eventLoop, "eventLoop");
+        return self();
+    }
+
+    /**
+     * Returns the {@link ByteBufAllocator}.
+     */
+    protected final ByteBufAllocator alloc() {
+        return alloc;
+    }
+
+    /**
+     * Sets the {@link ByteBufAllocator}. If not set, {@link ByteBufAllocator#DEFAULT} is used.
+     */
+    public final B alloc(ByteBufAllocator alloc) {
+        this.alloc = requireNonNull(alloc, "alloc");
+        return self();
+    }
+
+    /**
+     * Returns the {@link Request} of the context.
+     */
+    @SuppressWarnings("unchecked")
+    protected final <T extends Request> T request() {
+        return (T) request;
+    }
+
+    /**
+     * Returns the {@link SessionProtocol} of the request.
+     */
+    protected final SessionProtocol sessionProtocol() {
+        return sessionProtocol;
+    }
+
+    /**
+     * Sets the {@link SessionProtocol} of the request.
+     *
+     * @throws IllegalArgumentException if the specified {@link SessionProtocol} is not compatible with
+     *                                  the scheme of the {@link URI} you specified when creating this builder.
+     *                                  For example, you cannot specify {@link SessionProtocol#H2C} if you
+     *                                  created this builder with {@code h1c://example.com/}.
+     */
+    public final B sessionProtocol(SessionProtocol sessionProtocol) {
+        requireNonNull(sessionProtocol, "sessionProtocol");
+        if (request instanceof RpcRequest) {
+            checkArgument(sessionProtocol == this.sessionProtocol,
+                          "sessionProtocol: %s (expected: same as the session protocol specified in 'uri')",
+                          sessionProtocol);
+        } else {
+            this.sessionProtocol = sessionProtocol;
+        }
+        return self();
+    }
+
+    /**
+     * Returns the remote socket address of the connection.
+     */
+    protected final InetSocketAddress remoteAddress() {
+        if (remoteAddress == null) {
+            if (server) {
+                remoteAddress = new InetSocketAddress(NetUtil.LOCALHOST, randomClientPort());
+            } else {
+                remoteAddress = new InetSocketAddress(NetUtil.LOCALHOST,
+                                                      guessServerPort(sessionProtocol, authority));
+            }
+        }
+        return remoteAddress;
+    }
+
+    /**
+     * Sets the remote socket address of the connection. If not set, it is auto-generated with the localhost
+     * IP address (e.g. {@code "127.0.0.1"} or {@code "::1"}).
+     */
+    public final B remoteAddress(InetSocketAddress remoteAddress) {
+        this.remoteAddress = requireNonNull(remoteAddress, "remoteAddress");
+        return self();
+    }
+
+    /**
+     * Returns the local socket address of the connection.
+     */
+    protected final InetSocketAddress localAddress() {
+        if (localAddress == null) {
+            if (server) {
+                localAddress = new InetSocketAddress(NetUtil.LOCALHOST,
+                                                     guessServerPort(sessionProtocol, authority));
+            } else {
+                localAddress = new InetSocketAddress(NetUtil.LOCALHOST, randomClientPort());
+            }
+        }
+        return localAddress;
+    }
+
+    /**
+     * Sets the local socket address of the connection. If not set, it is auto-generated with the localhost
+     * IP address (e.g. {@code "127.0.0.1"} or {@code "::1"}).
+     */
+    public final B localAddress(InetSocketAddress localAddress) {
+        this.localAddress = requireNonNull(localAddress, "localAddress");
+        return self();
+    }
+
+    private static int guessServerPort(SessionProtocol sessionProtocol, @Nullable String authority) {
+        if (authority == null) {
+            return sessionProtocol.defaultPort();
+        }
+
+        final int lastColonPos = authority.lastIndexOf(':');
+        if (lastColonPos < 0) {
+            return sessionProtocol.defaultPort();
+        }
+
+        final int port;
+        try {
+            port = Integer.parseInt(authority.substring(lastColonPos + 1));
+        } catch (NumberFormatException e) {
+            return sessionProtocol.defaultPort();
+        }
+
+        if (port <= 0 || port >= 65536) {
+            return sessionProtocol.defaultPort();
+        }
+
+        return port;
+    }
+
+    private static int randomClientPort() {
+        return ThreadLocalRandom.current().nextInt(32768, 65536);
+    }
+
+    /**
+     * Returns the {@link SSLSession} of the connection.
+     *
+     * @return the {@link SSLSession}, or {@code null} if the {@link SessionProtocol} is not TLS.
+     */
+    @Nullable
+    protected final SSLSession sslSession() {
+        checkState(!sessionProtocol.isTls() || sslSession != null,
+                   "sslSession must be set for a TLS-enabled protocol: %s", sessionProtocol);
+        return sessionProtocol.isTls() ? sslSession : null;
+    }
+
+    /**
+     * Sets the {@link SSLSession} of the connection. If the current {@link SessionProtocol} is not TLS,
+     * the TLS version of the current {@link SessionProtocol} will be set automatically. For example,
+     * {@link SessionProtocol#H2C} will be automatically upgraded to {@link SessionProtocol#H2}.
+     * Note that upgrading the current {@link SessionProtocol} may trigger an {@link IllegalArgumentException},
+     * as described in {@link #sessionProtocol(SessionProtocol)}.
+     */
+    public final B sslSession(SSLSession sslSession) {
+        this.sslSession = requireNonNull(sslSession, "sslSession");
+        switch (sessionProtocol) {
+            case HTTP:
+                sessionProtocol(SessionProtocol.HTTP);
+                break;
+            case H1C:
+                sessionProtocol(SessionProtocol.H1);
+                break;
+            case H2C:
+                sessionProtocol(SessionProtocol.H2);
+                break;
+        }
+        return self();
+    }
+
+    /**
+     * Returns whether the request start time has been specified. If not specified, the builder will use
+     * the current time returned by {@link #requestStartTimeNanos()} and {@link #requestStartTimeMicros()}
+     * as the request start time.
+     */
+    protected final boolean isRequestStartTimeSet() {
+        return requestStartTimeSet;
+    }
+
+    /**
+     * Returns the {@link System#nanoTime()} value when the request started.
+     *
+     * @throws IllegalStateException if the request start time is unspecified.
+     */
+    protected final long requestStartTimeNanos() {
+        checkState(isRequestStartTimeSet(), "requestStartTime is not set.");
+        return requestStartTimeNanos;
+    }
+
+    /**
+     * Returns the number of microseconds since the epoch when the request started.
+     *
+     * @throws IllegalStateException if the request start time is unspecified.
+     */
+    protected final long requestStartTimeMicros() {
+        checkState(isRequestStartTimeSet(), "requestStartTime is not set.");
+        return requestStartTimeMicros;
+    }
+
+    /**
+     * Sets the request start time of the request.
+     *
+     * @param requestStartTimeNanos the {@link System#nanoTime()} value when the request started.
+     * @param requestStartTimeMicros the number of microseconds since the epoch when the request started.
+     */
+    public final B requestStartTime(long requestStartTimeNanos, long requestStartTimeMicros) {
+        this.requestStartTimeNanos = requestStartTimeNanos;
+        this.requestStartTimeMicros = requestStartTimeMicros;
+        requestStartTimeSet = true;
+        return self();
+    }
+
+    /**
+     * Returns the {@link HttpMethod} of the request.
+     */
+    protected final HttpMethod method() {
+        return method;
+    }
+
+    /**
+     * Set the {@link HttpMethod} of the request.
+     *
+     * @throws IllegalArgumentException if the specified {@link HttpMethod} is not same with the
+     *                                  {@link HttpMethod} of the {@link HttpRequest} you specified when
+     *                                  creating this builder. This exception is not thrown if you
+     *                                  created a builder with an {@link RpcRequest}.
+     */
+    protected B method(HttpMethod method) {
+        requireNonNull(method, "method");
+        if (request instanceof HttpRequest) {
+            checkArgument(method == ((HttpRequest) request).method(),
+                          "method: %s (expected: same as request.method)", method);
+        } else {
+            this.method = method;
+        }
+        return self();
+    }
+
+    /**
+     * Returns the authority of the request.
+     */
+    protected final String authority() {
+        return authority;
+    }
+
+    /**
+     * Returns the path of the request, excluding the query part.
+     */
+    protected final String path() {
+        return path;
+    }
+
+    /**
+     * Returns the query part of the request, excluding the leading question mark ({@code '?'}).
+     *
+     * @return the query string, or {@code null} if there is no query.
+     */
+    @Nullable
+    protected final String query() {
+        return query;
+    }
+
+    /**
+     * Returns a fake {@link Channel} which is required internally when creating a context.
+     */
+    protected final Channel fakeChannel() {
+        if (channel == null) {
+            channel = new FakeChannel(eventLoop(), alloc(), remoteAddress(), localAddress());
+        }
+        return channel;
+    }
+
+    @SuppressWarnings("ComparableImplementedButEqualsNotOverridden")
+    private static class FakeChannel implements Channel {
+
+        private final ChannelId id = DefaultChannelId.newInstance();
+        private final EventLoop eventLoop;
+        private final ByteBufAllocator alloc;
+        private final InetSocketAddress remoteAddress;
+        private final InetSocketAddress localAddress;
+
+        FakeChannel(EventLoop eventLoop, ByteBufAllocator alloc,
+                    InetSocketAddress remoteAddress, InetSocketAddress localAddress) {
+            this.eventLoop = eventLoop;
+            this.alloc = alloc;
+            this.remoteAddress = remoteAddress;
+            this.localAddress = localAddress;
+        }
+
+        @Override
+        public ChannelId id() {
+            return id;
+        }
+
+        @Override
+        public EventLoop eventLoop() {
+            return eventLoop;
+        }
+
+        @Nullable
+        @Override
+        public Channel parent() {
+            return null;
+        }
+
+        @Override
+        public ChannelConfig config() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isOpen() {
+            return false;
+        }
+
+        @Override
+        public boolean isRegistered() {
+            return false;
+        }
+
+        @Override
+        public boolean isActive() {
+            return false;
+        }
+
+        @Override
+        public ChannelMetadata metadata() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public SocketAddress localAddress() {
+            return localAddress;
+        }
+
+        @Override
+        public SocketAddress remoteAddress() {
+            return remoteAddress;
+        }
+
+        @Override
+        public ChannelFuture closeFuture() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isWritable() {
+            return false;
+        }
+
+        @Override
+        public long bytesBeforeUnwritable() {
+            return 0;
+        }
+
+        @Override
+        public long bytesBeforeWritable() {
+            return Long.MAX_VALUE;
+        }
+
+        @Override
+        public Unsafe unsafe() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelPipeline pipeline() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ByteBufAllocator alloc() {
+            return alloc;
+        }
+
+        @Override
+        public Channel read() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Channel flush() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture bind(SocketAddress localAddress) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture bind(SocketAddress localAddress, ChannelPromise promise) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture connect(SocketAddress remoteAddress) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture connect(SocketAddress remoteAddress, SocketAddress localAddress) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture connect(SocketAddress remoteAddress, ChannelPromise promise) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture connect(SocketAddress remoteAddress, SocketAddress localAddress,
+                                     ChannelPromise promise) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture disconnect() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture disconnect(ChannelPromise promise) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture close() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture close(ChannelPromise promise) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture deregister() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture deregister(ChannelPromise promise) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture write(Object msg) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture write(Object msg, ChannelPromise promise) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture writeAndFlush(Object msg, ChannelPromise promise) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture writeAndFlush(Object msg) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelPromise newPromise() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelProgressivePromise newProgressivePromise() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture newSucceededFuture() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture newFailedFuture(Throwable cause) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelPromise voidPromise() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <T> Attribute<T> attr(AttributeKey<T> key) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <T> boolean hasAttr(AttributeKey<T> key) {
+            return false;
+        }
+
+        @Override
+        public int compareTo(Channel o) {
+            return id().compareTo(o.id());
+        }
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/common/AbstractRequestContextBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AbstractRequestContextBuilder.java
@@ -333,7 +333,7 @@ public abstract class AbstractRequestContextBuilder<B extends AbstractRequestCon
         this.sslSession = requireNonNull(sslSession, "sslSession");
         switch (sessionProtocol) {
             case HTTP:
-                sessionProtocol(SessionProtocol.HTTP);
+                sessionProtocol(SessionProtocol.HTTPS);
                 break;
             case H1C:
                 sessionProtocol(SessionProtocol.H1);
@@ -395,7 +395,7 @@ public abstract class AbstractRequestContextBuilder<B extends AbstractRequestCon
     }
 
     /**
-     * Set the {@link HttpMethod} of the request.
+     * Sets the {@link HttpMethod} of the request.
      *
      * @throws IllegalArgumentException if the specified {@link HttpMethod} is not same with the
      *                                  {@link HttpMethod} of the {@link HttpRequest} you specified when

--- a/core/src/main/java/com/linecorp/armeria/common/NonWrappingRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/common/NonWrappingRequestContext.java
@@ -26,14 +26,12 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 import javax.annotation.Nullable;
-import javax.net.ssl.SSLSession;
 
 import com.linecorp.armeria.internal.ArmeriaHttpUtil;
 import com.linecorp.armeria.internal.DefaultAttributeMap;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.netty.channel.Channel;
-import io.netty.handler.ssl.SslHandler;
 import io.netty.util.Attribute;
 import io.netty.util.AttributeKey;
 
@@ -105,18 +103,6 @@ public abstract class NonWrappingRequestContext extends AbstractRequestContext {
     public <A extends SocketAddress> A localAddress() {
         final Channel ch = channel();
         return ch != null ? (A) ch.localAddress() : null;
-    }
-
-    @Nullable
-    @Override
-    public SSLSession sslSession() {
-        final Channel ch = channel();
-        if (ch == null) {
-            return null;
-        }
-
-        final SslHandler sslHandler = ch.pipeline().get(SslHandler.class);
-        return sslHandler != null ? sslHandler.engine().getSession() : null;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/logging/NoopRequestLogBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/NoopRequestLogBuilder.java
@@ -17,6 +17,7 @@
 package com.linecorp.armeria.common.logging;
 
 import javax.annotation.Nullable;
+import javax.net.ssl.SSLSession;
 
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.SerializationFormat;
@@ -33,7 +34,11 @@ final class NoopRequestLogBuilder implements RequestLogBuilder {
     public void endResponseWithLastChild() {}
 
     @Override
-    public void startRequest(Channel ch, SessionProtocol sessionProtocol) {}
+    public void startRequest(Channel ch, SessionProtocol sessionProtocol, @Nullable SSLSession sslSession) {}
+
+    @Override
+    public void startRequest(Channel channel, SessionProtocol sessionProtocol, @Nullable SSLSession sslSession,
+                             long requestStartTimeNanos, long requestStartTimeMicros) {}
 
     @Override
     public void serializationFormat(SerializationFormat serializationFormat) {}
@@ -68,7 +73,16 @@ final class NoopRequestLogBuilder implements RequestLogBuilder {
     public void endRequest(Throwable requestCause) {}
 
     @Override
+    public void endRequest(long requestEndTimeNanos) {}
+
+    @Override
+    public void endRequest(Throwable requestCause, long requestEndTimeNanos) {}
+
+    @Override
     public void startResponse() {}
+
+    @Override
+    public void startResponse(long responseStartTimeNanos, long responseStartTimeMicros) {}
 
     @Override
     public void increaseResponseLength(long deltaBytes) {}
@@ -98,4 +112,10 @@ final class NoopRequestLogBuilder implements RequestLogBuilder {
 
     @Override
     public void endResponse(Throwable responseCause) {}
+
+    @Override
+    public void endResponse(long responseEndTimeNanos) {}
+
+    @Override
+    public void endResponse(Throwable responseCause, long responseEndTimeNanos) {}
 }

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestLog.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import java.util.function.Function;
 
 import javax.annotation.Nullable;
+import javax.net.ssl.SSLSession;
 
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.common.HttpHeaders;
@@ -332,6 +333,15 @@ public interface RequestLog {
      */
     @Nullable
     Channel channel();
+
+    /**
+     * Returns the {@link SSLSession} of the connection which handled the {@link Request}.
+     *
+     * @return the {@link SSLSession}, or {@code null} if the {@link Request} has failed even before
+     *         a TLS connection is established.
+     */
+    @Nullable
+    SSLSession sslSession();
 
     /**
      * Returns the {@link SessionProtocol} of the {@link Request}.

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogBuilder.java
@@ -301,7 +301,7 @@ public interface RequestLogBuilder {
     /**
      * Finishes the collection of the {@link Response} information. If a {@link Throwable} cause has been set
      * with {@link #responseContent(Object, Object)}, it will be treated as the {@code responseCause} for this
-     * log. This method set the following properties:
+     * log. This method sets the following properties:
      * <ul>
      *   <li>{@link RequestLog#responseEndTimeNanos()}</li>
      *   <li>{@link RequestLog#responseDurationNanos()}</li>
@@ -311,7 +311,7 @@ public interface RequestLogBuilder {
     void endResponse();
 
     /**
-     * Finishes the collection of the {@link Response} information. This method set the following properties:
+     * Finishes the collection of the {@link Response} information. This method sets the following properties:
      * <ul>
      *   <li>{@link RequestLog#responseEndTimeNanos()}</li>
      *   <li>{@link RequestLog#responseDurationNanos()}</li>
@@ -325,7 +325,7 @@ public interface RequestLogBuilder {
     /**
      * Finishes the collection of the {@link Response} information. If a {@link Throwable} cause has been set
      * with {@link #responseContent(Object, Object)}, it will be treated as the {@code responseCause} for this
-     * log. This method set the following properties:
+     * log. This method sets the following properties:
      * <ul>
      *   <li>{@link RequestLog#responseEndTimeNanos()}</li>
      *   <li>{@link RequestLog#responseDurationNanos()}</li>
@@ -337,7 +337,7 @@ public interface RequestLogBuilder {
     void endResponse(long responseEndTimeNanos);
 
     /**
-     * Finishes the collection of the {@link Response} information. This method set the following properties:
+     * Finishes the collection of the {@link Response} information. This method sets the following properties:
      * <ul>
      *   <li>{@link RequestLog#responseEndTimeNanos()}</li>
      *   <li>{@link RequestLog#responseDurationNanos()}</li>

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogBuilder.java
@@ -58,8 +58,8 @@ public interface RequestLogBuilder {
     /**
      * Starts the collection of the {@link Request} information. This method sets the following properties:
      * <ul>
-     *   <li>{@link RequestLog#requestStartTimeMicros()}</li>
      *   <li>{@link RequestLog#requestStartTimeMillis()}</li>
+     *   <li>{@link RequestLog#requestStartTimeMicros()}</li>
      *   <li>{@link RequestLog#requestStartTimeNanos()}</li>
      *   <li>{@link RequestLog#channel()}</li>
      *   <li>{@link RequestLog#sessionProtocol()}</li>
@@ -68,7 +68,7 @@ public interface RequestLogBuilder {
      * </ul>
      *
      * @param channel the {@link Channel} which handled the {@link Request}.
-     * @param sessionProtocol the {@link SessionProtocol} protocol of the connection.
+     * @param sessionProtocol the {@link SessionProtocol} of the connection.
      */
     default void startRequest(Channel channel, SessionProtocol sessionProtocol) {
         requireNonNull(channel, "channel");
@@ -79,8 +79,8 @@ public interface RequestLogBuilder {
     /**
      * Starts the collection of the {@link Request} information. This method sets the following properties:
      * <ul>
-     *   <li>{@link RequestLog#requestStartTimeMicros()}</li>
      *   <li>{@link RequestLog#requestStartTimeMillis()}</li>
+     *   <li>{@link RequestLog#requestStartTimeMicros()}</li>
      *   <li>{@link RequestLog#requestStartTimeNanos()}</li>
      *   <li>{@link RequestLog#channel()}</li>
      *   <li>{@link RequestLog#sessionProtocol()}</li>
@@ -89,7 +89,7 @@ public interface RequestLogBuilder {
      * </ul>
      *
      * @param channel the {@link Channel} which handled the {@link Request}.
-     * @param sessionProtocol the {@link SessionProtocol} protocol of the connection.
+     * @param sessionProtocol the {@link SessionProtocol} of the connection.
      * @param sslSession the {@link SSLSession} of the connection, or {@code null}.
      */
     void startRequest(Channel channel, SessionProtocol sessionProtocol, @Nullable SSLSession sslSession);
@@ -97,8 +97,8 @@ public interface RequestLogBuilder {
     /**
      * Starts the collection of the {@link Request} information. This method sets the following properties:
      * <ul>
-     *   <li>{@link RequestLog#requestStartTimeMicros()}</li>
      *   <li>{@link RequestLog#requestStartTimeMillis()}</li>
+     *   <li>{@link RequestLog#requestStartTimeMicros()}</li>
      *   <li>{@link RequestLog#requestStartTimeNanos()}</li>
      *   <li>{@link RequestLog#channel()}</li>
      *   <li>{@link RequestLog#sessionProtocol()}</li>
@@ -107,7 +107,7 @@ public interface RequestLogBuilder {
      * </ul>
      *
      * @param channel the {@link Channel} which handled the {@link Request}.
-     * @param sessionProtocol the {@link SessionProtocol} protocol of the connection.
+     * @param sessionProtocol the {@link SessionProtocol} of the connection.
      * @param requestStartTimeNanos {@link System#nanoTime()} value when the request started.
      * @param requestStartTimeMicros the number of microseconds since the epoch,
      *                               e.g. {@code System.currentTimeMillis() * 1000}.
@@ -123,8 +123,8 @@ public interface RequestLogBuilder {
     /**
      * Starts the collection of the {@link Request} information. This method sets the following properties:
      * <ul>
-     *   <li>{@link RequestLog#requestStartTimeMicros()}</li>
      *   <li>{@link RequestLog#requestStartTimeMillis()}</li>
+     *   <li>{@link RequestLog#requestStartTimeMicros()}</li>
      *   <li>{@link RequestLog#requestStartTimeNanos()}</li>
      *   <li>{@link RequestLog#channel()}</li>
      *   <li>{@link RequestLog#sessionProtocol()}</li>
@@ -133,7 +133,7 @@ public interface RequestLogBuilder {
      * </ul>
      *
      * @param channel the {@link Channel} which handled the {@link Request}.
-     * @param sessionProtocol the {@link SessionProtocol} protocol of the connection.
+     * @param sessionProtocol the {@link SessionProtocol} of the connection.
      * @param sslSession the {@link SSLSession} of the connection, or {@code null}.
      * @param requestStartTimeNanos {@link System#nanoTime()} value when the request started.
      * @param requestStartTimeMicros the number of microseconds since the epoch,
@@ -238,8 +238,8 @@ public interface RequestLogBuilder {
     /**
      * Starts the collection of {@link Response} information. This method sets the following properties:
      * <ul>
-     *   <li>{@link RequestLog#responseStartTimeMicros()}</li>
      *   <li>{@link RequestLog#responseStartTimeMillis()}</li>
+     *   <li>{@link RequestLog#responseStartTimeMicros()}</li>
      *   <li>{@link RequestLog#responseStartTimeNanos()}</li>
      * </ul>
      */
@@ -248,8 +248,8 @@ public interface RequestLogBuilder {
     /**
      * Starts the collection of {@link Response} information. This method sets the following properties:
      * <ul>
-     *   <li>{@link RequestLog#responseStartTimeMicros()}</li>
      *   <li>{@link RequestLog#responseStartTimeMillis()}</li>
+     *   <li>{@link RequestLog#responseStartTimeMicros()}</li>
      *   <li>{@link RequestLog#responseStartTimeNanos()}</li>
      * </ul>
      *

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogBuilder.java
@@ -16,13 +16,17 @@
 
 package com.linecorp.armeria.common.logging;
 
+import static java.util.Objects.requireNonNull;
+
 import javax.annotation.Nullable;
+import javax.net.ssl.SSLSession;
 
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.internal.ChannelUtil;
 
 import io.netty.channel.Channel;
 
@@ -52,34 +56,91 @@ public interface RequestLogBuilder {
     // Methods related with a request:
 
     /**
-     * Starts the collection of information for the {@link Request}. This method sets the following
-     * properties:
+     * Starts the collection of the {@link Request} information. This method sets the following properties:
      * <ul>
+     *   <li>{@link RequestLog#requestStartTimeMicros()}</li>
      *   <li>{@link RequestLog#requestStartTimeMillis()}</li>
+     *   <li>{@link RequestLog#requestStartTimeNanos()}</li>
      *   <li>{@link RequestLog#channel()}</li>
      *   <li>{@link RequestLog#sessionProtocol()}</li>
      *   <li>{@link RequestLog#host()}</li>
-     * </ul>
-     */
-    void startRequest(Channel channel, SessionProtocol sessionProtocol);
-
-    /**
-     * Starts the collection of information for the {@link Request}. This method sets the following
-     * properties:
-     * <ul>
-     *   <li>{@link RequestLog#requestStartTimeMillis()}</li>
-     *   <li>{@link RequestLog#channel()}</li>
-     *   <li>{@link RequestLog#sessionProtocol()}</li>
-     *   <li>{@link RequestLog#host()}</li>
+     *   <li>{@link RequestLog#sslSession()}</li>
      * </ul>
      *
-     * @deprecated Use {@link #startRequest(Channel, SessionProtocol)}.
+     * @param channel the {@link Channel} which handled the {@link Request}.
+     * @param sessionProtocol the {@link SessionProtocol} protocol of the connection.
      */
-    @Deprecated
-    default void startRequest(Channel channel, SessionProtocol sessionProtocol,
-                              @SuppressWarnings("unused") String host) {
-        startRequest(channel, sessionProtocol);
+    default void startRequest(Channel channel, SessionProtocol sessionProtocol) {
+        requireNonNull(channel, "channel");
+        requireNonNull(sessionProtocol, "sessionProtocol");
+        startRequest(channel, sessionProtocol, ChannelUtil.findSslSession(channel, sessionProtocol));
     }
+
+    /**
+     * Starts the collection of the {@link Request} information. This method sets the following properties:
+     * <ul>
+     *   <li>{@link RequestLog#requestStartTimeMicros()}</li>
+     *   <li>{@link RequestLog#requestStartTimeMillis()}</li>
+     *   <li>{@link RequestLog#requestStartTimeNanos()}</li>
+     *   <li>{@link RequestLog#channel()}</li>
+     *   <li>{@link RequestLog#sessionProtocol()}</li>
+     *   <li>{@link RequestLog#host()}</li>
+     *   <li>{@link RequestLog#sslSession()}</li>
+     * </ul>
+     *
+     * @param channel the {@link Channel} which handled the {@link Request}.
+     * @param sessionProtocol the {@link SessionProtocol} protocol of the connection.
+     * @param sslSession the {@link SSLSession} of the connection, or {@code null}.
+     */
+    void startRequest(Channel channel, SessionProtocol sessionProtocol, @Nullable SSLSession sslSession);
+
+    /**
+     * Starts the collection of the {@link Request} information. This method sets the following properties:
+     * <ul>
+     *   <li>{@link RequestLog#requestStartTimeMicros()}</li>
+     *   <li>{@link RequestLog#requestStartTimeMillis()}</li>
+     *   <li>{@link RequestLog#requestStartTimeNanos()}</li>
+     *   <li>{@link RequestLog#channel()}</li>
+     *   <li>{@link RequestLog#sessionProtocol()}</li>
+     *   <li>{@link RequestLog#host()}</li>
+     *   <li>{@link RequestLog#sslSession()}</li>
+     * </ul>
+     *
+     * @param channel the {@link Channel} which handled the {@link Request}.
+     * @param sessionProtocol the {@link SessionProtocol} protocol of the connection.
+     * @param requestStartTimeNanos {@link System#nanoTime()} value when the request started.
+     * @param requestStartTimeMicros the number of microseconds since the epoch,
+     *                               e.g. {@code System.currentTimeMillis() * 1000}.
+     */
+    default void startRequest(Channel channel, SessionProtocol sessionProtocol,
+                              long requestStartTimeNanos, long requestStartTimeMicros) {
+        requireNonNull(channel, "channel");
+        requireNonNull(sessionProtocol, "sessionProtocol");
+        startRequest(channel, sessionProtocol, ChannelUtil.findSslSession(channel, sessionProtocol),
+                     requestStartTimeNanos, requestStartTimeMicros);
+    }
+
+    /**
+     * Starts the collection of the {@link Request} information. This method sets the following properties:
+     * <ul>
+     *   <li>{@link RequestLog#requestStartTimeMicros()}</li>
+     *   <li>{@link RequestLog#requestStartTimeMillis()}</li>
+     *   <li>{@link RequestLog#requestStartTimeNanos()}</li>
+     *   <li>{@link RequestLog#channel()}</li>
+     *   <li>{@link RequestLog#sessionProtocol()}</li>
+     *   <li>{@link RequestLog#host()}</li>
+     *   <li>{@link RequestLog#sslSession()}</li>
+     * </ul>
+     *
+     * @param channel the {@link Channel} which handled the {@link Request}.
+     * @param sessionProtocol the {@link SessionProtocol} protocol of the connection.
+     * @param sslSession the {@link SSLSession} of the connection, or {@code null}.
+     * @param requestStartTimeNanos {@link System#nanoTime()} value when the request started.
+     * @param requestStartTimeMicros the number of microseconds since the epoch,
+     *                               e.g. {@code System.currentTimeMillis() * 1000}.
+     */
+    void startRequest(Channel channel, SessionProtocol sessionProtocol, @Nullable SSLSession sslSession,
+                      long requestStartTimeNanos, long requestStartTimeMicros);
 
     /**
      * Sets the {@link SerializationFormat}.
@@ -126,22 +187,77 @@ public interface RequestLogBuilder {
     boolean isRequestContentDeferred();
 
     /**
-     * Sets {@link RequestLog#requestDurationNanos()} and finishes the collection of the information.
+     * Finishes the collection of the {@link Request} information. This method sets the following properties:
+     * <ul>
+     *   <li>{@link RequestLog#requestEndTimeNanos()}</li>
+     *   <li>{@link RequestLog#requestDurationNanos()}</li>
+     *   <li>{@link RequestLog#requestCause()}</li>
+     * </ul>
      */
     void endRequest();
 
     /**
-     * Sets {@link RequestLog#requestDurationNanos()} and finishes the collection of the information.
+     * Finishes the collection of the {@link Request} information. This method sets the following properties:
+     * <ul>
+     *   <li>{@link RequestLog#requestEndTimeNanos()}</li>
+     *   <li>{@link RequestLog#requestDurationNanos()}</li>
+     *   <li>{@link RequestLog#requestCause()}</li>
+     * </ul>
+     *
+     * @param requestCause the cause of the failure.
      */
     void endRequest(Throwable requestCause);
+
+    /**
+     * Finishes the collection of the {@link Request} information. This method sets the following properties:
+     * <ul>
+     *   <li>{@link RequestLog#requestEndTimeNanos()}</li>
+     *   <li>{@link RequestLog#requestDurationNanos()}</li>
+     *   <li>{@link RequestLog#requestCause()}</li>
+     * </ul>
+     *
+     * @param requestEndTimeNanos {@link System#nanoTime()} value when the request ended.
+     */
+    void endRequest(long requestEndTimeNanos);
+
+    /**
+     * Finishes the collection of the {@link Request} information. This method sets the following properties:
+     * <ul>
+     *   <li>{@link RequestLog#requestEndTimeNanos()}</li>
+     *   <li>{@link RequestLog#requestDurationNanos()}</li>
+     *   <li>{@link RequestLog#requestCause()}</li>
+     * </ul>
+     *
+     * @param requestCause the cause of the failure.
+     * @param requestEndTimeNanos {@link System#nanoTime()} value when the request ended.
+     */
+    void endRequest(Throwable requestCause, long requestEndTimeNanos);
 
     // Methods related with a response:
 
     /**
-     * Starts the collection of information for the {@link Response}. This method sets
-     * {@link RequestLog#responseStartTimeMillis()}.
+     * Starts the collection of {@link Response} information. This method sets the following properties:
+     * <ul>
+     *   <li>{@link RequestLog#responseStartTimeMicros()}</li>
+     *   <li>{@link RequestLog#responseStartTimeMillis()}</li>
+     *   <li>{@link RequestLog#responseStartTimeNanos()}</li>
+     * </ul>
      */
     void startResponse();
+
+    /**
+     * Starts the collection of {@link Response} information. This method sets the following properties:
+     * <ul>
+     *   <li>{@link RequestLog#responseStartTimeMicros()}</li>
+     *   <li>{@link RequestLog#responseStartTimeMillis()}</li>
+     *   <li>{@link RequestLog#responseStartTimeNanos()}</li>
+     * </ul>
+     *
+     * @param responseStartTimeNanos {@link System#nanoTime()} value when the response started.
+     * @param responseStartTimeMicros the number of microseconds since the epoch,
+     *                                e.g. {@code System.currentTimeMillis() * 1000}.
+     */
+    void startResponse(long responseStartTimeNanos, long responseStartTimeMicros);
 
     /**
      * Increases the {@link RequestLog#responseLength()} by {@code deltaBytes}.
@@ -183,14 +299,53 @@ public interface RequestLogBuilder {
     boolean isResponseContentDeferred();
 
     /**
-     * Sets {@link RequestLog#responseDurationNanos()} and finishes the collection of the information. If a
-     * {@link Throwable} cause has been set with {@link #responseContent(Object, Object)}, it will be treated
-     * as the {@code responseCause} for this log.
+     * Finishes the collection of the {@link Response} information. If a {@link Throwable} cause has been set
+     * with {@link #responseContent(Object, Object)}, it will be treated as the {@code responseCause} for this
+     * log. This method set the following properties:
+     * <ul>
+     *   <li>{@link RequestLog#responseEndTimeNanos()}</li>
+     *   <li>{@link RequestLog#responseDurationNanos()}</li>
+     *   <li>{@link RequestLog#responseCause()}</li>
+     * </ul>
      */
     void endResponse();
 
     /**
-     * Sets {@link RequestLog#responseDurationNanos()} and finishes the collection of the information.
+     * Finishes the collection of the {@link Response} information. This method set the following properties:
+     * <ul>
+     *   <li>{@link RequestLog#responseEndTimeNanos()}</li>
+     *   <li>{@link RequestLog#responseDurationNanos()}</li>
+     *   <li>{@link RequestLog#responseCause()}</li>
+     * </ul>
+     *
+     * @param responseCause the cause of the failure.
      */
     void endResponse(Throwable responseCause);
+
+    /**
+     * Finishes the collection of the {@link Response} information. If a {@link Throwable} cause has been set
+     * with {@link #responseContent(Object, Object)}, it will be treated as the {@code responseCause} for this
+     * log. This method set the following properties:
+     * <ul>
+     *   <li>{@link RequestLog#responseEndTimeNanos()}</li>
+     *   <li>{@link RequestLog#responseDurationNanos()}</li>
+     *   <li>{@link RequestLog#responseCause()}</li>
+     * </ul>
+     *
+     * @param responseEndTimeNanos {@link System#nanoTime()} value when the response ended.
+     */
+    void endResponse(long responseEndTimeNanos);
+
+    /**
+     * Finishes the collection of the {@link Response} information. This method set the following properties:
+     * <ul>
+     *   <li>{@link RequestLog#responseEndTimeNanos()}</li>
+     *   <li>{@link RequestLog#responseDurationNanos()}</li>
+     *   <li>{@link RequestLog#responseCause()}</li>
+     * </ul>
+     *
+     * @param responseCause the cause of the failure.
+     * @param responseEndTimeNanos {@link System#nanoTime()} value when the response ended.
+     */
+    void endResponse(Throwable responseCause, long responseEndTimeNanos);
 }

--- a/core/src/main/java/com/linecorp/armeria/common/util/EventLoopGroups.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/EventLoopGroups.java
@@ -108,7 +108,7 @@ public final class EventLoopGroups {
 
     /**
      * Returns a special {@link EventLoop} which executes submitted tasks in the caller thread.
-     * Note that this {@link EventLoop} will raise a {@link UnsupportedOperationException} for any operations
+     * Note that this {@link EventLoop} will raise an {@link UnsupportedOperationException} for any operations
      * related with {@link EventLoop} shutdown or {@link Channel} registration.
      */
     public static EventLoop directEventLoop() {

--- a/core/src/main/java/com/linecorp/armeria/common/util/EventLoopGroups.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/EventLoopGroups.java
@@ -20,20 +20,29 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
 
 import com.linecorp.armeria.internal.TransportType;
 
 import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.AbstractEventLoop;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.ServerChannel;
 import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.util.concurrent.DefaultThreadFactory;
+import io.netty.util.concurrent.Future;
 
 /**
  * Provides methods that are useful for creating an {@link EventLoopGroup}.
  */
 public final class EventLoopGroups {
+
+    private static final EventLoop directEventLoop = new DirectEventLoop();
 
     /**
      * Returns a newly-created {@link EventLoopGroup}.
@@ -98,6 +107,15 @@ public final class EventLoopGroups {
     }
 
     /**
+     * Returns a special {@link EventLoop} which executes submitted tasks in the caller thread.
+     * Note that this {@link EventLoop} will raise a {@link UnsupportedOperationException} for any operations
+     * related with {@link EventLoop} shutdown or {@link Channel} registration.
+     */
+    public static EventLoop directEventLoop() {
+        return directEventLoop;
+    }
+
+    /**
      * Returns the {@link ServerChannel} class that is available for this {@code eventLoopGroup}, for use in
      * configuring a custom {@link Bootstrap}.
      */
@@ -133,4 +151,71 @@ public final class EventLoopGroups {
     }
 
     private EventLoopGroups() {}
+
+    private static final class DirectEventLoop extends AbstractEventLoop {
+        @Override
+        public ChannelFuture register(Channel channel) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture register(ChannelPromise promise) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture register(Channel channel, ChannelPromise promise) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void shutdown() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean inEventLoop(Thread thread) {
+            return true;
+        }
+
+        @Override
+        public boolean isShuttingDown() {
+            return false;
+        }
+
+        @Override
+        public Future<?> shutdownGracefully(long quietPeriod, long timeout, TimeUnit unit) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Future<?> terminationFuture() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isShutdown() {
+            return false;
+        }
+
+        @Override
+        public boolean isTerminated() {
+            return false;
+        }
+
+        @Override
+        public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+            return false;
+        }
+
+        @Override
+        public void execute(Runnable command) {
+            command.run();
+        }
+
+        @Override
+        public String toString() {
+            return EventLoopGroups.class.getSimpleName() + ".directEventLoop()";
+        }
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/DecodedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DecodedHttpRequest.java
@@ -59,12 +59,6 @@ final class DecodedHttpRequest extends DefaultHttpRequest {
 
     void init(ServiceRequestContext ctx) {
         this.ctx = ctx;
-        ctx.logBuilder().requestHeaders(headers());
-
-        // For the server, request headers are processed well before ServiceRequestContext is created. It means
-        // there is some delay between the actual channel read and this logging, but it's the best we can do for
-        // now.
-        ctx.logBuilder().requestFirstBytesTransferred();
     }
 
     int id() {

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
@@ -117,9 +117,45 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
      */
     public DefaultServiceRequestContext(
             ServiceConfig cfg, Channel ch, MeterRegistry meterRegistry, SessionProtocol sessionProtocol,
-            PathMappingContext pathMappingContext, PathMappingResult pathMappingResult, Request request,
+            PathMappingContext pathMappingContext, PathMappingResult pathMappingResult, HttpRequest request,
             @Nullable SSLSession sslSession, @Nullable ProxiedAddresses proxiedAddresses,
             InetAddress clientAddress) {
+        this(cfg, ch, meterRegistry, sessionProtocol, pathMappingContext, pathMappingResult, request,
+             sslSession, proxiedAddresses, clientAddress, false, 0, 0);
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param cfg the {@link ServiceConfig}
+     * @param ch the {@link Channel} that handles the invocation
+     * @param meterRegistry the {@link MeterRegistry} that collects various stats
+     * @param sessionProtocol the {@link SessionProtocol} of the invocation
+     * @param pathMappingContext the parameters which is used when finding a matched {@link PathMapping}
+     * @param pathMappingResult the result of finding a matched {@link PathMapping}
+     * @param request the request associated with this context
+     * @param sslSession the {@link SSLSession} for this invocation if it is over TLS
+     * @param proxiedAddresses source and destination addresses retrieved from PROXY protocol header
+     * @param clientAddress the address of a client who initiated the request
+     * @param requestStartTimeNanos {@link System#nanoTime()} value when the request started.
+     * @param requestStartTimeMicros the number of microseconds since the epoch,
+     *                               e.g. {@code System.currentTimeMillis() * 1000}.
+     */
+    public DefaultServiceRequestContext(
+            ServiceConfig cfg, Channel ch, MeterRegistry meterRegistry, SessionProtocol sessionProtocol,
+            PathMappingContext pathMappingContext, PathMappingResult pathMappingResult, HttpRequest request,
+            @Nullable SSLSession sslSession, @Nullable ProxiedAddresses proxiedAddresses,
+            InetAddress clientAddress, long requestStartTimeNanos, long requestStartTimeMicros) {
+        this(cfg, ch, meterRegistry, sessionProtocol, pathMappingContext, pathMappingResult, request,
+             sslSession, proxiedAddresses, clientAddress, true, requestStartTimeNanos, requestStartTimeMicros);
+    }
+
+    private DefaultServiceRequestContext(
+            ServiceConfig cfg, Channel ch, MeterRegistry meterRegistry, SessionProtocol sessionProtocol,
+            PathMappingContext pathMappingContext, PathMappingResult pathMappingResult, HttpRequest request,
+            @Nullable SSLSession sslSession, @Nullable ProxiedAddresses proxiedAddresses,
+            InetAddress clientAddress, boolean requestStartTimeSet, long requestStartTimeNanos,
+            long requestStartTimeMicros) {
 
         super(meterRegistry, sessionProtocol,
               requireNonNull(pathMappingContext, "pathMappingContext").method(), pathMappingContext.path(),
@@ -135,7 +171,18 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
         this.clientAddress = requireNonNull(clientAddress, "clientAddress");
 
         log = new DefaultRequestLog(this);
-        log.startRequest(ch, sessionProtocol);
+        if (requestStartTimeSet) {
+            log.startRequest(ch, sessionProtocol, sslSession, requestStartTimeNanos, requestStartTimeMicros);
+        } else {
+            log.startRequest(ch, sessionProtocol, sslSession);
+        }
+        log.requestHeaders(request.headers());
+
+        // For the server, request headers are processed well before ServiceRequestContext is created. It means
+        // there is some delay between the actual channel read and this logging, but it's the best we can do for
+        // now.
+        log.requestFirstBytesTransferred();
+
         logger = newLogger(cfg);
 
         final ServerConfig serverCfg = cfg.server().config();
@@ -187,7 +234,7 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
     public ServiceRequestContext newDerivedContext(Request request) {
         final DefaultServiceRequestContext ctx = new DefaultServiceRequestContext(
                 cfg, ch, meterRegistry(), sessionProtocol(), pathMappingContext,
-                pathMappingResult, request, sslSession(), proxiedAddresses(), clientAddress);
+                pathMappingResult, (HttpRequest) request, sslSession(), proxiedAddresses(), clientAddress);
 
         final HttpHeaders additionalHeaders = additionalResponseHeaders();
         if (!additionalHeaders.isEmpty()) {

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
@@ -108,7 +108,7 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
      * @param ch the {@link Channel} that handles the invocation
      * @param meterRegistry the {@link MeterRegistry} that collects various stats
      * @param sessionProtocol the {@link SessionProtocol} of the invocation
-     * @param pathMappingContext the parameters which is used when finding a matched {@link PathMapping}
+     * @param pathMappingContext the parameters which are used when finding a matched {@link PathMapping}
      * @param pathMappingResult the result of finding a matched {@link PathMapping}
      * @param request the request associated with this context
      * @param sslSession the {@link SSLSession} for this invocation if it is over TLS
@@ -131,7 +131,7 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
      * @param ch the {@link Channel} that handles the invocation
      * @param meterRegistry the {@link MeterRegistry} that collects various stats
      * @param sessionProtocol the {@link SessionProtocol} of the invocation
-     * @param pathMappingContext the parameters which is used when finding a matched {@link PathMapping}
+     * @param pathMappingContext the parameters which are used when finding a matched {@link PathMapping}
      * @param pathMappingResult the result of finding a matched {@link PathMapping}
      * @param request the request associated with this context
      * @param sslSession the {@link SSLSession} for this invocation if it is over TLS

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -67,6 +67,7 @@ import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.common.util.SafeCloseable;
 import com.linecorp.armeria.internal.AbstractHttp2ConnectionHandler;
 import com.linecorp.armeria.internal.ArmeriaHttpUtil;
+import com.linecorp.armeria.internal.ChannelUtil;
 import com.linecorp.armeria.internal.Http1ObjectEncoder;
 import com.linecorp.armeria.internal.Http2ObjectEncoder;
 import com.linecorp.armeria.internal.HttpObjectEncoder;
@@ -731,6 +732,12 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
         @Override
         protected Channel channel() {
             return channel;
+        }
+
+        @Nullable
+        @Override
+        public SSLSession sslSession() {
+            return ChannelUtil.findSslSession(channel);
         }
 
         @Override

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
@@ -48,6 +48,18 @@ import io.netty.util.AsciiString;
 public interface ServiceRequestContext extends RequestContext {
 
     /**
+     * Returns a new {@link ServiceRequestContext} created from the specified {@link HttpRequest}.
+     * Note that it is not usually required to create a new context by yourself, because Armeria
+     * will always provide a context object for you. However, it may be useful in some cases such as
+     * unit testing.
+     *
+     * @see ServiceRequestContextBuilder
+     */
+    static ServiceRequestContext of(HttpRequest request) {
+        return ServiceRequestContextBuilder.of(request).build();
+    }
+
+    /**
      * Returns the remote address of this request.
      */
     @Nonnull

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextBuilder.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server;
+
+import static java.util.Objects.requireNonNull;
+
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import javax.annotation.Nullable;
+
+import com.linecorp.armeria.common.AbstractRequestContextBuilder;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+
+/**
+ * Builds a new {@link ServiceRequestContext}. Note that it is not usually required to create a new context by
+ * yourself, because Armeria will always provide a context object for you. However, it may be useful in some
+ * cases such as unit testing.
+ */
+public final class ServiceRequestContextBuilder
+        extends AbstractRequestContextBuilder<ServiceRequestContextBuilder> {
+
+    /**
+     * A placeholder service to make {@link ServerBuilder} happy.
+     */
+    private static final HttpService fakeService = (ctx, req) -> HttpResponse.of(HttpStatus.METHOD_NOT_ALLOWED);
+
+    /**
+     * A {@link ServerListener} which rejects an attempt to start a {@link Server}.
+     */
+    private static final ServerListener rejectingListener = new ServerListenerAdapter() {
+        @Override
+        public void serverStarting(Server server) throws Exception {
+            throw new UnsupportedOperationException();
+        }
+    };
+
+    /**
+     * Returns a new {@link ServiceRequestContextBuilder} created from the specified {@link HttpRequest}.
+     */
+    public static ServiceRequestContextBuilder of(HttpRequest request) {
+        return new ServiceRequestContextBuilder(request);
+    }
+
+    private final List<Consumer<? super ServerBuilder>> serverConfigurators = new ArrayList<>(4);
+
+    private Service<HttpRequest, HttpResponse> service = fakeService;
+    @Nullable
+    private PathMappingResult pathMappingResult;
+    @Nullable
+    private ProxiedAddresses proxiedAddresses;
+    @Nullable
+    private InetAddress clientAddress;
+
+    private ServiceRequestContextBuilder(HttpRequest request) {
+        super(true, request);
+    }
+
+    /**
+     * Sets the {@link Service} that handles the request. If not set, a dummy {@link Service}, which always
+     * returns a {@code "405 Method Not Allowed"} response, is used.
+     */
+    public ServiceRequestContextBuilder service(Service<HttpRequest, HttpResponse> service) {
+        this.service = requireNonNull(service, "service");
+        return this;
+    }
+
+    /**
+     * Sets the {@link PathMappingResult} of the request. If not set, it is auto-generated from the request.
+     */
+    public ServiceRequestContextBuilder pathMappingResult(PathMappingResult pathMappingResult) {
+        this.pathMappingResult = requireNonNull(pathMappingResult, "pathMappingResult");
+        return this;
+    }
+
+    /**
+     * Sets the {@link ProxiedAddresses} of the request.
+     * If not set, {@link ServiceRequestContext#proxiedAddresses()} will return {@code null}.
+     */
+    public ServiceRequestContextBuilder proxiedAddresses(ProxiedAddresses proxiedAddresses) {
+        this.proxiedAddresses = requireNonNull(proxiedAddresses, "proxiedAddresses");
+        return this;
+    }
+
+    /**
+     * Sets the client address of the request. If not set, {@link ServiceRequestContext#clientAddress()} will
+     * return the same value as {@link ServiceRequestContext#remoteAddress()}.
+     */
+    public ServiceRequestContextBuilder clientAddress(InetAddress clientAddress) {
+        this.clientAddress = requireNonNull(clientAddress, "clientAddress");
+        return this;
+    }
+
+    /**
+     * Adds the {@link Consumer} that configures the given {@link ServerBuilder}. The {@link Consumer}s added
+     * by thid method will be invoked when this builder builds a dummy {@link Server}. This may be useful
+     * when you need to update the default settings of the dummy {@link Server},
+     * such as {@link ServerConfig#defaultMaxRequestLength()}.
+     */
+    public ServiceRequestContextBuilder serverConfigurator(Consumer<? super ServerBuilder> serverConfigurator) {
+        requireNonNull(serverConfigurator, "serverConfigurator");
+        serverConfigurators.add(serverConfigurator);
+        return this;
+    }
+
+    /**
+     * Returns a new {@link ServiceRequestContext} created with the properties of this builder.
+     */
+    public ServiceRequestContext build() {
+        // Determine the client address; use remote address unless overridden.
+        final InetAddress clientAddress;
+        if (this.clientAddress != null) {
+            clientAddress = this.clientAddress;
+        } else {
+            clientAddress = remoteAddress().getAddress();
+        }
+
+        // Build a fake server which never starts up.
+        final ServerBuilder serverBuilder = new ServerBuilder().meterRegistry(meterRegistry())
+                                                               .workerGroup(eventLoop(), false)
+                                                               .service(path(), service);
+        serverConfigurators.forEach(configurator -> configurator.accept(serverBuilder));
+
+        final Server server = serverBuilder.build();
+        server.addListener(rejectingListener);
+
+        // Retrieve the ServiceConfig of the fake service.
+        final ServiceConfig serviceCfg = findServiceConfig(server, path(), service);
+
+        // Build a fake object related with path mapping.
+        final PathMappingContext pathMappingCtx = DefaultPathMappingContext.of(
+                server.config().defaultVirtualHost(),
+                localAddress().getHostString(),
+                path(),
+                query(),
+                ((HttpRequest) request()).headers(),
+                null);
+
+        final PathMappingResult pathMappingResult =
+                this.pathMappingResult != null ? this.pathMappingResult
+                                               : PathMappingResult.of(path(), query());
+
+        // Build the context with the properties set by a user and the fake objects.
+        if (isRequestStartTimeSet()) {
+            return new DefaultServiceRequestContext(
+                    serviceCfg, fakeChannel(), meterRegistry(), sessionProtocol(), pathMappingCtx,
+                    pathMappingResult, request(), sslSession(), proxiedAddresses, clientAddress,
+                    requestStartTimeNanos(), requestStartTimeMicros());
+        } else {
+            return new DefaultServiceRequestContext(
+                    serviceCfg, fakeChannel(), meterRegistry(), sessionProtocol(), pathMappingCtx,
+                    pathMappingResult, request(), sslSession(), proxiedAddresses, clientAddress);
+        }
+    }
+
+    private static ServiceConfig findServiceConfig(Server server, String path, Service<?, ?> service) {
+        for (ServiceConfig cfg : server.config().defaultVirtualHost().serviceConfigs()) {
+            final Optional<String> exactPath = cfg.pathMapping().exactPath();
+            if (!exactPath.isPresent()) {
+                continue;
+            }
+
+            if (!path.equals(exactPath.get())) {
+                continue;
+            }
+
+            if (cfg.service().as(service.getClass()).isPresent()) {
+                return cfg;
+            }
+        }
+
+        throw new Error(); // Never reaches here.
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientDelegateTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientDelegateTest.java
@@ -17,8 +17,6 @@ package com.linecorp.armeria.client;
 
 import static com.linecorp.armeria.client.HttpClientDelegate.extractHost;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import org.junit.Test;
 
@@ -75,8 +73,8 @@ public class HttpClientDelegateTest {
     }
 
     private static ClientRequestContext context(HttpHeaders additionalHeaders) {
-        final ClientRequestContext ctx = mock(ClientRequestContext.class);
-        when(ctx.additionalRequestHeaders()).thenReturn(additionalHeaders.asImmutable());
+        final ClientRequestContext ctx = ClientRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+        ctx.setAdditionalRequestHeaders(additionalHeaders);
         return ctx;
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerHttpClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerHttpClientTest.java
@@ -16,7 +16,6 @@
 
 package com.linecorp.armeria.client.circuitbreaker;
 
-import static com.linecorp.armeria.common.SessionProtocol.H2C;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
@@ -36,9 +35,8 @@ import org.junit.Test;
 import com.google.common.testing.FakeTicker;
 
 import com.linecorp.armeria.client.Client;
-import com.linecorp.armeria.client.ClientOptions;
 import com.linecorp.armeria.client.ClientRequestContext;
-import com.linecorp.armeria.client.DefaultClientRequestContext;
+import com.linecorp.armeria.client.ClientRequestContextBuilder;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.client.HttpClientBuilder;
@@ -47,20 +45,17 @@ import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.HttpStatusClass;
-import com.linecorp.armeria.common.metric.NoopMeterRegistry;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.testing.server.ServerRule;
-
-import io.netty.channel.DefaultEventLoop;
 
 public class CircuitBreakerHttpClientTest {
 
     private static final String remoteServiceName = "testService";
 
-    private static final ClientRequestContext ctx = new DefaultClientRequestContext(
-            new DefaultEventLoop(), NoopMeterRegistry.get(), H2C,
-            Endpoint.of("dummyhost", 8080),
-            HttpMethod.GET, "/", null, null, ClientOptions.DEFAULT, mock(HttpRequest.class));
+    private static final ClientRequestContext ctx =
+            ClientRequestContextBuilder.of(HttpRequest.of(HttpMethod.GET, "/"))
+                                       .endpoint(Endpoint.of("dummyhost", 8080))
+                                       .build();
 
     @ClassRule
     public static final ServerRule server = new ServerRule() {

--- a/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerRpcClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerRpcClientTest.java
@@ -16,7 +16,6 @@
 
 package com.linecorp.armeria.client.circuitbreaker;
 
-import static com.linecorp.armeria.common.SessionProtocol.H2C;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -34,18 +33,11 @@ import org.junit.Test;
 import com.google.common.testing.FakeTicker;
 
 import com.linecorp.armeria.client.Client;
-import com.linecorp.armeria.client.ClientOptions;
 import com.linecorp.armeria.client.ClientRequestContext;
-import com.linecorp.armeria.client.DefaultClientRequestContext;
-import com.linecorp.armeria.client.Endpoint;
-import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.RpcResponse;
-import com.linecorp.armeria.common.metric.NoopMeterRegistry;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.testing.internal.AnticipatedException;
-
-import io.netty.channel.DefaultEventLoop;
 
 public class CircuitBreakerRpcClientTest {
 
@@ -53,16 +45,10 @@ public class CircuitBreakerRpcClientTest {
 
     // Remote invocation parameters
     private static final RpcRequest reqA = RpcRequest.of(Object.class, "methodA", "a", "b");
-    private static final ClientRequestContext ctxA = new DefaultClientRequestContext(
-            new DefaultEventLoop(), NoopMeterRegistry.get(), H2C,
-            Endpoint.of("dummyhost", 8080),
-            HttpMethod.POST, "/", null, null, ClientOptions.DEFAULT, reqA);
+    private static final ClientRequestContext ctxA = ClientRequestContext.of(reqA, "h2c://dummyhost:8080/");
 
     private static final RpcRequest reqB = RpcRequest.of(Object.class, "methodB", "c", "d");
-    private static final ClientRequestContext ctxB = new DefaultClientRequestContext(
-            new DefaultEventLoop(), NoopMeterRegistry.get(), H2C,
-            Endpoint.of("dummyhost", 8080),
-            HttpMethod.POST, "/", null, null, ClientOptions.DEFAULT, reqB);
+    private static final ClientRequestContext ctxB = ClientRequestContext.of(reqB, "h2c://dummyhost:8080/");
 
     private static final RpcResponse successRes = RpcResponse.of(null);
     private static final RpcResponse failureRes = RpcResponse.ofFailure(

--- a/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/KeyedCircuitBreakerMappingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/KeyedCircuitBreakerMappingTest.java
@@ -17,13 +17,14 @@ package com.linecorp.armeria.client.circuitbreaker;
 
 import static com.linecorp.armeria.client.circuitbreaker.KeyedCircuitBreakerMapping.KeySelector.HOST;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import org.junit.Test;
 
 import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.ClientRequestContextBuilder;
 import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
 
 public class KeyedCircuitBreakerMappingTest {
     @Test
@@ -37,8 +38,8 @@ public class KeyedCircuitBreakerMappingTest {
     }
 
     private static ClientRequestContext context(Endpoint endpoint) {
-        final ClientRequestContext ctx = mock(ClientRequestContext.class);
-        when(ctx.endpoint()).thenReturn(endpoint);
-        return ctx;
+        return ClientRequestContextBuilder.of(HttpRequest.of(HttpMethod.GET, "/"))
+                                          .endpoint(endpoint)
+                                          .build();
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/RoundRobinStrategyTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/RoundRobinStrategyTest.java
@@ -20,14 +20,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
 
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
 
 public class RoundRobinStrategyTest {
     private static final EndpointGroup ENDPOINT_GROUP =
@@ -38,11 +36,7 @@ public class RoundRobinStrategyTest {
 
     private final RoundRobinStrategy strategy = new RoundRobinStrategy();
 
-    @Rule
-    public MockitoRule mocks = MockitoJUnit.rule();
-
-    @Mock
-    private ClientRequestContext ctx;
+    private final ClientRequestContext ctx = ClientRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
 
     @Before
     public void setup() {

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/StickyEndpointSelectionStrategyTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/StickyEndpointSelectionStrategyTest.java
@@ -18,8 +18,6 @@ package com.linecorp.armeria.client.endpoint;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import java.util.function.ToLongFunction;
 
@@ -99,9 +97,7 @@ public class StickyEndpointSelectionStrategyTest {
     }
 
     private static ClientRequestContext contextWithHeader(String k, String v) {
-        final ClientRequestContext ctx = mock(ClientRequestContext.class);
-        when(ctx.request()).thenReturn(HttpRequest.of(HttpHeaders.of(HttpMethod.GET, "/")
+        return ClientRequestContext.of(HttpRequest.of(HttpHeaders.of(HttpMethod.GET, "/")
                                                                  .set(HttpHeaderNames.of(k), v)));
-        return ctx;
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/WeightedRoundRobinStrategyTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/WeightedRoundRobinStrategyTest.java
@@ -24,16 +24,14 @@ import java.util.List;
 import java.util.Random;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
 
 import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
 
 public class WeightedRoundRobinStrategyTest {
     private static final EndpointGroup ENDPOINT_GROUP =
@@ -43,11 +41,7 @@ public class WeightedRoundRobinStrategyTest {
 
     private final WeightedRoundRobinStrategy strategy = new WeightedRoundRobinStrategy();
 
-    @Rule
-    public MockitoRule mocks = MockitoJUnit.rule();
-
-    @Mock
-    private ClientRequestContext ctx;
+    private final ClientRequestContext ctx = ClientRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
 
     @Before
     public void setup() {

--- a/core/src/test/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingHttpClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingHttpClientTest.java
@@ -32,7 +32,9 @@ import org.junit.Test;
 
 import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.ClientRequestContextBuilder;
 import com.linecorp.armeria.client.ResponseTimeoutException;
+import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpResponseWriter;
@@ -224,9 +226,9 @@ public class ConcurrencyLimitingHttpClientTest {
     }
 
     private static ClientRequestContext newContext() {
-        final ClientRequestContext ctx = mock(ClientRequestContext.class);
-        when(ctx.eventLoop()).thenReturn(eventLoop.get());
-        return ctx;
+        return ClientRequestContextBuilder.of(HttpRequest.of(HttpMethod.GET, "/"))
+                                          .eventLoop(eventLoop.get())
+                                          .build();
     }
 
     /**

--- a/core/src/test/java/com/linecorp/armeria/common/RequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/RequestContextTest.java
@@ -38,6 +38,9 @@ import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import javax.annotation.Nullable;
+import javax.net.ssl.SSLSession;
+
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -53,6 +56,7 @@ import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.logging.RequestLogBuilder;
 import com.linecorp.armeria.common.metric.NoopMeterRegistry;
 import com.linecorp.armeria.common.util.SafeCloseable;
+import com.linecorp.armeria.internal.ChannelUtil;
 import com.linecorp.armeria.testing.common.EventLoopRule;
 
 import io.netty.channel.Channel;
@@ -438,6 +442,12 @@ public class RequestContextTest {
         @Override
         protected Channel channel() {
             return channel;
+        }
+
+        @Nullable
+        @Override
+        public SSLSession sslSession() {
+            return ChannelUtil.findSslSession(channel);
         }
 
         @Override

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedValueResolverTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedValueResolverTest.java
@@ -15,26 +15,25 @@
  */
 package com.linecorp.armeria.internal.annotation;
 
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.linecorp.armeria.internal.annotation.AnnotatedValueResolver.toArguments;
 import static com.linecorp.armeria.internal.annotation.AnnotatedValueResolver.toRequestObjectResolvers;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import static org.reflections.ReflectionUtils.getAllConstructors;
 import static org.reflections.ReflectionUtils.getAllFields;
 import static org.reflections.ReflectionUtils.getAllMethods;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
+import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.junit.BeforeClass;
+import org.junit.AfterClass;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,15 +42,16 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 
-import com.linecorp.armeria.common.AggregatedHttpMessage;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
-import com.linecorp.armeria.common.HttpParameters;
+import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.internal.annotation.AnnotatedValueResolver.NoAnnotatedParameterException;
 import com.linecorp.armeria.internal.annotation.AnnotatedValueResolver.RequestObjectResolver;
 import com.linecorp.armeria.internal.annotation.AnnotatedValueResolver.ResolverContext;
+import com.linecorp.armeria.server.PathMappingResult;
 import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.ServiceRequestContextBuilder;
 import com.linecorp.armeria.server.annotation.Cookies;
 import com.linecorp.armeria.server.annotation.Default;
 import com.linecorp.armeria.server.annotation.Get;
@@ -79,41 +79,40 @@ public class AnnotatedValueResolverTest {
                                                               "value3",
                                                               "value2");
 
-    static final ResolverContext resolverContext = mock(ResolverContext.class);
-    static final ServiceRequestContext context = mock(ServiceRequestContext.class);
-    static final HttpRequest request = mock(HttpRequest.class);
-    static final AggregatedHttpMessage message = mock(AggregatedHttpMessage.class);
-    static final HttpHeaders headers = mock(HttpHeaders.class);
-    static final HttpParameters parameters = mock(HttpParameters.class);
+    static final ResolverContext resolverContext;
+    static final ServiceRequestContext context;
+    static final HttpRequest request;
+    static final HttpHeaders originalHeaders;
 
-    @BeforeClass
-    public static void setUp() throws Exception {
-        when(resolverContext.httpParameters()).thenReturn(parameters);
-        when(resolverContext.context()).thenReturn(context);
-        when(resolverContext.request()).thenReturn(request);
-        when(resolverContext.message()).thenReturn(message);
+    static {
+        final String path = "/";
+        final String query = existingHttpParameters.stream().map(p -> p + '=' + p)
+                                                   .collect(Collectors.joining("&"));
 
-        when(context.request()).thenReturn(request);
-        when(context.query())
-                .thenReturn(String.join("&",
-                                        existingHttpParameters.stream().map(p -> p + '=' + p)
-                                                              .collect(Collectors.toList())));
-        when(context.pathParam(anyString())).thenAnswer(arg -> arg.getArguments()[0]);
+        final HttpHeaders headers = HttpHeaders.of(HttpMethod.GET, path + '?' + query);
+        headers.set(HttpHeaderNames.COOKIE, "a=1;b=2", "c=3", "a=4");
+        headers.set(HttpHeaderNames.of("header1"), headerValues);
+        headers.set(HttpHeaderNames.of("header2"), headerValues);
 
-        when(parameters.getAll(anyString())).thenAnswer(arg -> {
-            final Object value = arg.getArguments()[0];
-            return existingHttpParameters.contains(value) ? ImmutableList.of(value) : null;
-        });
+        request = HttpRequest.of(headers);
+        originalHeaders = HttpHeaders.copyOf(request.headers()).asImmutable();
 
-        when(request.headers()).thenReturn(headers);
-        when(headers.getAll(any())).thenAnswer(arg -> {
-            final Object value = arg.getArguments()[0];
-            // Return values for 'Cookie' headers.
-            if (value.equals(HttpHeaderNames.COOKIE)) {
-                return ImmutableList.of("a=1;b=2", "c=3", "a=4");
-            }
-            return existingHttpHeaders.contains(value) ? headerValues : ImmutableList.of();
-        });
+        final PathMappingResult pathMappingResult = PathMappingResult.of(
+                path, query,
+                pathParams.stream()
+                          .map(v -> new SimpleImmutableEntry<>(v, v))
+                          .collect(toImmutableMap(Entry::getKey, Entry::getValue)));
+
+        context = ServiceRequestContextBuilder.of(request)
+                                              .pathMappingResult(pathMappingResult)
+                                              .build();
+
+        resolverContext = new ResolverContext(context, request, null);
+    }
+
+    @AfterClass
+    public static void ensureUnmodifiedHeaders() {
+        assertThat(request.headers()).isEqualTo(originalHeaders);
     }
 
     static boolean shouldHttpHeaderExist(AnnotatedValueResolver element) {
@@ -130,7 +129,6 @@ public class AnnotatedValueResolverTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void ofMethods() {
         getAllMethods(Service.class).forEach(method -> {
             try {
@@ -144,7 +142,6 @@ public class AnnotatedValueResolverTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void ofFieldBean() throws NoSuchFieldException {
         final FieldBean bean = new FieldBean();
 
@@ -167,8 +164,8 @@ public class AnnotatedValueResolverTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void ofConstructorBean() {
+        @SuppressWarnings("rawtypes")
         final Set<Constructor> constructors = getAllConstructors(ConstructorBean.class);
         assertThat(constructors.size()).isOne();
         constructors.forEach(constructor -> {
@@ -190,7 +187,6 @@ public class AnnotatedValueResolverTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void ofSetterBean() throws Exception {
         final SetterBean bean = SetterBean.class.getDeclaredConstructor().newInstance();
         getAllMethods(SetterBean.class).forEach(method -> testMethod(method, bean));
@@ -198,7 +194,7 @@ public class AnnotatedValueResolverTest {
     }
 
     @Test
-    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @SuppressWarnings("rawtypes")
     public void ofMixedBean() throws Exception {
         final Set<Constructor> constructors = getAllConstructors(MixedBean.class);
         assertThat(constructors.size()).isOne();

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedValueResolverTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedValueResolverTest.java
@@ -91,8 +91,7 @@ public class AnnotatedValueResolverTest {
 
         final HttpHeaders headers = HttpHeaders.of(HttpMethod.GET, path + '?' + query);
         headers.set(HttpHeaderNames.COOKIE, "a=1;b=2", "c=3", "a=4");
-        headers.set(HttpHeaderNames.of("header1"), headerValues);
-        headers.set(HttpHeaderNames.of("header2"), headerValues);
+        existingHttpHeaders.forEach(name -> headers.set(name, headerValues));
 
         request = HttpRequest.of(headers);
         originalHeaders = HttpHeaders.copyOf(request.headers()).asImmutable();

--- a/core/src/test/java/com/linecorp/armeria/internal/metric/RequestMetricSupportTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/metric/RequestMetricSupportTest.java
@@ -24,9 +24,8 @@ import java.util.Map;
 
 import org.junit.Test;
 
-import com.linecorp.armeria.client.ClientOptions;
 import com.linecorp.armeria.client.ClientRequestContext;
-import com.linecorp.armeria.client.DefaultClientRequestContext;
+import com.linecorp.armeria.client.ClientRequestContextBuilder;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.common.DefaultRpcRequest;
 import com.linecorp.armeria.common.HttpHeaders;
@@ -38,17 +37,17 @@ import com.linecorp.armeria.common.metric.PrometheusMeterRegistries;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.netty.channel.Channel;
-import io.netty.channel.EventLoop;
 
 public class RequestMetricSupportTest {
 
     @Test
     public void httpSuccess() {
         final MeterRegistry registry = PrometheusMeterRegistries.newRegistry();
-        final ClientRequestContext ctx = new DefaultClientRequestContext(
-                mock(EventLoop.class), registry, SessionProtocol.H2C,
-                Endpoint.of("example.com", 8080), HttpMethod.POST, "/foo", null, null,
-                ClientOptions.DEFAULT, HttpRequest.of(HttpMethod.POST, "/foo"));
+        final ClientRequestContext ctx =
+                ClientRequestContextBuilder.of(HttpRequest.of(HttpMethod.POST, "/foo"))
+                                           .meterRegistry(registry)
+                                           .endpoint(Endpoint.of("example.com", 8080))
+                                           .build();
 
         final MeterIdPrefixFunction meterIdPrefixFunction = MeterIdPrefixFunction.ofDefault("foo");
 
@@ -85,10 +84,11 @@ public class RequestMetricSupportTest {
     @Test
     public void httpFailure() {
         final MeterRegistry registry = PrometheusMeterRegistries.newRegistry();
-        final ClientRequestContext ctx = new DefaultClientRequestContext(
-                mock(EventLoop.class), registry, SessionProtocol.H2C,
-                Endpoint.of("example.com", 8080), HttpMethod.POST, "/foo", null, null,
-                ClientOptions.DEFAULT, HttpRequest.of(HttpMethod.POST, "/foo"));
+        final ClientRequestContext ctx =
+                ClientRequestContextBuilder.of(HttpRequest.of(HttpMethod.POST, "/foo"))
+                                           .meterRegistry(registry)
+                                           .endpoint(Endpoint.of("example.com", 8080))
+                                           .build();
 
         final MeterIdPrefixFunction meterIdPrefixFunction = MeterIdPrefixFunction.ofDefault("foo");
 
@@ -117,10 +117,11 @@ public class RequestMetricSupportTest {
     @Test
     public void rpc() {
         final MeterRegistry registry = PrometheusMeterRegistries.newRegistry();
-        final ClientRequestContext ctx = new DefaultClientRequestContext(
-                mock(EventLoop.class), registry, SessionProtocol.H2C,
-                Endpoint.of("example.com", 8080), HttpMethod.POST, "/bar", null, null,
-                ClientOptions.DEFAULT, HttpRequest.of(HttpMethod.POST, "/bar"));
+        final ClientRequestContext ctx =
+                ClientRequestContextBuilder.of(HttpRequest.of(HttpMethod.POST, "/bar"))
+                                           .meterRegistry(registry)
+                                           .endpoint(Endpoint.of("example.com", 8080))
+                                           .build();
 
         final MeterIdPrefixFunction meterIdPrefixFunction = MeterIdPrefixFunction.ofDefault("bar");
 

--- a/core/src/test/java/com/linecorp/armeria/server/DefaultServiceRequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/DefaultServiceRequestContextTest.java
@@ -42,6 +42,7 @@ public class DefaultServiceRequestContextTest {
     @Test
     public void deriveContext() {
         final VirtualHost virtualHost = virtualHost();
+        final HttpRequest request = HttpRequest.of(HttpMethod.GET, "/hello");
         final DefaultPathMappingContext mappingCtx = new DefaultPathMappingContext(
                 virtualHost, "example.com", HttpMethod.GET, "/hello", null, MediaType.JSON_UTF_8,
                 ImmutableList.of(MediaType.JSON_UTF_8, MediaType.XML_UTF_8));
@@ -50,7 +51,7 @@ public class DefaultServiceRequestContextTest {
                 virtualHost.serviceConfigs().get(0), mock(Channel.class), NoopMeterRegistry.get(),
                 SessionProtocol.H2,
                 mappingCtx, PathMappingResult.of("/foo"),
-                mock(Request.class), null, null, NetUtil.LOCALHOST4);
+                request, null, null, NetUtil.LOCALHOST4);
 
         setAdditionalHeaders(originalCtx);
         setAdditionalTrailers(originalCtx);
@@ -58,7 +59,7 @@ public class DefaultServiceRequestContextTest {
         final AttributeKey<String> foo = AttributeKey.valueOf(DefaultServiceRequestContextTest.class, "foo");
         originalCtx.attr(foo).set("foo");
 
-        final Request newRequest = mock(Request.class);
+        final HttpRequest newRequest = HttpRequest.of(HttpMethod.GET, "/derived/hello");
         final ServiceRequestContext derivedCtx = originalCtx.newDerivedContext(newRequest);
         assertThat(derivedCtx.server()).isSameAs(originalCtx.server());
         assertThat(derivedCtx.sessionProtocol()).isSameAs(originalCtx.sessionProtocol());

--- a/core/src/test/java/com/linecorp/armeria/server/auth/AuthorizerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/auth/AuthorizerTest.java
@@ -37,7 +37,10 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.ServiceRequestContextBuilder;
 import com.linecorp.armeria.testing.common.EventLoopRule;
 
 public class AuthorizerTest {
@@ -50,8 +53,9 @@ public class AuthorizerTest {
 
     @BeforeClass
     public static void setServiceContext() {
-        serviceCtx = mock(ServiceRequestContext.class);
-        when(serviceCtx.contextAwareEventLoop()).thenReturn(eventLoop.get());
+        serviceCtx = ServiceRequestContextBuilder.of(HttpRequest.of(HttpMethod.GET, "/"))
+                                                 .eventLoop(eventLoop.get())
+                                                 .build();
     }
 
     @AfterClass

--- a/core/src/test/java/com/linecorp/armeria/server/file/CachingHttpFileTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/file/CachingHttpFileTest.java
@@ -67,8 +67,9 @@ public class CachingHttpFileTest {
         assertThat(cached.read(executor, alloc)).isNull();
         assertThat(cached.aggregate(executor).join()).isSameAs(HttpFile.nonExistent());
         assertThat(cached.aggregateWithPooledObjects(executor, alloc).join()).isSameAs(HttpFile.nonExistent());
-        assertThat(cached.asService().serve(mock(ServiceRequestContext.class),
-                                            HttpRequest.of(HttpMethod.GET, "/")).aggregate().join().status())
+
+        final ServiceRequestContext ctx = ServiceRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+        assertThat(cached.asService().serve(ctx, ctx.request()).aggregate().join().status())
                 .isEqualTo(HttpStatus.NOT_FOUND);
     }
 

--- a/core/src/test/java/com/linecorp/armeria/server/healthcheck/HttpHealthCheckServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/healthcheck/HttpHealthCheckServiceTest.java
@@ -38,7 +38,6 @@ import com.linecorp.armeria.common.AggregatedHttpMessage;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpStatus;
-import com.linecorp.armeria.common.logging.DefaultRequestLog;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.ServiceRequestContext;
@@ -59,14 +58,10 @@ public class HttpHealthCheckServiceTest {
     @Mock
     private HealthChecker health3;
 
-    @Mock
-    private ServiceRequestContext context;
-
     private HttpHealthCheckService service;
 
     @Before
     public void setUp() {
-        when(context.logBuilder()).thenReturn(new DefaultRequestLog(context));
         service = new HttpHealthCheckService(health1, health2, health3);
         service.serverHealth.setHealthy(true);
     }
@@ -78,6 +73,7 @@ public class HttpHealthCheckServiceTest {
         when(health3.isHealthy()).thenReturn(true);
 
         final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/");
+        final ServiceRequestContext context = ServiceRequestContext.of(req);
         final AggregatedHttpMessage res = service.serve(context, req).aggregate().get();
 
         assertEquals(HttpStatus.OK, res.status());
@@ -105,6 +101,7 @@ public class HttpHealthCheckServiceTest {
 
     private void assertNotOk() throws Exception {
         final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/");
+        final ServiceRequestContext context = ServiceRequestContext.of(req);
         final AggregatedHttpMessage res = service.serve(context, req).aggregate().get();
 
         assertEquals(HttpStatus.SERVICE_UNAVAILABLE, res.status());

--- a/site/src/sphinx/advanced-unit-testing.rst
+++ b/site/src/sphinx/advanced-unit-testing.rst
@@ -1,0 +1,128 @@
+.. _advanced-unit-testing:
+
+Unit-testing ``Client`` and ``Service``
+=======================================
+
+A unit test of a :api:`Client` or a :api:`Service` will require you to prepare two objects:
+
+- :api:`ClientRequestContext` or :api:`ServiceRequestContext`
+- :api:`HttpRequest` or :api:`RpcRequest`
+
+:api:`ClientRequestContext` or :api:`ServiceRequestContext` is a more complex object with many properties than
+:api:`HttpRequest` or :api:`RpcRequest`, and thus Armeria provides the API dedicated to building a fake
+context object easily:
+
+.. code-block:: java
+
+   import org.junit.Before;
+   import org.junit.Test;
+
+   import com.linecorp.armeria.common.HttpRequest;
+   import com.linecorp.armeria.common.HttpResponse;
+   import com.linecorp.armeria.client.ClientRequestContext;
+   import com.linecorp.armeria.server.ServiceRequestContext;
+
+   public class MyJUnit4Test {
+
+       private MyClient client;
+       private MyService service;
+
+       @Before
+       public void setUp() {
+           client = ...;
+           service = ...;
+       }
+
+       @Test
+       public void testClient() throws Exception {
+           HttpRequest req = HttpRequest.of(HttpMethod.GET, "/greet?name=foo");
+           ClientRequestContext cctx = ClientRequestContext.of(req);
+           HttpResponse res = client.execute(cctx, req);
+           // TODO: Add assertions here.
+       }
+
+       @Test
+       public void testService() throws Exception {
+           HttpRequest req = HttpRequest.of(HttpMethod.POST, "/greet",
+                                            MediaType.JSON_UTF_8,
+                                            "{ \"name\": \"foo\" }");
+           ServiceRequestContext sctx = ServiceRequestContext.of(req);
+           HttpResponse res = service.serve(sctx, req);
+           // TODO: Add assertions here.
+       }
+   }
+
+Although the fake context returned by ``ClientRequestContext.of()`` and ``ServiceRequestContext.of()`` will
+provide sensible defaults, you can override its default properties using a builder:
+
+.. code-block:: java
+
+   import java.net.InetAddress;
+   import java.net.InetSocketAddress;
+   import java.util.Map;
+
+   import com.linecorp.armeria.common.SessionProtocol;
+   import com.linecorp.armeria.client.ClientRequestContextBuilder;
+   import com.linecorp.armeria.server.PathMappingResult;
+   import com.linecorp.armeria.server.ServiceRequestContextBuilder;
+
+   HttpRequest req = HttpRequest.of(...);
+
+   ClientRequestContext cctx =
+           ClientRequestContextBuilder.of(req)
+                                      .sessionProtocol(SessionProtocol.H1C)
+                                      .remoteAddress(new InetSocketAddress("192.168.0.2", 443))
+                                      .build();
+
+   PathMappingResult mappingResult =
+           PathMappingResult.of("/mapped/path",                // Mapped path
+                                "foo=bar&baz=qux",             // Query string
+                                Map.of("pathParam1", "value1", // Path parameters
+                                       "pathParam2", "value2"));
+
+   ServiceRequestContext sctx =
+           ServiceRequestContextBuilder.of(req)
+                                       .clientAddress(InetAddress.getByName("192.168.1.2"))
+                                       .pathMappingResult(mappingResult);
+                                       .build();
+
+Using a fake context to emulate an incoming request
+---------------------------------------------------
+
+It is usually not necessary to build a context object by yourself except when writing a unit test,
+because Armeria will always create a context object for you. However, you may need to build a fake context and
+invoke your request processing pipeline with it when you want to handle the requests received via other sources
+such as:
+
+- Non-Armeria services
+- Non-HTTP protocols, e.g. Kafka and STOMP
+- Timers, i.e. Trigger a certain request every N minutes.
+
+The following example shows how to emit a fake request every minute:
+
+.. code-block:: java
+
+   import java.util.concurrent.ScheduledExecutorService;
+   import java.util.concurrent.TimeUnit;
+
+   import com.linecorp.armeria.common.AggregatedHttpMessage;
+
+   ScheduledExecutorService executor = ...;
+   HttpService sessionManagementService = (ctx, req) -> ...;
+
+   // Send a session expiration request to the session management service
+   // every minute.
+   executor.scheduleWithFixedDelay(() -> {
+       HttpRequest req = HttpRequest.of(HttpMethod.POST, "/expire_stall_sessions");
+       ServiceRequestContext ctx = ServiceRequestContext.of(req);
+       try {
+           HttpResponse res = sessionManagementService.servce(ctx, req);
+           AggregatedHttpMessage aggregatedRes = res.aggregate().get();
+           if (aggregatedRes.status().code() != 200) {
+               System.err.println("Failed to expire stall sessions: " +
+                                  aggregatedRes);
+           }
+       } catch (Exception e) {
+           e.printStackTrace();
+       }
+   }, 1, 1, TimeUnit.MINUTES);

--- a/site/src/sphinx/advanced-unit-testing.rst
+++ b/site/src/sphinx/advanced-unit-testing.rst
@@ -9,8 +9,8 @@ A unit test of a :api:`Client` or a :api:`Service` will require you to prepare t
 - :api:`HttpRequest` or :api:`RpcRequest`
 
 :api:`ClientRequestContext` or :api:`ServiceRequestContext` is a more complex object with many properties than
-:api:`HttpRequest` or :api:`RpcRequest`, and thus Armeria provides the API dedicated to building a fake
-context object easily:
+:api:`HttpRequest` or :api:`RpcRequest`, and thus Armeria provides the API dedicated to build a fake context
+object easily:
 
 .. code-block:: java
 
@@ -19,6 +19,7 @@ context object easily:
 
    import com.linecorp.armeria.common.HttpRequest;
    import com.linecorp.armeria.common.HttpResponse;
+   import com.linecorp.armeria.common.AggregatedHttpMessage;
    import com.linecorp.armeria.client.ClientRequestContext;
    import com.linecorp.armeria.server.ServiceRequestContext;
 
@@ -35,20 +36,32 @@ context object easily:
 
        @Test
        public void testClient() throws Exception {
+           // Given
            HttpRequest req = HttpRequest.of(HttpMethod.GET, "/greet?name=foo");
            ClientRequestContext cctx = ClientRequestContext.of(req);
+
+           // When
            HttpResponse res = client.execute(cctx, req);
-           // TODO: Add assertions here.
+
+           // Then
+           AggregatedHttpMessage aggregatedRes = res.aggregate().get();
+           assertEquals(200, aggregatedRes.status().code());
        }
 
        @Test
        public void testService() throws Exception {
+           // Given
            HttpRequest req = HttpRequest.of(HttpMethod.POST, "/greet",
                                             MediaType.JSON_UTF_8,
                                             "{ \"name\": \"foo\" }");
            ServiceRequestContext sctx = ServiceRequestContext.of(req);
+
+           // When
            HttpResponse res = service.serve(sctx, req);
-           // TODO: Add assertions here.
+
+           // Then
+           AggregatedHttpMessage aggregatedRes = res.aggregate().get();
+           assertEquals(200, aggregatedRes.status().code());
        }
    }
 
@@ -105,7 +118,7 @@ The following example shows how to emit a fake request every minute:
    import java.util.concurrent.ScheduledExecutorService;
    import java.util.concurrent.TimeUnit;
 
-   import com.linecorp.armeria.common.AggregatedHttpMessage;
+   import com.linecorp.armeria.server.HttpService;
 
    ScheduledExecutorService executor = ...;
    HttpService sessionManagementService = (ctx, req) -> ...;

--- a/site/src/sphinx/advanced-unit-testing.rst
+++ b/site/src/sphinx/advanced-unit-testing.rst
@@ -9,7 +9,7 @@ A unit test of a :api:`Client` or a :api:`Service` will require you to prepare t
 - :api:`HttpRequest` or :api:`RpcRequest`
 
 :api:`ClientRequestContext` or :api:`ServiceRequestContext` is a more complex object with many properties than
-:api:`HttpRequest` or :api:`RpcRequest`, and thus Armeria provides the API dedicated to build a fake context
+:api:`HttpRequest` or :api:`RpcRequest`, and thus Armeria provides the API dedicated to building a fake context
 object easily:
 
 .. code-block:: java

--- a/site/src/sphinx/advanced.rst
+++ b/site/src/sphinx/advanced.rst
@@ -9,8 +9,9 @@ Advanced topics
     advanced-logging
     advanced-structured-logging
     advanced-structured-logging-kafka
+    advanced-unit-testing
+    advanced-production-checklist
     advanced-zipkin
     advanced-zookeeper
-    advanced-production-checklist
     advanced-saml
     advanced-spring-webflux-integration

--- a/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpRequestTest.java
+++ b/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpRequestTest.java
@@ -18,18 +18,13 @@ package com.linecorp.armeria.spring.web.reactive;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.springframework.http.HttpCookie;
 import org.springframework.util.MultiValueMap;
-
-import com.google.common.util.concurrent.MoreExecutors;
 
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaderNames;
@@ -37,23 +32,17 @@ import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.stream.CancelledSubscriptionException;
+import com.linecorp.armeria.common.util.EventLoopGroups;
 import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.ServiceRequestContextBuilder;
 
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 
 public class ArmeriaServerHttpRequestTest {
 
-    static final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
-
-    @BeforeClass
-    public static void setup() {
-        when(ctx.sslSession()).thenReturn(null);
-        when(ctx.contextAwareExecutor()).thenReturn(MoreExecutors.directExecutor());
-    }
-
-    private static ArmeriaServerHttpRequest request(HttpRequest httpRequest) {
-        return new ArmeriaServerHttpRequest(ctx, httpRequest, DataBufferFactoryWrapper.DEFAULT);
+    private static ArmeriaServerHttpRequest request(ServiceRequestContext ctx) {
+        return new ArmeriaServerHttpRequest(ctx, ctx.request(), DataBufferFactoryWrapper.DEFAULT);
     }
 
     @Test
@@ -63,7 +52,8 @@ public class ArmeriaServerHttpRequestTest {
                                Flux.just("a", "b", "c", "d", "e")
                                    .map(HttpData::ofUtf8));
 
-        final ArmeriaServerHttpRequest req = request(httpRequest);
+        final ServiceRequestContext ctx = newRequestContext(httpRequest);
+        final ArmeriaServerHttpRequest req = request(ctx);
         assertThat(req.getMethodValue()).isEqualTo(HttpMethod.POST.name());
         assertThat(req.<Object>getNativeRequest()).isInstanceOf(HttpRequest.class).isEqualTo(httpRequest);
 
@@ -84,9 +74,10 @@ public class ArmeriaServerHttpRequestTest {
 
     @Test
     public void getCookies() {
-        final ArmeriaServerHttpRequest req = request(
-                HttpRequest.of(HttpHeaders.of(HttpMethod.POST, "/")
-                                          .add(HttpHeaderNames.COOKIE, "a=1;b=2")));
+        final HttpRequest httpRequest = HttpRequest.of(HttpHeaders.of(HttpMethod.POST, "/")
+                                                         .add(HttpHeaderNames.COOKIE, "a=1;b=2"));
+        final ServiceRequestContext ctx = newRequestContext(httpRequest);
+        final ArmeriaServerHttpRequest req = request(ctx);
 
         // Check cached.
         final MultiValueMap<String, HttpCookie> cookie1 = req.getCookies();
@@ -104,7 +95,8 @@ public class ArmeriaServerHttpRequestTest {
                                Flux.just("a", "b", "c", "d", "e")
                                    .map(HttpData::ofUtf8));
 
-        final ArmeriaServerHttpRequest req = request(httpRequest);
+        final ServiceRequestContext ctx = newRequestContext(httpRequest);
+        final ArmeriaServerHttpRequest req = request(ctx);
 
         assertThat(httpRequest.completionFuture().isDone()).isFalse();
 
@@ -120,5 +112,11 @@ public class ArmeriaServerHttpRequestTest {
         assertThat(f.isCompletedExceptionally()).isTrue();
         assertThatThrownBy(f::get).isInstanceOf(ExecutionException.class)
                                   .hasCauseInstanceOf(CancelledSubscriptionException.class);
+    }
+
+    private static ServiceRequestContext newRequestContext(HttpRequest httpRequest) {
+        return ServiceRequestContextBuilder.of(httpRequest)
+                                           .eventLoop(EventLoopGroups.directEventLoop())
+                                           .build();
     }
 }

--- a/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpRequestTest.java
+++ b/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpRequestTest.java
@@ -75,7 +75,7 @@ public class ArmeriaServerHttpRequestTest {
     @Test
     public void getCookies() {
         final HttpRequest httpRequest = HttpRequest.of(HttpHeaders.of(HttpMethod.POST, "/")
-                                                         .add(HttpHeaderNames.COOKIE, "a=1;b=2"));
+                                                                  .add(HttpHeaderNames.COOKIE, "a=1;b=2"));
         final ServiceRequestContext ctx = newRequestContext(httpRequest);
         final ArmeriaServerHttpRequest req = request(ctx);
 

--- a/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpResponseTest.java
+++ b/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpResponseTest.java
@@ -18,21 +18,19 @@ package com.linecorp.armeria.spring.web.reactive;
 import static com.linecorp.armeria.spring.web.reactive.TestUtil.ensureHttpDataOfString;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 
-import com.linecorp.armeria.common.CommonPools;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
@@ -44,12 +42,7 @@ import reactor.test.StepVerifier;
 
 public class ArmeriaServerHttpResponseTest {
 
-    static final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
-
-    @BeforeClass
-    public static void setup() {
-        when(ctx.eventLoop()).thenReturn(CommonPools.workerGroup().next());
-    }
+    static final ServiceRequestContext ctx = ServiceRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
 
     private static ArmeriaServerHttpResponse response(
             ServiceRequestContext ctx, CompletableFuture<HttpResponse> future) {

--- a/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftServiceTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftServiceTest.java
@@ -20,9 +20,6 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.linecorp.armeria.common.util.Functions.voidFunction;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -54,14 +51,12 @@ import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpRequestWriter;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.SerializationFormat;
-import com.linecorp.armeria.common.logging.DefaultRequestLog;
 import com.linecorp.armeria.common.thrift.ThriftProtocolFactories;
 import com.linecorp.armeria.common.thrift.ThriftSerializationFormats;
 import com.linecorp.armeria.common.util.CompletionActions;
 import com.linecorp.armeria.common.util.Exceptions;
-import com.linecorp.armeria.server.Server;
-import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.ServiceRequestContextBuilder;
 import com.linecorp.armeria.service.test.thrift.main.BinaryService;
 import com.linecorp.armeria.service.test.thrift.main.DevNullService;
 import com.linecorp.armeria.service.test.thrift.main.FileService;
@@ -73,7 +68,6 @@ import com.linecorp.armeria.service.test.thrift.main.NameSortService;
 import com.linecorp.armeria.service.test.thrift.main.OnewayHelloService;
 import com.linecorp.armeria.testing.common.EventLoopRule;
 
-import io.netty.buffer.ByteBufAllocator;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 
 /**
@@ -635,27 +629,18 @@ public class ThriftServiceTest {
 
     private static void invoke0(THttpService service, HttpData content,
                                 CompletableFuture<HttpData> promise) throws Exception {
-        final Server server = new ServerBuilder()
-                .service("/", service)
-                .verboseResponses(true)
-                .build();
-
-        final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
-        when(ctx.alloc()).thenReturn(ByteBufAllocator.DEFAULT);
-        when(ctx.eventLoop()).thenReturn(eventLoop.get());
-        when(ctx.server()).thenReturn(server);
-        when(ctx.blockingTaskExecutor()).thenReturn(ImmediateEventExecutor.INSTANCE);
-
-        final DefaultRequestLog reqLogBuilder = new DefaultRequestLog(ctx);
-        when(ctx.log()).thenReturn(reqLogBuilder);
-        when(ctx.logBuilder()).thenReturn(reqLogBuilder);
-
-        doNothing().when(ctx).invokeOnEnterCallbacks();
-        doNothing().when(ctx).invokeOnExitCallbacks();
-
         final HttpRequestWriter req = HttpRequest.streaming(HttpHeaders.of(HttpMethod.POST, "/"));
         req.write(content);
         req.close();
+
+        final ServiceRequestContext ctx =
+                ServiceRequestContextBuilder.of(req)
+                                            .eventLoop(eventLoop.get())
+                                            .serverConfigurator(builder -> {
+                                                builder.blockingTaskExecutor(ImmediateEventExecutor.INSTANCE);
+                                                builder.verboseResponses(true);
+                                            })
+                                            .build();
 
         final HttpResponse res = service.serve(ctx, req);
         res.aggregate().handle(voidFunction((aReq, cause) -> {

--- a/zipkin/src/test/java/com/linecorp/armeria/server/tracing/HttpTracingServiceTest.java
+++ b/zipkin/src/test/java/com/linecorp/armeria/server/tracing/HttpTracingServiceTest.java
@@ -16,18 +16,15 @@
 
 package com.linecorp.armeria.server.tracing;
 
-import static com.linecorp.armeria.common.SessionProtocol.H2C;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
 
 import org.junit.After;
 import org.junit.Test;
@@ -41,16 +38,16 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.RpcResponse;
-import com.linecorp.armeria.common.logging.DefaultRequestLog;
+import com.linecorp.armeria.common.logging.RequestLogBuilder;
 import com.linecorp.armeria.common.tracing.HelloService;
 import com.linecorp.armeria.common.tracing.RequestContextCurrentTraceContext;
 import com.linecorp.armeria.common.tracing.SpanCollectingReporter;
 import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.ServiceRequestContextBuilder;
 
 import brave.Tracing;
 import brave.sampler.Sampler;
-import io.netty.channel.Channel;
 import zipkin2.Span;
 import zipkin2.Span.Kind;
 
@@ -131,41 +128,30 @@ public class HttpTracingServiceTest {
 
         final HttpTracingService stub = new HttpTracingService(delegate, tracing);
 
-        final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
         final HttpRequest req = HttpRequest.of(HttpHeaders.of(HttpMethod.POST, "/hello/trustin")
                                                           .authority("foo.com"));
+        final ServiceRequestContext ctx = ServiceRequestContextBuilder.of(req)
+                                                                      .service(stub)
+                                                                      .build();
+
         final RpcRequest rpcReq = RpcRequest.of(HelloService.Iface.class, "hello", "trustin");
         final HttpResponse res = HttpResponse.of(HttpStatus.OK);
         final RpcResponse rpcRes = RpcResponse.of("Hello, trustin!");
-        final DefaultRequestLog log = new DefaultRequestLog(ctx);
-        log.startRequest(mock(Channel.class), H2C);
-        log.requestHeaders(req.headers());
-        log.requestFirstBytesTransferred();
-        log.requestContent(rpcReq, req);
-        log.endRequest();
+        final RequestLogBuilder logBuilder = ctx.logBuilder();
+        logBuilder.requestContent(rpcReq, req);
+        logBuilder.endRequest();
 
-        when(ctx.method()).thenReturn(HttpMethod.POST);
-        when(ctx.log()).thenReturn(log);
-        when(ctx.logBuilder()).thenReturn(log);
-        when(ctx.path()).thenReturn("/hello/trustin");
-        checkCtxOnEnterAndExitParameter(ctx);
         when(delegate.serve(ctx, req)).thenReturn(res);
 
         // do invoke
         stub.serve(ctx, req);
 
         verify(delegate, times(1)).serve(eq(ctx), eq(req));
-        log.responseHeaders(HttpHeaders.of(HttpStatus.OK));
-        log.responseFirstBytesTransferred();
-        log.responseContent(rpcRes, res);
-        log.endResponse();
+        logBuilder.responseHeaders(HttpHeaders.of(HttpStatus.OK));
+        logBuilder.responseFirstBytesTransferred();
+        logBuilder.responseContent(rpcRes, res);
+        logBuilder.endResponse();
 
         return reporter;
-    }
-
-    @SuppressWarnings("unchecked")
-    private static void checkCtxOnEnterAndExitParameter(ServiceRequestContext ctx) {
-        ctx.onEnter(isA(Consumer.class));
-        ctx.onExit(isA(Consumer.class));
     }
 }


### PR DESCRIPTION
Motivation:

- It is often hard to create a mock of a `RequestContext`.
- Sometimes a user want to emulate an incoming request and feed it into
  his or her processing pipeline. For example, if a user implemented complex
  logic which pulls some common information like socket addresses and custom
  attributes from `RequestContext`, the user might want to create a 
  `ServiceRequestContext` for a request which was streamed from other source
  than Armeria, such as a Kafka queue.

Modifications:

- Added `AbstractRequestContextBuilder`.
- Added `ClientRequestContextBuilder`.
- Added `ServiceRequestContextBuilder`.
- Added more variants of `startRequest()`, `endRequest()`,
  `startResponse()` and `endResponse()` to `RequestLogBuilder` so that a
  user can specify exact timestamps for easier matching.
- Added `RequestLog.sslSession()`
- Updated most test cases to use the builder instead of mocks.

Result:

- Closes #1464