### PR TITLE
Improve AnnotationUtil

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/annotation/Order.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/Order.java
@@ -25,7 +25,7 @@ import java.lang.annotation.Target;
  * Specifies an order which is used to sort the annotated service methods.
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.METHOD)
+@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 public @interface Order {
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/RequestConverters.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/RequestConverters.java
@@ -25,7 +25,13 @@ import java.lang.annotation.Target;
  * The containing annotation type for {@link RequestConverter}.
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.TYPE, ElementType.METHOD })
+@Target({
+        ElementType.TYPE,
+        ElementType.METHOD,
+        ElementType.PARAMETER,
+        ElementType.CONSTRUCTOR,
+        ElementType.FIELD
+})
 public @interface RequestConverters {
     /**
      * An array of {@link RequestConverter}s.

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/StatusCode.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/StatusCode.java
@@ -27,7 +27,7 @@ import java.lang.annotation.Target;
  * {@code @StatusCode(204)} would be applied. Otherwise, {@code @StatusCode(200)} would be applied.
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.METHOD)
+@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 public @interface StatusCode {
     /**
      * A default HTTP status code of a response produced by an annotated HTTP service.

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceAnnotationAliasTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceAnnotationAliasTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.util.function.Function;
 
 import javax.annotation.Nullable;
 
@@ -28,34 +29,171 @@ import org.junit.Test;
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.common.AggregatedHttpMessage;
 import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.common.logging.LogLevel;
+import com.linecorp.armeria.server.DecoratingServiceFunction;
 import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.SimpleDecoratingService;
+import com.linecorp.armeria.server.annotation.Consumes;
+import com.linecorp.armeria.server.annotation.ConsumesJson;
+import com.linecorp.armeria.server.annotation.Decorator;
+import com.linecorp.armeria.server.annotation.DecoratorFactory;
+import com.linecorp.armeria.server.annotation.DecoratorFactoryFunction;
+import com.linecorp.armeria.server.annotation.ExceptionHandler;
+import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
 import com.linecorp.armeria.server.annotation.Get;
-import com.linecorp.armeria.server.annotation.Param;
+import com.linecorp.armeria.server.annotation.Order;
+import com.linecorp.armeria.server.annotation.Post;
 import com.linecorp.armeria.server.annotation.Produces;
+import com.linecorp.armeria.server.annotation.ProducesJson;
+import com.linecorp.armeria.server.annotation.RequestConverter;
+import com.linecorp.armeria.server.annotation.RequestConverterFunction;
 import com.linecorp.armeria.server.annotation.ResponseConverter;
 import com.linecorp.armeria.server.annotation.ResponseConverterFunction;
+import com.linecorp.armeria.server.annotation.StatusCode;
+import com.linecorp.armeria.server.annotation.decorator.LoggingDecorator;
 import com.linecorp.armeria.testing.server.ServerRule;
+
+import io.netty.util.Attribute;
+import io.netty.util.AttributeKey;
 
 public class AnnotatedHttpServiceAnnotationAliasTest {
 
-    @Retention(RetentionPolicy.RUNTIME)
+    @RequestConverter(MyRequestConverter.class)
     @ResponseConverter(MyResponseConverter.class)
-    @Produces("text/plain")
-    @interface MyResponse {}
+    @Consumes("text/plain; charset=utf-8")
+    @Consumes("application/xml")
+    @ConsumesJson
+    @Produces("text/plain; charset=utf-8")
+    @Produces("application/xml")
+    @ProducesJson
+    @ExceptionHandler(MyExceptionHandler1.class)
+    @ExceptionHandler(MyExceptionHandler2.class)
+    @LoggingDecorator(requestLogLevel = LogLevel.DEBUG, successfulResponseLogLevel = LogLevel.DEBUG)
+    @Decorator(MyDecorator1.class)
+    @Decorator(MyDecorator2.class)
+    @MyDecorator3
+    @Order  // Just checking whether @Order annotation can be present as a meta-annotation.
+    @StatusCode(201)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface MyPostServiceSpecifications {}
+
+    @RequestConverter(MyRequestConverter.class)
+    @ResponseConverter(MyResponseConverter.class)
+    @ProducesJson
+    @ExceptionHandler(MyExceptionHandler1.class)
+    @ExceptionHandler(MyExceptionHandler2.class)
+    @LoggingDecorator(requestLogLevel = LogLevel.DEBUG, successfulResponseLogLevel = LogLevel.DEBUG)
+    @Decorator(MyDecorator1.class)
+    @Decorator(MyDecorator2.class)
+    @MyDecorator3
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface MyGetServiceSpecifications {}
+
+    static class MyRequest {
+        private final String name;
+
+        MyRequest(String name) {
+            this.name = name;
+        }
+    }
+
+    static class MyRequestConverter implements RequestConverterFunction {
+        @Nullable
+        @Override
+        public Object convertRequest(ServiceRequestContext ctx, AggregatedHttpMessage request,
+                                     Class<?> expectedResultType) throws Exception {
+            if (expectedResultType == MyRequest.class) {
+                final String decorated = ctx.attr(decoratedFlag).get();
+                return new MyRequest(request.content().toStringUtf8() + decorated);
+            }
+            return RequestConverterFunction.fallthrough();
+        }
+    }
 
     static class MyResponseConverter implements ResponseConverterFunction {
         @Override
-        public HttpResponse convertResponse(ServiceRequestContext ctx, HttpHeaders headers,
-                                            @Nullable Object result, HttpHeaders trailingHeaders)
-                throws Exception {
-            return HttpResponse.of(
-                    headers, HttpData.ofUtf8("Hello, %s!", result), trailingHeaders);
+        public HttpResponse convertResponse(
+                ServiceRequestContext ctx, HttpHeaders headers,
+                @Nullable Object result, HttpHeaders trailingHeaders) throws Exception {
+            return HttpResponse.of(headers, HttpData.ofUtf8("Hello, %s!", result), trailingHeaders);
         }
+    }
+
+    static class MyExceptionHandler1 implements ExceptionHandlerFunction {
+        @Override
+        public HttpResponse handleException(RequestContext ctx, HttpRequest req, Throwable cause) {
+            if (cause instanceof IllegalArgumentException) {
+                return HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR, MediaType.PLAIN_TEXT_UTF_8,
+                                       "Cause:" + IllegalArgumentException.class.getSimpleName());
+            }
+            return ExceptionHandlerFunction.fallthrough();
+        }
+    }
+
+    static class MyExceptionHandler2 implements ExceptionHandlerFunction {
+        @Override
+        public HttpResponse handleException(RequestContext ctx, HttpRequest req, Throwable cause) {
+            if (cause instanceof IllegalStateException) {
+                return HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR, MediaType.PLAIN_TEXT_UTF_8,
+                                       "Cause:" + IllegalStateException.class.getSimpleName());
+            }
+            return ExceptionHandlerFunction.fallthrough();
+        }
+    }
+
+    static class MyDecorator1 implements DecoratingServiceFunction<HttpRequest, HttpResponse> {
+        @Override
+        public HttpResponse serve(Service<HttpRequest, HttpResponse> delegate,
+                                  ServiceRequestContext ctx, HttpRequest req) throws Exception {
+            appendAttribute(ctx, " (decorated-1)");
+            return delegate.serve(ctx, req);
+        }
+    }
+
+    static class MyDecorator2 implements DecoratingServiceFunction<HttpRequest, HttpResponse> {
+        @Override
+        public HttpResponse serve(Service<HttpRequest, HttpResponse> delegate,
+                                  ServiceRequestContext ctx, HttpRequest req) throws Exception {
+            appendAttribute(ctx, " (decorated-2)");
+            return delegate.serve(ctx, req);
+        }
+    }
+
+    @DecoratorFactory(MyDecorator3Factory.class)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface MyDecorator3 {}
+
+    static class MyDecorator3Factory implements DecoratorFactoryFunction<MyDecorator3> {
+        @Override
+        public Function<Service<HttpRequest, HttpResponse>,
+                ? extends Service<HttpRequest, HttpResponse>> newDecorator(MyDecorator3 parameter) {
+            return delegate -> new SimpleDecoratingService<HttpRequest, HttpResponse>(delegate) {
+                @Override
+                public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+                    appendAttribute(ctx, " (decorated-3)");
+                    return delegate().serve(ctx, req);
+                }
+            };
+        }
+    }
+
+    static final AttributeKey<String> decoratedFlag =
+            AttributeKey.valueOf(AnnotatedHttpServiceAnnotationAliasTest.class, "decorated");
+
+    private static void appendAttribute(ServiceRequestContext ctx, String value) {
+        final Attribute<String> attr = ctx.attr(decoratedFlag);
+        final String v = attr.get();
+        attr.set((v == null ? "" : v) + value);
     }
 
     @ClassRule
@@ -63,21 +201,73 @@ public class AnnotatedHttpServiceAnnotationAliasTest {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
             sb.annotatedService(new Object() {
-                @Get("/hello/{name}")
-                @MyResponse
-                public String name(@Param String name) {
-                    return name;
+                @Post("/hello")
+                @MyPostServiceSpecifications
+                public String hello(MyRequest myRequest) {
+                    return myRequest.name;
+                }
+
+                @Get("/exception1")
+                @MyGetServiceSpecifications
+                public String exception1() {
+                    throw new IllegalArgumentException("Anticipated!");
+                }
+
+                @Get("/exception2")
+                @MyGetServiceSpecifications
+                public String exception2() {
+                    throw new IllegalStateException("Anticipated!");
                 }
             });
         }
     };
 
     @Test
-    public void serviceConfiguredWithAlias() {
-        final AggregatedHttpMessage msg = HttpClient.of(rule.uri("/")).get("/hello/Armeria")
-                                                    .aggregate().join();
-        assertThat(msg.status()).isEqualTo(HttpStatus.OK);
-        assertThat(msg.headers().contentType()).isEqualTo(MediaType.parse("text/plain"));
-        assertThat(msg.content().toStringUtf8()).isEqualTo("Hello, Armeria!");
+    public void metaAnnotations() {
+        final AggregatedHttpMessage msg =
+                HttpClient.of(rule.uri("/"))
+                          .execute(HttpHeaders.of(HttpMethod.POST, "/hello")
+                                              .contentType(MediaType.PLAIN_TEXT_UTF_8)
+                                              .add(HttpHeaderNames.ACCEPT, "text/*"),
+                                   HttpData.ofUtf8("Armeria"))
+                          .aggregate().join();
+        assertThat(msg.status()).isEqualTo(HttpStatus.CREATED);
+        assertThat(msg.headers().contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
+        assertThat(msg.content().toStringUtf8())
+                .isEqualTo("Hello, Armeria (decorated-1) (decorated-2) (decorated-3)!");
+    }
+
+    @Test
+    public void metaOfMetaAnnotation_ProducesJson() {
+        final AggregatedHttpMessage msg =
+                HttpClient.of(rule.uri("/"))
+                          .execute(HttpHeaders.of(HttpMethod.POST, "/hello")
+                                              .contentType(MediaType.PLAIN_TEXT_UTF_8)
+                                              .add(HttpHeaderNames.ACCEPT,
+                                                   "application/json; charset=utf-8"),
+                                   HttpData.ofUtf8("Armeria"))
+                          .aggregate().join();
+        assertThat(msg.status()).isEqualTo(HttpStatus.CREATED);
+        assertThat(msg.headers().contentType()).isEqualTo(MediaType.JSON_UTF_8);
+        assertThat(msg.content().toStringUtf8())
+                .isEqualTo("Hello, Armeria (decorated-1) (decorated-2) (decorated-3)!");
+    }
+
+    @Test
+    public void exception1() {
+        final AggregatedHttpMessage msg =
+                HttpClient.of(rule.uri("/")).get("/exception1").aggregate().join();
+        assertThat(msg.status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        assertThat(msg.content().toStringUtf8())
+                .isEqualTo("Cause:" + IllegalArgumentException.class.getSimpleName());
+    }
+
+    @Test
+    public void exception2() {
+        final AggregatedHttpMessage msg =
+                HttpClient.of(rule.uri("/")).get("/exception2").aggregate().join();
+        assertThat(msg.status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        assertThat(msg.content().toStringUtf8())
+                .isEqualTo("Cause:" + IllegalStateException.class.getSimpleName());
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotationUtilTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotationUtilTest.java
@@ -373,8 +373,17 @@ public class AnnotationUtilTest {
     }
 
     @Test
-    public void unsupportMetaOfMetaAnnotation() {
-        assertThat(findAll(TestClass.class, TestMetaOfMetaAnnotation.class)).isEmpty();
+    public void findAll_metaAnnotationOfMetaAnnotation() {
+        List<TestMetaOfMetaAnnotation> list;
+
+        list = findAll(TestClass.class, TestMetaOfMetaAnnotation.class);
+        assertThat(list).hasSize(2);
+
+        list = findAll(TestChildClass.class, TestMetaOfMetaAnnotation.class);
+        assertThat(list).hasSize(4);
+
+        list = findAll(TestGrandChildClass.class, TestMetaOfMetaAnnotation.class);
+        assertThat(list).hasSize(6);
     }
 
     @Test
@@ -430,14 +439,16 @@ public class AnnotationUtilTest {
     @Test
     public void getAnnotations_all() {
         final List<Annotation> list = getAllAnnotations(TestGrandChildClass.class);
-        assertThat(list.size()).isEqualTo(12);
-        for (int i = 0; i < 3 * 4; i += 4) {
-            assertThat(list.get(i)).isInstanceOf(TestMetaAnnotation.class);
-            assertThat(((TestMetaAnnotation) list.get(i)).value()).isEqualTo("TestRepeatables");
-            assertThat(list.get(i + 1)).isInstanceOf(TestRepeatables.class);
-            assertThat(list.get(i + 2)).isInstanceOf(TestMetaAnnotation.class);
-            assertThat(((TestMetaAnnotation) list.get(i + 2)).value()).isEqualTo("TestAnnotation");
-            assertThat(list.get(i + 3)).isInstanceOf(TestAnnotation.class);
+        assertThat(list.size()).isEqualTo(18);
+        for (int i = 0; i < 3 * 6; i += 6) {
+            assertThat(list.get(i)).isInstanceOf(TestMetaOfMetaAnnotation.class);
+            assertThat(list.get(i + 1)).isInstanceOf(TestMetaAnnotation.class);
+            assertThat(((TestMetaAnnotation) list.get(i + 1)).value()).isEqualTo("TestRepeatables");
+            assertThat(list.get(i + 2)).isInstanceOf(TestRepeatables.class);
+            assertThat(list.get(i + 3)).isInstanceOf(TestMetaOfMetaAnnotation.class);
+            assertThat(list.get(i + 4)).isInstanceOf(TestMetaAnnotation.class);
+            assertThat(((TestMetaAnnotation) list.get(i + 4)).value()).isEqualTo("TestAnnotation");
+            assertThat(list.get(i + 5)).isInstanceOf(TestAnnotation.class);
         }
     }
 }


### PR DESCRIPTION
Motivation:
Follow-up work after #1560.

Modifications:
- `AnnotationUtil` will lookup meta-annotations of a meta-annotation to support the following case:
```
@ProducesJson
@Produces("text/plain")
@interface MyPostServiceSpecifications {}
```
  - `@ProducesJson` will also be found with this PR, which wasn't found before.
- Add `ElementType.ANNOTATION_TYPE` to `Target` annotation for `@Order` and `@StatusCode` so that a user can use them as a meta-annotation for his or her custom annotation.