### PR TITLE
Implement spring-boot actuator with armeria.

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -404,6 +404,7 @@ org.springframework.boot:
     version: &SPRING_BOOT_VERSION '2.1.2.RELEASE'
     javadocs:
     - https://docs.spring.io/spring/docs/current/javadoc-api/
+  spring-boot-actuator-autoconfigure: { version: *SPRING_BOOT_VERSION }
   spring-boot-starter-actuator: { version: *SPRING_BOOT_VERSION }
   spring-boot-starter-test: { version: *SPRING_BOOT_VERSION }
   spring-boot-starter-web: { version: *SPRING_BOOT_VERSION }

--- a/settings.gradle
+++ b/settings.gradle
@@ -13,6 +13,8 @@ includeWithFlags ':jetty',                              'java', 'publish', 'relo
 includeWithFlags ':kafka',                              'java', 'publish', 'relocate'
 includeWithFlags ':logback',                            'java', 'publish', 'relocate'
 includeWithFlags ':retrofit2',                          'java', 'publish', 'relocate'
+includeWithFlags ':spring:boot-actuator-autoconfigure', 'java', 'publish', 'relocate'
+includeWithFlags ':spring:boot-actuator-starter',       'java', 'publish', 'relocate'
 includeWithFlags ':spring:boot-autoconfigure',          'java', 'publish', 'relocate'
 includeWithFlags ':spring:boot-starter',                'java', 'publish', 'relocate'
 includeWithFlags ':spring:boot-webflux-autoconfigure',  'java', 'publish', 'relocate'

--- a/spring/boot-actuator-autoconfigure/build.gradle
+++ b/spring/boot-actuator-autoconfigure/build.gradle
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+dependencies {
+    compile project(':spring:boot-autoconfigure')
+
+    compile 'org.springframework.boot:spring-boot-actuator-autoconfigure'
+
+    testCompile project(':spring:boot-starter')
+    testCompile 'org.springframework.boot:spring-boot-starter-actuator'
+    testCompile 'org.springframework.boot:spring-boot-starter-test'
+}

