### PR TITLE
Tell why a request is bad for a 400 Bad Request response

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/Http2RequestDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http2RequestDecoder.java
@@ -23,6 +23,8 @@ import static io.netty.handler.codec.http2.Http2Exception.streamError;
 
 import java.nio.charset.StandardCharsets;
 
+import javax.annotation.Nullable;
+
 import com.linecorp.armeria.common.ClosedSessionException;
 import com.linecorp.armeria.common.ContentTooLargeException;
 import com.linecorp.armeria.common.HttpHeaderNames;
@@ -53,6 +55,16 @@ import io.netty.util.collection.IntObjectHashMap;
 import io.netty.util.collection.IntObjectMap;
 
 final class Http2RequestDecoder extends Http2EventAdapter {
+
+    private static final ByteBuf DATA_MISSING_METHOD =
+            Unpooled.copiedBuffer(HttpResponseStatus.BAD_REQUEST + "\nMissing method",
+                                  StandardCharsets.UTF_8).asReadOnly();
+    private static final ByteBuf DATA_UNSUPPORTED_METHOD =
+            Unpooled.copiedBuffer(HttpResponseStatus.METHOD_NOT_ALLOWED + "\nUnsupported method",
+                                  StandardCharsets.UTF_8).asReadOnly();
+    private static final ByteBuf DATA_INVALID_CONTENT_LENGTH =
+            Unpooled.copiedBuffer(HttpResponseStatus.BAD_REQUEST + "\nInvalid content length",
+                                  StandardCharsets.UTF_8).asReadOnly();
 
     private final ServerConfig cfg;
     private final Channel channel;
@@ -88,11 +100,12 @@ final class Http2RequestDecoder extends Http2EventAdapter {
             // Validate the method.
             final CharSequence method = headers.method();
             if (method == null) {
-                writeErrorResponse(ctx, streamId, HttpResponseStatus.BAD_REQUEST);
+                writeErrorResponse(ctx, streamId, HttpResponseStatus.BAD_REQUEST, DATA_MISSING_METHOD);
                 return;
             }
             if (!HttpMethod.isSupported(method.toString())) {
-                writeErrorResponse(ctx, streamId, HttpResponseStatus.METHOD_NOT_ALLOWED);
+                writeErrorResponse(ctx, streamId, HttpResponseStatus.METHOD_NOT_ALLOWED,
+                                   DATA_UNSUPPORTED_METHOD);
                 return;
             }
 
@@ -101,7 +114,8 @@ final class Http2RequestDecoder extends Http2EventAdapter {
             if (headers.contains(HttpHeaderNames.CONTENT_LENGTH)) {
                 final long contentLength = headers.getLong(HttpHeaderNames.CONTENT_LENGTH, -1L);
                 if (contentLength < 0) {
-                    writeErrorResponse(ctx, streamId, HttpResponseStatus.BAD_REQUEST);
+                    writeErrorResponse(ctx, streamId, HttpResponseStatus.BAD_REQUEST,
+                                       DATA_INVALID_CONTENT_LENGTH);
                     return;
                 }
                 contentEmpty = contentLength == 0;
@@ -110,7 +124,7 @@ final class Http2RequestDecoder extends Http2EventAdapter {
             }
 
             if (!handle100Continue(ctx, streamId, headers)) {
-                writeErrorResponse(ctx, streamId, HttpResponseStatus.EXPECTATION_FAILED);
+                writeErrorResponse(ctx, streamId, HttpResponseStatus.EXPECTATION_FAILED, null);
                 return;
             }
 
@@ -209,7 +223,7 @@ final class Http2RequestDecoder extends Http2EventAdapter {
         if (maxContentLength > 0 && req.transferredBytes() > maxContentLength) {
             final Http2Stream stream = writer.connection().stream(streamId);
             if (isWritable(stream)) {
-                writeErrorResponse(ctx, streamId, HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE);
+                writeErrorResponse(ctx, streamId, HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE, null);
                 writer.writeRstStream(ctx, streamId, Http2Error.CANCEL.code(), ctx.voidPromise());
                 if (req.isOpen()) {
                     req.close(ContentTooLargeException.get());
@@ -245,19 +259,21 @@ final class Http2RequestDecoder extends Http2EventAdapter {
         }
     }
 
-    private void writeErrorResponse(ChannelHandlerContext ctx, int streamId,
-                                    HttpResponseStatus status) throws Http2Exception {
-        final byte[] content = status.toString().getBytes(StandardCharsets.UTF_8);
+    private void writeErrorResponse(ChannelHandlerContext ctx, int streamId, HttpResponseStatus status,
+                                    @Nullable ByteBuf content) throws Http2Exception {
+        final ByteBuf data =
+                content != null ? content
+                                : Unpooled.wrappedBuffer(status.toString().getBytes(StandardCharsets.UTF_8));
 
         writer.writeHeaders(
                 ctx, streamId,
                 new DefaultHttp2Headers(false)
                         .status(status.codeAsText())
                         .set(HttpHeaderNames.CONTENT_TYPE, MediaType.PLAIN_TEXT_UTF_8.toString())
-                        .setInt(HttpHeaderNames.CONTENT_LENGTH, content.length),
+                        .setInt(HttpHeaderNames.CONTENT_LENGTH, data.readableBytes()),
                 0, false, ctx.voidPromise());
 
-        writer.writeData(ctx, streamId, Unpooled.wrappedBuffer(content), 0, true, ctx.voidPromise());
+        writer.writeData(ctx, streamId, data, 0, true, ctx.voidPromise());
 
         final Http2Stream stream = writer.connection().stream(streamId);
         if (stream != null && writer.flowController().hasFlowControlled(stream)) {

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -17,7 +17,6 @@
 package com.linecorp.armeria.server;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
-import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.linecorp.armeria.common.SessionProtocol.H1;
 import static com.linecorp.armeria.common.SessionProtocol.H1C;
 import static com.linecorp.armeria.common.SessionProtocol.H2;
@@ -42,7 +41,6 @@ import javax.net.ssl.SSLSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.linecorp.armeria.common.AggregatedHttpMessage;
 import com.linecorp.armeria.common.ClosedSessionException;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaderNames;
@@ -53,6 +51,7 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.NonWrappingRequestContext;
+import com.linecorp.armeria.common.ProtocolViolationException;
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.SessionProtocol;
@@ -103,11 +102,14 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
                     HttpMethod.OPTIONS, HttpMethod.GET, HttpMethod.HEAD, HttpMethod.POST,
                     HttpMethod.PUT, HttpMethod.PATCH, HttpMethod.DELETE, HttpMethod.TRACE));
 
-    private static final Set<String> ALLOWED_METHOD_NAMES =
-            ALLOWED_METHODS.stream().map(HttpMethod::name).collect(toImmutableSet());
-
     private static final String ALLOWED_METHODS_STRING =
             ALLOWED_METHODS.stream().map(HttpMethod::name).collect(Collectors.joining(","));
+
+    private static final String MSG_MISSING_REQUEST_PATH = HttpStatus.BAD_REQUEST + "\nMissing request path";
+    private static final String MSG_INVALID_REQUEST_PATH = HttpStatus.BAD_REQUEST + "\nInvalid request path";
+
+    private static final HttpData DATA_MISSING_REQUEST_PATH = HttpData.ofUtf8(MSG_MISSING_REQUEST_PATH);
+    private static final HttpData DATA_INVALID_REQUEST_PATH = HttpData.ofUtf8(MSG_INVALID_REQUEST_PATH);
 
     private static final ChannelFutureListener CLOSE = future -> {
         final Throwable cause = future.cause();
@@ -309,31 +311,19 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
         }
 
         final HttpHeaders headers = req.headers();
-        final String methodName = headers.get(HttpHeaderNames.METHOD);
-        if (methodName == null) {
-            respond(ctx, req, HttpStatus.BAD_REQUEST,
-                    new IllegalArgumentException("Method is missing."));
-            return;
-        }
-        if (!ALLOWED_METHOD_NAMES.contains(methodName)) {
-            respond(ctx, req, HttpStatus.METHOD_NOT_ALLOWED,
-                    new IllegalArgumentException("Request method is not allowed: " + methodName));
-            return;
-        }
 
         // Handle 'OPTIONS * HTTP/1.1'.
         final String originalPath = headers.path();
         if (originalPath == null) {
-            respond(ctx, req, HttpStatus.BAD_REQUEST,
-                    new IllegalArgumentException("Request path is missing."));
+            respond(ctx, req, HttpStatus.BAD_REQUEST, DATA_MISSING_REQUEST_PATH,
+                    new ProtocolViolationException(MSG_MISSING_REQUEST_PATH));
             return;
         }
         if (originalPath.isEmpty() || originalPath.charAt(0) != '/') {
             if (headers.method() == HttpMethod.OPTIONS && "*".equals(originalPath)) {
                 handleOptions(ctx, req);
             } else {
-                respond(ctx, req, HttpStatus.BAD_REQUEST,
-                        new IllegalArgumentException("Request path is invalid: " + originalPath));
+                rejectInvalidPath(ctx, req);
             }
             return;
         }
@@ -341,9 +331,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
         // Validate and split path and query.
         final PathAndQuery pathAndQuery = PathAndQuery.parse(originalPath);
         if (pathAndQuery == null) {
-            // Reject requests without a valid path.
-            respond(ctx, req, HttpStatus.NOT_FOUND,
-                    new IllegalArgumentException("Request path is invalid: " + originalPath));
+            rejectInvalidPath(ctx, req);
             return;
         }
 
@@ -360,11 +348,11 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
             mapped = host.findServiceConfig(mappingCtx);
         } catch (HttpStatusException cause) {
             // We do not need to handle HttpResponseException here because we do not use it internally.
-            respond(ctx, req, pathAndQuery, cause.httpStatus(), cause);
+            respond(ctx, req, pathAndQuery, cause.httpStatus(), null, cause);
             return;
         } catch (Throwable cause) {
             logger.warn("{} Unexpected exception: {}", ctx.channel(), req, cause);
-            respond(ctx, req, pathAndQuery, HttpStatus.INTERNAL_SERVER_ERROR, cause);
+            respond(ctx, req, pathAndQuery, HttpStatus.INTERNAL_SERVER_ERROR, null, cause);
             return;
         }
         if (!mapped.isPresent()) {
@@ -404,10 +392,10 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
             } catch (Throwable cause) {
                 try {
                     if (cause instanceof HttpStatusException) {
-                        respond(ctx, req, ((HttpStatusException) cause).httpStatus(), reqCtx, cause);
+                        respond(ctx, reqCtx, ((HttpStatusException) cause).httpStatus(), null, cause);
                     } else {
                         logger.warn("{} Unexpected exception: {}, {}", reqCtx, service, req, cause);
-                        respond(ctx, req, HttpStatus.INTERNAL_SERVER_ERROR, reqCtx, cause);
+                        respond(ctx, reqCtx, HttpStatus.INTERNAL_SERVER_ERROR, null, cause);
                     }
                 } finally {
                     logBuilder.endRequest(cause);
@@ -472,11 +460,17 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
     }
 
     private void handleOptions(ChannelHandlerContext ctx, DecodedHttpRequest req) {
-        respond(ctx, req,
-                AggregatedHttpMessage.of(
-                        HttpHeaders.of(HttpStatus.OK)
-                                   .set(HttpHeaderNames.ALLOW, ALLOWED_METHODS_STRING)),
-                newEarlyRespondingRequestContext(ctx, req, req.path(), null), null);
+        respond(ctx,
+                newEarlyRespondingRequestContext(ctx, req, req.path(), null),
+                HttpHeaders.of(HttpStatus.OK)
+                           .set(HttpHeaderNames.ALLOW, ALLOWED_METHODS_STRING),
+                null, null);
+    }
+
+    private void rejectInvalidPath(ChannelHandlerContext ctx, DecodedHttpRequest req) {
+        // Reject requests without a valid path.
+        respond(ctx, req, HttpStatus.BAD_REQUEST, DATA_INVALID_REQUEST_PATH,
+                new ProtocolViolationException(MSG_INVALID_REQUEST_PATH));
     }
 
     private void handleNonExistentMapping(ChannelHandlerContext ctx, DecodedHttpRequest req,
@@ -500,7 +494,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
             }
         }
 
-        respond(ctx, req, HttpStatus.NOT_FOUND, null);
+        respond(ctx, req, HttpStatus.NOT_FOUND, null, null);
     }
 
     private void fillSchemeIfMissing(HttpHeaders headers) {
@@ -530,54 +524,53 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
 
     private void redirect(ChannelHandlerContext ctx, DecodedHttpRequest req,
                           PathAndQuery pathAndQuery, String location) {
-        respond(ctx, req,
-                AggregatedHttpMessage.of(
-                        HttpHeaders.of(HttpStatus.TEMPORARY_REDIRECT)
-                                   .set(HttpHeaderNames.LOCATION, location)),
+        respond(ctx,
                 newEarlyRespondingRequestContext(ctx, req, pathAndQuery.path(), pathAndQuery.query()),
-                null);
+                HttpHeaders.of(HttpStatus.TEMPORARY_REDIRECT)
+                           .set(HttpHeaderNames.LOCATION, location),
+                null, null);
     }
 
     private void respond(ChannelHandlerContext ctx, DecodedHttpRequest req,
-                         HttpStatus status, @Nullable Throwable cause) {
-        respond(ctx, req, status,
-                newEarlyRespondingRequestContext(ctx, req, req.path(), null), cause);
+                         HttpStatus status, @Nullable HttpData resContent, @Nullable Throwable cause) {
+        respond(ctx, newEarlyRespondingRequestContext(ctx, req, req.path(), null),
+                status, resContent, cause);
     }
 
     private void respond(ChannelHandlerContext ctx, DecodedHttpRequest req, PathAndQuery pathAndQuery,
-                         HttpStatus status, @Nullable Throwable cause) {
-        respond(ctx, req, status,
-                newEarlyRespondingRequestContext(ctx, req, pathAndQuery.path(), pathAndQuery.query()), cause);
+                         HttpStatus status, @Nullable HttpData resContent, @Nullable Throwable cause) {
+        respond(ctx, newEarlyRespondingRequestContext(ctx, req, pathAndQuery.path(), pathAndQuery.query()),
+                status, resContent, cause);
     }
 
-    private void respond(ChannelHandlerContext ctx, DecodedHttpRequest req, HttpStatus status,
-                         RequestContext reqCtx, @Nullable Throwable cause) {
+    private void respond(ChannelHandlerContext ctx, RequestContext reqCtx,
+                         HttpStatus status, @Nullable HttpData resContent, @Nullable Throwable cause) {
 
         if (status.code() < 400) {
-            respond(ctx, req, AggregatedHttpMessage.of(HttpHeaders.of(status)), reqCtx, cause);
+            respond(ctx, reqCtx, HttpHeaders.of(status), null, cause);
             return;
         }
 
-        final HttpData content;
-        if (req.method() == HttpMethod.HEAD || ArmeriaHttpUtil.isContentAlwaysEmpty(status)) {
-            content = HttpData.EMPTY_DATA;
+        if (reqCtx.method() == HttpMethod.HEAD || ArmeriaHttpUtil.isContentAlwaysEmpty(status)) {
+            resContent = null;
+        } else if (resContent == null) {
+            resContent = status.toHttpData();
         } else {
-            content = status.toHttpData();
+            assert !resContent.isEmpty();
         }
 
-        respond(ctx, req,
-                AggregatedHttpMessage.of(
-                        HttpHeaders.of(status)
-                                   .contentType(ERROR_CONTENT_TYPE),
-                        content), reqCtx, cause);
+        respond(ctx, reqCtx,
+                HttpHeaders.of(status)
+                           .contentType(ERROR_CONTENT_TYPE),
+                resContent, cause);
     }
 
-    private void respond(ChannelHandlerContext ctx, DecodedHttpRequest req, AggregatedHttpMessage res,
-                         RequestContext reqCtx, @Nullable Throwable cause) {
+    private void respond(ChannelHandlerContext ctx, RequestContext reqCtx,
+                         HttpHeaders resHeaders, @Nullable HttpData resContent, @Nullable Throwable cause) {
         if (!handledLastRequest) {
-            respond0(req, res, reqCtx, true, cause).addListener(CLOSE_ON_FAILURE);
+            respond0(reqCtx, true, resHeaders, resContent, cause).addListener(CLOSE_ON_FAILURE);
         } else {
-            respond0(req, res, reqCtx, false, cause).addListener(CLOSE);
+            respond0(reqCtx, false, resHeaders, resContent, cause).addListener(CLOSE);
         }
 
         if (!isReading) {
@@ -585,40 +578,36 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
         }
     }
 
-    private ChannelFuture respond0(DecodedHttpRequest req, AggregatedHttpMessage res, RequestContext reqCtx,
-                                   boolean addKeepAlive, @Nullable Throwable cause) {
+    private ChannelFuture respond0(
+            RequestContext reqCtx, boolean addKeepAlive,
+            HttpHeaders resHeaders, @Nullable HttpData resContent, @Nullable Throwable cause) {
+
+        assert resContent == null || !resContent.isEmpty() : resContent;
 
         // No need to consume further since the response is ready.
+        final DecodedHttpRequest req = reqCtx.request();
         req.close();
 
-        final boolean trailingHeadersEmpty = res.trailingHeaders().isEmpty();
-        final HttpData content = res.content();
-        final boolean contentAndTrailingHeadersEmpty = content.isEmpty() && trailingHeadersEmpty;
-
+        final boolean hasContent = resContent != null;
         final RequestLogBuilder logBuilder = reqCtx.logBuilder();
 
         logBuilder.startResponse();
         assert responseEncoder != null;
-        final HttpHeaders mutableHeaders = res.headers().toMutable();
+        final HttpHeaders mutableHeaders = resHeaders.toMutable();
         if (addKeepAlive) {
-            addKeepAliveHeaders(req, mutableHeaders);
+            addKeepAliveHeaders(mutableHeaders);
         }
         // Note that it is perfectly fine not to set the 'content-length' header to the last response
         // of an HTTP/1 connection. We set it anyway to work around overly strict HTTP clients that always
         // require a 'content-length' header for non-chunked responses.
-        setContentLength(req, mutableHeaders, content.length());
+        setContentLength(req, mutableHeaders, hasContent ? resContent.length() : 0);
 
         ChannelFuture future = responseEncoder.writeHeaders(
-                req.id(), req.streamId(), mutableHeaders, contentAndTrailingHeadersEmpty);
+                req.id(), req.streamId(), mutableHeaders, !hasContent);
         logBuilder.responseHeaders(mutableHeaders);
-        if (!contentAndTrailingHeadersEmpty) {
-            future = responseEncoder.writeData(
-                    req.id(), req.streamId(), content, trailingHeadersEmpty);
-            logBuilder.increaseResponseLength(content.length());
-            if (!trailingHeadersEmpty) {
-                future = responseEncoder.writeHeaders(
-                        req.id(), req.streamId(), res.trailingHeaders(), true);
-            }
+        if (hasContent) {
+            future = responseEncoder.writeData(req.id(), req.streamId(), resContent, true);
+            logBuilder.increaseResponseLength(resContent.length());
         }
 
         future.addListener(f -> {
@@ -637,7 +626,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
      * Sets the keep alive header as per:
      * - https://www.w3.org/Protocols/HTTP/1.1/draft-ietf-http-v11-spec-01.html#Connection
      */
-    private void addKeepAliveHeaders(HttpRequest req, HttpHeaders headers) {
+    private void addKeepAliveHeaders(HttpHeaders headers) {
         if (protocol == H1 || protocol == H1C) {
             headers.set(HttpHeaderNames.CONNECTION, "keep-alive");
         } else {

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerPathTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerPathTest.java
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -58,7 +58,7 @@ public class HttpServerPathTest {
         }
     };
 
-    private static final Map<String, HttpStatus> TEST_URLS = new HashMap<>();
+    private static final Map<String, HttpStatus> TEST_URLS = new LinkedHashMap<>();
 
     static {
         // 200 test
@@ -97,11 +97,9 @@ public class HttpServerPathTest {
         TEST_URLS.put("/\\\\", HttpStatus.BAD_REQUEST);
         TEST_URLS.put("/service/foo>bar", HttpStatus.BAD_REQUEST);
         TEST_URLS.put("/service/foo<bar", HttpStatus.BAD_REQUEST);
-
-        // 404 test
-        TEST_URLS.put("/gwturl#user:45/comments", HttpStatus.NOT_FOUND);
-        TEST_URLS.put("/service:name/hello", HttpStatus.NOT_FOUND);
-        TEST_URLS.put("/service::::name/hello", HttpStatus.NOT_FOUND);
+        TEST_URLS.put("/gwturl#user:45/comments", HttpStatus.BAD_REQUEST);
+        TEST_URLS.put("/service:name/hello", HttpStatus.BAD_REQUEST);
+        TEST_URLS.put("/service::::name/hello", HttpStatus.BAD_REQUEST);
     }
 
     @Test(timeout = 10000)

--- a/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaHttpHandlerAdapter.java
+++ b/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaHttpHandlerAdapter.java
@@ -28,6 +28,7 @@ import org.springframework.http.server.reactive.HttpHandler;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
 import reactor.core.publisher.Mono;
@@ -52,8 +53,11 @@ final class ArmeriaHttpHandlerAdapter {
         try {
             convertedRequest = new ArmeriaServerHttpRequest(ctx, req, factoryWrapper);
         } catch (Exception e) {
-            logger.warn("{} Invalid request path: {}", ctx, req.path(), e);
-            future.complete(HttpResponse.of(HttpStatus.BAD_REQUEST));
+            final String path = req.path();
+            logger.warn("{} Invalid request path: {}", ctx, path, e);
+            future.complete(HttpResponse.of(HttpStatus.BAD_REQUEST,
+                                            MediaType.PLAIN_TEXT_UTF_8,
+                                            HttpStatus.BAD_REQUEST + "\nInvalid request path: " + path));
             return Mono.empty();
         }
 


### PR DESCRIPTION
Motivation:

It is sometimes hard for a client to know why a request is bad.

Modifications:

- Added short error messages to 400 Bad Request responses
- Used `ProtocolViolationException` instead of `IllegalArgumentException` for bad requests.
- Removed unnecessary validation of HTTP method in `HttpServerHandler`.
- Cleaned up response generation in `HttpServerHandler`.

Result:

- User friendliness.