### PR TITLE
Update dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.google.gradle:osdetector-gradle-plugin:1.6.1'
+        classpath 'com.google.gradle:osdetector-gradle-plugin:1.6.2'
         classpath 'io.spring.gradle:dependency-management-plugin:1.0.6.RELEASE'
     }
 }

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -44,7 +44,7 @@ com.github.jengelman.gradle.plugins:
   shadow: { version: '4.0.4' }
 
 com.google.api:
-  gax-grpc: { version: '1.38.0' }
+  gax-grpc: { version: '1.39.0' }
 
 com.google.code.findbugs:
   jsr305: { version: '3.0.2' }
@@ -148,17 +148,17 @@ io.grpc:
 
 io.micrometer:
   micrometer-core:
-    version: &MICROMETER_VERSION '1.1.2'
+    version: &MICROMETER_VERSION '1.1.3'
     javadocs:
-    - https://static.javadoc.io/io.micrometer/micrometer-core/1.1.2/
+    - https://static.javadoc.io/io.micrometer/micrometer-core/1.1.3/
   micrometer-registry-prometheus:
     version: *MICROMETER_VERSION
     javadocs:
-    - https://static.javadoc.io/io.micrometer/micrometer-registry-prometheus/1.1.2/
+    - https://static.javadoc.io/io.micrometer/micrometer-registry-prometheus/1.1.3/
   micrometer-spring-legacy:
     version: *MICROMETER_VERSION
     javadocs:
-    - https://static.javadoc.io/io.micrometer/micrometer-spring-legacy/1.1.2/
+    - https://static.javadoc.io/io.micrometer/micrometer-spring-legacy/1.1.3/
     exclusions:
     - org.springframework:spring-web
     - org.springframework:spring-webmvc
@@ -239,7 +239,7 @@ me.champeau.gradle:
   jmh-gradle-plugin: { version: '0.4.8' }
 
 net.javacrumbs.json-unit:
-  json-unit: { version: &JSON_UNIT_VERSION '2.3.0' }
+  json-unit: { version: &JSON_UNIT_VERSION '2.4.0' }
   json-unit-fluent: { version: *JSON_UNIT_VERSION }
 
 net.sf.proguard:
@@ -303,7 +303,7 @@ org.apache.zookeeper:
     - org.slf4j:slf4j-log4j12
 
 org.assertj:
-  assertj-core: { version: '3.11.1' }
+  assertj-core: { version: '3.12.0' }
 
 org.awaitility:
   awaitility: { version: '3.1.6' }

--- a/site/build.gradle
+++ b/site/build.gradle
@@ -44,11 +44,7 @@ task xref(group: 'Documentation',
 
     def outputDir = "${project.buildDir}/site/xref"
     def sourceDirs = aggregatedProjects.inject([]) { srcDirs, project ->
-        project.sourceSets.main.java.srcDirs.each {
-            if (it.exists()) {
-                srcDirs << it.path
-            }
-        }
+        project.sourceSets.main.java.srcDirs.each { srcDirs << it.path }
         return srcDirs
     }
 
@@ -63,7 +59,8 @@ task xref(group: 'Documentation',
         jxr.log = new JxrLog(logger: logger)
 
         def title = "Armeria ${project.version} cross-reference"
-        jxr.xref(sourceDirs, 'templates', title, title, rootProject.ext.copyrightFooter)
+        jxr.xref(sourceDirs.findAll { new File(it).isDirectory() }, 'templates',
+                 title, title, rootProject.ext.copyrightFooter)
         ant.copy(file: "${project.projectDir}/src/xref/stylesheet.css", todir: jxr.dest)
     }
 }


### PR DESCRIPTION
- Micrometer 1.1.2 -> 1.1.3
- Build time:
  - os-gradle-plugin 1.6.1 -> 1.6.2
  - gax-grpc 1.38.0 -> 1.39.0
  - json-unit 2.3.0 -> 2.4.0
  - AssertJ 3.11.1 -> 3.12.0
- Miscellaneous:
  - Fixed build failure when running `:site:xref`.