### PR TITLE
Add total-attempts header/Add totalAttempts in log when RetryingClien…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
@@ -51,7 +51,7 @@ public abstract class RetryingClient<I extends Request, O extends Response>
     private static final Logger logger = LoggerFactory.getLogger(RetryingClient.class);
 
     /**
-     * The header which indicates the retry count of the {@link Request}.
+     * The header which indicates the retry count of a {@link Request}.
      * The server might use this value to reject excessive retries, etc.
      */
     public static final AsciiString ARMERIA_RETRY_COUNT = HttpHeaderNames.of("armeria-retry-count");
@@ -245,9 +245,7 @@ public abstract class RetryingClient<I extends Request, O extends Response>
     protected static int getTotalAttempts(ClientRequestContext ctx) {
         final State state = ctx.attr(STATE).get();
         if (state == null) {
-            throw new IllegalStateException("state is null. You should call " +
-                                            "RetryingClient.execute(ClientRequestContext ctx, I req) " +
-                                            "before this method is called.");
+            return 0;
         }
         return state.totalAttemptNo;
     }

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingHttpClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingHttpClient.java
@@ -173,7 +173,7 @@ public final class RetryingHttpClient extends RetryingClient<HttpRequest, HttpRe
 
         final int totalAttempts = getTotalAttempts(ctx);
         if (totalAttempts > 1) {
-            duplicateReq.headers().setInt(TOTAL_ATTEMPTS, totalAttempts);
+            duplicateReq.headers().setInt(ARMERIA_RETRY_COUNT, totalAttempts - 1);
         }
 
         final HttpResponse response = executeWithFallback(delegate(), derivedCtx, duplicateReq, fallback);

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingHttpClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingHttpClient.java
@@ -170,6 +170,12 @@ public final class RetryingHttpClient extends RetryingClient<HttpRequest, HttpRe
         if (!hasInitialAuthority) {
             duplicateReq.headers().remove(HttpHeaderNames.AUTHORITY);
         }
