### PR TITLE
Add more shortcut methods for convenience

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/AggregatedHttpMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AggregatedHttpMessage.java
@@ -21,6 +21,7 @@ import static com.linecorp.armeria.internal.ArmeriaHttpUtil.isContentAlwaysEmpty
 import static com.linecorp.armeria.internal.ArmeriaHttpUtil.setOrRemoveContentLength;
 import static java.util.Objects.requireNonNull;
 
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Formatter;
@@ -61,13 +62,34 @@ public interface AggregatedHttpMessage {
      * @param mediaType the {@link MediaType} of the request content
      * @param content the content of the request
      */
+    static AggregatedHttpMessage of(HttpMethod method, String path, MediaType mediaType, CharSequence content) {
+        if (content instanceof String) {
+            return of(method, path, mediaType, (String) content);
+        }
+
+        requireNonNull(method, "method");
+        requireNonNull(path, "path");
+        requireNonNull(content, "content");
+        requireNonNull(mediaType, "mediaType");
+        return of(method, path, mediaType,
+                  HttpData.of(mediaType.charset().orElse(StandardCharsets.UTF_8), content));
+    }
+
+    /**
+     * Creates a new HTTP request.
+     *
+     * @param method the HTTP method of the request
+     * @param path the path of the request
+     * @param mediaType the {@link MediaType} of the request content
+     * @param content the content of the request
+     */
     static AggregatedHttpMessage of(HttpMethod method, String path, MediaType mediaType, String content) {
         requireNonNull(method, "method");
         requireNonNull(path, "path");
         requireNonNull(content, "content");
         requireNonNull(mediaType, "mediaType");
-        return of(method, path,
-                  mediaType, content.getBytes(mediaType.charset().orElse(StandardCharsets.UTF_8)));
+        return of(method, path, mediaType,
+                  HttpData.of(mediaType.charset().orElse(StandardCharsets.UTF_8), content));
     }
 
     /**
@@ -87,11 +109,8 @@ public interface AggregatedHttpMessage {
         requireNonNull(mediaType, "mediaType");
         requireNonNull(format, "format");
         requireNonNull(args, "args");
-        return of(method,
-                  path,
-                  mediaType,
-                  String.format(Locale.ENGLISH, format, args).getBytes(
-                          mediaType.charset().orElse(StandardCharsets.UTF_8)));
+        return of(method, path, mediaType,
+                  HttpData.of(mediaType.charset().orElse(StandardCharsets.UTF_8), format, args));
     }
 
     /**
@@ -196,12 +215,30 @@ public interface AggregatedHttpMessage {
      * @param mediaType the {@link MediaType} of the response content
      * @param content the content of the response
      */
+    static AggregatedHttpMessage of(HttpStatus status, MediaType mediaType, CharSequence content) {
+        if (content instanceof String) {
+            return of(status, mediaType, (String) content);
+        }
+
+        requireNonNull(status, "status");
+        requireNonNull(mediaType, "mediaType");
+        requireNonNull(content, "content");
+        return of(status, mediaType,
+                  HttpData.of(mediaType.charset().orElse(StandardCharsets.UTF_8), content));
+    }
+
+    /**
+     * Creates a new HTTP response of the specified {@link HttpStatus}.
+     *
+     * @param mediaType the {@link MediaType} of the response content
+     * @param content the content of the response
+     */
     static AggregatedHttpMessage of(HttpStatus status, MediaType mediaType, String content) {
         requireNonNull(status, "status");
         requireNonNull(mediaType, "mediaType");
         requireNonNull(content, "content");
-        return of(status,
-                  mediaType, content.getBytes(mediaType.charset().orElse(StandardCharsets.UTF_8)));
+        return of(status, mediaType,
+                  HttpData.of(mediaType.charset().orElse(StandardCharsets.UTF_8), content));
     }
 
     /**
@@ -375,6 +412,27 @@ public interface AggregatedHttpMessage {
     HttpData content();
 
     /**
+     * Returns the content of this message as a string encoded in the specified {@link Charset}.
+     */
+    default String content(Charset charset) {
+        return content().toString(charset);
+    }
+
+    /**
+     * Returns the content of this message as a UTF-8 string.
+     */
+    default String contentUtf8() {
+        return content().toStringUtf8();
+    }
+
+    /**
+     * Returns the content of this message as an ASCII string.
+     */
+    default String contentAscii() {
+        return content().toStringAscii();
+    }
+
+    /**
      * Returns the {@link HttpHeaderNames#SCHEME SCHEME} of this message.
      *
      * @return the scheme, or {@code null} if there's no such header
@@ -423,6 +481,15 @@ public interface AggregatedHttpMessage {
     @Nullable
     default HttpStatus status() {
         return headers().status();
+    }
+
+    /**
+     * Returns the value of the {@code 'content-type'} header.
+     * @return the valid header value if present. {@code null} otherwise.
+     */
+    @Nullable
+    default MediaType contentType() {
+        return headers().contentType();
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/HttpData.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpData.java
@@ -21,6 +21,8 @@ import static java.util.Objects.requireNonNull;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Formatter;
@@ -88,6 +90,31 @@ public interface HttpData extends HttpObject {
      *
      * @return a new {@link HttpData}. {@link #EMPTY_DATA} if the length of {@code text} is 0.
      */
+    static HttpData of(Charset charset, CharSequence text) {
+        requireNonNull(charset, "charset");
+        requireNonNull(text, "text");
+
+        if (text instanceof String) {
+            return of(charset, (String) text);
+        }
+
+        if (text.length() == 0) {
+            return EMPTY_DATA;
+        }
+
+        final CharBuffer cb = CharBuffer.wrap(text);
+        final ByteBuffer buf = charset.encode(cb);
+        return of(buf.array(), buf.arrayOffset(), buf.remaining());
+    }
+
+    /**
+     * Converts the specified {@code text} into an {@link HttpData}.
+     *
+     * @param charset the {@link Charset} to use for encoding {@code text}
+     * @param text the {@link String} to convert
+     *
+     * @return a new {@link HttpData}. {@link #EMPTY_DATA} if the length of {@code text} is 0.
+     */
     static HttpData of(Charset charset, String text) {
         requireNonNull(charset, "charset");
         requireNonNull(text, "text");
@@ -141,6 +168,17 @@ public interface HttpData extends HttpObject {
      *
      * @return a new {@link HttpData}. {@link #EMPTY_DATA} if the length of {@code text} is 0.
      */
+    static HttpData ofUtf8(CharSequence text) {
+        return of(StandardCharsets.UTF_8, text);
+    }
+
+    /**
+     * Converts the specified {@code text} into a UTF-8 {@link HttpData}.
+     *
+     * @param text the {@link String} to convert
+     *
+     * @return a new {@link HttpData}. {@link #EMPTY_DATA} if the length of {@code text} is 0.
+     */
     static HttpData ofUtf8(String text) {
         return of(StandardCharsets.UTF_8, text);
     }
@@ -156,6 +194,17 @@ public interface HttpData extends HttpObject {
      */
     static HttpData ofUtf8(String format, Object... args) {
         return of(StandardCharsets.UTF_8, format, args);
+    }
+
+    /**
+     * Converts the specified {@code text} into a US-ASCII {@link HttpData}.
+     *
+     * @param text the {@link String} to convert
+     *
+     * @return a new {@link HttpData}. {@link #EMPTY_DATA} if the length of {@code text} is 0.
+     */
+    static HttpData ofAscii(CharSequence text) {
+        return of(StandardCharsets.US_ASCII, text);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -107,8 +107,24 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
      * @param mediaType the {@link MediaType} of the response content
      * @param content the content of the response
      */
+    static HttpResponse of(HttpStatus status, MediaType mediaType, CharSequence content) {
+        if (content instanceof String) {
+            return of(status, mediaType, (String) content);
+        }
+
+        return of(status, mediaType,
+                  HttpData.of(mediaType.charset().orElse(StandardCharsets.UTF_8), content));
+    }
+
+    /**
+     * Creates a new HTTP response of the specified {@link HttpStatus} and closes the stream.
+     *
+     * @param mediaType the {@link MediaType} of the response content
+     * @param content the content of the response
+     */
     static HttpResponse of(HttpStatus status, MediaType mediaType, String content) {
-        return of(status, mediaType, content.getBytes(mediaType.charset().orElse(StandardCharsets.UTF_8)));
+        return of(status, mediaType,
+                  HttpData.of(mediaType.charset().orElse(StandardCharsets.UTF_8), content));
     }
 
     /**
@@ -165,10 +181,9 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
      * @param args the arguments referenced by the format specifiers in the format string
      */
     static HttpResponse of(HttpStatus status, MediaType mediaType, String format, Object... args) {
-        return of(status,
-                  mediaType,
-                  String.format(Locale.ENGLISH, format, args).getBytes(
-                          mediaType.charset().orElse(StandardCharsets.UTF_8)));
+        requireNonNull(mediaType, "mediaType");
+        return of(status, mediaType,
+                  HttpData.of(mediaType.charset().orElse(StandardCharsets.UTF_8), format, args));
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -112,6 +112,7 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
             return of(status, mediaType, (String) content);
         }
 
+        requireNonNull(mediaType, "mediaType");
         return of(status, mediaType,
                   HttpData.of(mediaType.charset().orElse(StandardCharsets.UTF_8), content));
     }
@@ -123,6 +124,7 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
      * @param content the content of the response
      */
     static HttpResponse of(HttpStatus status, MediaType mediaType, String content) {
+        requireNonNull(mediaType, "mediaType");
         return of(status, mediaType,
                   HttpData.of(mediaType.charset().orElse(StandardCharsets.UTF_8), content));
     }

--- a/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedValueResolver.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedValueResolver.java
@@ -1098,7 +1098,7 @@ final class AnnotatedValueResolver {
                 case ALWAYS:
                     return true;
                 case FOR_FORM_DATA:
-                    return isFormData(req.headers().contentType());
+                    return isFormData(req.contentType());
             }
             return false;
         }
@@ -1162,7 +1162,7 @@ final class AnnotatedValueResolver {
                     result = httpParameters;
                     if (result == null) {
                         httpParameters = result = httpParametersOf(context.query(),
-                                                                   request.headers().contentType(),
+                                                                   request.contentType(),
                                                                    message);
                     }
                 }
@@ -1202,7 +1202,7 @@ final class AnnotatedValueResolver {
 
                 if (message != null && isFormData(contentType)) {
                     // Respect 'charset' attribute of the 'content-type' header if it exists.
-                    final String body = message.content().toString(
+                    final String body = message.content(
                             contentType.charset().orElse(StandardCharsets.US_ASCII));
                     if (!body.isEmpty()) {
                         final Map<String, List<String>> p =

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/ByteArrayRequestConverterFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/ByteArrayRequestConverterFunction.java
@@ -36,7 +36,7 @@ public class ByteArrayRequestConverterFunction implements RequestConverterFuncti
     @Override
     public Object convertRequest(ServiceRequestContext ctx, AggregatedHttpMessage request,
                                  Class<?> expectedResultType) throws Exception {
-        final MediaType mediaType = request.headers().contentType();
+        final MediaType mediaType = request.contentType();
         if (mediaType == null ||
             mediaType.is(MediaType.OCTET_STREAM) ||
             mediaType.is(MediaType.APPLICATION_BINARY)) {

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/JacksonRequestConverterFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/JacksonRequestConverterFunction.java
@@ -65,13 +65,12 @@ public class JacksonRequestConverterFunction implements RequestConverterFunction
     public Object convertRequest(ServiceRequestContext ctx, AggregatedHttpMessage request,
                                  Class<?> expectedResultType) throws Exception {
 
-        final MediaType contentType = request.headers().contentType();
+        final MediaType contentType = request.contentType();
         if (contentType != null && (contentType.is(MediaType.JSON) ||
                                     contentType.subtype().endsWith("+json"))) {
             final ObjectReader reader = readers.computeIfAbsent(expectedResultType, mapper::readerFor);
             if (reader != null) {
-                final String content = request.content().toString(
-                        contentType.charset().orElse(StandardCharsets.UTF_8));
+                final String content = request.content(contentType.charset().orElse(StandardCharsets.UTF_8));
                 try {
                     return reader.readValue(content);
                 } catch (JsonProcessingException e) {

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/StringRequestConverterFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/StringRequestConverterFunction.java
@@ -35,11 +35,10 @@ public class StringRequestConverterFunction implements RequestConverterFunction 
                                  Class<?> expectedResultType) throws Exception {
         if (expectedResultType == String.class ||
             expectedResultType == CharSequence.class) {
-            final MediaType contentType = request.headers().contentType();
+            final MediaType contentType = request.contentType();
             if (contentType != null && contentType.is(MediaType.ANY_TEXT_TYPE)) {
                 // See https://tools.ietf.org/html/rfc2616#section-3.7.1
-                return request.content().toString(
-                        contentType.charset().orElse(StandardCharsets.ISO_8859_1));
+                return request.content(contentType.charset().orElse(StandardCharsets.ISO_8859_1));
             }
         }
         return RequestConverterFunction.fallthrough();

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientPipeliningTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientPipeliningTest.java
@@ -139,8 +139,8 @@ public class HttpClientPipeliningTest {
         semaphore.release(2);
 
         // Two requests should go through two different connections.
-        final String remoteAddress1 = res1.aggregate(aggregateExecutors.next()).get().content().toStringUtf8();
-        final String remoteAddress2 = res2.aggregate(aggregateExecutors.next()).get().content().toStringUtf8();
+        final String remoteAddress1 = res1.aggregate(aggregateExecutors.next()).get().contentUtf8();
+        final String remoteAddress2 = res2.aggregate(aggregateExecutors.next()).get().contentUtf8();
         assertThat(remoteAddress1).isNotEqualTo(remoteAddress2);
     }
 
@@ -173,8 +173,8 @@ public class HttpClientPipeliningTest {
         semaphore.release(2);
 
         // Two requests should go through one same connection.
-        final String remoteAddress1 = res1.aggregate(aggregateExecutors.next()).get().content().toStringUtf8();
-        final String remoteAddress2 = res2.aggregate(aggregateExecutors.next()).get().content().toStringUtf8();
+        final String remoteAddress1 = res1.aggregate(aggregateExecutors.next()).get().contentUtf8();
+        final String remoteAddress2 = res2.aggregate(aggregateExecutors.next()).get().contentUtf8();
         assertThat(remoteAddress1).isEqualTo(remoteAddress2);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientSniTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientSniTest.java
@@ -18,7 +18,6 @@ package com.linecorp.armeria.client;
 
 import static org.junit.Assert.assertEquals;
 
-import java.nio.charset.StandardCharsets;
 import java.security.cert.X509Certificate;
 import java.util.concurrent.CompletableFuture;
 
@@ -126,8 +125,8 @@ public class HttpClientSniTest {
 
         final AggregatedHttpMessage response = client.get("/").aggregate().get();
 
-        assertEquals(HttpStatus.OK, response.headers().status());
-        return response.content().toString(StandardCharsets.UTF_8);
+        assertEquals(HttpStatus.OK, response.status());
+        return response.contentUtf8();
     }
 
     @Test
@@ -138,8 +137,8 @@ public class HttpClientSniTest {
                                           .set(HttpHeaderNames.AUTHORITY, "a.com:" + httpsPort))
                       .aggregate().get();
 
-        assertEquals(HttpStatus.OK, response.headers().status());
-        assertEquals("a.com: CN=a.com", response.content().toStringUtf8());
+        assertEquals(HttpStatus.OK, response.status());
+        assertEquals("a.com: CN=a.com", response.contentUtf8());
     }
 
     @Test
@@ -147,8 +146,8 @@ public class HttpClientSniTest {
         final HttpClient client = HttpClient.of(clientFactory, "https://127.0.0.1:" + httpsPort);
         try (SafeCloseable unused = Clients.withHttpHeader(HttpHeaderNames.AUTHORITY, "a.com:" + httpsPort)) {
             final AggregatedHttpMessage response = client.get("/").aggregate().get();
-            assertEquals(HttpStatus.OK, response.headers().status());
-            assertEquals("a.com: CN=a.com", response.content().toStringUtf8());
+            assertEquals(HttpStatus.OK, response.status());
+            assertEquals("a.com: CN=a.com", response.contentUtf8());
         }
     }
 

--- a/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerHttpClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerHttpClientTest.java
@@ -162,7 +162,7 @@ public class CircuitBreakerHttpClientTest {
         for (int i = 0; i < minimumRequestThreshold + 1; i++) {
             // Need to call execute() one more to change the state of the circuit breaker.
             final long currentTime = ticker.read();
-            assertThat(client.get("/unavailable").aggregate().join().headers().status())
+            assertThat(client.get("/unavailable").aggregate().join().status())
                     .isSameAs(HttpStatus.SERVICE_UNAVAILABLE);
             await().until(() -> currentTime != ticker.read());
         }

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientAuthorityHeaderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientAuthorityHeaderTest.java
@@ -74,7 +74,7 @@ public class RetryingClientAuthorityHeaderTest {
         final HttpClient client = newHttpClientWithEndpointGroup();
 
         final AggregatedHttpMessage msg = client.get("/").aggregate().join();
-        assertThat(msg.content().toStringUtf8()).contains("www.bar.com");
+        assertThat(msg.contentUtf8()).contains("www.bar.com");
     }
 
     @Test
@@ -83,7 +83,7 @@ public class RetryingClientAuthorityHeaderTest {
 
         final HttpHeaders headers = HttpHeaders.of(GET, "/").authority("www.armeria.com");
         final AggregatedHttpMessage msg = client.execute(headers).aggregate().join();
-        assertThat(msg.content().toStringUtf8()).contains("www.armeria.com");
+        assertThat(msg.contentUtf8()).contains("www.armeria.com");
     }
 
     private static HttpClient newHttpClientWithEndpointGroup() {

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientWithLoggingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientWithLoggingTest.java
@@ -101,7 +101,7 @@ public class RetryingClientWithLoggingTest {
                 .decorator(loggingDecorator())
                 .decorator(RetryingHttpClient.newDecorator(RetryStrategy.onServerErrorStatus()))
                 .build();
-        assertThat(client.get("/hello").aggregate().join().content().toStringUtf8()).isEqualTo("hello");
+        assertThat(client.get("/hello").aggregate().join().contentUtf8()).isEqualTo("hello");
 
         // wait until 6 logs(3 requests and 3 responses) are called back
         await().untilAsserted(() -> assertThat(logResult.size()).isEqualTo(successLogIndex + 1));
@@ -116,7 +116,7 @@ public class RetryingClientWithLoggingTest {
                 .decorator(RetryingHttpClient.newDecorator(RetryStrategy.onServerErrorStatus()))
                 .decorator(loggingDecorator())
                 .build();
-        assertThat(client.get("/hello").aggregate().join().content().toStringUtf8()).isEqualTo("hello");
+        assertThat(client.get("/hello").aggregate().join().contentUtf8()).isEqualTo("hello");
 
         // wait until 2 logs are called back
         await().untilAsserted(() -> assertThat(logResult.size()).isEqualTo(successLogIndex + 1));

--- a/core/src/test/java/com/linecorp/armeria/common/HttpDataTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/HttpDataTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.InputStream;
 import java.io.Reader;
+import java.nio.CharBuffer;
 import java.nio.charset.StandardCharsets;
 
 import org.junit.Test;
@@ -66,5 +67,17 @@ public class HttpDataTest {
         assertThat(in.read()).isEqualTo(65533);
         assertThat(in.read()).isEqualTo((int) 'C');
         assertThat(in.read()).isEqualTo(-1);
+    }
+
+    @Test
+    public void fromUtf8CharSequence() throws Exception {
+        assertThat(HttpData.ofUtf8((CharSequence) "가A").toStringUtf8()).isEqualTo("가A");
+        assertThat(HttpData.ofUtf8(CharBuffer.wrap("あB")).toStringUtf8()).isEqualTo("あB");
+    }
+
+    @Test
+    public void fromAsciiCharSequence() throws Exception {
+        assertThat(HttpData.ofAscii((CharSequence) "가A").toStringUtf8()).isEqualTo("?A");
+        assertThat(HttpData.ofAscii(CharBuffer.wrap("あB")).toStringUtf8()).isEqualTo("?B");
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/common/HttpResponseDuplicatorTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/HttpResponseDuplicatorTest.java
@@ -38,14 +38,14 @@ public class HttpResponseDuplicatorTest {
         final AggregatedHttpMessage res2 = resDuplicator.duplicateStream().aggregate().join();
 
         assertThat(res1.status()).isEqualTo(HttpStatus.OK);
-        assertThat(res1.headers().contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
+        assertThat(res1.contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
         assertThat(res1.headers().get(VARY)).isNull();
-        assertThat(res1.content().toStringUtf8()).isEqualTo("Armeria is awesome!");
+        assertThat(res1.contentUtf8()).isEqualTo("Armeria is awesome!");
 
         assertThat(res2.status()).isEqualTo(HttpStatus.OK);
-        assertThat(res2.headers().contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
+        assertThat(res2.contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
         assertThat(res2.headers().get(VARY)).isNull();
-        assertThat(res2.content().toStringUtf8()).isEqualTo("Armeria is awesome!");
+        assertThat(res2.contentUtf8()).isEqualTo("Armeria is awesome!");
         resDuplicator.close();
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/common/HttpResponseTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/HttpResponseTest.java
@@ -28,7 +28,7 @@ public class HttpResponseTest {
         final HttpResponse res = HttpResponse.of("Armeriaはいろんな使い方がアルメリア");
         final AggregatedHttpMessage message = res.aggregate().join();
         assertThat(message.status()).isEqualTo(HttpStatus.OK);
-        assertThat(message.content().toStringUtf8())
+        assertThat(message.contentUtf8())
                 .isEqualTo("Armeriaはいろんな使い方がアルメリア");
     }
 
@@ -39,7 +39,7 @@ public class HttpResponseTest {
                 "%sはいろんな使い方が%s", "Armeria", "アルメリア");
         final AggregatedHttpMessage message = res.aggregate().join();
         assertThat(message.status()).isEqualTo(HttpStatus.OK);
-        assertThat(message.content().toStringUtf8())
+        assertThat(message.contentUtf8())
                 .isEqualTo("Armeriaはいろんな使い方がアルメリア");
     }
 
@@ -50,7 +50,7 @@ public class HttpResponseTest {
                 MediaType.PLAIN_TEXT_UTF_8, "Armeriaはいろんな使い方がアルメリア");
         final AggregatedHttpMessage message = res.aggregate().join();
         assertThat(message.status()).isEqualTo(HttpStatus.OK);
-        assertThat(message.content().toStringUtf8())
+        assertThat(message.contentUtf8())
                 .isEqualTo("Armeriaはいろんな使い方がアルメリア");
     }
 
@@ -62,7 +62,7 @@ public class HttpResponseTest {
                 "%sはいろんな使い方が%s", "Armeria", "アルメリア");
         final AggregatedHttpMessage message = res.aggregate().join();
         assertThat(message.status()).isEqualTo(HttpStatus.OK);
-        assertThat(message.content().toStringUtf8())
+        assertThat(message.contentUtf8())
                 .isEqualTo("Armeriaはいろんな使い方がアルメリア");
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/internal/DefaultHttpRequestTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/DefaultHttpRequestTest.java
@@ -122,7 +122,7 @@ public class DefaultHttpRequestTest {
                 HttpHeaders.of(HttpMethod.GET, "/foo")
                            .add(HttpHeaderNames.CONTENT_LENGTH, "3"));
         // Content
-        assertThat(aggregated.content().toStringUtf8()).isEqualTo("foo");
+        assertThat(aggregated.contentUtf8()).isEqualTo("foo");
         // Trailing headers
         assertThat(aggregated.trailingHeaders()).isEqualTo(
                 HttpHeaders.of(HttpHeaderNames.of("a"), "b", HttpHeaderNames.of("c"), "d"));

--- a/core/src/test/java/com/linecorp/armeria/internal/DefaultHttpResponseTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/DefaultHttpResponseTest.java
@@ -127,7 +127,7 @@ public class DefaultHttpResponseTest {
                 HttpHeaders.of(200)
                            .add(HttpHeaderNames.of("c"), "d"));
         // Content
-        assertThat(aggregated.content().toStringUtf8()).isEqualTo("foo");
+        assertThat(aggregated.contentUtf8()).isEqualTo("foo");
         // Trailing headers
         assertThat(aggregated.trailingHeaders()).isEqualTo(
                 HttpHeaders.of(HttpHeaderNames.of("e"), "f", HttpHeaderNames.of("g"), "h"));

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpDocServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpDocServiceTest.java
@@ -136,7 +136,7 @@ public class AnnotatedHttpDocServiceTest {
         final HttpClient client = HttpClient.of(server.uri("/"));
         final AggregatedHttpMessage msg = client.get("/docs/specification.json").aggregate().join();
         assertThat(msg.status()).isEqualTo(HttpStatus.OK);
-        assertThatJson(msg.content().toStringUtf8()).when(IGNORING_ARRAY_ORDER).isEqualTo(expectedJson);
+        assertThatJson(msg.contentUtf8()).when(IGNORING_ARRAY_ORDER).isEqualTo(expectedJson);
     }
 
     private static void addFooMethodInfo(Map<Class<?>, Set<MethodInfo>> methodInfos) {

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceAnnotationAliasTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceAnnotationAliasTest.java
@@ -122,7 +122,7 @@ public class AnnotatedHttpServiceAnnotationAliasTest {
                                      Class<?> expectedResultType) throws Exception {
             if (expectedResultType == MyRequest.class) {
                 final String decorated = ctx.attr(decoratedFlag).get();
-                return new MyRequest(request.content().toStringUtf8() + decorated);
+                return new MyRequest(request.contentUtf8() + decorated);
             }
             return RequestConverterFunction.fallthrough();
         }
@@ -240,10 +240,10 @@ public class AnnotatedHttpServiceAnnotationAliasTest {
                                    HttpData.ofUtf8("Armeria"))
                           .aggregate().join();
         assertThat(msg.status()).isEqualTo(HttpStatus.CREATED);
-        assertThat(msg.headers().contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
+        assertThat(msg.contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
         assertThat(msg.headers().get(HttpHeaderNames.of("x-foo"))).isEqualTo("foo");
         assertThat(msg.headers().get(HttpHeaderNames.of("x-bar"))).isEqualTo("bar");
-        assertThat(msg.content().toStringUtf8())
+        assertThat(msg.contentUtf8())
                 .isEqualTo("Hello, Armeria (decorated-1) (decorated-2) (decorated-3)!");
         assertThat(msg.trailingHeaders().get(HttpHeaderNames.of("x-baz"))).isEqualTo("baz");
         assertThat(msg.trailingHeaders().get(HttpHeaderNames.of("x-qux"))).isEqualTo("qux");
@@ -260,10 +260,10 @@ public class AnnotatedHttpServiceAnnotationAliasTest {
                                    HttpData.ofUtf8("Armeria"))
                           .aggregate().join();
         assertThat(msg.status()).isEqualTo(HttpStatus.CREATED);
-        assertThat(msg.headers().contentType()).isEqualTo(MediaType.JSON_UTF_8);
+        assertThat(msg.contentType()).isEqualTo(MediaType.JSON_UTF_8);
         assertThat(msg.headers().get(HttpHeaderNames.of("x-foo"))).isEqualTo("foo");
         assertThat(msg.headers().get(HttpHeaderNames.of("x-bar"))).isEqualTo("bar");
-        assertThat(msg.content().toStringUtf8())
+        assertThat(msg.contentUtf8())
                 .isEqualTo("Hello, Armeria (decorated-1) (decorated-2) (decorated-3)!");
         assertThat(msg.trailingHeaders().get(HttpHeaderNames.of("x-baz"))).isEqualTo("baz");
         assertThat(msg.trailingHeaders().get(HttpHeaderNames.of("x-qux"))).isEqualTo("qux");
@@ -277,7 +277,7 @@ public class AnnotatedHttpServiceAnnotationAliasTest {
         // @AdditionalHeader/Trailer is added using ServiceRequestContext, so they are added even if
         // the request is not succeeded.
         assertThat(msg.headers().get(HttpHeaderNames.of("x-foo"))).isEqualTo("foo");
-        assertThat(msg.content().toStringUtf8())
+        assertThat(msg.contentUtf8())
                 .isEqualTo("Cause:" + IllegalArgumentException.class.getSimpleName());
         assertThat(msg.trailingHeaders().get(HttpHeaderNames.of("x-bar"))).isEqualTo("bar");
     }
@@ -290,7 +290,7 @@ public class AnnotatedHttpServiceAnnotationAliasTest {
         // @AdditionalHeader/Trailer is added using ServiceRequestContext, so they are added even if
         // the request is not succeeded.
         assertThat(msg.headers().get(HttpHeaderNames.of("x-foo"))).isEqualTo("foo");
-        assertThat(msg.content().toStringUtf8())
+        assertThat(msg.contentUtf8())
                 .isEqualTo("Cause:" + IllegalStateException.class.getSimpleName());
         assertThat(msg.trailingHeaders().get(HttpHeaderNames.of("x-bar"))).isEqualTo("bar");
     }

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceDecorationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceDecorationTest.java
@@ -171,36 +171,35 @@ public class AnnotatedHttpServiceDecorationTest {
         AggregatedHttpMessage response;
 
         response = client.execute(HttpHeaders.of(HttpMethod.GET, "/1/ok")).aggregate().get();
-        assertThat(response.headers().status()).isEqualTo(HttpStatus.OK);
+        assertThat(response.status()).isEqualTo(HttpStatus.OK);
 
         response = client.execute(HttpHeaders.of(HttpMethod.GET, "/1/tooManyRequests")).aggregate().get();
-        assertThat(response.headers().status()).isEqualTo(
-                HttpStatus.TOO_MANY_REQUESTS);
+        assertThat(response.status()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS);
 
         response = client.execute(HttpHeaders.of(HttpMethod.GET, "/1/locked")).aggregate().get();
-        assertThat(response.headers().status()).isEqualTo(HttpStatus.LOCKED);
+        assertThat(response.status()).isEqualTo(HttpStatus.LOCKED);
 
         // Call inherited methods.
         response = client.execute(HttpHeaders.of(HttpMethod.GET, "/2/tooManyRequests")).aggregate().get();
-        assertThat(response.headers().status()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS);
+        assertThat(response.status()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS);
 
         response = client.execute(HttpHeaders.of(HttpMethod.GET, "/2/locked")).aggregate().get();
-        assertThat(response.headers().status()).isEqualTo(HttpStatus.LOCKED);
+        assertThat(response.status()).isEqualTo(HttpStatus.LOCKED);
 
         // Call a new method.
         response = client.execute(HttpHeaders.of(HttpMethod.GET, "/2/added")).aggregate().get();
-        assertThat(response.headers().status()).isEqualTo(HttpStatus.OK);
+        assertThat(response.status()).isEqualTo(HttpStatus.OK);
 
         // Call an overriding method.
         response = client.execute(HttpHeaders.of(HttpMethod.GET, "/2/override")).aggregate().get();
-        assertThat(response.headers().status()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS);
+        assertThat(response.status()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS);
 
         // Respond by the class-level decorator.
         response = client.execute(HttpHeaders.of(HttpMethod.GET, "/3/tooManyRequests")).aggregate().get();
-        assertThat(response.headers().status()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS);
+        assertThat(response.status()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS);
 
         // Respond by the method-level decorator.
         response = client.execute(HttpHeaders.of(HttpMethod.GET, "/4/tooManyRequests")).aggregate().get();
-        assertThat(response.headers().status()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS);
+        assertThat(response.status()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceExceptionHandlerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceExceptionHandlerTest.java
@@ -252,61 +252,61 @@ public class AnnotatedHttpServiceExceptionHandlerTest {
         NoExceptionHandler.counter.set(0);
 
         response = client.execute(HttpHeaders.of(HttpMethod.GET, "/1/sync")).aggregate().join();
-        assertThat(response.headers().status()).isEqualTo(HttpStatus.OK);
-        assertThat(response.content().toStringUtf8()).isEqualTo("handler1");
+        assertThat(response.status()).isEqualTo(HttpStatus.OK);
+        assertThat(response.contentUtf8()).isEqualTo("handler1");
 
         assertThat(NoExceptionHandler.counter.get()).isEqualTo(1);
 
         response = client.execute(HttpHeaders.of(HttpMethod.GET, "/1/async")).aggregate().join();
-        assertThat(response.headers().status()).isEqualTo(HttpStatus.OK);
-        assertThat(response.content().toStringUtf8()).isEqualTo("handler1");
+        assertThat(response.status()).isEqualTo(HttpStatus.OK);
+        assertThat(response.contentUtf8()).isEqualTo("handler1");
 
         assertThat(NoExceptionHandler.counter.get()).isEqualTo(2);
 
         response = client.execute(HttpHeaders.of(HttpMethod.GET, "/1/resp1")).aggregate().join();
-        assertThat(response.headers().status()).isEqualTo(HttpStatus.OK);
-        assertThat(response.content().toStringUtf8()).isEqualTo("handler1");
+        assertThat(response.status()).isEqualTo(HttpStatus.OK);
+        assertThat(response.contentUtf8()).isEqualTo("handler1");
 
         assertThat(NoExceptionHandler.counter.get()).isEqualTo(3);
 
         response = client.execute(HttpHeaders.of(HttpMethod.GET, "/1/resp2")).aggregate().join();
-        assertThat(response.headers().status()).isEqualTo(HttpStatus.OK);
-        assertThat(response.content().toStringUtf8()).isEqualTo("handler2");
+        assertThat(response.status()).isEqualTo(HttpStatus.OK);
+        assertThat(response.contentUtf8()).isEqualTo("handler2");
 
         assertThat(NoExceptionHandler.counter.get()).isEqualTo(4);
 
         // By default exception handler.
         response = client.execute(HttpHeaders.of(HttpMethod.GET, "/2/sync")).aggregate().join();
-        assertThat(response.headers().status()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.status()).isEqualTo(HttpStatus.BAD_REQUEST);
 
         // The method returns CompletionStage<?>. It throws an exception immediately if it is called.
         response = client.execute(HttpHeaders.of(HttpMethod.GET, "/2/async")).aggregate().join();
-        assertThat(response.headers().status()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.status()).isEqualTo(HttpStatus.BAD_REQUEST);
 
         // The method returns CompletionStage<?>. It throws an exception after the request is aggregated.
         response = client.execute(HttpHeaders.of(HttpMethod.GET, "/2/async/aggregation"))
                          .aggregate().join();
-        assertThat(response.headers().status()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.status()).isEqualTo(HttpStatus.BAD_REQUEST);
 
         // Timeout because of bad exception handler.
         response = client.execute(HttpHeaders.of(HttpMethod.GET, "/3/bad1")).aggregate().join();
-        assertThat(response.headers().status()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+        assertThat(response.status()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
 
         // Internal server error would be returned due to invalid response.
         response = client.execute(HttpHeaders.of(HttpMethod.GET, "/3/bad2")).aggregate().join();
-        assertThat(response.headers().status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        assertThat(response.status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
 
         NoExceptionHandler.counter.set(0);
 
         response = client.execute(HttpHeaders.of(HttpMethod.GET, "/4/handler3")).aggregate().join();
-        assertThat(response.headers().status()).isEqualTo(HttpStatus.OK);
-        assertThat(response.content().toStringUtf8()).isEqualTo("handler3");
+        assertThat(response.status()).isEqualTo(HttpStatus.OK);
+        assertThat(response.contentUtf8()).isEqualTo("handler3");
 
         assertThat(NoExceptionHandler.counter.get()).isZero();
 
         // A decorator throws an exception.
         response = client.execute(HttpHeaders.of(HttpMethod.GET, "/5/handler3")).aggregate().join();
-        assertThat(response.headers().status()).isEqualTo(HttpStatus.OK);
-        assertThat(response.content().toStringUtf8()).isEqualTo("handler3");
+        assertThat(response.status()).isEqualTo(HttpStatus.OK);
+        assertThat(response.contentUtf8()).isEqualTo("handler3");
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceHandlersOrderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceHandlersOrderTest.java
@@ -228,9 +228,9 @@ public class AnnotatedHttpServiceHandlersOrderTest {
 
         final AggregatedHttpMessage aRes = executeRequest(aReq);
 
-        assertThat(aRes.headers().status()).isEqualTo(HttpStatus.OK);
+        assertThat(aRes.status()).isEqualTo(HttpStatus.OK);
         // Converted from the default converter which is JacksonRequestConverterFunction.
-        assertThat(aRes.content().toStringUtf8()).isEqualTo(body);
+        assertThat(aRes.contentUtf8()).isEqualTo(body);
 
         // parameter level(+1) -> method level(+1) -> class level(+1) -> service level(+1) -> default
         assertThat(requestCounter.get()).isEqualTo(4);
@@ -242,9 +242,9 @@ public class AnnotatedHttpServiceHandlersOrderTest {
                 HttpMethod.POST, "/1/responseConverterOrder", MediaType.PLAIN_TEXT_UTF_8, "foo");
         final AggregatedHttpMessage aRes = executeRequest(aReq);
 
-        assertThat(aRes.headers().status()).isEqualTo(HttpStatus.OK);
+        assertThat(aRes.status()).isEqualTo(HttpStatus.OK);
         // Converted from the ServiceLevelResponseConverter.
-        assertThat(aRes.content().toStringUtf8()).isEqualTo("hello foo");
+        assertThat(aRes.contentUtf8()).isEqualTo("hello foo");
 
         // method level(+1) -> class level(+1) -> service level(+1)
         assertThat(responseCounter.get()).isEqualTo(3);
@@ -256,9 +256,9 @@ public class AnnotatedHttpServiceHandlersOrderTest {
                 HttpMethod.POST, "/1/exceptionHandlerOrder", MediaType.PLAIN_TEXT_UTF_8, "foo");
         final AggregatedHttpMessage aRes = executeRequest(aReq);
 
-        assertThat(aRes.headers().status()).isEqualTo(HttpStatus.NOT_IMPLEMENTED);
+        assertThat(aRes.status()).isEqualTo(HttpStatus.NOT_IMPLEMENTED);
         // Converted from the default Handler which is DefaultExceptionHandler in AnnotatedHttpServices.
-        assertThat(aRes.content().toStringUtf8()).isEqualTo("hello foo");
+        assertThat(aRes.contentUtf8()).isEqualTo("hello foo");
 
         // method level(+1) -> class level(+1) -> service level(+1) -> default
         assertThat(exceptionCounter.get()).isEqualTo(3);

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceRequestConverterTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceRequestConverterTest.java
@@ -570,7 +570,7 @@ public class AnnotatedHttpServiceRequestConverterTest {
         public RequestJsonObj1 convertRequest(ServiceRequestContext ctx, AggregatedHttpMessage request,
                                               Class<?> expectedResultType) throws Exception {
             if (expectedResultType.isAssignableFrom(RequestJsonObj1.class)) {
-                return mapper.readValue(request.content().toStringUtf8(), RequestJsonObj1.class);
+                return mapper.readValue(request.contentUtf8(), RequestJsonObj1.class);
             }
             return RequestConverterFunction.fallthrough();
         }
@@ -583,7 +583,7 @@ public class AnnotatedHttpServiceRequestConverterTest {
         public RequestJsonObj1 convertRequest(ServiceRequestContext ctx, AggregatedHttpMessage request,
                                               Class<?> expectedResultType) throws Exception {
             if (expectedResultType.isAssignableFrom(RequestJsonObj1.class)) {
-                final RequestJsonObj1 obj1 = mapper.readValue(request.content().toStringUtf8(),
+                final RequestJsonObj1 obj1 = mapper.readValue(request.contentUtf8(),
                                                               RequestJsonObj1.class);
                 return new RequestJsonObj1(obj1.intVal() + 1, obj1.strVal() + 'a');
             }
@@ -609,7 +609,7 @@ public class AnnotatedHttpServiceRequestConverterTest {
         public Optional<RequestJsonObj1> convertRequest(ServiceRequestContext ctx,
                                                         AggregatedHttpMessage request,
                                                         Class<?> expectedResultType) throws Exception {
-            return Optional.of(mapper.readValue(request.content().toStringUtf8(), RequestJsonObj1.class));
+            return Optional.of(mapper.readValue(request.contentUtf8(), RequestJsonObj1.class));
         }
     }
 
@@ -633,19 +633,19 @@ public class AnnotatedHttpServiceRequestConverterTest {
         final String content1 = mapper.writeValueAsString(obj1);
 
         response = client.post("/1/convert1", content1).aggregate().join();
-        assertThat(response.headers().status()).isEqualTo(HttpStatus.OK);
-        assertThat(response.content().toStringUtf8()).isEqualTo(obj1.toString());
+        assertThat(response.status()).isEqualTo(HttpStatus.OK);
+        assertThat(response.contentUtf8()).isEqualTo(obj1.toString());
 
         // The order of converters
         final RequestJsonObj1 obj1a = new RequestJsonObj1(2, "abca");
         response = client.post("/1/convert2", content1).aggregate().join();
-        assertThat(response.headers().status()).isEqualTo(HttpStatus.OK);
-        assertThat(response.content().toStringUtf8()).isEqualTo(obj1a.toString());
+        assertThat(response.status()).isEqualTo(HttpStatus.OK);
+        assertThat(response.contentUtf8()).isEqualTo(obj1a.toString());
 
         // Multiple @RequestConverter annotated parameters
         response = client.post("/1/convert3", content1).aggregate().join();
-        assertThat(response.headers().status()).isEqualTo(HttpStatus.OK);
-        assertThat(response.content().toStringUtf8()).isEqualTo(HttpMethod.POST.name());
+        assertThat(response.status()).isEqualTo(HttpStatus.OK);
+        assertThat(response.contentUtf8()).isEqualTo(HttpMethod.POST.name());
     }
 
     @Test
@@ -675,8 +675,8 @@ public class AnnotatedHttpServiceRequestConverterTest {
                                             .contentType(MediaType.FORM_DATA);
 
         response = client.execute(AggregatedHttpMessage.of(reqHeaders, formData)).aggregate().join();
-        assertThat(response.headers().status()).isEqualTo(HttpStatus.OK);
-        assertThat(response.content().toStringUtf8()).isEqualTo(expectedResponseContent);
+        assertThat(response.status()).isEqualTo(HttpStatus.OK);
+        assertThat(response.contentUtf8()).isEqualTo(expectedResponseContent);
 
         // Normal Request: GET + Query String
         reqHeaders = HttpHeaders.of(HttpMethod.GET,
@@ -685,8 +685,8 @@ public class AnnotatedHttpServiceRequestConverterTest {
                                 .set(HttpHeaderNames.of("x-client-name"), "TestClient");
 
         response = client.execute(AggregatedHttpMessage.of(reqHeaders)).aggregate().join();
-        assertThat(response.headers().status()).isEqualTo(HttpStatus.OK);
-        assertThat(response.content().toStringUtf8()).isEqualTo(expectedResponseContent);
+        assertThat(response.status()).isEqualTo(HttpStatus.OK);
+        assertThat(response.contentUtf8()).isEqualTo(expectedResponseContent);
 
         // Bad Request: age=badParam
         reqHeaders = HttpHeaders.of(HttpMethod.GET,
@@ -695,7 +695,7 @@ public class AnnotatedHttpServiceRequestConverterTest {
                                 .set(HttpHeaderNames.of("x-client-name"), "TestClient");
 
         response = client.execute(AggregatedHttpMessage.of(reqHeaders)).aggregate().join();
-        assertThat(response.headers().status()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.status()).isEqualTo(HttpStatus.BAD_REQUEST);
 
         // Bad Request: seqNum=badParam
         reqHeaders = HttpHeaders.of(HttpMethod.GET,
@@ -704,7 +704,7 @@ public class AnnotatedHttpServiceRequestConverterTest {
                                 .set(HttpHeaderNames.of("x-client-name"), "TestClient");
 
         response = client.execute(AggregatedHttpMessage.of(reqHeaders)).aggregate().join();
-        assertThat(response.headers().status()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.status()).isEqualTo(HttpStatus.BAD_REQUEST);
 
         // Bad Request: gender=badParam
         reqHeaders = HttpHeaders.of(HttpMethod.GET,
@@ -713,7 +713,7 @@ public class AnnotatedHttpServiceRequestConverterTest {
                                 .set(HttpHeaderNames.of("x-client-name"), "TestClient");
 
         response = client.execute(AggregatedHttpMessage.of(reqHeaders)).aggregate().join();
-        assertThat(response.headers().status()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.status()).isEqualTo(HttpStatus.BAD_REQUEST);
     }
 
     @Test
@@ -742,8 +742,8 @@ public class AnnotatedHttpServiceRequestConverterTest {
                                             .contentType(MediaType.FORM_DATA);
 
         response = client.execute(AggregatedHttpMessage.of(reqHeaders, formData)).aggregate().join();
-        assertThat(response.headers().status()).isEqualTo(HttpStatus.OK);
-        assertThat(response.content().toStringUtf8()).isEqualTo(expectedResponseContent);
+        assertThat(response.status()).isEqualTo(HttpStatus.OK);
+        assertThat(response.contentUtf8()).isEqualTo(expectedResponseContent);
 
         // Normal Request: GET + Query String
         reqHeaders = HttpHeaders.of(HttpMethod.GET,
@@ -753,8 +753,8 @@ public class AnnotatedHttpServiceRequestConverterTest {
                                 .set(HttpHeaderNames.of("uid"), "abcd-efgh");
 
         response = client.execute(AggregatedHttpMessage.of(reqHeaders)).aggregate().join();
-        assertThat(response.headers().status()).isEqualTo(HttpStatus.OK);
-        assertThat(response.content().toStringUtf8()).isEqualTo(expectedResponseContent);
+        assertThat(response.status()).isEqualTo(HttpStatus.OK);
+        assertThat(response.contentUtf8()).isEqualTo(expectedResponseContent);
     }
 
     @Test
@@ -782,8 +782,8 @@ public class AnnotatedHttpServiceRequestConverterTest {
                                             .contentType(MediaType.FORM_DATA);
 
         response = client.execute(AggregatedHttpMessage.of(reqHeaders, formData)).aggregate().join();
-        assertThat(response.headers().status()).isEqualTo(HttpStatus.OK);
-        assertThat(response.content().toStringUtf8()).isEqualTo(expectedResponseContent);
+        assertThat(response.status()).isEqualTo(HttpStatus.OK);
+        assertThat(response.contentUtf8()).isEqualTo(expectedResponseContent);
 
         // Normal Request: GET + Query String
         reqHeaders = HttpHeaders.of(HttpMethod.GET,
@@ -792,8 +792,8 @@ public class AnnotatedHttpServiceRequestConverterTest {
                                 .set(HttpHeaderNames.of("x-client-name"), "TestClient");
 
         response = client.execute(AggregatedHttpMessage.of(reqHeaders)).aggregate().join();
-        assertThat(response.headers().status()).isEqualTo(HttpStatus.OK);
-        assertThat(response.content().toStringUtf8()).isEqualTo(expectedResponseContent);
+        assertThat(response.status()).isEqualTo(HttpStatus.OK);
+        assertThat(response.contentUtf8()).isEqualTo(expectedResponseContent);
     }
 
     @Test
@@ -804,19 +804,19 @@ public class AnnotatedHttpServiceRequestConverterTest {
         AggregatedHttpMessage response;
 
         response = client.get("/composite1/10").aggregate().join();
-        assertThat(response.content().toStringUtf8())
+        assertThat(response.contentUtf8())
                 .isEqualTo(CompositeRequestBean1.class.getSimpleName() + ":10:20");
 
         response = client.get("/composite2/10").aggregate().join();
-        assertThat(response.content().toStringUtf8())
+        assertThat(response.contentUtf8())
                 .isEqualTo(CompositeRequestBean2.class.getSimpleName() + ":10:20");
 
         response = client.get("/composite3/10").aggregate().join();
-        assertThat(response.content().toStringUtf8())
+        assertThat(response.contentUtf8())
                 .isEqualTo(CompositeRequestBean3.class.getSimpleName() + ":10:20");
 
         response = client.get("/composite4/10").aggregate().join();
-        assertThat(response.content().toStringUtf8())
+        assertThat(response.contentUtf8())
                 .isEqualTo(CompositeRequestBean4.class.getSimpleName() + ":10:20");
 
         final RequestJsonObj1 obj1 = new RequestJsonObj1(1, "abc");
@@ -824,7 +824,7 @@ public class AnnotatedHttpServiceRequestConverterTest {
 
         response = client.execute(AggregatedHttpMessage.of(
                 HttpMethod.POST, "/composite5/10", MediaType.JSON_UTF_8, content1)).aggregate().join();
-        assertThat(response.content().toStringUtf8())
+        assertThat(response.contentUtf8())
                 .isEqualTo(CompositeRequestBean5.class.getSimpleName() + ":10:20:" +
                            obj1.strVal() + ':' + obj1.intVal());
     }
@@ -843,8 +843,8 @@ public class AnnotatedHttpServiceRequestConverterTest {
         response = client.execute(AggregatedHttpMessage.of(HttpMethod.POST, "/2/default/json",
                                                            MediaType.JSON_UTF_8, content1))
                          .aggregate().join();
-        assertThat(response.headers().status()).isEqualTo(HttpStatus.OK);
-        assertThat(response.content().toStringUtf8()).isEqualTo("abc");
+        assertThat(response.status()).isEqualTo(HttpStatus.OK);
+        assertThat(response.contentUtf8()).isEqualTo("abc");
 
         // MediaType.JSON_PATCH
         // obj1 is not a json-patch+json format, but just check if it's converted by
@@ -852,22 +852,22 @@ public class AnnotatedHttpServiceRequestConverterTest {
         response = client.execute(AggregatedHttpMessage.of(HttpMethod.POST, "/2/default/json",
                                                            MediaType.JSON_PATCH, content1))
                          .aggregate().join();
-        assertThat(response.headers().status()).isEqualTo(HttpStatus.OK);
-        assertThat(response.content().toStringUtf8()).isEqualTo("abc");
+        assertThat(response.status()).isEqualTo(HttpStatus.OK);
+        assertThat(response.contentUtf8()).isEqualTo("abc");
 
         // "application/vnd.api+json"
         response = client.execute(AggregatedHttpMessage.of(HttpMethod.POST, "/2/default/json",
                                                            MediaType.create("application", "vnd.api+json"),
                                                            content1))
                          .aggregate().join();
-        assertThat(response.headers().status()).isEqualTo(HttpStatus.OK);
-        assertThat(response.content().toStringUtf8()).isEqualTo("abc");
+        assertThat(response.status()).isEqualTo(HttpStatus.OK);
+        assertThat(response.contentUtf8()).isEqualTo("abc");
 
         final String invalidJson = "{\"foo:\"bar\"}"; // should be \"foo\"
         response = client.execute(AggregatedHttpMessage.of(HttpMethod.POST, "/2/default/invalidJson",
                                                            MediaType.JSON_UTF_8, invalidJson))
                          .aggregate().join();
-        assertThat(response.headers().status()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.status()).isEqualTo(HttpStatus.BAD_REQUEST);
     }
 
     @Test
@@ -880,7 +880,7 @@ public class AnnotatedHttpServiceRequestConverterTest {
         response = client.execute(AggregatedHttpMessage.of(HttpMethod.POST, "/2/default/binary",
                                                            MediaType.OCTET_STREAM, binary))
                          .aggregate().join();
-        assertThat(response.headers().status()).isEqualTo(HttpStatus.OK);
+        assertThat(response.status()).isEqualTo(HttpStatus.OK);
         assertThat(response.content().array()).isEqualTo(binary);
     }
 
@@ -894,7 +894,7 @@ public class AnnotatedHttpServiceRequestConverterTest {
         response = client.execute(AggregatedHttpMessage.of(HttpMethod.POST, "/2/default/text",
                                                            MediaType.PLAIN_TEXT_UTF_8, utf8))
                          .aggregate().join();
-        assertThat(response.headers().status()).isEqualTo(HttpStatus.OK);
+        assertThat(response.status()).isEqualTo(HttpStatus.OK);
         assertThat(response.content().array()).isEqualTo(utf8);
 
         final MediaType textPlain = MediaType.create("text", "plain");
@@ -902,7 +902,7 @@ public class AnnotatedHttpServiceRequestConverterTest {
         response = client.execute(AggregatedHttpMessage.of(HttpMethod.POST, "/2/default/text",
                                                            textPlain, iso8859_1))
                          .aggregate().join();
-        assertThat(response.headers().status()).isEqualTo(HttpStatus.OK);
+        assertThat(response.status()).isEqualTo(HttpStatus.OK);
         // Response is encoded as UTF-8.
         assertThat(response.content().array()).isEqualTo(utf8);
     }
@@ -920,7 +920,7 @@ public class AnnotatedHttpServiceRequestConverterTest {
                                                   .setObject(HttpHeaderNames.of("foo"), 200);
 
         final AggregatedHttpMessage response = client.execute(reqHeaders).aggregate().join();
-        assertThat(response.headers().status()).isEqualTo(HttpStatus.OK);
-        assertThat(response.content().toStringUtf8()).isEqualTo(expectedResponseContent);
+        assertThat(response.status()).isEqualTo(HttpStatus.OK);
+        assertThat(response.contentUtf8()).isEqualTo(expectedResponseContent);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceResponseConverterTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceResponseConverterTest.java
@@ -497,24 +497,24 @@ public class AnnotatedHttpServiceResponseConverterTest {
         shouldBeConvertedByDefaultResponseConverter(HttpClient.of(rule.uri("/publish/single")));
     }
 
-    private void shouldBeConvertedByDefaultResponseConverter(HttpClient client) throws Exception {
+    private static void shouldBeConvertedByDefaultResponseConverter(HttpClient client) throws Exception {
         AggregatedHttpMessage msg;
 
         msg = aggregated(client.get("/string"));
-        assertThat(msg.headers().contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
-        assertThat(msg.content().toStringUtf8()).isEqualTo("¥");
-        assertThat(msg.content().toStringAscii()).isNotEqualTo("¥");
+        assertThat(msg.contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
+        assertThat(msg.contentUtf8()).isEqualTo("¥");
+        assertThat(msg.contentAscii()).isNotEqualTo("¥");
 
         msg = aggregated(client.get("/byteArray"));
-        assertThat(msg.headers().contentType()).isEqualTo(MediaType.OCTET_STREAM);
+        assertThat(msg.contentType()).isEqualTo(MediaType.OCTET_STREAM);
         assertThat(msg.content().array()).isEqualTo("¥".getBytes());
 
         msg = aggregated(client.get("/httpData"));
-        assertThat(msg.headers().contentType()).isEqualTo(MediaType.OCTET_STREAM);
+        assertThat(msg.contentType()).isEqualTo(MediaType.OCTET_STREAM);
         assertThat(msg.content().array()).isEqualTo("¥".getBytes());
 
         msg = aggregated(client.get("/jsonNode"));
-        assertThat(msg.headers().contentType()).isEqualTo(MediaType.JSON_UTF_8);
+        assertThat(msg.contentType()).isEqualTo(MediaType.JSON_UTF_8);
         final JsonNode expected = mapper.readTree("{\"a\":\"¥\"}");
         assertThat(msg.content().array()).isEqualTo(mapper.writeValueAsBytes(expected));
     }
@@ -526,14 +526,14 @@ public class AnnotatedHttpServiceResponseConverterTest {
         AggregatedHttpMessage msg;
 
         msg = aggregated(client.get("/string"));
-        assertThat(msg.headers().contentType()).isEqualTo(MediaType.JSON_UTF_8);
-        assertThatJson(msg.content().toStringUtf8())
+        assertThat(msg.contentType()).isEqualTo(MediaType.JSON_UTF_8);
+        assertThatJson(msg.contentUtf8())
                 .isArray().ofLength(3)
                 .thatContains("a").thatContains("b").thatContains("c");
 
         msg = aggregated(client.get("/jsonNode"));
-        assertThat(msg.headers().contentType()).isEqualTo(MediaType.JSON_UTF_8);
-        assertThatJson(msg.content().toStringUtf8())
+        assertThat(msg.contentType()).isEqualTo(MediaType.JSON_UTF_8);
+        assertThatJson(msg.contentUtf8())
                 .isEqualTo("[{\"a\":\"1\"},{\"b\":\"2\"},{\"c\":\"3\"}]");
     }
 
@@ -557,19 +557,19 @@ public class AnnotatedHttpServiceResponseConverterTest {
         AggregatedHttpMessage msg;
 
         msg = aggregated(client.get("/string"));
-        assertThat(msg.headers().contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
+        assertThat(msg.contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
         assertThat(msg.content().array()).isEqualTo("100".getBytes());
 
         msg = aggregated(client.get("/byteArray"));
-        assertThat(msg.headers().contentType()).isEqualTo(MediaType.OCTET_STREAM);
+        assertThat(msg.contentType()).isEqualTo(MediaType.OCTET_STREAM);
         assertThat(msg.content().array()).isEqualTo("¥".getBytes());
 
         msg = aggregated(client.get("/httpData"));
-        assertThat(msg.headers().contentType()).isEqualTo(MediaType.OCTET_STREAM);
+        assertThat(msg.contentType()).isEqualTo(MediaType.OCTET_STREAM);
         assertThat(msg.content().array()).isEqualTo("¥".getBytes());
 
         msg = aggregated(client.get("/jsonNode"));
-        assertThat(msg.headers().contentType()).isEqualTo(MediaType.JSON_UTF_8);
+        assertThat(msg.contentType()).isEqualTo(MediaType.JSON_UTF_8);
         final JsonNode expected = mapper.readTree("{\"a\":\"¥\"}");
         assertThat(msg.content().array()).isEqualTo(mapper.writeValueAsBytes(expected));
     }
@@ -606,7 +606,7 @@ public class AnnotatedHttpServiceResponseConverterTest {
             final AggregatedHttpMessage message = aggregated(client.get(path));
             assertThat(message.status()).isEqualTo(HttpStatus.OK);
             assertThat(message.headers().get(HttpHeaderNames.of("x-custom-header"))).isEqualTo("value");
-            assertThatJson(message.content().toStringUtf8()).isEqualTo(ImmutableMap.of("a", "b"));
+            assertThatJson(message.contentUtf8()).isEqualTo(ImmutableMap.of("a", "b"));
             assertThat(message.headers().get(HttpHeaderNames.of("x-custom-annotated-header"))).isEqualTo(
                     "annotated-value");
         });
@@ -616,7 +616,7 @@ public class AnnotatedHttpServiceResponseConverterTest {
             final AggregatedHttpMessage message = aggregated(client.get(path));
             assertThat(message.status()).isEqualTo(HttpStatus.OK);
             assertThat(message.headers().get(HttpHeaderNames.of("x-custom-header"))).isEqualTo("value");
-            assertThatJson(message.content().toStringUtf8()).isEqualTo(ImmutableList.of("a", "b"));
+            assertThatJson(message.contentUtf8()).isEqualTo(ImmutableList.of("a", "b"));
             assertThat(message.trailingHeaders().get(HttpHeaderNames.of("x-custom-trailing-header")))
                     .isEqualTo("value");
             assertThat(message.trailingHeaders().get(HttpHeaderNames.of("x-custom-annotated-trailing-header")))
@@ -629,7 +629,7 @@ public class AnnotatedHttpServiceResponseConverterTest {
         ImmutableList.of("/wildcard", "/generic").forEach(path -> {
             final AggregatedHttpMessage message = aggregated(client.get(path));
             assertThat(message.status()).isEqualTo(HttpStatus.OK);
-            assertThatJson(message.content().toStringUtf8()).isEqualTo(ImmutableList.of("a", "b"));
+            assertThatJson(message.contentUtf8()).isEqualTo(ImmutableList.of("a", "b"));
         });
 
         msg = aggregated(client.get("/header"));
@@ -649,14 +649,13 @@ public class AnnotatedHttpServiceResponseConverterTest {
 
         msg = aggregated(client.get("/mono/jsonNode"));
         assertThat(msg.status()).isEqualTo(HttpStatus.OK);
-        assertThat(msg.headers().contentType()).isEqualTo(MediaType.JSON_UTF_8);
-        assertThatJson(msg.content().toStringUtf8()).isEqualTo(ImmutableMap.of("a", "¥"));
+        assertThat(msg.contentType()).isEqualTo(MediaType.JSON_UTF_8);
+        assertThatJson(msg.contentUtf8()).isEqualTo(ImmutableMap.of("a", "¥"));
 
         msg = aggregated(client.get("/jsonNode"));
         assertThat(msg.status()).isEqualTo(HttpStatus.OK);
-        assertThat(msg.headers().contentType()).isEqualTo(MediaType.JSON_UTF_8);
-        assertThatJson(msg.content().toStringUtf8())
-                .isEqualTo(ImmutableList.of(ImmutableMap.of("a", "¥")));
+        assertThat(msg.contentType()).isEqualTo(MediaType.JSON_UTF_8);
+        assertThatJson(msg.contentUtf8()).isEqualTo(ImmutableList.of(ImmutableMap.of("a", "¥")));
 
         msg = aggregated(client.get("/defer"));
         assertThat(msg.status()).isEqualTo(HttpStatus.BAD_REQUEST);

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceTest.java
@@ -315,14 +315,14 @@ public class AnnotatedHttpServiceTest {
         @Path("/a/string")
         public String postString(AggregatedHttpMessage message, RequestContext ctx) {
             validateContext(ctx);
-            return message.content().toStringUtf8();
+            return message.contentUtf8();
         }
 
         @Post
         @Path("/a/string-async1")
         public CompletionStage<String> postStringAsync1(AggregatedHttpMessage message, RequestContext ctx) {
             validateContext(ctx);
-            return CompletableFuture.supplyAsync(() -> message.content().toStringUtf8());
+            return CompletableFuture.supplyAsync(message::contentUtf8);
         }
 
         @Post

--- a/core/src/test/java/com/linecorp/armeria/server/HttpResponseExceptionTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpResponseExceptionTest.java
@@ -37,6 +37,6 @@ public class HttpResponseExceptionTest {
 
         final AggregatedHttpMessage message = exception.httpResponse().aggregate().join();
         assertThat(message.status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
-        assertThat(message.headers().contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
+        assertThat(message.contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerStreamingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerStreamingTest.java
@@ -168,8 +168,8 @@ public class HttpServerStreamingTest {
         final AggregatedHttpMessage res = f.get();
 
         assertThat(res.status()).isEqualTo(HttpStatus.REQUEST_ENTITY_TOO_LARGE);
-        assertThat(res.headers().contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
-        assertThat(res.content().toStringUtf8()).isEqualTo("413 Request Entity Too Large");
+        assertThat(res.contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
+        assertThat(res.contentUtf8()).isEqualTo("413 Request Entity Too Large");
     }
 
     @Test(timeout = 10000)
@@ -179,8 +179,8 @@ public class HttpServerStreamingTest {
 
         final byte[] content = new byte[maxContentLength + 1];
         final AggregatedHttpMessage res = client().post("/non-existent", content).aggregate().get();
-        assertThat(res.headers().status()).isEqualTo(HttpStatus.NOT_FOUND);
-        assertThat(res.content().toStringUtf8()).isEqualTo("404 Not Found");
+        assertThat(res.status()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(res.contentUtf8()).isEqualTo("404 Not Found");
     }
 
     @Test(timeout = 60000)
@@ -212,8 +212,8 @@ public class HttpServerStreamingTest {
             final AggregatedHttpMessage res = f.get();
 
             assertThat(res.status()).isEqualTo(HttpStatus.OK);
-            assertThat(res.headers().contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
-            assertThat(res.content().toStringUtf8()).isEqualTo(
+            assertThat(res.contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
+            assertThat(res.contentUtf8()).isEqualTo(
                     String.valueOf(expectedContentLength));
         } finally {
             // Make sure the stream is closed even when this test fails due to timeout.

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerTest.java
@@ -473,14 +473,14 @@ public class HttpServerTest {
     @Test(timeout = 10000)
     public void testGet() throws Exception {
         final AggregatedHttpMessage res = client().get("/path/foo").aggregate().get();
-        assertThat(res.headers().status()).isEqualTo(HttpStatus.OK);
-        assertThat(res.content().toStringUtf8()).isEqualTo("/foo");
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.contentUtf8()).isEqualTo("/foo");
     }
 
     @Test(timeout = 10000)
     public void testHead() throws Exception {
         final AggregatedHttpMessage res = client().head("/path/blah").aggregate().get();
-        assertThat(res.headers().status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
         assertThat(res.content().isEmpty()).isTrue();
         assertThat(res.headers().getInt(HttpHeaderNames.CONTENT_LENGTH)).isEqualTo(5);
     }
@@ -488,17 +488,17 @@ public class HttpServerTest {
     @Test(timeout = 10000)
     public void testPost() throws Exception {
         final AggregatedHttpMessage res = client().post("/echo", "foo").aggregate().get();
-        assertThat(res.headers().status()).isEqualTo(HttpStatus.OK);
-        assertThat(res.content().toStringUtf8()).isEqualTo("foo");
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.contentUtf8()).isEqualTo("foo");
     }
 
     @Test(timeout = 10000)
     public void testTimeout() throws Exception {
         serverRequestTimeoutMillis = 100L;
         final AggregatedHttpMessage res = client().get("/delay/2000").aggregate().get();
-        assertThat(res.headers().status()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
-        assertThat(res.headers().contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
-        assertThat(res.content().toStringUtf8()).isEqualTo("503 Service Unavailable");
+        assertThat(res.status()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+        assertThat(res.contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
+        assertThat(res.contentUtf8()).isEqualTo("503 Service Unavailable");
         assertThat(requestLogs.take().statusCode()).isEqualTo(503);
     }
 
@@ -506,9 +506,9 @@ public class HttpServerTest {
     public void testTimeout_deferred() throws Exception {
         serverRequestTimeoutMillis = 100L;
         final AggregatedHttpMessage res = client().get("/delay-deferred/2000").aggregate().get();
-        assertThat(res.headers().status()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
-        assertThat(res.headers().contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
-        assertThat(res.content().toStringUtf8()).isEqualTo("503 Service Unavailable");
+        assertThat(res.status()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+        assertThat(res.contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
+        assertThat(res.contentUtf8()).isEqualTo("503 Service Unavailable");
         assertThat(requestLogs.take().statusCode()).isEqualTo(503);
     }
 
@@ -516,9 +516,9 @@ public class HttpServerTest {
     public void testTimeout_customHandler() throws Exception {
         serverRequestTimeoutMillis = 100L;
         final AggregatedHttpMessage res = client().get("/delay-custom/2000").aggregate().get();
-        assertThat(res.headers().status()).isEqualTo(HttpStatus.OK);
-        assertThat(res.headers().contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
-        assertThat(res.content().toStringUtf8()).isEqualTo("timed out");
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
+        assertThat(res.contentUtf8()).isEqualTo("timed out");
         assertThat(requestLogs.take().statusCode()).isEqualTo(200);
     }
 
@@ -526,9 +526,9 @@ public class HttpServerTest {
     public void testTimeout_customHandler_deferred() throws Exception {
         serverRequestTimeoutMillis = 100L;
         final AggregatedHttpMessage res = client().get("/delay-custom-deferred/2000").aggregate().get();
-        assertThat(res.headers().status()).isEqualTo(HttpStatus.OK);
-        assertThat(res.headers().contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
-        assertThat(res.content().toStringUtf8()).isEqualTo("timed out");
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
+        assertThat(res.contentUtf8()).isEqualTo("timed out");
         assertThat(requestLogs.take().statusCode()).isEqualTo(200);
     }
 
@@ -542,9 +542,9 @@ public class HttpServerTest {
             assertThat(h.names()).contains(HttpHeaderNames.STATUS);
         });
 
-        assertThat(res.headers().status()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
-        assertThat(res.headers().contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
-        assertThat(res.content().toStringUtf8()).isEqualTo("503 Service Unavailable");
+        assertThat(res.status()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+        assertThat(res.contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
+        assertThat(res.contentUtf8()).isEqualTo("503 Service Unavailable");
         assertThat(requestLogs.take().statusCode()).isEqualTo(503);
     }
 
@@ -587,8 +587,8 @@ public class HttpServerTest {
     public void testTooLargeContentToNonExistentService() throws Exception {
         final byte[] content = new byte[(int) MAX_CONTENT_LENGTH + 1];
         final AggregatedHttpMessage res = client().post("/non-existent", content).aggregate().get();
-        assertThat(res.headers().status()).isEqualTo(HttpStatus.NOT_FOUND);
-        assertThat(res.content().toStringUtf8()).isEqualTo("404 Not Found");
+        assertThat(res.status()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(res.contentUtf8()).isEqualTo("404 Not Found");
     }
 
     @Test(timeout = 10000)
@@ -601,7 +601,7 @@ public class HttpServerTest {
         assertThat(res.status()).isEqualTo(HttpStatus.OK);
         assertThat(res.headers().get(HttpHeaderNames.CONTENT_ENCODING)).isNull();
         assertThat(res.headers().get(HttpHeaderNames.VARY)).isNull();
-        assertThat(res.content().toStringUtf8()).isEqualTo("Armeria is awesome!");
+        assertThat(res.contentUtf8()).isEqualTo("Armeria is awesome!");
     }
 
     @Test(timeout = 10000)
@@ -636,7 +636,7 @@ public class HttpServerTest {
         assertThat(res.status()).isEqualTo(HttpStatus.OK);
         assertThat(res.headers().get(HttpHeaderNames.CONTENT_ENCODING)).isNull();
         assertThat(res.headers().get(HttpHeaderNames.VARY)).isNull();
-        assertThat(res.content().toStringUtf8()).isEqualTo("Armeria is awesome!");
+        assertThat(res.contentUtf8()).isEqualTo("Armeria is awesome!");
     }
 
     @Test(timeout = 10000)
@@ -650,7 +650,7 @@ public class HttpServerTest {
         assertThat(res.status()).isEqualTo(HttpStatus.OK);
         assertThat(res.headers().get(HttpHeaderNames.CONTENT_ENCODING)).isNull();
         assertThat(res.headers().get(HttpHeaderNames.VARY)).isNull();
-        assertThat(res.content().toStringUtf8()).isEqualTo(Strings.repeat("a", 1023));
+        assertThat(res.contentUtf8()).isEqualTo(Strings.repeat("a", 1023));
     }
 
     @Test(timeout = 10000)
@@ -703,7 +703,7 @@ public class HttpServerTest {
         assertThat(res.status()).isEqualTo(HttpStatus.OK);
         assertThat(res.headers().get(HttpHeaderNames.CONTENT_ENCODING)).isNull();
         assertThat(res.headers().get(HttpHeaderNames.VARY)).isNull();
-        assertThat(res.content().toStringUtf8()).isEqualTo("Armeria is awesome!");
+        assertThat(res.contentUtf8()).isEqualTo("Armeria is awesome!");
     }
 
     @Test(timeout = 10000)
@@ -743,7 +743,7 @@ public class HttpServerTest {
 
         assertThat(res.status()).isEqualTo(HttpStatus.OK);
         assertThat(res.informationals()).containsExactly(HttpHeaders.of(100));
-        assertThat(res.content().toStringUtf8()).isEqualTo("met expectation");
+        assertThat(res.contentUtf8()).isEqualTo("met expectation");
 
         // Makes sure the server does not send a '100 Continue' response if 'expect: 100-continue' header
         // does not exists.
@@ -753,7 +753,7 @@ public class HttpServerTest {
 
         assertThat(res2.status()).isEqualTo(HttpStatus.OK);
         assertThat(res2.informationals()).isEmpty();
-        assertThat(res2.content().toStringUtf8()).isEqualTo("without expectation");
+        assertThat(res2.contentUtf8()).isEqualTo("without expectation");
     }
 
     @Test(timeout = 10000)
@@ -802,7 +802,7 @@ public class HttpServerTest {
         Thread.sleep(2000);
         request.write(HttpData.ofUtf8("e"));
         request.close();
-        assertThat(response.aggregate().get().content().toStringUtf8()).isEqualTo("abcde");
+        assertThat(response.aggregate().get().contentUtf8()).isEqualTo("abcde");
     }
 
     @Test(timeout = 10000)
@@ -822,7 +822,7 @@ public class HttpServerTest {
 
         assertThat(res.headers().get(HttpHeaderNames.of("x-custom-header1"))).isEqualTo("custom1");
         assertThat(res.headers().get(HttpHeaderNames.of("x-custom-header2"))).isEqualTo("custom2");
-        assertThat(res.content().toStringUtf8()).isEqualTo("headers");
+        assertThat(res.contentUtf8()).isEqualTo("headers");
     }
 
     @Test(timeout = 10000)

--- a/core/src/test/java/com/linecorp/armeria/server/PortUnificationServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/PortUnificationServerTest.java
@@ -89,6 +89,6 @@ public class PortUnificationServerTest {
                                                 scheme + "://127.0.0.1:" + server.httpsPort() + '/');
         final AggregatedHttpMessage response = client.execute(HttpRequest.of(HttpMethod.GET, "/"))
                                                      .aggregate().join();
-        assertThat(response.content().toStringUtf8()).isEqualToIgnoringCase(scheme);
+        assertThat(response.contentUtf8()).isEqualToIgnoringCase(scheme);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/RedirectServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/RedirectServiceTest.java
@@ -268,7 +268,7 @@ public class RedirectServiceTest {
             }
 
             assertThat(msg.status()).isEqualTo(HttpStatus.OK);
-            assertThat(msg.content().toStringUtf8()).isEqualTo(expectedResponse[i]);
+            assertThat(msg.contentUtf8()).isEqualTo(expectedResponse[i]);
         }
         serverRule1.stop();
     }

--- a/core/src/test/java/com/linecorp/armeria/server/file/CachingHttpFileTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/file/CachingHttpFileTest.java
@@ -114,7 +114,7 @@ public class CachingHttpFileTest {
         // First read() should trigger uncached.aggregate().
         HttpResponse res = cached.read(executor, alloc);
         assertThat(res).isNotNull();
-        assertThat(res.aggregate().join().content().toStringUtf8()).isEqualTo("foo");
+        assertThat(res.aggregate().join().contentUtf8()).isEqualTo("foo");
         verify(uncached, times(1)).readAttributes();
         verify(uncached, times(1)).aggregate(executor);
         verifyNoMoreInteractions(uncached);
@@ -123,7 +123,7 @@ public class CachingHttpFileTest {
         // Second read() should not trigger uncached.aggregate().
         res = cached.read(executor, alloc);
         assertThat(res).isNotNull();
-        assertThat(res.aggregate().join().content().toStringUtf8()).isEqualTo("foo");
+        assertThat(res.aggregate().join().contentUtf8()).isEqualTo("foo");
         verify(uncached, times(1)).readAttributes();
         verifyNoMoreInteractions(uncached);
         clearInvocations(uncached);
@@ -137,7 +137,7 @@ public class CachingHttpFileTest {
         // Make sure read() invalidates the cache and triggers uncached.aggregate().
         res = cached.read(executor, alloc);
         assertThat(res).isNotNull();
-        assertThat(res.aggregate().join().content().toStringUtf8()).isEqualTo("bar");
+        assertThat(res.aggregate().join().contentUtf8()).isEqualTo("bar");
         verify(uncached, times(1)).readAttributes();
         verify(uncached, times(1)).aggregate(executor);
         verifyNoMoreInteractions(uncached);

--- a/core/src/test/java/com/linecorp/armeria/server/healthcheck/HttpHealthCheckServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/healthcheck/HttpHealthCheckServiceTest.java
@@ -77,7 +77,7 @@ public class HttpHealthCheckServiceTest {
         final AggregatedHttpMessage res = service.serve(context, req).aggregate().get();
 
         assertEquals(HttpStatus.OK, res.status());
-        assertEquals("ok", res.content().toStringUtf8());
+        assertEquals("ok", res.contentUtf8());
     }
 
     @Test
@@ -105,7 +105,7 @@ public class HttpHealthCheckServiceTest {
         final AggregatedHttpMessage res = service.serve(context, req).aggregate().get();
 
         assertEquals(HttpStatus.SERVICE_UNAVAILABLE, res.status());
-        assertEquals("not ok", res.content().toStringUtf8());
+        assertEquals("not ok", res.contentUtf8());
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/server/healthcheck/ManagedHttpHealthCheckServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/healthcheck/ManagedHttpHealthCheckServiceTest.java
@@ -52,7 +52,7 @@ public class ManagedHttpHealthCheckServiceTest {
         assertThat(res.status()).isEqualTo(HttpStatus.OK);
         assertThat(res.headers().get(HttpHeaderNames.CONTENT_TYPE))
                   .isEqualTo(MediaType.PLAIN_TEXT_UTF_8.toString());
-        assertThat(res.content().toStringUtf8()).isEqualTo("Set unhealthy.");
+        assertThat(res.contentUtf8()).isEqualTo("Set unhealthy.");
 
         ctx = ServiceRequestContextBuilder.of(hcReq).service(service).build();
         res = service.serve(ctx, hcReq).aggregate().get();
@@ -70,7 +70,7 @@ public class ManagedHttpHealthCheckServiceTest {
         assertThat(res.status()).isEqualTo(HttpStatus.OK);
         assertThat(res.headers().get(HttpHeaderNames.CONTENT_TYPE)).isEqualTo(
                 MediaType.PLAIN_TEXT_UTF_8.toString());
-        assertThat(res.content().toStringUtf8()).isEqualTo("Set healthy.");
+        assertThat(res.contentUtf8()).isEqualTo("Set healthy.");
 
         ctx = ServiceRequestContextBuilder.of(hcReq).service(service).build();
         res = service.serve(ctx, hcReq).aggregate().get();
@@ -92,7 +92,7 @@ public class ManagedHttpHealthCheckServiceTest {
         assertThat(res.status()).isEqualTo(HttpStatus.BAD_REQUEST);
         assertThat(res.headers().get(HttpHeaderNames.CONTENT_TYPE)).isEqualTo(
                 MediaType.PLAIN_TEXT_UTF_8.toString());
-        assertThat(res.content().toStringUtf8()).isEqualTo("Not supported.");
+        assertThat(res.contentUtf8()).isEqualTo("Not supported.");
 
         service.serverHealth.setHealthy(true);
 
@@ -106,6 +106,6 @@ public class ManagedHttpHealthCheckServiceTest {
         assertThat(res.status()).isEqualTo(HttpStatus.BAD_REQUEST);
         assertThat(res.headers().get(HttpHeaderNames.CONTENT_TYPE)).isEqualTo(
                 MediaType.PLAIN_TEXT_UTF_8.toString());
-        assertThat(res.content().toStringUtf8()).isEqualTo("Not supported.");
+        assertThat(res.contentUtf8()).isEqualTo("Not supported.");
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/other/AnnotatedHttpServiceAccessModifierTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/other/AnnotatedHttpServiceAccessModifierTest.java
@@ -97,16 +97,16 @@ public class AnnotatedHttpServiceAccessModifierTest {
     public void testAccessModifier() throws Exception {
         final HttpClient client = HttpClient.of(rule.uri("/"));
 
-        assertThat(client.get("/anonymous/public").aggregate().join().content().toStringUtf8())
+        assertThat(client.get("/anonymous/public").aggregate().join().contentUtf8())
                 .isEqualTo("hello");
         assertThat(client.get("/anonymous/package").aggregate().join().status())
                 .isEqualTo(HttpStatus.NOT_FOUND);
         assertThat(client.get("/anonymous/private").aggregate().join().status())
                 .isEqualTo(HttpStatus.NOT_FOUND);
 
-        assertThat(client.get("/named/public").aggregate().join().content().toStringUtf8())
+        assertThat(client.get("/named/public").aggregate().join().contentUtf8())
                 .isEqualTo("hello");
-        assertThat(client.get("/named/public/static").aggregate().join().content().toStringUtf8())
+        assertThat(client.get("/named/public/static").aggregate().join().contentUtf8())
                 .isEqualTo("hello");
         assertThat(client.get("/named/package").aggregate().join().status())
                 .isEqualTo(HttpStatus.NOT_FOUND);

--- a/examples/annotated-http-service/src/main/java/example/armeria/server/annotated/MessageConverterService.java
+++ b/examples/annotated-http-service/src/main/java/example/armeria/server/annotated/MessageConverterService.java
@@ -171,9 +171,9 @@ public class MessageConverterService {
         @Override
         public Object convertRequest(ServiceRequestContext ctx, AggregatedHttpMessage request,
                                      Class<?> expectedResultType) throws Exception {
-            final MediaType mediaType = request.headers().contentType();
+            final MediaType mediaType = request.contentType();
             if (mediaType != null && mediaType.is(MediaType.PLAIN_TEXT_UTF_8)) {
-                return new Request(request.content().toStringUtf8());
+                return new Request(request.contentUtf8());
             }
             return RequestConverterFunction.fallthrough();
         }

--- a/examples/annotated-http-service/src/test/java/example/armeria/server/annotated/AnnotatedHttpServiceTest.java
+++ b/examples/annotated-http-service/src/test/java/example/armeria/server/annotated/AnnotatedHttpServiceTest.java
@@ -48,15 +48,15 @@ public class AnnotatedHttpServiceTest {
         AggregatedHttpMessage res;
 
         res = client.get("/pathPattern/path/armeria").aggregate().join();
-        assertThat(res.content().toStringUtf8()).isEqualTo("path: armeria");
+        assertThat(res.contentUtf8()).isEqualTo("path: armeria");
         assertThat(res.status()).isEqualTo(HttpStatus.OK);
 
         res = client.get("/pathPattern/regex/armeria").aggregate().join();
-        assertThat(res.content().toStringUtf8()).isEqualTo("regex: armeria");
+        assertThat(res.contentUtf8()).isEqualTo("regex: armeria");
         assertThat(res.status()).isEqualTo(HttpStatus.OK);
 
         res = client.get("/pathPattern/glob/armeria").aggregate().join();
-        assertThat(res.content().toStringUtf8()).isEqualTo("glob: armeria");
+        assertThat(res.contentUtf8()).isEqualTo("glob: armeria");
         assertThat(res.status()).isEqualTo(HttpStatus.OK);
     }
 
@@ -66,7 +66,7 @@ public class AnnotatedHttpServiceTest {
 
         res = client.get("/injection/param/armeria/1?gender=male").aggregate().join();
         assertThat(res.status()).isEqualTo(HttpStatus.OK);
-        assertThatJson(res.content().toStringUtf8()).isArray()
+        assertThatJson(res.contentUtf8()).isArray()
                                                     .ofLength(3)
                                                     .thatContains("armeria")
                                                     .thatContains(1)
@@ -81,11 +81,11 @@ public class AnnotatedHttpServiceTest {
 
         res = client.execute(headers).aggregate().join();
         assertThat(res.status()).isEqualTo(HttpStatus.OK);
-        assertThatJson(res.content().toStringUtf8()).isArray()
-                                                    .ofLength(3)
-                                                    .thatContains("armeria")
-                                                    .thatContains(Arrays.asList(1, 2))
-                                                    .thatContains(Arrays.asList("a", "b"));
+        assertThatJson(res.contentUtf8()).isArray()
+                                         .ofLength(3)
+                                         .thatContains("armeria")
+                                         .thatContains(Arrays.asList(1, 2))
+                                         .thatContains(Arrays.asList("a", "b"));
     }
 
     @Test
@@ -103,9 +103,9 @@ public class AnnotatedHttpServiceTest {
                                  "{\"name\":\"armeria\"}").aggregate().join();
 
             assertThat(res.status()).isEqualTo(HttpStatus.OK);
-            assertThat(res.headers().contentType().is(MediaType.JSON_UTF_8)).isTrue();
+            assertThat(res.contentType().is(MediaType.JSON_UTF_8)).isTrue();
 
-            body = res.content().toStringUtf8();
+            body = res.contentUtf8();
             assertThatJson(body).node("result").isStringEqualTo("success");
             assertThatJson(body).node("from").isStringEqualTo("armeria");
         }
@@ -115,8 +115,8 @@ public class AnnotatedHttpServiceTest {
                                         .contentType(MediaType.PLAIN_TEXT_UTF_8),
                              "armeria").aggregate().join();
         assertThat(res.status()).isEqualTo(HttpStatus.OK);
-        assertThat(res.headers().contentType().is(MediaType.PLAIN_TEXT_UTF_8)).isTrue();
-        assertThat(res.content().toStringUtf8()).isEqualTo("success:armeria");
+        assertThat(res.contentType().is(MediaType.PLAIN_TEXT_UTF_8)).isTrue();
+        assertThat(res.contentUtf8()).isEqualTo("success:armeria");
     }
 
     @Test

--- a/examples/spring-boot-minimal/src/test/java/example/springframework/boot/minimal/HelloApplicationIntegrationTest.java
+++ b/examples/spring-boot-minimal/src/test/java/example/springframework/boot/minimal/HelloApplicationIntegrationTest.java
@@ -23,7 +23,7 @@ public class HelloApplicationIntegrationTest {
     public void success() {
         final AggregatedHttpMessage response = client.get("/hello/Spring").aggregate().join();
         assertThat(response.status()).isEqualTo(HttpStatus.OK);
-        assertThat(response.content().toStringUtf8())
+        assertThat(response.contentUtf8())
                 .isEqualTo("Hello, Spring! This message is from Armeria annotated service!");
     }
 
@@ -31,7 +31,7 @@ public class HelloApplicationIntegrationTest {
     public void failure() {
         final AggregatedHttpMessage response = client.get("/hello/a").aggregate().join();
         assertThat(response.status()).isEqualTo(HttpStatus.BAD_REQUEST);
-        assertThatJson(response.content().toStringUtf8())
+        assertThatJson(response.contentUtf8())
                 .node("message")
                 .isEqualTo("hello.name: name should have between 3 and 10 characters");
     }

--- a/examples/spring-boot-tomcat/src/test/java/example/springframework/boot/tomcat/HelloIntegrationTest.java
+++ b/examples/spring-boot-tomcat/src/test/java/example/springframework/boot/tomcat/HelloIntegrationTest.java
@@ -44,20 +44,20 @@ public class HelloIntegrationTest {
     public void index() {
         final AggregatedHttpMessage res = client.get("/").aggregate().join();
         assertThat(res.status()).isEqualTo(HttpStatus.OK);
-        assertThat(res.content().toStringUtf8()).isEqualTo("index");
+        assertThat(res.contentUtf8()).isEqualTo("index");
     }
 
     @Test
     public void hello() throws Exception {
         final AggregatedHttpMessage res = client.get("/hello").aggregate().join();
         assertThat(res.status()).isEqualTo(HttpStatus.OK);
-        assertThat(res.content().toStringUtf8()).isEqualTo("Hello, World");
+        assertThat(res.contentUtf8()).isEqualTo("Hello, World");
     }
 
     @Test
     public void healthCheck() throws Exception {
         final AggregatedHttpMessage res = client.get("/internal/healthcheck").aggregate().join();
         assertThat(res.status()).isEqualTo(HttpStatus.OK);
-        assertThat(res.content().toStringUtf8()).isEqualTo("ok");
+        assertThat(res.contentUtf8()).isEqualTo("ok");
     }
 }

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
@@ -120,7 +120,7 @@ public final class GrpcService extends AbstractHttpService
 
     @Override
     protected HttpResponse doPost(ServiceRequestContext ctx, HttpRequest req) throws Exception {
-        final MediaType contentType = req.headers().contentType();
+        final MediaType contentType = req.contentType();
         final SerializationFormat serializationFormat = findSerializationFormat(contentType);
         if (serializationFormat == null) {
             return HttpResponse.of(HttpStatus.UNSUPPORTED_MEDIA_TYPE,

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcService.java
@@ -242,7 +242,7 @@ class UnframedGrpcService extends SimpleDecoratingService<HttpRequest, HttpRespo
             return;
         }
 
-        final MediaType grpcMediaType = grpcResponse.headers().contentType();
+        final MediaType grpcMediaType = grpcResponse.contentType();
         final HttpHeaders unframedHeaders = HttpHeaders.copyOf(grpcResponse.headers());
         if (grpcMediaType != null) {
             if (grpcMediaType.is(GrpcSerializationFormats.PROTO.mediaType())) {

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnframedGrpcServiceTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnframedGrpcServiceTest.java
@@ -83,8 +83,8 @@ public class UnframedGrpcServiceTest {
 
         final HttpResponse response = unframedGrpcService.serve(ctx, request);
         final AggregatedHttpMessage aggregatedHttpMessage = response.aggregate().get();
-        assertThat(aggregatedHttpMessage.headers().status()).isEqualTo(HttpStatus.OK);
-        assertThat(aggregatedHttpMessage.content().toStringUtf8()).isEqualTo("{}");
+        assertThat(aggregatedHttpMessage.status()).isEqualTo(HttpStatus.OK);
+        assertThat(aggregatedHttpMessage.contentUtf8()).isEqualTo("{}");
     }
 
     @Test
@@ -103,8 +103,8 @@ public class UnframedGrpcServiceTest {
                                                               .build();
         final HttpResponse response = unframedGrpcService.serve(ctx, request);
         final AggregatedHttpMessage aggregatedHttpMessage = response.aggregate().get();
-        assertThat(aggregatedHttpMessage.headers().status()).isEqualTo(HttpStatus.CLIENT_CLOSED_REQUEST);
-        assertThat(aggregatedHttpMessage.content().toStringUtf8())
+        assertThat(aggregatedHttpMessage.status()).isEqualTo(HttpStatus.CLIENT_CLOSED_REQUEST);
+        assertThat(aggregatedHttpMessage.contentUtf8())
                 .isEqualTo("http-status: 499, Client Closed Request\n" +
                            "Caused by: \n" +
                            "grpc-status: 1, CANCELLED, grpc error message");

--- a/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/ArmeriaCallFactoryTest.java
+++ b/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/ArmeriaCallFactoryTest.java
@@ -233,7 +233,7 @@ public class ArmeriaCallFactoryTest {
                                                      MediaType.PLAIN_TEXT_UTF_8,
                                                      Exceptions.traceText(cause));
                           }
-                          final String text = aReq.content().toStringUtf8();
+                          final String text = aReq.contentUtf8();
                           final Pojo request;
                           try {
                               request = OBJECT_MAPPER.readValue(text, Pojo.class);
@@ -257,8 +257,7 @@ public class ArmeriaCallFactoryTest {
                                                      Exceptions.traceText(cause));
                           }
                           final Map<String, List<String>> params = new QueryStringDecoder(
-                                  aReq.content().toStringUtf8(), false)
-                                  .parameters();
+                                  aReq.contentUtf8(), false).parameters();
                           return HttpResponse.of(HttpStatus.OK, MediaType.JSON_UTF_8,
                                                  "{\"name\":\"" + params.get("name").get(0) + "\", " +
                                                  "\"age\":" + params.get("age").get(0) + '}');
@@ -274,7 +273,7 @@ public class ArmeriaCallFactoryTest {
                                                      MediaType.PLAIN_TEXT_UTF_8,
                                                      Exceptions.traceText(cause));
                           }
-                          assertThat(req.headers().contentType()).isNull();
+                          assertThat(req.contentType()).isNull();
                           return HttpResponse.of(HttpStatus.OK);
                       }));
                   }

--- a/rxjava/src/test/java/com/linecorp/armeria/server/rxjava/ObservableResponseConverterFunctionTest.java
+++ b/rxjava/src/test/java/com/linecorp/armeria/server/rxjava/ObservableResponseConverterFunctionTest.java
@@ -175,19 +175,19 @@ public class ObservableResponseConverterFunctionTest {
         AggregatedHttpMessage msg;
 
         msg = client.get("/string").aggregate().join();
-        assertThat(msg.headers().contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
-        assertThat(msg.content().toStringUtf8()).isEqualTo("a");
+        assertThat(msg.contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
+        assertThat(msg.contentUtf8()).isEqualTo("a");
 
         msg = client.get("/json").aggregate().join();
-        assertThat(msg.headers().contentType()).isEqualTo(MediaType.JSON_UTF_8);
-        assertThatJson(msg.content().toStringUtf8()).isStringEqualTo("a");
+        assertThat(msg.contentType()).isEqualTo(MediaType.JSON_UTF_8);
+        assertThatJson(msg.contentUtf8()).isStringEqualTo("a");
 
         msg = client.get("/empty").aggregate().join();
-        assertThat(msg.headers().status()).isEqualTo(HttpStatus.OK);
+        assertThat(msg.status()).isEqualTo(HttpStatus.OK);
         assertThat(msg.content().isEmpty()).isTrue();
 
         msg = client.get("/error").aggregate().join();
-        assertThat(msg.headers().status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        assertThat(msg.status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
     @Test
@@ -197,15 +197,15 @@ public class ObservableResponseConverterFunctionTest {
         AggregatedHttpMessage msg;
 
         msg = client.get("/string").aggregate().join();
-        assertThat(msg.headers().contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
-        assertThat(msg.content().toStringUtf8()).isEqualTo("a");
+        assertThat(msg.contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
+        assertThat(msg.contentUtf8()).isEqualTo("a");
 
         msg = client.get("/json").aggregate().join();
-        assertThat(msg.headers().contentType()).isEqualTo(MediaType.JSON_UTF_8);
-        assertThatJson(msg.content().toStringUtf8()).isStringEqualTo("a");
+        assertThat(msg.contentType()).isEqualTo(MediaType.JSON_UTF_8);
+        assertThatJson(msg.contentUtf8()).isStringEqualTo("a");
 
         msg = client.get("/error").aggregate().join();
-        assertThat(msg.headers().status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        assertThat(msg.status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
     @Test
@@ -215,10 +215,10 @@ public class ObservableResponseConverterFunctionTest {
         AggregatedHttpMessage msg;
 
         msg = client.get("/done").aggregate().join();
-        assertThat(msg.headers().status()).isEqualTo(HttpStatus.OK);
+        assertThat(msg.status()).isEqualTo(HttpStatus.OK);
 
         msg = client.get("/error").aggregate().join();
-        assertThat(msg.headers().status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        assertThat(msg.status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
     @Test
@@ -228,21 +228,21 @@ public class ObservableResponseConverterFunctionTest {
         AggregatedHttpMessage msg;
 
         msg = client.get("/string").aggregate().join();
-        assertThat(msg.headers().contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
-        assertThat(msg.content().toStringUtf8()).isEqualTo("a");
+        assertThat(msg.contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
+        assertThat(msg.contentUtf8()).isEqualTo("a");
 
         msg = client.get("/json/1").aggregate().join();
-        assertThat(msg.headers().contentType()).isEqualTo(MediaType.JSON_UTF_8);
-        assertThatJson(msg.content().toStringUtf8())
+        assertThat(msg.contentType()).isEqualTo(MediaType.JSON_UTF_8);
+        assertThatJson(msg.contentUtf8())
                 .isArray().ofLength(1).thatContains("a");
 
         msg = client.get("/json/3").aggregate().join();
-        assertThat(msg.headers().contentType()).isEqualTo(MediaType.JSON_UTF_8);
-        assertThatJson(msg.content().toStringUtf8())
+        assertThat(msg.contentType()).isEqualTo(MediaType.JSON_UTF_8);
+        assertThatJson(msg.contentUtf8())
                 .isArray().ofLength(3).thatContains("a").thatContains("b").thatContains("c");
 
         msg = client.get("/error").aggregate().join();
-        assertThat(msg.headers().status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        assertThat(msg.status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
     @Test

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/SamlService.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/SamlService.java
@@ -157,12 +157,11 @@ final class SamlService implements ServiceWithPathMappings<HttpRequest, HttpResp
          */
         SamlParameters(AggregatedHttpMessage msg) {
             requireNonNull(msg, "msg");
-            final MediaType contentType = msg.headers().contentType();
+            final MediaType contentType = msg.contentType();
 
             final QueryStringDecoder decoder;
             if (contentType != null && contentType.belongsTo(MediaType.FORM_DATA)) {
-                final String query = msg.content().toString(
-                        contentType.charset().orElse(StandardCharsets.UTF_8));
+                final String query = msg.content(contentType.charset().orElse(StandardCharsets.UTF_8));
                 decoder = new QueryStringDecoder(query, false);
             } else {
                 final String path = msg.path();

--- a/saml/src/test/java/com/linecorp/armeria/server/saml/SamlServiceProviderTest.java
+++ b/saml/src/test/java/com/linecorp/armeria/server/saml/SamlServiceProviderTest.java
@@ -317,9 +317,9 @@ public class SamlServiceProviderTest {
     public void shouldRespondAuthnRequest_HttpPost() throws Exception {
         final AggregatedHttpMessage resp = client.get("/post").aggregate().join();
         assertThat(resp.status()).isEqualTo(HttpStatus.OK);
-        assertThat(resp.headers().contentType()).isEqualTo(MediaType.HTML_UTF_8);
+        assertThat(resp.contentType()).isEqualTo(MediaType.HTML_UTF_8);
 
-        final Document doc = Jsoup.parse(resp.content().toStringUtf8());
+        final Document doc = Jsoup.parse(resp.contentUtf8());
         assertThat(doc.body().attr("onLoad")).isEqualTo("document.forms[0].submit()");
 
         // SAMLRequest will be posted to the IdP's SSO URL.
@@ -336,17 +336,17 @@ public class SamlServiceProviderTest {
                                            .add(HttpHeaderNames.COOKIE, "test=test");
         final AggregatedHttpMessage resp = client.execute(req).aggregate().join();
         assertThat(resp.status()).isEqualTo(HttpStatus.OK);
-        assertThat(resp.content().toStringUtf8()).isEqualTo("authenticated");
+        assertThat(resp.contentUtf8()).isEqualTo("authenticated");
     }
 
     @Test
     public void shouldRespondMetadataWithoutAuthentication() throws Exception {
         final AggregatedHttpMessage resp = client.get("/saml/metadata").aggregate().join();
         assertThat(resp.status()).isEqualTo(HttpStatus.OK);
-        assertThat(resp.headers().contentType()).isEqualTo(CONTENT_TYPE_SAML_METADATA);
+        assertThat(resp.contentType()).isEqualTo(CONTENT_TYPE_SAML_METADATA);
 
         final EntityDescriptor metadata =
-                (EntityDescriptor) deserialize(resp.content().toStringUtf8().getBytes());
+                (EntityDescriptor) deserialize(resp.contentUtf8().getBytes());
         assertThat(metadata).isNotNull();
 
         final SPSSODescriptor sp = metadata.getSPSSODescriptor(SAMLConstants.SAML20P_NS);
@@ -472,9 +472,9 @@ public class SamlServiceProviderTest {
                                                                          SAML_REQUEST, logoutRequest);
 
         assertThat(msg.status()).isEqualTo(HttpStatus.OK);
-        assertThat(msg.headers().contentType()).isEqualTo(MediaType.HTML_UTF_8);
+        assertThat(msg.contentType()).isEqualTo(MediaType.HTML_UTF_8);
 
-        final Document doc = Jsoup.parse(msg.content().toStringUtf8());
+        final Document doc = Jsoup.parse(msg.contentUtf8());
         assertThat(doc.body().attr("onLoad")).isEqualTo("document.forms[0].submit()");
 
         // SAMLResponse will be posted to the IdP's logout response URL.

--- a/site/src/sphinx/client-circuit-breaker.rst
+++ b/site/src/sphinx/client-circuit-breaker.rst
@@ -177,7 +177,7 @@ you should implement :api:`CircuitBreakerStrategyWithContent` and specify it whe
                             return false;
                         }
 
-                        final String content = res.content().toStringUtf8();
+                        final String content = res.contentUtf8();
                         if ("Success".equals(content)) {
                             return true;
                         } else if ("Failure".equals(content)) {

--- a/site/src/sphinx/client-retry.rst
+++ b/site/src/sphinx/client-retry.rst
@@ -164,7 +164,7 @@ using :api:`RetryingHttpClientBuilder`:
                         // The response timed out or the request has not been handled by the server.
                         return backoff;
                     }
-                } else if ("Should I retry?".equals(result.content().toStringUtf8())) {
+                } else if ("Should I retry?".equals(result.contentUtf8())) {
                     return backoff;
                 }
                 return null; // Return null to stop retrying.

--- a/site/src/sphinx/server-annotated-service.rst
+++ b/site/src/sphinx/server-annotated-service.rst
@@ -454,7 +454,7 @@ converter is not able to convert the request.
                                      Class<?> expectedResultType) {
             if (expectedResultType == Greeting.class) {
                 // Convert the request to a Java object.
-                return new Greeting(translateToEnglish(request.content().toStringUtf8()));
+                return new Greeting(translateToEnglish(request.contentUtf8()));
             }
 
             // To the next request converter.
@@ -1143,13 +1143,13 @@ You can annotate them with :api:`@Consumes` annotation.
         @Post("/hello")
         @Consumes("text/plain")
         public HttpResponse helloText(AggregatedHttpMessage message) {
-            // Get a text content by calling message.content().toStringAscii().
+            // Get a text content by calling message.contentAscii().
         }
 
         @Post("/hello")
         @Consumes("application/json")
         public HttpResponse helloJson(AggregatedHttpMessage message) {
-            // Get a JSON object by calling message.content().toStringUtf8().
+            // Get a JSON object by calling message.contentUtf8().
         }
     }
 
@@ -1191,7 +1191,7 @@ as follows. ``helloCatchAll()`` method would accept every request except for the
         @Post("/hello")
         @Consumes("application/json")
         public HttpResponse helloJson(AggregatedHttpMessage message) {
-            // Get a JSON object by calling message.content().toStringUtf8().
+            // Get a JSON object by calling message.contentUtf8().
         }
     }
 

--- a/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaAutoConfigurationTest.java
+++ b/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaAutoConfigurationTest.java
@@ -177,7 +177,7 @@ public class ArmeriaAutoConfigurationTest {
 
         final AggregatedHttpMessage msg = response.aggregate().get();
         assertThat(msg.status()).isEqualTo(HttpStatus.OK);
-        assertThat(msg.content().toStringUtf8()).isEqualTo("ok");
+        assertThat(msg.contentUtf8()).isEqualTo("ok");
     }
 
     @Test
@@ -188,12 +188,12 @@ public class ArmeriaAutoConfigurationTest {
 
         AggregatedHttpMessage msg = response.aggregate().get();
         assertThat(msg.status()).isEqualTo(HttpStatus.OK);
-        assertThat(msg.content().toStringUtf8()).isEqualTo("annotated");
+        assertThat(msg.contentUtf8()).isEqualTo("annotated");
 
         response = client.get("/annotated/get/2");
         msg = response.aggregate().get();
         assertThat(msg.status()).isEqualTo(HttpStatus.OK);
-        assertThat(msg.content().toStringUtf8()).isEqualTo("exception");
+        assertThat(msg.contentUtf8()).isEqualTo("exception");
     }
 
     @Test
@@ -208,7 +208,7 @@ public class ArmeriaAutoConfigurationTest {
 
         final AggregatedHttpMessage msg = response.aggregate().get();
         assertThat(msg.status()).isEqualTo(HttpStatus.OK);
-        assertThatJson(msg.content().toStringUtf8())
+        assertThatJson(msg.contentUtf8())
                 .node("services[1].exampleHttpHeaders[0].x-additional-header").isStringEqualTo("headerVal");
     }
 
@@ -225,7 +225,7 @@ public class ArmeriaAutoConfigurationTest {
         final String metricReport = HttpClient.of(newUrl("http"))
                                               .get("/internal/metrics")
                                               .aggregate().join()
-                                              .content().toStringUtf8();
+                                              .contentUtf8();
         assertThat(metricReport).contains("# TYPE jvm_gc_live_data_size_bytes gauge");
     }
 }

--- a/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaAutoConfigurationWithoutMeterTest.java
+++ b/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaAutoConfigurationWithoutMeterTest.java
@@ -92,6 +92,6 @@ public class ArmeriaAutoConfigurationWithoutMeterTest {
 
         final AggregatedHttpMessage msg = response.aggregate().get();
         assertThat(msg.status()).isEqualTo(HttpStatus.OK);
-        assertThat(msg.content().toStringUtf8()).isEqualTo("ok");
+        assertThat(msg.contentUtf8()).isEqualTo("ok");
     }
 }

--- a/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaClientAutoConfigurationTest.java
+++ b/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaClientAutoConfigurationTest.java
@@ -72,6 +72,6 @@ public class ArmeriaClientAutoConfigurationTest {
     public void shouldGetHelloFromRestController() throws Exception {
         final HttpClient client = HttpClient.of("http://127.0.0.1:" + port);
         final AggregatedHttpMessage response = client.get("/proxy?port=" + port).aggregate().join();
-        assertThat(response.content().toStringUtf8()).isEqualTo("hello");
+        assertThat(response.contentUtf8()).isEqualTo("hello");
     }
 }

--- a/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactoryTest.java
+++ b/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactoryTest.java
@@ -100,7 +100,7 @@ public class ArmeriaReactiveWebServerFactoryTest {
 
             final AggregatedHttpMessage res = client.get("/hello").aggregate().join();
             assertThat(res.status()).isEqualTo(com.linecorp.armeria.common.HttpStatus.OK);
-            assertThat(res.content().toStringUtf8()).isEmpty();
+            assertThat(res.contentUtf8()).isEmpty();
         });
     }
 
@@ -142,7 +142,7 @@ public class ArmeriaReactiveWebServerFactoryTest {
             final AggregatedHttpMessage res = sendPostRequest(httpClient(server));
             assertThat(res.status()).isEqualTo(com.linecorp.armeria.common.HttpStatus.OK);
             assertThat(res.headers().get(HttpHeaderNames.CONTENT_ENCODING)).isEqualTo("gzip");
-            assertThat(res.content().toStringUtf8()).isNotEqualTo("hello");
+            assertThat(res.contentUtf8()).isNotEqualTo("hello");
         });
     }
 
@@ -186,7 +186,7 @@ public class ArmeriaReactiveWebServerFactoryTest {
 
     private void validateEchoResponse(AggregatedHttpMessage res) {
         assertThat(res.status()).isEqualTo(com.linecorp.armeria.common.HttpStatus.OK);
-        assertThat(res.content().toStringUtf8()).isEqualTo(POST_BODY);
+        assertThat(res.contentUtf8()).isEqualTo(POST_BODY);
     }
 
     private void runEchoServer(ReactiveWebServerFactory factory,

--- a/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ReactiveWebServerAutoConfigurationTest.java
+++ b/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ReactiveWebServerAutoConfigurationTest.java
@@ -138,7 +138,7 @@ public class ReactiveWebServerAutoConfigurationTest {
         protocols.forEach(scheme -> {
             final HttpClient client = HttpClient.of(clientFactory, scheme + "://example.com:" + port);
             final AggregatedHttpMessage response = client.get("/hello").aggregate().join();
-            assertThat(response.content().toStringUtf8()).isEqualTo("hello");
+            assertThat(response.contentUtf8()).isEqualTo("hello");
         });
     }
 
@@ -148,15 +148,15 @@ public class ReactiveWebServerAutoConfigurationTest {
             final HttpClient client = HttpClient.of(clientFactory, scheme + "://example.com:" + port);
 
             final AggregatedHttpMessage res = client.get("/route").aggregate().join();
-            assertThat(res.content().toStringUtf8()).isEqualTo("route");
+            assertThat(res.contentUtf8()).isEqualTo("route");
 
             final AggregatedHttpMessage res2 =
                     client.execute(HttpHeaders.of(HttpMethod.POST, "/route2")
                                               .contentType(com.linecorp.armeria.common.MediaType.JSON_UTF_8),
                                    HttpData.of("{\"a\":1}".getBytes())).aggregate().join();
-            assertThatJson(res2.content().toStringUtf8()).isArray()
-                                                         .ofLength(1)
-                                                         .thatContains("route");
+            assertThatJson(res2.contentUtf8()).isArray()
+                                              .ofLength(1)
+                                              .thatContains("route");
         });
     }
 

--- a/testing-internal/src/main/java/com/linecorp/armeria/testing/internal/webapp/WebAppContainerTest.java
+++ b/testing-internal/src/main/java/com/linecorp/armeria/testing/internal/webapp/WebAppContainerTest.java
@@ -144,7 +144,7 @@ public abstract class WebAppContainerTest {
                 .build();
         final HttpClient client = HttpClient.of(clientFactory, server().httpsUri("/"));
         final AggregatedHttpMessage response = client.get("/jsp/index.jsp").aggregate().get();
-        final String actualContent = CR_OR_LF.matcher(response.content().toStringUtf8())
+        final String actualContent = CR_OR_LF.matcher(response.contentUtf8())
                                              .replaceAll("");
         assertThat(actualContent).isEqualTo(
                 "<html><body>" +

--- a/thrift/src/main/java/com/linecorp/armeria/client/thrift/THttpClientDelegate.java
+++ b/thrift/src/main/java/com/linecorp/armeria/client/thrift/THttpClientDelegate.java
@@ -131,7 +131,7 @@ final class THttpClientDelegate implements Client<RpcRequest, RpcResponse> {
                     return null;
                 }
 
-                final HttpStatus status = res.headers().status();
+                final HttpStatus status = res.status();
                 if (status.code() != HttpStatus.OK.code()) {
                     handlePreDecodeException(ctx, reply, func, new InvalidResponseException(status.toString()));
                     return null;

--- a/thrift/src/test/java/com/linecorp/armeria/it/metric/PrometheusMetricsIntegrationTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/metric/PrometheusMetricsIntegrationTest.java
@@ -119,7 +119,7 @@ public class PrometheusMetricsIntegrationTest {
         makeRequest1("world");
 
         // Wait until all RequestLogs are collected.
-        await().untilAsserted(() -> assertThat(makeMetricsRequest().content().toStringUtf8())
+        await().untilAsserted(() -> assertThat(makeMetricsRequest().contentUtf8())
                 .contains("server_active_requests{handler=\"Foo\"",
                           "server_active_requests{handler=\"Foo\"",
                           "server_requests_total{handler=\"Foo\",",
@@ -146,7 +146,7 @@ public class PrometheusMetricsIntegrationTest {
                           "client_total_duration_seconds_count{handler=\"Foo\",",
                           "client_total_duration_seconds_sum{handler=\"Foo\","));
 
-        final String content = makeMetricsRequest().content().toStringUtf8();
+        final String content = makeMetricsRequest().contentUtf8();
         logger.debug("Metrics reported by the exposition service:\n{}", content);
 
         // Server entry count check
@@ -209,7 +209,7 @@ public class PrometheusMetricsIntegrationTest {
         makeRequest2("world");
 
         // Wait until all RequestLogs are collected.
-        await().untilAsserted(() -> assertThat(makeMetricsRequest().content().toStringUtf8())
+        await().untilAsserted(() -> assertThat(makeMetricsRequest().contentUtf8())
                 .contains("server_active_requests{handler=\"Bar\"",
                           "server_active_requests{handler=\"Bar\"",
                           "server_requests_total{handler=\"Bar\",",
@@ -236,7 +236,7 @@ public class PrometheusMetricsIntegrationTest {
                           "client_total_duration_seconds_count{handler=\"Bar\",",
                           "client_total_duration_seconds_sum{handler=\"Bar\","));
 
-        final String content = makeMetricsRequest().content().toStringUtf8();
+        final String content = makeMetricsRequest().contentUtf8();
 
         // Server entry count check
         assertThat(content).containsPattern(

--- a/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftServiceTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftServiceTest.java
@@ -22,7 +22,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -645,12 +644,11 @@ public class ThriftServiceTest {
         final HttpResponse res = service.serve(ctx, req);
         res.aggregate().handle(voidFunction((aReq, cause) -> {
             if (cause == null) {
-                if (aReq.headers().status().code() == 200) {
+                if (aReq.status().code() == 200) {
                     promise.complete(aReq.content());
                 } else {
-                    promise.completeExceptionally(new AssertionError(
-                            aReq.headers().status() + ", " +
-                            aReq.content().toString(StandardCharsets.UTF_8)));
+                    promise.completeExceptionally(
+                            new AssertionError(aReq.status() + ", " + aReq.contentUtf8()));
                 }
             } else {
                 promise.completeExceptionally(cause);


### PR DESCRIPTION
Motivation:

Skimmed through our test cases and thought a few shortcut methods would
be useful to reduce some tedious repetition.

Modifications:

- Added `contentType()` to:
  - `HttpRequest`
  - `AggregatedHttpMessage`
- Added `contentUtf8()`, `contentAscii()` and `content(Charset)` to
  `AggregatedHttpMessage`.
- Accepted `CharSequence` as well as String in:
  - `HttpRequest.of()`
  - `HttpRespons.of()`
  - `AggregatedHttpMessage.of()`
- Replaced the old usage with the new concise usage.

Result:

Brevity.