### PR TITLE
Do not set Content-length header when trailing headers exists

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/AggregatedHttpMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AggregatedHttpMessage.java
@@ -280,10 +280,10 @@ public interface AggregatedHttpMessage {
         requireNonNull(content, "content");
         requireNonNull(trailingHeaders, "trailingHeaders");
 
-        final HttpHeaders headers =
-                HttpHeaders.of(status)
-                           .contentType(mediaType)
-                           .setInt(CONTENT_LENGTH, content.length());
+        final HttpHeaders headers = HttpHeaders.of(status).contentType(mediaType);
+        if (trailingHeaders.isEmpty()) {
+            headers.setInt(CONTENT_LENGTH, content.length());
+        }
 
         return of(headers, content, trailingHeaders);
     }
@@ -344,7 +344,7 @@ public interface AggregatedHttpMessage {
         final HttpStatus status = headers.status();
         if (status != null) { // Response
             if (!isContentAlwaysEmptyWithValidation(status, content, trailingHeaders) &&
-                !headers.contains(CONTENT_LENGTH)) {
+                !headers.contains(CONTENT_LENGTH) && trailingHeaders.isEmpty()) {
                 // But do not overwrite the 'content-length' header because a response to a HEAD request
                 // will have no content even if it has non-zero content-length header.
                 headers.setInt(CONTENT_LENGTH, content.length());

--- a/core/src/main/java/com/linecorp/armeria/common/AggregatedHttpMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AggregatedHttpMessage.java
@@ -18,7 +18,7 @@ package com.linecorp.armeria.common;
 
 import static com.linecorp.armeria.common.HttpHeaderNames.CONTENT_LENGTH;
 import static com.linecorp.armeria.internal.ArmeriaHttpUtil.isContentAlwaysEmpty;
-import static com.linecorp.armeria.internal.ArmeriaHttpUtil.setOrRemoveContentLengthInResponseHeaders;
+import static com.linecorp.armeria.internal.ArmeriaHttpUtil.setOrRemoveContentLength;
 import static java.util.Objects.requireNonNull;
 
 import java.nio.charset.StandardCharsets;
@@ -340,7 +340,7 @@ public interface AggregatedHttpMessage {
         final HttpStatus status = headers.status();
         final HttpHeaders newHeaders;
         if (status != null) { // Response
-            newHeaders = setOrRemoveContentLengthInResponseHeaders(headers,content, trailingHeaders);
+            newHeaders = setOrRemoveContentLength(headers, content, trailingHeaders);
         } else { // Request
             newHeaders = headers.toMutable();
             if (content.isEmpty()) {

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -17,7 +17,7 @@
 package com.linecorp.armeria.common;
 
 import static com.linecorp.armeria.internal.ArmeriaHttpUtil.isContentAlwaysEmpty;
-import static com.linecorp.armeria.internal.ArmeriaHttpUtil.setOrRemoveContentLengthInResponseHeaders;
+import static com.linecorp.armeria.internal.ArmeriaHttpUtil.setOrRemoveContentLength;
 import static java.util.Objects.requireNonNull;
 
 import java.nio.charset.StandardCharsets;
@@ -252,8 +252,7 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
             throw new IllegalStateException("not a response (missing :status)");
         }
 
-        final HttpHeaders newHeaders = setOrRemoveContentLengthInResponseHeaders(headers, content,
-                                                                                 trailingHeaders);
+        final HttpHeaders newHeaders = setOrRemoveContentLength(headers, content, trailingHeaders);
         if (content.isEmpty() && trailingHeaders.isEmpty()) {
             ReferenceCountUtil.safeRelease(content);
             return new OneElementFixedHttpResponse(newHeaders);

--- a/core/src/main/java/com/linecorp/armeria/internal/ArmeriaHttpUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/ArmeriaHttpUtil.java
@@ -724,7 +724,7 @@ public final class ArmeriaHttpUtil {
     }
 
     /**
-     * Returns a {@link HttpHeaders} which {@link HttpHeaderNames#CONTENT_LENGTH} is added or removed
+     * Returns an {@link HttpHeaders} whose {@link HttpHeaderNames#CONTENT_LENGTH} is added or removed
      * according to the status of the specified {@code headers}, {@code content} and {@code trailingHeaders}.
      * The {@link HttpHeaderNames#CONTENT_LENGTH} is removed when:
      * <ul>

--- a/core/src/main/java/com/linecorp/armeria/internal/Http1ObjectEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/Http1ObjectEncoder.java
@@ -200,7 +200,7 @@ public final class Http1ObjectEncoder extends HttpObjectEncoder {
                     Unpooled.EMPTY_BUFFER, false);
 
             final io.netty.handler.codec.http.HttpHeaders outHeaders = res.headers();
-            convert(streamId, headers, outHeaders, false);
+            convert(streamId, headers, outHeaders, false, false);
 
             if (ArmeriaHttpUtil.isContentAlwaysEmpty(status)) {
                 outHeaders.remove(HttpHeaderNames.CONTENT_LENGTH);
@@ -215,7 +215,7 @@ public final class Http1ObjectEncoder extends HttpObjectEncoder {
         } else {
             res = new DefaultHttpResponse(HttpVersion.HTTP_1_1, nettyStatus, false);
             // Perform conversion.
-            convert(streamId, headers, res.headers(), false);
+            convert(streamId, headers, res.headers(), false, false);
             setTransferEncoding(res);
         }
 
@@ -239,7 +239,7 @@ public final class Http1ObjectEncoder extends HttpObjectEncoder {
                 io.netty.handler.codec.http.HttpMethod.valueOf(method.name()),
                 path, false);
 
-        convert(streamId, headers, req.headers(), false);
+        convert(streamId, headers, req.headers(), false, true);
 
         if (endStream) {
             req.headers().remove(HttpHeaderNames.TRANSFER_ENCODING);
@@ -274,12 +274,12 @@ public final class Http1ObjectEncoder extends HttpObjectEncoder {
         return req;
     }
 
-    private void convert(
-            int streamId, HttpHeaders inHeaders,
-            io.netty.handler.codec.http.HttpHeaders outHeaders, boolean trailer) throws Http2Exception {
+    private void convert(int streamId, HttpHeaders inHeaders,
+                         io.netty.handler.codec.http.HttpHeaders outHeaders, boolean trailer,
+                         boolean isRequest) throws Http2Exception {
 
         ArmeriaHttpUtil.toNettyHttp1(
-                streamId, inHeaders, outHeaders, HttpVersion.HTTP_1_1, trailer, false);
+                streamId, inHeaders, outHeaders, HttpVersion.HTTP_1_1, trailer, isRequest);
 
         outHeaders.remove(ExtensionHeaderNames.STREAM_ID.text());
         if (server) {
@@ -295,7 +295,7 @@ public final class Http1ObjectEncoder extends HttpObjectEncoder {
             lastContent = LastHttpContent.EMPTY_LAST_CONTENT;
         } else {
             lastContent = new DefaultLastHttpContent(Unpooled.EMPTY_BUFFER, false);
-            convert(streamId, headers, lastContent.trailingHeaders(), true);
+            convert(streamId, headers, lastContent.trailingHeaders(), true, false);
         }
         return lastContent;
     }

--- a/core/src/main/java/com/linecorp/armeria/server/encoding/HttpEncodedResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/server/encoding/HttpEncodedResponse.java
@@ -97,18 +97,19 @@ class HttpEncodedResponse extends FilteredHttpResponse {
             encodedStream = new ByteArrayOutputStream();
             encodingStream = HttpEncoders.getEncodingOutputStream(encodingType, encodedStream);
 
+            final HttpHeaders mutable = headers.toMutable();
             // Always use chunked encoding when compressing.
-            headers.remove(HttpHeaderNames.CONTENT_LENGTH);
+            mutable.remove(HttpHeaderNames.CONTENT_LENGTH);
             switch (encodingType) {
                 case GZIP:
-                    headers.set(HttpHeaderNames.CONTENT_ENCODING, "gzip");
+                    mutable.set(HttpHeaderNames.CONTENT_ENCODING, "gzip");
                     break;
                 case DEFLATE:
-                    headers.set(HttpHeaderNames.CONTENT_ENCODING, "deflate");
+                    mutable.set(HttpHeaderNames.CONTENT_ENCODING, "deflate");
                     break;
             }
-            headers.set(HttpHeaderNames.VARY, HttpHeaderNames.ACCEPT_ENCODING.toString());
-            return headers;
+            mutable.set(HttpHeaderNames.VARY, HttpHeaderNames.ACCEPT_ENCODING.toString());
+            return mutable;
         }
 
         if (encodingStream == null) {

--- a/core/src/test/java/com/linecorp/armeria/common/DefaultAggregatedHttpMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/DefaultAggregatedHttpMessageTest.java
@@ -153,6 +153,72 @@ public class DefaultAggregatedHttpMessageTest {
     }
 
     @Test
+    public void errorWhenContentOrTrailingHeadersShouldBeEmpty() throws Exception {
+        contentAndTrailingHeadersShouldBeEmpty(HttpStatus.CONTINUE, HttpData.ofUtf8("bob"),
+                                               HttpHeaders.EMPTY_HEADERS);
+        contentAndTrailingHeadersShouldBeEmpty(HttpStatus.NO_CONTENT, HttpData.ofUtf8("bob"),
+                                               HttpHeaders.EMPTY_HEADERS);
+        contentAndTrailingHeadersShouldBeEmpty(HttpStatus.RESET_CONTENT, HttpData.ofUtf8("bob"),
+                                               HttpHeaders.EMPTY_HEADERS);
+        contentAndTrailingHeadersShouldBeEmpty(HttpStatus.NOT_MODIFIED, HttpData.ofUtf8("bob"),
+                                               HttpHeaders.EMPTY_HEADERS);
+
+        contentAndTrailingHeadersShouldBeEmpty(HttpStatus.CONTINUE, HttpData.EMPTY_DATA,
+                                               HttpHeaders.of(CONTENT_MD5, "9f9d51bc70ef21ca5c14f307980a29d8"));
+        contentAndTrailingHeadersShouldBeEmpty(HttpStatus.NO_CONTENT, HttpData.EMPTY_DATA,
+                                               HttpHeaders.of(CONTENT_MD5, "9f9d51bc70ef21ca5c14f307980a29d8"));
+        contentAndTrailingHeadersShouldBeEmpty(HttpStatus.RESET_CONTENT, HttpData.EMPTY_DATA,
+                                               HttpHeaders.of(CONTENT_MD5, "9f9d51bc70ef21ca5c14f307980a29d8"));
+        contentAndTrailingHeadersShouldBeEmpty(HttpStatus.NOT_MODIFIED, HttpData.EMPTY_DATA,
+                                               HttpHeaders.of(CONTENT_MD5, "9f9d51bc70ef21ca5c14f307980a29d8"));
+    }
+
+    private static void contentAndTrailingHeadersShouldBeEmpty(HttpStatus status, HttpData content,
+                                                               HttpHeaders trailingHeaders) {
+        assertThatThrownBy(() -> AggregatedHttpMessage.of(status, PLAIN_TEXT_UTF_8, content, trailingHeaders))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void contentLengthIsNotSetWhen1xxOr204Or205() {
+        HttpHeaders headers = HttpHeaders.of(HttpStatus.CONTINUE).addInt(CONTENT_LENGTH, 100);
+        assertThat(AggregatedHttpMessage.of(headers).headers().get(CONTENT_LENGTH)).isNull();
+
+        headers = HttpHeaders.of(HttpStatus.NO_CONTENT).addInt(CONTENT_LENGTH, 100);
+        assertThat(AggregatedHttpMessage.of(headers).headers().get(CONTENT_LENGTH)).isNull();
+
+        headers = HttpHeaders.of(HttpStatus.RESET_CONTENT).addInt(CONTENT_LENGTH, 100);
+        assertThat(AggregatedHttpMessage.of(headers).headers().get(CONTENT_LENGTH)).isNull();
+
+        // 304 response can have the 'Content-length' header when it is a response to a conditional
+        // GET request. See https://tools.ietf.org/html/rfc7230#section-3.3.2
+        headers = HttpHeaders.of(HttpStatus.NOT_MODIFIED).addInt(CONTENT_LENGTH, 100);
+        assertThat(AggregatedHttpMessage.of(headers).headers().getInt(CONTENT_LENGTH)).isEqualTo(100);
+    }
+
+    @Test
+    public void contentLengthIsSet() {
+        AggregatedHttpMessage msg = AggregatedHttpMessage.of(HttpStatus.OK);
+        assertThat(msg.headers().getInt(CONTENT_LENGTH)).isEqualTo(6); // the length of status.toHttpData()
+
+        msg = AggregatedHttpMessage.of(HttpStatus.OK, PLAIN_TEXT_UTF_8, HttpData.ofUtf8("foo"));
+        assertThat(msg.headers().getInt(CONTENT_LENGTH)).isEqualTo(3);
+
+        msg = AggregatedHttpMessage.of(HttpStatus.OK, PLAIN_TEXT_UTF_8, HttpData.ofUtf8(""));
+        assertThat(msg.headers().getInt(CONTENT_LENGTH)).isEqualTo(0);
+
+        final HttpHeaders headers = HttpHeaders.of(HttpStatus.OK).addInt(CONTENT_LENGTH, 1000000);
+        // It can have 'Content-length' even though, it does not have content because it can be a response
+        // to a HEAD request.
+        assertThat(AggregatedHttpMessage.of(headers).headers().getInt(CONTENT_LENGTH)).isEqualTo(1000000);
+
+        msg = AggregatedHttpMessage.of(headers, HttpData.ofUtf8("foo"));
+        // TODO(minwoox) The length is different from the content length because the user specified it with
+        //               the wrong value. Should we prevent this?
+        assertThat(msg.headers().getInt(CONTENT_LENGTH)).isEqualTo(1000000);
+    }
+
+    @Test
     public void toHttpResponseAgainstRequest() {
         final AggregatedHttpMessage aReq = AggregatedHttpMessage.of(HttpMethod.GET, "/qux");
         assertThatThrownBy(() -> HttpResponse.of(aReq)).isInstanceOf(IllegalStateException.class);

--- a/core/src/test/java/com/linecorp/armeria/common/DefaultAggregatedHttpMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/DefaultAggregatedHttpMessageTest.java
@@ -213,9 +213,7 @@ public class DefaultAggregatedHttpMessageTest {
         assertThat(AggregatedHttpMessage.of(headers).headers().getInt(CONTENT_LENGTH)).isEqualTo(1000000);
 
         msg = AggregatedHttpMessage.of(headers, HttpData.ofUtf8("foo"));
-        // TODO(minwoox) The length is different from the content length because the user specified it with
-        //               the wrong value. Should we prevent this?
-        assertThat(msg.headers().getInt(CONTENT_LENGTH)).isEqualTo(1000000);
+        assertThat(msg.headers().getInt(CONTENT_LENGTH)).isEqualTo(3); // The length is reset to 3 from 1000000.
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/common/DefaultAggregatedHttpMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/DefaultAggregatedHttpMessageTest.java
@@ -208,7 +208,7 @@ public class DefaultAggregatedHttpMessageTest {
         assertThat(msg.headers().getInt(CONTENT_LENGTH)).isEqualTo(0);
 
         final HttpHeaders headers = HttpHeaders.of(HttpStatus.OK).addInt(CONTENT_LENGTH, 1000000);
-        // It can have 'Content-length' even though, it does not have content because it can be a response
+        // It can have 'Content-length' even though it does not have content, because it can be a response
         // to a HEAD request.
         assertThat(AggregatedHttpMessage.of(headers).headers().getInt(CONTENT_LENGTH)).isEqualTo(1000000);
 

--- a/core/src/test/java/com/linecorp/armeria/common/DefaultAggregatedHttpMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/DefaultAggregatedHttpMessageTest.java
@@ -132,8 +132,7 @@ public class DefaultAggregatedHttpMessageTest {
 
         assertThat(unaggregated).containsExactly(
                 HttpHeaders.of(HttpStatus.OK)
-                           .contentType(PLAIN_TEXT_UTF_8)
-                           .setInt(CONTENT_LENGTH, 3),
+                           .contentType(PLAIN_TEXT_UTF_8),
                 HttpData.of(StandardCharsets.UTF_8, "bob"),
                 HttpHeaders.of(CONTENT_MD5, "9f9d51bc70ef21ca5c14f307980a29d8"));
     }

--- a/core/src/test/java/com/linecorp/armeria/internal/DefaultHttpResponseTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/DefaultHttpResponseTest.java
@@ -125,8 +125,7 @@ public class DefaultHttpResponseTest {
         // Non-informational header
         assertThat(aggregated.headers()).isEqualTo(
                 HttpHeaders.of(200)
-                           .add(HttpHeaderNames.of("c"), "d")
-                           .add(HttpHeaderNames.CONTENT_LENGTH, "3"));
+                           .add(HttpHeaderNames.of("c"), "d"));
         // Content
         assertThat(aggregated.content().toStringUtf8()).isEqualTo("foo");
         // Trailing headers

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerTest.java
@@ -778,7 +778,7 @@ public class HttpServerTest {
             assertThat(new String(ByteStreams.toByteArray(in)))
                     .isEqualTo(Strings.repeat("HTTP/1.1 100 Continue\r\n\r\n" +
                                               "HTTP/1.1 200 OK\r\n" +
-                                              "transfer-encoding: chunked\r\n\r\n0\r\n\r\n", 4));
+                                              "content-length: 0\r\n\r\n", 4));
         }
     }
 

--- a/core/src/test/java/com/linecorp/armeria/server/annotation/StringResponseConverterFunctionTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/annotation/StringResponseConverterFunctionTest.java
@@ -29,6 +29,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.MoreExecutors;
 
 import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
@@ -45,7 +46,8 @@ public class StringResponseConverterFunctionTest {
     private static final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
 
     private static final HttpHeaders PLAIN_TEXT_HEADERS =
-            HttpHeaders.of(HttpStatus.OK).contentType(MediaType.PLAIN_TEXT_UTF_8);
+            HttpHeaders.of(HttpStatus.OK).contentType(MediaType.PLAIN_TEXT_UTF_8)
+                       .addInt(HttpHeaderNames.CONTENT_LENGTH, 6);
     private static final HttpHeaders DEFAULT_TRAILING_HEADERS = HttpHeaders.EMPTY_HEADERS;
 
     @BeforeClass
@@ -71,7 +73,8 @@ public class StringResponseConverterFunctionTest {
     public void withoutContentType() throws Exception {
         StepVerifier.create(function.convertResponse(ctx, HttpHeaders.of(HttpStatus.OK),
                                                      "foo", DEFAULT_TRAILING_HEADERS))
-                    .expectNext(PLAIN_TEXT_HEADERS)
+                    .expectNext(HttpHeaders.of(HttpStatus.OK).contentType(MediaType.PLAIN_TEXT_UTF_8)
+                                           .addInt(HttpHeaderNames.CONTENT_LENGTH, 3))
                     .expectNext(HttpData.ofUtf8("foo"))
                     .expectComplete()
                     .verify();

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceTest.java
@@ -50,7 +50,8 @@ public class GrpcServiceTest {
         final HttpResponse response = grpcService.doPost(ctx, req);
         assertThat(response.aggregate().get()).isEqualTo(AggregatedHttpMessage.of(
                 HttpHeaders.of(HttpStatus.UNSUPPORTED_MEDIA_TYPE)
-                           .contentType(MediaType.PLAIN_TEXT_UTF_8),
+                           .contentType(MediaType.PLAIN_TEXT_UTF_8)
+                           .setInt(HttpHeaderNames.CONTENT_LENGTH, 39),
                 HttpData.ofUtf8("Missing or invalid Content-Type header.")));
     }
 
@@ -63,7 +64,8 @@ public class GrpcServiceTest {
         final HttpResponse response = grpcService.doPost(ctx, req);
         assertThat(response.aggregate().get()).isEqualTo(AggregatedHttpMessage.of(
                 HttpHeaders.of(HttpStatus.UNSUPPORTED_MEDIA_TYPE)
-                           .contentType(MediaType.PLAIN_TEXT_UTF_8),
+                           .contentType(MediaType.PLAIN_TEXT_UTF_8)
+                           .setInt(HttpHeaderNames.CONTENT_LENGTH, 39),
                 HttpData.ofUtf8("Missing or invalid Content-Type header.")));
     }
 
@@ -79,7 +81,8 @@ public class GrpcServiceTest {
         final HttpResponse response = grpcService.doPost(ctx, req);
         assertThat(response.aggregate().get()).isEqualTo(AggregatedHttpMessage.of(
                 HttpHeaders.of(HttpStatus.BAD_REQUEST)
-                           .contentType(MediaType.PLAIN_TEXT_UTF_8),
+                           .contentType(MediaType.PLAIN_TEXT_UTF_8)
+                           .setInt(HttpHeaderNames.CONTENT_LENGTH, 13),
                 HttpData.ofUtf8("Invalid path.")));
     }
 
@@ -99,7 +102,7 @@ public class GrpcServiceTest {
                            .set(HttpHeaderNames.of("grpc-status"), "12")
                            .set(HttpHeaderNames.of("grpc-message"),
                                 "Method not found: grpc.testing.TestService/FooCall")
-                           .set(HttpHeaderNames.CONTENT_LENGTH, "0"),
+                           .setInt(HttpHeaderNames.CONTENT_LENGTH, 0),
                 HttpData.EMPTY_DATA));
     }
 


### PR DESCRIPTION
Motivations:
Some of the client implementations such as `curl` ignores trailing headers if the `Content-length` header is present.
We should not set `Content-length` header when trailing headers exists so that those clients can receive the trailing headers.

Modification:
- Do not set `Content-length` header when trailing headers exists
- Make a backlist which must not be included in trailing headers
  - https://tools.ietf.org/html/rfc7230#section-4.1.2
- Allow `Trailer` headers in response headers which was not before
- Set `Content-length` to `0` when the `HttpResponse` contains only a status so that the response is not transfer encoding

Result:
- Closes #1554