### PR TITLE
Add `responseCauseSanitizer` to `LoggingDecoratorBuilder`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/logging/LoggingClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/logging/LoggingClientBuilder.java
@@ -42,6 +42,7 @@ public class LoggingClientBuilder extends LoggingDecoratorBuilder<LoggingClientB
                                    requestContentSanitizer(),
                                    responseHeadersSanitizer(),
                                    responseContentSanitizer(),
+                                   responseCauseSanitizer(),
                                    Sampler.create(samplingRate()));
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
@@ -912,8 +912,8 @@ public class DefaultRequestLog implements RequestLog, RequestLogBuilder {
     }
 
     @Override
-    public String toStringRequestOnly(Function<HttpHeaders, HttpHeaders> headersSanitizer,
-                                      Function<Object, Object> contentSanitizer) {
+    public String toStringRequestOnly(Function<? super HttpHeaders, ? extends HttpHeaders> headersSanitizer,
+                                      Function<Object, ?> contentSanitizer) {
         final int flags = this.flags & 0xFFFF; // Only interested in the bits related with request.
         if (requestStrFlags == flags) {
             return requestStr;
@@ -966,8 +966,8 @@ public class DefaultRequestLog implements RequestLog, RequestLogBuilder {
     }
 
     @Override
-    public String toStringResponseOnly(Function<HttpHeaders, HttpHeaders> headersSanitizer,
-                                       Function<Object, Object> contentSanitizer) {
+    public String toStringResponseOnly(Function<? super HttpHeaders, ? extends HttpHeaders> headersSanitizer,
+                                       Function<Object, ?> contentSanitizer) {
 
         final int flags = this.flags & 0xFFFF0000; // Only interested in the bits related with response.
         if (responseStrFlags == flags) {

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestLog.java
@@ -496,8 +496,8 @@ public interface RequestLog {
      * @param contentSanitizer a {@link Function} for sanitizing request content for logging. The result of the
      *     {@link Function} is what is actually logged as content.
      */
-    String toStringRequestOnly(Function<HttpHeaders, HttpHeaders> headersSanitizer,
-                               Function<Object, Object> contentSanitizer);
+    String toStringRequestOnly(Function<? super HttpHeaders, ? extends HttpHeaders> headersSanitizer,
+                               Function<Object, ?> contentSanitizer);
 
     /**
      * Returns the string representation of the {@link Response}, with no sanitization of headers or content.
@@ -512,6 +512,6 @@ public interface RequestLog {
      * @param contentSanitizer a {@link Function} for sanitizing response content for logging. The result of the
      *     {@link Function} is what is actually logged as content.
      */
-    String toStringResponseOnly(Function<HttpHeaders, HttpHeaders> headersSanitizer,
-                                Function<Object, Object> contentSanitizer);
+    String toStringResponseOnly(Function<? super HttpHeaders, ? extends HttpHeaders> headersSanitizer,
+                                Function<Object, ?> contentSanitizer);
 }

--- a/core/src/main/java/com/linecorp/armeria/internal/logging/LoggingDecorators.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/logging/LoggingDecorators.java
@@ -36,9 +36,11 @@ public final class LoggingDecorators {
     /**
      * Logs a stringified request of {@link RequestLog}.
      */
-    public static void logRequest(Logger logger, RequestLog log, LogLevel requestLogLevel,
-                                  Function<HttpHeaders, HttpHeaders> requestHeadersSanitizer,
-                                  Function<Object, Object> requestContentSanitizer) {
+    public static void logRequest(
+            Logger logger, RequestLog log, LogLevel requestLogLevel,
+            Function<? super HttpHeaders, ? extends HttpHeaders> requestHeadersSanitizer,
+            Function<Object, ?> requestContentSanitizer) {
+
         if (requestLogLevel.isEnabled(logger)) {
             requestLogLevel.log(logger, REQUEST_FORMAT,
                                 log.toStringRequestOnly(requestHeadersSanitizer, requestContentSanitizer));
@@ -48,29 +50,38 @@ public final class LoggingDecorators {
     /**
      * Logs a stringified response of {@link RequestLog}.
      */
-    public static void logResponse(Logger logger, RequestLog log, LogLevel requestLogLevel,
-                                   Function<HttpHeaders, HttpHeaders> requestHeadersSanitizer,
-                                   Function<Object, Object> requestContentSanitizer,
-                                   LogLevel successfulResponseLogLevel,
-                                   LogLevel failedResponseLogLevel,
-                                   Function<HttpHeaders, HttpHeaders> responseHeadersSanitizer,
-                                   Function<Object, Object> responseContentSanitizer) {
-        final LogLevel level = log.responseCause() == null ? successfulResponseLogLevel
-                                                           : failedResponseLogLevel;
+    public static void logResponse(
+            Logger logger, RequestLog log, LogLevel requestLogLevel,
+            Function<? super HttpHeaders, ? extends HttpHeaders> requestHeadersSanitizer,
+            Function<Object, ?> requestContentSanitizer,
+            LogLevel successfulResponseLogLevel,
+            LogLevel failedResponseLogLevel,
+            Function<? super HttpHeaders, ? extends HttpHeaders> responseHeadersSanitizer,
+            Function<Object, ?> responseContentSanitizer,
+            Function<? super Throwable, ? extends Throwable> responseCauseSanitizer) {
+
+        final Throwable responseCause = log.responseCause();
+        final LogLevel level = responseCause == null ? successfulResponseLogLevel
+                                                     : failedResponseLogLevel;
         if (level.isEnabled(logger)) {
-            if (log.responseCause() == null) {
-                level.log(logger, RESPONSE_FORMAT,
-                          log.toStringResponseOnly(responseHeadersSanitizer, responseContentSanitizer));
+            final String responseStr = log.toStringResponseOnly(responseHeadersSanitizer,
+                                                                responseContentSanitizer);
+            if (responseCause == null) {
+                level.log(logger, RESPONSE_FORMAT, responseStr);
             } else {
                 if (!requestLogLevel.isEnabled(logger)) {
                     // Request wasn't logged but this is an unsuccessful response, log the request too to help
                     // debugging.
                     level.log(logger, REQUEST_FORMAT, log.toStringRequestOnly(requestHeadersSanitizer,
-                                                                              responseContentSanitizer));
+                                                                              requestContentSanitizer));
                 }
-                level.log(logger, RESPONSE_FORMAT,
-                          log.toStringResponseOnly(responseHeadersSanitizer, responseContentSanitizer),
-                          log.responseCause());
+
+                final Throwable sanitizedResponseCause = responseCauseSanitizer.apply(responseCause);
+                if (sanitizedResponseCause != null) {
+                    level.log(logger, RESPONSE_FORMAT, responseStr, sanitizedResponseCause);
+                } else {
+                    level.log(logger, RESPONSE_FORMAT, responseStr);
+                }
             }
         }
     }

--- a/core/src/main/java/com/linecorp/armeria/server/logging/LoggingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/LoggingService.java
@@ -69,10 +69,11 @@ public final class LoggingService<I extends Request, O extends Response> extends
     private final LogLevel requestLogLevel;
     private final LogLevel successfulResponseLogLevel;
     private final LogLevel failedResponseLogLevel;
-    private final Function<HttpHeaders, HttpHeaders> requestHeadersSanitizer;
-    private final Function<Object, Object> requestContentSanitizer;
-    private final Function<HttpHeaders, HttpHeaders> responseHeadersSanitizer;
-    private final Function<Object, Object> responseContentSanitizer;
+    private final Function<? super HttpHeaders, ? extends HttpHeaders> requestHeadersSanitizer;
+    private final Function<Object, ?> requestContentSanitizer;
+    private final Function<? super HttpHeaders, ? extends HttpHeaders> responseHeadersSanitizer;
+    private final Function<Object, ?> responseContentSanitizer;
+    private final Function<? super Throwable, ? extends Throwable> responseCauseSanitizer;
     private final Sampler sampler;
 
     /**
@@ -100,6 +101,7 @@ public final class LoggingService<I extends Request, O extends Response> extends
              Function.identity(),
              Function.identity(),
              Function.identity(),
+             Function.identity(),
              Sampler.always());
     }
 
@@ -112,10 +114,11 @@ public final class LoggingService<I extends Request, O extends Response> extends
             LogLevel requestLogLevel,
             LogLevel successfulResponseLogLevel,
             LogLevel failedResponseLogLevel,
-            Function<HttpHeaders, HttpHeaders> requestHeadersSanitizer,
-            Function<Object, Object> requestContentSanitizer,
-            Function<HttpHeaders, HttpHeaders> responseHeadersSanitizer,
-            Function<Object, Object> responseContentSanitizer,
+            Function<? super HttpHeaders, ? extends HttpHeaders> requestHeadersSanitizer,
+            Function<Object, ?> requestContentSanitizer,
+            Function<? super HttpHeaders, ? extends HttpHeaders> responseHeadersSanitizer,
+            Function<Object, ?> responseContentSanitizer,
+            Function<? super Throwable, ? extends Throwable> responseCauseSanitizer,
             Sampler sampler) {
         super(requireNonNull(delegate, "delegate"));
         this.requestLogLevel = requireNonNull(requestLogLevel, "requestLogLevel");
@@ -125,7 +128,8 @@ public final class LoggingService<I extends Request, O extends Response> extends
         this.requestHeadersSanitizer = requireNonNull(requestHeadersSanitizer, "requestHeadersSanitizer");
         this.requestContentSanitizer = requireNonNull(requestContentSanitizer, "requestContentSanitizer");
         this.responseHeadersSanitizer = requireNonNull(responseHeadersSanitizer, "responseHeadersSanitizer");
-        this.responseContentSanitizer = requireNonNull(responseContentSanitizer, "resposneContentSanitizer");
+        this.responseContentSanitizer = requireNonNull(responseContentSanitizer, "responseContentSanitizer");
+        this.responseCauseSanitizer = requireNonNull(responseCauseSanitizer, "responseCauseSanitizer");
         this.sampler = requireNonNull(sampler, "sampler");
     }
 
@@ -140,7 +144,9 @@ public final class LoggingService<I extends Request, O extends Response> extends
                                                      requestLogLevel, requestHeadersSanitizer,
                                                      requestContentSanitizer,
                                                      successfulResponseLogLevel, failedResponseLogLevel,
-                                                     responseHeadersSanitizer, responseContentSanitizer),
+                                                     responseHeadersSanitizer,
+                                                     responseContentSanitizer,
+                                                     responseCauseSanitizer),
                                   RequestLogAvailability.COMPLETE);
         }
         return delegate().serve(ctx, req);

--- a/core/src/main/java/com/linecorp/armeria/server/logging/LoggingServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/LoggingServiceBuilder.java
@@ -42,6 +42,7 @@ public class LoggingServiceBuilder extends LoggingDecoratorBuilder<LoggingServic
                                     requestContentSanitizer(),
                                     responseHeadersSanitizer(),
                                     responseContentSanitizer(),
+                                    responseCauseSanitizer(),
                                     Sampler.create(samplingRate()));
     }
 


### PR DESCRIPTION
Motivation:

A user wants to sanitize the stack trace of `RequestLog.responseCause()`
or avoid logging the stack trace completely.

Modifications:

- Added LoggingDecoratorBuilder.responseCauseSanitizer()` and applied
  the specified `Function` to the response cause.
- Widened the type parameters of sanitizer functions.
- Miscellaneous:
  - Fixed a bug where a response content sanitizer is applied on request
    content on a certain case.
  - Added `contentSanitizer()` and `headersSanitizer()` shortcut methods.
  - Javadoc clean-up

Result:

- A user can sanitize/drop the stack trace of `RequestLog.responseCause()`.
- Request content is always sanitized with an intended sanitizer.
- More shortcut methods in `LoggingClientBuilder` and `LoggingServiceBuilder`.