--- a/spring/boot-actuator-autoconfigure/build.gradle
+++ b/spring/boot-actuator-autoconfigure/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 LINE Corporation
- *
- * LINE Corporation licenses this file to you under the Apache License,
- * version 2.0 (the "License"); you may not use this file except in compliance
- * with the License. You may obtain a copy of the License at:
- *
- *   https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
-
 dependencies {
     compile project(':spring:boot-autoconfigure')
 

--- a/spring/boot-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/ArmeriaSpringActuatorAutoConfiguration.java
+++ b/spring/boot-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/ArmeriaSpringActuatorAutoConfiguration.java
@@ -74,13 +74,13 @@ public class ArmeriaSpringActuatorAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public EndpointMediaTypes endpointMediaTypes() {
+    EndpointMediaTypes endpointMediaTypes() {
         return new EndpointMediaTypes(MEDIA_TYPES, MEDIA_TYPES);
     }
 
     @Bean
     @ConditionalOnMissingBean(WebEndpointsSupplier.class)
-    public WebEndpointDiscoverer webEndpointDiscoverer(
+    WebEndpointDiscoverer webEndpointDiscoverer(
             ApplicationContext applicationContext,
             ParameterValueMapper parameterValueMapper,
             EndpointMediaTypes endpointMediaTypes,
@@ -96,7 +96,7 @@ public class ArmeriaSpringActuatorAutoConfiguration {
     }
 
     @Bean
-    public ArmeriaServerConfigurator actuatorServerConfigurator(
+    ArmeriaServerConfigurator actuatorServerConfigurator(
             WebEndpointsSupplier endpointsSupplier,
             EndpointMediaTypes mediaTypes,
             WebEndpointProperties properties) {

--- a/spring/boot-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/ArmeriaSpringActuatorAutoConfiguration.java
+++ b/spring/boot-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/ArmeriaSpringActuatorAutoConfiguration.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.spring.actuate;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties;
+import org.springframework.boot.actuate.endpoint.EndpointFilter;
+import org.springframework.boot.actuate.endpoint.http.ActuatorMediaType;
+import org.springframework.boot.actuate.endpoint.invoke.OperationInvokerAdvisor;
+import org.springframework.boot.actuate.endpoint.invoke.ParameterValueMapper;
+import org.springframework.boot.actuate.endpoint.web.EndpointLinksResolver;
+import org.springframework.boot.actuate.endpoint.web.EndpointMapping;
+import org.springframework.boot.actuate.endpoint.web.EndpointMediaTypes;
+import org.springframework.boot.actuate.endpoint.web.ExposableWebEndpoint;
+import org.springframework.boot.actuate.endpoint.web.Link;
+import org.springframework.boot.actuate.endpoint.web.PathMapper;
+import org.springframework.boot.actuate.endpoint.web.WebEndpointsSupplier;
+import org.springframework.boot.actuate.endpoint.web.WebOperationRequestPredicate;
+import org.springframework.boot.actuate.endpoint.web.annotation.WebEndpointDiscoverer;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.StringUtils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Streams;
+
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.server.PathMapping;
+import com.linecorp.armeria.spring.ArmeriaServerConfigurator;
+
+/**
+ * A {@link Configuration} to enable actuator endpoints on an Armeria server. Corresponds to
+ * {@link org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointAutoConfiguration}.
+ */
+@Configuration
+@AutoConfigureAfter(EndpointAutoConfiguration.class)
+@EnableConfigurationProperties(WebEndpointProperties.class)
+public class ArmeriaSpringActuatorAutoConfiguration {
+
+    private static final List<String> MEDIA_TYPES =
+            ImmutableList.of(ActuatorMediaType.V2_JSON, "application/json");
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @Bean
+    @ConditionalOnMissingBean
+    public EndpointMediaTypes endpointMediaTypes() {
+        return new EndpointMediaTypes(MEDIA_TYPES, MEDIA_TYPES);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(WebEndpointsSupplier.class)
+    public WebEndpointDiscoverer webEndpointDiscoverer(
+            ApplicationContext applicationContext,
+            ParameterValueMapper parameterValueMapper,
+            EndpointMediaTypes endpointMediaTypes,
+            ObjectProvider<PathMapper> endpointPathMappers,
+            ObjectProvider<OperationInvokerAdvisor> invokerAdvisors,
+            ObjectProvider<EndpointFilter<ExposableWebEndpoint>> filters) {
+        return new WebEndpointDiscoverer(applicationContext,
+                                         parameterValueMapper,
+                                         endpointMediaTypes,
+                                         endpointPathMappers.orderedStream().collect(toImmutableList()),
+                                         invokerAdvisors.orderedStream().collect(toImmutableList()),
+                                         filters.orderedStream().collect(toImmutableList()));
+    }
+
+    @Bean
+    public ArmeriaServerConfigurator actuatorServerConfigurator(
+            WebEndpointsSupplier endpointsSupplier,
+            EndpointMediaTypes mediaTypes,
+            WebEndpointProperties properties) {
+        EndpointMapping endpointMapping = new EndpointMapping(properties.getBasePath());
+
+        Collection<ExposableWebEndpoint> endpoints = endpointsSupplier.getEndpoints();
+        return sb -> {
+            endpoints
+                             .stream()
+                             .flatMap(endpoint -> endpoint.getOperations().stream())
+                             .forEach(operation -> {
+                                 final WebOperationRequestPredicate predicate = operation.getRequestPredicate();
+                                 sb.service(getPathMapping(predicate.getHttpMethod().name(),
+                                                           endpointMapping.createSubPath(predicate.getPath()),
+                                                           predicate.getConsumes(),
+                                                           predicate.getProduces()),
+                                            new WebOperationHttpService(operation));
+                             });
+            if (StringUtils.hasText(endpointMapping.getPath())) {
+                PathMapping mapping = getPathMapping(
+                        HttpMethod.GET.name(),
+                        endpointMapping.getPath(),
+                        mediaTypes.getConsumed(),
+                        mediaTypes.getProduced()
+                );
+                sb.service(mapping, (ctx, req) -> {
+                    Map<String, Link> links = new EndpointLinksResolver(endpoints).resolveLinks(req.path());
+                    return HttpResponse.of(
+                            HttpStatus.OK,
+                            MediaType.JSON,
+                            OBJECT_MAPPER.writeValueAsBytes(ImmutableMap.of("_links", links))
+                    );
+                });
+            }
+        };
+    }
+
+    private static PathMapping getPathMapping(
+            String method, String path, Collection<String> consumes, Collection<String> produces) {
+        return PathMapping.ofExact(path)
+                          .withHttpHeaderInfo(
+                                  ImmutableSet.of(HttpMethod.valueOf(method)),
+                                  convertMediaTypes(consumes),
+                                  convertMediaTypes(produces));
+    }
+
+    private static List<MediaType> convertMediaTypes(Iterable<String> mediaTypes) {
+        return Streams.stream(mediaTypes).map(MediaType::parse).collect(toImmutableList());
+    }
+}

--- a/spring/boot-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/ArmeriaSpringActuatorAutoConfiguration.java
+++ b/spring/boot-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/ArmeriaSpringActuatorAutoConfiguration.java
@@ -119,7 +119,7 @@ public class ArmeriaSpringActuatorAutoConfiguration {
                 PathMapping mapping = getPathMapping(
                         HttpMethod.GET.name(),
                         endpointMapping.getPath(),
-                        mediaTypes.getConsumed(),
+                        ImmutableList.of(),
                         mediaTypes.getProduced()
                 );
                 sb.service(mapping, (ctx, req) -> {
@@ -136,7 +136,7 @@ public class ArmeriaSpringActuatorAutoConfiguration {
 
     private static PathMapping getPathMapping(
             String method, String path, Collection<String> consumes, Collection<String> produces) {
-        return PathMapping.ofExact(path)
+        return PathMapping.of(path)
                           .withHttpHeaderInfo(
                                   ImmutableSet.of(HttpMethod.valueOf(method)),
                                   convertMediaTypes(consumes),

--- a/spring/boot-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/ArmeriaSpringActuatorAutoConfiguration.java
+++ b/spring/boot-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/ArmeriaSpringActuatorAutoConfiguration.java
@@ -104,17 +104,16 @@ public class ArmeriaSpringActuatorAutoConfiguration {
 
         final Collection<ExposableWebEndpoint> endpoints = endpointsSupplier.getEndpoints();
         return sb -> {
-            endpoints
-                             .stream()
-                             .flatMap(endpoint -> endpoint.getOperations().stream())
-                             .forEach(operation -> {
-                                 final WebOperationRequestPredicate predicate = operation.getRequestPredicate();
-                                 sb.service(getPathMapping(predicate.getHttpMethod().name(),
-                                                           endpointMapping.createSubPath(predicate.getPath()),
-                                                           predicate.getConsumes(),
-                                                           predicate.getProduces()),
-                                            new WebOperationHttpService(operation));
-                             });
+            endpoints.stream()
+                     .flatMap(endpoint -> endpoint.getOperations().stream())
+                     .forEach(operation -> {
+                         final WebOperationRequestPredicate predicate = operation.getRequestPredicate();
+                         sb.service(getPathMapping(predicate.getHttpMethod().name(),
+                                                   endpointMapping.createSubPath(predicate.getPath()),
+                                                   predicate.getConsumes(),
+                                                   predicate.getProduces()),
+                                    new WebOperationHttpService(operation));
+                     });
             if (StringUtils.hasText(endpointMapping.getPath())) {
                 final PathMapping mapping = getPathMapping(
                         HttpMethod.GET.name(),

--- a/spring/boot-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/ArmeriaSpringActuatorAutoConfiguration.java
+++ b/spring/boot-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/ArmeriaSpringActuatorAutoConfiguration.java
@@ -100,9 +100,9 @@ public class ArmeriaSpringActuatorAutoConfiguration {
             WebEndpointsSupplier endpointsSupplier,
             EndpointMediaTypes mediaTypes,
             WebEndpointProperties properties) {
-        EndpointMapping endpointMapping = new EndpointMapping(properties.getBasePath());
+        final EndpointMapping endpointMapping = new EndpointMapping(properties.getBasePath());
 
-        Collection<ExposableWebEndpoint> endpoints = endpointsSupplier.getEndpoints();
+        final Collection<ExposableWebEndpoint> endpoints = endpointsSupplier.getEndpoints();
         return sb -> {
             endpoints
                              .stream()
@@ -116,7 +116,7 @@ public class ArmeriaSpringActuatorAutoConfiguration {
                                             new WebOperationHttpService(operation));
                              });
             if (StringUtils.hasText(endpointMapping.getPath())) {
-                PathMapping mapping = getPathMapping(
+                final PathMapping mapping = getPathMapping(
                         HttpMethod.GET.name(),
                         endpointMapping.getPath(),
                         ImmutableList.of(),

--- a/spring/boot-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/WebOperationHttpService.java
+++ b/spring/boot-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/WebOperationHttpService.java
@@ -61,7 +61,7 @@ final class WebOperationHttpService implements HttpService {
 
     @Override
     public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) {
-        CompletableFuture<HttpResponse> resFuture = new CompletableFuture<>();
+        final CompletableFuture<HttpResponse> resFuture = new CompletableFuture<>();
         req.aggregate().thenAccept(msg -> {
             if (operation.isBlocking()) {
                 ctx.blockingTaskExecutor().execute(() -> invoke(ctx, msg, resFuture));
@@ -75,11 +75,11 @@ final class WebOperationHttpService implements HttpService {
     private void invoke(ServiceRequestContext ctx,
                         AggregatedHttpMessage msg,
                         CompletableFuture<HttpResponse> resFuture) {
-        Map<String, Object> arguments = getArguments(ctx, msg);
-        Object result = operation.invoke(new InvocationContext(SecurityContext.NONE, arguments));
+        final Map<String, Object> arguments = getArguments(ctx, msg);
+        final Object result = operation.invoke(new InvocationContext(SecurityContext.NONE, arguments));
 
         try {
-            HttpResponse res = handleResult(result, msg.method());
+            final HttpResponse res = handleResult(result, msg.method());
             resFuture.complete(res);
         } catch (IOException e) {
             resFuture.completeExceptionally(e);
@@ -97,7 +97,7 @@ final class WebOperationHttpService implements HttpService {
                                    OBJECT_MAPPER.writeValueAsBytes(result));
         }
 
-        WebEndpointResponse<?> response = (WebEndpointResponse<?>) result;
+        final WebEndpointResponse<?> response = (WebEndpointResponse<?>) result;
         return HttpResponse.of(
                 HttpStatus.valueOf(response.getStatus()),
                 MediaType.JSON_UTF_8,

--- a/spring/boot-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/WebOperationHttpService.java
+++ b/spring/boot-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/WebOperationHttpService.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.spring.actuate;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import javax.annotation.Nullable;
+
+import org.springframework.boot.actuate.endpoint.InvocationContext;
+import org.springframework.boot.actuate.endpoint.SecurityContext;
+import org.springframework.boot.actuate.endpoint.web.WebEndpointResponse;
+import org.springframework.boot.actuate.endpoint.web.WebOperation;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+
+import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.server.HttpService;
+import com.linecorp.armeria.server.ServiceRequestContext;
+
+import io.netty.handler.codec.http.QueryStringDecoder;
+
+/**
+ * {@link HttpService} to handle a {@link WebOperation}. Mostly inspired by reactive implementation in
+ * {@link org.springframework.boot.actuate.endpoint.web.reactive.AbstractWebFluxEndpointHandlerMapping}.
+ */
+final class WebOperationHttpService implements HttpService {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final TypeReference<Map<String, Object>> JSON_MAP =
+            new TypeReference<Map<String, Object>>() {};
+
+    private final WebOperation operation;
+
+    WebOperationHttpService(WebOperation operation) {
+        this.operation = operation;
+    }
+
+    @Override
+    public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) {
+        CompletableFuture<HttpResponse> resFuture = new CompletableFuture<>();
+        req.aggregate().thenAccept(msg -> {
+            if (operation.isBlocking()) {
+                ctx.blockingTaskExecutor().execute(() -> invoke(ctx, msg, resFuture));
+            } else {
+                invoke(ctx, msg, resFuture);
+            }
+        });
+        return HttpResponse.from(resFuture);
+    }
+
+    private void invoke(ServiceRequestContext ctx,
+                        AggregatedHttpMessage msg,
+                        CompletableFuture<HttpResponse> resFuture) {
+        Map<String, Object> arguments = getArguments(ctx, msg);
+        Object result = operation.invoke(new InvocationContext(SecurityContext.NONE, arguments));
+
+        try {
+            HttpResponse res = handleResult(result, msg.method());
+            resFuture.complete(res);
+        } catch (IOException e) {
+            resFuture.completeExceptionally(e);
+        }
+    }
+
+    private static HttpResponse handleResult(@Nullable Object result, HttpMethod method) throws IOException {
+        if (result == null) {
+            return HttpResponse.of(method != HttpMethod.GET ? HttpStatus.NO_CONTENT : HttpStatus.NOT_FOUND);
+        }
+
+        if (!(result instanceof WebEndpointResponse)) {
+            return HttpResponse.of(HttpStatus.OK,
+                                   MediaType.JSON_UTF_8,
+                                   OBJECT_MAPPER.writeValueAsBytes(result));
+        }
+
+        WebEndpointResponse<?> response = (WebEndpointResponse<?>) result;
+        return HttpResponse.of(
+                HttpStatus.valueOf(response.getStatus()),
+                MediaType.JSON_UTF_8,
+                OBJECT_MAPPER.writeValueAsBytes(response.getBody())
+        );
+    }
+
+    private static Map<String, Object> getArguments(ServiceRequestContext ctx, AggregatedHttpMessage msg) {
+        final Map<String, Object> arguments = new LinkedHashMap<>();
+        arguments.putAll(ctx.pathParams());
+        if (!msg.content().isEmpty()) {
+            final Map<String, Object> bodyParams;
+            try {
+                bodyParams = OBJECT_MAPPER.readValue(msg.content().array(), JSON_MAP);
+            } catch (IOException e) {
+                throw new IllegalArgumentException("Invalid JSON in request.");
+            }
+            arguments.putAll(bodyParams);
+        }
+        final String query = ctx.query();
+        if (query != null) {
+            QueryStringDecoder queryStringDecoder = new QueryStringDecoder(query, false);
+            queryStringDecoder.parameters().forEach(
+                    (key, values) -> arguments.put(key, values.size() != 1 ? values : values.get(0)));
+        }
+        return ImmutableMap.copyOf(arguments);
+    }
+}

--- a/spring/boot-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/package-info.java
+++ b/spring/boot-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * <a href="https://projects.spring.io/spring-boot/">Spring Boot</a> actuator integration.
+ */
+@NonNullByDefault
+package com.linecorp.armeria.spring.actuate;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/spring/boot-actuator-autoconfigure/src/test/java/com/linecorp/armeria/spring/actuate/ArmeriaSpringActuatorAutoConfigurationTest.java
+++ b/spring/boot-actuator-autoconfigure/src/test/java/com/linecorp/armeria/spring/actuate/ArmeriaSpringActuatorAutoConfigurationTest.java
@@ -64,7 +64,6 @@ public class ArmeriaSpringActuatorAutoConfigurationTest {
 
     @SpringBootApplication
     public static class TestConfiguration {
-
     }
 
     @Rule

--- a/spring/boot-actuator-autoconfigure/src/test/java/com/linecorp/armeria/spring/actuate/ArmeriaSpringActuatorAutoConfigurationTest.java
+++ b/spring/boot-actuator-autoconfigure/src/test/java/com/linecorp/armeria/spring/actuate/ArmeriaSpringActuatorAutoConfigurationTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.spring.actuate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Inject;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.DisableOnDebug;
+import org.junit.rules.TestRule;
+import org.junit.rules.Timeout;
+import org.junit.runner.RunWith;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.server.Server;
+
+/**
+ * This uses {@link com.linecorp.armeria.spring.ArmeriaAutoConfiguration} for integration tests.
+ * application-autoConfTest.yml will be loaded with minimal settings to make it work.
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = TestConfiguration.class)
+@ActiveProfiles({ "local", "autoConfTest" })
+@DirtiesContext
+@EnableAutoConfiguration
+@ImportAutoConfiguration(ArmeriaSpringActuatorAutoConfiguration.class)
+public class ArmeriaSpringActuatorAutoConfigurationTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final TypeReference<Map<String, Object>> JSON_MAP =
+            new TypeReference<Map<String, Object>>() {};
+
+    @SpringBootApplication
+    public static class TestConfiguration {
+
+    }
+
+    @Rule
+    public TestRule globalTimeout = new DisableOnDebug(new Timeout(10, TimeUnit.SECONDS));
+
+    @Inject
+    private Server server;
+
+    private String newUrl(String scheme) {
+        final int port = server.activePort().get().localAddress().getPort();
+        return scheme + "://127.0.0.1:" + port;
+    }
+
+    @Test
+    public void testHealth() throws Exception {
+        HttpClient client = HttpClient.of(newUrl("h2c"));
+        AggregatedHttpMessage msg = client.get("/actuator/health").aggregate().get();
+        assertThat(msg.status()).isEqualTo(HttpStatus.OK);
+
+        Map<String, Object> values = OBJECT_MAPPER.readValue(msg.content().array(), JSON_MAP);
+        assertThat(values).containsEntry("status", "UP");
+    }
+}

--- a/spring/boot-actuator-autoconfigure/src/test/java/com/linecorp/armeria/spring/actuate/ArmeriaSpringActuatorAutoConfigurationTest.java
+++ b/spring/boot-actuator-autoconfigure/src/test/java/com/linecorp/armeria/spring/actuate/ArmeriaSpringActuatorAutoConfigurationTest.java
@@ -23,12 +23,15 @@ import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.DisableOnDebug;
 import org.junit.rules.TestRule;
 import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -40,10 +43,14 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
 
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.server.Server;
 
 /**
@@ -62,6 +69,11 @@ public class ArmeriaSpringActuatorAutoConfigurationTest {
     private static final TypeReference<Map<String, Object>> JSON_MAP =
             new TypeReference<Map<String, Object>>() {};
 
+    private static final String TEST_LOGGER_NAME = "com.linecorp.armeria.spring.actuate.testing.TestLogger";
+
+    // We use this logger to test the /loggers endpoint, so set the name manually instead of using class name.
+    private static final Logger TEST_LOGGER = LoggerFactory.getLogger(TEST_LOGGER_NAME);
+
     @SpringBootApplication
     public static class TestConfiguration {
     }
@@ -77,13 +89,71 @@ public class ArmeriaSpringActuatorAutoConfigurationTest {
         return scheme + "://127.0.0.1:" + port;
     }
 
+    private HttpClient client;
+
+    @Before
+    public void setUp() {
+        client = HttpClient.of(newUrl("h2c"));
+    }
+
     @Test
     public void testHealth() throws Exception {
-        HttpClient client = HttpClient.of(newUrl("h2c"));
-        AggregatedHttpMessage msg = client.get("/actuator/health").aggregate().get();
+        AggregatedHttpMessage msg = client.get("/internal/actuator/health").aggregate().get();
         assertThat(msg.status()).isEqualTo(HttpStatus.OK);
 
         Map<String, Object> values = OBJECT_MAPPER.readValue(msg.content().array(), JSON_MAP);
         assertThat(values).containsEntry("status", "UP");
+    }
+
+    @Test
+    public void testLoggers() throws Exception {
+        String loggerPath = "/internal/actuator/loggers/" + TEST_LOGGER_NAME;
+        AggregatedHttpMessage msg = client.get(loggerPath).aggregate().get();
+        assertThat(msg.status()).isEqualTo(HttpStatus.OK);
+
+        Map<String, Object> values = OBJECT_MAPPER.readValue(msg.content().array(), JSON_MAP);
+        assertThat(values).containsEntry("effectiveLevel", "DEBUG");
+
+        msg = client.execute(HttpHeaders.of(HttpMethod.POST, loggerPath)
+                                        .contentType(MediaType.JSON_UTF_8),
+                          OBJECT_MAPPER.writeValueAsBytes(ImmutableMap.of("configuredLevel", "info")))
+                    .aggregate().get();
+        assertThat(msg.status()).isEqualTo(HttpStatus.NO_CONTENT);
+
+        msg = client.get(loggerPath).aggregate().get();
+        values = OBJECT_MAPPER.readValue(msg.content().array(), JSON_MAP);
+        assertThat(values).containsEntry("effectiveLevel", "INFO");
+
+        client.post(loggerPath, OBJECT_MAPPER.writeValueAsBytes(ImmutableMap.of()))
+              .aggregate().get();
+    }
+
+    @Test
+    public void testLinks() throws Exception {
+        AggregatedHttpMessage msg = client.get("/internal/actuator").aggregate().get();
+        assertThat(msg.status()).isEqualTo(HttpStatus.OK);
+        Map<String, Object> values = OBJECT_MAPPER.readValue(msg.content().array(), JSON_MAP);
+        assertThat(values).containsKey("_links");
+    }
+
+    @Test
+    public void testMissingMediaType() throws Exception {
+        String loggerPath = "/internal/actuator/loggers/" + TEST_LOGGER_NAME;
+        AggregatedHttpMessage msg =
+                client.execute(HttpHeaders.of(HttpMethod.POST, loggerPath),
+                               OBJECT_MAPPER.writeValueAsBytes(ImmutableMap.of("configuredLevel", "info")))
+                      .aggregate().get();
+        assertThat(msg.status()).isEqualTo(HttpStatus.UNSUPPORTED_MEDIA_TYPE);
+    }
+
+    @Test
+    public void testInvalidMediaType() throws Exception {
+        String loggerPath = "/internal/actuator/loggers/" + TEST_LOGGER_NAME;
+        AggregatedHttpMessage msg =
+                client.execute(HttpHeaders.of(HttpMethod.POST, loggerPath)
+                                          .contentType(MediaType.PROTOBUF),
+                               OBJECT_MAPPER.writeValueAsBytes(ImmutableMap.of("configuredLevel", "info")))
+                      .aggregate().get();
+        assertThat(msg.status()).isEqualTo(HttpStatus.UNSUPPORTED_MEDIA_TYPE);
     }
 }

--- a/spring/boot-actuator-autoconfigure/src/test/resources/application-autoConfTest.yml
+++ b/spring/boot-actuator-autoconfigure/src/test/resources/application-autoConfTest.yml
@@ -1,0 +1,10 @@
+armeria:
+  ports:
+    - port: 0
+      protocol: HTTP
+    - ip: 127.0.0.1
+      port: 0
+      protocol: HTTP
+    - ip: 0.0.0.0
+      port: 0
+      protocol: HTTP

--- a/spring/boot-actuator-autoconfigure/src/test/resources/application-autoConfTest.yml
+++ b/spring/boot-actuator-autoconfigure/src/test/resources/application-autoConfTest.yml
@@ -8,3 +8,5 @@ armeria:
     - ip: 0.0.0.0
       port: 0
       protocol: HTTP
+
+management.endpoints.web.base-path: /internal/actuator

--- a/spring/boot-actuator-starter/build.gradle
+++ b/spring/boot-actuator-starter/build.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+dependencies {
+    compile project(':spring:boot-actuator-autoconfigure')
+    compile project(':spring:boot-starter')
+}

--- a/spring/boot-actuator-starter/build.gradle
+++ b/spring/boot-actuator-starter/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 LINE Corporation
- *
- * LINE Corporation licenses this file to you under the Apache License,
- * version 2.0 (the "License"); you may not use this file except in compliance
- * with the License. You may obtain a copy of the License at:
- *
- *   https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
-
 dependencies {
     compile project(':spring:boot-actuator-autoconfigure')
     compile project(':spring:boot-starter')


### PR DESCRIPTION
Ever since spring-boot 2.0, actuator is abstracted on top of generic web operations and can be implemented directly in armeria, so servers can serve actuator without needing Tomcat, etc.

Much of this code is taken from https://github.com/openzipkin/zipkin/pull/2348/files#diff-9b461e029eeefaccd44534eb0d550ae2R124

Still need to add more tests and possibly handle some corner cases (trying to understand what `TolerantPathMapping` in that zipkin PR is for). But sending out for now.