### PR TITLE
Execute blocking gRPC callbacks in order

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/internal/grpc/ArmeriaMessageDeframer.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/grpc/ArmeriaMessageDeframer.java
@@ -177,13 +177,13 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
 
     private boolean compressedFlag;
     private boolean endOfStream;
+    private boolean closeWhenComplete;
 
     @Nullable
     private Queue<ByteBuf> unprocessed;
     private int unprocessedBytes;
 
     private long pendingDeliveries;
-    private boolean deliveryStalled = true;
     private boolean inDelivery;
     private boolean startedDeframing;
 
@@ -219,7 +219,7 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
      * that no additional data can be delivered to the application.
      */
     public boolean isStalled() {
-        return deliveryStalled;
+        return unprocessedBytes == 0;
     }
 
     /**
@@ -255,7 +255,19 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
         // Indicate that all of the data for this stream has been received.
         this.endOfStream = endOfStream;
         deliver();
+    };
+
+    /** Close when any messages currently queued have been requested and delivered. */
+    public void closeWhenComplete() {
+        if (isClosed()) {
+            return;
+        } else if (isStalled()) {
+            close();
+        } else {
+            closeWhenComplete = true;
+        }
     }
+
 
     /**
      * Closes this deframer and frees any resources. After this method is called, additional
@@ -330,23 +342,9 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
             * frame and not in unprocessed.  If there is extra data but no pending deliveries, it will
             * be in unprocessed.
             */
-            final boolean stalled = !hasRequiredBytes();
-
-            if (endOfStream && stalled) {
-                assert unprocessed != null;
-                final boolean havePartialMessage = !unprocessed.isEmpty();
-                if (!havePartialMessage) {
-                    listener.endOfStream();
-                    deliveryStalled = false;
-                    return;
-                } else {
-                    // We've received the entire stream and have data available but we don't have
-                    // enough to read the next frame ... this is bad.
-                    throw Status.INTERNAL.withDescription(
-                            DEBUG_STRING + ": Encountered end-of-stream mid-frame").asRuntimeException();
-                }
+            if (closeWhenComplete && isStalled()) {
+                close();
             }
-            deliveryStalled = stalled;
         } finally {
             inDelivery = false;
         }
@@ -492,6 +490,10 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
 
     private static ByteBufOrStream getUncompressedBody(ByteBuf buf) {
         return new ByteBufOrStream(buf);
+    }
+
+    private boolean isClosedOrScheduledToClose() {
+        return isClosed() || closeWhenComplete;
     }
 
     private ByteBufOrStream getCompressedBody(ByteBuf buf) {

--- a/grpc/src/main/java/com/linecorp/armeria/internal/grpc/ArmeriaMessageDeframer.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/grpc/ArmeriaMessageDeframer.java
@@ -255,7 +255,7 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
         // Indicate that all of the data for this stream has been received.
         this.endOfStream = endOfStream;
         deliver();
-    };
+    }
 
     /** Close when any messages currently queued have been requested and delivered. */
     public void closeWhenComplete() {
@@ -268,7 +268,6 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
         }
     }
 
