### PR TITLE
Enable DNS query traces by default / Add ClientFactoryBuilder.domainN…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/DefaultAddressResolverGroupFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultAddressResolverGroupFactory.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client;
+
+import static java.util.Objects.requireNonNull;
+
+import java.net.InetSocketAddress;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import com.linecorp.armeria.internal.TransportType;
+
+import io.netty.channel.EventLoopGroup;
+import io.netty.resolver.AddressResolverGroup;
+import io.netty.resolver.dns.DnsAddressResolverGroup;
+import io.netty.resolver.dns.DnsNameResolverBuilder;
+import io.netty.resolver.dns.DnsServerAddressStreamProviders;
+
+/**
+ * The default {@link AddressResolverGroup} factory implementation, which enables asynchronous
+ * DNS resolution and tracing by default.
+ */
+final class DefaultAddressResolverGroupFactory
+        implements Function<EventLoopGroup, AddressResolverGroup<InetSocketAddress>> {
+
+    private final Iterable<Consumer<? super DnsNameResolverBuilder>> customizers;
+
+    DefaultAddressResolverGroupFactory(Iterable<Consumer<? super DnsNameResolverBuilder>> customizers) {
+        this.customizers = requireNonNull(customizers, "customizers");
+    }
+
+    @Override
+    public AddressResolverGroup<InetSocketAddress> apply(EventLoopGroup eventLoopGroup) {
+        final DnsNameResolverBuilder nameResolverBuilder = new DnsNameResolverBuilder();
+        nameResolverBuilder.nameServerProvider(DnsServerAddressStreamProviders.platformDefault());
+        nameResolverBuilder.traceEnabled(true);
+        customizers.forEach(customizer -> customizer.accept(nameResolverBuilder));
+        nameResolverBuilder.channelType(TransportType.datagramChannelType(eventLoopGroup));
+        return new DnsAddressResolverGroup(nameResolverBuilder);
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/client/ClientFactoryBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientFactoryBuilderTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.Test;
+
+public class ClientFactoryBuilderTest {
+
+    @Test
+    public void addressResolverGroupFactoryAndDomainNameResolverCustomizerAreMutuallyExclusive() {
+        final ClientFactoryBuilder builder1 = new ClientFactoryBuilder();
+        builder1.addressResolverGroupFactory(eventLoopGroup -> null);
+        assertThatThrownBy(() -> builder1.domainNameResolverCustomizer(b -> {}))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("mutually exclusive");
+
+        final ClientFactoryBuilder builder2 = new ClientFactoryBuilder();
+        builder2.domainNameResolverCustomizer(b -> {});
+        assertThatThrownBy(() -> builder2.addressResolverGroupFactory(eventLoopGroup -> null))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("mutually exclusive");
+    }
+}

--- a/testing-internal/src/main/resources/logback-test.xml
+++ b/testing-internal/src/main/resources/logback-test.xml
@@ -32,6 +32,7 @@
   <logger name="com.linecorp.armeria.logging.traffic.server" level="OFF" />
   <logger name="com.linecorp.armeria.logging.traffic.client" level="OFF" />
   <logger name="com.linecorp.armeria.internal.Http2GoAwayHandler" level="INFO" />
+  <logger name="io.netty.resolver.dns.TraceDnsQueryLifeCycleObserverFactory" level="DEBUG" />
   <logger name="armeria" level="DEBUG" />
   <logger name="loggerTest" level="ALL" additivity="false">
     <appender-ref ref="NOP" />


### PR DESCRIPTION
…ameResolverCustomizer()

Motivation:

- A user often wants to know why a domain name resolution attempt has
  failed in detail.
- `ClientFactoryBuilder.addressResolverGroupFactory()` provides a way to
  customize the `DomainNameResolver`, but it often involves more
  boilerplate code than a user expects.

Modifications:

- Added `ClientFactoryBuilder.domainNameResolverCustomizer()` which
  enables simpler customization of `DomainNameResolver`.
  - Made sure it is mutually exclusive with `addressResolverGroupFactory()`.
- Added `DefaultAddressResolverGroupFactory` which enables DNS query
  tracing by default.

Result:

- A user can easily figure out how a domain name resolution attempt
  failed by configuring the logging framework. For example, a Logback
  user can add the following:

      <logger name="io.netty.resolver.dns.TraceDnsQueryLifeCycleObserverFactory" level="DEBUG" />

- A user can easily customize `DomainNameResolver`, such as specifying
  non-default set of DNS servers.
- Closes #1512
- Closes #1552