### PR TITLE
Explain how to get the address corresponding to '%a' token of access log

### DIFF
--- a/site/src/sphinx/server-access-log.rst
+++ b/site/src/sphinx/server-access-log.rst
@@ -127,6 +127,12 @@ Tokens for the log format are listed in the following table.
 |                           |                   | remote IP address where the channel is connected   |
 |                           |                   | to, which may yield a different value when there   |
 |                           |                   | is an intermediary proxy server.                   |
+|                           |                   | This value relies on the ``clientAddress()`` and   |
+|                           |                   | ``remoteAddress()`` methods of                     |
+|                           |                   | :api:`ServiceRequestContext`, please refer to      |
+|                           |                   | :ref:`client_address` about how to configure the   |
+|                           |                   | :api:`ServerBuilder` to get the client address you |
+|                           |                   | interest.                                          |
 +---------------------------+-------------------+----------------------------------------------------+
 | ``%h``                    | No                | the remote hostname or IP address if DNS           |
 |                           |                   | hostname lookup is not available                   |

--- a/site/src/sphinx/server-basics.rst
+++ b/site/src/sphinx/server-basics.rst
@@ -215,6 +215,8 @@ Use ``ServerBuilder.withVirtualHost()`` to configure `a name-based virtual host`
       .tls(...);
     ...
 
+.. _client_address:
+
 Getting an IP address of a client who initiated a request
 ---------------------------------------------------------
 


### PR DESCRIPTION
Modifications:
- Add a link to `Getting an IP address of a client who initiated a request` section in `server-basic.rst`.