+
+        final int totalAttempts = getTotalAttempts(ctx);
+        if (totalAttempts > 1) {
+            duplicateReq.headers().setInt(TOTAL_ATTEMPTS, totalAttempts);
+        }
+
         final HttpResponse response = executeWithFallback(delegate(), derivedCtx, duplicateReq, fallback);
 
         derivedCtx.log().addListener(log -> {

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClient.java
@@ -106,6 +106,12 @@ public final class RetryingRpcClient extends RetryingClient<RpcRequest, RpcRespo
         ctx.logBuilder().addChild(derivedCtx.log());
         final BiFunction<ClientRequestContext, Throwable, RpcResponse> fallback =
                 (context, cause) -> new DefaultRpcResponse(cause);
+
+        final int totalAttempts = getTotalAttempts(ctx);
+        if (totalAttempts > 1) {
+            derivedCtx.addAdditionalRequestHeader(TOTAL_ATTEMPTS, Integer.toString(totalAttempts));
+        }
+
         final RpcResponse res = executeWithFallback(delegate(), derivedCtx, req, fallback);
 
         res.handle((unused1, unused2) -> {

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClient.java
@@ -109,7 +109,7 @@ public final class RetryingRpcClient extends RetryingClient<RpcRequest, RpcRespo
 
         final int totalAttempts = getTotalAttempts(ctx);
         if (totalAttempts > 1) {
-            derivedCtx.addAdditionalRequestHeader(ARMERIA_RETRY_COUNT, Integer.toString(totalAttempts - 1));
+            derivedCtx.setAdditionalRequestHeader(ARMERIA_RETRY_COUNT, Integer.toString(totalAttempts - 1));
         }
 
         final RpcResponse res = executeWithFallback(delegate(), derivedCtx, req, fallback);

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClient.java
@@ -109,7 +109,7 @@ public final class RetryingRpcClient extends RetryingClient<RpcRequest, RpcRespo
 
         final int totalAttempts = getTotalAttempts(ctx);
         if (totalAttempts > 1) {
-            derivedCtx.addAdditionalRequestHeader(TOTAL_ATTEMPTS, Integer.toString(totalAttempts));
+            derivedCtx.addAdditionalRequestHeader(ARMERIA_RETRY_COUNT, Integer.toString(totalAttempts - 1));
         }
 
         final RpcResponse res = executeWithFallback(delegate(), derivedCtx, req, fallback);

--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequestDuplicator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequestDuplicator.java
@@ -56,7 +56,7 @@ public class HttpRequestDuplicator extends AbstractStreamMessageDuplicator<HttpO
     /**
      * Creates a new instance wrapping a {@link HttpRequest} and publishing to multiple subscribers.
      * The length of request is limited by default with the server-side parameter which is
-     * {@link Flags#DEFAULT_MAX_REQUEST_LENGTH}. If you are at client-side, you need to use
+     * {@link Flags#defaultMaxResponseLength()}. If you are at client-side, you need to use
      * {@link #HttpRequestDuplicator(HttpRequest, long)} and the {@code long} value should be greater than
      * the length of request or {@code 0} which disables the limit.
      * @param req the request that will publish data to subscribers

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponseDuplicator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponseDuplicator.java
@@ -57,7 +57,7 @@ public class HttpResponseDuplicator
     /**
      * Creates a new instance wrapping a {@link HttpResponse} and publishing to multiple subscribers.
      * The length of response is limited by default with the client-side parameter which is
-     * {@link Flags#DEFAULT_MAX_RESPONSE_LENGTH}. If you are at server-side, you need to use
+     * {@link Flags#defaultMaxResponseLength()}. If you are at server-side, you need to use
      * {@link #HttpResponseDuplicator(HttpResponse, long)} and the {@code long} value should be greater than
      * the length of response or {@code 0} which disables the limit.
      * @param res the response that will publish data to subscribers

--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
@@ -167,7 +167,7 @@ public class DefaultRequestLog implements RequestLog, RequestLogBuilder {
         child.addListener(log -> requestContent(log.requestContent(), log.rawRequestContent()),
                           REQUEST_CONTENT);
         child.addListener(log -> {
-            increaseRequestLength(log.requestLength());
+            requestLength(log.requestLength());
             endRequest0(log.requestCause(), log.requestEndTimeNanos());
         }, REQUEST_END);
     }
@@ -200,7 +200,7 @@ public class DefaultRequestLog implements RequestLog, RequestLogBuilder {
         }
 
         if (lastChild.isAvailable(RESPONSE_END)) {
-            increaseResponseLength(lastChild.responseLength());
+            responseLength(lastChild.responseLength());
             endResponse0(lastChild.responseCause(), lastChild.responseEndTimeNanos());
         }
 
@@ -212,7 +212,7 @@ public class DefaultRequestLog implements RequestLog, RequestLogBuilder {
         lastChild.addListener(log -> responseContent(
                 log.responseContent(), log.rawResponseContent()), RESPONSE_CONTENT);
         lastChild.addListener(log -> {
-            increaseResponseLength(lastChild.responseLength());
+            responseLength(lastChild.responseLength());
             endResponse0(log.responseCause(), log.responseEndTimeNanos());
         }, RESPONSE_END);
     }
@@ -897,13 +897,14 @@ public class DefaultRequestLog implements RequestLog, RequestLogBuilder {
            .append(", res=") // 6 chars
            .append(res)
            .append('}');     // 1 char
-        if (children != null && children.size() > 1) {
+        final int numChildren = children != null ? children.size() : 0;
+        if (numChildren > 0) {
             buf.append(", {");
-            for (int i = 0; i < children.size(); i++) {
+            for (int i = 0; i < numChildren; i++) {
                 buf.append('[');
                 buf.append(children.get(i));
                 buf.append(']');
-                if (i != children.size() - 1) {
+                if (i != numChildren - 1) {
                     buf.append(", ");
                 }
             }
@@ -1010,9 +1011,11 @@ public class DefaultRequestLog implements RequestLog, RequestLogBuilder {
         }
         buf.append('}');
 
-        if (children != null && children.size() > 1) {
+        final int numChildren = children != null ? children.size() : 0;
+        if (numChildren > 1) {
+            // Append only when there were retries which the numChildren is greater than 1.
             buf.append(", {totalAttempts=");
-            buf.append(children.size());
+            buf.append(numChildren);
             buf.append('}');
         }
 

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryingHttpClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryingHttpClientTest.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.client.retry;
 
+import static com.linecorp.armeria.client.retry.RetryingClient.TOTAL_ATTEMPTS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
@@ -98,7 +99,11 @@ public class RetryingHttpClientTest {
                 @Override
                 protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req)
                         throws Exception {
-                    if (reqCount.getAndIncrement() < 2) {
+                    final int retryCount = reqCount.getAndIncrement();
+                    if (retryCount != 0) {
+                        assertThat(retryCount + 1).isEqualTo(req.headers().getInt(TOTAL_ATTEMPTS));
+                    }
+                    if (retryCount < 2) {
                         return HttpResponse.of("Need to retry");
                     } else {
                         return HttpResponse.of("Succeeded after retry");

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryingHttpClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryingHttpClientTest.java
@@ -16,7 +16,7 @@
 
 package com.linecorp.armeria.client.retry;
 
-import static com.linecorp.armeria.client.retry.RetryingClient.TOTAL_ATTEMPTS;
+import static com.linecorp.armeria.client.retry.RetryingClient.ARMERIA_RETRY_COUNT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
@@ -101,7 +101,7 @@ public class RetryingHttpClientTest {
                         throws Exception {
                     final int retryCount = reqCount.getAndIncrement();
                     if (retryCount != 0) {
-                        assertThat(retryCount + 1).isEqualTo(req.headers().getInt(TOTAL_ATTEMPTS));
+                        assertThat(retryCount).isEqualTo(req.headers().getInt(ARMERIA_RETRY_COUNT));
                     }
                     if (retryCount < 2) {
                         return HttpResponse.of("Need to retry");

--- a/core/src/test/java/com/linecorp/armeria/internal/metric/RequestMetricSupportTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/metric/RequestMetricSupportTest.java
@@ -206,8 +206,8 @@ public class RequestMetricSupportTest {
         derivedCtx.logBuilder().requestLength(123);
 
         derivedCtx.logBuilder().responseHeaders(HttpHeaders.of(500));
-        ctx.logBuilder().responseFirstBytesTransferred();
-        ctx.logBuilder().responseLength(456);
+        derivedCtx.logBuilder().responseFirstBytesTransferred();
+        derivedCtx.logBuilder().responseLength(456);
         derivedCtx.logBuilder().endRequest();
         derivedCtx.logBuilder().endResponse();
     }

--- a/core/src/test/java/com/linecorp/armeria/internal/metric/RequestMetricSupportTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/metric/RequestMetricSupportTest.java
@@ -75,7 +75,9 @@ public class RequestMetricSupportTest {
                                 .containsEntry("foo.responseDuration#count{httpStatus=200,method=POST}", 1.0)
                                 .containsEntry("foo.responseLength#count{httpStatus=200,method=POST}", 1.0)
                                 .containsEntry("foo.responseLength#total{httpStatus=200,method=POST}", 456.0)
-                                .containsEntry("foo.totalDuration#count{httpStatus=200,method=POST}", 1.0);
+                                .containsEntry("foo.totalDuration#count{httpStatus=200,method=POST}", 1.0)
+                                // This metric is inserted only when RetryingClient is Used.
+                                .doesNotContainKey("foo.actualRequests#count{httpStatus=200,method=POST}");
     }
 
     @Test

--- a/site/src/sphinx/client-retry.rst
+++ b/site/src/sphinx/client-retry.rst
@@ -320,7 +320,7 @@ This will produce following logs when there are three attempts:
 .. note::
 
     Did you notice that the ``armeria-retry-count`` header is inserted from the second request?
-    :api:`RetryingClient` inserts the header to indicate the retry count of the request.
+    :api:`RetryingClient` inserts it to indicate the retry count of a request.
     The server might use this value to reject excessive retries, etc.
 
 If you want to log the first request and the last response, no matter if it's successful or not,

--- a/site/src/sphinx/client-retry.rst
+++ b/site/src/sphinx/client-retry.rst
@@ -331,12 +331,12 @@ do the reverse:
             .decorator(LoggingClient.newDecorator())
             .build();
 
-This will produce only single request and response log pair regardless how many attempts are made:
+This will produce only single request and response log pair and the total attempts count:
 
 .. code-block:: java
 
     LoggingClient - Request: {startTime=..., length=..., duration=..., scheme=..., host=..., headers=[...]
-    LoggingClient - Response: {startTime=..., length=..., duration=..., headers=[:status=200, ...]
+    LoggingClient - Response: {startTime=..., length=..., headers=[:status=200, ...]}, {totalAttempts=3}
 
 .. note::
 

--- a/site/src/sphinx/client-retry.rst
+++ b/site/src/sphinx/client-retry.rst
@@ -312,10 +312,16 @@ This will produce following logs when there are three attempts:
 
     LoggingClient - Request: {startTime=..., length=..., duration=..., scheme=..., host=..., headers=[...]
     LoggingClient - Response: {startTime=..., length=..., duration=..., headers=[:status=500, ...]
-    LoggingClient - Request: {startTime=..., length=..., duration=..., scheme=..., host=..., headers=[...]
+    LoggingClient - Request: {startTime=..., ..., headers=[..., armeria-retry-count=1, ...]
     LoggingClient - Response: {startTime=..., length=..., duration=..., headers=[:status=500, ...]
-    LoggingClient - Request: {startTime=..., length=..., duration=..., scheme=..., host=..., headers=[...]
+    LoggingClient - Request: {startTime=..., ..., headers=[..., armeria-retry-count=2, ...]
     LoggingClient - Response: {startTime=..., length=..., duration=..., headers=[:status=200, ...]
+
+.. note::
+
+    Did you notice that the ``armeria-retry-count`` header is inserted from the second request?
+    :api:`RetryingClient` inserts the header to indicate the retry count of the request.
+    The server might use this value to reject excessive retries, etc.
 
 If you want to log the first request and the last response, no matter if it's successful or not,
 do the reverse:
@@ -331,7 +337,8 @@ do the reverse:
             .decorator(LoggingClient.newDecorator())
             .build();
 
-This will produce only single request and response log pair and the total attempts count:
+This will produce single request and response log pair and the total number of attempts only, regardless
+how many attempts are made:
 
 .. code-block:: java
 

--- a/thrift/src/test/java/com/linecorp/armeria/it/client/retry/RetryingRpcClientTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/client/retry/RetryingRpcClientTest.java
@@ -15,7 +15,7 @@
  */
 package com.linecorp.armeria.it.client.retry;
 
-import static com.linecorp.armeria.client.retry.RetryingClient.TOTAL_ATTEMPTS;
+import static com.linecorp.armeria.client.retry.RetryingClient.ARMERIA_RETRY_COUNT;
 import static com.linecorp.armeria.common.thrift.ThriftSerializationFormats.BINARY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -79,7 +79,7 @@ public class RetryingRpcClientTest {
                     (delegate, ctx, req) -> {
                         final int count = retryCount.getAndIncrement();
                         if (count != 0) {
-                            assertThat(count + 1).isEqualTo(req.headers().getInt(TOTAL_ATTEMPTS));
+                            assertThat(count).isEqualTo(req.headers().getInt(ARMERIA_RETRY_COUNT));
                         }
                         return delegate.serve(ctx, req);
                     }));

--- a/thrift/src/test/java/com/linecorp/armeria/it/client/retry/RetryingRpcClientTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/client/retry/RetryingRpcClientTest.java
@@ -15,6 +15,7 @@
  */
 package com.linecorp.armeria.it.client.retry;
 
+import static com.linecorp.armeria.client.retry.RetryingClient.TOTAL_ATTEMPTS;
 import static com.linecorp.armeria.common.thrift.ThriftSerializationFormats.BINARY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -32,6 +33,7 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.thrift.TApplicationException;
 import org.junit.Rule;
@@ -72,7 +74,15 @@ public class RetryingRpcClientTest {
     public final ServerRule server = new ServerRule() {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
-            sb.service("/thrift", THttpService.of(serviceHandler));
+            final AtomicInteger retryCount = new AtomicInteger();
+            sb.service("/thrift", THttpService.of(serviceHandler).decorate(
+                    (delegate, ctx, req) -> {
+                        final int count = retryCount.getAndIncrement();
+                        if (count != 0) {
+                            assertThat(count + 1).isEqualTo(req.headers().getInt(TOTAL_ATTEMPTS));
+                        }
+                        return delegate.serve(ctx, req);
+                    }));
             sb.service("/thrift-devnull", THttpService.of(devNullServiceHandler));
         }
     };


### PR DESCRIPTION
…t is used

Motivation:
If we set a header which indicates the number of attempts so far when using `RetryingClient`,
the server can use it to reject excessive retries, etc.
Also, the log and metrics are now insufficient to contain total attempts info, we should fix it.

Modifications:
- Add total-attempts header only when retry happens(from the second attempt)
- Log `totalAttempts` in response
- Add `actualRequests` counter to metric so that a user can calculate how many retries happened
- Fix a bug where `requestLength` and `responseLength` is not set properly

Result:
- Close #1583
- More information in log and metric