-
     /**
      * Closes this deframer and frees any resources. After this method is called, additional
      * calls will have no effect.
@@ -278,6 +277,10 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
         try {
             if (unprocessed != null) {
                 unprocessed.forEach(ByteBuf::release);
+
+                if (endOfStream) {
+                    listener.endOfStream();
+                }
             }
         } finally {
             unprocessed = null;

--- a/grpc/src/main/java/com/linecorp/armeria/internal/grpc/ArmeriaMessageDeframer.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/grpc/ArmeriaMessageDeframer.java
@@ -219,7 +219,7 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
      * that no additional data can be delivered to the application.
      */
     public boolean isStalled() {
-        return unprocessedBytes == 0;
+        return !hasRequiredBytes();
     }
 
     /**
@@ -274,16 +274,16 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
      */
     @Override
     public void close() {
-        try {
-            if (unprocessed != null) {
+        if (unprocessed != null) {
+            try {
                 unprocessed.forEach(ByteBuf::release);
-
-                if (endOfStream) {
-                    listener.endOfStream();
-                }
+            } finally {
+                unprocessed = null;
             }
-        } finally {
-            unprocessed = null;
+
+            if (endOfStream) {
+                listener.endOfStream();
+            }
         }
     }
 

--- a/grpc/src/main/java/com/linecorp/armeria/internal/grpc/ArmeriaMessageDeframer.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/grpc/ArmeriaMessageDeframer.java
@@ -257,7 +257,7 @@ public class ArmeriaMessageDeframer implements AutoCloseable {
         deliver();
     }
 
-    /** Close when any messages currently queued have been requested and delivered. */
+    /** Requests closing this deframer when any messages currently queued have been requested and delivered. */
     public void closeWhenComplete() {
         if (isClosed()) {
             return;

--- a/grpc/src/main/java/com/linecorp/armeria/internal/grpc/HttpStreamReader.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/grpc/HttpStreamReader.java
@@ -214,7 +214,7 @@ public class HttpStreamReader implements Subscriber<HttpObject>, BiFunction<Void
     private void closeDeframer() {
         if (!deframer.isClosed()) {
             deframer.deframe(HttpData.EMPTY_DATA, true);
-            deframer.close();
+            deframer.closeWhenComplete();
         }
     }
 

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
@@ -96,10 +96,6 @@ class ArmeriaServerCall<I, O> extends ServerCall<I, O>
     private static final AtomicIntegerFieldUpdater<ArmeriaServerCall> pendingMessagesUpdater =
             AtomicIntegerFieldUpdater.newUpdater(ArmeriaServerCall.class, "pendingMessages");
 
-    @SuppressWarnings("rawtypes")
-    private static final AtomicIntegerFieldUpdater<ArmeriaServerCall> flushingCallbacksUpdater =
-            AtomicIntegerFieldUpdater.newUpdater(ArmeriaServerCall.class, "flushingCallbacks");
-
     // Only most significant bit of a byte is set.
     @VisibleForTesting
     static final byte TRAILERS_FRAME_HEADER = (byte) (1 << 7);
@@ -135,8 +131,6 @@ class ArmeriaServerCall<I, O> extends ServerCall<I, O>
     private Compressor compressor;
     private boolean messageCompression;
     private boolean messageReceived;
-
-    private volatile int flushingCallbacks;
 
     // state
     private volatile boolean cancelled;

--- a/grpc/src/test/java/com/linecorp/armeria/internal/grpc/ArmeriaMessageDeframerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/internal/grpc/ArmeriaMessageDeframerTest.java
@@ -171,6 +171,7 @@ public class ArmeriaMessageDeframerTest {
     public void deframe_endOfStream() throws Exception {
         deframer.request(1);
         deframer.deframe(HttpData.EMPTY_DATA, true);
+        deframer.closeWhenComplete();
         verify(listener).endOfStream();
         verifyNoMoreInteractions(listener);
     }

--- a/grpc/src/test/java/com/linecorp/armeria/internal/grpc/HttpStreamReaderTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/internal/grpc/HttpStreamReaderTest.java
@@ -152,7 +152,7 @@ public class HttpStreamReaderTest {
     public void clientDone() {
         reader.apply(null, null);
         verify(deframer).deframe(HttpData.EMPTY_DATA, true);
-        verify(deframer).close();
+        verify(deframer).closeWhenComplete();
     }
 
     @Test

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.awaitility.Awaitility.await;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Collection;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedTransferQueue;
 import java.util.concurrent.TimeUnit;
@@ -39,8 +40,12 @@ import org.junit.Test;
 import org.junit.rules.DisableOnDebug;
 import org.junit.rules.TestRule;
 import org.junit.rules.Timeout;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Bytes;
 import com.google.common.primitives.Ints;
 import com.google.protobuf.ByteString;
@@ -99,11 +104,17 @@ import io.netty.util.AsciiString;
 import io.netty.util.Attribute;
 import io.netty.util.AttributeKey;
 
+@RunWith(Parameterized.class)
 public class GrpcServiceServerTest {
 
     private static final int MAX_MESSAGE_SIZE = 16 * 1024 * 1024;
 
     private static AsciiString LARGE_PAYLOAD;
+
+    @Parameters(name = "{index}: useBlockingExecutor={0}")
+    public static Collection<Boolean> parameters() {
+        return ImmutableList.of(false, true);
+    }
 
     @BeforeClass
     public static void createLargePayload() {
@@ -287,6 +298,28 @@ public class GrpcServiceServerTest {
     };
 
     @ClassRule
+    public static ServerRule serverWithBlockingExecutor = new ServerRule() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.workerGroup(EventLoopGroups.newEventLoopGroup(1), true);
+            sb.defaultMaxRequestLength(0);
+
+            sb.serviceUnder("/", new GrpcServiceBuilder()
+                    .setMaxInboundMessageSizeBytes(MAX_MESSAGE_SIZE)
+                    .addService(new UnitTestServiceImpl())
+                    .enableUnframedRequests(true)
+                    .supportedSerializationFormats(GrpcSerializationFormats.values())
+                    .useBlockingTaskExecutor(true)
+                    .build()
+                    .decorate(LoggingService.newDecorator())
+                    .decorate((delegate, ctx, req) -> {
+                        ctx.log().addListener(requestLogQueue::add, RequestLogAvailability.COMPLETE);
+                        return delegate.serve(ctx, req);
+                    }));
+        }
+    };
+
+    @ClassRule
     public static ServerRule serverWithNoMaxMessageSize = new ServerRule() {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
@@ -326,6 +359,13 @@ public class GrpcServiceServerTest {
     public TestRule globalTimeout = new DisableOnDebug(new Timeout(10, TimeUnit.SECONDS));
 
     private static ManagedChannel channel;
+    private static ManagedChannel blockingChannel;
+
+    private final boolean useBlockingExecutor;
+
+    public GrpcServiceServerTest(boolean useBlockingExecutor) {
+        this.useBlockingExecutor = useBlockingExecutor;
+    }
 
     private UnitTestServiceBlockingStub blockingClient;
     private UnitTestServiceStub streamingClient;
@@ -335,19 +375,23 @@ public class GrpcServiceServerTest {
         channel = ManagedChannelBuilder.forAddress("127.0.0.1", server.httpPort())
                                        .usePlaintext()
                                        .build();
+        blockingChannel = ManagedChannelBuilder.forAddress("127.0.0.1", serverWithBlockingExecutor.httpPort())
+                                       .usePlaintext()
+                                       .build();
     }
 
     @AfterClass
     public static void tearDownChannel() {
         channel.shutdownNow();
+        blockingChannel.shutdownNow();
     }
 
     @Before
     public void setUp() {
         COMPLETED.set(false);
         CLIENT_CLOSED.set(false);
-        blockingClient = UnitTestServiceGrpc.newBlockingStub(channel);
-        streamingClient = UnitTestServiceGrpc.newStub(channel);
+        blockingClient = UnitTestServiceGrpc.newBlockingStub(useBlockingExecutor ? blockingChannel : channel);
+        streamingClient = UnitTestServiceGrpc.newStub(useBlockingExecutor ? blockingChannel : channel);
 
         PathAndQuery.clearCachedPaths();
         requestLogQueue.clear();

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
@@ -402,8 +402,8 @@ public class GrpcServiceServerTest {
         assertThat(blockingClient.staticUnaryCall(REQUEST_MESSAGE)).isEqualTo(RESPONSE_MESSAGE);
 
         // Confirm gRPC paths are cached despite using serviceUnder
-        assertThat(PathAndQuery.cachedPaths())
-                .contains("/armeria.grpc.testing.UnitTestService/StaticUnaryCall");
+        await().untilAsserted(() -> assertThat(PathAndQuery.cachedPaths())
+                .contains("/armeria.grpc.testing.UnitTestService/StaticUnaryCall"));
 
         checkRequestLog((rpcReq, rpcRes, grpcStatus) -> {
             assertThat(rpcReq.method()).isEqualTo("armeria.grpc.testing.UnitTestService/StaticUnaryCall");


### PR DESCRIPTION
Fixes #1524 hopefully doesn't break other things though ><

I was expecting this to just be running callbacks in order, but it turned out also needing to rework many aspects of deframing to allow the deframing and business logic to happen on separate threads. It seems like upstream also has added similar logic after our fork of the class, though the context seems to be moving deframing off the transport thread which confuses me since I would expect the ordering issue to happen when it is _on_ the transport thread. Oh well, didn't dig deeper on that.

https://github.com/grpc/grpc-java/pull/3145

Now, when the HTTP reader is finished, the business logic listener is not notified right away, but only if all messages have first been delivered. Previously, the ordering worked out that this was always the case but when message processing happens on a different thread, it isn't anymore.