### PR TITLE
Add more information about client timeouts

### DIFF
--- a/site/src/sphinx/client-grpc.rst
+++ b/site/src/sphinx/client-grpc.rst
@@ -158,7 +158,7 @@ requests and responses. You might be interested in decorating a client using oth
 to gather metrics. Please also refer to :api:`ClientBuilder` for more configuration options.
 
 Exception propagation
-=====================
+---------------------
 
 If you have enabled ``Flags.verboseResponses()`` in the server being accessed by specifying
 ``-Dcom.linecorp.armeria.verboseResponses=true`` system property, then any exception during processing

--- a/site/src/sphinx/client-timeouts.rst
+++ b/site/src/sphinx/client-timeouts.rst
@@ -2,7 +2,26 @@
 
 Overriding client timeouts
 ==========================
-Sometimes, the default timeouts used by the Armeria-generated client does not suit a particular scenario well. In these cases, you might want to override the timeout settings.
+
+Sometimes, the default timeouts used by the Armeria clients does not suit a particular scenario well.
+In these cases, you might want to override the timeout settings.
+
+Using ``ClientBuilder``
+-----------------------
+
+.. code-block:: java
+
+    import java.time.Duration;
+
+    import com.linecorp.armeria.client.ClientBuilder;
+
+    int responseTimeout = 15;
+    int writeTimeout = 1;
+
+    HelloService.Iface client = new ClientBuilder("tbinary+http://example.com/hello")
+            .defaultResponseTimeout(Duration.ofSeconds(responseTimeout))
+            .defaultWriteTimeout(Duration.ofSeconds(writeTimeout))
+            .build(HelloService.Iface.class);
 
 Using ``ClientOptionsBuilder``
 ------------------------------
@@ -29,19 +48,44 @@ Using ``ClientOptionsBuilder``
                     .build()
     );
 
-Using ``ClientBuilder``
------------------------
+Using JVM system properties
+---------------------------
+
+You can override the default client timeouts by specifying the following JVM system properties if you do not
+prefer setting it programmatically:
+
+- ``com.linecorp.armeria.defaultResponseTimeoutMillis``
+
+  - the default client-side timeout of a response in milliseconds.
+
+- ``com.linecorp.armeria.defaultClientIdleTimeoutMillis``
+
+  - the default client-side idle timeout of a connection for keep-alive in milliseconds.
+
+Note that these properties have effect only when you did not specify these properties programmatically.
+
+.. note::
+
+    See :api:`Flags` for the complete list of JVM system properties in Armeria.
+
+Adjusting connection idle timeout programmatically
+--------------------------------------------------
+
+You need to build a non-default :api:`ClientFactory` using :api:`ClientFactoryBuilder` to override the default
+client connection idle timeout of 10 seconds programmatically:
 
 .. code-block:: java
 
-    import java.time.Duration;
+    import com.linecorp.armeria.client.ClientFactory;
+    import com.linecorp.armeria.client.ClientFactoryBuilder;
 
-    import com.linecorp.armeria.client.ClientBuilder;
+    ClientFactory factory = new ClientFactoryBuilder()
+            // Shorten the idle connection timeout from 10s to 5s.
+            .idleTimeout(Duration.ofSeconds(5))
+            // Enable HTTP/1 request pipelining.
+            .useHttp1Pipelining(true)
+            .build();
 
-    int responseTimeout = 15;
-    int writeTimeout = 1;
-
-    HelloService.Iface client = new ClientBuilder("tbinary+http://example.com/hello")
-            .defaultResponseTimeout(Duration.ofSeconds(responseTimeout))
-            .defaultWriteTimeout(Duration.ofSeconds(writeTimeout))
-            .build(HelloService.Iface.class);
+Note that :api:`ClientFactory` implements ``java.lang.AutoCloseable`` and thus needs to be closed when you
+terminate your application. On ``close()``, :api:`ClientFactory` will close all the connections it manages
+and abort any requests in progress.

--- a/site/src/sphinx/client-timeouts.rst
+++ b/site/src/sphinx/client-timeouts.rst
@@ -3,7 +3,7 @@
 Overriding client timeouts
 ==========================
 
-Sometimes, the default timeouts used by the Armeria clients does not suit a particular scenario well.
+Sometimes, the default timeouts used by the Armeria clients do not suit a particular scenario well.
 In these cases, you might want to override the timeout settings.
 
 Using ``ClientBuilder``
@@ -48,31 +48,11 @@ Using ``ClientOptionsBuilder``
                     .build()
     );
 
