### PR TITLE
Fix a bug where ByteBuf is released before storing it for content preview

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/HttpRequestSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpRequestSubscriber.java
@@ -279,8 +279,8 @@ final class HttpRequestSubscriber implements Subscriber<HttpObject>, ChannelFutu
         final ChannelFuture future;
         if (o instanceof HttpData) {
             final HttpData data = (HttpData) o;
-            future = encoder.writeData(id, streamId(), data, endOfStream);
             logBuilder.increaseRequestLength(data);
+            future = encoder.writeData(id, streamId(), data, endOfStream);
         } else if (o instanceof HttpHeaders) {
             future = encoder.writeHeaders(id, streamId(), (HttpHeaders) o, endOfStream);
         } else {

--- a/core/src/main/java/com/linecorp/armeria/server/DecodedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DecodedHttpRequest.java
@@ -106,12 +106,12 @@ final class DecodedHttpRequest extends DefaultHttpRequest {
             // Close this stream because HTTP trailers is the last element of the request.
             close();
         } else {
-            published = super.tryWrite(obj);
+            final HttpData httpData = (HttpData) obj;
+            assert ctx != null : "uninitialized DecodedHttpRequest must be aborted.";
+            ctx.logBuilder().increaseRequestLength(httpData);
+            published = super.tryWrite(httpData);
             if (published) {
-                final HttpData httpData = (HttpData) obj;
                 inboundTrafficController.inc(httpData.length());
-                assert ctx != null : "uninitialized DecodedHttpRequest must be aborted.";
-                ctx.logBuilder().increaseRequestLength(httpData);
             }
         }
 

--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
@@ -299,8 +299,8 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject>, RequestTim
         if (o instanceof HttpData) {
             final HttpData data = (HttpData) o;
             wroteEmptyData = data.isEmpty();
-            future = responseEncoder.writeData(req.id(), req.streamId(), data, endOfStream);
             logBuilder().increaseResponseLength(data);
+            future = responseEncoder.writeData(req.id(), req.streamId(), data, endOfStream);
         } else if (o instanceof HttpHeaders) {
             wroteEmptyData = false;
             future = responseEncoder.writeHeaders(req.id(), req.streamId(), (HttpHeaders) o, endOfStream);

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -606,8 +606,8 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
                 req.id(), req.streamId(), mutableHeaders, !hasContent);
         logBuilder.responseHeaders(mutableHeaders);
         if (hasContent) {
-            future = responseEncoder.writeData(req.id(), req.streamId(), resContent, true);
             logBuilder.increaseResponseLength(resContent);
+            future = responseEncoder.writeData(req.id(), req.streamId(), resContent, true);
         }
 
         future.addListener(f -> {

--- a/core/src/test/java/com/linecorp/armeria/server/DecodedHttpRequestTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/DecodedHttpRequestTest.java
@@ -17,11 +17,14 @@
 package com.linecorp.armeria.server;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 import java.util.List;
 
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
 
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaderNames;
@@ -29,8 +32,14 @@ import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpObject;
 import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.internal.InboundTrafficController;
 import com.linecorp.armeria.testing.common.EventLoopRule;
+import com.linecorp.armeria.unsafe.ByteBufHttpData;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.util.ReferenceCountUtil;
 
 public class DecodedHttpRequestTest {
 
@@ -92,14 +101,61 @@ public class DecodedHttpRequestTest {
                                             HttpHeaders.of(HttpHeaderNames.of("bar"), "baz"));
     }
 
+    @Test
+    public void contentPreview() {
+        final HttpHeaders headers = HttpHeaders.of(HttpMethod.GET, "/").contentType(MediaType.PLAIN_TEXT_UTF_8);
+        final ServiceRequestContext sctx =
+                ServiceRequestContextBuilder.of(HttpRequest.of(headers))
+                                            .serverConfigurator(sb -> sb.contentPreview(100))
+                                            .build();
+        final DecodedHttpRequest req = decodedHttpRequest(headers, sctx);
+        req.completionFuture().handle((ret, cause) -> {
+            sctx.logBuilder().endRequest();
+            return null;
+        });
+
+        req.subscribe(new ImmediateReleaseSubscriber());
+
+        assertThat(req.tryWrite(new ByteBufHttpData(newBuffer("hello"), false))).isTrue();
+        req.close();
+
+        await().untilAsserted(() -> assertThat(sctx.log().requestContentPreview()).isEqualTo("hello"));
+    }
+
     private static DecodedHttpRequest decodedHttpRequest() {
         final HttpHeaders headers = HttpHeaders.of(HttpMethod.GET, "/");
         final ServiceRequestContext sctx = ServiceRequestContext.of(HttpRequest.of(headers));
+        return decodedHttpRequest(headers, sctx);
+    }
 
+    private static DecodedHttpRequest decodedHttpRequest(HttpHeaders headers, ServiceRequestContext sctx) {
         final DecodedHttpRequest request = new DecodedHttpRequest(sctx.eventLoop(), 1, 1, headers, true,
                                                                   InboundTrafficController.disabled(),
                                                                   sctx.maxRequestLength());
         request.init(sctx);
         return request;
+    }
+
+    private static ByteBuf newBuffer(String content) {
+        return ByteBufAllocator.DEFAULT.buffer().writeBytes(content.getBytes());
+    }
+
+    private static class ImmediateReleaseSubscriber implements Subscriber<HttpObject> {
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            s.request(Integer.MAX_VALUE);
+        }
+
+        @Override
+        public void onNext(HttpObject obj) {
+            ReferenceCountUtil.safeRelease(obj);
+        }
+
+        @Override
+        public void onError(Throwable t) {}
+
+        @Override
+        public void onComplete() {}
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/HttpResponseSubscriberTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpResponseSubscriberTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import org.junit.Test;
+import org.reactivestreams.Subscription;
+
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.util.EventLoopGroups;
+import com.linecorp.armeria.internal.HttpObjectEncoder;
+import com.linecorp.armeria.internal.InboundTrafficController;
+import com.linecorp.armeria.unsafe.ByteBufHttpData;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.DefaultChannelPromise;
+import io.netty.handler.codec.http2.Http2Error;
+import io.netty.util.ReferenceCountUtil;
+
+public class HttpResponseSubscriberTest {
+
+    @Test
+    public void contentPreview() {
+        final HttpHeaders headers = HttpHeaders.of(HttpMethod.GET, "/");
+        final DefaultServiceRequestContext sctx = serviceRequestContext(headers);
+        final HttpResponseSubscriber responseSubscriber = responseSubscriber(headers, sctx);
+
+        responseSubscriber.onSubscribe(mock(Subscription.class));
+        responseSubscriber.onNext(HttpHeaders.of(200).contentType(MediaType.PLAIN_TEXT_UTF_8));
+        responseSubscriber.onNext(new ByteBufHttpData(newBuffer("hello"), true));
+        responseSubscriber.onComplete();
+
+        assertThat(sctx.log().responseContentPreview()).isEqualTo("hello");
+    }
+
+    private static DefaultServiceRequestContext serviceRequestContext(HttpHeaders headers) {
+        return (DefaultServiceRequestContext)
+                ServiceRequestContextBuilder.of(HttpRequest.of(headers))
+                                            .eventLoop(EventLoopGroups.directEventLoop())
+                                            .serverConfigurator(sb -> {
+                                                sb.contentPreview(100);
+                                                sb.defaultRequestTimeoutMillis(0);
+                                            })
+                                            .build();
+    }
+
+    private static HttpResponseSubscriber responseSubscriber(HttpHeaders headers,
+                                                             DefaultServiceRequestContext sctx) {
+
+        final DecodedHttpRequest req = new DecodedHttpRequest(sctx.eventLoop(), 1, 1, headers, true,
+                                                              InboundTrafficController.disabled(),
+                                                              sctx.maxRequestLength());
+        req.init(sctx);
+        return new HttpResponseSubscriber(mock(ChannelHandlerContext.class),
+                                          new ImmediateWriteEmulator(sctx.channel()),
+                                          sctx, req, unused -> {});
+    }
+
+    private static ByteBuf newBuffer(String content) {
+        return ByteBufAllocator.DEFAULT.buffer().writeBytes(content.getBytes());
+    }
+
+    private static class ImmediateWriteEmulator extends HttpObjectEncoder {
+
+        private Channel channel;
+
+        ImmediateWriteEmulator(Channel channel) {
+            this.channel = channel;
+        }
+
+        @Override
+        protected Channel channel() {
+            return channel;
+        }
+
+        @Override
+        protected ChannelFuture doWriteHeaders(int id, int streamId, HttpHeaders headers, boolean endStream) {
+            return successChannelFuture();
+        }
+
+        @Override
+        protected ChannelFuture doWriteData(int id, int streamId, HttpData data, boolean endStream) {
+            ReferenceCountUtil.safeRelease(data);
+            return successChannelFuture();
+        }
+
+        @Override
+        protected ChannelFuture doWriteReset(int id, int streamId, Http2Error error) {
+            return successChannelFuture();
+        }
+
+        private ChannelFuture successChannelFuture() {
+            final DefaultChannelPromise future = new DefaultChannelPromise(channel);
+            future.setSuccess();
+            return future;
+        }
+
+        @Override
+        protected void doClose() {}
+    }
+}


### PR DESCRIPTION
Motivation:
The HTTP response content is released after writing the socket in `ChannelOutboundBuffer`.
If we want to log the content, we should do it before we write it to the socket.

Modifications:
- Call `increase(Response|Request)Length` before writing to channel.

Result:
- Fewer bugs.