### PR TITLE
Support an alias for a bunch of annotations

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -122,6 +122,11 @@ This product depends on Caffeine, distributed by Ben Manes:
   * License: licenses/LICENSE.caffeine.al20.txt (Apache License v2.0)
   * Homepage: https://github.com/ben-manes/caffeine
 
+This product depends on cglib, distributed by the cglib authors:
+
+  * License: licenses/LICENSE.cglib.al20.txt (Apache License v2.0)
+  * Homepage: https://github.com/cglib/cglib
+
 This product depends on completable-futures, distributed by Spotify AB:
 
   * License: license/LICENSE.completable-futures.al20.txt (Apache License v2.0)

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,4 +1,7 @@
 dependencies {
+    // cglib
+    testCompile 'cglib:cglib'
+
     // Caffeine
     compile 'com.github.ben-manes.caffeine:caffeine'
 

--- a/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotationUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotationUtil.java
@@ -77,11 +77,14 @@ final class AnnotationUtil {
                             Retention.class, Repeatable.class, Target.class);
 
     /**
-     * Returns an annotation of the {@code annotationType} or {@link Optional#empty()}, which is found
-     * from the specified {@code element}.
-     *
-     * <p>Note that this method will <em>not</em> find annotations from both the super classes of
-     * the {@code element} and the meta-annotations.
+     * Returns an annotation of the {@code annotationType} if it is found from one of the following:
+     * <ul>
+     *     <li>the specified {@code element}</li>
+     *     <li>the super classes of the specified {@code element} if the {@code element} is a class</li>
+     *     <li>the meta-annotations of the annotations specified on the {@code element}
+     *     or its super classes</li>
+     * </ul>
+     * Otherwise, {@link Optional#empty()} will be returned.
      *
      * @param element the {@link AnnotatedElement} to find annotations
      * @param annotationType the type of the annotation to find
@@ -108,11 +111,13 @@ final class AnnotationUtil {
     }
 
     /**
-     * Returns the annotations of the {@code annotationType}, which are found from the specified
-     * {@code element}.
-     *
-     * <p>Note that this method will find annotations from both the super classes of the {@code element}
-     * and the meta-annotations.
+     * Returns all annotations of the {@code annotationType} which are found from the following.
+     * <ul>
+     *     <li>the specified {@code element}</li>
+     *     <li>the super classes of the specified {@code element} if the {@code element} is a class</li>
+     *     <li>the meta-annotations of the annotations specified on the {@code element}
+     *     or its super classes</li>
+     * </ul>
      *
      * @param element the {@link AnnotatedElement} to find annotations
      * @param annotationType the type of the annotation to find
@@ -123,11 +128,13 @@ final class AnnotationUtil {
     }
 
     /**
-     * Returns the annotations of the {@code annotationType}, which are found from the specified
-     * {@code element}.
+     * Returns all annotations of the {@code annotationType} if which are found from the following.
+     * <ul>
+     *     <li>the specified {@code element}</li>
+     *     <li>the super classes of the specified {@code element} if the {@code element} is a class</li>
+     * </ul>
      *
-     * <p>Note that this method will find annotations from the super classes of the {@code element}
-     * but will <em>not</em> find annotations from the meta-annotations.
+     * <p>Note that this method will <em>not</em> find annotations from the meta-annotations.
      *
      * @param element the {@link AnnotatedElement} to find annotations
      * @param annotationType the type of the annotation to find
@@ -138,7 +145,7 @@ final class AnnotationUtil {
     }
 
     /**
-     * Returns the annotations of the {@code annotationType}, which are found from the specified
+     * Returns all annotations of the {@code annotationType} which are found from the specified
      * {@code element}.
      *
      * <p>Note that this method will <em>not</em> find annotations from both the super classes
@@ -153,8 +160,8 @@ final class AnnotationUtil {
     }
 
     /**
-     * Returns the annotations of the {@code annotationType}, which are found from the specified
-     * {@code element}.
+     * Returns all annotations of the {@code annotationType} searching from the specified {@code element}.
+     * The search range depends on the specified {@link FindOption}s.
      *
      * @param element the {@link AnnotatedElement} to find annotations
      * @param annotationType the type of the annotation to find
@@ -167,8 +174,8 @@ final class AnnotationUtil {
     }
 
     /**
-     * Returns the annotations of the {@code annotationType}, which are found from the specified
-     * {@code element}.
+     * Returns all annotations of the {@code annotationType} searching from the specified {@code element}.
+     * The search range depends on the specified {@link FindOption}s.
      *
      * @param element the {@link AnnotatedElement} to find annotations
      * @param annotationType the type of the annotation to find
@@ -205,10 +212,13 @@ final class AnnotationUtil {
     }
 
     /**
-     * Returns the annotations found from the specified {@code element}.
-     *
-     * <p>Note that this method will return every annotation found from the super classes of the
-     * {@code element} including the annotation specified as a meta-annotation.
+     * Returns all annotations which are found from the following.
+     * <ul>
+     *     <li>the specified {@code element}</li>
+     *     <li>the super classes of the specified {@code element} if the {@code element} is a class</li>
+     *     <li>the meta-annotations of the annotations specified on the {@code element}
+     *     or its super classes</li>
+     * </ul>
      *
      * @param element the {@link AnnotatedElement} to find annotations
      */
@@ -218,7 +228,8 @@ final class AnnotationUtil {
     }
 
     /**
-     * Returns the annotations found from the specified {@code element}.
+     * Returns all annotations searching from the specified {@code element}. The search range depends on
+     * the specified {@link FindOption}s and the built-in Java meta-annotations will not be collected.
      *
      * @param element the {@link AnnotatedElement} to find annotations
      * @param findOptions the options to be applied when retrieving annotations
@@ -231,7 +242,8 @@ final class AnnotationUtil {
     }
 
     /**
-     * Returns the annotations found from the specified {@code element}.
+     * Returns all annotations searching from the specified {@code element}. The search range depends on
+     * the specified {@link FindOption}s and the built-in Java meta-annotations will not be collected.
      *
      * @param element the {@link AnnotatedElement} to find annotations
      * @param findOptions the options to be applied when retrieving annotations
@@ -244,10 +256,9 @@ final class AnnotationUtil {
     }
 
     /**
-     * Returns the annotations found from the specified {@code element}.
-     *
-     * <p>Note that this method will return every annotation found from the super classes of the
-     * {@code element} including the annotation specified as a meta-annotation.
+     * Returns all annotations searching from the specified {@code element}. The search range depends on
+     * the specified {@link FindOption}s and the specified {@code collectingFilter} decides whether
+     * an annotation is collected or not.
      *
      * @param element the {@link AnnotatedElement} to find annotations
      * @param findOptions the options to be applied when retrieving annotations

--- a/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotationUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotationUtil.java
@@ -72,7 +72,7 @@ final class AnnotationUtil {
     /**
      * Built-in meta annotations defined in {@code java.lang.annotation} package.
      */
-    private static final Set<Class<? extends Annotation>> BUILTIN_META_ANNOTATIONS =
+    private static final Set<Class<? extends Annotation>> BUILT_IN_META_ANNOTATIONS =
             ImmutableSet.of(Documented.class, Inherited.class, Native.class,
                             Retention.class, Repeatable.class, Target.class);
 
@@ -86,7 +86,7 @@ final class AnnotationUtil {
      * </ul>
      * Otherwise, {@link Optional#empty()} will be returned.
      *
-     * @param element the {@link AnnotatedElement} to find annotations
+     * @param element the {@link AnnotatedElement} to find the first annotation
      * @param annotationType the type of the annotation to find
      */
     static <T extends Annotation> Optional<T> findFirst(AnnotatedElement element, Class<T> annotationType) {
@@ -101,7 +101,7 @@ final class AnnotationUtil {
      * <p>Note that this method will <em>not</em> find annotations from both the super classes of
      * the {@code element} and the meta-annotations.
      *
-     * @param element the {@link AnnotatedElement} to find annotations
+     * @param element the {@link AnnotatedElement} to find the first annotation
      * @param annotationType the type of the annotation to find
      */
     static <T extends Annotation> Optional<T> findFirstDeclared(AnnotatedElement element,
@@ -128,7 +128,7 @@ final class AnnotationUtil {
     }
 
     /**
-     * Returns all annotations of the {@code annotationType} if which are found from the following.
+     * Returns all annotations of the {@code annotationType} which are found from the following.
      * <ul>
      *     <li>the specified {@code element}</li>
      *     <li>the super classes of the specified {@code element} if the {@code element} is a class</li>
@@ -252,7 +252,7 @@ final class AnnotationUtil {
         // A user may not be interested in the built-in meta annotations, so the default predicate filters out
         // the default Java meta-annotations.
         return getAnnotations(element, findOptions,
-                              annotation -> !BUILTIN_META_ANNOTATIONS.contains(annotation.annotationType()));
+                              annotation -> !BUILT_IN_META_ANNOTATIONS.contains(annotation.annotationType()));
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotationUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotationUtil.java
@@ -1,0 +1,358 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.internal.annotation;
+
+import static java.util.Objects.requireNonNull;
+import static org.reflections.ReflectionUtils.getMethods;
+import static org.reflections.ReflectionUtils.withName;
+import static org.reflections.ReflectionUtils.withParametersCount;
+
+import java.lang.annotation.Annotation;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Native;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import javax.annotation.Nullable;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableList.Builder;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+
+/**
+ * A utility class which helps to get annotations from an {@link AnnotatedElement}.
+ */
+final class AnnotationUtil {
+    /**
+     * Options to be used for finding annotations from an {@link AnnotatedElement}.
+     */
+    enum FindOption {
+        /**
+         * Get annotations from super classes of the given {@link AnnotatedElement} if the element is a
+         * {@link Class}. Otherwise, this option will be ignored.
+         */
+        LOOKUP_SUPER_CLASSES,
+        /**
+         * Get additional annotations from the meta-annotations which annotate the annotations specified
+         * on the given {@link AnnotatedElement}.
+         */
+        LOOKUP_META_ANNOTATIONS,
+        /**
+         * Collect the annotations specified in the super classes first, the annotations specified on the
+         * given {@link AnnotatedElement} will be collected at last. This option will work only with
+         * the {@link #LOOKUP_SUPER_CLASSES}.
+         */
+        COLLECT_SUPER_CLASSES_FIRST
+    }
+
+    /**
+     * Built-in meta annotations defined in {@code java.lang.annotation} package.
+     */
+    private static final Set<Class<? extends Annotation>> BUILTIN_META_ANNOTATIONS =
+            ImmutableSet.of(Documented.class, Inherited.class, Native.class,
+                            Retention.class, Repeatable.class, Target.class);
+
+    /**
+     * Returns an annotation of the {@code annotationType} or {@link Optional#empty()}, which is found
+     * from the specified {@code element}.
+     *
+     * <p>Note that this method will <em>not</em> find annotations from both the super classes of
+     * the {@code element} and the meta-annotations.
+     *
+     * @param element the {@link AnnotatedElement} to find annotations
+     * @param annotationType the type of the annotation to find
+     */
+    static <T extends Annotation> Optional<T> findFirst(AnnotatedElement element, Class<T> annotationType) {
+        final List<T> founds = findAll(element, annotationType);
+        return founds.isEmpty() ? Optional.empty() : Optional.of(founds.get(0));
+    }
+
+    /**
+     * Returns an annotation of the {@code annotationType} if it is found from the specified {@code element}.
+     * Otherwise, the {@link Optional#empty()} will be returned.
+     *
+     * <p>Note that this method will <em>not</em> find annotations from both the super classes of
+     * the {@code element} and the meta-annotations.
+     *
+     * @param element the {@link AnnotatedElement} to find annotations
+     * @param annotationType the type of the annotation to find
+     */
+    static <T extends Annotation> Optional<T> findFirstDeclared(AnnotatedElement element,
+                                                                Class<T> annotationType) {
+        final List<T> founds = findDeclared(element, annotationType);
+        return founds.isEmpty() ? Optional.empty() : Optional.of(founds.get(0));
+    }
+
+    /**
+     * Returns the annotations of the {@code annotationType}, which are found from the specified
+     * {@code element}.
+     *
+     * <p>Note that this method will find annotations from both the super classes of the {@code element}
+     * and the meta-annotations.
+     *
+     * @param element the {@link AnnotatedElement} to find annotations
+     * @param annotationType the type of the annotation to find
+     */
+    static <T extends Annotation> List<T> findAll(AnnotatedElement element, Class<T> annotationType) {
+        return find(element, annotationType, EnumSet.of(FindOption.LOOKUP_SUPER_CLASSES,
+                                                        FindOption.LOOKUP_META_ANNOTATIONS));
+    }
+
+    /**
+     * Returns the annotations of the {@code annotationType}, which are found from the specified
+     * {@code element}.
+     *
+     * <p>Note that this method will find annotations from the super classes of the {@code element}
+     * but will <em>not</em> find annotations from the meta-annotations.
+     *
+     * @param element the {@link AnnotatedElement} to find annotations
+     * @param annotationType the type of the annotation to find
+     */
+    static <T extends Annotation> List<T> findInherited(
+            AnnotatedElement element, Class<T> annotationType) {
+        return find(element, annotationType, EnumSet.of(FindOption.LOOKUP_SUPER_CLASSES));
+    }
+
+    /**
+     * Returns the annotations of the {@code annotationType}, which are found from the specified
+     * {@code element}.
+     *
+     * <p>Note that this method will <em>not</em> find annotations from both the super classes
+     * of the {@code element} and the meta-annotations.
+     *
+     * @param element the {@link AnnotatedElement} to find annotations
+     * @param annotationType the type of the annotation to find
+     */
+    static <T extends Annotation> List<T> findDeclared(
+            AnnotatedElement element, Class<T> annotationType) {
+        return find(element, annotationType, EnumSet.noneOf(FindOption.class));
+    }
+
+    /**
+     * Returns the annotations of the {@code annotationType}, which are found from the specified
+     * {@code element}.
+     *
+     * @param element the {@link AnnotatedElement} to find annotations
+     * @param annotationType the type of the annotation to find
+     * @param findOptions the options to be applied when finding annotations
+     */
+    static <T extends Annotation> List<T> find(AnnotatedElement element, Class<T> annotationType,
+                                               FindOption... findOptions) {
+        return find(element, annotationType, EnumSet.copyOf(
+                ImmutableList.copyOf(requireNonNull(findOptions, "findOptions"))));
+    }
+
+    /**
+     * Returns the annotations of the {@code annotationType}, which are found from the specified
+     * {@code element}.
+     *
+     * @param element the {@link AnnotatedElement} to find annotations
+     * @param annotationType the type of the annotation to find
+     * @param findOptions the options to be applied when finding annotations
+     */
+    static <T extends Annotation> List<T> find(AnnotatedElement element, Class<T> annotationType,
+                                               EnumSet<FindOption> findOptions) {
+        requireNonNull(element, "element");
+        requireNonNull(annotationType, "annotationType");
+
+        final Builder<T> builder = new Builder<>();
+
+        // Repeatable is not a repeatable. So the length of the returning array is 0 or 1.
+        final Repeatable[] repeatableAnnotations = annotationType.getAnnotationsByType(Repeatable.class);
+        final Class<? extends Annotation> containerType =
+                repeatableAnnotations.length > 0 ? repeatableAnnotations[0].value() : null;
+
+        for (final AnnotatedElement e : resolveTargetElements(element, findOptions)) {
+            for (final Annotation annotation : e.getDeclaredAnnotations()) {
+                if (findOptions.contains(FindOption.LOOKUP_META_ANNOTATIONS)) {
+                    final Annotation[] metaAnnotations = annotation.annotationType().getDeclaredAnnotations();
+                    for (final Annotation metaAnnotation : metaAnnotations) {
+                        // If the metaAnnotation is "repeatable", we can try to find the annotation
+                        // from the container annotation which is defined by "@Repeatable" annotation.
+                        // There is no way to know whether the metaAnnotation is a container of
+                        // repeatable annotations.
+                        collectAnnotations(builder, metaAnnotation, annotationType, containerType);
+                    }
+                }
+                collectAnnotations(builder, annotation, annotationType, containerType);
+            }
+        }
+        return builder.build();
+    }
+
+    /**
+     * Returns the annotations found from the specified {@code element}.
+     *
+     * <p>Note that this method will return every annotation found from the super classes of the
+     * {@code element} including the annotation specified as a meta-annotation.
+     *
+     * @param element the {@link AnnotatedElement} to find annotations
+     */
+    static List<Annotation> getAllAnnotations(AnnotatedElement element) {
+        return getAnnotations(element, EnumSet.of(FindOption.LOOKUP_SUPER_CLASSES,
+                                                  FindOption.LOOKUP_META_ANNOTATIONS));
+    }
+
+    /**
+     * Returns the annotations found from the specified {@code element}.
+     *
+     * @param element the {@link AnnotatedElement} to find annotations
+     * @param findOptions the options to be applied when retrieving annotations
+     */
+    static List<Annotation> getAnnotations(AnnotatedElement element, FindOption... findOptions) {
+        requireNonNull(findOptions, "findOptions");
+        return getAnnotations(element,
+                              findOptions.length > 0 ? EnumSet.copyOf(ImmutableList.copyOf(findOptions))
+                                                     : EnumSet.noneOf(FindOption.class));
+    }
+
+    /**
+     * Returns the annotations found from the specified {@code element}.
+     *
+     * @param element the {@link AnnotatedElement} to find annotations
+     * @param findOptions the options to be applied when retrieving annotations
+     */
+    static List<Annotation> getAnnotations(AnnotatedElement element, EnumSet<FindOption> findOptions) {
+        // A user may not be interested in the built-in meta annotations, so the default predicate filters out
+        // the default Java meta-annotations.
+        return getAnnotations(element, findOptions,
+                              annotation -> !BUILTIN_META_ANNOTATIONS.contains(annotation.annotationType()));
+    }
+
+    /**
+     * Returns the annotations found from the specified {@code element}.
+     *
+     * <p>Note that this method will return every annotation found from the super classes of the
+     * {@code element} including the annotation specified as a meta-annotation.
+     *
+     * @param element the {@link AnnotatedElement} to find annotations
+     * @param findOptions the options to be applied when retrieving annotations
+     * @param collectingFilter the predicate which decides whether the annotation is to be collected or not
+     */
+    static List<Annotation> getAnnotations(AnnotatedElement element, EnumSet<FindOption> findOptions,
+                                           Predicate<Annotation> collectingFilter) {
+        requireNonNull(element, "element");
+        requireNonNull(collectingFilter, "collectingFilter");
+
+        final Builder<Annotation> builder = new Builder<>();
+
+        for (final AnnotatedElement e : resolveTargetElements(element, findOptions)) {
+            for (final Annotation annotation : e.getDeclaredAnnotations()) {
+                if (findOptions.contains(FindOption.LOOKUP_META_ANNOTATIONS)) {
+                    final Annotation[] metaAnnotations = annotation.annotationType().getDeclaredAnnotations();
+                    for (final Annotation metaAnnotation : metaAnnotations) {
+                        if (collectingFilter.test(metaAnnotation)) {
+                            builder.add(metaAnnotation);
+                        }
+                    }
+                }
+                if (collectingFilter.test(annotation)) {
+                    builder.add(annotation);
+                }
+            }
+        }
+        return builder.build();
+    }
+
+    /**
+     * Collects the list of {@link AnnotatedElement}s which are to be used to find annotations.
+     */
+    private static List<AnnotatedElement> resolveTargetElements(AnnotatedElement element,
+                                                                EnumSet<FindOption> findOptions) {
+        final List<AnnotatedElement> elements;
+        if (findOptions.contains(FindOption.LOOKUP_SUPER_CLASSES) && element instanceof Class) {
+            final Class<?> superclass = ((Class<?>) element).getSuperclass();
+            if ((superclass == null || superclass == Object.class) &&
+                ((Class<?>) element).getInterfaces().length == 0) {
+                elements = ImmutableList.of(element);
+            } else {
+                final Builder<AnnotatedElement> collector = new Builder<>();
+                collectSuperClasses((Class<?>) element, collector,
+                                    findOptions.contains(FindOption.COLLECT_SUPER_CLASSES_FIRST));
+                elements = collector.build();
+            }
+        } else {
+            elements = ImmutableList.of(element);
+        }
+        return elements;
+    }
+
+    private static void collectSuperClasses(Class<?> clazz, Builder<AnnotatedElement> collector,
+                                            boolean collectSuperClassesFirst) {
+        final Class<?> superClass = clazz.getSuperclass();
+        final Class<?>[] superInterfaces = clazz.getInterfaces();
+
+        if (!collectSuperClassesFirst) {
+            collector.add(clazz);
+        }
+        if (superInterfaces.length > 0) {
+            Arrays.stream(superInterfaces)
+                  .forEach(superInterface -> collectSuperClasses(
+                          superInterface, collector, collectSuperClassesFirst));
+        }
+        if (superClass != null && superClass != Object.class) {
+            collectSuperClasses(superClass, collector, collectSuperClassesFirst);
+        }
+        if (collectSuperClassesFirst) {
+            collector.add(clazz);
+        }
+    }
+
+    private static <T extends Annotation> void collectAnnotations(
+            Builder<T> builder, Annotation annotation,
+            Class<T> annotationType, @Nullable Class<? extends Annotation> containerType) {
+        final Class<? extends Annotation> type = annotation.annotationType();
+        if (type == annotationType) {
+            builder.add(annotationType.cast(annotation));
+            return;
+        }
+
+        if (containerType == null || type != containerType) {
+            return;
+        }
+
+        final Method method = Iterables.getFirst(
+                getMethods(containerType, withName("value"), withParametersCount(0)), null);
+        if (method == null) {
+            return;
+        }
+
+        method.setAccessible(true);
+
+        try {
+            @SuppressWarnings("unchecked")
+            final T[] values = (T[]) method.invoke(annotation);
+            Arrays.stream(values).forEach(builder::add);
+        } catch (Exception e) {
+            // Should not reach here.
+            throw new Error("Failed to invoke 'value' method of the repeatable annotation: " +
+                            containerType.getName(), e);
+        }
+    }
+
+    private AnnotationUtil() {}
+}

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceAnnotationAliasTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceAnnotationAliasTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.internal.annotation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import javax.annotation.Nullable;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.annotation.Get;
+import com.linecorp.armeria.server.annotation.Param;
+import com.linecorp.armeria.server.annotation.Produces;
+import com.linecorp.armeria.server.annotation.ResponseConverter;
+import com.linecorp.armeria.server.annotation.ResponseConverterFunction;
+import com.linecorp.armeria.testing.server.ServerRule;
+
+public class AnnotatedHttpServiceAnnotationAliasTest {
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @ResponseConverter(MyResponseConverter.class)
+    @Produces("text/plain")
+    @interface MyResponse {}
+
+    static class MyResponseConverter implements ResponseConverterFunction {
+        @Override
+        public HttpResponse convertResponse(ServiceRequestContext ctx, HttpHeaders headers,
+                                            @Nullable Object result, HttpHeaders trailingHeaders)
+                throws Exception {
+            return HttpResponse.of(
+                    headers, HttpData.ofUtf8("Hello, %s!", result), trailingHeaders);
+        }
+    }
+
+    @ClassRule
+    public static ServerRule rule = new ServerRule() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.annotatedService(new Object() {
+                @Get("/hello/{name}")
+                @MyResponse
+                public String name(@Param String name) {
+                    return name;
+                }
+            });
+        }
+    };
+
+    @Test
+    public void serviceConfiguredWithAlias() {
+        final AggregatedHttpMessage msg = HttpClient.of(rule.uri("/")).get("/hello/Armeria")
+                                                    .aggregate().join();
+        assertThat(msg.status()).isEqualTo(HttpStatus.OK);
+        assertThat(msg.headers().contentType()).isEqualTo(MediaType.parse("text/plain"));
+        assertThat(msg.content().toStringUtf8()).isEqualTo("Hello, Armeria!");
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceResponseConverterTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceResponseConverterTest.java
@@ -365,7 +365,6 @@ public class AnnotatedHttpServiceResponseConverterTest {
 
     @Retention(RetentionPolicy.RUNTIME)
     @Target({ ElementType.TYPE, ElementType.METHOD })
-    @Produces("application/binary")
     @Produces("application/octet-stream")
     @interface UserProduceBinary {}
 

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotationUtilTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotationUtilTest.java
@@ -1,0 +1,443 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.internal.annotation;
+
+import static com.linecorp.armeria.internal.annotation.AnnotationUtil.find;
+import static com.linecorp.armeria.internal.annotation.AnnotationUtil.findAll;
+import static com.linecorp.armeria.internal.annotation.AnnotationUtil.findDeclared;
+import static com.linecorp.armeria.internal.annotation.AnnotationUtil.findInherited;
+import static com.linecorp.armeria.internal.annotation.AnnotationUtil.getAllAnnotations;
+import static com.linecorp.armeria.internal.annotation.AnnotationUtil.getAnnotations;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.annotation.Annotation;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.EnumSet;
+import java.util.List;
+
+import org.junit.Test;
+
+import net.sf.cglib.proxy.Enhancer;
+import net.sf.cglib.proxy.FixedValue;
+
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.internal.annotation.AnnotationUtil.FindOption;
+
+public class AnnotationUtilTest {
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface TestMetaOfMetaAnnotation {}
+
+    @TestMetaOfMetaAnnotation
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface TestMetaAnnotation {
+        String value();
+    }
+
+    @TestMetaAnnotation("TestAnnotation")
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface TestAnnotation {
+        String value();
+    }
+
+    @TestMetaAnnotation("TestRepeatables")
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface TestRepeatables {
+        TestRepeatable[] value();
+    }
+
+    @TestMetaAnnotation("TestRepeatable")
+    @Retention(RetentionPolicy.RUNTIME)
+    @Repeatable(TestRepeatables.class)
+    @interface TestRepeatable {
+        String value();
+    }
+
+    @TestRepeatable("class-level:TestClass:Repeatable1")
+    @TestRepeatable("class-level:TestClass:Repeatable2")
+    @TestAnnotation("class-level:TestClass")
+    static class TestClass {
+        @TestAnnotation("method-level:directlyPresent")
+        public void directlyPresent() {}
+
+        @TestRepeatable("method-level:directlyPresentRepeatableSingle")
+        public void directlyPresentRepeatableSingle() {}
+
+        @TestRepeatable("method-level:directlyPresentRepeatableMulti:1")
+        @TestRepeatable("method-level:directlyPresentRepeatableMulti:2")
+        @TestRepeatable("method-level:directlyPresentRepeatableMulti:3")
+        public void directlyPresentRepeatableMulti() {}
+    }
+
+    @TestRepeatable("class-level:TestChildClass:Repeatable1")
+    @TestRepeatable("class-level:TestChildClass:Repeatable2")
+    @TestAnnotation("class-level:TestChildClass")
+    static class TestChildClass extends TestClass {}
+
+    @TestRepeatable("class-level:TestGrandChildClass:Repeatable1")
+    @TestRepeatable("class-level:TestGrandChildClass:Repeatable2")
+    @TestAnnotation("class-level:TestGrandChildClass")
+    static class TestGrandChildClass extends TestChildClass {}
+
+    @TestRepeatable("class-level:SingleRepeatableTestClass")
+    static class SingleRepeatableTestClass {}
+
+    @TestRepeatable("class-level:SingleRepeatableTestChildClass")
+    static class SingleRepeatableTestChildClass extends SingleRepeatableTestClass {}
+
+    @TestRepeatable("class-level:SingleRepeatableTestGrandChildClass")
+    static class SingleRepeatableTestGrandChildClass extends SingleRepeatableTestChildClass {}
+
+    @TestAnnotation("TestIface")
+    interface TestIface {
+        default void action() {}
+    }
+
+    @TestAnnotation("TestChildIface")
+    interface TestChildIface extends TestIface {
+        default void moreAction() {}
+    }
+
+    @TestAnnotation("TestAnotherIface")
+    interface TestAnotherIface {
+        default void anotherAction() {}
+    }
+
+    @TestAnnotation("TestClassWithIface")
+    static class TestClassWithIface implements TestChildIface {}
+
+    @TestAnnotation("TestChildClassWithIface")
+    static class TestChildClassWithIface extends TestClassWithIface implements TestAnotherIface {}
+
+    @Test
+    public void declared() throws NoSuchMethodException {
+        List<TestAnnotation> list;
+
+        list = findDeclared(TestClass.class.getMethod("directlyPresent"), TestAnnotation.class);
+        assertThat(list.size()).isOne();
+        assertThat(list.get(0).value()).isEqualTo("method-level:directlyPresent");
+
+        list = findDeclared(TestClass.class, TestAnnotation.class);
+        assertThat(list.size()).isOne();
+        assertThat(list.get(0).value()).isEqualTo("class-level:TestClass");
+
+        list = findDeclared(TestChildClass.class, TestAnnotation.class);
+        assertThat(list.size()).isOne();
+        assertThat(list.get(0).value()).isEqualTo("class-level:TestChildClass");
+
+        list = findDeclared(TestGrandChildClass.class, TestAnnotation.class);
+        assertThat(list.size()).isOne();
+        assertThat(list.get(0).value()).isEqualTo("class-level:TestGrandChildClass");
+    }
+
+    @Test
+    public void declared_repeatable() throws NoSuchMethodException {
+        List<TestRepeatable> list;
+
+        list = findDeclared(TestClass.class.getMethod("directlyPresentRepeatableSingle"),
+                            TestRepeatable.class);
+        assertThat(list.size()).isOne();
+        assertThat(list.get(0).value()).isEqualTo("method-level:directlyPresentRepeatableSingle");
+
+        list = findDeclared(SingleRepeatableTestClass.class, TestRepeatable.class);
+        assertThat(list.size()).isEqualTo(1);
+        assertThat(list.get(0).value()).isEqualTo("class-level:SingleRepeatableTestClass");
+
+        list = findDeclared(SingleRepeatableTestChildClass.class, TestRepeatable.class);
+        assertThat(list.size()).isEqualTo(1);
+        assertThat(list.get(0).value()).isEqualTo("class-level:SingleRepeatableTestChildClass");
+
+        list = findDeclared(SingleRepeatableTestGrandChildClass.class, TestRepeatable.class);
+        assertThat(list.size()).isEqualTo(1);
+        assertThat(list.get(0).value()).isEqualTo("class-level:SingleRepeatableTestGrandChildClass");
+    }
+
+    @Test
+    public void declared_repeatable_multi() throws NoSuchMethodException {
+        List<TestRepeatable> list;
+
+        list = findDeclared(TestClass.class.getMethod("directlyPresentRepeatableMulti"),
+                            TestRepeatable.class);
+        assertThat(list.size()).isEqualTo(3);
+        assertThat(list.get(0).value()).isEqualTo("method-level:directlyPresentRepeatableMulti:1");
+        assertThat(list.get(1).value()).isEqualTo("method-level:directlyPresentRepeatableMulti:2");
+        assertThat(list.get(2).value()).isEqualTo("method-level:directlyPresentRepeatableMulti:3");
+
+        list = findDeclared(TestClass.class, TestRepeatable.class);
+        assertThat(list.size()).isEqualTo(2);
+        assertThat(list.get(0).value()).isEqualTo("class-level:TestClass:Repeatable1");
+        assertThat(list.get(1).value()).isEqualTo("class-level:TestClass:Repeatable2");
+
+        list = findDeclared(TestChildClass.class, TestRepeatable.class);
+        assertThat(list.size()).isEqualTo(2);
+        assertThat(list.get(0).value()).isEqualTo("class-level:TestChildClass:Repeatable1");
+        assertThat(list.get(1).value()).isEqualTo("class-level:TestChildClass:Repeatable2");
+
+        list = findDeclared(TestGrandChildClass.class, TestRepeatable.class);
+        assertThat(list.size()).isEqualTo(2);
+        assertThat(list.get(0).value()).isEqualTo("class-level:TestGrandChildClass:Repeatable1");
+        assertThat(list.get(1).value()).isEqualTo("class-level:TestGrandChildClass:Repeatable2");
+    }
+
+    @Test
+    public void lookupSuperClass() {
+        List<TestAnnotation> list;
+
+        list = findInherited(TestClass.class, TestAnnotation.class);
+        assertThat(list.size()).isOne();
+        assertThat(list.get(0).value()).isEqualTo("class-level:TestClass");
+
+        list = findInherited(TestChildClass.class, TestAnnotation.class);
+        assertThat(list.size()).isEqualTo(2);
+        assertThat(list.get(0).value()).isEqualTo("class-level:TestChildClass");
+        assertThat(list.get(1).value()).isEqualTo("class-level:TestClass");
+
+        list = findInherited(TestGrandChildClass.class, TestAnnotation.class);
+        assertThat(list.size()).isEqualTo(3);
+        assertThat(list.get(0).value()).isEqualTo("class-level:TestGrandChildClass");
+        assertThat(list.get(1).value()).isEqualTo("class-level:TestChildClass");
+        assertThat(list.get(2).value()).isEqualTo("class-level:TestClass");
+
+        list = find(TestGrandChildClass.class, TestAnnotation.class,
+                    FindOption.LOOKUP_SUPER_CLASSES, FindOption.COLLECT_SUPER_CLASSES_FIRST);
+        assertThat(list.size()).isEqualTo(3);
+        assertThat(list.get(0).value()).isEqualTo("class-level:TestClass");
+        assertThat(list.get(1).value()).isEqualTo("class-level:TestChildClass");
+        assertThat(list.get(2).value()).isEqualTo("class-level:TestGrandChildClass");
+    }
+
+    @Test
+    public void lookupSuperClass_repeatable() {
+        List<TestRepeatable> list;
+
+        list = findInherited(SingleRepeatableTestClass.class, TestRepeatable.class);
+        assertThat(list.size()).isOne();
+        assertThat(list.get(0).value()).isEqualTo("class-level:SingleRepeatableTestClass");
+
+        list = findInherited(SingleRepeatableTestChildClass.class, TestRepeatable.class);
+        assertThat(list.size()).isEqualTo(2);
+        assertThat(list.get(0).value()).isEqualTo("class-level:SingleRepeatableTestChildClass");
+        assertThat(list.get(1).value()).isEqualTo("class-level:SingleRepeatableTestClass");
+
+        list = findInherited(SingleRepeatableTestGrandChildClass.class, TestRepeatable.class);
+        assertThat(list.size()).isEqualTo(3);
+        assertThat(list.get(0).value()).isEqualTo("class-level:SingleRepeatableTestGrandChildClass");
+        assertThat(list.get(1).value()).isEqualTo("class-level:SingleRepeatableTestChildClass");
+        assertThat(list.get(2).value()).isEqualTo("class-level:SingleRepeatableTestClass");
+
+        list = find(SingleRepeatableTestGrandChildClass.class, TestRepeatable.class,
+                    FindOption.LOOKUP_SUPER_CLASSES, FindOption.COLLECT_SUPER_CLASSES_FIRST);
+        assertThat(list.size()).isEqualTo(3);
+        assertThat(list.get(0).value()).isEqualTo("class-level:SingleRepeatableTestClass");
+        assertThat(list.get(1).value()).isEqualTo("class-level:SingleRepeatableTestChildClass");
+        assertThat(list.get(2).value()).isEqualTo("class-level:SingleRepeatableTestGrandChildClass");
+    }
+
+    @Test
+    public void lookupSuperClass_repeatable_multi() {
+        List<TestRepeatable> list;
+
+        list = findInherited(TestClass.class, TestRepeatable.class);
+        assertThat(list.size()).isEqualTo(2);
+        assertThat(list.get(0).value()).isEqualTo("class-level:TestClass:Repeatable1");
+        assertThat(list.get(1).value()).isEqualTo("class-level:TestClass:Repeatable2");
+
+        list = findInherited(TestChildClass.class, TestRepeatable.class);
+        assertThat(list.size()).isEqualTo(4);
+        assertThat(list.get(0).value()).isEqualTo("class-level:TestChildClass:Repeatable1");
+        assertThat(list.get(1).value()).isEqualTo("class-level:TestChildClass:Repeatable2");
+        assertThat(list.get(2).value()).isEqualTo("class-level:TestClass:Repeatable1");
+        assertThat(list.get(3).value()).isEqualTo("class-level:TestClass:Repeatable2");
+
+        list = findInherited(TestGrandChildClass.class, TestRepeatable.class);
+        assertThat(list.size()).isEqualTo(6);
+        assertThat(list.get(0).value()).isEqualTo("class-level:TestGrandChildClass:Repeatable1");
+        assertThat(list.get(1).value()).isEqualTo("class-level:TestGrandChildClass:Repeatable2");
+        assertThat(list.get(2).value()).isEqualTo("class-level:TestChildClass:Repeatable1");
+        assertThat(list.get(3).value()).isEqualTo("class-level:TestChildClass:Repeatable2");
+        assertThat(list.get(4).value()).isEqualTo("class-level:TestClass:Repeatable1");
+        assertThat(list.get(5).value()).isEqualTo("class-level:TestClass:Repeatable2");
+
+        list = find(TestGrandChildClass.class, TestRepeatable.class,
+                    FindOption.LOOKUP_SUPER_CLASSES, FindOption.COLLECT_SUPER_CLASSES_FIRST);
+        assertThat(list.size()).isEqualTo(6);
+        assertThat(list.get(0).value()).isEqualTo("class-level:TestClass:Repeatable1");
+        assertThat(list.get(1).value()).isEqualTo("class-level:TestClass:Repeatable2");
+        assertThat(list.get(2).value()).isEqualTo("class-level:TestChildClass:Repeatable1");
+        assertThat(list.get(3).value()).isEqualTo("class-level:TestChildClass:Repeatable2");
+        assertThat(list.get(4).value()).isEqualTo("class-level:TestGrandChildClass:Repeatable1");
+        assertThat(list.get(5).value()).isEqualTo("class-level:TestGrandChildClass:Repeatable2");
+    }
+
+    @Test
+    public void lookupMetaAnnotations_declared() {
+        List<TestMetaAnnotation> list;
+
+        for (final Class<?> clazz : ImmutableList.of(TestClass.class,
+                                                     TestChildClass.class,
+                                                     TestGrandChildClass.class)) {
+            list = find(clazz, TestMetaAnnotation.class, EnumSet.of(FindOption.LOOKUP_META_ANNOTATIONS));
+            assertThat(list.size()).isEqualTo(2);
+            assertThat(list.get(0).value()).isEqualTo("TestRepeatables");   // From the container annotation.
+            assertThat(list.get(1).value()).isEqualTo("TestAnnotation");
+        }
+
+        for (final Class<?> clazz : ImmutableList.of(SingleRepeatableTestClass.class,
+                                                     SingleRepeatableTestChildClass.class,
+                                                     SingleRepeatableTestGrandChildClass.class)) {
+            list = find(clazz, TestMetaAnnotation.class, EnumSet.of(FindOption.LOOKUP_META_ANNOTATIONS));
+            assertThat(list.size()).isOne();
+            assertThat(list.get(0).value()).isEqualTo("TestRepeatable");
+        }
+    }
+
+    @Test
+    public void findAll_includingRepeatable() {
+        List<TestMetaAnnotation> list;
+
+        list = findAll(SingleRepeatableTestClass.class, TestMetaAnnotation.class);
+        assertThat(list.size()).isOne();
+        assertThat(list.get(0).value()).isEqualTo("TestRepeatable");
+
+        list = findAll(SingleRepeatableTestChildClass.class, TestMetaAnnotation.class);
+        assertThat(list.size()).isEqualTo(2);
+        assertThat(list.get(0).value()).isEqualTo("TestRepeatable");
+        assertThat(list.get(1).value()).isEqualTo("TestRepeatable");
+
+        list = findAll(SingleRepeatableTestGrandChildClass.class, TestMetaAnnotation.class);
+        assertThat(list.size()).isEqualTo(3);
+        assertThat(list.get(0).value()).isEqualTo("TestRepeatable");
+        assertThat(list.get(1).value()).isEqualTo("TestRepeatable");
+        assertThat(list.get(2).value()).isEqualTo("TestRepeatable");
+    }
+
+    @Test
+    public void findAll_includingRepeatable_multi() {
+        List<TestMetaAnnotation> list;
+
+        list = findAll(TestClass.class, TestMetaAnnotation.class);
+        assertThat(list.size()).isEqualTo(2);
+        assertThat(list.get(0).value()).isEqualTo("TestRepeatables");
+        assertThat(list.get(1).value()).isEqualTo("TestAnnotation");
+
+        list = findAll(TestChildClass.class, TestMetaAnnotation.class);
+        assertThat(list.size()).isEqualTo(4);
+        assertThat(list.get(0).value()).isEqualTo("TestRepeatables");
+        assertThat(list.get(1).value()).isEqualTo("TestAnnotation");
+        assertThat(list.get(2).value()).isEqualTo("TestRepeatables");
+        assertThat(list.get(3).value()).isEqualTo("TestAnnotation");
+
+        list = findAll(TestGrandChildClass.class, TestMetaAnnotation.class);
+        assertThat(list.size()).isEqualTo(6);
+        assertThat(list.get(0).value()).isEqualTo("TestRepeatables");
+        assertThat(list.get(1).value()).isEqualTo("TestAnnotation");
+        assertThat(list.get(2).value()).isEqualTo("TestRepeatables");
+        assertThat(list.get(3).value()).isEqualTo("TestAnnotation");
+        assertThat(list.get(4).value()).isEqualTo("TestRepeatables");
+        assertThat(list.get(5).value()).isEqualTo("TestAnnotation");
+    }
+
+    @Test
+    public void findAll_interfaces() {
+        List<TestAnnotation> list;
+
+        list = findAll(TestClassWithIface.class, TestAnnotation.class);
+        assertThat(list.size()).isEqualTo(3);
+        assertThat(list.get(0).value()).isEqualTo("TestClassWithIface");
+        assertThat(list.get(1).value()).isEqualTo("TestChildIface");
+        assertThat(list.get(2).value()).isEqualTo("TestIface");
+
+        list = findAll(TestChildClassWithIface.class, TestAnnotation.class);
+        assertThat(list.size()).isEqualTo(5);
+        assertThat(list.get(0).value()).isEqualTo("TestChildClassWithIface");
+        assertThat(list.get(1).value()).isEqualTo("TestAnotherIface");
+        assertThat(list.get(2).value()).isEqualTo("TestClassWithIface");
+        assertThat(list.get(3).value()).isEqualTo("TestChildIface");
+        assertThat(list.get(4).value()).isEqualTo("TestIface");
+    }
+
+    @Test
+    public void unsupportMetaOfMetaAnnotation() {
+        assertThat(findAll(TestClass.class, TestMetaOfMetaAnnotation.class)).isEmpty();
+    }
+
+    @Test
+    public void cglibProxy() {
+        final Enhancer enhancer = new Enhancer();
+        enhancer.setSuperclass(TestGrandChildClass.class);
+        enhancer.setCallback((FixedValue) () -> null);
+        final TestGrandChildClass proxy = (TestGrandChildClass) enhancer.create();
+
+        // No declared annotations on proxy.
+        assertThat(findDeclared(proxy.getClass(), TestAnnotation.class)).isEmpty();
+        // No declared annotations on proxy, so no meta annotations as well.
+        assertThat(find(proxy.getClass(), TestMetaAnnotation.class,
+                        EnumSet.of(FindOption.LOOKUP_META_ANNOTATIONS))).isEmpty();
+
+        final List<TestAnnotation> list1 = findAll(proxy.getClass(), TestAnnotation.class);
+        assertThat(list1.size()).isEqualTo(3);
+        assertThat(list1.get(0).value()).isEqualTo("class-level:TestGrandChildClass");
+        assertThat(list1.get(1).value()).isEqualTo("class-level:TestChildClass");
+        assertThat(list1.get(2).value()).isEqualTo("class-level:TestClass");
+
+        final List<TestMetaAnnotation> list2 = findAll(proxy.getClass(), TestMetaAnnotation.class);
+        assertThat(list2.size()).isEqualTo(6);
+        assertThat(list2.get(0).value()).isEqualTo("TestRepeatables");
+        assertThat(list2.get(1).value()).isEqualTo("TestAnnotation");
+        assertThat(list2.get(2).value()).isEqualTo("TestRepeatables");
+        assertThat(list2.get(3).value()).isEqualTo("TestAnnotation");
+        assertThat(list2.get(4).value()).isEqualTo("TestRepeatables");
+        assertThat(list2.get(5).value()).isEqualTo("TestAnnotation");
+    }
+
+    @Test
+    public void getAnnotations_declared() {
+        final List<Annotation> list = getAnnotations(TestGrandChildClass.class);
+        assertThat(list.size()).isEqualTo(2);
+        assertThat(list.get(0)).isInstanceOf(TestRepeatables.class);
+        assertThat(list.get(1)).isInstanceOf(TestAnnotation.class);
+    }
+
+    @Test
+    public void getAnnotations_inherited() {
+        final List<Annotation> list =
+                getAnnotations(TestGrandChildClass.class, FindOption.LOOKUP_SUPER_CLASSES);
+        assertThat(list.size()).isEqualTo(6);
+        assertThat(list.get(0)).isInstanceOf(TestRepeatables.class);
+        assertThat(list.get(1)).isInstanceOf(TestAnnotation.class);
+        assertThat(list.get(2)).isInstanceOf(TestRepeatables.class);
+        assertThat(list.get(3)).isInstanceOf(TestAnnotation.class);
+        assertThat(list.get(4)).isInstanceOf(TestRepeatables.class);
+        assertThat(list.get(5)).isInstanceOf(TestAnnotation.class);
+    }
+
+    @Test
+    public void getAnnotations_all() {
+        final List<Annotation> list = getAllAnnotations(TestGrandChildClass.class);
+        assertThat(list.size()).isEqualTo(12);
+        for (int i = 0; i < 3 * 4; i += 4) {
+            assertThat(list.get(i)).isInstanceOf(TestMetaAnnotation.class);
+            assertThat(((TestMetaAnnotation) list.get(i)).value()).isEqualTo("TestRepeatables");
+            assertThat(list.get(i + 1)).isInstanceOf(TestRepeatables.class);
+            assertThat(list.get(i + 2)).isInstanceOf(TestMetaAnnotation.class);
+            assertThat(((TestMetaAnnotation) list.get(i + 2)).value()).isEqualTo("TestAnnotation");
+            assertThat(list.get(i + 3)).isInstanceOf(TestAnnotation.class);
+        }
+    }
+}

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -2,6 +2,9 @@
 # NB: Update NOTICE.txt and add/remove LICENSE.*.txt when adding/removing a dependency.
 #
 
+cglib:
+  cglib: { version: '3.2.10' }
+
 ch.qos.logback:
   logback-classic:
     version: '1.2.3'

--- a/licenses/LICENSE.cglib.al20.txt
+++ b/licenses/LICENSE.cglib.al20.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.


### PR DESCRIPTION
Motivation:
A user may want to define his or her annotations as a custom annotation in order to apply the custom annotation to his or her annotated HTTP services. e.g:
```
// Define a custom annotation:
@ProducesJson
@LoggingDecorator
@interface MyApiSpecification {}

// Apply it to the annotated HTTP service:
@Get("/api")
@MyApiSpecification
public Something getSomething() {}
```

Modifications:
- Add `AnnotationUtil` for finding a specific annotation or getting all annotations from an `AnnotatedElement`.
- Use `AnnotationUtil` instead of `ReflectionUtils.getAllAnnotations()`. The old one does not respect the order of the annotations because its return type is a `Set<Annotation>` (more specifically it's `HashSet`).

Result:
- Won't depend on the `ReflectionUtils`'s implementation when getting annotations.
- Closes #1224 