### PR TITLE
Support RequestObject in DocService

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedBeanFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedBeanFactory.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.internal.annotation;
+
+import static java.util.Objects.requireNonNull;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.AbstractMap;
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import com.google.common.collect.ImmutableMap;
+
+import com.linecorp.armeria.internal.annotation.AnnotatedBeanFactoryRegistry.BeanFactoryId;
+import com.linecorp.armeria.internal.annotation.AnnotatedValueResolver.ResolverContext;
+
+final class AnnotatedBeanFactory<T> {
+
+    private final BeanFactoryId beanFactoryId;
+    private final Entry<Constructor<T>, List<AnnotatedValueResolver>> constructor;
+    private final Map<Field, AnnotatedValueResolver> fields;
+    private final Map<Method, List<AnnotatedValueResolver>> methods;
+
+    AnnotatedBeanFactory(BeanFactoryId beanFactoryId,
+                                 Entry<Constructor<T>, List<AnnotatedValueResolver>> constructor,
+                                 Map<Method, List<AnnotatedValueResolver>> methods,
+                                 Map<Field, AnnotatedValueResolver> fields) {
+        this.beanFactoryId = requireNonNull(beanFactoryId, "beanFactoryId");
+        this.constructor = immutableEntry(requireNonNull(constructor, "constructor"));
+        this.fields = ImmutableMap.copyOf(requireNonNull(fields, "fields"));
+        this.methods = ImmutableMap.copyOf(requireNonNull(methods, "methods"));
+    }
+
+    private static <K, V> Entry<K, V> immutableEntry(Entry<K, V> entry) {
+        if (entry instanceof AbstractMap.SimpleImmutableEntry) {
+            return entry;
+        }
+        return new SimpleImmutableEntry<>(entry);
+    }
+
+    T create(ResolverContext resolverContext) {
+        try {
+            final Object[] constructorArgs = AnnotatedValueResolver.toArguments(
+                    constructor.getValue(), resolverContext);
+            final T instance = constructor.getKey().newInstance(constructorArgs);
+
+            for (final Entry<Method, List<AnnotatedValueResolver>> method : methods.entrySet()) {
+                final Object[] methodArgs = AnnotatedValueResolver.toArguments(
+                        method.getValue(), resolverContext);
+                method.getKey().invoke(instance, methodArgs);
+            }
+
+            for (final Entry<Field, AnnotatedValueResolver> field : fields.entrySet()) {
+                final Object fieldArg = field.getValue().resolve(resolverContext);
+                field.getKey().set(instance, fieldArg);
+            }
+
+            return instance;
+        } catch (Throwable cause) {
+            throw new IllegalArgumentException(
+                    "cannot instantiate a new object: " + beanFactoryId, cause);
+        }
+    }
+
+    Entry<Constructor<T>, List<AnnotatedValueResolver>> constructor() {
+        return constructor;
+    }
+
+    Map<Method, List<AnnotatedValueResolver>> methods() {
+        return methods;
+    }
+
+    Map<Field, AnnotatedValueResolver> fields() {
+        return fields;
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedBeanFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedBeanFactory.java
@@ -39,9 +39,9 @@ final class AnnotatedBeanFactory<T> {
     private final Map<Method, List<AnnotatedValueResolver>> methods;
 
     AnnotatedBeanFactory(BeanFactoryId beanFactoryId,
-                                 Entry<Constructor<T>, List<AnnotatedValueResolver>> constructor,
-                                 Map<Method, List<AnnotatedValueResolver>> methods,
-                                 Map<Field, AnnotatedValueResolver> fields) {
+                         Entry<Constructor<T>, List<AnnotatedValueResolver>> constructor,
+                         Map<Method, List<AnnotatedValueResolver>> methods,
+                         Map<Field, AnnotatedValueResolver> fields) {
         this.beanFactoryId = requireNonNull(beanFactoryId, "beanFactoryId");
         this.constructor = immutableEntry(requireNonNull(constructor, "constructor"));
         this.fields = ImmutableMap.copyOf(requireNonNull(fields, "fields"));

--- a/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedBeanFactoryRegistry.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedBeanFactoryRegistry.java
@@ -104,7 +104,7 @@ final class AnnotatedBeanFactoryRegistry {
                                                                     : Optional.empty();
     }
 
-    static TreeSet<AnnotatedValueResolver> uniqueResolverSet() {
+    static Set<AnnotatedValueResolver> uniqueResolverSet() {
         return new TreeSet<>((o1, o2) -> {
             final String o1Name = o1.httpElementName();
             final String o2Name = o2.httpElementName();
@@ -220,7 +220,7 @@ final class AnnotatedBeanFactoryRegistry {
     private static Map<Method, List<AnnotatedValueResolver>> findMethods(
             List<AnnotatedValueResolver> constructorAnnotatedResolvers,
             BeanFactoryId beanFactoryId, List<RequestObjectResolver> objectResolvers) {
-        final TreeSet<AnnotatedValueResolver> uniques = uniqueResolverSet();
+        final Set<AnnotatedValueResolver> uniques = uniqueResolverSet();
         uniques.addAll(constructorAnnotatedResolvers);
 
         final Builder<Method, List<AnnotatedValueResolver>> methodsBuilder = ImmutableMap.builder();
@@ -259,7 +259,7 @@ final class AnnotatedBeanFactoryRegistry {
             List<AnnotatedValueResolver> constructorAnnotatedResolvers,
             Map<Method, List<AnnotatedValueResolver>> methods,
             BeanFactoryId beanFactoryId, List<RequestObjectResolver> objectResolvers) {
-        final TreeSet<AnnotatedValueResolver> uniques = uniqueResolverSet();
+        final Set<AnnotatedValueResolver> uniques = uniqueResolverSet();
         uniques.addAll(constructorAnnotatedResolvers);
         methods.values().forEach(uniques::addAll);
 

--- a/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedBeanFactoryRegistry.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedBeanFactoryRegistry.java
@@ -16,6 +16,7 @@
 package com.linecorp.armeria.internal.annotation;
 
 import static com.linecorp.armeria.internal.annotation.AnnotatedValueResolver.addToFirstIfExists;
+import static com.linecorp.armeria.internal.annotation.AnnotationUtil.findDeclared;
 import static java.util.Objects.requireNonNull;
 import static org.reflections.ReflectionUtils.getAllFields;
 import static org.reflections.ReflectionUtils.getAllMethods;
@@ -146,7 +147,7 @@ final class AnnotatedBeanFactoryRegistry {
         //     ...
         // }
         final List<RequestObjectResolver> resolvers = addToFirstIfExists(
-                objectResolvers, beanFactoryId.type.getAnnotationsByType(RequestConverter.class));
+                objectResolvers, findDeclared(beanFactoryId.type, RequestConverter.class));
 
         final Entry<Constructor<T>, List<AnnotatedValueResolver>> constructor =
                 findConstructor(beanFactoryId, resolvers);
@@ -195,7 +196,7 @@ final class AnnotatedBeanFactoryRegistry {
             }
 
             try {
-                final RequestConverter[] converters = constructor.getAnnotationsByType(RequestConverter.class);
+                final List<RequestConverter> converters = findDeclared(constructor, RequestConverter.class);
                 final List<AnnotatedValueResolver> resolvers =
                         AnnotatedValueResolver.ofBeanConstructorOrMethod(
                                 constructor, beanFactoryId.pathParams,
@@ -226,7 +227,7 @@ final class AnnotatedBeanFactoryRegistry {
         final Builder<Method, List<AnnotatedValueResolver>> methodsBuilder = ImmutableMap.builder();
         final Set<Method> methods = getAllMethods(beanFactoryId.type);
         for (final Method method : methods) {
-            final RequestConverter[] converters = method.getAnnotationsByType(RequestConverter.class);
+            final List<RequestConverter> converters = findDeclared(method, RequestConverter.class);
             try {
                 final List<AnnotatedValueResolver> resolvers =
                         AnnotatedValueResolver.ofBeanConstructorOrMethod(
@@ -266,7 +267,7 @@ final class AnnotatedBeanFactoryRegistry {
         final Builder<Field, AnnotatedValueResolver> builder = ImmutableMap.builder();
         final Set<Field> fields = getAllFields(beanFactoryId.type);
         for (final Field field : fields) {
-            final RequestConverter[] converters = field.getAnnotationsByType(RequestConverter.class);
+            final List<RequestConverter> converters = findDeclared(field, RequestConverter.class);
             AnnotatedValueResolver.ofBeanField(field, beanFactoryId.pathParams,
                                                addToFirstIfExists(objectResolvers, converters))
                                   .ifPresent(resolver -> {

--- a/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpDocServicePlugin.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpDocServicePlugin.java
@@ -90,11 +90,11 @@ public final class AnnotatedHttpDocServicePlugin implements DocServicePlugin {
     @VisibleForTesting
     static final TypeSignature VOID = TypeSignature.ofBase("void");
     @VisibleForTesting
-    static final TypeSignature BOOL = TypeSignature.ofBase("boolean");
+    static final TypeSignature BOOLEAN = TypeSignature.ofBase("boolean");
     @VisibleForTesting
-    static final TypeSignature INT32 = TypeSignature.ofBase("int32");
+    static final TypeSignature INT = TypeSignature.ofBase("int");
     @VisibleForTesting
-    static final TypeSignature INT64 = TypeSignature.ofBase("int64");
+    static final TypeSignature LONG = TypeSignature.ofBase("long");
     @VisibleForTesting
     static final TypeSignature FLOAT = TypeSignature.ofBase("float");
     @VisibleForTesting
@@ -106,9 +106,9 @@ public final class AnnotatedHttpDocServicePlugin implements DocServicePlugin {
 
     // Not defined in the spec.
     @VisibleForTesting
-    static final TypeSignature INT8 = TypeSignature.ofBase("int8");
+    static final TypeSignature BYTE = TypeSignature.ofBase("byte");
     @VisibleForTesting
-    static final TypeSignature INT16 = TypeSignature.ofBase("int16");
+    static final TypeSignature SHORT = TypeSignature.ofBase("short");
     @VisibleForTesting
     static final TypeSignature BEAN = TypeSignature.ofBase("bean");
 
@@ -286,15 +286,15 @@ public final class AnnotatedHttpDocServicePlugin implements DocServicePlugin {
         if (type == Void.class || type == void.class) {
             return VOID;
         } else if (type == Boolean.class || type == boolean.class) {
-            return BOOL;
+            return BOOLEAN;
         } else if (type == Byte.class || type == byte.class) {
-            return INT8;
+            return BYTE;
         } else if (type == Short.class || type == short.class) {
-            return INT16;
+            return SHORT;
         } else if (type == Integer.class || type == int.class) {
-            return INT32;
+            return INT;
         } else if (type == Long.class || type == long.class) {
-            return INT64;
+            return LONG;
         } else if (type == Float.class || type == float.class) {
             return FLOAT;
         } else if (type == Double.class || type == double.class) {
@@ -401,8 +401,7 @@ public final class AnnotatedHttpDocServicePlugin implements DocServicePlugin {
         final Field[] declaredFields = structClass.getDeclaredFields();
         final List<FieldInfo> fields =
                 Stream.of(declaredFields)
-                      .map(f -> new FieldInfoBuilder(f.getName(), toTypeSignature(f.getGenericType()))
-                              .build())
+                      .map(f -> FieldInfo.of(f.getName(), toTypeSignature(f.getGenericType())))
                       .collect(Collectors.toList());
         return new StructInfo(name, fields);
     }

--- a/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpDocServicePlugin.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpDocServicePlugin.java
@@ -24,8 +24,13 @@ import static com.linecorp.armeria.internal.PathMappingUtil.PREFIX;
 import static com.linecorp.armeria.internal.PathMappingUtil.REGEX;
 import static com.linecorp.armeria.internal.annotation.AnnotatedHttpDocServiceUtil.getNormalizedTriePath;
 import static com.linecorp.armeria.internal.annotation.AnnotatedHttpServiceFactory.findDescription;
+import static com.linecorp.armeria.server.docs.FieldLocation.DEFAULT;
+import static com.linecorp.armeria.server.docs.FieldLocation.HEADER;
+import static com.linecorp.armeria.server.docs.FieldLocation.PATH;
+import static com.linecorp.armeria.server.docs.FieldLocation.QUERY;
 import static java.util.Objects.requireNonNull;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.Method;
@@ -53,16 +58,21 @@ import com.google.common.collect.ImmutableList.Builder;
 import com.google.common.collect.ImmutableSet;
 
 import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.internal.annotation.AnnotatedBeanFactoryRegistry.AnnotatedBeanFactory;
+import com.linecorp.armeria.internal.annotation.AnnotatedBeanFactoryRegistry.BeanFactoryId;
 import com.linecorp.armeria.server.PathMapping;
 import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceConfig;
 import com.linecorp.armeria.server.annotation.Header;
 import com.linecorp.armeria.server.annotation.Param;
+import com.linecorp.armeria.server.annotation.RequestObject;
 import com.linecorp.armeria.server.docs.DocServicePlugin;
 import com.linecorp.armeria.server.docs.EndpointInfo;
 import com.linecorp.armeria.server.docs.EndpointInfoBuilder;
 import com.linecorp.armeria.server.docs.EnumInfo;
 import com.linecorp.armeria.server.docs.FieldInfo;
+import com.linecorp.armeria.server.docs.FieldInfoBuilder;
+import com.linecorp.armeria.server.docs.FieldLocation;
 import com.linecorp.armeria.server.docs.FieldRequirement;
 import com.linecorp.armeria.server.docs.MethodInfo;
 import com.linecorp.armeria.server.docs.NamedTypeInfo;
@@ -76,22 +86,12 @@ import com.linecorp.armeria.server.docs.TypeSignature;
  */
 public final class AnnotatedHttpDocServicePlugin implements DocServicePlugin {
 
-    private static final String PATH_PARAM = "path";
-    private static final String QUERY_PARAM = "query";
-    private static final String HEADER_PARAM = "header";
-
     // The formats defined by OpenAPI Specification
     // (https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#dataTypes):
     @VisibleForTesting
     static final TypeSignature VOID = TypeSignature.ofBase("void");
     @VisibleForTesting
     static final TypeSignature BOOL = TypeSignature.ofBase("boolean");
-    // Not defined in the spec, but added to support byte type.
-    @VisibleForTesting
-    static final TypeSignature INT8 = TypeSignature.ofBase("int8");
-    // Not defined in the spec, but added to support char and short types.
-    @VisibleForTesting
-    static final TypeSignature INT16 = TypeSignature.ofBase("int16");
     @VisibleForTesting
     static final TypeSignature INT32 = TypeSignature.ofBase("int32");
     @VisibleForTesting
@@ -104,6 +104,14 @@ public final class AnnotatedHttpDocServicePlugin implements DocServicePlugin {
     static final TypeSignature STRING = TypeSignature.ofBase("string");
     @VisibleForTesting
     static final TypeSignature BINARY = TypeSignature.ofBase("binary");
+
+    // Not defined in the spec.
+    @VisibleForTesting
+    static final TypeSignature INT8 = TypeSignature.ofBase("int8");
+    @VisibleForTesting
+    static final TypeSignature INT16 = TypeSignature.ofBase("int16");
+    @VisibleForTesting
+    static final TypeSignature BEAN = TypeSignature.ofBase("bean");
 
     private static final ObjectMapper mapper = new ObjectMapper();
 
@@ -129,7 +137,8 @@ public final class AnnotatedHttpDocServicePlugin implements DocServicePlugin {
         return generate(serviceDescription, methodInfos);
     }
 
-    private void addServiceDescription(Map<Class<?>, String> serviceDescription, AnnotatedHttpService service) {
+    private static void addServiceDescription(Map<Class<?>, String> serviceDescription,
+                                              AnnotatedHttpService service) {
         final Class<?> clazz = service.object().getClass();
         serviceDescription.computeIfAbsent(clazz, AnnotatedHttpServiceFactory::findDescription);
     }
@@ -203,38 +212,71 @@ public final class AnnotatedHttpDocServicePlugin implements DocServicePlugin {
         return builder.build();
     }
 
-    @VisibleForTesting
-    static List<FieldInfo> fieldInfos(List<AnnotatedValueResolver> resolvers) {
-        final ImmutableList.Builder<FieldInfo> fieldInfoBuilder = ImmutableList.builder();
+    private static List<FieldInfo> fieldInfos(List<AnnotatedValueResolver> resolvers) {
+        final ImmutableList.Builder<FieldInfo> fieldInfosBuilder = ImmutableList.builder();
         for (AnnotatedValueResolver resolver : resolvers) {
-            if (!(resolver.annotationType() == Param.class || resolver.annotationType() == Header.class)) {
-                continue;
+            final FieldInfo fieldInfo = fieldInfo(resolver);
+            if (fieldInfo != null) {
+                fieldInfosBuilder.add(fieldInfo);
             }
-            final TypeSignature signature;
-            if (resolver.hasContainer()) {
-                final Class<?> containerType = resolver.containerType();
-                assert containerType != null;
-                final TypeSignature parameterTypeSignature = toTypeSignature(resolver.elementType());
-                if (List.class.isAssignableFrom(containerType)) {
-                    signature = TypeSignature.ofList(parameterTypeSignature);
-                } else if (Set.class.isAssignableFrom(containerType)) {
-                    signature = TypeSignature.ofSet(parameterTypeSignature);
-                } else {
-                    // Only List and Set are supported for the containerType.
-                    continue;
-                }
-            } else {
-                signature = toTypeSignature(resolver.elementType());
-            }
-            final String name = resolver.httpElementName();
-            assert name != null;
-
-            fieldInfoBuilder.add(
-                    new FieldInfo(name, location(resolver), resolver.shouldExist() ? FieldRequirement.REQUIRED
-                                                                                   : FieldRequirement.OPTIONAL,
-                                  signature, resolver.description()));
         }
-        return fieldInfoBuilder.build();
+        return fieldInfosBuilder.build();
+    }
+
+    @Nullable
+    private static FieldInfo fieldInfo(AnnotatedValueResolver resolver) {
+        final Class<? extends Annotation> annotationType = resolver.annotationType();
+        if (annotationType == RequestObject.class) {
+            final BeanFactoryId beanFactoryId = resolver.beanFactoryId();
+            final Optional<AnnotatedBeanFactory<?>> optional =
+                    AnnotatedBeanFactoryRegistry.find(beanFactoryId);
+            if (optional.isPresent()) {
+                final AnnotatedBeanFactory<?> factory = optional.get();
+                final Builder<AnnotatedValueResolver> builder = ImmutableList.builder();
+                factory.constructor().getValue().forEach(builder::add);
+                factory.methods().values().forEach(resolvers -> resolvers.forEach(builder::add));
+                factory.fields().values().forEach(builder::add);
+                final List<AnnotatedValueResolver> resolvers = builder.build();
+                if (!resolvers.isEmpty()) {
+                    // TODO(minwoox) Should we support http element name for the bean type?
+                    return new FieldInfoBuilder(beanFactoryId.type().getSimpleName(), BEAN,
+                                                fieldInfos(resolvers)).build();
+                }
+            }
+            return null;
+        }
+
+        if (annotationType != Param.class && annotationType != Header.class) {
+            return null;
+        }
+        final TypeSignature signature;
+        if (resolver.hasContainer()) {
+            final Class<?> containerType = resolver.containerType();
+            assert containerType != null;
+            final TypeSignature parameterTypeSignature = toTypeSignature(resolver.elementType()
+            );
+            if (List.class.isAssignableFrom(containerType)) {
+                signature = TypeSignature.ofList(parameterTypeSignature);
+            } else if (Set.class.isAssignableFrom(containerType)) {
+                signature = TypeSignature.ofSet(parameterTypeSignature);
+            } else {
+                // Only List and Set are supported for the containerType.
+                return null;
+            }
+        } else {
+            signature = toTypeSignature(resolver.elementType());
+        }
+        final String name = resolver.httpElementName();
+        assert name != null;
+
+        final FieldInfoBuilder builder = new FieldInfoBuilder(name, signature)
+                .location(location(resolver))
+                .requirement(resolver.shouldExist() ? FieldRequirement.REQUIRED
+                                                    : FieldRequirement.OPTIONAL);
+        if (resolver.description() != null) {
+            builder.docString(resolver.description());
+        }
+        return builder.build();
     }
 
     @VisibleForTesting
@@ -312,18 +354,17 @@ public final class AnnotatedHttpDocServicePlugin implements DocServicePlugin {
         return TypeSignature.ofBase(clazz.getSimpleName());
     }
 
-    @Nullable
-    private static String location(AnnotatedValueResolver resolver) {
+    private static FieldLocation location(AnnotatedValueResolver resolver) {
         if (resolver.isPathVariable()) {
-            return PATH_PARAM;
+            return PATH;
         }
         if (resolver.annotationType() == Param.class) {
-            return QUERY_PARAM;
+            return QUERY;
         }
         if (resolver.annotationType() == Header.class) {
-            return HEADER_PARAM;
+            return HEADER;
         }
-        return null;
+        return DEFAULT;
     }
 
     @VisibleForTesting
@@ -362,8 +403,8 @@ public final class AnnotatedHttpDocServicePlugin implements DocServicePlugin {
         final Field[] declaredFields = structClass.getDeclaredFields();
         final List<FieldInfo> fields =
                 Stream.of(declaredFields)
-                      .map(f -> new FieldInfo(f.getName(), FieldRequirement.DEFAULT,
-                                              toTypeSignature(f.getGenericType())))
+                      .map(f -> new FieldInfoBuilder(f.getName(), toTypeSignature(f.getGenericType()))
+                              .build())
                       .collect(Collectors.toList());
         return new StructInfo(name, fields);
     }

--- a/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpDocServicePlugin.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpDocServicePlugin.java
@@ -237,7 +237,7 @@ public final class AnnotatedHttpDocServicePlugin implements DocServicePlugin {
                 factory.fields().values().forEach(builder::add);
                 final List<AnnotatedValueResolver> resolvers = builder.build();
                 if (!resolvers.isEmpty()) {
-                    // TODO(minwoox) Should we support http element name for the bean type?
+                    // Just use the simple name of the bean class as the field name.
                     return new FieldInfoBuilder(beanFactoryId.type().getSimpleName(), BEAN,
                                                 fieldInfos(resolvers)).build();
                 }

--- a/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpDocServicePlugin.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpDocServicePlugin.java
@@ -24,10 +24,10 @@ import static com.linecorp.armeria.internal.PathMappingUtil.PREFIX;
 import static com.linecorp.armeria.internal.PathMappingUtil.REGEX;
 import static com.linecorp.armeria.internal.annotation.AnnotatedHttpDocServiceUtil.getNormalizedTriePath;
 import static com.linecorp.armeria.internal.annotation.AnnotatedHttpServiceFactory.findDescription;
-import static com.linecorp.armeria.server.docs.FieldLocation.DEFAULT;
 import static com.linecorp.armeria.server.docs.FieldLocation.HEADER;
 import static com.linecorp.armeria.server.docs.FieldLocation.PATH;
 import static com.linecorp.armeria.server.docs.FieldLocation.QUERY;
+import static com.linecorp.armeria.server.docs.FieldLocation.UNSPECIFIED;
 import static java.util.Objects.requireNonNull;
 
 import java.lang.annotation.Annotation;
@@ -58,7 +58,6 @@ import com.google.common.collect.ImmutableList.Builder;
 import com.google.common.collect.ImmutableSet;
 
 import com.linecorp.armeria.common.MediaType;
-import com.linecorp.armeria.internal.annotation.AnnotatedBeanFactoryRegistry.AnnotatedBeanFactory;
 import com.linecorp.armeria.internal.annotation.AnnotatedBeanFactoryRegistry.BeanFactoryId;
 import com.linecorp.armeria.server.PathMapping;
 import com.linecorp.armeria.server.Service;
@@ -253,8 +252,7 @@ public final class AnnotatedHttpDocServicePlugin implements DocServicePlugin {
         if (resolver.hasContainer()) {
             final Class<?> containerType = resolver.containerType();
             assert containerType != null;
-            final TypeSignature parameterTypeSignature = toTypeSignature(resolver.elementType()
-            );
+            final TypeSignature parameterTypeSignature = toTypeSignature(resolver.elementType());
             if (List.class.isAssignableFrom(containerType)) {
                 signature = TypeSignature.ofList(parameterTypeSignature);
             } else if (Set.class.isAssignableFrom(containerType)) {
@@ -364,7 +362,7 @@ public final class AnnotatedHttpDocServicePlugin implements DocServicePlugin {
         if (resolver.annotationType() == Header.class) {
             return HEADER;
         }
-        return DEFAULT;
+        return UNSPECIFIED;
     }
 
     @VisibleForTesting

--- a/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedValueResolver.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedValueResolver.java
@@ -48,7 +48,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
-import java.util.TreeSet;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -427,7 +426,7 @@ final class AnnotatedValueResolver {
 
     private static void warnOnRedundantUse(Executable constructorOrMethod,
                                            List<AnnotatedValueResolver> list) {
-        final TreeSet<AnnotatedValueResolver> uniques = uniqueResolverSet();
+        final Set<AnnotatedValueResolver> uniques = uniqueResolverSet();
         list.forEach(element -> {
             if (!uniques.add(element)) {
                 warnRedundantUse(element, constructorOrMethod.toGenericString());

--- a/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedValueResolver.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedValueResolver.java
@@ -27,6 +27,7 @@ import static com.linecorp.armeria.internal.annotation.AnnotatedHttpServiceFacto
 import static com.linecorp.armeria.internal.annotation.AnnotatedHttpServiceTypeUtil.normalizeContainerType;
 import static com.linecorp.armeria.internal.annotation.AnnotatedHttpServiceTypeUtil.stringToType;
 import static com.linecorp.armeria.internal.annotation.AnnotatedHttpServiceTypeUtil.validateElementType;
+import static com.linecorp.armeria.internal.annotation.AnnotationUtil.findDeclared;
 import static java.util.Objects.requireNonNull;
 
 import java.lang.annotation.Annotation;
@@ -216,9 +217,8 @@ final class AnnotatedValueResolver {
             resolver = of(constructorOrMethod,
                           parameters[0], parameters[0].getType(), pathParams, objectResolvers,
                           implicitRequestObjectAnnotation);
-        } else if (!isServiceMethod &&
-                   constructorOrMethod.getAnnotationsByType(RequestConverter.class).length > 0 &&
-                   parameters.length == 1) {
+        } else if (!isServiceMethod && parameters.length == 1 &&
+                   !findDeclared(constructorOrMethod, RequestConverter.class).isEmpty()) {
             //
             // Filter out the cases like the following:
             //
@@ -372,7 +372,7 @@ final class AnnotatedValueResolver {
         final RequestObject requestObject = annotatedElement.getAnnotation(RequestObject.class);
         if (requestObject != null) {
             // Find more request converters from a field or parameter.
-            final RequestConverter[] converters = typeElement.getAnnotationsByType(RequestConverter.class);
+            final List<RequestConverter> converters = findDeclared(typeElement, RequestConverter.class);
             return Optional.of(ofRequestObject(annotatedElement, type, pathParams,
                                                addToFirstIfExists(objectResolvers, converters),
                                                description));
@@ -390,8 +390,8 @@ final class AnnotatedValueResolver {
             return Optional.of(resolver);
         }
 
-        final RequestConverter[] converters = typeElement.getAnnotationsByType(RequestConverter.class);
-        if (converters.length > 0) {
+        final List<RequestConverter> converters = findDeclared(typeElement, RequestConverter.class);
+        if (!converters.isEmpty()) {
             // Apply @RequestObject implicitly when a @RequestConverter is specified.
             return Optional.of(ofRequestObject(annotatedElement, type, pathParams,
                                                addToFirstIfExists(objectResolvers, converters), description));
@@ -406,14 +406,14 @@ final class AnnotatedValueResolver {
     }
 
     static List<RequestObjectResolver> addToFirstIfExists(List<RequestObjectResolver> resolvers,
-                                                          RequestConverter[] converters) {
-        if (converters.length == 0) {
+                                                          List<RequestConverter> converters) {
+        if (converters.isEmpty()) {
             return resolvers;
         }
 
         final ImmutableList.Builder<RequestObjectResolver> builder = new ImmutableList.Builder<>();
-        Arrays.stream(converters).forEach(c -> builder.add(
-                RequestObjectResolver.of(AnnotatedHttpServiceFactory.getInstance(c.value()))));
+        converters.forEach(c -> builder.add(RequestObjectResolver.of(
+                AnnotatedHttpServiceFactory.getInstance(c.value()))));
         builder.addAll(resolvers);
         return builder.build();
     }

--- a/core/src/main/java/com/linecorp/armeria/server/docs/DocService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/DocService.java
@@ -223,6 +223,7 @@ public class DocService extends AbstractCompositeService<HttpRequest, HttpRespon
                              field.location(),
                              field.requirement(),
                              field.typeSignature(),
+                             field.childFieldInfos(),
                              docString(service.name() + '/' + method.name() + '/' + field.name(),
                                        field.docString(), docStrings));
     }
@@ -263,6 +264,7 @@ public class DocService extends AbstractCompositeService<HttpRequest, HttpRespon
                              field.location(),
                              field.requirement(),
                              field.typeSignature(),
+                             field.childFieldInfos(),
                              docString(parent.name() + '/' + field.name(), field.docString(), docStrings));
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/docs/EndpointInfoBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/EndpointInfoBuilder.java
@@ -151,7 +151,7 @@ public final class EndpointInfoBuilder {
      * Returns a newly-created {@link EndpointInfo} based on the properties of this builder.
      */
     public EndpointInfo build() {
-        checkState(availableMimeTypes != null && !Iterables.isEmpty(availableMimeTypes),
+        checkState(availableMimeTypes != null && !availableMimeTypes.isEmpty(),
                    "Should at least have an available media type.");
         return new EndpointInfo(hostnamePattern, pathMapping, regexPathPrefix,
                                 fragment, defaultMimeType, availableMimeTypes);

--- a/core/src/main/java/com/linecorp/armeria/server/docs/FieldInfo.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/FieldInfo.java
@@ -28,6 +28,8 @@ import com.google.common.base.MoreObjects;
 
 /**
  * Metadata about a field of a struct or an exception.
+ *
+ * @see FieldInfoBuilder
  */
 public final class FieldInfo {
 

--- a/core/src/main/java/com/linecorp/armeria/server/docs/FieldInfo.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/FieldInfo.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableList;
 
 /**
  * Metadata about a field of a struct or an exception.
@@ -40,6 +41,16 @@ public final class FieldInfo {
     private final List<FieldInfo> childFieldInfos;
     @Nullable
     private final String docString;
+
+    /**
+     * Creates a new {@link FieldInfo} with the specified {@code name} and {@link TypeSignature}.
+     * The {@link FieldLocation} and {@link FieldRequirement} of the {@link FieldInfo} will be
+     * {@code UNSPECIFIED}.
+     */
+    public static FieldInfo of(String name, TypeSignature typeSignature) {
+        return new FieldInfo(name, FieldLocation.UNSPECIFIED, FieldRequirement.UNSPECIFIED, typeSignature,
+                             ImmutableList.of(), null);
+    }
 
     /**
      * Creates a new instance.

--- a/core/src/main/java/com/linecorp/armeria/server/docs/FieldInfo.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/FieldInfo.java
@@ -16,8 +16,7 @@
 
 package com.linecorp.armeria.server.docs;
 
-import static java.util.Objects.requireNonNull;
-
+import java.util.List;
 import java.util.Objects;
 
 import javax.annotation.Nullable;
@@ -26,7 +25,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Strings;
 
 /**
  * Metadata about a field of a struct or an exception.
@@ -34,46 +32,24 @@ import com.google.common.base.Strings;
 public final class FieldInfo {
 
     private final String name;
-    @Nullable
-    private final String location;
+    private final FieldLocation location;
     private final FieldRequirement requirement;
     private final TypeSignature typeSignature;
+    private final List<FieldInfo> childFieldInfos;
     @Nullable
     private final String docString;
 
     /**
      * Creates a new instance.
      */
-    public FieldInfo(String name, FieldRequirement requirement, TypeSignature typeSignature) {
-        this(name, null, requirement, typeSignature, null);
-    }
-
-    /**
-     * Creates a new instance.
-     */
-    public FieldInfo(String name, @Nullable String location, FieldRequirement requirement,
-                     TypeSignature typeSignature) {
-        this(name, location, requirement, typeSignature, null);
-    }
-
-    /**
-     * Creates a new instance.
-     */
-    public FieldInfo(String name, FieldRequirement requirement,
-                     TypeSignature typeSignature, @Nullable String docString) {
-        this(name, null, requirement, typeSignature, docString);
-    }
-
-    /**
-     * Creates a new instance.
-     */
-    public FieldInfo(String name, @Nullable String location, FieldRequirement requirement,
-                     TypeSignature typeSignature, @Nullable String docString) {
-        this.name = requireNonNull(name, "name");
-        this.location = Strings.emptyToNull(location);
-        this.requirement = requireNonNull(requirement, "requirement");
-        this.typeSignature = requireNonNull(typeSignature, "typeSignature");
-        this.docString = Strings.emptyToNull(docString);
+    FieldInfo(String name, FieldLocation location, FieldRequirement requirement,
+              TypeSignature typeSignature, List<FieldInfo> childFieldInfos, @Nullable String docString) {
+        this.name = name;
+        this.location = location;
+        this.requirement = requirement;
+        this.typeSignature = typeSignature;
+        this.childFieldInfos = childFieldInfos;
+        this.docString = docString;
     }
 
     /**
@@ -86,12 +62,9 @@ public final class FieldInfo {
 
     /**
      * Returns the location of the field.
-     * e.g. {@code "param"}, {@code "header"} and {@code "query"}
      */
     @JsonProperty
-    @JsonInclude(Include.NON_NULL)
-    @Nullable
-    public String location() {
+    public FieldLocation location() {
         return location;
     }
 
@@ -109,6 +82,14 @@ public final class FieldInfo {
     @JsonProperty
     public TypeSignature typeSignature() {
         return typeSignature;
+    }
+
+    /**
+     * Returns the child field infos of the field.
+     */
+    @JsonProperty
+    public List<FieldInfo> childFieldInfos() {
+        return childFieldInfos;
     }
 
     /**
@@ -133,13 +114,15 @@ public final class FieldInfo {
 
         final FieldInfo that = (FieldInfo) o;
         return name.equals(that.name) &&
+               location == that.location &&
                requirement == that.requirement &&
-               typeSignature.equals(that.typeSignature);
+               typeSignature.equals(that.typeSignature) &&
+               childFieldInfos.equals(that.childFieldInfos);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, requirement, typeSignature);
+        return Objects.hash(name, location, requirement, typeSignature, childFieldInfos);
     }
 
     @Override
@@ -149,6 +132,7 @@ public final class FieldInfo {
                           .add("location", location)
                           .add("requirement", requirement)
                           .add("typeSignature", typeSignature)
+                          .add("childFieldInfos", childFieldInfos)
                           .add("docString", docString)
                           .toString();
     }

--- a/core/src/main/java/com/linecorp/armeria/server/docs/FieldInfoBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/FieldInfoBuilder.java
@@ -1,0 +1,112 @@
+/*
+ *  Copyright 2019 LINE Corporation
+ *
+ *  LINE Corporation licenses this file to you under the Apache License,
+ *  version 2.0 (the "License"); you may not use this file except in compliance
+ *  with the License. You may obtain a copy of the License at:
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations
+ *  under the License.
+ */
+package com.linecorp.armeria.server.docs;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+
+/**
+ * Creates a new {@link FieldInfo} using the builder pattern.
+ */
+public class FieldInfoBuilder {
+
+    private final String name;
+    private final TypeSignature typeSignature;
+    private final List<FieldInfo> childFieldInfos;
+
+    private FieldRequirement requirement = FieldRequirement.DEFAULT;
+    private FieldLocation location = FieldLocation.DEFAULT;
+    @Nullable
+    private String docString;
+
+    /**
+     * Creates a new {@link FieldInfoBuilder}.
+     */
+    public FieldInfoBuilder(String name, TypeSignature typeSignature) {
+        this.name = requireNonNull(name, "name");
+        this.typeSignature = requireNonNull(typeSignature, "typeSignature");
+        childFieldInfos = ImmutableList.of();
+    }
+
+    /**
+     * Creates a new {@link FieldInfoBuilder}.
+     */
+    public FieldInfoBuilder(String name, TypeSignature typeSignature, FieldInfo... childFieldInfos) {
+        this(name, typeSignature, ImmutableList.copyOf(childFieldInfos));
+    }
+
+    /**
+     * Creates a new {@link FieldInfoBuilder}.
+     */
+    public FieldInfoBuilder(String name, TypeSignature typeSignature, Iterable<FieldInfo> childFieldInfos) {
+        this.name = requireNonNull(name, "name");
+        this.typeSignature = typeSignature;
+        checkArgument(!Iterables.isEmpty(requireNonNull(childFieldInfos, "childFieldInfos")),
+                      "childFieldInfos can't be empty");
+        this.childFieldInfos = ImmutableList.copyOf(childFieldInfos);
+    }
+
+    /**
+     * Sets the {@link FieldRequirement} of the field.
+     */
+    public FieldInfoBuilder requirement(FieldRequirement requirement) {
+        this.requirement = requireNonNull(requirement, "requirement");
+        return this;
+    }
+
+    /**
+     * Sets the {@link FieldLocation} of the field.
+     */
+    public FieldInfoBuilder location(FieldLocation location) {
+        this.location = requireNonNull(location, "location");
+        return this;
+    }
+
+    /**
+     * Sets the documentation string of the field.
+     */
+    public FieldInfoBuilder docString(String docString) {
+        this.docString = requireNonNull(docString, "docString");
+        return this;
+    }
+
+    /**
+     * Returns a newly-created {@link FieldInfo} based on the properties of this builder.
+     */
+    public FieldInfo build() {
+        return new FieldInfo(name, location, requirement, typeSignature, childFieldInfos, docString);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).omitNullValues()
+                          .add("name", name)
+                          .add("location", location)
+                          .add("requirement", requirement)
+                          .add("typeSignature", typeSignature)
+                          .add("childFieldInfos", childFieldInfos)
+                          .add("docString", docString)
+                          .toString();
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/docs/FieldInfoBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/FieldInfoBuilder.java
@@ -35,8 +35,8 @@ public class FieldInfoBuilder {
     private final TypeSignature typeSignature;
     private final List<FieldInfo> childFieldInfos;
 
-    private FieldRequirement requirement = FieldRequirement.DEFAULT;
-    private FieldLocation location = FieldLocation.DEFAULT;
+    private FieldRequirement requirement = FieldRequirement.UNSPECIFIED;
+    private FieldLocation location = FieldLocation.UNSPECIFIED;
     @Nullable
     private String docString;
 

--- a/core/src/main/java/com/linecorp/armeria/server/docs/FieldLocation.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/FieldLocation.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.docs;
+
+/**
+ * The location of a field.
+ */
+public enum FieldLocation {
+
+    /**
+     * The field is located in the path.
+     */
+    PATH,
+
+    /**
+     * The field is located in the header.
+     */
+    HEADER,
+
+    /**
+     * The field is located in the query.
+     */
+    QUERY,
+
+    /**
+     * The field is located in the request body.
+     */
+    BODY,
+
+    /**
+     * The location of the field is unspecified.
+     */
+    DEFAULT
+}

--- a/core/src/main/java/com/linecorp/armeria/server/docs/FieldLocation.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/FieldLocation.java
@@ -44,5 +44,5 @@ public enum FieldLocation {
     /**
      * The location of the field is unspecified.
      */
-    DEFAULT
+    UNSPECIFIED
 }

--- a/core/src/main/java/com/linecorp/armeria/server/docs/FieldRequirement.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/FieldRequirement.java
@@ -33,5 +33,5 @@ public enum FieldRequirement {
     /**
      * The requirement level is unspecified and will be handled implicitly by the serialization layer.
      */
-    DEFAULT
+    UNSPECIFIED
 }

--- a/core/src/main/java/com/linecorp/armeria/server/docs/TypeSignature.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/TypeSignature.java
@@ -271,28 +271,28 @@ public final class TypeSignature {
     }
 
     /**
-     * Returns if this type signature represents a base type.
+     * Returns {@code true} if this type signature represents a base type.
      */
     public boolean isBase() {
         return !isUnresolved() && !isNamed() && !isContainer();
     }
 
     /**
-     * Returns if this type signature represents a container type.
+     * Returns {@code true} if this type signature represents a container type.
      */
     public boolean isContainer() {
         return !typeParameters.isEmpty();
     }
 
     /**
-     * Returns if this type signature represents a named type.
+     * Returns {@code true} if this type signature represents a named type.
      */
     public boolean isNamed() {
         return namedTypeDescriptor != null;
     }
 
     /**
-     * Returns if this type signature represents an unresolved type.
+     * Returns {@code true} if this type signature represents an unresolved type.
      */
     public boolean isUnresolved() {
         return name.startsWith("?");

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedBeanFactoryRegistryTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedBeanFactoryRegistryTest.java
@@ -15,8 +15,8 @@
  */
 package com.linecorp.armeria.internal.annotation;
 
-import static com.linecorp.armeria.internal.annotation.AnnotatedBeanFactory.find;
-import static com.linecorp.armeria.internal.annotation.AnnotatedBeanFactory.register;
+import static com.linecorp.armeria.internal.annotation.AnnotatedBeanFactoryRegistry.find;
+import static com.linecorp.armeria.internal.annotation.AnnotatedBeanFactoryRegistry.register;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -31,12 +31,12 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
 import com.linecorp.armeria.common.HttpRequest;
-import com.linecorp.armeria.internal.annotation.AnnotatedBeanFactory.BeanFactoryId;
+import com.linecorp.armeria.internal.annotation.AnnotatedBeanFactoryRegistry.BeanFactoryId;
 import com.linecorp.armeria.internal.annotation.AnnotatedValueResolver.RequestObjectResolver;
 import com.linecorp.armeria.server.annotation.Header;
 import com.linecorp.armeria.server.annotation.Param;
 
-public class AnnotatedBeanFactoryTest {
+public class AnnotatedBeanFactoryRegistryTest {
 
     private static final Set<String> vars = ImmutableSet.of();
     private static final List<RequestObjectResolver> resolvers = ImmutableList.of();

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpDocServicePluginTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpDocServicePluginTest.java
@@ -17,13 +17,19 @@
 package com.linecorp.armeria.internal.annotation;
 
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.linecorp.armeria.internal.annotation.AnnotatedHttpDocServicePlugin.BEAN;
+import static com.linecorp.armeria.internal.annotation.AnnotatedHttpDocServicePlugin.INT32;
 import static com.linecorp.armeria.internal.annotation.AnnotatedHttpDocServicePlugin.INT64;
 import static com.linecorp.armeria.internal.annotation.AnnotatedHttpDocServicePlugin.STRING;
 import static com.linecorp.armeria.internal.annotation.AnnotatedHttpDocServicePlugin.VOID;
 import static com.linecorp.armeria.internal.annotation.AnnotatedHttpDocServicePlugin.endpointInfo;
 import static com.linecorp.armeria.internal.annotation.AnnotatedHttpDocServicePlugin.toTypeSignature;
+import static com.linecorp.armeria.server.docs.FieldLocation.HEADER;
+import static com.linecorp.armeria.server.docs.FieldLocation.QUERY;
+import static com.linecorp.armeria.server.docs.FieldRequirement.REQUIRED;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -31,14 +37,18 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
+import javax.annotation.Nullable;
+
 import org.junit.Test;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.internal.annotation.AnnotatedHttpDocServicePluginTest.RequestBean2.InsideBean;
 import com.linecorp.armeria.internal.annotation.AnnotatedHttpServiceFactory.PrefixAddingPathMapping;
 import com.linecorp.armeria.server.PathMapping;
 import com.linecorp.armeria.server.ServiceConfig;
@@ -47,10 +57,11 @@ import com.linecorp.armeria.server.VirtualHostBuilder;
 import com.linecorp.armeria.server.annotation.Get;
 import com.linecorp.armeria.server.annotation.Header;
 import com.linecorp.armeria.server.annotation.Param;
+import com.linecorp.armeria.server.annotation.RequestObject;
 import com.linecorp.armeria.server.docs.EndpointInfo;
 import com.linecorp.armeria.server.docs.EndpointInfoBuilder;
 import com.linecorp.armeria.server.docs.FieldInfo;
-import com.linecorp.armeria.server.docs.FieldRequirement;
+import com.linecorp.armeria.server.docs.FieldInfoBuilder;
 import com.linecorp.armeria.server.docs.MethodInfo;
 import com.linecorp.armeria.server.docs.ServiceInfo;
 import com.linecorp.armeria.server.docs.ServiceSpecification;
@@ -215,9 +226,12 @@ public class AnnotatedHttpDocServicePluginTest {
 
         assertThat(services).containsOnlyKeys(FooClass.class.getName(), BarClass.class.getName());
 
-        final ServiceInfo fooServiceInfo = services.get(FooClass.class.getName());
-        assertThat(fooServiceInfo.exampleHttpHeaders()).isEmpty();
+        checkFooService(services.get(FooClass.class.getName()));
+        checkBarService(services.get(BarClass.class.getName()));
+    }
 
+    private static void checkFooService(ServiceInfo fooServiceInfo) {
+        assertThat(fooServiceInfo.exampleHttpHeaders()).isEmpty();
         final Map<String, MethodInfo> methods =
                 fooServiceInfo.methods().stream()
                               .collect(toImmutableMap(MethodInfo::name, Function.identity()));
@@ -229,14 +243,39 @@ public class AnnotatedHttpDocServicePluginTest {
 
         assertThat(fooMethod.parameters()).hasSize(2);
         assertThat(fooMethod.parameters()).containsExactlyInAnyOrder(
-                new FieldInfo("foo", FieldRequirement.REQUIRED, STRING),
-                new FieldInfo("foo1", FieldRequirement.REQUIRED, INT64));
+                new FieldInfoBuilder("foo", STRING).requirement(REQUIRED)
+                                                   .location(QUERY)
+                                                   .build(),
+                new FieldInfoBuilder("foo1", INT64).requirement(REQUIRED)
+                                                   .location(HEADER)
+                                                   .build());
 
         assertThat(fooMethod.returnTypeSignature()).isEqualTo(VOID);
 
         assertThat(fooMethod.endpoints()).containsExactly(
                 new EndpointInfoBuilder("*", "exact:/foo").defaultMimeType(MediaType.JSON).build());
-        final ServiceInfo barServiceInfo = services.get(BarClass.class.getName());
+    }
+
+    private static void checkBarService(ServiceInfo barServiceInfo) {
+        assertThat(barServiceInfo.exampleHttpHeaders()).isEmpty();
+        final Map<String, MethodInfo> methods =
+                barServiceInfo.methods().stream()
+                              .collect(toImmutableMap(MethodInfo::name, Function.identity()));
+        assertThat(methods).containsKeys("barMethod");
+
+        final MethodInfo barMethod = methods.get("barMethod");
+        assertThat(barMethod.exampleHttpHeaders()).isEmpty();
+        assertThat(barMethod.exampleRequests()).isEmpty();
+        assertThat(barMethod.returnTypeSignature()).isEqualTo(VOID);
+
+        assertThat(barMethod.endpoints()).containsExactly(
+                new EndpointInfoBuilder("*", "exact:/bar").defaultMimeType(MediaType.JSON).build());
+
+        final FieldInfo bar = new FieldInfoBuilder("bar", STRING).requirement(REQUIRED)
+                                                                 .location(QUERY)
+                                                                 .build();
+        final List<FieldInfo> fieldInfos = barMethod.parameters();
+        assertFieldInfos(fieldInfos, ImmutableList.of(bar, compositeBean()));
     }
 
     private static List<ServiceConfig> serviceConfigs() {
@@ -251,6 +290,41 @@ public class AnnotatedHttpDocServicePluginTest {
         barElements.forEach(element -> builder.add(
                 new ServiceConfig(virtualHost, element.pathMapping(), element.service(), null)));
         return builder.build();
+    }
+
+    static FieldInfo compositeBean() {
+        return new FieldInfoBuilder(CompositeBean.class.getSimpleName(), BEAN,
+                                    createBean1(), createBean2()).build();
+    }
+
+    private static FieldInfo createBean1() {
+        final FieldInfo uid = new FieldInfoBuilder("uid", STRING).location(HEADER).requirement(REQUIRED)
+                                                                 .build();
+        final FieldInfo seqNum = new FieldInfoBuilder("seqNum", INT64).location(QUERY).requirement(REQUIRED)
+                                                                      .build();
+        return new FieldInfoBuilder(RequestBean1.class.getSimpleName(), BEAN, uid, seqNum).build();
+    }
+
+    private static FieldInfo createBean2() {
+        final FieldInfo inside1 = new FieldInfoBuilder("inside1", INT64).location(QUERY).requirement(REQUIRED)
+                                                                        .build();
+        final FieldInfo inside2 = new FieldInfoBuilder("inside2", INT32).location(QUERY).requirement(REQUIRED)
+                                                                        .build();
+        final FieldInfo insideBean = new FieldInfoBuilder(InsideBean.class.getSimpleName(), BEAN,
+                                                          inside1, inside2).build();
+        return new FieldInfoBuilder(RequestBean2.class.getSimpleName(), BEAN, insideBean).build();
+    }
+
+    private static void assertFieldInfos(List<FieldInfo> fieldInfos, List<FieldInfo> expected) {
+        final Comparator<List<FieldInfo>> comparator = (o1, o2) -> {
+            assertFieldInfos(o1, o2);
+            // If assertFieldInfos does not throw an exception, it contains same elements.
+            return 0;
+        };
+        assertThat(fieldInfos).usingComparatorForElementFieldsWithNames(
+                comparator,
+                "childFieldInfos").usingFieldByFieldElementComparator().containsExactlyInAnyOrderElementsOf(
+                expected);
     }
 
     private static class FieldContainer<T> {
@@ -277,6 +351,52 @@ public class AnnotatedHttpDocServicePluginTest {
 
     private static class BarClass {
         @Get("/bar")
-        public void barMethod(@Param String bar) {}
+        public void barMethod(@Param String bar, CompositeBean compositeBean) {}
+    }
+
+    static class CompositeBean {
+        @RequestObject
+        private RequestBean1 bean1;
+
+        @RequestObject
+        private RequestBean2 bean2;
+    }
+
+    static class RequestBean1 {
+        @Nullable
+        @JsonProperty
+        @Param
+        private Long seqNum;
+
+        @JsonProperty
+        private String uid;
+
+        @Nullable
+        private String notPopulatedStr;
+
+        RequestBean1(@Header String uid) {
+            this.uid = uid;
+        }
+    }
+
+    static class RequestBean2 {
+
+        @JsonProperty
+        private InsideBean insideBean;
+
+        public void setInsideBean(@RequestObject InsideBean insideBean) {
+            this.insideBean = insideBean;
+        }
+
+        static class InsideBean {
+
+            @JsonProperty
+            @Param
+            private Long inside1;
+
+            @JsonProperty
+            @Param
+            private int inside2;
+        }
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpDocServicePluginTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpDocServicePluginTest.java
@@ -18,8 +18,8 @@ package com.linecorp.armeria.internal.annotation;
 
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.linecorp.armeria.internal.annotation.AnnotatedHttpDocServicePlugin.BEAN;
-import static com.linecorp.armeria.internal.annotation.AnnotatedHttpDocServicePlugin.INT32;
-import static com.linecorp.armeria.internal.annotation.AnnotatedHttpDocServicePlugin.INT64;
+import static com.linecorp.armeria.internal.annotation.AnnotatedHttpDocServicePlugin.INT;
+import static com.linecorp.armeria.internal.annotation.AnnotatedHttpDocServicePlugin.LONG;
 import static com.linecorp.armeria.internal.annotation.AnnotatedHttpDocServicePlugin.STRING;
 import static com.linecorp.armeria.internal.annotation.AnnotatedHttpDocServicePlugin.VOID;
 import static com.linecorp.armeria.internal.annotation.AnnotatedHttpDocServicePlugin.endpointInfo;
@@ -77,14 +77,14 @@ public class AnnotatedHttpDocServicePluginTest {
         assertThat(toTypeSignature(void.class)).isEqualTo(TypeSignature.ofBase("void"));
         assertThat(toTypeSignature(Boolean.class)).isEqualTo(TypeSignature.ofBase("boolean"));
         assertThat(toTypeSignature(boolean.class)).isEqualTo(TypeSignature.ofBase("boolean"));
-        assertThat(toTypeSignature(Byte.class)).isEqualTo(TypeSignature.ofBase("int8"));
-        assertThat(toTypeSignature(byte.class)).isEqualTo(TypeSignature.ofBase("int8"));
-        assertThat(toTypeSignature(Short.class)).isEqualTo(TypeSignature.ofBase("int16"));
-        assertThat(toTypeSignature(short.class)).isEqualTo(TypeSignature.ofBase("int16"));
-        assertThat(toTypeSignature(Integer.class)).isEqualTo(TypeSignature.ofBase("int32"));
-        assertThat(toTypeSignature(int.class)).isEqualTo(TypeSignature.ofBase("int32"));
-        assertThat(toTypeSignature(Long.class)).isEqualTo(TypeSignature.ofBase("int64"));
-        assertThat(toTypeSignature(long.class)).isEqualTo(TypeSignature.ofBase("int64"));
+        assertThat(toTypeSignature(Byte.class)).isEqualTo(TypeSignature.ofBase("byte"));
+        assertThat(toTypeSignature(byte.class)).isEqualTo(TypeSignature.ofBase("byte"));
+        assertThat(toTypeSignature(Short.class)).isEqualTo(TypeSignature.ofBase("short"));
+        assertThat(toTypeSignature(short.class)).isEqualTo(TypeSignature.ofBase("short"));
+        assertThat(toTypeSignature(Integer.class)).isEqualTo(TypeSignature.ofBase("int"));
+        assertThat(toTypeSignature(int.class)).isEqualTo(TypeSignature.ofBase("int"));
+        assertThat(toTypeSignature(Long.class)).isEqualTo(TypeSignature.ofBase("long"));
+        assertThat(toTypeSignature(long.class)).isEqualTo(TypeSignature.ofBase("long"));
         assertThat(toTypeSignature(Float.class)).isEqualTo(TypeSignature.ofBase("float"));
         assertThat(toTypeSignature(float.class)).isEqualTo(TypeSignature.ofBase("float"));
         assertThat(toTypeSignature(Double.class)).isEqualTo(TypeSignature.ofBase("double"));
@@ -94,7 +94,7 @@ public class AnnotatedHttpDocServicePluginTest {
         assertThat(toTypeSignature(Byte[].class)).isEqualTo(TypeSignature.ofBase("binary"));
         assertThat(toTypeSignature(byte[].class)).isEqualTo(TypeSignature.ofBase("binary"));
 
-        assertThat(toTypeSignature(int[].class)).isEqualTo(TypeSignature.ofList(TypeSignature.ofBase("int32")));
+        assertThat(toTypeSignature(int[].class)).isEqualTo(TypeSignature.ofList(TypeSignature.ofBase("int")));
 
         final TypeSignature typeVariable = toTypeSignature(FieldContainer.class.getDeclaredField("typeVariable")
                                                                                .getGenericType());
@@ -112,7 +112,7 @@ public class AnnotatedHttpDocServicePluginTest {
 
         final TypeSignature map = toTypeSignature(FieldContainer.class.getDeclaredField("map")
                                                                       .getGenericType());
-        assertThat(map).isEqualTo(TypeSignature.ofMap(TypeSignature.ofBase("int64"),
+        assertThat(map).isEqualTo(TypeSignature.ofMap(TypeSignature.ofBase("long"),
                                                       TypeSignature.ofUnresolved("")));
 
         final TypeSignature future = toTypeSignature(FieldContainer.class.getDeclaredField("future")
@@ -246,9 +246,9 @@ public class AnnotatedHttpDocServicePluginTest {
                 new FieldInfoBuilder("foo", STRING).requirement(REQUIRED)
                                                    .location(QUERY)
                                                    .build(),
-                new FieldInfoBuilder("foo1", INT64).requirement(REQUIRED)
-                                                   .location(HEADER)
-                                                   .build());
+                new FieldInfoBuilder("foo1", LONG).requirement(REQUIRED)
+                                                  .location(HEADER)
+                                                  .build());
 
         assertThat(fooMethod.returnTypeSignature()).isEqualTo(VOID);
 
@@ -300,16 +300,16 @@ public class AnnotatedHttpDocServicePluginTest {
     private static FieldInfo createBean1() {
         final FieldInfo uid = new FieldInfoBuilder("uid", STRING).location(HEADER).requirement(REQUIRED)
                                                                  .build();
-        final FieldInfo seqNum = new FieldInfoBuilder("seqNum", INT64).location(QUERY).requirement(REQUIRED)
-                                                                      .build();
+        final FieldInfo seqNum = new FieldInfoBuilder("seqNum", LONG).location(QUERY).requirement(REQUIRED)
+                                                                     .build();
         return new FieldInfoBuilder(RequestBean1.class.getSimpleName(), BEAN, uid, seqNum).build();
     }
 
     private static FieldInfo createBean2() {
-        final FieldInfo inside1 = new FieldInfoBuilder("inside1", INT64).location(QUERY).requirement(REQUIRED)
-                                                                        .build();
-        final FieldInfo inside2 = new FieldInfoBuilder("inside2", INT32).location(QUERY).requirement(REQUIRED)
-                                                                        .build();
+        final FieldInfo inside1 = new FieldInfoBuilder("inside1", LONG).location(QUERY).requirement(REQUIRED)
+                                                                       .build();
+        final FieldInfo inside2 = new FieldInfoBuilder("inside2", INT).location(QUERY).requirement(REQUIRED)
+                                                                      .build();
         final FieldInfo insideBean = new FieldInfoBuilder(InsideBean.class.getSimpleName(), BEAN,
                                                           inside1, inside2).build();
         return new FieldInfoBuilder(RequestBean2.class.getSimpleName(), BEAN, insideBean).build();

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpDocServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpDocServiceTest.java
@@ -16,8 +16,8 @@
 
 package com.linecorp.armeria.internal.annotation;
 
-import static com.linecorp.armeria.internal.annotation.AnnotatedHttpDocServicePlugin.INT32;
-import static com.linecorp.armeria.internal.annotation.AnnotatedHttpDocServicePlugin.INT64;
+import static com.linecorp.armeria.internal.annotation.AnnotatedHttpDocServicePlugin.INT;
+import static com.linecorp.armeria.internal.annotation.AnnotatedHttpDocServicePlugin.LONG;
 import static com.linecorp.armeria.internal.annotation.AnnotatedHttpDocServicePlugin.STRING;
 import static com.linecorp.armeria.internal.annotation.AnnotatedHttpDocServicePlugin.toTypeSignature;
 import static com.linecorp.armeria.internal.annotation.AnnotatedHttpDocServicePluginTest.compositeBean;
@@ -143,12 +143,12 @@ public class AnnotatedHttpDocServiceTest {
         final EndpointInfo endpoint = new EndpointInfoBuilder("*", "exact:/service/foo")
                 .availableMimeTypes(MediaType.JSON_UTF_8).build();
         final List<FieldInfo> fieldInfos = ImmutableList.of(
-                new FieldInfoBuilder("header", INT32).requirement(REQUIRED)
-                                                     .location(FieldLocation.HEADER)
-                                                     .docString("header parameter").build(),
-                new FieldInfoBuilder("query", INT64).requirement(REQUIRED)
-                                                    .location(QUERY)
-                                                    .docString("query parameter").build());
+                new FieldInfoBuilder("header", INT).requirement(REQUIRED)
+                                                   .location(FieldLocation.HEADER)
+                                                   .docString("header parameter").build(),
+                new FieldInfoBuilder("query", LONG).requirement(REQUIRED)
+                                                   .location(QUERY)
+                                                   .docString("query parameter").build());
         final MethodInfo methodInfo = new MethodInfo(
                 "foo", TypeSignature.ofBase("T"), fieldInfos, ImmutableList.of(),
                 ImmutableList.of(endpoint), HttpMethod.GET, "foo method");
@@ -175,10 +175,10 @@ public class AnnotatedHttpDocServiceTest {
         final EndpointInfo endpoint = new EndpointInfoBuilder("*", "exact:/service/ints")
                 .availableMimeTypes(MediaType.JSON_UTF_8).build();
         final List<FieldInfo> fieldInfos = ImmutableList.of(
-                new FieldInfoBuilder("ints", TypeSignature.ofList(INT32)).requirement(REQUIRED)
-                                                                         .location(QUERY).build());
+                new FieldInfoBuilder("ints", TypeSignature.ofList(INT)).requirement(REQUIRED)
+                                                                       .location(QUERY).build());
         final MethodInfo methodInfo = new MethodInfo(
-                "ints", TypeSignature.ofList(INT32),
+                "ints", TypeSignature.ofList(INT),
                 fieldInfos, ImmutableList.of(),
                 ImmutableList.of(endpoint), HttpMethod.GET, null);
         methodInfos.computeIfAbsent(MyService.class, unused -> new HashSet<>()).add(methodInfo);

--- a/docs-client/src/components/VariableList/index.tsx
+++ b/docs-client/src/components/VariableList/index.tsx
@@ -110,6 +110,15 @@ class FieldInfos extends React.Component<FieldInfosProps, State> {
     return `${'\xa0'.repeat(indent)}${s}`;
   }
 
+  private static printIfNotUnspecified(s: string): string {
+    const lowerCase = s.toLowerCase();
+    if ('unspecified' === lowerCase) {
+      return '-';
+    }
+
+    return lowerCase;
+  }
+
   constructor(props: FieldInfosProps) {
     super(props);
 
@@ -170,11 +179,19 @@ class FieldInfos extends React.Component<FieldInfosProps, State> {
                 {this.props.hasLocation &&
                   variable.location && (
                     <TableCell>
-                      <code>{variable.location.toLowerCase()}</code>
+                      <code>
+                        {FieldInfos.printIfNotUnspecified(
+                          variable.location.toLowerCase(),
+                        )}
+                      </code>
                     </TableCell>
                   )}
                 <TableCell>
-                  <code>{variable.requirement.toLowerCase()}</code>
+                  <code>
+                    {FieldInfos.printIfNotUnspecified(
+                      variable.requirement.toLowerCase(),
+                    )}
+                  </code>
                 </TableCell>
                 <TableCell>
                   <code>

--- a/docs-client/src/components/VariableList/index.tsx
+++ b/docs-client/src/components/VariableList/index.tsx
@@ -48,12 +48,10 @@ export default function({
   hasLocation,
   specification,
 }: Props) {
-  let hasBean = false;
-  for (const variable of variables) {
-    if (variable.childFieldInfos && variable.childFieldInfos.length > 0) {
-      hasBean = true;
-    }
-  }
+  const hasBean = variables.some(
+    (variable) =>
+      !!variable.childFieldInfos && variable.childFieldInfos.length > 0,
+  );
   return (
     <>
       <Typography variant="title">{title}</Typography>
@@ -124,21 +122,16 @@ class FieldInfos extends React.Component<FieldInfosProps, State> {
 
     const fieldInfos = props.variables;
 
-    let isEmpty;
+    const isEmpty = fieldInfos.length === 0;
     let isBeans: boolean[] = [];
     let openBeans: boolean[] = [];
-    if (fieldInfos.length > 0) {
-      isEmpty = false;
-      isBeans = Array(fieldInfos.length).fill(false);
-      for (let i = 0; i < fieldInfos.length; i += 1) {
-        const childFieldInfos = fieldInfos[i].childFieldInfos;
-        if (childFieldInfos && childFieldInfos.length > 0) {
-          isBeans[i] = true;
-        }
-      }
+    if (!isEmpty) {
+      isBeans = fieldInfos.map(
+        ({ childFieldInfos }) =>
+          !!childFieldInfos && childFieldInfos.length > 0,
+      );
+
       openBeans = Array(fieldInfos.length).fill(false);
-    } else {
-      isEmpty = true;
     }
 
     let colSpanLength = 4;
@@ -167,9 +160,7 @@ class FieldInfos extends React.Component<FieldInfosProps, State> {
             <>
               <TableRow
                 key={FieldInfos.generateKey(variable.name)}
-                onClick={() =>
-                  this.handleCollapse(this.state.isBeans[index], index)
-                }
+                onClick={() => this.handleCollapse(index)}
               >
                 <TableCell>
                   <code>
@@ -233,11 +224,11 @@ class FieldInfos extends React.Component<FieldInfosProps, State> {
     );
   }
 
-  private handleCollapse = (isBean: boolean, index: number) => {
-    if (!isBean) {
+  private handleCollapse = (index: number) => {
+    const state = this.state;
+    if (!state.isBeans[index]) {
       return;
     }
-    const state = this.state;
     state.openBeans[index] = !state.openBeans[index];
     this.setState(state);
 

--- a/docs-client/src/components/VariableList/index.tsx
+++ b/docs-client/src/components/VariableList/index.tsx
@@ -110,7 +110,11 @@ class FieldInfos extends React.Component<FieldInfosProps, State> {
     return `${'\xa0'.repeat(indent)}${s}`;
   }
 
-  private static printIfNotUnspecified(s: string): string {
+  private static formatLocation(s: string): string {
+    return this.formatRequirement(s);
+  }
+
+  private static formatRequirement(s: string): string {
     const lowerCase = s.toLowerCase();
     if ('unspecified' === lowerCase) {
       return '-';
@@ -180,17 +184,13 @@ class FieldInfos extends React.Component<FieldInfosProps, State> {
                   variable.location && (
                     <TableCell>
                       <code>
-                        {FieldInfos.printIfNotUnspecified(
-                          variable.location.toLowerCase(),
-                        )}
+                        {FieldInfos.formatLocation(variable.location)}
                       </code>
                     </TableCell>
                   )}
                 <TableCell>
                   <code>
-                    {FieldInfos.printIfNotUnspecified(
-                      variable.requirement.toLowerCase(),
-                    )}
+                    {FieldInfos.formatRequirement(variable.requirement)}
                   </code>
                 </TableCell>
                 <TableCell>

--- a/docs-client/src/components/VariableList/index.tsx
+++ b/docs-client/src/components/VariableList/index.tsx
@@ -20,6 +20,8 @@ import TableCell from '@material-ui/core/TableCell';
 import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
 import Typography from '@material-ui/core/Typography';
+import ExpandLess from '@material-ui/icons/ExpandLess';
+import ExpandMore from '@material-ui/icons/ExpandMore';
 import React from 'react';
 
 import { Specification } from '../../lib/specification';
@@ -27,6 +29,7 @@ import { Specification } from '../../lib/specification';
 interface Variable {
   name: string;
   location?: string;
+  childFieldInfos?: Variable[];
   requirement: string;
   typeSignature: string;
   docString?: string | JSX.Element;
@@ -45,6 +48,12 @@ export default function({
   hasLocation,
   specification,
 }: Props) {
+  let hasBean = false;
+  for (const variable of variables) {
+    if (variable.childFieldInfos && variable.childFieldInfos.length > 0) {
+      hasBean = true;
+    }
+  }
   return (
     <>
       <Typography variant="title">{title}</Typography>
@@ -56,39 +65,184 @@ export default function({
             <TableCell>Required</TableCell>
             <TableCell>Type</TableCell>
             <TableCell>Description</TableCell>
+            {hasBean && <TableCell />}
           </TableRow>
         </TableHead>
         <TableBody>
-          {variables.length > 0 ? (
-            variables.map((variable) => (
-              <TableRow key={variable.name}>
-                <TableCell>
-                  <code>{variable.name}</code>
-                </TableCell>
-                {hasLocation && (
-                  <TableCell>
-                    <code>{variable.location}</code>
-                  </TableCell>
-                )}
-                <TableCell>{variable.requirement.toLowerCase()}</TableCell>
-                <TableCell>
-                  <code>
-                    {specification.getTypeSignatureHtml(variable.typeSignature)}
-                  </code>
-                </TableCell>
-                <TableCell>{variable.docString}</TableCell>
-              </TableRow>
-            ))
-          ) : (
-            <TableRow>
-              <TableCell colSpan={4}>
-                There are no {title.toLowerCase()}
-              </TableCell>
-            </TableRow>
-          )}
+          <FieldInfos
+            indent={0}
+            title={title}
+            hasLocation={hasLocation}
+            variables={variables}
+            specification={specification}
+            hasBean={hasBean}
+            childIndex={0}
+          />
         </TableBody>
       </Table>
       <Typography variant="body1" paragraph />
     </>
   );
+}
+
+interface State {
+  isEmpty: boolean;
+  isBeans: boolean[];
+  openBeans: boolean[];
+  colSpanLength: number;
+  childStates: { [key: number]: State };
+}
+
+interface OwnProps {
+  indent: number;
+  hasBean: boolean;
+  state?: State;
+  setChildStateInParent?: (index: number, childState: State) => void;
+  childIndex: number;
+}
+
+type FieldInfosProps = OwnProps & Props;
+
+class FieldInfos extends React.Component<FieldInfosProps, State> {
+  private static generateKey(pre: string): string {
+    return `${pre}_${new Date().getTime()}`;
+  }
+
+  private static indentString(indent: number, s: string): string {
+    return `${'\xa0'.repeat(indent)}${s}`;
+  }
+
+  constructor(props: FieldInfosProps) {
+    super(props);
+
+    this.setChildStateInParent = this.setChildStateInParent.bind(this);
+
+    if (props.state) {
+      this.state = props.state;
+      return;
+    }
+
+    const fieldInfos = props.variables;
+
+    let isEmpty;
+    let isBeans: boolean[] = [];
+    let openBeans: boolean[] = [];
+    if (fieldInfos.length > 0) {
+      isEmpty = false;
+      isBeans = Array(fieldInfos.length).fill(false);
+      for (let i = 0; i < fieldInfos.length; i += 1) {
+        const childFieldInfos = fieldInfos[i].childFieldInfos;
+        if (childFieldInfos && childFieldInfos.length > 0) {
+          isBeans[i] = true;
+        }
+      }
+      openBeans = Array(fieldInfos.length).fill(false);
+    } else {
+      isEmpty = true;
+    }
+
+    let colSpanLength = 4;
+    if (this.props.hasLocation) {
+      colSpanLength += 1;
+    }
+    if (this.props.hasBean) {
+      colSpanLength += 1;
+    }
+
+    const childStates = {};
+    this.state = {
+      isEmpty,
+      isBeans,
+      openBeans,
+      colSpanLength,
+      childStates,
+    };
+  }
+
+  public render() {
+    return (
+      <>
+        {!this.state.isEmpty ? (
+          this.props.variables.map((variable, index) => (
+            <>
+              <TableRow
+                key={FieldInfos.generateKey(variable.name)}
+                onClick={() =>
+                  this.handleCollapse(this.state.isBeans[index], index)
+                }
+              >
+                <TableCell>
+                  <code>
+                    {FieldInfos.indentString(this.props.indent, variable.name)}
+                  </code>
+                </TableCell>
+                {this.props.hasLocation &&
+                  variable.location && (
+                    <TableCell>
+                      <code>{variable.location.toLowerCase()}</code>
+                    </TableCell>
+                  )}
+                <TableCell>
+                  <code>{variable.requirement.toLowerCase()}</code>
+                </TableCell>
+                <TableCell>
+                  <code>
+                    {this.props.specification.getTypeSignatureHtml(
+                      variable.typeSignature,
+                    )}
+                  </code>
+                </TableCell>
+                <TableCell>{variable.docString}</TableCell>
+                {this.props.hasBean && this.showExpandIfBean(index)}
+              </TableRow>
+              {this.state.openBeans[index] && (
+                <FieldInfos
+                  {...this.props}
+                  indent={this.props.indent + 2}
+                  variables={variable.childFieldInfos!}
+                  state={this.state.childStates[index]}
+                  childIndex={index}
+                  setChildStateInParent={this.setChildStateInParent}
+                />
+              )}
+            </>
+          ))
+        ) : (
+          <TableRow>
+            <TableCell colSpan={this.state.colSpanLength}>
+              There are no {this.props.title.toLowerCase()}
+            </TableCell>
+          </TableRow>
+        )}
+      </>
+    );
+  }
+
+  private setChildStateInParent(index: number, childState: State) {
+    this.state.childStates[index] = childState;
+  }
+
+  private showExpandIfBean(index: number) {
+    return (
+      <>
+        <TableCell>
+          {this.state.isBeans[index] &&
+            (this.state.openBeans[index] ? <ExpandLess /> : <ExpandMore />)}
+        </TableCell>
+      </>
+    );
+  }
+
+  private handleCollapse = (isBean: boolean, index: number) => {
+    if (!isBean) {
+      return;
+    }
+    const state = this.state;
+    state.openBeans[index] = !state.openBeans[index];
+    this.setState(state);
+
+    if (this.props.setChildStateInParent) {
+      this.props.setChildStateInParent(this.props.childIndex, state);
+    }
+  };
 }

--- a/docs-client/src/containers/MethodPage/index.tsx
+++ b/docs-client/src/containers/MethodPage/index.tsx
@@ -146,6 +146,7 @@ export default class MethodPage extends React.PureComponent<Props, State> {
         </Typography>
         <Section>
           <VariableList
+            key={method.name}
             title="Parameters"
             variables={method.parameters}
             hasLocation={isAnnotatedHttpService}

--- a/docs-client/src/lib/specification.tsx
+++ b/docs-client/src/lib/specification.tsx
@@ -26,6 +26,7 @@ interface HasDocString {
 export interface Parameter {
   name: string;
   location?: string;
+  childFieldInfos: Parameter[];
   requirement: string;
   typeSignature: string;
   docString?: DocString;

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcDocServicePlugin.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcDocServicePlugin.java
@@ -54,6 +54,7 @@ import com.linecorp.armeria.server.docs.EndpointInfoBuilder;
 import com.linecorp.armeria.server.docs.EnumInfo;
 import com.linecorp.armeria.server.docs.EnumValueInfo;
 import com.linecorp.armeria.server.docs.FieldInfo;
+import com.linecorp.armeria.server.docs.FieldInfoBuilder;
 import com.linecorp.armeria.server.docs.FieldRequirement;
 import com.linecorp.armeria.server.docs.MethodInfo;
 import com.linecorp.armeria.server.docs.NamedTypeInfo;
@@ -240,11 +241,8 @@ public class GrpcDocServicePlugin implements DocServicePlugin {
                 method.getName(),
                 namedMessageSignature(method.getOutputType()),
                 // gRPC methods always take a single request parameter of message type.
-                ImmutableList.of(
-                        new FieldInfo(
-                                "request",
-                                FieldRequirement.REQUIRED,
-                                namedMessageSignature(method.getInputType()))),
+                ImmutableList.of(new FieldInfoBuilder("request", namedMessageSignature(method.getInputType()))
+                                         .requirement(FieldRequirement.REQUIRED).build()),
                 ImmutableList.of(),
                 methodEndpoints);
     }
@@ -259,10 +257,10 @@ public class GrpcDocServicePlugin implements DocServicePlugin {
     }
 
     private static FieldInfo newFieldInfo(FieldDescriptor fieldDescriptor) {
-        return new FieldInfo(
-                fieldDescriptor.getName(),
-                fieldDescriptor.isRequired() ? FieldRequirement.REQUIRED : FieldRequirement.OPTIONAL,
-                newFieldTypeInfo(fieldDescriptor));
+        return new FieldInfoBuilder(fieldDescriptor.getName(), newFieldTypeInfo(fieldDescriptor))
+                .requirement(fieldDescriptor.isRequired() ? FieldRequirement.REQUIRED
+                                                          : FieldRequirement.OPTIONAL)
+                .build();
     }
 
     @VisibleForTesting

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcDocServicePluginTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcDocServicePluginTest.java
@@ -54,7 +54,7 @@ import com.linecorp.armeria.server.VirtualHostBuilder;
 import com.linecorp.armeria.server.docs.EndpointInfoBuilder;
 import com.linecorp.armeria.server.docs.EnumInfo;
 import com.linecorp.armeria.server.docs.EnumValueInfo;
-import com.linecorp.armeria.server.docs.FieldInfo;
+import com.linecorp.armeria.server.docs.FieldInfoBuilder;
 import com.linecorp.armeria.server.docs.FieldRequirement;
 import com.linecorp.armeria.server.docs.MethodInfo;
 import com.linecorp.armeria.server.docs.ServiceInfo;
@@ -196,11 +196,11 @@ public class GrpcDocServicePluginTest {
         final MethodInfo emptyCall = functions.get("EmptyCall");
         assertThat(emptyCall.name()).isEqualTo("EmptyCall");
         assertThat(emptyCall.parameters())
-                .containsExactly(
-                        new FieldInfo(
-                                "request",
-                                FieldRequirement.REQUIRED,
-                                TypeSignature.ofNamed("armeria.grpc.testing.Empty", Empty.getDescriptor())));
+                .containsExactly(new FieldInfoBuilder("request",
+                                                      TypeSignature.ofNamed("armeria.grpc.testing.Empty",
+                                                                            Empty.getDescriptor()))
+                                         .requirement(FieldRequirement.REQUIRED)
+                                         .build());
         assertThat(emptyCall.returnTypeSignature())
                 .isEqualTo(TypeSignature.ofNamed("armeria.grpc.testing.Empty", Empty.getDescriptor()));
 

--- a/thrift/src/main/java/com/linecorp/armeria/server/thrift/ThriftDocServicePlugin.java
+++ b/thrift/src/main/java/com/linecorp/armeria/server/thrift/ThriftDocServicePlugin.java
@@ -63,6 +63,7 @@ import com.linecorp.armeria.server.docs.EndpointInfoBuilder;
 import com.linecorp.armeria.server.docs.EnumInfo;
 import com.linecorp.armeria.server.docs.ExceptionInfo;
 import com.linecorp.armeria.server.docs.FieldInfo;
+import com.linecorp.armeria.server.docs.FieldInfoBuilder;
 import com.linecorp.armeria.server.docs.FieldRequirement;
 import com.linecorp.armeria.server.docs.MethodInfo;
 import com.linecorp.armeria.server.docs.NamedTypeInfo;
@@ -180,7 +181,7 @@ public class ThriftDocServicePlugin implements DocServicePlugin {
 
         Class<?> resultClass;
         try {
-            resultClass =  Class.forName(serviceName + '$' + methodName + "_result", false, classLoader);
+            resultClass = Class.forName(serviceName + '$' + methodName + "_result", false, classLoader);
         } catch (ClassNotFoundException ignored) {
             // Oneway function does not have a result type.
             resultClass = null;
@@ -315,9 +316,8 @@ public class ThriftDocServicePlugin implements DocServicePlugin {
             typeSignature = toTypeSignature(fieldValueMetaData);
         }
 
-        return new FieldInfo(fieldMetaData.fieldName,
-                             convertRequirement(fieldMetaData.requirementType),
-                             typeSignature);
+        return new FieldInfoBuilder(fieldMetaData.fieldName, typeSignature)
+                .requirement(convertRequirement(fieldMetaData.requirementType)).build();
     }
 
     @VisibleForTesting

--- a/thrift/src/main/java/com/linecorp/armeria/server/thrift/ThriftDocServicePlugin.java
+++ b/thrift/src/main/java/com/linecorp/armeria/server/thrift/ThriftDocServicePlugin.java
@@ -383,7 +383,8 @@ public class ThriftDocServicePlugin implements DocServicePlugin {
             case TFieldRequirementType.OPTIONAL:
                 return FieldRequirement.OPTIONAL;
             case TFieldRequirementType.DEFAULT:
-                return FieldRequirement.DEFAULT;
+                // Convert to unspecified for consistency with gRPC and AnnotatedHttpService.
+                return FieldRequirement.UNSPECIFIED;
             default:
                 throw new IllegalArgumentException("unknown requirement type: " + value);
         }

--- a/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftDocServicePluginTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftDocServicePluginTest.java
@@ -177,37 +177,37 @@ public class ThriftDocServicePluginTest {
         final TypeSignature foo = TypeSignature.ofNamed(FooStruct.class);
         final MethodInfo bar3 = methods.get("bar3");
         assertThat(bar3.parameters()).containsExactly(
-                new FieldInfoBuilder("intVal", TypeSignature.ofBase("i32")).build(),
-                new FieldInfoBuilder("foo", foo).build());
+                FieldInfo.of("intVal", TypeSignature.ofBase("i32")),
+                FieldInfo.of("foo", foo));
         assertThat(bar3.returnTypeSignature()).isEqualTo(foo);
         assertThat(bar3.exceptionTypeSignatures()).hasSize(1);
         assertThat(bar3.exampleRequests()).isEmpty();
 
         final MethodInfo bar4 = methods.get("bar4");
         assertThat(bar4.parameters()).containsExactly(
-                new FieldInfoBuilder("foos", TypeSignature.ofList(foo)).build());
+                FieldInfo.of("foos", TypeSignature.ofList(foo)));
         assertThat(bar4.returnTypeSignature()).isEqualTo(TypeSignature.ofList(foo));
         assertThat(bar4.exceptionTypeSignatures()).hasSize(1);
         assertThat(bar4.exampleRequests()).isEmpty();
 
         final MethodInfo bar5 = methods.get("bar5");
         assertThat(bar5.parameters()).containsExactly(
-                new FieldInfoBuilder("foos", TypeSignature.ofMap(string, foo)).build());
+                FieldInfo.of("foos", TypeSignature.ofMap(string, foo)));
         assertThat(bar5.returnTypeSignature()).isEqualTo(TypeSignature.ofMap(string, foo));
         assertThat(bar5.exceptionTypeSignatures()).hasSize(1);
         assertThat(bar5.exampleRequests()).isEmpty();
 
         final MethodInfo bar6 = methods.get("bar6");
         assertThat(bar6.parameters()).containsExactly(
-                new FieldInfoBuilder("foo1", string).build(),
-                new FieldInfoBuilder("foo2", TypeSignature.ofUnresolved("TypedefedStruct")).build(),
-                new FieldInfoBuilder("foo3", TypeSignature.ofUnresolved("TypedefedEnum")).build(),
-                new FieldInfoBuilder("foo4", TypeSignature.ofUnresolved("TypedefedMap")).build(),
-                new FieldInfoBuilder("foo5", TypeSignature.ofUnresolved("TypedefedList")).build(),
-                new FieldInfoBuilder("foo6", TypeSignature.ofUnresolved("TypedefedSet")).build(),
-                new FieldInfoBuilder("foo7", TypeSignature.ofUnresolved("NestedTypedefedStructs")).build(),
-                new FieldInfoBuilder("foo8", TypeSignature.ofList(TypeSignature.ofList(
-                        TypeSignature.ofUnresolved("TypedefedStruct")))).build());
+                FieldInfo.of("foo1", string),
+                FieldInfo.of("foo2", TypeSignature.ofUnresolved("TypedefedStruct")),
+                FieldInfo.of("foo3", TypeSignature.ofUnresolved("TypedefedEnum")),
+                FieldInfo.of("foo4", TypeSignature.ofUnresolved("TypedefedMap")),
+                FieldInfo.of("foo5", TypeSignature.ofUnresolved("TypedefedList")),
+                FieldInfo.of("foo6", TypeSignature.ofUnresolved("TypedefedSet")),
+                FieldInfo.of("foo7", TypeSignature.ofUnresolved("NestedTypedefedStructs")),
+                FieldInfo.of("foo8", TypeSignature.ofList(TypeSignature.ofList(
+                        TypeSignature.ofUnresolved("TypedefedStruct")))));
 
         assertThat(bar6.returnTypeSignature()).isEqualTo(TypeSignature.ofBase("void"));
         assertThat(bar6.exceptionTypeSignatures()).isEmpty();
@@ -221,20 +221,20 @@ public class ThriftDocServicePluginTest {
     public void testNewStructInfoTest() throws Exception {
         final TypeSignature string = TypeSignature.ofBase("string");
         final List<FieldInfo> fields = new ArrayList<>();
-        fields.add(new FieldInfoBuilder("boolVal", TypeSignature.ofBase("bool")).build());
-        fields.add(new FieldInfoBuilder("byteVal", TypeSignature.ofBase("i8")).build());
-        fields.add(new FieldInfoBuilder("i16Val", TypeSignature.ofBase("i16")).build());
-        fields.add(new FieldInfoBuilder("i32Val", TypeSignature.ofBase("i32")).build());
-        fields.add(new FieldInfoBuilder("i64Val", TypeSignature.ofBase("i64")).build());
-        fields.add(new FieldInfoBuilder("doubleVal", TypeSignature.ofBase("double")).build());
-        fields.add(new FieldInfoBuilder("stringVal", string).build());
-        fields.add(new FieldInfoBuilder("binaryVal", TypeSignature.ofBase("binary")).build());
-        fields.add(new FieldInfoBuilder("enumVal", TypeSignature.ofNamed(FooEnum.class)).build());
-        fields.add(new FieldInfoBuilder("unionVal", TypeSignature.ofNamed(FooUnion.class)).build());
-        fields.add(new FieldInfoBuilder("mapVal", TypeSignature.ofMap(
-                string, TypeSignature.ofNamed(FooEnum.class))).build());
-        fields.add(new FieldInfoBuilder("setVal", TypeSignature.ofSet(FooUnion.class)).build());
-        fields.add(new FieldInfoBuilder("listVal", TypeSignature.ofList(string)).build());
+        fields.add(FieldInfo.of("boolVal", TypeSignature.ofBase("bool")));
+        fields.add(FieldInfo.of("byteVal", TypeSignature.ofBase("i8")));
+        fields.add(FieldInfo.of("i16Val", TypeSignature.ofBase("i16")));
+        fields.add(FieldInfo.of("i32Val", TypeSignature.ofBase("i32")));
+        fields.add(FieldInfo.of("i64Val", TypeSignature.ofBase("i64")));
+        fields.add(FieldInfo.of("doubleVal", TypeSignature.ofBase("double")));
+        fields.add(FieldInfo.of("stringVal", string));
+        fields.add(FieldInfo.of("binaryVal", TypeSignature.ofBase("binary")));
+        fields.add(FieldInfo.of("enumVal", TypeSignature.ofNamed(FooEnum.class)));
+        fields.add(FieldInfo.of("unionVal", TypeSignature.ofNamed(FooUnion.class)));
+        fields.add(FieldInfo.of("mapVal", TypeSignature.ofMap(
+                string, TypeSignature.ofNamed(FooEnum.class))));
+        fields.add(FieldInfo.of("setVal", TypeSignature.ofSet(FooUnion.class)));
+        fields.add(FieldInfo.of("listVal", TypeSignature.ofList(string)));
         fields.add(new FieldInfoBuilder("selfRef", TypeSignature.ofNamed(FooStruct.class))
                            .requirement(FieldRequirement.OPTIONAL).build());
 

--- a/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftDocServicePluginTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftDocServicePluginTest.java
@@ -51,6 +51,7 @@ import com.linecorp.armeria.server.docs.EnumInfo;
 import com.linecorp.armeria.server.docs.EnumValueInfo;
 import com.linecorp.armeria.server.docs.ExceptionInfo;
 import com.linecorp.armeria.server.docs.FieldInfo;
+import com.linecorp.armeria.server.docs.FieldInfoBuilder;
 import com.linecorp.armeria.server.docs.FieldRequirement;
 import com.linecorp.armeria.server.docs.MethodInfo;
 import com.linecorp.armeria.server.docs.ServiceInfo;
@@ -176,44 +177,37 @@ public class ThriftDocServicePluginTest {
         final TypeSignature foo = TypeSignature.ofNamed(FooStruct.class);
         final MethodInfo bar3 = methods.get("bar3");
         assertThat(bar3.parameters()).containsExactly(
-                new FieldInfo("intVal", FieldRequirement.DEFAULT, TypeSignature.ofBase("i32")),
-                new FieldInfo("foo", FieldRequirement.DEFAULT, foo));
+                new FieldInfoBuilder("intVal", TypeSignature.ofBase("i32")).build(),
+                new FieldInfoBuilder("foo", foo).build());
         assertThat(bar3.returnTypeSignature()).isEqualTo(foo);
         assertThat(bar3.exceptionTypeSignatures()).hasSize(1);
         assertThat(bar3.exampleRequests()).isEmpty();
 
         final MethodInfo bar4 = methods.get("bar4");
         assertThat(bar4.parameters()).containsExactly(
-                new FieldInfo("foos", FieldRequirement.DEFAULT, TypeSignature.ofList(foo)));
+                new FieldInfoBuilder("foos", TypeSignature.ofList(foo)).build());
         assertThat(bar4.returnTypeSignature()).isEqualTo(TypeSignature.ofList(foo));
         assertThat(bar4.exceptionTypeSignatures()).hasSize(1);
         assertThat(bar4.exampleRequests()).isEmpty();
 
         final MethodInfo bar5 = methods.get("bar5");
         assertThat(bar5.parameters()).containsExactly(
-                new FieldInfo("foos", FieldRequirement.DEFAULT, TypeSignature.ofMap(string, foo)));
+                new FieldInfoBuilder("foos", TypeSignature.ofMap(string, foo)).build());
         assertThat(bar5.returnTypeSignature()).isEqualTo(TypeSignature.ofMap(string, foo));
         assertThat(bar5.exceptionTypeSignatures()).hasSize(1);
         assertThat(bar5.exampleRequests()).isEmpty();
 
         final MethodInfo bar6 = methods.get("bar6");
         assertThat(bar6.parameters()).containsExactly(
-                new FieldInfo("foo1", FieldRequirement.DEFAULT, string),
-                new FieldInfo("foo2", FieldRequirement.DEFAULT,
-                              TypeSignature.ofUnresolved("TypedefedStruct")),
-                new FieldInfo("foo3", FieldRequirement.DEFAULT,
-                              TypeSignature.ofUnresolved("TypedefedEnum")),
-                new FieldInfo("foo4", FieldRequirement.DEFAULT,
-                              TypeSignature.ofUnresolved("TypedefedMap")),
-                new FieldInfo("foo5", FieldRequirement.DEFAULT,
-                              TypeSignature.ofUnresolved("TypedefedList")),
-                new FieldInfo("foo6", FieldRequirement.DEFAULT,
-                              TypeSignature.ofUnresolved("TypedefedSet")),
-                new FieldInfo("foo7", FieldRequirement.DEFAULT,
-                              TypeSignature.ofUnresolved("NestedTypedefedStructs")),
-                new FieldInfo("foo8", FieldRequirement.DEFAULT,
-                              TypeSignature.ofList(TypeSignature.ofList(
-                                      TypeSignature.ofUnresolved("TypedefedStruct")))));
+                new FieldInfoBuilder("foo1", string).build(),
+                new FieldInfoBuilder("foo2", TypeSignature.ofUnresolved("TypedefedStruct")).build(),
+                new FieldInfoBuilder("foo3", TypeSignature.ofUnresolved("TypedefedEnum")).build(),
+                new FieldInfoBuilder("foo4", TypeSignature.ofUnresolved("TypedefedMap")).build(),
+                new FieldInfoBuilder("foo5", TypeSignature.ofUnresolved("TypedefedList")).build(),
+                new FieldInfoBuilder("foo6", TypeSignature.ofUnresolved("TypedefedSet")).build(),
+                new FieldInfoBuilder("foo7", TypeSignature.ofUnresolved("NestedTypedefedStructs")).build(),
+                new FieldInfoBuilder("foo8", TypeSignature.ofList(TypeSignature.ofList(
+                        TypeSignature.ofUnresolved("TypedefedStruct")))).build());
 
         assertThat(bar6.returnTypeSignature()).isEqualTo(TypeSignature.ofBase("void"));
         assertThat(bar6.exceptionTypeSignatures()).isEmpty();
@@ -227,21 +221,22 @@ public class ThriftDocServicePluginTest {
     public void testNewStructInfoTest() throws Exception {
         final TypeSignature string = TypeSignature.ofBase("string");
         final List<FieldInfo> fields = new ArrayList<>();
-        fields.add(new FieldInfo("boolVal", FieldRequirement.DEFAULT, TypeSignature.ofBase("bool")));
-        fields.add(new FieldInfo("byteVal", FieldRequirement.DEFAULT, TypeSignature.ofBase("i8")));
-        fields.add(new FieldInfo("i16Val", FieldRequirement.DEFAULT, TypeSignature.ofBase("i16")));
-        fields.add(new FieldInfo("i32Val", FieldRequirement.DEFAULT, TypeSignature.ofBase("i32")));
-        fields.add(new FieldInfo("i64Val", FieldRequirement.DEFAULT, TypeSignature.ofBase("i64")));
-        fields.add(new FieldInfo("doubleVal", FieldRequirement.DEFAULT, TypeSignature.ofBase("double")));
-        fields.add(new FieldInfo("stringVal", FieldRequirement.DEFAULT, string));
-        fields.add(new FieldInfo("binaryVal", FieldRequirement.DEFAULT, TypeSignature.ofBase("binary")));
-        fields.add(new FieldInfo("enumVal", FieldRequirement.DEFAULT, TypeSignature.ofNamed(FooEnum.class)));
-        fields.add(new FieldInfo("unionVal", FieldRequirement.DEFAULT, TypeSignature.ofNamed(FooUnion.class)));
-        fields.add(new FieldInfo("mapVal", FieldRequirement.DEFAULT,
-                                 TypeSignature.ofMap(string, TypeSignature.ofNamed(FooEnum.class))));
-        fields.add(new FieldInfo("setVal", FieldRequirement.DEFAULT, TypeSignature.ofSet(FooUnion.class)));
-        fields.add(new FieldInfo("listVal", FieldRequirement.DEFAULT, TypeSignature.ofList(string)));
-        fields.add(new FieldInfo("selfRef", FieldRequirement.OPTIONAL, TypeSignature.ofNamed(FooStruct.class)));
+        fields.add(new FieldInfoBuilder("boolVal", TypeSignature.ofBase("bool")).build());
+        fields.add(new FieldInfoBuilder("byteVal", TypeSignature.ofBase("i8")).build());
+        fields.add(new FieldInfoBuilder("i16Val", TypeSignature.ofBase("i16")).build());
+        fields.add(new FieldInfoBuilder("i32Val", TypeSignature.ofBase("i32")).build());
+        fields.add(new FieldInfoBuilder("i64Val", TypeSignature.ofBase("i64")).build());
+        fields.add(new FieldInfoBuilder("doubleVal", TypeSignature.ofBase("double")).build());
+        fields.add(new FieldInfoBuilder("stringVal", string).build());
+        fields.add(new FieldInfoBuilder("binaryVal", TypeSignature.ofBase("binary")).build());
+        fields.add(new FieldInfoBuilder("enumVal", TypeSignature.ofNamed(FooEnum.class)).build());
+        fields.add(new FieldInfoBuilder("unionVal", TypeSignature.ofNamed(FooUnion.class)).build());
+        fields.add(new FieldInfoBuilder("mapVal", TypeSignature.ofMap(
+                string, TypeSignature.ofNamed(FooEnum.class))).build());
+        fields.add(new FieldInfoBuilder("setVal", TypeSignature.ofSet(FooUnion.class)).build());
+        fields.add(new FieldInfoBuilder("listVal", TypeSignature.ofList(string)).build());
+        fields.add(new FieldInfoBuilder("selfRef", TypeSignature.ofNamed(FooStruct.class))
+                           .requirement(FieldRequirement.OPTIONAL).build());
 
         final StructInfo fooStruct = newStructInfo(FooStruct.class);
         assertThat(fooStruct).isEqualTo(new StructInfo(FooStruct.class.getName(), fields));


### PR DESCRIPTION
Motivation:
Currently, `RequestObject`s are not shown in `DocService`.

Modifications:
- Rename `AnnotatedBeanFactory` to `AnnotatedBeanFactoryRegistry`
- Add `AnnotatedBeanFactory` which has information about the bean factory
- Add `EndpointInfoBuilder` to make it `EndpointInfo` easily
- Add `FieldLocation` enum

Result:
- Better developer experience