### PR TITLE
Add `verboseSocketExceptions` flag

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/util/Exceptions.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/Exceptions.java
@@ -137,9 +137,11 @@ public final class Exceptions {
      *   <li>{@link Http2Exception} - 'Stream closed'</li>
      *   <li>{@link SSLException} - 'SSLEngine closed already'</li>
      * </ul>
+     *
+     * @see Flags#verboseSocketExceptions()
      */
     public static boolean isExpected(Throwable cause) {
-        if (Flags.verboseExceptions()) {
+        if (Flags.verboseSocketExceptions()) {
             return false;
         }
 

--- a/core/src/test/java/com/linecorp/armeria/common/util/ExceptionsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/util/ExceptionsTest.java
@@ -80,7 +80,7 @@ public class ExceptionsTest {
 
     @Test
     public void testIsExpected() {
-        final boolean expected = !Flags.verboseExceptions();
+        final boolean expected = !Flags.verboseSocketExceptions();
 
         assertThat(Exceptions.isExpected(new Exception())).isFalse();
         assertThat(Exceptions.isExpected(new Exception("broken pipe"))).isFalse();


### PR DESCRIPTION
Motivation:

Since we fixed the behavior of `verboseExceptions` flag with respect to
`Exceptions.isExpected()`, we received the report of increased
exceptions logged. However, most of them were harmless socket-related
ones such as `connection reset by peer`, where we do not have control
over, because network disconnection can always happen.

Modifications:

- Added a new flag `verboseSocketException` which defaults to `false`.
- Modified `Exceptions.isExpected()` to use `verboseSocketException`
  instead of `verboseException`.

Result:

- Less noisy log messages