### PR TITLE
Avoid using `whenComplete()`; use `handle()`

### DIFF
--- a/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
+++ b/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
@@ -155,11 +155,12 @@ public class ArmeriaReactiveWebServerFactory extends AbstractReactiveWebServerFa
             final CompletableFuture<HttpResponse> future = new CompletableFuture<>();
             final HttpResponse response = HttpResponse.from(future);
             final Disposable disposable = handler.handle(ctx, req, future, serverHeader).subscribe();
-            response.completionFuture().whenComplete((unused, cause) -> {
+            response.completionFuture().handle((unused, cause) -> {
                 if (cause != null) {
                     logger.debug("{} Response stream has been cancelled.", ctx, cause);
                     disposable.dispose();
                 }
+                return null;
             });
             return response;
         });


### PR DESCRIPTION
Motivation:

As we discovered in #1440, `whenComplete()` is harmful for performance.

Modifications:

- Use `handle()` instead of `whenComplete()`

Result:

- Potentially less unnecessary instantiation of `CompletionException`.