### PR TITLE
Add CacheControl, CacheControlBuilder and their subtypes

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/AbstractClientOptionsBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/AbstractClientOptionsBuilder.java
@@ -209,7 +209,7 @@ class AbstractClientOptionsBuilder<B extends AbstractClientOptionsBuilder<?>> {
      * </ul>
      * @param length the maximum length of the preview.
      * @param defaultCharset the default charset for a request/response with unspecified charset in
-     *                       {@code "Content-Type"} header.
+     *                       {@code "content-type"} header.
      */
     public B contentPreview(int length, Charset defaultCharset) {
         return contentPreviewerFactory(ContentPreviewerFactory.ofText(length, defaultCharset));

--- a/core/src/main/java/com/linecorp/armeria/client/ClientCacheControl.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientCacheControl.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client;
+
+import javax.annotation.Nullable;
+
+import com.linecorp.armeria.common.CacheControl;
+
+/**
+ * Directives for HTTP caching mechanisms in requests.
+ *
+ * @see ClientCacheControlBuilder
+ * @see <a href="https://developer.mozilla.org/docs/Web/HTTP/Headers/Cache-Control">Cache-Control (MDN)</a>
+ * @see <a href="https://stackoverflow.com/q/14541077">Why is Cache-Control header sent in a request?</a>
+ */
+public final class ClientCacheControl extends CacheControl {
+
+    /**
+     * An empty instance with all directives disabled.
+     */
+    public static final ClientCacheControl EMPTY = new ClientCacheControlBuilder().build();
+
+    /**
+     * {@code "no-cache"}.
+     */
+    public static final ClientCacheControl FORCE_NETWORK = new ClientCacheControlBuilder()
+            .noCache().build();
+
+    /**
+     * {@code "only-if-cached, max-stale=2147483647"}.
+     */
+    public static final ClientCacheControl FORCE_CACHE = new ClientCacheControlBuilder()
+            .onlyIfCached()
+            .maxStaleSeconds(Integer.MAX_VALUE)
+            .build();
+
+    static final long UNSPECIFIED_MAX_STALE = -2;
+
+    private final boolean onlyIfCached;
+    final long maxStaleSeconds;
+    private final long minFreshSeconds;
+    private final long staleWhileRevalidateSeconds;
+    private final long staleIfErrorSeconds;
+    @Nullable
+    private String headerValue;
+
+    ClientCacheControl(boolean noCache, boolean noStore, boolean noTransform, long maxAgeSeconds,
+                       boolean onlyIfCached, long maxStaleSeconds, long minFreshSeconds,
+                       long staleWhileRevalidateSeconds, long staleIfErrorSeconds) {
+        super(noCache, noStore, noTransform, maxAgeSeconds);
+        this.onlyIfCached = onlyIfCached;
+        this.maxStaleSeconds = maxStaleSeconds;
+        this.minFreshSeconds = minFreshSeconds;
+        this.staleWhileRevalidateSeconds = staleWhileRevalidateSeconds;
+        this.staleIfErrorSeconds = staleIfErrorSeconds;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return super.isEmpty() && !onlyIfCached && !hasMaxStale() && minFreshSeconds < 0 &&
+               staleWhileRevalidateSeconds < 0 && staleIfErrorSeconds < 0;
+    }
+
+    /**
+     * Returns whether the {@code "only-if-cached"} directive is enabled.
+     */
+    public boolean onlyIfCached() {
+        return onlyIfCached;
+    }
+
+    /**
+     * Returns whether the {@code "max-stale"} directive is enabled.
+     *
+     * @see #maxStaleSeconds()
+     */
+    public boolean hasMaxStale() {
+        return maxStaleSeconds >= 0 || maxStaleSeconds == UNSPECIFIED_MAX_STALE;
+    }
+
+    /**
+     * Returns the value of the {@code "max-stale"} directive or {@code -1} if disabled or the value is not
+     * specified.
+     *
+     * @see #hasMaxStale()
+     */
+    public long maxStaleSeconds() {
+        return maxStaleSeconds < 0 ? -1 : maxStaleSeconds;
+    }
+
+    /**
+     * Returns the value of the {@code "min-fresh"} directive or {@code -1} if disabled.
+     */
+    public long minFreshSeconds() {
+        return minFreshSeconds;
+    }
+
+    /**
+     * Returns the value of the {@code "stale-while-revalidate"} directive or {@code -1} if disabled.
+     */
+    public long staleWhileRevalidateSeconds() {
+        return staleWhileRevalidateSeconds;
+    }
+
+    /**
+     * Returns the value of the {@code "stale-if-error"} directive or {@code -1} if disabled.
+     */
+    public long staleIfErrorSeconds() {
+        return staleIfErrorSeconds;
+    }
+
+    /**
+     * Returns a newly created {@link ClientCacheControlBuilder} which has the same initial directives with
+     * this {@link ClientCacheControl}.
+     */
+    @Override
+    public ClientCacheControlBuilder toBuilder() {
+        return new ClientCacheControlBuilder(this);
+    }
+
+    @Override
+    public String asHeaderValue() {
+        if (headerValue != null) {
+            return headerValue;
+        }
+
+        final StringBuilder buf = newHeaderValueBuffer();
+        if (onlyIfCached) {
+            buf.append(", only-if-cached");
+        }
+        if (maxStaleSeconds >= 0) {
+            buf.append(", max-stale=").append(maxStaleSeconds);
+        } else if (maxStaleSeconds == UNSPECIFIED_MAX_STALE) {
+            buf.append(", max-stale");
+        }
+        if (minFreshSeconds >= 0) {
+            buf.append(", min-fresh=").append(minFreshSeconds);
+        }
+        if (staleWhileRevalidateSeconds >= 0) {
+            buf.append(", stale-while-revalidate=").append(staleWhileRevalidateSeconds);
+        }
+        if (staleIfErrorSeconds >= 0) {
+            buf.append(", stale-if-error=").append(staleIfErrorSeconds);
+        }
+
+        if (buf.length() == 0) {
+            return headerValue = "";
+        } else {
+            return headerValue = buf.substring(2);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        final ClientCacheControl that = (ClientCacheControl) o;
+        return onlyIfCached == that.onlyIfCached &&
+               maxStaleSeconds == that.maxStaleSeconds &&
+               minFreshSeconds == that.minFreshSeconds &&
+               staleWhileRevalidateSeconds == that.staleWhileRevalidateSeconds &&
+               staleIfErrorSeconds == that.staleIfErrorSeconds;
+    }
+
+    @Override
+    public int hashCode() {
+        return ((((super.hashCode() * 31 + (onlyIfCached ? 1 : 0)) * 31 +
+                  (int) (maxStaleSeconds ^ (maxStaleSeconds >>> 32))) * 31 +
+                 (int) (minFreshSeconds ^ (minFreshSeconds >>> 32))) * 31 +
+                (int) (staleWhileRevalidateSeconds ^ (staleWhileRevalidateSeconds >>> 32))) * 31 +
+               (int) (staleIfErrorSeconds ^ (staleIfErrorSeconds >>> 32));
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/client/ClientCacheControlBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientCacheControlBuilder.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client;
+
+import java.time.Duration;
+
+import javax.annotation.Nullable;
+
+import com.linecorp.armeria.common.CacheControlBuilder;
+import com.linecorp.armeria.server.ServerCacheControlBuilder;
+
+/**
+ * Creates a new {@link ClientCacheControl} using the builder pattern.
+ *
+ * <pre>{@code
+ * ClientCacheControl cacheControl =
+ *     new ClientCacheControlBuilder().noCache().build();
+ * }</pre>
+ *
+ * @see ServerCacheControlBuilder
+ * @see <a href="https://developer.mozilla.org/docs/Web/HTTP/Headers/Cache-Control">Cache-Control (MDN)</a>
+ * @see <a href="https://stackoverflow.com/q/14541077">Why is Cache-Control header sent in a request?</a>
+ */
+public final class ClientCacheControlBuilder extends CacheControlBuilder<ClientCacheControlBuilder> {
+
+    private boolean onlyIfCached;
+    private long maxStaleSeconds = -1;
+    private long minFreshSeconds = -1;
+    private long staleWhileRevalidateSeconds = -1;
+    private long staleIfErrorSeconds = -1;
+
+    /**
+     * Creates a new builder with all directives disabled initially.
+     */
+    public ClientCacheControlBuilder() {}
+
+    ClientCacheControlBuilder(ClientCacheControl c) {
+        super(c);
+        onlyIfCached = c.onlyIfCached();
+        maxStaleSeconds = c.maxStaleSeconds;
+        minFreshSeconds = c.minFreshSeconds();
+        staleWhileRevalidateSeconds = c.staleWhileRevalidateSeconds();
+        staleIfErrorSeconds = c.staleIfErrorSeconds();
+    }
+
+    /**
+     * Enables the {@code "only-if-cached"} directive.
+     */
+    public ClientCacheControlBuilder onlyIfCached() {
+        return onlyIfCached(true);
+    }
+
+    /**
+     * Enables or disables the {@code "only-if-cached"} directive.
+     *
+     * @param onlyIfCached {@code true} to enable or {@code false} to disable.
+     */
+    public ClientCacheControlBuilder onlyIfCached(boolean onlyIfCached) {
+        this.onlyIfCached = onlyIfCached;
+        return this;
+    }
+
+    /**
+     * Enables the {@code "max-stale} directive without a value.
+     */
+    public ClientCacheControlBuilder maxStale() {
+        return maxStale(true);
+    }
+
+    /**
+     * Enables or disables the {@code "max-stale"} directive.
+     *
+     * @param maxStale {@code true} to enable without a value or {@code false} to disable.
+     */
+    public ClientCacheControlBuilder maxStale(boolean maxStale) {
+        maxStaleSeconds = maxStale ? ClientCacheControl.UNSPECIFIED_MAX_STALE : -1;
+        return this;
+    }
+
+    /**
+     * Enables or disables the {@code "max-stale"} directive.
+     *
+     * @param maxStale the value of the directive to enable, or {@code null} to disable.
+     */
+    public ClientCacheControlBuilder maxStale(@Nullable Duration maxStale) {
+        maxStaleSeconds = validateDuration(maxStale, "maxStale");
+        return this;
+    }
+
+    /**
+     * Enables the {@code "max-stale"} directive.
+     *
+     * @param maxStaleSeconds the value in seconds.
+     */
+    public ClientCacheControlBuilder maxStaleSeconds(long maxStaleSeconds) {
+        this.maxStaleSeconds = validateSeconds(maxStaleSeconds, "maxStaleSeconds");
+        return this;
+    }
+
+    /**
+     * Enables or disables the {@code "min-fresh"} directive.
+     *
+     * @param minFresh the value of the directive to enable, or {@code null} to disable.
+     */
+    public ClientCacheControlBuilder minFresh(@Nullable Duration minFresh) {
+        minFreshSeconds = validateDuration(minFresh, "minFresh");
+        return this;
+    }
+
+    /**
+     * Enables the {@code "min-fresh"} directive.
+     *
+     * @param minFreshSeconds the value in seconds.
+     */
+    public ClientCacheControlBuilder minFreshSeconds(long minFreshSeconds) {
+        this.minFreshSeconds = validateSeconds(minFreshSeconds, "minFreshSeconds");
+        return this;
+    }
+
+    /**
+     * Enables or disables the {@code "stale-while-revalidate"} directive.
+     *
+     * @param staleWhileRevalidate the value of the directive to enable, or {@code null} to disable.
+     */
+    public ClientCacheControlBuilder staleWhileRevalidate(@Nullable Duration staleWhileRevalidate) {
+        staleWhileRevalidateSeconds = validateDuration(staleWhileRevalidate, "staleWhileRevalidate");
+        return this;
+    }
+
+    /**
+     * Enables the {@code "stale-while-revalidate"} directive.
+     *
+     * @param staleWhileRevalidateSeconds the value in seconds.
+     */
+    public ClientCacheControlBuilder staleWhileRevalidateSeconds(long staleWhileRevalidateSeconds) {
+        this.staleWhileRevalidateSeconds = validateSeconds(staleWhileRevalidateSeconds,
+                                                           "staleWhileRevalidateSeconds");
+        return this;
+    }
+
+    /**
+     * Enables or disables the {@code "stale-if-error"} directive.
+     *
+     * @param staleIfError the value of the directive to enable, or {@code null} to disable.
+     */
+    public ClientCacheControlBuilder staleIfError(@Nullable Duration staleIfError) {
+        staleIfErrorSeconds = validateDuration(staleIfError, "staleIfError");
+        return this;
+    }
+
+    /**
+     * Enables the {@code "stale-if-error"} directive.
+     *
+     * @param staleIfErrorSeconds the value in seconds.
+     */
+    public ClientCacheControlBuilder staleIfErrorSeconds(long staleIfErrorSeconds) {
+        this.staleIfErrorSeconds = validateSeconds(staleIfErrorSeconds, "staleIfErrorSeconds");
+        return this;
+    }
+
+    /**
+     * Returns a newly created {@link ClientCacheControl} with the directives enabled so far.
+     */
+    @Override
+    public ClientCacheControl build() {
+        return (ClientCacheControl) super.build();
+    }
+
+    @Override
+    protected ClientCacheControl build(boolean noCache, boolean noStore,
+                                       boolean noTransform, long maxAgeSeconds) {
+        return new ClientCacheControl(noCache, noStore, noTransform, maxAgeSeconds,
+                                      onlyIfCached, maxStaleSeconds, minFreshSeconds,
+                                      staleWhileRevalidateSeconds, staleIfErrorSeconds);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/common/CacheControl.java
+++ b/core/src/main/java/com/linecorp/armeria/common/CacheControl.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common;
+
+import com.linecorp.armeria.client.ClientCacheControl;
+import com.linecorp.armeria.server.ServerCacheControl;
+
+/**
+ * Directives for HTTP caching mechanisms in requests or responses. Use {@link ServerCacheControl} for
+ * response-side and {@link ClientCacheControl} for request-side.
+ *
+ * @see CacheControlBuilder
+ * @see <a href="https://developer.mozilla.org/docs/Web/HTTP/Headers/Cache-Control">Cache-Control (MDN)</a>
+ */
+public abstract class CacheControl {
+
+    private final boolean noCache;
+    private final boolean noStore;
+    private final boolean noTransform;
+    private final long maxAgeSeconds;
+
+    /**
+     * Creates a new instance with the specified directives.
+     *
+     * @param noCache whether the {@code "no-cache"} directive is enabled.
+     * @param noStore whether the {@code "no-store"} directive is enabled.
+     * @param noTransform whether the {@code "no-transform"} directive is enabled.
+     * @param maxAgeSeconds the value of the {@code "max-age"} directive, or {@code -1} if disabled.
+     */
+    protected CacheControl(boolean noCache, boolean noStore, boolean noTransform, long maxAgeSeconds) {
+        assert maxAgeSeconds >= -1 : maxAgeSeconds;
+        this.noCache = noCache;
+        this.noStore = noStore;
+        this.noTransform = noTransform;
+        this.maxAgeSeconds = maxAgeSeconds;
+    }
+
+    /**
+     * Returns {@code true} if all directives are disabled.
+     */
+    public boolean isEmpty() {
+        return !noCache && !noStore && !noTransform && maxAgeSeconds < 0;
+    }
+
+    /**
+     * Returns whether the {@code "no-cache"} directive is enabled.
+     */
+    public final boolean noCache() {
+        return noCache;
+    }
+
+    /**
+     * Returns whether the {@code "no-store"} directive is enabled.
+     */
+    public final boolean noStore() {
+        return noStore;
+    }
+
+    /**
+     * Returns whether the {@code "no-transform"} directive is enabled.
+     */
+    public final boolean noTransform() {
+        return noTransform;
+    }
+
+    /**
+     * Returns the value of the {@code "max-age"} directive or {@code -1} if disabled.
+     */
+    public final long maxAgeSeconds() {
+        return maxAgeSeconds;
+    }
+
+    /**
+     * Returns a newly created {@link CacheControlBuilder} which has the same initial directives with
+     * this {@link CacheControl}.
+     */
+    public abstract CacheControlBuilder<?> toBuilder();
+
+    /**
+     * Encodes the directives in this {@link CacheControl} into an HTTP {@code "cache-control"} header value.
+     *
+     * @return the {@code "cache-control"} header value, or an empty string if no directives were enabled.
+     */
+    public abstract String asHeaderValue();
+
+    /**
+     * Returns a new {@link StringBuilder} with the common directives appended.
+     * Note that the first two characters ({@code ", "} must be stripped.
+     */
+    protected final StringBuilder newHeaderValueBuffer() {
+        final StringBuilder buf = new StringBuilder(40);
+        if (noCache) {
+            buf.append(", no-cache");
+        }
+        if (noStore) {
+            buf.append(", no-store");
+        }
+        if (noTransform) {
+            buf.append(", no-transform");
+        }
+        if (maxAgeSeconds >= 0) {
+            buf.append(", max-age=").append(maxAgeSeconds);
+        }
+        return buf;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final CacheControl that = (CacheControl) o;
+        return noCache == that.noCache &&
+               noStore == that.noStore &&
+               noTransform == that.noTransform &&
+               maxAgeSeconds == that.maxAgeSeconds;
+    }
+
+    @Override
+    public int hashCode() {
+        return (((noCache ? 1 : 0) * 31 + (noStore ? 1 : 0)) * 31 + (noTransform ? 1 : 0)) * 31 +
+               (int) (maxAgeSeconds ^ (maxAgeSeconds >>> 32));
+    }
+
+    @Override
+    public String toString() {
+        final String value = asHeaderValue();
+        return value.isEmpty() ? (getClass().getSimpleName() + "(<empty>)")
+                               : (getClass().getSimpleName() + '(' + value + ')');
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/common/CacheControlBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/CacheControlBuilder.java
@@ -165,6 +165,8 @@ public abstract class CacheControlBuilder<B extends CacheControlBuilder<B>> {
      * Returns a newly created {@link CacheControl} with the directives enabled so far.
      */
     public CacheControl build() {
+        // 'no-cache' and 'no-store' are mutually exclusive.
+        final boolean noCache = noStore ? false : this.noCache;
         return build(noCache, noStore, noTransform, maxAgeSeconds);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/CacheControlBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/CacheControlBuilder.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.time.Duration;
+
+import javax.annotation.Nullable;
+
+import com.linecorp.armeria.client.ClientCacheControl;
+import com.linecorp.armeria.client.ClientCacheControlBuilder;
+import com.linecorp.armeria.server.ServerCacheControl;
+import com.linecorp.armeria.server.ServerCacheControlBuilder;
+
+/**
+ * A skeletal builder implementation of {@link CacheControl}. Use {@link ServerCacheControlBuilder} for
+ * building {@link ServerCacheControl} and {@link ClientCacheControlBuilder} for building
+ * {@link ClientCacheControl}.
+ *
+ * @param <B> the self type
+ *
+ * @see <a href="https://developer.mozilla.org/docs/Web/HTTP/Headers/Cache-Control">Cache-Control (MDN)</a>
+ */
+public abstract class CacheControlBuilder<B extends CacheControlBuilder<B>> {
+
+    private boolean noCache;
+    private boolean noStore;
+    private boolean noTransform;
+    private long maxAgeSeconds = -1;
+
+    /**
+     * Creates a new builder with all directives disabled initially.
+     */
+    protected CacheControlBuilder() {}
+
+    /**
+     * Creates a new builder using the specified {@link CacheControl} as the initial directives.
+     */
+    protected CacheControlBuilder(CacheControl c) {
+        noCache = c.noCache();
+        noStore = c.noStore();
+        noTransform = c.noTransform();
+        maxAgeSeconds = c.maxAgeSeconds();
+    }
+
+    @SuppressWarnings("unchecked")
+    private B self() {
+        return (B) this;
+    }
+
+    /**
+     * Enables the {@code "no-cache"} directive.
+     */
+    public final B noCache() {
+        return noCache(true);
+    }
+
+    /**
+     * Enables or disables the {@code "no-cache"} directive.
+     *
+     * @param noCache {@code true} to enable or {@code false} to disable.
+     */
+    public final B noCache(boolean noCache) {
+        this.noCache = noCache;
+        return self();
+    }
+
+    /**
+     * Enables the {@code "no-store"} directive.
+     */
+    public final B noStore() {
+        return noStore(true);
+    }
+
+    /**
+     * Enables or disables the {@code "no-store"} directive.
+     *
+     * @param noStore {@code true} to enable or {@code false} to disable.
+     */
+    public final B noStore(boolean noStore) {
+        this.noStore = noStore;
+        return self();
+    }
+
+    /**
+     * Enables the {@code "no-transform"} directive.
+     */
+    public final B noTransform() {
+        return noTransform(true);
+    }
+
+    /**
+     * Enables or disables the {@code "no-transform"} directive.
+     *
+     * @param noTransform {@code true} to enable or {@code false} to disable.
+     */
+    public final B noTransform(boolean noTransform) {
+        this.noTransform = noTransform;
+        return self();
+    }
+
+    /**
+     * Enables or disables the {@code "max-age"} directive.
+     *
+     * @param maxAge the value of the directive to enable, or {@code null} to disable.
+     */
+    public final B maxAge(@Nullable Duration maxAge) {
+        maxAgeSeconds = validateDuration(maxAge, "maxAge");
+        return self();
+    }
+
+    /**
+     * Makes sure the specified {@link Duration} is not negative.
+     *
+     * @param value the duration
+     * @param name the name of the parameter
+     * @return the duration converted into seconds
+     */
+    protected static long validateDuration(@Nullable Duration value, String name) {
+        if (value == null) {
+            return -1;
+        }
+
+        checkArgument(!value.isNegative(), "%s: %s (expected: >= 0)", name, value);
+        return value.getSeconds();
+    }
+
+    /**
+     * Enables the {@code "max-age"} directive.
+     *
+     * @param maxAgeSeconds the value in seconds.
+     */
+    public final B maxAgeSeconds(long maxAgeSeconds) {
+        this.maxAgeSeconds = validateSeconds(maxAgeSeconds, "maxAgeSeconds");
+        return self();
+    }
+
+    /**
+     * Makes sure the specified {@code value} is not negative.
+     *
+     * @param value the value in seconds
+     * @param name the name of the parameter
+     * @return {@code value}
+     */
+    protected static long validateSeconds(long value, String name) {
+        checkArgument(value >= 0, "%s: %s (expected: >= 0)", name, value);
+        return value;
+    }
+
+    /**
+     * Returns a newly created {@link CacheControl} with the directives enabled so far.
+     */
+    public CacheControl build() {
+        return build(noCache, noStore, noTransform, maxAgeSeconds);
+    }
+
+    /**
+     * Returns a newly created instance with the specified properties.
+     */
+    protected abstract CacheControl build(boolean noCache, boolean noStore,
+                                          boolean noTransform, long maxAgeSeconds);
+}

--- a/core/src/main/java/com/linecorp/armeria/common/CacheControlBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/CacheControlBuilder.java
@@ -165,8 +165,8 @@ public abstract class CacheControlBuilder<B extends CacheControlBuilder<B>> {
      * Returns a newly created {@link CacheControl} with the directives enabled so far.
      */
     public CacheControl build() {
-        // 'no-cache' and 'no-store' are mutually exclusive.
-        final boolean noCache = noStore ? false : this.noCache;
+        // Note: 'no-cache' and 'no-store' are mutually exclusive, but we need to allow a user to specify
+        //       both to work around known browser issues. See: https://stackoverflow.com/q/866822
         return build(noCache, noStore, noTransform, maxAgeSeconds);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultHttpHeaders.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultHttpHeaders.java
@@ -212,17 +212,6 @@ public final class DefaultHttpHeaders
     }
 
     @Override
-    public HttpHeaders cacheControl(CacheControl cacheControl) {
-        requireNonNull(cacheControl, "cacheControl");
-        if (cacheControl.isEmpty()){
-            remove(HttpHeaderNames.CACHE_CONTROL);
-        } else {
-            set(HttpHeaderNames.CACHE_CONTROL, cacheControl.asHeaderValue());
-        }
-        return this;
-    }
-
-    @Override
     public boolean isEndOfStream() {
         return endOfStream;
     }

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultHttpHeaders.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultHttpHeaders.java
@@ -212,6 +212,17 @@ public final class DefaultHttpHeaders
     }
 
     @Override
+    public HttpHeaders cacheControl(CacheControl cacheControl) {
+        requireNonNull(cacheControl, "cacheControl");
+        if (cacheControl.isEmpty()){
+            remove(HttpHeaderNames.CACHE_CONTROL);
+        } else {
+            set(HttpHeaderNames.CACHE_CONTROL, cacheControl.asHeaderValue());
+        }
+        return this;
+    }
+
+    @Override
     public boolean isEndOfStream() {
         return endOfStream;
     }

--- a/core/src/main/java/com/linecorp/armeria/common/HttpHeaders.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpHeaders.java
@@ -193,11 +193,6 @@ public interface HttpHeaders extends HttpObject, Headers<AsciiString, String, Ht
     HttpHeaders contentType(MediaType mediaType);
 
     /**
-     * Sets the {@link HttpHeaderNames#CACHE_CONTROL} header.
-     */
-    HttpHeaders cacheControl(CacheControl cacheControl);
-
-    /**
      * Copies the entries missing in this headers from the specified {@link Headers}.
      * This method is a shortcut of the following code:
      * <pre>{@code

--- a/core/src/main/java/com/linecorp/armeria/common/HttpHeaders.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpHeaders.java
@@ -193,6 +193,11 @@ public interface HttpHeaders extends HttpObject, Headers<AsciiString, String, Ht
     HttpHeaders contentType(MediaType mediaType);
 
     /**
+     * Sets the {@link HttpHeaderNames#CACHE_CONTROL} header.
+     */
+    HttpHeaders cacheControl(CacheControl cacheControl);
+
+    /**
      * Copies the entries missing in this headers from the specified {@link Headers}.
      * This method is a shortcut of the following code:
      * <pre>{@code

--- a/core/src/main/java/com/linecorp/armeria/common/ImmutableHttpHeaders.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ImmutableHttpHeaders.java
@@ -103,6 +103,11 @@ final class ImmutableHttpHeaders implements HttpHeaders {
     }
 
     @Override
+    public HttpHeaders cacheControl(CacheControl cacheControl) {
+        return unsupported();
+    }
+
+    @Override
     public HttpHeaders setAllIfAbsent(Headers<AsciiString, String, ?> headers) {
         return unsupported();
     }

--- a/core/src/main/java/com/linecorp/armeria/common/ImmutableHttpHeaders.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ImmutableHttpHeaders.java
@@ -103,11 +103,6 @@ final class ImmutableHttpHeaders implements HttpHeaders {
     }
 
     @Override
-    public HttpHeaders cacheControl(CacheControl cacheControl) {
-        return unsupported();
-    }
-
-    @Override
     public HttpHeaders setAllIfAbsent(Headers<AsciiString, String, ?> headers) {
         return unsupported();
     }

--- a/core/src/main/java/com/linecorp/armeria/common/StringValueConverter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/StringValueConverter.java
@@ -71,6 +71,9 @@ final class StringValueConverter implements ValueConverter<String> {
             return DateFormatter.format(new Date(((Instant) value).toEpochMilli()));
         }
 
+        if (value instanceof CacheControl) {
+            return ((CacheControl) value).asHeaderValue();
+        }
         return value.toString();
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/logging/ContentPreviewer.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/ContentPreviewer.java
@@ -60,7 +60,7 @@ public interface ContentPreviewer {
      * with the maximum {@code length} limit.
      * @param length the maximum length of the preview.
      * @param defaultCharset the default charset for a request/response with unspecified charset in
-     *                       {@code "Content-Type"} header.
+     *                       {@code "content-type"} header.
      */
     static ContentPreviewer ofText(int length, Charset defaultCharset) {
         checkArgument(length >= 0, "length : %d (expected: >= 0)", length);

--- a/core/src/main/java/com/linecorp/armeria/common/logging/ContentPreviewerFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/ContentPreviewerFactory.java
@@ -106,7 +106,7 @@ public interface ContentPreviewerFactory {
 
     /**
      * Creates a new instance of {@link ContentPreviewerFactory} which creates a {@link ContentPreviewer}
-     * through the supplier that matches with {@code "Content-Type"} header.
+     * through the supplier that matches with {@code "content-type"} header.
      */
     @SuppressWarnings("unchecked")
     static ContentPreviewerFactory of(Map<MediaType, ? extends Supplier<? extends ContentPreviewer>> map) {
@@ -191,7 +191,7 @@ public interface ContentPreviewerFactory {
      *
      * @param length the maximum length of the preview.
      * @param defaultCharset the default charset for a request/response with unspecified charset in
-     *                       {@code "Content-Type"} header.
+     *                       {@code "content-type"} header.
      */
     static ContentPreviewerFactory ofText(int length, Charset defaultCharset) {
         if (length == 0) {

--- a/core/src/main/java/com/linecorp/armeria/internal/ArmeriaHttpUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/ArmeriaHttpUtil.java
@@ -51,13 +51,16 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.StringJoiner;
+import java.util.function.BiConsumer;
 
 import javax.annotation.Nullable;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Ascii;
 import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
 
 import com.linecorp.armeria.common.DefaultHttpHeaders;
 import com.linecorp.armeria.common.Flags;
@@ -340,16 +343,6 @@ public final class ArmeriaHttpUtil {
     }
 
     /**
-     * Returns {@code true} if the specified {@code request} is a CORS preflight request.
-     */
-    public static boolean isCorsPreflightRequest(com.linecorp.armeria.common.HttpRequest request) {
-        requireNonNull(request, "request");
-        return request.method() == HttpMethod.OPTIONS &&
-               request.headers().contains(HttpHeaderNames.ORIGIN) &&
-               request.headers().contains(HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD);
-    }
-
-    /**
      * Returns {@code true} if the content of the response with the given {@link HttpStatus} is expected to
      * be always empty (1xx, 204, 205 and 304 responses.)
      *
@@ -372,6 +365,118 @@ public final class ArmeriaHttpUtil {
         }
 
         return true;
+    }
+
+    /**
+     * Returns {@code true} if the specified {@code request} is a CORS preflight request.
+     */
+    public static boolean isCorsPreflightRequest(com.linecorp.armeria.common.HttpRequest request) {
+        requireNonNull(request, "request");
+        return request.method() == HttpMethod.OPTIONS &&
+               request.headers().contains(HttpHeaderNames.ORIGIN) &&
+               request.headers().contains(HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD);
+    }
+
+    /**
+     * Parses the specified {@code "cache-control"} directives and invokes the specified {@code callback}
+     * with the directive names and values.
+     */
+    public static void parseCacheControl(String directives, BiConsumer<String, String> callback) {
+        final int len = directives.length();
+        for (int i = 0; i < len;) {
+            final int nameStart = i;
+            final String name;
+            final String value;
+
+            // Find the name.
+            for (; i < len; i++) {
+                final char ch = directives.charAt(i);
+                if (ch == ',' || ch == '=') {
+                    break;
+                }
+            }
+            name = directives.substring(nameStart, i).trim();
+
+            // Find the value.
+            if (i == len || directives.charAt(i) == ',') {
+                // Skip comma or go beyond 'len' to break the loop.
+                i++;
+                value = null;
+            } else {
+                // Skip '='.
+                i++;
+
+                // Skip whitespaces.
+                for (; i < len; i++) {
+                    final char ch = directives.charAt(i);
+                    if (ch != ' ' && ch != '\t') {
+                        break;
+                    }
+                }
+
+                if (i < len && directives.charAt(i) == '\"') {
+                    // Handle quoted string.
+                    // Skip the opening quote.
+                    i++;
+                    final int valueStart = i;
+
+                    // Find the closing quote.
+                    for (; i < len; i++) {
+                        if (directives.charAt(i) == '\"') {
+                            break;
+                        }
+                    }
+                    value = directives.substring(valueStart, i);
+
+                    // Skip the closing quote.
+                    i++;
+
+                    // Find the comma and skip it.
+                    for (; i < len; i++) {
+                        if (directives.charAt(i) == ',') {
+                            i++;
+                            break;
+                        }
+                    }
+                } else {
+                    // Handle unquoted string.
+                    final int valueStart = i;
+
+                    // Find the comma.
+                    for (; i < len; i++) {
+                        if (directives.charAt(i) == ',') {
+                            break;
+                        }
+                    }
+                    value = directives.substring(valueStart, i).trim();
+
+                    // Skip the comma.
+                    i++;
+                }
+            }
+
+            if (!name.isEmpty()) {
+                callback.accept(Ascii.toLowerCase(name), Strings.emptyToNull(value));
+            }
+        }
+    }
+
+    /**
+     * Converts the specified {@code "cache-control"} directive value into a long integer.
+     *
+     * @return the converted value or {@code -1} if {@code value} is {@code null} or not an integer.
+     */
+    public static long parseCacheControlSeconds(@Nullable String value) {
+        if (value == null) {
+            return -1;
+        }
+
+        try {
+            final long converted = Long.parseLong(value);
+            return converted >= 0 ? converted : -1;
+        } catch (NumberFormatException e) {
+            return -1;
+        }
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/internal/ArmeriaHttpUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/ArmeriaHttpUtil.java
@@ -464,7 +464,8 @@ public final class ArmeriaHttpUtil {
     /**
      * Converts the specified {@code "cache-control"} directive value into a long integer.
      *
-     * @return the converted value or {@code -1} if {@code value} is {@code null} or not an integer.
+     * @return the converted value if {@code value} is equal to or greater than {@code 0}.
+     *         {@code -1} otherwise, i.e. if a negative integer or not a number.
      */
     public static long parseCacheControlSeconds(@Nullable String value) {
         if (value == null) {

--- a/core/src/main/java/com/linecorp/armeria/server/AbstractVirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AbstractVirtualHostBuilder.java
@@ -604,7 +604,7 @@ abstract class AbstractVirtualHostBuilder<B extends AbstractVirtualHostBuilder> 
      * </ul>
      * @param length the maximum length of the preview.
      * @param defaultCharset the default charset for a request/response with unspecified charset in
-     *                       {@code "Content-Type"} header.
+     *                       {@code "content-type"} header.
      */
     public B contentPreview(int length, Charset defaultCharset) {
         return contentPreviewerFactory(ContentPreviewerFactory.ofText(length, defaultCharset));

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -1246,7 +1246,7 @@ public final class ServerBuilder {
      * </ul>
      * @param length the maximum length of the preview.
      * @param defaultCharset the default charset for a request/response with unspecified charset in
-     *                       {@code "Content-Type"} header.
+     *                       {@code "content-type"} header.
      */
     public ServerBuilder contentPreview(int length, Charset defaultCharset) {
         return contentPreviewerFactory(ContentPreviewerFactory.ofText(length, defaultCharset));

--- a/core/src/main/java/com/linecorp/armeria/server/ServerCacheControl.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerCacheControl.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server;
+
+import javax.annotation.Nullable;
+
+import com.linecorp.armeria.common.CacheControl;
+
+/**
+ * Directives for HTTP caching mechanisms in responses.
+ *
+ * @see ServerCacheControlBuilder
+ * @see <a href="https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/http-caching">HTTP Caching (Google)</a>
+ * @see <a href="https://developer.mozilla.org/docs/Web/HTTP/Headers/Cache-Control">Cache-Control (MDN)</a>
+ */
+public final class ServerCacheControl extends CacheControl {
+
+    /**
+     * An empty instance with all directives disabled.
+     */
+    public static final ServerCacheControl EMPTY = new ServerCacheControlBuilder().build();
+
+    /**
+     * {@code "no-cache, no-store, must-revalidate"}.
+     */
+    public static final ServerCacheControl DISABLED = new ServerCacheControlBuilder()
+            .noCache().noStore().mustRevalidate().build();
+
+    /**
+     * {@code "no-cache"}.
+     */
+    public static final ServerCacheControl REVALIDATED = new ServerCacheControlBuilder()
+            .noCache().build();
+
+    /**
+     * {@code "max-age=31536000, public, immutable"}.
+     */
+    public static final ServerCacheControl IMMUTABLE = new ServerCacheControlBuilder()
+            .maxAgeSeconds(31536000).cachePublic().cacheImmutable().build();
+
+    private final boolean cachePublic;
+    private final boolean cachePrivate;
+    private final boolean cacheImmutable;
+    private final boolean mustRevalidate;
+    private final boolean proxyRevalidate;
+    private final long sMaxAgeSeconds;
+    @Nullable
+    private String headerValue;
+
+    ServerCacheControl(boolean noCache, boolean noStore, boolean noTransform, long maxAgeSeconds,
+                       boolean cachePublic, boolean cachePrivate, boolean cacheImmutable,
+                       boolean mustRevalidate, boolean proxyRevalidate, long sMaxAgeSeconds) {
+        super(noCache, noStore, noTransform, maxAgeSeconds);
+        this.cachePublic = cachePublic;
+        this.cachePrivate = cachePrivate;
+        this.cacheImmutable = cacheImmutable;
+        this.mustRevalidate = mustRevalidate;
+        this.proxyRevalidate = proxyRevalidate;
+        this.sMaxAgeSeconds = sMaxAgeSeconds;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return super.isEmpty() && !cachePublic && !cachePrivate && !cacheImmutable &&
+               !mustRevalidate && !proxyRevalidate && sMaxAgeSeconds < 0;
+    }
+
+    /**
+     * Returns whether the {@code "public"} directive is enabled.
+     */
+    public boolean cachePublic() {
+        return cachePublic;
+    }
+
+    /**
+     * Returns whether the {@code "private"} directive is enabled.
+     */
+    public boolean cachePrivate() {
+        return cachePrivate;
+    }
+
+    /**
+     * Returns whether the {@code "immutable"} directive is enabled.
+     */
+    public boolean cacheImmutable() {
+        return cacheImmutable;
+    }
+
+    /**
+     * Returns whether the {@code "must-revalidate"} directive is enabled.
+     */
+    public boolean mustRevalidate() {
+        return mustRevalidate;
+    }
+
+    /**
+     * Returns whether the {@code "proxy-revalidate"} directive is enabled.
+     */
+    public boolean proxyRevalidate() {
+        return proxyRevalidate;
+    }
+
+    /**
+     * Returns the value of the {@code "s-maxage"} directive or {@code -1} if disabled.
+     */
+    public long sMaxAgeSeconds() {
+        return sMaxAgeSeconds;
+    }
+
+    /**
+     * Returns a newly created {@link ServerCacheControlBuilder} which has the same initial directives with
+     * this {@link ServerCacheControl}.
+     */
+    @Override
+    public ServerCacheControlBuilder toBuilder() {
+        return new ServerCacheControlBuilder(this);
+    }
+
+    @Override
+    public String asHeaderValue() {
+        if (headerValue != null) {
+            return headerValue;
+        }
+
+        final StringBuilder buf = newHeaderValueBuffer();
+        if (cachePublic) {
+            buf.append(", public");
+        }
+        if (cachePrivate) {
+            buf.append(", private");
+        }
+        if (cacheImmutable) {
+            buf.append(", immutable");
+        }
+        if (mustRevalidate) {
+            buf.append(", must-revalidate");
+        }
+        if (proxyRevalidate) {
+            buf.append(", proxy-revalidate");
+        }
+        if (sMaxAgeSeconds >= 0) {
+            buf.append(", s-maxage=").append(sMaxAgeSeconds);
+        }
+
+        if (buf.length() == 0) {
+            return headerValue = "";
+        } else {
+            return headerValue = buf.substring(2);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        final ServerCacheControl that = (ServerCacheControl) o;
+        return cachePublic == that.cachePublic &&
+               cachePrivate == that.cachePrivate &&
+               cacheImmutable == that.cacheImmutable &&
+               mustRevalidate == that.mustRevalidate &&
+               proxyRevalidate == that.proxyRevalidate &&
+               sMaxAgeSeconds == that.sMaxAgeSeconds;
+    }
+
+    @Override
+    public int hashCode() {
+        return (((((super.hashCode() * 31 +
+                    (cachePublic ? 1 : 0)) * 31 +
+                   (cachePrivate ? 1 : 0)) * 31 +
+                  (cacheImmutable ? 1 : 0)) * 31 +
+                 (mustRevalidate ? 1 : 0)) * 31 +
+                (proxyRevalidate ? 1 : 0)) * 31 +
+               (int) (sMaxAgeSeconds ^ (sMaxAgeSeconds >>> 32));
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/ServerCacheControl.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerCacheControl.java
@@ -55,7 +55,7 @@ public final class ServerCacheControl extends CacheControl {
      * {@code "max-age=31536000, public, immutable"}.
      */
     public static final ServerCacheControl IMMUTABLE = new ServerCacheControlBuilder()
-            .maxAgeSeconds(31536000).cachePublic().cacheImmutable().build();
+            .maxAgeSeconds(31536000).cachePublic().immutable().build();
 
     /**
      * Parses the specified {@code "cache-control"} header values into a {@link ServerCacheControl}.
@@ -101,7 +101,7 @@ public final class ServerCacheControl extends CacheControl {
                         builder.cachePrivate();
                         break;
                     case "immutable":
-                        builder.cacheImmutable();
+                        builder.immutable();
                         break;
                     case "must-revalidate":
                         builder.mustRevalidate();
@@ -124,7 +124,7 @@ public final class ServerCacheControl extends CacheControl {
 
     private final boolean cachePublic;
     private final boolean cachePrivate;
-    private final boolean cacheImmutable;
+    private final boolean immutable;
     private final boolean mustRevalidate;
     private final boolean proxyRevalidate;
     private final long sMaxAgeSeconds;
@@ -132,12 +132,12 @@ public final class ServerCacheControl extends CacheControl {
     private String headerValue;
 
     ServerCacheControl(boolean noCache, boolean noStore, boolean noTransform, long maxAgeSeconds,
-                       boolean cachePublic, boolean cachePrivate, boolean cacheImmutable,
+                       boolean cachePublic, boolean cachePrivate, boolean immutable,
                        boolean mustRevalidate, boolean proxyRevalidate, long sMaxAgeSeconds) {
         super(noCache, noStore, noTransform, maxAgeSeconds);
         this.cachePublic = cachePublic;
         this.cachePrivate = cachePrivate;
-        this.cacheImmutable = cacheImmutable;
+        this.immutable = immutable;
         this.mustRevalidate = mustRevalidate;
         this.proxyRevalidate = proxyRevalidate;
         this.sMaxAgeSeconds = sMaxAgeSeconds;
@@ -145,7 +145,7 @@ public final class ServerCacheControl extends CacheControl {
 
     @Override
     public boolean isEmpty() {
-        return super.isEmpty() && !cachePublic && !cachePrivate && !cacheImmutable &&
+        return super.isEmpty() && !cachePublic && !cachePrivate && !immutable &&
                !mustRevalidate && !proxyRevalidate && sMaxAgeSeconds < 0;
     }
 
@@ -166,8 +166,8 @@ public final class ServerCacheControl extends CacheControl {
     /**
      * Returns whether the {@code "immutable"} directive is enabled.
      */
-    public boolean cacheImmutable() {
-        return cacheImmutable;
+    public boolean immutable() {
+        return immutable;
     }
 
     /**
@@ -213,7 +213,7 @@ public final class ServerCacheControl extends CacheControl {
         if (cachePrivate) {
             buf.append(", private");
         }
-        if (cacheImmutable) {
+        if (immutable) {
             buf.append(", immutable");
         }
         if (mustRevalidate) {
@@ -242,7 +242,7 @@ public final class ServerCacheControl extends CacheControl {
         final ServerCacheControl that = (ServerCacheControl) o;
         return cachePublic == that.cachePublic &&
                cachePrivate == that.cachePrivate &&
-               cacheImmutable == that.cacheImmutable &&
+               immutable == that.immutable &&
                mustRevalidate == that.mustRevalidate &&
                proxyRevalidate == that.proxyRevalidate &&
                sMaxAgeSeconds == that.sMaxAgeSeconds;
@@ -253,7 +253,7 @@ public final class ServerCacheControl extends CacheControl {
         return (((((super.hashCode() * 31 +
                     (cachePublic ? 1 : 0)) * 31 +
                    (cachePrivate ? 1 : 0)) * 31 +
-                  (cacheImmutable ? 1 : 0)) * 31 +
+                  (immutable ? 1 : 0)) * 31 +
                  (mustRevalidate ? 1 : 0)) * 31 +
                 (proxyRevalidate ? 1 : 0)) * 31 +
                (int) (sMaxAgeSeconds ^ (sMaxAgeSeconds >>> 32));

--- a/core/src/main/java/com/linecorp/armeria/server/ServerCacheControlBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerCacheControlBuilder.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server;
+
+import java.time.Duration;
+
+import javax.annotation.Nullable;
+
+import com.linecorp.armeria.client.ClientCacheControlBuilder;
+import com.linecorp.armeria.common.CacheControlBuilder;
+
+/**
+ * Creates a new {@link ServerCacheControl} using the builder pattern.
+ *
+ * <pre>{@code
+ * ServerCacheControl cacheControl =
+ *     new ServerCacheControlBuilder()
+ *         .noCache()
+ *         .noStore()
+ *         .mustRevalidate()
+ *         .build();
+ * }</pre>
+ *
+ * @see ClientCacheControlBuilder
+ * @see <a href="https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/http-caching">HTTP Caching (Google)</a>
+ * @see <a href="https://developer.mozilla.org/docs/Web/HTTP/Headers/Cache-Control">Cache-Control (MDN)</a>
+ */
+public final class ServerCacheControlBuilder extends CacheControlBuilder<ServerCacheControlBuilder> {
+
+    private boolean cachePublic;
+    private boolean cachePrivate;
+    private boolean cacheImmutable;
+    private boolean mustRevalidate;
+    private boolean proxyRevalidate;
+    private long sMaxAgeSeconds = -1;
+
+    /**
+     * Creates a new builder with all directives disabled initially.
+     */
+    public ServerCacheControlBuilder() {}
+
+    ServerCacheControlBuilder(ServerCacheControl c) {
+        super(c);
+        cachePublic = c.cachePublic();
+        cachePrivate = c.cachePrivate();
+        cacheImmutable = c.cacheImmutable();
+        mustRevalidate = c.mustRevalidate();
+        proxyRevalidate = c.proxyRevalidate();
+        sMaxAgeSeconds = c.sMaxAgeSeconds();
+    }
+
+    /**
+     * Enables the {@code "public"} directive.
+     */
+    public ServerCacheControlBuilder cachePublic() {
+        return cachePublic(true);
+    }
+
+    /**
+     * Enables or disables the {@code "public"} directive.
+     *
+     * @param cachePublic {@code true} to enable or {@code false} to disable.
+     */
+    public ServerCacheControlBuilder cachePublic(boolean cachePublic) {
+        this.cachePublic = cachePublic;
+        return this;
+    }
+
+    /**
+     * Enables the {@code "private"} directive.
+     */
+    public ServerCacheControlBuilder cachePrivate() {
+        return cachePrivate(true);
+    }
+
+    /**
+     * Enables or disables the {@code "private"} directive.
+     *
+     * @param cachePrivate {@code true} to enable or {@code false} to disable.
+     */
+    public ServerCacheControlBuilder cachePrivate(boolean cachePrivate) {
+        this.cachePrivate = cachePrivate;
+        return this;
+    }
+
+    /**
+     * Enables the {@code "immutable"} directive.
+     */
+    public ServerCacheControlBuilder cacheImmutable() {
+        return cacheImmutable(true);
+    }
+
+    /**
+     * Enables or disables the {@code "immutable"} directive.
+     *
+     * @param cacheImmutable {@code true} to enable or {@code false} to disable.
+     */
+    public ServerCacheControlBuilder cacheImmutable(boolean cacheImmutable) {
+        this.cacheImmutable = cacheImmutable;
+        return this;
+    }
+
+    /**
+     * Enables the {@code "must-revalidate"} directive.
+     */
+    public ServerCacheControlBuilder mustRevalidate() {
+        return mustRevalidate(true);
+    }
+
+    /**
+     * Enables or disables the {@code "must-revalidate"} directive.
+     *
+     * @param mustRevalidate {@code true} to enable or {@code false} to disable.
+     */
+    public ServerCacheControlBuilder mustRevalidate(boolean mustRevalidate) {
+        this.mustRevalidate = mustRevalidate;
+        return this;
+    }
+
+    /**
+     * Enables the {@code "proxy-revalidate"} directive.
+     */
+    public ServerCacheControlBuilder proxyRevalidate() {
+        return proxyRevalidate(true);
+    }
+
+    /**
+     * Enables or disables the {@code "proxy-revalidate"} directive.
+     *
+     * @param proxyRevalidate {@code true} to enable or {@code false} to disable.
+     */
+    public ServerCacheControlBuilder proxyRevalidate(boolean proxyRevalidate) {
+        this.proxyRevalidate = proxyRevalidate;
+        return this;
+    }
+
+    /**
+     * Enables or disables the {@code "s-maxage"} directive.
+     *
+     * @param sMaxAge the value of the directive to enable, or {@code null} to disable.
+     */
+    public ServerCacheControlBuilder sMaxAge(@Nullable Duration sMaxAge) {
+        sMaxAgeSeconds = validateDuration(sMaxAge, "sMaxAge");
+        return this;
+    }
+
+    /**
+     * Enables the {@code "s-maxage"} directive.
+     *
+     * @param sMaxAgeSeconds the value in seconds.
+     */
+    public ServerCacheControlBuilder sMaxAgeSeconds(long sMaxAgeSeconds) {
+        this.sMaxAgeSeconds = validateSeconds(sMaxAgeSeconds, "sMaxAgeSeconds");
+        return this;
+    }
+
+    /**
+     * Returns a newly created {@link ServerCacheControl} with the directives enabled so far.
+     */
+    @Override
+    public ServerCacheControl build() {
+        return (ServerCacheControl) super.build();
+    }
+
+    @Override
+    protected ServerCacheControl build(boolean noCache, boolean noStore,
+                                       boolean noTransform, long maxAgeSeconds) {
+        return new ServerCacheControl(noCache, noStore, noTransform, maxAgeSeconds,
+                                      cachePublic, cachePrivate, cacheImmutable,
+                                      mustRevalidate, proxyRevalidate, sMaxAgeSeconds);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/ServerCacheControlBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerCacheControlBuilder.java
@@ -178,6 +178,8 @@ public final class ServerCacheControlBuilder extends CacheControlBuilder<ServerC
     @Override
     protected ServerCacheControl build(boolean noCache, boolean noStore,
                                        boolean noTransform, long maxAgeSeconds) {
+        // 'public' and 'private' are mutually exclusive.
+        final boolean cachePublic = cachePrivate ? false : this.cachePublic;
         return new ServerCacheControl(noCache, noStore, noTransform, maxAgeSeconds,
                                       cachePublic, cachePrivate, immutable,
                                       mustRevalidate, proxyRevalidate, sMaxAgeSeconds);

--- a/core/src/main/java/com/linecorp/armeria/server/ServerCacheControlBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerCacheControlBuilder.java
@@ -42,7 +42,7 @@ public final class ServerCacheControlBuilder extends CacheControlBuilder<ServerC
 
     private boolean cachePublic;
     private boolean cachePrivate;
-    private boolean cacheImmutable;
+    private boolean immutable;
     private boolean mustRevalidate;
     private boolean proxyRevalidate;
     private long sMaxAgeSeconds = -1;
@@ -56,7 +56,7 @@ public final class ServerCacheControlBuilder extends CacheControlBuilder<ServerC
         super(c);
         cachePublic = c.cachePublic();
         cachePrivate = c.cachePrivate();
-        cacheImmutable = c.cacheImmutable();
+        immutable = c.immutable();
         mustRevalidate = c.mustRevalidate();
         proxyRevalidate = c.proxyRevalidate();
         sMaxAgeSeconds = c.sMaxAgeSeconds();
@@ -99,17 +99,17 @@ public final class ServerCacheControlBuilder extends CacheControlBuilder<ServerC
     /**
      * Enables the {@code "immutable"} directive.
      */
-    public ServerCacheControlBuilder cacheImmutable() {
-        return cacheImmutable(true);
+    public ServerCacheControlBuilder immutable() {
+        return immutable(true);
     }
 
     /**
      * Enables or disables the {@code "immutable"} directive.
      *
-     * @param cacheImmutable {@code true} to enable or {@code false} to disable.
+     * @param immutable {@code true} to enable or {@code false} to disable.
      */
-    public ServerCacheControlBuilder cacheImmutable(boolean cacheImmutable) {
-        this.cacheImmutable = cacheImmutable;
+    public ServerCacheControlBuilder immutable(boolean immutable) {
+        this.immutable = immutable;
         return this;
     }
 
@@ -179,7 +179,7 @@ public final class ServerCacheControlBuilder extends CacheControlBuilder<ServerC
     protected ServerCacheControl build(boolean noCache, boolean noStore,
                                        boolean noTransform, long maxAgeSeconds) {
         return new ServerCacheControl(noCache, noStore, noTransform, maxAgeSeconds,
-                                      cachePublic, cachePrivate, cacheImmutable,
+                                      cachePublic, cachePrivate, immutable,
                                       mustRevalidate, proxyRevalidate, sMaxAgeSeconds);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/docs/DocService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/DocService.java
@@ -44,13 +44,13 @@ import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Streams;
 
 import com.linecorp.armeria.common.HttpData;
-import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.ServerCacheControl;
 import com.linecorp.armeria.server.ServerConfig;
 import com.linecorp.armeria.server.ServerListenerAdapter;
 import com.linecorp.armeria.server.Service;
@@ -326,8 +326,8 @@ public class DocService extends AbstractCompositeService<HttpRequest, HttpRespon
         private volatile HttpFile file = HttpFile.nonExistent();
 
         @Override
-        public HttpFile get(String path, Clock clock,
-                            @Nullable String contentEncoding) {
+        public HttpFile get(String path, Clock clock, @Nullable String contentEncoding,
+                            HttpHeaders additionalHeaders) {
             return file;
         }
 
@@ -343,7 +343,8 @@ public class DocService extends AbstractCompositeService<HttpRequest, HttpRespon
         void setContent(byte[] content, MediaType mediaType) {
             assert file == HttpFile.nonExistent();
             file = HttpFileBuilder.of(HttpData.of(content))
-                                  .setHeader(HttpHeaderNames.CONTENT_TYPE, mediaType)
+                                  .contentType(mediaType)
+                                  .cacheControl(ServerCacheControl.REVALIDATED)
                                   .build();
         }
     }

--- a/core/src/main/java/com/linecorp/armeria/server/file/AbstractHttpFileBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/AbstractHttpFileBuilder.java
@@ -245,8 +245,7 @@ public abstract class AbstractHttpFileBuilder<B extends AbstractHttpFileBuilder<
      */
     public final B cacheControl(CacheControl cacheControl) {
         requireNonNull(cacheControl, "cacheControl");
-        getOrCreateHeaders().cacheControl(cacheControl);
-        return self();
+        return setHeader(HttpHeaderNames.CACHE_CONTROL, cacheControl);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/file/AbstractHttpFileBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/AbstractHttpFileBuilder.java
@@ -220,7 +220,8 @@ public abstract class AbstractHttpFileBuilder<B extends AbstractHttpFileBuilder<
     public final B contentType(MediaType contentType) {
         requireNonNull(contentType, "contentType");
         autoDetectedContentType(false);
-        return setHeader(HttpHeaderNames.CONTENT_TYPE, contentType);
+        getOrCreateHeaders().contentType(contentType);
+        return self();
     }
 
     /**
@@ -243,6 +244,18 @@ public abstract class AbstractHttpFileBuilder<B extends AbstractHttpFileBuilder<
      * }</pre>
      */
     public final B cacheControl(CacheControl cacheControl) {
+        requireNonNull(cacheControl, "cacheControl");
+        getOrCreateHeaders().cacheControl(cacheControl);
+        return self();
+    }
+
+    /**
+     * Sets the {@code "cache-control"} header. This method is a shortcut of:
+     * <pre>{@code
+     * builder.setHeader(HttpHeaderNames.CACHE_CONTROL, cacheControl);
+     * }</pre>
+     */
+    public final B cacheControl(CharSequence cacheControl) {
         requireNonNull(cacheControl, "cacheControl");
         return setHeader(HttpHeaderNames.CACHE_CONTROL, cacheControl);
     }

--- a/core/src/main/java/com/linecorp/armeria/server/file/AbstractHttpFileBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/AbstractHttpFileBuilder.java
@@ -22,9 +22,11 @@ import java.util.function.BiFunction;
 
 import javax.annotation.Nullable;
 
+import com.linecorp.armeria.common.CacheControl;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.MediaType;
 
 import io.netty.handler.codec.Headers;
 import io.netty.util.AsciiString;
@@ -105,6 +107,9 @@ public abstract class AbstractHttpFileBuilder<B extends AbstractHttpFileBuilder<
      * Sets whether to set the {@code "content-type"} header automatically based on the extension of the file.
      */
     protected final boolean isContentTypeAutoDetectionEnabled() {
+        if (headers != null && headers.contains(HttpHeaderNames.CONTENT_TYPE)) {
+            return false;
+        }
         return contentTypeAutoDetectionEnabled;
     }
 
@@ -199,7 +204,46 @@ public abstract class AbstractHttpFileBuilder<B extends AbstractHttpFileBuilder<
      */
     public final B setHeaders(Headers<AsciiString, String, ?> headers) {
         requireNonNull(headers, "headers");
-        getOrCreateHeaders().setAll(headers);
+        if (!headers.isEmpty()) {
+            getOrCreateHeaders().setAll(headers);
+        }
         return self();
+    }
+
+    /**
+     * Sets the {@code "content-type"} header. This method is a shortcut of:
+     * <pre>{@code
+     * builder.autoDetectedContentType(false);
+     * builder.setHeader(HttpHeaderNames.CONTENT_TYPE, contentType);
+     * }</pre>
+     */
+    public final B contentType(MediaType contentType) {
+        requireNonNull(contentType, "contentType");
+        autoDetectedContentType(false);
+        return setHeader(HttpHeaderNames.CONTENT_TYPE, contentType);
+    }
+
+    /**
+     * Sets the {@code "content-type"} header. This method is a shortcut of:
+     * <pre>{@code
+     * builder.autoDetectedContentType(false);
+     * builder.setHeader(HttpHeaderNames.CONTENT_TYPE, contentType);
+     * }</pre>
+     */
+    public final B contentType(CharSequence contentType) {
+        requireNonNull(contentType, "contentType");
+        autoDetectedContentType(false);
+        return setHeader(HttpHeaderNames.CONTENT_TYPE, contentType);
+    }
+
+    /**
+     * Sets the {@code "cache-control"} header. This method is a shortcut of:
+     * <pre>{@code
+     * builder.setHeader(HttpHeaderNames.CACHE_CONTROL, cacheControl);
+     * }</pre>
+     */
+    public final B cacheControl(CacheControl cacheControl) {
+        requireNonNull(cacheControl, "cacheControl");
+        return setHeader(HttpHeaderNames.CACHE_CONTROL, cacheControl);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/file/ClassPathHttpVfs.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/ClassPathHttpVfs.java
@@ -21,6 +21,7 @@ import java.time.Clock;
 
 import javax.annotation.Nullable;
 
+import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.internal.PathMappingUtil;
 
 final class ClassPathHttpVfs extends AbstractHttpVfs {
@@ -47,12 +48,12 @@ final class ClassPathHttpVfs extends AbstractHttpVfs {
     }
 
     @Override
-    public HttpFile get(String path, Clock clock,
-                        @Nullable String contentEncoding) {
+    public HttpFile get(String path, Clock clock, @Nullable String contentEncoding,
+                        HttpHeaders additionalHeaders) {
         PathMappingUtil.ensureAbsolutePath(path, "path");
         final String resourcePath = rootDir.isEmpty() ? path.substring(1) : rootDir + path;
         final HttpFileBuilder builder = HttpFileBuilder.ofResource(classLoader, resourcePath);
-        return FileSystemHttpVfs.build(builder, clock, path, contentEncoding);
+        return FileSystemHttpVfs.build(builder, clock, path, contentEncoding, additionalHeaders);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/file/FileSystemHttpVfs.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/FileSystemHttpVfs.java
@@ -33,6 +33,7 @@ import javax.annotation.Nullable;
 import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.internal.PathMappingUtil;
 
@@ -50,11 +51,12 @@ final class FileSystemHttpVfs extends AbstractHttpVfs {
     }
 
     @Override
-    public HttpFile get(String path, Clock clock, @Nullable String contentEncoding) {
+    public HttpFile get(String path, Clock clock, @Nullable String contentEncoding,
+                        HttpHeaders additionalHeaders) {
         path = normalizePath(path);
 
         final HttpFileBuilder builder = HttpFileBuilder.of(Paths.get(rootDir + path));
-        return build(builder, clock, path, contentEncoding);
+        return build(builder, clock, path, contentEncoding, additionalHeaders);
     }
 
     @Override
@@ -93,14 +95,16 @@ final class FileSystemHttpVfs extends AbstractHttpVfs {
     static HttpFile build(HttpFileBuilder builder,
                           Clock clock,
                           String pathOrUri,
-                          @Nullable String contentEncoding) {
+                          @Nullable String contentEncoding,
+                          HttpHeaders additionalHeaders) {
 
         builder.autoDetectedContentType(false);
         builder.clock(clock);
+        builder.setHeaders(additionalHeaders);
 
         final MediaType contentType = MimeTypeUtil.guessFromPath(pathOrUri, contentEncoding);
         if (contentType != null) {
-            builder.setHeader(HttpHeaderNames.CONTENT_TYPE, contentType);
+            builder.contentType(contentType);
         }
         if (contentEncoding != null) {
             builder.setHeader(HttpHeaderNames.CONTENT_ENCODING, contentEncoding);

--- a/core/src/main/java/com/linecorp/armeria/server/file/HttpFileService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/HttpFileService.java
@@ -210,6 +210,7 @@ public final class HttpFileService extends AbstractHttpService {
                         AutoIndex.listingToHtml(ctx.decodedPath(), decodedMappedPath, listing);
                 return HttpFileBuilder.of(autoIndex)
                                       .addHeader(HttpHeaderNames.CONTENT_TYPE, MediaType.HTML_UTF_8)
+                                      .setHeaders(config.headers())
                                       .build();
             }
         } else {
@@ -242,7 +243,7 @@ public final class HttpFileService extends AbstractHttpService {
     @Nullable
     private HttpFile findFile(ServiceRequestContext ctx, String path,
                               @Nullable String contentEncoding) throws IOException {
-        final HttpFile uncachedFile = config.vfs().get(path, config.clock(), contentEncoding);
+        final HttpFile uncachedFile = config.vfs().get(path, config.clock(), contentEncoding, config.headers());
         final HttpFileAttributes uncachedAttrs = uncachedFile.readAttributes();
         if (cache == null) {
             return uncachedAttrs != null ? uncachedFile : null;

--- a/core/src/main/java/com/linecorp/armeria/server/file/HttpFileServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/HttpFileServiceBuilder.java
@@ -205,6 +205,18 @@ public final class HttpFileServiceBuilder {
      */
     public HttpFileServiceBuilder cacheControl(CacheControl cacheControl) {
         requireNonNull(cacheControl, "cacheControl");
+        getOrCreateHeaders().cacheControl(cacheControl);
+        return this;
+    }
+
+    /**
+     * Sets the {@code "cache-control"} header. This method is a shortcut of:
+     * <pre>{@code
+     * builder.setHeader(HttpHeaderNames.CACHE_CONTROL, cacheControl);
+     * }</pre>
+     */
+    public HttpFileServiceBuilder cacheControl(CharSequence cacheControl) {
+        requireNonNull(cacheControl, "cacheControl");
         return setHeader(HttpHeaderNames.CACHE_CONTROL, cacheControl);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/file/HttpFileServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/HttpFileServiceBuilder.java
@@ -21,6 +21,16 @@ import static java.util.Objects.requireNonNull;
 import java.nio.file.Path;
 import java.time.Clock;
 
+import javax.annotation.Nullable;
+
+import com.linecorp.armeria.common.CacheControl;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpResponse;
+
+import io.netty.handler.codec.Headers;
+import io.netty.util.AsciiString;
+
 /**
  * Builds a new {@link HttpFileService} and its {@link HttpFileServiceConfig}. Use the factory methods in
  * {@link HttpFileService} if you do not override the default settings.
@@ -73,6 +83,8 @@ public final class HttpFileServiceBuilder {
     private int maxCacheEntrySizeBytes = DEFAULT_MAX_CACHE_ENTRY_SIZE_BYTES;
     private boolean serveCompressedFiles;
     private boolean autoIndex;
+    @Nullable
+    private HttpHeaders headers;
 
     private HttpFileServiceBuilder(HttpVfs vfs) {
         this.vfs = requireNonNull(vfs, "vfs");
@@ -131,17 +143,83 @@ public final class HttpFileServiceBuilder {
     }
 
     /**
+     * Returns the immutable additional {@link HttpHeaders} which will be set when building an
+     * {@link HttpResponse}.
+     */
+    private HttpHeaders headers() {
+        return headers != null ? headers.asImmutable() : HttpHeaders.EMPTY_HEADERS;
+    }
+
+    private HttpHeaders getOrCreateHeaders() {
+        if (headers == null) {
+            headers = HttpHeaders.of();
+        }
+        return headers;
+    }
+
+    /**
+     * Adds the specified HTTP header.
+     */
+    public HttpFileServiceBuilder addHeader(CharSequence name, Object value) {
+        requireNonNull(name, "name");
+        requireNonNull(value, "value");
+        getOrCreateHeaders().addObject(HttpHeaderNames.of(name), value);
+        return this;
+    }
+
+    /**
+     * Adds the specified HTTP headers.
+     */
+    public HttpFileServiceBuilder addHeaders(Headers<AsciiString, String, ?> headers) {
+        requireNonNull(headers, "headers");
+        getOrCreateHeaders().add(headers);
+        return this;
+    }
+
+    /**
+     * Sets the specified HTTP header.
+     */
+    public HttpFileServiceBuilder setHeader(CharSequence name, Object value) {
+        requireNonNull(name, "name");
+        requireNonNull(value, "value");
+        getOrCreateHeaders().setObject(HttpHeaderNames.of(name), value);
+        return this;
+    }
+
+    /**
+     * Sets the specified HTTP headers.
+     */
+    public HttpFileServiceBuilder setHeaders(Headers<AsciiString, String, ?> headers) {
+        requireNonNull(headers, "headers");
+        if (!headers.isEmpty()) {
+            getOrCreateHeaders().setAll(headers);
+        }
+        return this;
+    }
+
+    /**
+     * Sets the {@code "cache-control"} header. This method is a shortcut of:
+     * <pre>{@code
+     * builder.setHeader(HttpHeaderNames.CACHE_CONTROL, cacheControl);
+     * }</pre>
+     */
+    public HttpFileServiceBuilder cacheControl(CacheControl cacheControl) {
+        requireNonNull(cacheControl, "cacheControl");
+        return setHeader(HttpHeaderNames.CACHE_CONTROL, cacheControl);
+    }
+
+    /**
      * Returns a newly-created {@link HttpFileService} based on the properties of this builder.
      */
     public HttpFileService build() {
         return new HttpFileService(new HttpFileServiceConfig(
                 vfs, clock, maxCacheEntries, maxCacheEntrySizeBytes,
-                serveCompressedFiles, autoIndex));
+                serveCompressedFiles, autoIndex, headers()));
     }
 
     @Override
     public String toString() {
         return HttpFileServiceConfig.toString(this, vfs, clock, maxCacheEntries, maxCacheEntrySizeBytes,
-                                              serveCompressedFiles, autoIndex);
+                                              serveCompressedFiles, autoIndex, headers());
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/file/HttpFileServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/HttpFileServiceBuilder.java
@@ -205,8 +205,7 @@ public final class HttpFileServiceBuilder {
      */
     public HttpFileServiceBuilder cacheControl(CacheControl cacheControl) {
         requireNonNull(cacheControl, "cacheControl");
-        getOrCreateHeaders().cacheControl(cacheControl);
-        return this;
+        return setHeader(HttpHeaderNames.CACHE_CONTROL, cacheControl);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/file/HttpFileServiceConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/HttpFileServiceConfig.java
@@ -22,6 +22,8 @@ import java.time.Clock;
 
 import com.google.common.base.MoreObjects;
 
+import com.linecorp.armeria.common.HttpHeaders;
+
 /**
  * {@link HttpFileService} configuration.
  */
@@ -33,15 +35,17 @@ public final class HttpFileServiceConfig {
     private final int maxCacheEntrySizeBytes;
     private final boolean serveCompressedFiles;
     private final boolean autoIndex;
+    private final HttpHeaders headers;
 
     HttpFileServiceConfig(HttpVfs vfs, Clock clock, int maxCacheEntries, int maxCacheEntrySizeBytes,
-                          boolean serveCompressedFiles, boolean autoIndex) {
+                          boolean serveCompressedFiles, boolean autoIndex, HttpHeaders headers) {
         this.vfs = requireNonNull(vfs, "vfs");
         this.clock = requireNonNull(clock, "clock");
         this.maxCacheEntries = validateMaxCacheEntries(maxCacheEntries);
         this.maxCacheEntrySizeBytes = validateMaxCacheEntrySizeBytes(maxCacheEntrySizeBytes);
         this.serveCompressedFiles = serveCompressedFiles;
         this.autoIndex = autoIndex;
+        this.headers = requireNonNull(headers, "headers").asImmutable();
     }
 
     static int validateMaxCacheEntries(int maxCacheEntries) {
@@ -103,15 +107,23 @@ public final class HttpFileServiceConfig {
         return autoIndex;
     }
 
+    /**
+     * Returns the additional {@link HttpHeaders} to send in a response.
+     */
+    public HttpHeaders headers() {
+        return headers;
+    }
+
     @Override
     public String toString() {
         return toString(this, vfs(), clock(), maxCacheEntries(), maxCacheEntrySizeBytes(),
-                        serveCompressedFiles(), autoIndex());
+                        serveCompressedFiles(), autoIndex(), headers());
     }
 
     static String toString(Object holder, HttpVfs vfs, Clock clock,
                            int maxCacheEntries, int maxCacheEntrySizeBytes,
-                           boolean serveCompressedFiles, boolean autoIndex) {
+                           boolean serveCompressedFiles, boolean autoIndex,
+                           HttpHeaders headers) {
 
         return MoreObjects.toStringHelper(holder)
                           .add("vfs", vfs)
@@ -120,6 +132,7 @@ public final class HttpFileServiceConfig {
                           .add("maxCacheEntrySizeBytes", maxCacheEntrySizeBytes)
                           .add("serveCompressedFiles", serveCompressedFiles)
                           .add("autoIndex", autoIndex)
+                          .add("headers", headers)
                           .toString();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/file/HttpVfs.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/HttpVfs.java
@@ -25,6 +25,8 @@ import java.util.List;
 
 import javax.annotation.Nullable;
 
+import com.linecorp.armeria.common.HttpHeaders;
+
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Tag;
 
@@ -68,10 +70,11 @@ public interface HttpVfs {
      * @param clock the {@link Clock} which provides the current date and time
      * @param contentEncoding the desired {@code 'content-encoding'} header value of the file.
      *                        {@code null} to omit the header.
+     * @param additionalHeaders the additional HTTP headers to add to the returned {@link HttpFile}.
      *
      * @return the {@link HttpFile} at the specified {@code path}
      */
-    HttpFile get(String path, Clock clock, @Nullable String contentEncoding);
+    HttpFile get(String path, Clock clock, @Nullable String contentEncoding, HttpHeaders additionalHeaders);
 
     /**
      * Returns whether the file at the specified {@code path} is a directory.

--- a/core/src/main/java/com/linecorp/armeria/server/file/StreamingHttpFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/StreamingHttpFile.java
@@ -34,7 +34,6 @@ import org.slf4j.LoggerFactory;
 import com.spotify.futures.CompletableFutures;
 
 import com.linecorp.armeria.common.HttpData;
-import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpResponseWriter;
@@ -228,7 +227,7 @@ public abstract class StreamingHttpFile<T extends Closeable> extends AbstractHtt
                                            .lastModified(isLastModifiedEnabled());
 
                     if (contentType() != null) {
-                        builder.setHeader(HttpHeaderNames.CONTENT_TYPE, contentType());
+                        builder.contentType(contentType());
                     }
 
                     final String etag = generateEntityTag(attrs);

--- a/core/src/test/java/com/linecorp/armeria/client/ClientCacheControlTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientCacheControlTest.java
@@ -156,4 +156,34 @@ public class ClientCacheControlTest {
                      .staleIfError(null)
                      .build().isEmpty()).isTrue();
     }
+
+    @Test
+    public void testParse() {
+        // Make sure an empty directives return an empty object.
+        assertThat(ClientCacheControl.parse("")).isEqualTo(ClientCacheControl.EMPTY);
+
+        // Make sure unknown directives are ignored.
+        assertThat(ClientCacheControl.parse("proxy-revalidate, s-maxage=1"))
+                .isEqualTo(ClientCacheControl.EMPTY);
+
+        // Make sure all directives are set.
+        assertThat(ClientCacheControl.parse("no-cache, no-store, no-transform, only-if-cached, " +
+                                            "max-age=1, max-stale=2, min-fresh=3, " +
+                                            "stale-while-revalidate=4, stale-if-error=5"))
+                .isEqualTo(new ClientCacheControlBuilder()
+                                   .noCache()
+                                   .noStore()
+                                   .noTransform()
+                                   .maxAgeSeconds(1)
+                                   .onlyIfCached()
+                                   .maxStaleSeconds(2)
+                                   .minFreshSeconds(3)
+                                   .staleWhileRevalidateSeconds(4)
+                                   .staleIfErrorSeconds(5)
+                                   .build());
+
+        // Make sure 'max-stale' without a value is parsed.
+        assertThat(ClientCacheControl.parse("max-stale"))
+                .isEqualTo(new ClientCacheControlBuilder().maxStale().build());
+    }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/ClientCacheControlTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientCacheControlTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+
+import org.junit.Test;
+
+public class ClientCacheControlTest {
+
+    @Test
+    public void testConstants() {
+        assertThat(ClientCacheControl.EMPTY.isEmpty()).isTrue();
+        assertThat(ClientCacheControl.FORCE_CACHE.asHeaderValue())
+                .isEqualTo("only-if-cached, max-stale=2147483647");
+        assertThat(ClientCacheControl.FORCE_NETWORK.asHeaderValue())
+                .isEqualTo("no-cache");
+    }
+
+    @Test
+    public void testIsEmpty() {
+        final ClientCacheControl cc = new ClientCacheControlBuilder().build();
+        assertThat(cc.isEmpty()).isTrue();
+        assertThat(cc.noCache()).isFalse();
+        assertThat(cc.noStore()).isFalse();
+        assertThat(cc.noTransform()).isFalse();
+        assertThat(cc.maxAgeSeconds()).isEqualTo(-1);
+        assertThat(cc.onlyIfCached()).isFalse();
+        assertThat(cc.hasMaxStale()).isFalse();
+        assertThat(cc.maxStaleSeconds()).isEqualTo(-1);
+        assertThat(cc.minFreshSeconds()).isEqualTo(-1);
+        assertThat(cc.staleWhileRevalidateSeconds()).isEqualTo(-1);
+        assertThat(cc.staleIfErrorSeconds()).isEqualTo(-1);
+        assertThat(cc.asHeaderValue()).isEmpty();
+        assertThat(cc.toString()).isEqualTo("ClientCacheControl(<empty>)");
+    }
+
+    @Test
+    public void testOnlyIfCached() {
+        final ClientCacheControl cc = new ClientCacheControlBuilder().onlyIfCached().build();
+        assertThat(cc.onlyIfCached()).isTrue();
+        assertThat(cc.hasMaxStale()).isFalse();
+        assertThat(cc.maxStaleSeconds()).isEqualTo(-1);
+        assertThat(cc.minFreshSeconds()).isEqualTo(-1);
+        assertThat(cc.staleWhileRevalidateSeconds()).isEqualTo(-1);
+        assertThat(cc.staleIfErrorSeconds()).isEqualTo(-1);
+        assertThat(cc.asHeaderValue()).isEqualTo("only-if-cached");
+        assertThat(cc.toString()).isEqualTo("ClientCacheControl(only-if-cached)");
+    }
+
+    @Test
+    public void testMaxStale() {
+        final ClientCacheControl cc = new ClientCacheControlBuilder().maxStale().build();
+        assertThat(cc.onlyIfCached()).isFalse();
+        assertThat(cc.hasMaxStale()).isTrue();
+        assertThat(cc.maxStaleSeconds()).isEqualTo(-1);
+        assertThat(cc.minFreshSeconds()).isEqualTo(-1);
+        assertThat(cc.staleWhileRevalidateSeconds()).isEqualTo(-1);
+        assertThat(cc.staleIfErrorSeconds()).isEqualTo(-1);
+        assertThat(cc.asHeaderValue()).isEqualTo("max-stale");
+        assertThat(cc.toString()).isEqualTo("ClientCacheControl(max-stale)");
+    }
+
+    @Test
+    public void testMaxStaleWithValue() {
+        final ClientCacheControl cc = new ClientCacheControlBuilder().maxStale(Duration.ofHours(1)).build();
+        assertThat(cc.onlyIfCached()).isFalse();
+        assertThat(cc.hasMaxStale()).isTrue();
+        assertThat(cc.maxStaleSeconds()).isEqualTo(3600);
+        assertThat(cc.minFreshSeconds()).isEqualTo(-1);
+        assertThat(cc.staleWhileRevalidateSeconds()).isEqualTo(-1);
+        assertThat(cc.staleIfErrorSeconds()).isEqualTo(-1);
+        assertThat(cc.asHeaderValue()).isEqualTo("max-stale=3600");
+        assertThat(cc.toString()).isEqualTo("ClientCacheControl(max-stale=3600)");
+
+        assertThat(new ClientCacheControlBuilder().maxStaleSeconds(3600).build()).isEqualTo(cc);
+    }
+
+    @Test
+    public void testMinFresh() {
+        final ClientCacheControl cc = new ClientCacheControlBuilder().minFresh(Duration.ofHours(1)).build();
+        assertThat(cc.onlyIfCached()).isFalse();
+        assertThat(cc.hasMaxStale()).isFalse();
+        assertThat(cc.maxStaleSeconds()).isEqualTo(-1);
+        assertThat(cc.minFreshSeconds()).isEqualTo(3600);
+        assertThat(cc.staleWhileRevalidateSeconds()).isEqualTo(-1);
+        assertThat(cc.staleIfErrorSeconds()).isEqualTo(-1);
+        assertThat(cc.asHeaderValue()).isEqualTo("min-fresh=3600");
+        assertThat(cc.toString()).isEqualTo("ClientCacheControl(min-fresh=3600)");
+
+        assertThat(new ClientCacheControlBuilder().minFreshSeconds(3600).build()).isEqualTo(cc);
+    }
+
+    @Test
+    public void testStaleWhileRevalidate() {
+        final ClientCacheControl cc = new ClientCacheControlBuilder().staleWhileRevalidate(Duration.ofHours(1))
+                                                                     .build();
+        assertThat(cc.onlyIfCached()).isFalse();
+        assertThat(cc.hasMaxStale()).isFalse();
+        assertThat(cc.maxStaleSeconds()).isEqualTo(-1);
+        assertThat(cc.minFreshSeconds()).isEqualTo(-1);
+        assertThat(cc.staleWhileRevalidateSeconds()).isEqualTo(3600);
+        assertThat(cc.staleIfErrorSeconds()).isEqualTo(-1);
+        assertThat(cc.asHeaderValue()).isEqualTo("stale-while-revalidate=3600");
+        assertThat(cc.toString()).isEqualTo("ClientCacheControl(stale-while-revalidate=3600)");
+
+        assertThat(new ClientCacheControlBuilder().staleWhileRevalidateSeconds(3600).build()).isEqualTo(cc);
+    }
+
+    @Test
+    public void testStaleIfError() {
+        final ClientCacheControl cc = new ClientCacheControlBuilder().staleIfError(Duration.ofHours(1)).build();
+        assertThat(cc.onlyIfCached()).isFalse();
+        assertThat(cc.hasMaxStale()).isFalse();
+        assertThat(cc.maxStaleSeconds()).isEqualTo(-1);
+        assertThat(cc.minFreshSeconds()).isEqualTo(-1);
+        assertThat(cc.staleWhileRevalidateSeconds()).isEqualTo(-1);
+        assertThat(cc.staleIfErrorSeconds()).isEqualTo(3600);
+        assertThat(cc.asHeaderValue()).isEqualTo("stale-if-error=3600");
+        assertThat(cc.toString()).isEqualTo("ClientCacheControl(stale-if-error=3600)");
+
+        assertThat(new ClientCacheControlBuilder().staleIfErrorSeconds(3600).build()).isEqualTo(cc);
+    }
+
+    @Test
+    public void testToBuilder() {
+        final ClientCacheControl cc = new ClientCacheControlBuilder().onlyIfCached()
+                                                                     .maxStaleSeconds(60)
+                                                                     .minFreshSeconds(60)
+                                                                     .staleWhileRevalidateSeconds(60)
+                                                                     .staleIfErrorSeconds(60)
+                                                                     .build();
+        assertThat(cc.asHeaderValue()).isEqualTo(
+                "only-if-cached, max-stale=60, min-fresh=60, stale-while-revalidate=60, stale-if-error=60");
+        assertThat(cc.toBuilder().build()).isEqualTo(cc);
+        assertThat(cc.toBuilder()
+                     .onlyIfCached(false)
+                     .maxStale(null)
+                     .minFresh(null)
+                     .staleWhileRevalidate(null)
+                     .staleIfError(null)
+                     .build().isEmpty()).isTrue();
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/common/CacheControlTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/CacheControlTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+
+import org.junit.Test;
+
+public class CacheControlTest {
+
+    @Test
+    public void testIsEmpty() {
+        final CacheControl cc = new CacheControlImplBuilder().build();
+        assertThat(cc.isEmpty()).isTrue();
+        assertThat(cc.noCache()).isFalse();
+        assertThat(cc.noStore()).isFalse();
+        assertThat(cc.noTransform()).isFalse();
+        assertThat(cc.maxAgeSeconds()).isEqualTo(-1);
+        assertThat(cc.asHeaderValue()).isEmpty();
+        assertThat(cc.toString()).isEqualTo("CacheControlImpl(<empty>)");
+    }
+
+    @Test
+    public void testNoCache() {
+        final CacheControl cc = new CacheControlImplBuilder().noCache().build();
+        assertThat(cc.isEmpty()).isFalse();
+        assertThat(cc.noCache()).isTrue();
+        assertThat(cc.noStore()).isFalse();
+        assertThat(cc.noTransform()).isFalse();
+        assertThat(cc.maxAgeSeconds()).isEqualTo(-1);
+        assertThat(cc.asHeaderValue()).isEqualTo("no-cache");
+        assertThat(cc.toString()).isEqualTo("CacheControlImpl(no-cache)");
+    }
+
+    @Test
+    public void testNoStore() {
+        final CacheControl cc = new CacheControlImplBuilder().noStore().build();
+        assertThat(cc.isEmpty()).isFalse();
+        assertThat(cc.noCache()).isFalse();
+        assertThat(cc.noStore()).isTrue();
+        assertThat(cc.noTransform()).isFalse();
+        assertThat(cc.maxAgeSeconds()).isEqualTo(-1);
+        assertThat(cc.asHeaderValue()).isEqualTo("no-store");
+        assertThat(cc.toString()).isEqualTo("CacheControlImpl(no-store)");
+    }
+
+    @Test
+    public void testNoTransform() {
+        final CacheControl cc = new CacheControlImplBuilder().noTransform().build();
+        assertThat(cc.isEmpty()).isFalse();
+        assertThat(cc.noCache()).isFalse();
+        assertThat(cc.noStore()).isFalse();
+        assertThat(cc.noTransform()).isTrue();
+        assertThat(cc.maxAgeSeconds()).isEqualTo(-1);
+        assertThat(cc.asHeaderValue()).isEqualTo("no-transform");
+        assertThat(cc.toString()).isEqualTo("CacheControlImpl(no-transform)");
+    }
+
+    @Test
+    public void testMaxAge() {
+        final CacheControl cc = new CacheControlImplBuilder().maxAge(Duration.ofDays(1)).build();
+        assertThat(cc.isEmpty()).isFalse();
+        assertThat(cc.noCache()).isFalse();
+        assertThat(cc.noStore()).isFalse();
+        assertThat(cc.noTransform()).isFalse();
+        assertThat(cc.maxAgeSeconds()).isEqualTo(86400);
+        assertThat(cc.asHeaderValue()).isEqualTo("max-age=86400");
+        assertThat(cc.toString()).isEqualTo("CacheControlImpl(max-age=86400)");
+
+        assertThat(new CacheControlImplBuilder().maxAgeSeconds(86400).build()).isEqualTo(cc);
+    }
+
+    @Test
+    public void testToBuilder() {
+        final CacheControl cc = new CacheControlImplBuilder().noCache()
+                                                             .noStore()
+                                                             .noTransform()
+                                                             .maxAgeSeconds(3600)
+                                                             .build();
+        assertThat(cc.asHeaderValue()).isEqualTo("no-cache, no-store, no-transform, max-age=3600");
+        assertThat(cc.toBuilder().build()).isEqualTo(cc);
+        assertThat(cc.toBuilder()
+                     .noCache(false)
+                     .noStore(false)
+                     .noTransform(false)
+                     .maxAge(null)
+                     .build().isEmpty()).isTrue();
+    }
+
+    private static final class CacheControlImplBuilder extends CacheControlBuilder<CacheControlImplBuilder> {
+
+        CacheControlImplBuilder() {}
+
+        CacheControlImplBuilder(CacheControl c) {
+            super(c);
+        }
+
+        @Override
+        protected CacheControlImpl build(boolean noCache, boolean noStore,
+                                         boolean noTransform, long maxAgeSeconds) {
+            return new CacheControlImpl(noCache, noStore, noTransform, maxAgeSeconds);
+        }
+    }
+
+    private static final class CacheControlImpl extends CacheControl {
+
+        private CacheControlImpl(boolean noCache, boolean noStore, boolean noTransform, long maxAgeSeconds) {
+            super(noCache, noStore, noTransform, maxAgeSeconds);
+        }
+
+        @Override
+        public CacheControlBuilder<?> toBuilder() {
+            return new CacheControlImplBuilder(this);
+        }
+
+        @Override
+        public String asHeaderValue() {
+            final StringBuilder buf = newHeaderValueBuffer();
+            return buf.length() == 0 ? "" : buf.substring(2);
+        }
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/common/HttpHeadersTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/HttpHeadersTest.java
@@ -87,6 +87,19 @@ public class HttpHeadersTest {
     }
 
     @Test
+    public void cacheControl() {
+        final HttpHeaders headers = HttpHeaders.of();
+
+        headers.cacheControl(ServerCacheControl.DISABLED);
+        assertThat(headers).hasSize(1);
+        assertThat(headers.getAll(CACHE_CONTROL)).containsExactly("no-cache, no-store, must-revalidate");
+
+        // An empty directives must clear the header.
+        headers.cacheControl(ServerCacheControl.EMPTY);
+        assertThat(headers).isEmpty();
+    }
+
+    @Test
     public void testSetObject() {
         final String expectedDate = "Mon, 3 Dec 2007 10:15:30 GMT";
         final Instant instant = Instant.parse("2007-12-03T10:15:30.00Z");
@@ -99,10 +112,12 @@ public class HttpHeadersTest {
         headers.setObject(LAST_MODIFIED, instant);
         headers.setObject(IF_MODIFIED_SINCE, calendar);
         headers.setObject(CACHE_CONTROL, ServerCacheControl.DISABLED);
+        headers.setObject(CONTENT_TYPE, MediaType.PLAIN_TEXT_UTF_8);
 
         assertThat(headers.get(DATE)).isEqualTo(expectedDate);
         assertThat(headers.get(LAST_MODIFIED)).isEqualTo(expectedDate);
         assertThat(headers.get(IF_MODIFIED_SINCE)).isEqualTo(expectedDate);
         assertThat(headers.get(CACHE_CONTROL)).isEqualTo("no-cache, no-store, must-revalidate");
+        assertThat(headers.get(CONTENT_TYPE)).isEqualTo("text/plain; charset=utf-8");
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/common/HttpHeadersTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/HttpHeadersTest.java
@@ -87,19 +87,6 @@ public class HttpHeadersTest {
     }
 
     @Test
-    public void cacheControl() {
-        final HttpHeaders headers = HttpHeaders.of();
-
-        headers.cacheControl(ServerCacheControl.DISABLED);
-        assertThat(headers).hasSize(1);
-        assertThat(headers.getAll(CACHE_CONTROL)).containsExactly("no-cache, no-store, must-revalidate");
-
-        // An empty directives must clear the header.
-        headers.cacheControl(ServerCacheControl.EMPTY);
-        assertThat(headers).isEmpty();
-    }
-
-    @Test
     public void testSetObject() {
         final String expectedDate = "Mon, 3 Dec 2007 10:15:30 GMT";
         final Instant instant = Instant.parse("2007-12-03T10:15:30.00Z");

--- a/core/src/test/java/com/linecorp/armeria/common/HttpHeadersTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/HttpHeadersTest.java
@@ -16,7 +16,11 @@
 
 package com.linecorp.armeria.common;
 
+import static com.linecorp.armeria.common.HttpHeaderNames.CACHE_CONTROL;
 import static com.linecorp.armeria.common.HttpHeaderNames.CONTENT_TYPE;
+import static com.linecorp.armeria.common.HttpHeaderNames.DATE;
+import static com.linecorp.armeria.common.HttpHeaderNames.IF_MODIFIED_SINCE;
+import static com.linecorp.armeria.common.HttpHeaderNames.LAST_MODIFIED;
 import static com.linecorp.armeria.common.HttpHeaderNames.of;
 import static com.linecorp.armeria.common.MediaType.ANY_APPLICATION_TYPE;
 import static com.linecorp.armeria.common.MediaType.ANY_AUDIO_TYPE;
@@ -25,7 +29,14 @@ import static com.linecorp.armeria.common.MediaType.ANY_TYPE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.time.Instant;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.TimeZone;
+
 import org.junit.Test;
+
+import com.linecorp.armeria.server.ServerCacheControl;
 
 import io.netty.util.AsciiString;
 
@@ -73,5 +84,25 @@ public class HttpHeadersTest {
         headers.set(CONTENT_TYPE, ANY_AUDIO_TYPE.toString());
         assertThat(headers.contentType()).isSameAs(ANY_AUDIO_TYPE);
         assertThat(headers.get(CONTENT_TYPE)).isEqualTo(ANY_AUDIO_TYPE.toString());
+    }
+
+    @Test
+    public void testSetObject() {
+        final String expectedDate = "Mon, 3 Dec 2007 10:15:30 GMT";
+        final Instant instant = Instant.parse("2007-12-03T10:15:30.00Z");
+        final Date date = new Date(instant.toEpochMilli());
+        final Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+        calendar.setTimeInMillis(instant.toEpochMilli());
+
+        final HttpHeaders headers = HttpHeaders.of();
+        headers.setObject(DATE, date);
+        headers.setObject(LAST_MODIFIED, instant);
+        headers.setObject(IF_MODIFIED_SINCE, calendar);
+        headers.setObject(CACHE_CONTROL, ServerCacheControl.DISABLED);
+
+        assertThat(headers.get(DATE)).isEqualTo(expectedDate);
+        assertThat(headers.get(LAST_MODIFIED)).isEqualTo(expectedDate);
+        assertThat(headers.get(IF_MODIFIED_SINCE)).isEqualTo(expectedDate);
+        assertThat(headers.get(CACHE_CONTROL)).isEqualTo("no-cache, no-store, must-revalidate");
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpDocServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpDocServiceTest.java
@@ -136,7 +136,7 @@ public class AnnotatedHttpDocServiceTest {
         final HttpClient client = HttpClient.of(server.uri("/"));
         final AggregatedHttpMessage msg = client.get("/docs/specification.json").aggregate().join();
         assertThat(msg.status()).isEqualTo(HttpStatus.OK);
-        assertThat(msg.headers().get(HttpHeaderNames.CACHE_CONTROL)).isEqualTo("no-cache");
+        assertThat(msg.headers().get(HttpHeaderNames.CACHE_CONTROL)).isEqualTo("no-cache, must-revalidate");
         assertThatJson(msg.contentUtf8()).when(IGNORING_ARRAY_ORDER).isEqualTo(expectedJson);
     }
 

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpDocServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpDocServiceTest.java
@@ -136,6 +136,7 @@ public class AnnotatedHttpDocServiceTest {
         final HttpClient client = HttpClient.of(server.uri("/"));
         final AggregatedHttpMessage msg = client.get("/docs/specification.json").aggregate().join();
         assertThat(msg.status()).isEqualTo(HttpStatus.OK);
+        assertThat(msg.headers().get(HttpHeaderNames.CACHE_CONTROL)).isEqualTo("no-cache");
         assertThatJson(msg.contentUtf8()).when(IGNORING_ARRAY_ORDER).isEqualTo(expectedJson);
     }
 

--- a/core/src/test/java/com/linecorp/armeria/server/ServerCacheControlTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerCacheControlTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+
+import org.junit.Test;
+
+public class ServerCacheControlTest {
+
+    @Test
+    public void testConstants() {
+        assertThat(ServerCacheControl.EMPTY.isEmpty()).isTrue();
+        assertThat(ServerCacheControl.DISABLED.asHeaderValue())
+                .isEqualTo("no-cache, no-store, must-revalidate");
+        assertThat(ServerCacheControl.IMMUTABLE.asHeaderValue())
+                .isEqualTo("max-age=31536000, public, immutable");
+        assertThat(ServerCacheControl.REVALIDATED.asHeaderValue())
+                .isEqualTo("no-cache");
+    }
+
+    @Test
+    public void testIsEmpty() {
+        final ServerCacheControl cc = new ServerCacheControlBuilder().build();
+        assertThat(cc.isEmpty()).isTrue();
+        assertThat(cc.noCache()).isFalse();
+        assertThat(cc.noStore()).isFalse();
+        assertThat(cc.noTransform()).isFalse();
+        assertThat(cc.maxAgeSeconds()).isEqualTo(-1);
+        assertThat(cc.cachePublic()).isFalse();
+        assertThat(cc.cachePrivate()).isFalse();
+        assertThat(cc.cacheImmutable()).isFalse();
+        assertThat(cc.mustRevalidate()).isFalse();
+        assertThat(cc.proxyRevalidate()).isFalse();
+        assertThat(cc.sMaxAgeSeconds()).isEqualTo(-1);
+        assertThat(cc.asHeaderValue()).isEmpty();
+        assertThat(cc.toString()).isEqualTo("ServerCacheControl(<empty>)");
+    }
+
+    @Test
+    public void testPublic() {
+        final ServerCacheControl cc = new ServerCacheControlBuilder().cachePublic().build();
+        assertThat(cc.cachePublic()).isTrue();
+        assertThat(cc.cachePrivate()).isFalse();
+        assertThat(cc.cacheImmutable()).isFalse();
+        assertThat(cc.mustRevalidate()).isFalse();
+        assertThat(cc.proxyRevalidate()).isFalse();
+        assertThat(cc.sMaxAgeSeconds()).isEqualTo(-1);
+        assertThat(cc.asHeaderValue()).isEqualTo("public");
+        assertThat(cc.toString()).isEqualTo("ServerCacheControl(public)");
+    }
+
+    @Test
+    public void testPrivate() {
+        final ServerCacheControl cc = new ServerCacheControlBuilder().cachePrivate().build();
+        assertThat(cc.cachePublic()).isFalse();
+        assertThat(cc.cachePrivate()).isTrue();
+        assertThat(cc.cacheImmutable()).isFalse();
+        assertThat(cc.mustRevalidate()).isFalse();
+        assertThat(cc.proxyRevalidate()).isFalse();
+        assertThat(cc.sMaxAgeSeconds()).isEqualTo(-1);
+        assertThat(cc.asHeaderValue()).isEqualTo("private");
+        assertThat(cc.toString()).isEqualTo("ServerCacheControl(private)");
+    }
+
+    @Test
+    public void testImmutable() {
+        final ServerCacheControl cc = new ServerCacheControlBuilder().cacheImmutable().build();
+        assertThat(cc.cachePublic()).isFalse();
+        assertThat(cc.cachePrivate()).isFalse();
+        assertThat(cc.cacheImmutable()).isTrue();
+        assertThat(cc.mustRevalidate()).isFalse();
+        assertThat(cc.proxyRevalidate()).isFalse();
+        assertThat(cc.sMaxAgeSeconds()).isEqualTo(-1);
+        assertThat(cc.asHeaderValue()).isEqualTo("immutable");
+        assertThat(cc.toString()).isEqualTo("ServerCacheControl(immutable)");
+    }
+
+    @Test
+    public void testMustRevalidate() {
+        final ServerCacheControl cc = new ServerCacheControlBuilder().mustRevalidate().build();
+        assertThat(cc.cachePublic()).isFalse();
+        assertThat(cc.cachePrivate()).isFalse();
+        assertThat(cc.cacheImmutable()).isFalse();
+        assertThat(cc.mustRevalidate()).isTrue();
+        assertThat(cc.proxyRevalidate()).isFalse();
+        assertThat(cc.sMaxAgeSeconds()).isEqualTo(-1);
+        assertThat(cc.asHeaderValue()).isEqualTo("must-revalidate");
+        assertThat(cc.toString()).isEqualTo("ServerCacheControl(must-revalidate)");
+    }
+
+    @Test
+    public void testProxyRevalidate() {
+        final ServerCacheControl cc = new ServerCacheControlBuilder().proxyRevalidate().build();
+        assertThat(cc.cachePublic()).isFalse();
+        assertThat(cc.cachePrivate()).isFalse();
+        assertThat(cc.cacheImmutable()).isFalse();
+        assertThat(cc.mustRevalidate()).isFalse();
+        assertThat(cc.proxyRevalidate()).isTrue();
+        assertThat(cc.sMaxAgeSeconds()).isEqualTo(-1);
+        assertThat(cc.asHeaderValue()).isEqualTo("proxy-revalidate");
+        assertThat(cc.toString()).isEqualTo("ServerCacheControl(proxy-revalidate)");
+    }
+
+    @Test
+    public void testSMaxAge() {
+        final ServerCacheControl cc = new ServerCacheControlBuilder().sMaxAge(Duration.ofMinutes(1)).build();
+        assertThat(cc.cachePublic()).isFalse();
+        assertThat(cc.cachePrivate()).isFalse();
+        assertThat(cc.cacheImmutable()).isFalse();
+        assertThat(cc.mustRevalidate()).isFalse();
+        assertThat(cc.proxyRevalidate()).isFalse();
+        assertThat(cc.sMaxAgeSeconds()).isEqualTo(60);
+        assertThat(cc.asHeaderValue()).isEqualTo("s-maxage=60");
+        assertThat(cc.toString()).isEqualTo("ServerCacheControl(s-maxage=60)");
+
+        assertThat(new ServerCacheControlBuilder().sMaxAgeSeconds(60).build()).isEqualTo(cc);
+    }
+
+    @Test
+    public void testToBuilder() {
+        final ServerCacheControl cc = new ServerCacheControlBuilder().cachePublic()
+                                                                     .cachePrivate()
+                                                                     .cacheImmutable()
+                                                                     .mustRevalidate()
+                                                                     .proxyRevalidate()
+                                                                     .sMaxAgeSeconds(3600)
+                                                                     .build();
+        assertThat(cc.asHeaderValue())
+                .isEqualTo("public, private, immutable, must-revalidate, proxy-revalidate, s-maxage=3600");
+        assertThat(cc.toBuilder().build()).isEqualTo(cc);
+        assertThat(cc.toBuilder()
+                     .cachePublic(false)
+                     .cachePrivate(false)
+                     .cacheImmutable(false)
+                     .mustRevalidate(false)
+                     .proxyRevalidate(false)
+                     .sMaxAge(null)
+                     .build().isEmpty()).isTrue();
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/ServerCacheControlTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerCacheControlTest.java
@@ -44,7 +44,7 @@ public class ServerCacheControlTest {
         assertThat(cc.maxAgeSeconds()).isEqualTo(-1);
         assertThat(cc.cachePublic()).isFalse();
         assertThat(cc.cachePrivate()).isFalse();
-        assertThat(cc.cacheImmutable()).isFalse();
+        assertThat(cc.immutable()).isFalse();
         assertThat(cc.mustRevalidate()).isFalse();
         assertThat(cc.proxyRevalidate()).isFalse();
         assertThat(cc.sMaxAgeSeconds()).isEqualTo(-1);
@@ -57,7 +57,7 @@ public class ServerCacheControlTest {
         final ServerCacheControl cc = new ServerCacheControlBuilder().cachePublic().build();
         assertThat(cc.cachePublic()).isTrue();
         assertThat(cc.cachePrivate()).isFalse();
-        assertThat(cc.cacheImmutable()).isFalse();
+        assertThat(cc.immutable()).isFalse();
         assertThat(cc.mustRevalidate()).isFalse();
         assertThat(cc.proxyRevalidate()).isFalse();
         assertThat(cc.sMaxAgeSeconds()).isEqualTo(-1);
@@ -70,7 +70,7 @@ public class ServerCacheControlTest {
         final ServerCacheControl cc = new ServerCacheControlBuilder().cachePrivate().build();
         assertThat(cc.cachePublic()).isFalse();
         assertThat(cc.cachePrivate()).isTrue();
-        assertThat(cc.cacheImmutable()).isFalse();
+        assertThat(cc.immutable()).isFalse();
         assertThat(cc.mustRevalidate()).isFalse();
         assertThat(cc.proxyRevalidate()).isFalse();
         assertThat(cc.sMaxAgeSeconds()).isEqualTo(-1);
@@ -80,10 +80,10 @@ public class ServerCacheControlTest {
 
     @Test
     public void testImmutable() {
-        final ServerCacheControl cc = new ServerCacheControlBuilder().cacheImmutable().build();
+        final ServerCacheControl cc = new ServerCacheControlBuilder().immutable().build();
         assertThat(cc.cachePublic()).isFalse();
         assertThat(cc.cachePrivate()).isFalse();
-        assertThat(cc.cacheImmutable()).isTrue();
+        assertThat(cc.immutable()).isTrue();
         assertThat(cc.mustRevalidate()).isFalse();
         assertThat(cc.proxyRevalidate()).isFalse();
         assertThat(cc.sMaxAgeSeconds()).isEqualTo(-1);
@@ -96,7 +96,7 @@ public class ServerCacheControlTest {
         final ServerCacheControl cc = new ServerCacheControlBuilder().mustRevalidate().build();
         assertThat(cc.cachePublic()).isFalse();
         assertThat(cc.cachePrivate()).isFalse();
-        assertThat(cc.cacheImmutable()).isFalse();
+        assertThat(cc.immutable()).isFalse();
         assertThat(cc.mustRevalidate()).isTrue();
         assertThat(cc.proxyRevalidate()).isFalse();
         assertThat(cc.sMaxAgeSeconds()).isEqualTo(-1);
@@ -109,7 +109,7 @@ public class ServerCacheControlTest {
         final ServerCacheControl cc = new ServerCacheControlBuilder().proxyRevalidate().build();
         assertThat(cc.cachePublic()).isFalse();
         assertThat(cc.cachePrivate()).isFalse();
-        assertThat(cc.cacheImmutable()).isFalse();
+        assertThat(cc.immutable()).isFalse();
         assertThat(cc.mustRevalidate()).isFalse();
         assertThat(cc.proxyRevalidate()).isTrue();
         assertThat(cc.sMaxAgeSeconds()).isEqualTo(-1);
@@ -122,7 +122,7 @@ public class ServerCacheControlTest {
         final ServerCacheControl cc = new ServerCacheControlBuilder().sMaxAge(Duration.ofMinutes(1)).build();
         assertThat(cc.cachePublic()).isFalse();
         assertThat(cc.cachePrivate()).isFalse();
-        assertThat(cc.cacheImmutable()).isFalse();
+        assertThat(cc.immutable()).isFalse();
         assertThat(cc.mustRevalidate()).isFalse();
         assertThat(cc.proxyRevalidate()).isFalse();
         assertThat(cc.sMaxAgeSeconds()).isEqualTo(60);
@@ -136,7 +136,7 @@ public class ServerCacheControlTest {
     public void testToBuilder() {
         final ServerCacheControl cc = new ServerCacheControlBuilder().cachePublic()
                                                                      .cachePrivate()
-                                                                     .cacheImmutable()
+                                                                     .immutable()
                                                                      .mustRevalidate()
                                                                      .proxyRevalidate()
                                                                      .sMaxAgeSeconds(3600)
@@ -147,7 +147,7 @@ public class ServerCacheControlTest {
         assertThat(cc.toBuilder()
                      .cachePublic(false)
                      .cachePrivate(false)
-                     .cacheImmutable(false)
+                     .immutable(false)
                      .mustRevalidate(false)
                      .proxyRevalidate(false)
                      .sMaxAge(null)
@@ -174,7 +174,7 @@ public class ServerCacheControlTest {
                                    .maxAgeSeconds(1)
                                    .cachePublic()
                                    .cachePrivate()
-                                   .cacheImmutable()
+                                   .immutable()
                                    .mustRevalidate()
                                    .proxyRevalidate()
                                    .sMaxAgeSeconds(2)

--- a/core/src/test/java/com/linecorp/armeria/server/ServerCacheControlTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerCacheControlTest.java
@@ -153,4 +153,31 @@ public class ServerCacheControlTest {
                      .sMaxAge(null)
                      .build().isEmpty()).isTrue();
     }
+
+    @Test
+    public void testParse() {
+        // Make sure an empty directives return an empty object.
+        assertThat(ServerCacheControl.parse("")).isEqualTo(ServerCacheControl.EMPTY);
+
+        // Make sure unknown directives are ignored.
+        assertThat(ServerCacheControl.parse("only-if-cached, stall-if-error=1"))
+                .isEqualTo(ServerCacheControl.EMPTY);
+
+        // Make sure all directives are set.
+        assertThat(ServerCacheControl.parse("no-cache, no-store, no-transform, must-revalidate, " +
+                                            "max-age=1, public, private, immutable, proxy-revalidate, " +
+                                            "s-maxage=2"))
+                .isEqualTo(new ServerCacheControlBuilder()
+                                   .noCache()
+                                   .noStore()
+                                   .noTransform()
+                                   .maxAgeSeconds(1)
+                                   .cachePublic()
+                                   .cachePrivate()
+                                   .cacheImmutable()
+                                   .mustRevalidate()
+                                   .proxyRevalidate()
+                                   .sMaxAgeSeconds(2)
+                                   .build());
+    }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/ServerCacheControlTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerCacheControlTest.java
@@ -31,7 +31,7 @@ public class ServerCacheControlTest {
         assertThat(ServerCacheControl.IMMUTABLE.asHeaderValue())
                 .isEqualTo("max-age=31536000, public, immutable");
         assertThat(ServerCacheControl.REVALIDATED.asHeaderValue())
-                .isEqualTo("no-cache");
+                .isEqualTo("no-cache, must-revalidate");
     }
 
     @Test
@@ -141,11 +141,12 @@ public class ServerCacheControlTest {
                                                                      .proxyRevalidate()
                                                                      .sMaxAgeSeconds(3600)
                                                                      .build();
+
+        // 'public' and 'private' are mutually exclusive. 'private' must win.
         assertThat(cc.asHeaderValue())
-                .isEqualTo("public, private, immutable, must-revalidate, proxy-revalidate, s-maxage=3600");
+                .isEqualTo("private, immutable, must-revalidate, proxy-revalidate, s-maxage=3600");
         assertThat(cc.toBuilder().build()).isEqualTo(cc);
         assertThat(cc.toBuilder()
-                     .cachePublic(false)
                      .cachePrivate(false)
                      .immutable(false)
                      .mustRevalidate(false)
@@ -172,7 +173,6 @@ public class ServerCacheControlTest {
                                    .noStore()
                                    .noTransform()
                                    .maxAgeSeconds(1)
-                                   .cachePublic()
                                    .cachePrivate()
                                    .immutable()
                                    .mustRevalidate()

--- a/core/src/test/java/com/linecorp/armeria/server/file/HttpFileServiceAdditionalHeadersTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/file/HttpFileServiceAdditionalHeadersTest.java
@@ -52,6 +52,7 @@ public class HttpFileServiceAdditionalHeadersTest {
         assertThat(res.status()).isEqualTo(HttpStatus.OK);
         assertThat(res.headers().getAll(HttpHeaderNames.of("foo"))).containsExactly("1", "2");
         assertThat(res.headers().getAll(HttpHeaderNames.of("bar"))).containsExactly("3");
-        assertThat(res.headers().getAll(HttpHeaderNames.CACHE_CONTROL)).containsExactly("no-cache");
+        assertThat(res.headers().getAll(HttpHeaderNames.CACHE_CONTROL))
+                .containsExactly("no-cache, must-revalidate");
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/file/HttpFileServiceAdditionalHeadersTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/file/HttpFileServiceAdditionalHeadersTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.file;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.ServerCacheControl;
+import com.linecorp.armeria.testing.server.ServerRule;
+
+public class HttpFileServiceAdditionalHeadersTest {
+
+    @ClassRule
+    public static final ServerRule server = new ServerRule() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.serviceUnder(
+                    "/",
+                    HttpFileServiceBuilder.forClassPath("/")
+                                          .addHeader("foo", "1")
+                                          .addHeader("foo", "2")
+                                          .setHeader("bar", "3")
+                                          .cacheControl(ServerCacheControl.REVALIDATED)
+                                          .build());
+        }
+    };
+
+    @Test
+    public void testAdditionalHeaders() {
+        final HttpClient client = HttpClient.of(server.uri("/"));
+        final AggregatedHttpMessage res = client.get("/java/lang/Object.class").aggregate().join();
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.headers().getAll(HttpHeaderNames.of("foo"))).containsExactly("1", "2");
+        assertThat(res.headers().getAll(HttpHeaderNames.of("bar"))).containsExactly("3");
+        assertThat(res.headers().getAll(HttpHeaderNames.CACHE_CONTROL)).containsExactly("no-cache");
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/file/HttpFileTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/file/HttpFileTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.file;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.server.ServerCacheControl;
+
+public class HttpFileTest {
+
+    @Test
+    public void additionalHeaders() throws Exception {
+        final HttpFile f = HttpFileBuilder.ofResource(ClassLoader.getSystemClassLoader(),
+                                                      "java/lang/Object.class")
+                                          .addHeader("foo", "1")
+                                          .addHeader("foo", "2")
+                                          .setHeader("bar", "3")
+                                          .contentType(MediaType.PLAIN_TEXT_UTF_8)
+                                          .cacheControl(ServerCacheControl.REVALIDATED)
+                                          .build();
+
+        // Make sure content-type auto-detection is disabled.
+        assertThat(((AbstractHttpFile) f).contentType()).isNull();
+
+        // Make sure all additional headers are set as expected.
+        final HttpHeaders headers = f.readHeaders();
+        assertThat(headers).isNotNull();
+        assertThat(headers.getAll(HttpHeaderNames.of("foo"))).containsExactly("1", "2");
+        assertThat(headers.getAll(HttpHeaderNames.of("bar"))).containsExactly("3");
+        assertThat(headers.getAll(HttpHeaderNames.CONTENT_TYPE))
+                .containsExactly(MediaType.PLAIN_TEXT_UTF_8.toString());
+        assertThat(headers.getAll(HttpHeaderNames.CACHE_CONTROL))
+                .containsExactly(ServerCacheControl.REVALIDATED.asHeaderValue());
+    }
+}

--- a/site/src/sphinx/server-http-file.rst
+++ b/site/src/sphinx/server-http-file.rst
@@ -47,6 +47,28 @@ an ``index.html`` file using the ``autoIndex(boolean)`` method in :api:`HttpFile
 
    Be careful when you enable this feature in production environment; consider its security implications.
 
+Specifying additional response headers
+--------------------------------------
+
+You can specify additional response headers such as ``cache-control`` and other custom headers.
+
+.. code-block:: java
+
+    HttpFileServiceBuilder fsb =
+            HttpFileServiceBuilder.forFileSystem("/var/lib/www/images");
+
+    // Specify cache control directives.
+    ServerCacheControl cc = new ServerCacheControlBuilder()
+            .maxAgeSeconds(86400)
+            .cachePublic()
+            .build();
+    fsb.cacheControl(cc /* "max-age=86400, public" */);
+
+    // Specify a custom header.
+    fsb.setHeader("foo", "bar");
+
+    HttpFileService fs = fsb.build();
+
 Adjusting static file cache
 ---------------------------
 
@@ -190,7 +212,9 @@ An :api:`HttpFile` can be configured to send different headers than the auto-fil
     // Disable the 'Content-Type' header.
     fb.autoDetectContentType(false);
     // Set the 'Content-Type' header manually.
-    fb.setHeader(HttpHeaderNames.CONTENT_TYPE, "text/html; charset=EUC-KR");
+    fb.contentType("text/html; charset=EUC-KR");
+    // Set the 'Cache-Control' header.
+    fb.cacheControl(ServerCacheControl.REVALIDATED /* "no-cache" */);
     // Set a custom header.
     fb.setHeader("x-powered-by", "Armeria");
     HttpFile f = fb.build();

--- a/site/src/sphinx/server-http-file.rst
+++ b/site/src/sphinx/server-http-file.rst
@@ -54,6 +54,9 @@ You can specify additional response headers such as ``cache-control`` and other 
 
 .. code-block:: java
 
+    import com.linecorp.armeria.server.ServerCacheControl;
+    import com.linecorp.armeria.server.ServerCacheControlBuilder;
+
     HttpFileServiceBuilder fsb =
             HttpFileServiceBuilder.forFileSystem("/var/lib/www/images");
 


### PR DESCRIPTION
Motivation:

It will be useful if a user can generate `cache-control` header value
programatically.

Modifications:

- Added `CacheControl`, `ClientCacheControl` and `ServerCacheControl`.
- Added `CacheControlBuilder`, `ClientCacheControlBuilder` and
  `ServerCacheControlBuilder`.
- Added `cacheControl()` to `HttpFileServiceBuilder` and `AbstractHttpFileBuilder`.
- Made `HttpHeaders.setObject()` supports `CacheControl`.
- Miscellaneous:
  - Added a way to specify additional headers to `HttpFileServiceBuilder`.
  - Added `AbstractHttpFileBuilder.contentType()`.
  - `Content-Type` -> `content-type` for consistency

Result:

- It is more convenient to set `cache-control` or `content-type` headers.
- A user can now specify additional headers to the responses created by
  `HttpFileService`.
- `HttpVfs.get()` has a breaking change.
