### PR TITLE
Update dependencies

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -13,9 +13,9 @@ ch.qos.logback:
 
 com.auth0:
   java-jwt:
-    version: '3.6.0'
+    version: '3.7.0'
     javadocs:
-    - https://static.javadoc.io/com.auth0/java-jwt/3.6.0/
+    - https://static.javadoc.io/com.auth0/java-jwt/3.7.0/
 
 com.fasterxml.jackson.core:
   jackson-annotations:
@@ -41,10 +41,10 @@ com.github.ben-manes.caffeine:
       to: com.linecorp.armeria.internal.shaded.caffeine
 
 com.github.jengelman.gradle.plugins:
-  shadow: { version: '4.0.3' }
+  shadow: { version: '4.0.4' }
 
 com.google.api:
-  gax-grpc: { version: '1.37.0' }
+  gax-grpc: { version: '1.38.0' }
 
 com.google.code.findbugs:
   jsr305: { version: '3.0.2' }
@@ -184,7 +184,7 @@ io.netty:
 
 io.projectreactor:
   reactor-core:
-    version: &REACTOR_VERSION '3.2.5.RELEASE'
+    version: &REACTOR_VERSION '3.2.6.RELEASE'
     javadocs:
     - https://projectreactor.io/docs/core/release/api/
   reactor-test: { version: *REACTOR_VERSION }
@@ -288,7 +288,7 @@ org.apache.thrift:
 
 org.apache.tomcat.embed:
   tomcat-embed-core:
-    version: &TOMCAT_VERSION '9.0.14'
+    version: &TOMCAT_VERSION '9.0.16'
     javadocs:
     - https://tomcat.apache.org/tomcat-9.0-doc/api/
   tomcat-embed-jasper: { version: *TOMCAT_VERSION }
@@ -306,11 +306,11 @@ org.assertj:
   assertj-core: { version: '3.11.1' }
 
 org.awaitility:
-  awaitility: { version: '3.1.5' }
+  awaitility: { version: '3.1.6' }
 
 org.bouncycastle:
   bcprov-jdk15on:
-    version: '1.60'
+    version: '1.61'
     relocations:
     - from: org.bouncycastle
       to: com.linecorp.armeria.internal.shaded.bouncycastle
@@ -358,7 +358,7 @@ org.jsoup:
   jsoup: { version: '1.11.3' }
 
 org.mockito:
-  mockito-core: { version: '2.23.4' }
+  mockito-core: { version: '2.24.0' }
 
 org.mortbay.jetty.alpn:
   jetty-alpn-agent: { version: '2.0.9' }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
-distributionSha256Sum=53b71812f18cdb2777e9f1b2a0f2038683907c90bdc406bc64d8b400e1fb2c3b
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-all.zip
+distributionSha256Sum=9dc729f6dbfbbc4df1692665d301e028976dacac296a126f16148941a9cf012e
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/it/spring/boot-tomcat8.5/build.gradle
+++ b/it/spring/boot-tomcat8.5/build.gradle
@@ -13,7 +13,7 @@ apply plugin: 'org.springframework.boot'
 dependencyManagement {
     // Override Tomcat versions.
     dependencies {
-        dependencySet(group: 'org.apache.tomcat.embed', version: '8.5.37') {
+        dependencySet(group: 'org.apache.tomcat.embed', version: '8.5.38') {
             entry 'tomcat-embed-core'
             entry 'tomcat-embed-jasper'
             entry 'tomcat-embed-el'

--- a/tomcat8.5/build.gradle
+++ b/tomcat8.5/build.gradle
@@ -1,7 +1,7 @@
 dependencyManagement {
     // Override Tomcat versions.
     dependencies {
-        dependencySet(group: 'org.apache.tomcat.embed', version: '8.5.37') {
+        dependencySet(group: 'org.apache.tomcat.embed', version: '8.5.38') {
             entry 'tomcat-embed-core'
             entry 'tomcat-embed-jasper'
             entry 'tomcat-embed-el'


### PR DESCRIPTION
- java-jwt 3.6.0 -> 3.7.0
- Project Reactor 3.2.5 -> 3.2.6
- Tomcat 9.0.14 -> 9.0.16, 8.5.37 -> 8.5.38
- Bouncy Castle 1.60 -> 1.61
- Build-time
  - shadow 4.0.3 -> 4.0.4
  - gax-grpc 1.37.0 -> 1.38.0
  - Awaitility 3.1.5 -> 3.1.6
  - Mockito 2.23.4 -> 2.24.0
  - Gradle 5.1.1 -> 5.2.1