### PR TITLE
Fix the API for adding decorated `ServiceWithPathMappings` and update…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -884,16 +884,20 @@ public final class ServerBuilder {
     }
 
     /**
-     * Binds the specified {@link ServiceWithPathMappings} at multiple {@link PathMapping}s
+     * Decorates and binds the specified {@link ServiceWithPathMappings} at multiple {@link PathMapping}s
      * of the default {@link VirtualHost}.
      *
+     * @param serviceWithPathMappings the {@link ServiceWithPathMappings}.
+     * @param decorators the decorator functions, which will be applied in the order specified.
      * @throws IllegalStateException if the default {@link VirtualHost} has been set via
      *                               {@link #defaultVirtualHost(VirtualHost)} already
      */
-    public <T extends ServiceWithPathMappings<HttpRequest, HttpResponse>>
-    ServerBuilder service(T serviceWithPathMappings) {
+    public ServerBuilder service(
+            ServiceWithPathMappings<HttpRequest, HttpResponse> serviceWithPathMappings,
+            Iterable<Function<? super Service<HttpRequest, HttpResponse>,
+                              ? extends Service<HttpRequest, HttpResponse>>> decorators) {
         defaultVirtualHostBuilderUpdated();
-        defaultVirtualHostBuilder.service(serviceWithPathMappings);
+        defaultVirtualHostBuilder.service(serviceWithPathMappings, decorators);
         return this;
     }
 
@@ -901,14 +905,18 @@ public final class ServerBuilder {
      * Decorates and binds the specified {@link ServiceWithPathMappings} at multiple {@link PathMapping}s
      * of the default {@link VirtualHost}.
      *
+     * @param serviceWithPathMappings the {@link ServiceWithPathMappings}.
+     * @param decorators the decorator functions, which will be applied in the order specified.
      * @throws IllegalStateException if the default {@link VirtualHost} has been set via
      *                               {@link #defaultVirtualHost(VirtualHost)} already
      */
-    public <T extends ServiceWithPathMappings<HttpRequest, HttpResponse>,
-            R extends Service<HttpRequest, HttpResponse>>
-    ServerBuilder service(T serviceWithPathMappings, Function<? super T, R> decorator) {
+    @SafeVarargs
+    public final ServerBuilder service(
+            ServiceWithPathMappings<HttpRequest, HttpResponse> serviceWithPathMappings,
+            Function<? super Service<HttpRequest, HttpResponse>,
+                     ? extends Service<HttpRequest, HttpResponse>>... decorators) {
         defaultVirtualHostBuilderUpdated();
-        defaultVirtualHostBuilder.service(serviceWithPathMappings, decorator);
+        defaultVirtualHostBuilder.service(serviceWithPathMappings, decorators);
         return this;
     }
 

--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcMetricsIntegrationTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcMetricsIntegrationTest.java
@@ -175,7 +175,7 @@ public class GrpcMetricsIntegrationTest {
                 "server." + suffix + '#' + type.getTagValueRepresentation(),
                 "method", "armeria.grpc.testing.TestService/" + method,
                 "hostnamePattern", "*",
-                "pathMapping", "catch-all");
+                "pathMapping", "exact:/armeria.grpc.testing.TestService/" + method);
         final String meterIdStr = prefix.withTags(keyValues).toString();
         return Optional.ofNullable(MoreMeters.measureAll(registry).get(meterIdStr));
     }

--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcMetricsIntegrationTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcMetricsIntegrationTest.java
@@ -54,6 +54,7 @@ import com.linecorp.armeria.grpc.testing.TestServiceGrpc.TestServiceBlockingStub
 import com.linecorp.armeria.grpc.testing.TestServiceGrpc.TestServiceImplBase;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.grpc.GrpcServiceBuilder;
+import com.linecorp.armeria.server.logging.LoggingService;
 import com.linecorp.armeria.server.metric.MetricCollectingService;
 import com.linecorp.armeria.testing.server.ServerRule;
 
@@ -92,12 +93,11 @@ public class GrpcMetricsIntegrationTest {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
             sb.meterRegistry(registry);
-            sb.serviceUnder("/", new GrpcServiceBuilder()
-                    .addService(new TestServiceImpl())
-                    .enableUnframedRequests(true)
-                    .build()
-                    .decorate(MetricCollectingService.newDecorator(
-                            MeterIdPrefixFunction.ofDefault("server"))));
+            sb.service(new GrpcServiceBuilder().addService(new TestServiceImpl())
+                                               .enableUnframedRequests(true)
+                                               .build(),
+                       MetricCollectingService.newDecorator(MeterIdPrefixFunction.ofDefault("server")),
+                       LoggingService.newDecorator());
         }
     };
 

--- a/site/src/sphinx/server-decorator.rst
+++ b/site/src/sphinx/server-decorator.rst
@@ -141,8 +141,8 @@ Decorating ``ServiceWithPathMappings``
 --------------------------------------
 
 :api:`ServiceWithPathMappings` is a special variant of :api:`Service` which allows a user to register multiple
-routes for a single service. It has a method called ``pathMappings()`` which returns a ``Set<PathMapping>``
-so that you do not have to specify path mappings when registering your service:
+routes for a single service. It has a method called ``pathMappings()`` which returns a ``Set`` of
+:apiplural:`PathMapping` so that you do not have to specify path mappings when registering your service:
 
 .. code-block:: java
 

--- a/site/src/sphinx/server-decorator.rst
+++ b/site/src/sphinx/server-decorator.rst
@@ -51,6 +51,12 @@ If your decorator is expected to be reusable, it is recommended to define a new 
 
 .. code-block:: java
 
+    import com.linecorp.armeria.common.HttpRequest;
+    import com.linecorp.armeria.common.HttpResponse;
+    import com.linecorp.armeria.server.Service;
+    import com.linecorp.armeria.server.ServiceRequestContext;
+    import com.linecorp.armeria.server.SimpleDecoratingService;
+
     public class AuthService extends SimpleDecoratingService<HttpRequest, HttpResponse> {
         public AuthService(Service<HttpRequest, HttpResponse> delegate) {
             super(delegate);
@@ -82,6 +88,9 @@ So far, we only demonstrated the case where a decorating service does not transf
 response. You can do that as well, of course, using :api:`DecoratingService`:
 
 .. code-block:: java
+
+    import com.linecorp.armeria.common.RpcRequest;
+    import com.linecorp.armeria.common.RpcResponse;
 
     // Transforms a Service<RpcRequest, RpcResponse> into Service<HttpRequest, HttpResponse>.
     public class MyRpcService extends DecoratingService<RpcRequest, RpcResponse,
@@ -126,6 +135,9 @@ a certain type from a server:
 
 .. code-block:: java
 
+    import com.linecorp.armeria.server.ServerConfig;
+    import java.util.List;
+
     Server server = ...;
     ServerConfig serverConfig = server.config();
     List<ServiceConfig> serviceConfigs = serverConfig.serviceConfigs();
@@ -145,6 +157,11 @@ routes for a single service. It has a method called ``pathMappings()`` which ret
 :apiplural:`PathMapping` so that you do not have to specify path mappings when registering your service:
 
 .. code-block:: java
+
+    import com.linecorp.armeria.server.PathMapping;
+    import com.linecorp.armeria.server.ServiceWithPathMappings;
+    import java.util.HashSet;
+    import java.util.Set;
 
     public class MyServiceWithPathMappings implements ServiceWithPathMappings<HttpRequest, HttpResponse> {
         @Override
@@ -170,6 +187,8 @@ register it without specifying a path mapping explicitly, because a decorated se
 :api:`ServiceWithPathMappings` anymore but just a :api:`Service`:
 
 .. code-block:: java
+
+    import com.linecorp.armeria.server.logging.LoggingService;
 
     ServerBuilder sb = new ServerBuilder();
 

--- a/site/src/sphinx/server-decorator.rst
+++ b/site/src/sphinx/server-decorator.rst
@@ -32,16 +32,15 @@ a decorating service. It enables you to write a decorating service with a single
 
     ServerBuilder sb = new ServerBuilder();
     HttpService service = ...;
-    sb.serviceUnder("/web",
-                    service.decorate((delegate, ctx, req) -> {
-                        if (!authenticate(req)) {
-                            // Authentication failed; fail the request.
-                            return HttpResponse.of(HttpStatus.UNAUTHORIZED);
-                        }
+    sb.serviceUnder("/web", service.decorate((delegate, ctx, req) -> {
+        if (!authenticate(req)) {
+            // Authentication failed; fail the request.
+            return HttpResponse.of(HttpStatus.UNAUTHORIZED);
+        }
 
-                        // Authenticated; pass the request to the actual service.
-                        return delegate.serve(ctx, req);
-                    });
+        // Authenticated; pass the request to the actual service.
+        return delegate.serve(ctx, req);
+    });
 
 Extending ``SimpleDecoratingService``
 -------------------------------------

--- a/site/src/sphinx/server-decorator.rst
+++ b/site/src/sphinx/server-decorator.rst
@@ -135,6 +135,45 @@ a certain type from a server:
         }
     }
 
+.. _server-decorator-service-with-path-mappings:
+
+Decorating ``ServiceWithPathMappings``
+--------------------------------------
+
+:api:`ServiceWithPathMappings` is a special variant of :api:`Service` which allows a user to register multiple
+routes for a single service easily. Because it requires a special treatment unlike usual :apiplural:`Service`,
+the two following restrictions apply:
+
+- You cannot specify path mappings when registering a :api:`ServiceWithPathMappings`.
+- You cannot use ``Service.decorate()`` method to decorate a :api:`ServiceWithPathMappings`. You have to
+  specify the decorators as extra parameters.
+
+The following example shows a simple :api:`ServiceWithPathMappings` implementation which is decorated with
+two decorators, :api:`LoggingService` and ``MyDecoratedService``:
+
+.. code-block:: java
+
+    public class MyServiceWithPathMappings implements ServiceWithPathMappings<HttpRequest, HttpResponse> {
+        @Override
+        public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) { ... }
+
+        @Override
+        public Set<PathMapping> pathMappings() {
+            Set<PathMapping> pathMappings = new HashSet<>();
+            pathMappings.add(PathMapping.of("/services/greet");
+            pathMappings.add(PathMapping.of("/services/hello");
+            return pathMappings;
+        }
+    }
+
+    ServerBuilder sb = new ServerBuilder();
+    sb.service(new MyServiceWithPathMappings(),
+               MyDecoratedService::new,
+               LoggingService.newDecorator())
+
+A good real-world example of :api:`ServiceWithPathMappings` is :api:`GrpcService`.
+See :ref:`server-grpc-decorator` for more information.
+
 See also
 --------
 

--- a/site/src/sphinx/server-grpc.rst
+++ b/site/src/sphinx/server-grpc.rst
@@ -99,8 +99,8 @@ Decorating a ``GrpcService``
 ----------------------------
 
 Unlike a usual Armeria :api:`Service`, :api:`GrpcService` implements a special interface called
-:api:`ServiceWithPathMappings`. It is recommended to decorate a :api:`GrpcService` by specifying decorator
-functions as extra parameters rather than using ``Service.decorate()``:
+:api:`ServiceWithPathMappings`. Therefore, it is recommended to decorate a :api:`GrpcService` by specifying
+decorator functions as extra parameters rather than using ``Service.decorate()``:
 
 .. code-block:: java
 

--- a/site/src/sphinx/server-grpc.rst
+++ b/site/src/sphinx/server-grpc.rst
@@ -99,8 +99,8 @@ Decorating a ``GrpcService``
 ----------------------------
 
 Unlike a usual Armeria :api:`Service`, :api:`GrpcService` implements a special interface called
-:api:`ServiceWithPathMappings`. You cannot decorate a :api:`GrpcService` using ``Service.decorate()`` but
-have to specify a decorator function as an extra parameter:
+:api:`ServiceWithPathMappings`. It is recommended to decorate a :api:`GrpcService` by specifying decorator
+functions as extra parameters rather than using ``Service.decorate()``:
 
 .. code-block:: java
 

--- a/site/src/sphinx/server-grpc.rst
+++ b/site/src/sphinx/server-grpc.rst
@@ -93,6 +93,30 @@ a :api:`GrpcServiceBuilder` and add it to the :api:`ServerBuilder`:
     We bound the :api:`GrpcService` without specifying any path mappings. It is because :api:`GrpcService`
     implements :api:`ServiceWithPathMappings`, which dynamically provides path mappings by itself.
 
+.. _server-grpc-decorator:
+
+Decorating a ``GrpcService``
+----------------------------
+
+Unlike a usual Armeria :api:`Service`, :api:`GrpcService` implements a special interface called
+:api:`ServiceWithPathMappings`. You cannot decorate a :api:`GrpcService` using ``Service.decorate()`` but
+have to specify a decorator function as an extra parameter:
+
+.. code-block:: java
+
+    import com.linecorp.armeria.server.logging.LoggingService;
+
+    ServerBuilder sb = new ServerBuilder();
+    ...
+    sb.service(new GrpcServiceBuilder().addService(new MyHelloService())
+                                       .build(),
+               LoggingService.newDecorator());
+    ...
+    Server server = sb.build();
+    server.start();
+
+See :ref:`server-decorator-service-with-path-mappings` for more information about :api:`ServiceWithPathMappings`.
+
 ``gRPC-Web``
 ------------
 
@@ -144,7 +168,9 @@ you build a :api:`GrpcService`:
 
     sb.service(new GrpcServiceBuilder().addService(new MyHelloService())
                                        .supportedSerializationFormats(GrpcSerializationFormats.values())
-                                       .build(), corsBuilder.newDecorator());
+                                       .build(),
+               corsBuilder.newDecorator(),
+               LoggingService.newDecorator());
     ...
     Server server = sb.build();
     server.start();


### PR DESCRIPTION
… documentation

Motivation:

We recently received a good question about how to decorate a
`GrpcService`, which is a `ServiceWithPathMappings`.

I found there is not enough explanation about such a question and it is
currently not easy to specify multiple decorators for a
`ServiceWithPathMappings`.

Modifications:

- Allow specifying multiple decorators when registering a
  `ServiceWithPathMappings`.
- Add some sections about decorating `ServiceWithPathMappings` and
  `GrpcService`.

Result:

- Easier to decorate a `ServiceWithPathMappings` such as `GrpcService`.
- Better documentation.