### PR TITLE
Provide a way to add multiple BindableService instances to GrpcServic…

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
@@ -93,7 +93,7 @@ public final class GrpcServiceBuilder {
     }
 
     /**
-     * Adds a gRPC {@link BindableService}s to this {@link GrpcServiceBuilder}. Most gRPC service
+     * Adds gRPC {@link BindableService}s to this {@link GrpcServiceBuilder}. Most gRPC service
      * implementations are {@link BindableService}s.
      */
     public GrpcServiceBuilder addServices(BindableService... bindableServices) {
@@ -102,12 +102,12 @@ public final class GrpcServiceBuilder {
     }
 
     /**
-     * Adds a gRPC {@link BindableService}s to this {@link GrpcServiceBuilder}. Most gRPC service
+     * Adds gRPC {@link BindableService}s to this {@link GrpcServiceBuilder}. Most gRPC service
      * implementations are {@link BindableService}s.
      */
     public GrpcServiceBuilder addServices(Iterable<BindableService> bindableServices) {
         requireNonNull(bindableServices, "bindableServices");
-        bindableServices.forEach(s -> addService(s.bindService()));
+        bindableServices.forEach(this::addService);
         return this;
     }
 

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
@@ -25,6 +25,7 @@ import java.util.concurrent.Executors;
 
 import javax.annotation.Nullable;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.ByteString;
 
@@ -89,6 +90,25 @@ public final class GrpcServiceBuilder {
      */
     public GrpcServiceBuilder addService(BindableService bindableService) {
         return addService(bindableService.bindService());
+    }
+
+    /**
+     * Adds a gRPC {@link BindableService}s to this {@link GrpcServiceBuilder}. Most gRPC service
+     * implementations are {@link BindableService}s.
+     */
+    public GrpcServiceBuilder addServices(BindableService... bindableServices) {
+        requireNonNull(bindableServices, "bindableServices");
+        return addServices(ImmutableList.copyOf(bindableServices));
+    }
+
+    /**
+     * Adds a gRPC {@link BindableService}s to this {@link GrpcServiceBuilder}. Most gRPC service
+     * implementations are {@link BindableService}s.
+     */
+    public GrpcServiceBuilder addServices(Iterable<BindableService> bindableServices) {
+        requireNonNull(bindableServices, "bindableServices");
+        bindableServices.forEach(s -> addService(s.bindService()));
+        return this;
     }
 
     /**
@@ -225,11 +245,11 @@ public final class GrpcServiceBuilder {
         final GrpcService grpcService = new GrpcService(
                 handlerRegistry,
                 handlerRegistry
-                      .methods()
-                      .keySet()
-                      .stream()
-                      .map(path -> PathMapping.ofExact('/' + path))
-                      .collect(ImmutableSet.toImmutableSet()),
+                        .methods()
+                        .keySet()
+                        .stream()
+                        .map(path -> PathMapping.ofExact('/' + path))
+                        .collect(ImmutableSet.toImmutableSet()),
                 firstNonNull(decompressorRegistry, DecompressorRegistry.getDefaultInstance()),
                 firstNonNull(compressorRegistry, CompressorRegistry.getDefaultInstance()),
                 supportedSerializationFormats,


### PR DESCRIPTION
…eBuilder at once

Motivation:
It would be useful to provide `addServices(Iterable<BindableService> services)` by `GrpcServiceBuilder`, especially a user uses Spring framework, e.g:

```
@Bean
public ArmeriaServerConfigurator armeriaServerConfigurator(List<BindableService> bindableServices) {
    return sb -> sb.service(new GrpcServiceBuilder().addServices(bindableServices)... )
}
```

Modifications:
- Add `addServices` methods to `GrpcServiceBuilder`.

Result:
- Closes #1563