### PR TITLE
Less noisy TLS handshake error logging

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
@@ -398,7 +398,9 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
 
         @Override
         protected void handshakeFailure(ChannelHandlerContext ctx, Throwable cause) throws Exception {
-            logger.warn("{} TLS handshake failed:", ctx.channel(), cause);
+            if (!Exceptions.isExpected(cause)) {
+                logger.warn("{} TLS handshake failed:", ctx.channel(), cause);
+            }
             ctx.close();
 
             // On handshake failure, ApplicationProtocolNegotiationHandler will remove itself,


### PR DESCRIPTION
Motivation:

Server might leave a log message like the following when a client
disconnects prematurely during TLS handshake:

    TLS handshake failed:
    java.nio.channels.ClosedChannelException: null
        at io.netty.handler.ssl.SslHandler.channelInactive(...)

.. which pollutes the server log file.

Modifications:

- Guarded the TLS handshake failure logging code with
  `!Exceptions.isExpected()`.

Result:

- Less noise