### PR TITLE
Add support for ProtoReflectionService.

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -143,6 +143,7 @@ io.grpc:
   grpc-netty-shaded: { version: *GRPC_VERSION }
   grpc-okhttp: { version: *GRPC_VERSION }
   grpc-protobuf: { version: *GRPC_VERSION }
+  grpc-services: { version: *GRPC_VERSION }
   grpc-stub: { version: *GRPC_VERSION }
   grpc-testing: { version: *GRPC_VERSION }
 

--- a/grpc/build.gradle
+++ b/grpc/build.gradle
@@ -3,7 +3,7 @@ dependencies {
     compile 'com.google.protobuf:protobuf-java-util'
 
     // gRPC
-    [ 'grpc-core', 'grpc-stub', 'grpc-protobuf' ].each {
+    [ 'grpc-core', 'grpc-protobuf', 'grpc-services', 'grpc-stub' ].each {
         compile "io.grpc:$it"
     }
 

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
@@ -99,6 +99,11 @@ import io.grpc.Status;
 import io.grpc.Status.Code;
 import io.grpc.StatusException;
 import io.grpc.StatusRuntimeException;
+import io.grpc.protobuf.services.ProtoReflectionService;
+import io.grpc.reflection.v1alpha.ServerReflectionGrpc;
+import io.grpc.reflection.v1alpha.ServerReflectionGrpc.ServerReflectionStub;
+import io.grpc.reflection.v1alpha.ServerReflectionRequest;
+import io.grpc.reflection.v1alpha.ServerReflectionResponse;
 import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
 import io.netty.util.AsciiString;
@@ -287,6 +292,7 @@ public class GrpcServiceServerTest {
             sb.serviceUnder("/", new GrpcServiceBuilder()
                     .setMaxInboundMessageSizeBytes(MAX_MESSAGE_SIZE)
                     .addService(new UnitTestServiceImpl())
+                    .addService(ProtoReflectionService.newInstance())
                     .enableUnframedRequests(true)
                     .supportedSerializationFormats(GrpcSerializationFormats.values())
                     .build()
@@ -891,6 +897,42 @@ public class GrpcServiceServerTest {
         } finally {
             channel.shutdownNow();
         }
+    }
+
+    @Test
+    public void reflectionService() {
+        ServerReflectionStub stub = ServerReflectionGrpc.newStub(channel);
+
+        AtomicReference<ServerReflectionResponse> response = new AtomicReference<>();
+
+        StreamObserver<ServerReflectionRequest> request = stub.serverReflectionInfo(
+                new StreamObserver<ServerReflectionResponse>() {
+                    @Override
+                    public void onNext(ServerReflectionResponse value) {
+                        response.set(value);
+                    }
+
+                    @Override
+                    public void onError(Throwable t) {
+                    }
+
+                    @Override
+                    public void onCompleted() {
+                    }
+                });
+        request.onNext(ServerReflectionRequest.newBuilder()
+                                              .setListServices("")
+                                              .build());
+        request.onCompleted();
+
+        await().untilAsserted(
+                () -> {
+                    assertThat(response).doesNotHaveValue(null);
+                    // Instead of making this test depend on every other one, just check that there is at least
+                    // two services returned corresponding to UnitTestService and ProtoReflectionService.
+                    assertThat(response.get().getListServicesResponse().getServiceList())
+                            .hasSizeGreaterThanOrEqualTo(2);
+                });
     }
 
     private static void checkRequestLog(RequestLogChecker checker) throws Exception {

--- a/site/src/sphinx/server-grpc.rst
+++ b/site/src/sphinx/server-grpc.rst
@@ -243,6 +243,26 @@ to all your clients before enabling this flag!
 
 See more details at :ref:`client-grpc`.
 
+Server Reflection
+=================
+
+Armeria supports gRPC server reflection - just add an instance of ``ProtoReflectionService`` to your server.
+
+.. code-block:: java
+
+    import io.grpc.protobuf.services.ProtoReflectionService;
+
+    ServerBuilder sb = new ServerBuilder();
+    ...
+    sb.service(new GrpcServiceBuilder().addService(new MyHelloService())
+                                       .addService(ProtoReflectionService.newInstance())
+                                       .build());
+    ...
+    Server server = sb.build();
+    server.start();
+
+For more information, see the official `Link tutorial <https://github.com/grpc/grpc-java/blob/master/documentation/server-reflection-tutorial.md>`_.
+
 See also
 --------
 

--- a/site/src/sphinx/server-grpc.rst
+++ b/site/src/sphinx/server-grpc.rst
@@ -232,7 +232,7 @@ and lifecycle callbacks.
                                        .build());
 
 Exception propagation
-=====================
+---------------------
 
 It can be very useful to enable ``Flags.verboseResponses()`` in your server by specifying the
 ``-Dcom.linecorp.armeria.verboseResponses=true`` system property, which will automatically return
@@ -244,7 +244,7 @@ to all your clients before enabling this flag!
 See more details at :ref:`client-grpc`.
 
 Server Reflection
-=================
+-----------------
 
 Armeria supports gRPC server reflection - just add an instance of ``ProtoReflectionService`` to your server.
 

--- a/site/src/sphinx/server-grpc.rst
+++ b/site/src/sphinx/server-grpc.rst
@@ -261,7 +261,7 @@ Armeria supports gRPC server reflection - just add an instance of ``ProtoReflect
     Server server = sb.build();
     server.start();
 
-For more information, see the official `Link tutorial <https://github.com/grpc/grpc-java/blob/master/documentation/server-reflection-tutorial.md>`_.
+For more information, see the official `gRPC Server Reflection tutorial <https://github.com/grpc/grpc-java/blob/master/documentation/server-reflection-tutorial.md>`_.
 
 See also
 --------


### PR DESCRIPTION
I was originally thinking of forking `ProtoReflectionService` from upstream, but realized it's not hard to just use it as is. This implementation is quite similar to upstream which essentially runs custom logic based on an `instanceof` check.

https://github.com/grpc/grpc-java/blob/master/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java#L111

Fixes #1621 