### PR TITLE
Update server-access-log.rst

### DIFF
--- a/site/src/sphinx/server-access-log.rst
+++ b/site/src/sphinx/server-access-log.rst
@@ -97,9 +97,9 @@ using :api:`ServerBuilder`. You may use one of the pre-defined log formats.
 
     ServerBuilder sb = new ServerBuilder();
     // Use NCSA common log format.
-    sb.accessLogWriter(AccessLogWriter.common());
+    sb.accessLogWriter(AccessLogWriter.common(), true);
     // Use NCSA combined log format.
-    sb.accessLogWriter(AccessLogWriter.combined());
+    sb.accessLogWriter(AccessLogWriter.combined(), true);
     // Use your own log format.
     sb.accessLogFormat("...log format...");
     ...
@@ -309,7 +309,7 @@ You can specify your own log writer which implements a ``Consumer`` of :api:`Req
     sb.accessLogWriter(requestLog -> {
         // Write your access log with the given RequestLog instance.
         ....
-    });
+    }, true);
 
 
 Customizing an access logger


### PR DESCRIPTION
The `ServerBuilder.accessLogWriter()` method now expects two parameters, the latter being `shutdownOnStop`. I assume `true` is a reasonable default for this, but feel free to change to `false` if you so prefer. The key element is to make the examples be correct.

Thanks for a nice project! :+1: 