### PR TITLE
Make sure server max request length of 0 or Long.MAX_VALUE doesn't ca…

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/internal/grpc/ArmeriaMessageDeframer.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/grpc/ArmeriaMessageDeframer.java
@@ -191,7 +191,7 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
                                   int maxMessageSizeBytes,
                                   ByteBufAllocator alloc) {
         this.listener = requireNonNull(listener, "listener");
-        this.maxMessageSizeBytes = maxMessageSizeBytes;
+        this.maxMessageSizeBytes = maxMessageSizeBytes > 0 ? maxMessageSizeBytes : Integer.MAX_VALUE;
         this.alloc = requireNonNull(alloc, "alloc");
 
         unprocessed = new ArrayDeque<>();

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
@@ -213,9 +213,10 @@ public final class GrpcService extends AbstractHttpService
     }
 
     @Override
-    public void serviceAdded(ServiceConfig cfg) throws Exception {
+    public void serviceAdded(ServiceConfig cfg) {
         if (maxInboundMessageSizeBytes == NO_MAX_INBOUND_MESSAGE_SIZE) {
-            maxInboundMessageSizeBytes = (int) cfg.server().config().defaultMaxRequestLength();
+            maxInboundMessageSizeBytes = (int) Math.min(cfg.server().config().defaultMaxRequestLength(),
+                                                        Integer.MAX_VALUE);
         }
     }
 

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
@@ -813,8 +813,13 @@ public class GrpcServiceServerTest {
                                                                   serverWithNoMaxMessageSize.httpPort())
                                                       .usePlaintext()
                                                       .build();
-        UnitTestServiceBlockingStub stub = UnitTestServiceGrpc.newBlockingStub(channel);
-        assertThat(stub.staticUnaryCall(REQUEST_MESSAGE)).isEqualTo(RESPONSE_MESSAGE);
+
+        try {
+            UnitTestServiceBlockingStub stub = UnitTestServiceGrpc.newBlockingStub(channel);
+            assertThat(stub.staticUnaryCall(REQUEST_MESSAGE)).isEqualTo(RESPONSE_MESSAGE);
+        } finally {
+            channel.shutdownNow();
+        }
     }
 
     @Test
@@ -823,8 +828,12 @@ public class GrpcServiceServerTest {
                                                                   serverWithLongMaxRequestLimit.httpPort())
                                                       .usePlaintext()
                                                       .build();
-        UnitTestServiceBlockingStub stub = UnitTestServiceGrpc.newBlockingStub(channel);
-        assertThat(stub.staticUnaryCall(REQUEST_MESSAGE)).isEqualTo(RESPONSE_MESSAGE);
+        try {
+            UnitTestServiceBlockingStub stub = UnitTestServiceGrpc.newBlockingStub(channel);
+            assertThat(stub.staticUnaryCall(REQUEST_MESSAGE)).isEqualTo(RESPONSE_MESSAGE);
+        } finally {
+            channel.shutdownNow();
+        }
     }
 
     private static void checkRequestLog(RequestLogChecker checker) throws Exception {

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
@@ -818,7 +818,7 @@ public class GrpcServiceServerTest {
     }
 
     @Test
-    public void longMaxRequestLength() {
+    public void longMaxRequestLimit() {
         ManagedChannel channel = ManagedChannelBuilder.forAddress("127.0.0.1",
                                                                   serverWithLongMaxRequestLimit.httpPort())
                                                       .usePlaintext()

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
@@ -286,6 +286,42 @@ public class GrpcServiceServerTest {
         }
     };
 
+    @ClassRule
+    public static ServerRule serverWithNoMaxMessageSize = new ServerRule() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.workerGroup(EventLoopGroups.newEventLoopGroup(1), true);
+            sb.defaultMaxRequestLength(0);
+
+            sb.serviceUnder("/", new GrpcServiceBuilder()
+                    .addService(new UnitTestServiceImpl())
+                    .build()
+                    .decorate(LoggingService.newDecorator())
+                    .decorate((delegate, ctx, req) -> {
+                        ctx.log().addListener(requestLogQueue::add, RequestLogAvailability.COMPLETE);
+                        return delegate.serve(ctx, req);
+                    }));
+        }
+    };
+
+    @ClassRule
+    public static ServerRule serverWithLongMaxRequestLimit = new ServerRule() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.workerGroup(EventLoopGroups.newEventLoopGroup(1), true);
+            sb.defaultMaxRequestLength(Long.MAX_VALUE);
+
+            sb.serviceUnder("/", new GrpcServiceBuilder()
+                    .addService(new UnitTestServiceImpl())
+                    .build()
+                    .decorate(LoggingService.newDecorator())
+                    .decorate((delegate, ctx, req) -> {
+                        ctx.log().addListener(requestLogQueue::add, RequestLogAvailability.COMPLETE);
+                        return delegate.serve(ctx, req);
+                    }));
+        }
+    };
+
     @Rule
     public TestRule globalTimeout = new DisableOnDebug(new Timeout(10, TimeUnit.SECONDS));
 
@@ -769,6 +805,26 @@ public class GrpcServiceServerTest {
             assertThat(rpcReq.params()).containsExactly(REQUEST_MESSAGE);
             assertThat(rpcRes.get()).isEqualTo(RESPONSE_MESSAGE);
         });
+    }
+
+    @Test
+    public void noMaxMessageSize() {
+        ManagedChannel channel = ManagedChannelBuilder.forAddress("127.0.0.1",
+                                                                  serverWithNoMaxMessageSize.httpPort())
+                                                      .usePlaintext()
+                                                      .build();
+        UnitTestServiceBlockingStub stub = UnitTestServiceGrpc.newBlockingStub(channel);
+        assertThat(stub.staticUnaryCall(REQUEST_MESSAGE)).isEqualTo(RESPONSE_MESSAGE);
+    }
+
+    @Test
+    public void longMaxRequestLength() {
+        ManagedChannel channel = ManagedChannelBuilder.forAddress("127.0.0.1",
+                                                                  serverWithLongMaxRequestLimit.httpPort())
+                                                      .usePlaintext()
+                                                      .build();
+        UnitTestServiceBlockingStub stub = UnitTestServiceGrpc.newBlockingStub(channel);
+        assertThat(stub.staticUnaryCall(REQUEST_MESSAGE)).isEqualTo(RESPONSE_MESSAGE);
     }
 
     private static void checkRequestLog(RequestLogChecker checker) throws Exception {


### PR DESCRIPTION
…use incorrect gRPC max message size.

Wish I did this ages ago when first running into it...