### PR TITLE
Remove spring-boot-starter-actuator dependency from spring-boot modules

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -390,6 +390,7 @@ org.springframework.boot:
     version: &SPRING_BOOT_VERSION '2.1.2.RELEASE'
     javadocs:
     - https://docs.spring.io/spring/docs/current/javadoc-api/
+  spring-boot-starter-actuator: { version: *SPRING_BOOT_VERSION }
   spring-boot-starter-test: { version: *SPRING_BOOT_VERSION }
   spring-boot-starter-web: { version: *SPRING_BOOT_VERSION }
   spring-boot-starter-webflux:

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -390,7 +390,6 @@ org.springframework.boot:
     version: &SPRING_BOOT_VERSION '2.1.2.RELEASE'
     javadocs:
     - https://docs.spring.io/spring/docs/current/javadoc-api/
-  spring-boot-starter-actuator: { version: *SPRING_BOOT_VERSION }
   spring-boot-starter-test: { version: *SPRING_BOOT_VERSION }
   spring-boot-starter-web: { version: *SPRING_BOOT_VERSION }
   spring-boot-starter-webflux:

--- a/spring/boot-autoconfigure/build.gradle
+++ b/spring/boot-autoconfigure/build.gradle
@@ -9,7 +9,6 @@ dependencies {
     compile 'javax.inject:javax.inject'
     compileOnly 'javax.validation:validation-api'
     compile 'org.springframework.boot:spring-boot-starter'
-    compile 'org.springframework.boot:spring-boot-starter-actuator'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
     testCompile 'org.springframework.boot:spring-boot-starter-test'

--- a/spring/boot-autoconfigure/build.gradle
+++ b/spring/boot-autoconfigure/build.gradle
@@ -11,5 +11,6 @@ dependencies {
     compile 'org.springframework.boot:spring-boot-starter'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
+    testCompile 'org.springframework.boot:spring-boot-starter-actuator'
     testCompile 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/spring/boot-webflux-autoconfigure/build.gradle
+++ b/spring/boot-webflux-autoconfigure/build.gradle
@@ -16,7 +16,6 @@ dependencies {
     compile 'io.dropwizard.metrics:metrics-json'
     compile 'javax.inject:javax.inject'
     compileOnly 'javax.validation:validation-api'
-    compile 'org.springframework.boot:spring-boot-starter-actuator'
     compile 'org.springframework.boot:spring-boot-starter-webflux'
 
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'


### PR DESCRIPTION
Motivations:
- Sometimes spring-boot-actuator pulls unrelated metrics to MeterRegistry. For example, if a user add `armeria-spring-boot-starter` dependency to an application, because it also pulls spring-boot-actuator dependency, [KafkaMetricsAutoConfiguration](https://docs.spring.io/spring-boot/docs/2.2.0.BUILD-SNAPSHOT/api/org/springframework/boot/actuate/autoconfigure/metrics/KafkaMetricsAutoConfiguration.html) is enabled if kafka client bean is existed. And it causes unintentional conflicts with user metrics configurations. 

Changes:
- Remove spring-boot-starter-actuator dependency from spring-boot modules

Result:
- Less surprise