### PR TITLE
Reduce the memory footprint of the default Dropwizard `HierarchicalNa…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/metric/DropwizardMeterRegistries.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/DropwizardMeterRegistries.java
@@ -44,7 +44,7 @@ public final class DropwizardMeterRegistries {
     @VisibleForTesting
     static final HierarchicalNameMapper DEFAULT_NAME_MAPPER = (id, convention) -> {
         final String name = id.getConventionName(convention);
-        if (!id.getTags().iterator().hasNext()) {
+        if (!id.getTagsAsIterable().iterator().hasNext()) {
             return name;
         }
 


### PR DESCRIPTION
…meMapper`

Motivation:

At some point, Micrometer's `Meter.Id.getTags()` started to return a
copy of its tag list. It was returning an `Iterable<Tag>` without any
additional copying before. We obviously want to avoid making a copy of
the tag list like we did before.

Modifications:

- Use `getTagsAsIterable()` instead of `getTags()`

Result:

- Less memory footprint when converting a `Meter.Id` into a Dropwizard
  meter name.