### PR TITLE
[docs] Add info about client timeouts

### DIFF
--- a/site/src/sphinx/client-custom-http-headers.rst
+++ b/site/src/sphinx/client-custom-http-headers.rst
@@ -2,7 +2,7 @@
 
 Sending custom HTTP headers
 ===========================
-When send an RPC request, it is sometimes required to send HTTP headers with it, such as authentication token.
+When sending an RPC request, it is sometimes required to send HTTP headers with it, such as an authentication token.
 There are four ways to customize the HTTP headers of your RPC request:
 
 - Using the ``Clients.withHttpHeaders()`` method

--- a/site/src/sphinx/client-timeouts.rst
+++ b/site/src/sphinx/client-timeouts.rst
@@ -1,0 +1,47 @@
+.. _client-timeouts:
+
+Overriding client timeouts
+==========================
+Sometimes, the default timeouts used by the Armeria-generated client does not suit a particular scenario well. In these cases, you might want to override the timeout settings.
+
+Using ``ClientOptionsBuilder``
+------------------------------
+
+.. code-block:: java
+
+    import java.time.Duration;
+
+    import com.linecorp.armeria.common.util.SafeCloseable
+    import com.linecorp.armeria.client.ClientOptionsBuilder;
+    import com.linecorp.armeria.client.Clients;
+
+    // Defaults are defined in com.linecorp.armeria.common.Flags and
+    // com.linecorp.armeria.client.ClientOptions
+    int responseTimeout = 15;
+    int writeTimeout = 1;
+
+    HelloService.Iface client = Clients.newClient(
+            "tbinary+http://example.com/hello",
+            HelloService.Iface.class,
+            new ClientOptionsBuilder()
+                    .defaultResponseTimeout(Duration.ofSeconds(responseTimeout))
+                    .defaultWriteTimeout(Duration.ofSeconds(writeTimeout))
+                    .build()
+    );
+
+Using ``ClientBuilder``
+-----------------------
+
+.. code-block:: java
+
+    import java.time.Duration;
+
+    import com.linecorp.armeria.client.ClientBuilder;
+
+    int responseTimeout = 15;
+    int writeTimeout = 1;
+
+    HelloService.Iface client = new ClientBuilder("tbinary+http://example.com/hello")
+            .defaultResponseTimeout(Duration.ofSeconds(responseTimeout))
+            .defaultWriteTimeout(Duration.ofSeconds(writeTimeout))
+            .build(HelloService.Iface.class);

--- a/site/src/sphinx/client.rst
+++ b/site/src/sphinx/client.rst
@@ -12,6 +12,7 @@ Writing a client
     client-grpc
     client-decorator
     client-custom-http-headers
+    client-timeouts
     client-retry
     client-circuit-breaker
     client-service-discovery


### PR DESCRIPTION
Slightly related to #723, this PR describes how the default client timeouts can be overridden.

(This wasn't obvious to me at first, so adding this in the hope that it helps others. Note that the `ClientBuilder` class can also be used to tweak this; it's not 100% clear to me when to use that one and when to go with the `Clients.newClient` method.)