### PR TITLE
Fix missing `httpStatus` tag in the default `MeterIdPrefixFunction`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
@@ -459,17 +459,25 @@ public class DefaultRequestLog implements RequestLog, RequestLogBuilder {
         this.requestLength = requestLength;
     }
 
-    private void requestFirstBytesTransferred(long timestamp) {
+    @Override
+    public void requestFirstBytesTransferred() {
         if (isAvailabilityAlreadyUpdated(REQUEST_FIRST_BYTES_TRANSFERRED)) {
             return;
         }
-        requestFirstBytesTransferredTimeNanos = timestamp;
-        updateAvailability(REQUEST_FIRST_BYTES_TRANSFERRED);
+        requestFirstBytesTransferred0(System.nanoTime());
     }
 
     @Override
-    public void requestFirstBytesTransferred() {
-        requestFirstBytesTransferred(System.nanoTime());
+    public void requestFirstBytesTransferred(long requestFirstBytesTransferredTimeNanos) {
+        if (isAvailabilityAlreadyUpdated(REQUEST_FIRST_BYTES_TRANSFERRED)) {
+            return;
+        }
+        requestFirstBytesTransferred0(requestFirstBytesTransferredTimeNanos);
+    }
+
+    private void requestFirstBytesTransferred0(long requestFirstBytesTransferredTimeNanos) {
+        this.requestFirstBytesTransferredTimeNanos = requestFirstBytesTransferredTimeNanos;
+        updateAvailability(REQUEST_FIRST_BYTES_TRANSFERRED);
     }
 
     @Override
@@ -665,17 +673,25 @@ public class DefaultRequestLog implements RequestLog, RequestLogBuilder {
         this.responseLength = responseLength;
     }
 
-    private void responseFirstBytesTransferred(long timestamp) {
+    @Override
+    public void responseFirstBytesTransferred() {
         if (isAvailabilityAlreadyUpdated(RESPONSE_FIRST_BYTES_TRANSFERRED)) {
             return;
         }
-        responseFirstBytesTransferredTimeNanos = timestamp;
-        updateAvailability(RESPONSE_FIRST_BYTES_TRANSFERRED);
+        responseFirstBytesTransferred0(System.nanoTime());
     }
 
     @Override
-    public void responseFirstBytesTransferred() {
-        responseFirstBytesTransferred(System.nanoTime());
+    public void responseFirstBytesTransferred(long responseFirstBytesTransferredTimeNanos) {
+        if (isAvailabilityAlreadyUpdated(RESPONSE_FIRST_BYTES_TRANSFERRED)) {
+            return;
+        }
+        responseFirstBytesTransferred0(responseFirstBytesTransferredTimeNanos);
+    }
+
+    private void responseFirstBytesTransferred0(long responseFirstBytesTransferredTimeNanos) {
+        this.responseFirstBytesTransferredTimeNanos = responseFirstBytesTransferredTimeNanos;
+        updateAvailability(RESPONSE_FIRST_BYTES_TRANSFERRED);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/logging/NoopRequestLogBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/NoopRequestLogBuilder.java
@@ -34,6 +34,13 @@ final class NoopRequestLogBuilder implements RequestLogBuilder {
     public void endResponseWithLastChild() {}
 
     @Override
+    public void startRequest(Channel channel, SessionProtocol sessionProtocol) {}
+
+    @Override
+    public void startRequest(Channel channel, SessionProtocol sessionProtocol,
+                             long requestStartTimeNanos, long requestStartTimeMicros) {}
+
+    @Override
     public void startRequest(Channel ch, SessionProtocol sessionProtocol, @Nullable SSLSession sslSession) {}
 
     @Override
@@ -51,6 +58,9 @@ final class NoopRequestLogBuilder implements RequestLogBuilder {
 
     @Override
     public void requestFirstBytesTransferred() {}
+
+    @Override
+    public void requestFirstBytesTransferred(long requestFirstBytesTransferredNanos) {}
 
     @Override
     public void requestHeaders(HttpHeaders requestHeaders) {}
@@ -92,6 +102,9 @@ final class NoopRequestLogBuilder implements RequestLogBuilder {
 
     @Override
     public void responseFirstBytesTransferred() {}
+
+    @Override
+    public void responseFirstBytesTransferred(long responseFirstBytesTransferredNanos) {}
 
     @Override
     public void responseHeaders(HttpHeaders responseHeaders) {}

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogAvailability.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogAvailability.java
@@ -45,9 +45,9 @@ public enum RequestLogAvailability {
 
     /**
      * {@link RequestLog#requestHeaders()} is available, as well as all the properties mentioned in
-     * {@link #REQUEST_START} and {@link #REQUEST_FIRST_BYTES_TRANSFERRED}.
+     * {@link #REQUEST_START}.
      */
-    REQUEST_HEADERS(1 | 4 | 8, 8),
+    REQUEST_HEADERS(1 | 8, 8),
     /**
      * {@link RequestLog#requestContent()} is available, as well as all the properties mentioned in
      * {@link #REQUEST_START}.
@@ -56,10 +56,9 @@ public enum RequestLogAvailability {
     /**
      * {@link RequestLog#requestLength()}, {@link RequestLog#requestCause()} and
      * {@link RequestLog#requestDurationNanos()} are available, as well as all the properties mentioned in
-     * {@link #REQUEST_START}, {@link #SCHEME}, {@link #REQUEST_FIRST_BYTES_TRANSFERRED}
-     * {@link #REQUEST_HEADERS} and {@link #REQUEST_CONTENT}.
+     * {@link #REQUEST_START}, {@link #SCHEME}, {@link #REQUEST_HEADERS} and {@link #REQUEST_CONTENT}.
      */
-    REQUEST_END(1 | 2 | 4 | 8 | 16 | 32, 1 | 2 | 4 | 8 | 16 | 32),
+    REQUEST_END(1 | 2 | 8 | 16 | 32, 1 | 2 | 8 | 16 | 32),
 
     // Response availability
     /**
@@ -75,9 +74,9 @@ public enum RequestLogAvailability {
 
     /**
      * {@link RequestLog#responseHeaders()} is available, as well as all the properties mentioned in
-     * {@link #RESPONSE_START} and {@link #RESPONSE_FIRST_BYTES_TRANSFERRED}.
+     * {@link #RESPONSE_START}.
      */
-    RESPONSE_HEADERS((1 | 2 | 4) << 16, 4 << 16),
+    RESPONSE_HEADERS((1 | 4) << 16, 4 << 16),
     /**
      * {@link RequestLog#responseContent()} is available, as well as all the properties mentioned in
      * {@link #RESPONSE_START}.
@@ -86,17 +85,18 @@ public enum RequestLogAvailability {
     /**
      * {@link RequestLog#responseLength()}, {@link RequestLog#responseCause()},
      * {@link RequestLog#responseDurationNanos()} and {@link RequestLog#totalDurationNanos()} are available,
-     * as well as all the properties mentioned in {@link #RESPONSE_START},
-     * {@link #RESPONSE_FIRST_BYTES_TRANSFERRED}, {@link #RESPONSE_HEADERS} and
+     * as well as all the properties mentioned in {@link #RESPONSE_START}, {@link #RESPONSE_HEADERS} and
      * {@link #RESPONSE_CONTENT}.
      */
-    RESPONSE_END((1 | 2 | 4 | 8 | 16) << 16, (1 | 2 | 4 | 8 | 16) << 16),
+    RESPONSE_END((1 | 4 | 8 | 16) << 16, (1 | 4 | 8 | 16) << 16),
 
     // Everything
     /**
      * All the properties mentioned in {@link #REQUEST_END} and {@link #RESPONSE_END} are available.
+     * Note that {@link #REQUEST_FIRST_BYTES_TRANSFERRED} and {@link #RESPONSE_FIRST_BYTES_TRANSFERRED}
+     * may not be fulfilled if network transfer did not occur.
      */
-    COMPLETE(1 | 2 | 4 | 8 | 16 | 32 | (1 | 2 | 4 | 8 | 16) << 16, /* unused */ 0);
+    COMPLETE(1 | 2 | 8 | 16 | 32 | (1 | 4 | 8 | 16) << 16, /* unused */ 0);
 
     private final int getterFlags;
     private final int setterFlags;

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogBuilder.java
@@ -163,6 +163,11 @@ public interface RequestLogBuilder {
     void requestFirstBytesTransferred();
 
     /**
+     * Sets {@link RequestLog#requestFirstBytesTransferredTimeNanos()} with the specified timestamp.
+     */
+    void requestFirstBytesTransferred(long requestFirstBytesTransferredNanos);
+
+    /**
      * Sets the {@link RequestLog#requestHeaders()}.
      */
     void requestHeaders(HttpHeaders requestHeaders);
@@ -273,6 +278,11 @@ public interface RequestLogBuilder {
      * Sets {@link RequestLog#responseFirstBytesTransferredTimeNanos()}.
      */
     void responseFirstBytesTransferred();
+
+    /**
+     * Sets {@link RequestLog#responseFirstBytesTransferredTimeNanos()} with the specified timestamp.
+     */
+    void responseFirstBytesTransferred(long responseFirstBytesTransferredNanos);
 
     /**
      * Sets the {@link RequestLog#responseHeaders()}.

--- a/core/src/main/java/com/linecorp/armeria/common/metric/MeterIdPrefixFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/MeterIdPrefixFunction.java
@@ -79,9 +79,15 @@ public interface MeterIdPrefixFunction {
             @Override
             public MeterIdPrefix apply(MeterRegistry registry, RequestLog log) {
                 final List<Tag> tags = buildTags(log);
+
+                // Add the 'httpStatus' tag.
+                final HttpStatus status;
                 if (log.isAvailable(RequestLogAvailability.RESPONSE_HEADERS)) {
-                    tags.add(Tag.of("httpStatus", log.status().codeAsText()));
+                    status = log.status();
+                } else {
+                    status = HttpStatus.UNKNOWN;
                 }
+                tags.add(Tag.of("httpStatus", status.codeAsText()));
 
                 return new MeterIdPrefix(name, tags);
             }

--- a/core/src/test/java/com/linecorp/armeria/common/metric/MeterIdPrefixFunctionTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/metric/MeterIdPrefixFunctionTest.java
@@ -18,13 +18,22 @@ package com.linecorp.armeria.common.metric;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import javax.annotation.Nullable;
+
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableList;
 
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.logging.RequestLog;
+import com.linecorp.armeria.server.ServiceRequestContext;
 
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
 
 public class MeterIdPrefixFunctionTest {
 
@@ -65,5 +74,85 @@ public class MeterIdPrefixFunctionTest {
                 .isEqualTo(new MeterIdPrefix("foo.bar", ImmutableList.of()));
         assertThat(f2.activeRequestPrefix(PrometheusMeterRegistries.newRegistry(), null))
                 .isEqualTo(new MeterIdPrefix("oof.bar", ImmutableList.of()));
+    }
+
+    @Test
+    public void defaultApply() {
+        final MeterRegistry registry = NoopMeterRegistry.get();
+        final MeterIdPrefixFunction f = MeterIdPrefixFunction.ofDefault("foo");
+
+        RequestContext ctx;
+        MeterIdPrefix res;
+
+        // A simple HTTP request.
+        ctx = newContext(HttpMethod.GET, "/", null);
+        res = f.apply(registry, ctx.log());
+        assertThat(res.name()).isEqualTo("foo");
+        assertThat(res.tags()).containsExactly(Tag.of("hostnamePattern", "*"),
+                                               Tag.of("httpStatus", "0"),
+                                               Tag.of("method", "GET"),
+                                               Tag.of("pathMapping", "exact:/"));
+
+        // An RPC request.
+        ctx = newContext(HttpMethod.POST, "/post", RpcRequest.of(Object.class, "doFoo"));
+        res = f.apply(registry, ctx.log());
+        assertThat(res.name()).isEqualTo("foo");
+        assertThat(res.tags()).containsExactly(Tag.of("hostnamePattern", "*"),
+                                               Tag.of("httpStatus", "0"),
+                                               Tag.of("method", "doFoo"),
+                                               Tag.of("pathMapping", "exact:/post"));
+
+        // HTTP response status.
+        ctx = newContext(HttpMethod.GET, "/get", null);
+        ctx.logBuilder().startResponse();
+        ctx.logBuilder().responseHeaders(HttpHeaders.of(200));
+        res = f.apply(registry, ctx.log());
+        assertThat(res.name()).isEqualTo("foo");
+        assertThat(res.tags()).containsExactly(Tag.of("hostnamePattern", "*"),
+                                               Tag.of("httpStatus", "200"),
+                                               Tag.of("method", "GET"),
+                                               Tag.of("pathMapping", "exact:/get"));
+    }
+
+    @Test
+    public void defaultActiveRequestPrefix() {
+        final MeterRegistry registry = NoopMeterRegistry.get();
+        final MeterIdPrefixFunction f = MeterIdPrefixFunction.ofDefault("foo");
+
+        RequestContext ctx;
+        MeterIdPrefix res;
+
+        // A simple HTTP request.
+        ctx = newContext(HttpMethod.GET, "/", null);
+        res = f.activeRequestPrefix(registry, ctx.log());
+        assertThat(res.name()).isEqualTo("foo");
+        assertThat(res.tags()).containsExactly(Tag.of("hostnamePattern", "*"),
+                                               Tag.of("method", "GET"),
+                                               Tag.of("pathMapping", "exact:/"));
+
+        // An RPC request.
+        ctx = newContext(HttpMethod.POST, "/post", RpcRequest.of(Object.class, "doFoo"));
+        res = f.activeRequestPrefix(registry, ctx.log());
+        assertThat(res.name()).isEqualTo("foo");
+        assertThat(res.tags()).containsExactly(Tag.of("hostnamePattern", "*"),
+                                               Tag.of("method", "doFoo"),
+                                               Tag.of("pathMapping", "exact:/post"));
+
+        // HTTP response status.
+        ctx = newContext(HttpMethod.GET, "/get", null);
+        ctx.logBuilder().startResponse();
+        ctx.logBuilder().responseHeaders(HttpHeaders.of(200));
+        res = f.activeRequestPrefix(registry, ctx.log());
+        assertThat(res.name()).isEqualTo("foo");
+        assertThat(res.tags()).containsExactly(Tag.of("hostnamePattern", "*"),
+                                               Tag.of("method", "GET"),
+                                               Tag.of("pathMapping", "exact:/get"));
+    }
+
+    private static RequestContext newContext(HttpMethod method, String path, @Nullable Object requestContent) {
+        final ServiceRequestContext ctx = ServiceRequestContext.of(HttpRequest.of(method, path));
+        ctx.logBuilder().requestContent(requestContent, null);
+        ctx.logBuilder().endRequest();
+        return ctx;
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/internal/metric/RequestMetricSupportTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/metric/RequestMetricSupportTest.java
@@ -63,7 +63,6 @@ public class RequestMetricSupportTest {
         assertThat(measurements).containsEntry("foo.activeRequests#value{method=POST}", 1.0);
 
         ctx.logBuilder().responseHeaders(HttpHeaders.of(200));
-        ctx.logBuilder().responseFirstBytesTransferred();
         ctx.logBuilder().responseLength(456);
 
         ctx.logBuilder().endRequest();


### PR DESCRIPTION
Related commits:
- ff918a90e7ccddf793b3752aa526de2e8f23f08d #1258 #1260
- b268e04650bdf677a3f7bd6712c5af678c68b765 #1421 #1423

Motivation:

1. The default `MeterIdPrefixFunction` sometimes does not add the
   `httpStatus` tag. We should add it with an unknown status instead.
2. `requestFirstBytesTransferred` and `responseFirstBytesTransferred` in
   `RequestLog` should be independent from other availability types,
   because a request can have headers even if the request or response
   was not transferred at all.

Modifications:

- Fixed the default `MeterIdPrefixFunction` implementation so that `0`
  is used for an unknown status.
- Changed the read/write dependency of `requestFirstBytesTransferred`
  and `responseFirstBytesTransferred` so that a request can be complete
  even if no bytes were transferred.

Result:

- Prometheus does not complain about inconsistent tags anymore.
- `RequestLog` reaches the `COMPLETE` availability even if no bytes were
  transferred, i.e. Fixed a bug where some `RequestLog` did not reach
  the `COMPLETE` availability forever.