-Using JVM system properties
----------------------------
-
-You can override the default client timeouts by specifying the following JVM system properties if you do not
-prefer setting it programmatically:
-
-- ``com.linecorp.armeria.defaultResponseTimeoutMillis``
-
-  - the default client-side timeout of a response in milliseconds.
-
-- ``com.linecorp.armeria.defaultClientIdleTimeoutMillis``
-
-  - the default client-side idle timeout of a connection for keep-alive in milliseconds.
-
-Note that these properties have effect only when you did not specify these properties programmatically.
-
-.. note::
-
-    See :api:`Flags` for the complete list of JVM system properties in Armeria.
-
-Adjusting connection idle timeout programmatically
---------------------------------------------------
+Adjusting connection-level timeouts
+-----------------------------------
 
 You need to build a non-default :api:`ClientFactory` using :api:`ClientFactoryBuilder` to override the default
-client connection idle timeout of 10 seconds programmatically:
+connection-level timeouts such as connect timeout and idle timeout programmatically:
 
 .. code-block:: java
 
@@ -80,12 +60,38 @@ client connection idle timeout of 10 seconds programmatically:
     import com.linecorp.armeria.client.ClientFactoryBuilder;
 
     ClientFactory factory = new ClientFactoryBuilder()
+            // Increase the connect timeout from 3.2s to 10s.
+            .connectTimeout(Duration.ofSeconds(10))
             // Shorten the idle connection timeout from 10s to 5s.
             .idleTimeout(Duration.ofSeconds(5))
-            // Enable HTTP/1 request pipelining.
+            // Note that you can also adjust other connection-level
+            // settings such as enabling HTTP/1 request pipelining.
             .useHttp1Pipelining(true)
             .build();
 
 Note that :api:`ClientFactory` implements ``java.lang.AutoCloseable`` and thus needs to be closed when you
 terminate your application. On ``close()``, :api:`ClientFactory` will close all the connections it manages
 and abort any requests in progress.
+
+Using JVM system properties
+---------------------------
+
+You can override the default client timeouts by specifying the following JVM system properties if you do not
+prefer setting it programmatically:
+
+- ``-Dcom.linecorp.armeria.defaultClientIdleTimeoutMillis=<integer>``
+
+  - the default client-side idle timeout of a connection for keep-alive in milliseconds. Default: ``10000``
+
+- ``-Dcom.linecorp.armeria.defaultConnectTimeoutMillis=<integer>``
+
+  - the default client-side timeout of a socket connection attempt in milliseconds. Default: ``3200``
+
+- ``-Dcom.linecorp.armeria.defaultResponseTimeoutMillis=<integer>``
+
+  - the default client-side timeout of a response in milliseconds. Default: ``15000``
+
+.. note::
+
+    The JVM system properties have effect only when you did not specify them programmatically.
+    See :api:`Flags` for the complete list of JVM system properties in Armeria.

--- a/site/src/sphinx/client-timeouts.rst
+++ b/site/src/sphinx/client-timeouts.rst
@@ -15,8 +15,8 @@ Using ``ClientBuilder``
 
     import com.linecorp.armeria.client.ClientBuilder;
 
-    int responseTimeout = 15;
-    int writeTimeout = 1;
+    int responseTimeout = 30;
+    int writeTimeout = 10;
 
     HelloService.Iface client = new ClientBuilder("tbinary+http://example.com/hello")
             .defaultResponseTimeout(Duration.ofSeconds(responseTimeout))
@@ -36,8 +36,8 @@ Using ``ClientOptionsBuilder``
 
     // Defaults are defined in com.linecorp.armeria.common.Flags and
     // com.linecorp.armeria.client.ClientOptions
-    int responseTimeout = 15;
-    int writeTimeout = 1;
+    int responseTimeout = 30;
+    int writeTimeout = 10;
 
     HelloService.Iface client = Clients.newClient(
             "tbinary+http://example.com/hello",

--- a/site/src/sphinx/client.rst
+++ b/site/src/sphinx/client.rst
@@ -7,10 +7,10 @@ Writing a client
     :maxdepth: 1
 
     client-http
-    client-retrofit
     client-thrift
     client-grpc
     client-decorator
+    client-retrofit
     client-custom-http-headers
     client-timeouts
     client-retry


### PR DESCRIPTION
- Reordered the existing sections so that the example that uses
  `ClientBuilder` comes first, because its used more commonly.
- Added a section about the system properties
- Added a section about adjusting idle connection timeout
  programmatically