### PR TITLE
Reduce the search space of AnnotationUtil.getAnnotations() and find()

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotationUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotationUtil.java
@@ -15,6 +15,7 @@
  */
 package com.linecorp.armeria.internal.annotation;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 import static org.reflections.ReflectionUtils.getMethods;
 import static org.reflections.ReflectionUtils.withName;
@@ -22,15 +23,16 @@ import static org.reflections.ReflectionUtils.withParametersCount;
 
 import java.lang.annotation.Annotation;
 import java.lang.annotation.Documented;
-import java.lang.annotation.Inherited;
-import java.lang.annotation.Native;
 import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.EnumSet;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -38,15 +40,20 @@ import java.util.function.Predicate;
 
 import javax.annotation.Nullable;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableList.Builder;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 
 /**
  * A utility class which helps to get annotations from an {@link AnnotatedElement}.
  */
 final class AnnotationUtil {
+
+    private static final Logger logger = LoggerFactory.getLogger(AnnotationUtil.class);
+
     /**
      * Options to be used for finding annotations from an {@link AnnotatedElement}.
      */
@@ -70,11 +77,17 @@ final class AnnotationUtil {
     }
 
     /**
-     * Built-in meta annotations defined in {@code java.lang.annotation} package.
+     * A thread-local hash set of annotation classes that contain cyclic references.
      */
-    private static final Set<Class<? extends Annotation>> BUILT_IN_META_ANNOTATIONS =
-            ImmutableSet.of(Documented.class, Inherited.class, Native.class,
-                            Retention.class, Repeatable.class, Target.class);
+    private static final ThreadLocal<Set<Class<? extends Annotation>>> knownCyclicAnnotationTypes =
+            ThreadLocal.withInitial(() -> {
+                final Set<Class<? extends Annotation>> map = Collections.newSetFromMap(new IdentityHashMap<>());
+                // Add well known JDK annotations with cyclic dependencies which will always be blacklisted.
+                map.add(Documented.class);
+                map.add(Retention.class);
+                map.add(Target.class);
+                return map;
+            });
 
     /**
      * Returns an annotation of the {@code annotationType} if it is found from one of the following:
@@ -207,16 +220,36 @@ final class AnnotationUtil {
     private static <T extends Annotation> void findMetaAnnotations(
             Builder<T> builder, Annotation annotation,
             Class<T> annotationType, Class<? extends Annotation> containerType) {
+        findMetaAnnotations(builder, annotation, annotationType, containerType,
+                            knownCyclicAnnotationTypes.get(),
+                            Collections.newSetFromMap(new IdentityHashMap<>()));
+    }
+
+    private static <T extends Annotation> boolean findMetaAnnotations(
+            Builder<T> builder, Annotation annotation,
+            Class<T> annotationType, Class<? extends Annotation> containerType,
+            Set<Class<? extends Annotation>> knownCyclicAnnotationTypes,
+            Set<Class<? extends Annotation>> visitedAnnotationTypes) {
+
+        final Class<? extends Annotation> actualAnnotationType = annotation.getClass();
+        if (knownCyclicAnnotationTypes.contains(actualAnnotationType)) {
+            return false;
+        }
+        if (!visitedAnnotationTypes.add(actualAnnotationType)) {
+            blacklistAnnotation(knownCyclicAnnotationTypes, actualAnnotationType);
+            return false;
+        }
+
         final Annotation[] metaAnnotations = annotation.annotationType().getDeclaredAnnotations();
         for (final Annotation metaAnnotation : metaAnnotations) {
-            // Lookup meta-annotations of a meta-annotation. Do not go into deeper if the metaAnnotation
-            // is one of built-in Java meta-annotations in order to avoid stack overflow.
-            if (!BUILT_IN_META_ANNOTATIONS.contains(metaAnnotation.annotationType())) {
-                findMetaAnnotations(builder, metaAnnotation, annotationType, containerType);
+            if (findMetaAnnotations(builder, metaAnnotation, annotationType, containerType,
+                                    knownCyclicAnnotationTypes, visitedAnnotationTypes)) {
+                collectAnnotations(builder, metaAnnotation, annotationType, containerType);
             }
-
-            collectAnnotations(builder, metaAnnotation, annotationType, containerType);
         }
+
+        visitedAnnotationTypes.remove(actualAnnotationType);
+        return true;
     }
 
     /**
@@ -237,7 +270,7 @@ final class AnnotationUtil {
 
     /**
      * Returns all annotations searching from the specified {@code element}. The search range depends on
-     * the specified {@link FindOption}s and the built-in Java meta-annotations will not be collected.
+     * the specified {@link FindOption}s.
      *
      * @param element the {@link AnnotatedElement} to find annotations
      * @param findOptions the options to be applied when retrieving annotations
@@ -251,16 +284,13 @@ final class AnnotationUtil {
 
     /**
      * Returns all annotations searching from the specified {@code element}. The search range depends on
-     * the specified {@link FindOption}s and the built-in Java meta-annotations will not be collected.
+     * the specified {@link FindOption}s.
      *
      * @param element the {@link AnnotatedElement} to find annotations
      * @param findOptions the options to be applied when retrieving annotations
      */
     static List<Annotation> getAnnotations(AnnotatedElement element, EnumSet<FindOption> findOptions) {
-        // A user may not be interested in the built-in meta annotations, so the default predicate filters out
-        // the default Java meta-annotations.
-        return getAnnotations(element, findOptions,
-                              annotation -> !BUILT_IN_META_ANNOTATIONS.contains(annotation.annotationType()));
+        return getAnnotations(element, findOptions, annotation -> true);
     }
 
     /**
@@ -294,16 +324,54 @@ final class AnnotationUtil {
 
     private static void getMetaAnnotations(Builder<Annotation> builder, Annotation annotation,
                                            Predicate<Annotation> collectingFilter) {
-        final Annotation[] metaAnnotations = annotation.annotationType().getDeclaredAnnotations();
-        for (final Annotation metaAnnotation : metaAnnotations) {
-            // Get meta-annotations of a meta-annotation. Do not go into deeper even if one of the built-in Java
-            // meta-annotations can be accepted by the collectingFilter, in order to avoid stack overflow.
-            if (!BUILT_IN_META_ANNOTATIONS.contains(metaAnnotation.annotationType())) {
-                getMetaAnnotations(builder, metaAnnotation, collectingFilter);
-            }
+        getMetaAnnotations(builder, annotation, collectingFilter,
+                           knownCyclicAnnotationTypes.get(),
+                           Collections.newSetFromMap(new IdentityHashMap<>()));
+    }
 
-            if (collectingFilter.test(metaAnnotation)) {
+    private static boolean getMetaAnnotations(Builder<Annotation> builder, Annotation annotation,
+                                             Predicate<Annotation> collectingFilter,
+                                             Set<Class<? extends Annotation>> knownCyclicAnnotationTypes,
+                                             Set<Class<? extends Annotation>> visitedAnnotationTypes) {
+
+        final Class<? extends Annotation> annotationType = annotation.annotationType();
+
+        if (knownCyclicAnnotationTypes.contains(annotationType)) {
+            return false;
+        }
+        if (!visitedAnnotationTypes.add(annotationType)) {
+            blacklistAnnotation(knownCyclicAnnotationTypes, annotationType);
+            return false;
+        }
+
+        final Annotation[] metaAnnotations = annotationType.getDeclaredAnnotations();
+        for (final Annotation metaAnnotation : metaAnnotations) {
+
+            if (getMetaAnnotations(builder, metaAnnotation, collectingFilter,
+                                   knownCyclicAnnotationTypes, visitedAnnotationTypes) &&
+                collectingFilter.test(metaAnnotation)) {
                 builder.add(metaAnnotation);
+            }
+        }
+
+        visitedAnnotationTypes.remove(annotationType);
+        return true;
+    }
+
+    private static void blacklistAnnotation(Set<Class<? extends Annotation>> knownCyclicAnnotationTypes,
+                                            Class<? extends Annotation> annotationType) {
+        knownCyclicAnnotationTypes.add(annotationType);
+        if (logger.isDebugEnabled()) {
+            final String typeName = annotationType.getName();
+            if (Proxy.class.isAssignableFrom(annotationType) && typeName.contains(".$Proxy")) {
+                final List<String> actualTypeNames = Arrays.stream(annotationType.getInterfaces())
+                                                           .filter(Class::isAnnotation)
+                                                           .map(Class::getName)
+                                                           .collect(toImmutableList());
+                logger.debug("Blacklisting an annotation with a cyclic reference: {}={}",
+                             typeName, actualTypeNames);
+            } else {
+                logger.debug("Blacklisting an annotation with a cyclic reference: {}", typeName);
             }
         }
     }

--- a/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotationUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotationUtil.java
@@ -35,6 +35,7 @@ import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.function.Predicate;
 
 import javax.annotation.Nullable;
@@ -80,7 +81,7 @@ final class AnnotationUtil {
      */
     private static final ThreadLocal<Set<Class<? extends Annotation>>> knownCyclicAnnotationTypes =
             ThreadLocal.withInitial(() -> {
-                final Set<Class<? extends Annotation>> map = Collections.newSetFromMap(new IdentityHashMap<>());
+                final Set<Class<? extends Annotation>> map = Collections.newSetFromMap(new WeakHashMap<>());
                 // Add well known JDK annotations with cyclic dependencies which will always be blacklisted.
                 map.add(Documented.class);
                 map.add(Retention.class);

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotationUtilTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotationUtilTest.java
@@ -125,24 +125,34 @@ public class AnnotationUtilTest {
     @TestAnnotation("TestChildClassWithIface")
     static class TestChildClassWithIface extends TestClassWithIface implements TestAnotherIface {}
 
+    @CyclicAnnotation
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface CyclicAnnotation {}
+
+    @CyclicAnnotation
+    static class TestClassWithCyclicAnnotation {
+        @CyclicAnnotation
+        public void foo() {}
+    }
+
     @Test
     public void declared() throws NoSuchMethodException {
         List<TestAnnotation> list;
 
         list = findDeclared(TestClass.class.getMethod("directlyPresent"), TestAnnotation.class);
-        assertThat(list.size()).isOne();
+        assertThat(list).hasSize(1);
         assertThat(list.get(0).value()).isEqualTo("method-level:directlyPresent");
 
         list = findDeclared(TestClass.class, TestAnnotation.class);
-        assertThat(list.size()).isOne();
+        assertThat(list).hasSize(1);
         assertThat(list.get(0).value()).isEqualTo("class-level:TestClass");
 
         list = findDeclared(TestChildClass.class, TestAnnotation.class);
-        assertThat(list.size()).isOne();
+        assertThat(list).hasSize(1);
         assertThat(list.get(0).value()).isEqualTo("class-level:TestChildClass");
 
         list = findDeclared(TestGrandChildClass.class, TestAnnotation.class);
-        assertThat(list.size()).isOne();
+        assertThat(list).hasSize(1);
         assertThat(list.get(0).value()).isEqualTo("class-level:TestGrandChildClass");
     }
 
@@ -152,19 +162,19 @@ public class AnnotationUtilTest {
 
         list = findDeclared(TestClass.class.getMethod("directlyPresentRepeatableSingle"),
                             TestRepeatable.class);
-        assertThat(list.size()).isOne();
+        assertThat(list).hasSize(1);
         assertThat(list.get(0).value()).isEqualTo("method-level:directlyPresentRepeatableSingle");
 
         list = findDeclared(SingleRepeatableTestClass.class, TestRepeatable.class);
-        assertThat(list.size()).isEqualTo(1);
+        assertThat(list).hasSize(1);
         assertThat(list.get(0).value()).isEqualTo("class-level:SingleRepeatableTestClass");
 
         list = findDeclared(SingleRepeatableTestChildClass.class, TestRepeatable.class);
-        assertThat(list.size()).isEqualTo(1);
+        assertThat(list).hasSize(1);
         assertThat(list.get(0).value()).isEqualTo("class-level:SingleRepeatableTestChildClass");
 
         list = findDeclared(SingleRepeatableTestGrandChildClass.class, TestRepeatable.class);
-        assertThat(list.size()).isEqualTo(1);
+        assertThat(list).hasSize(1);
         assertThat(list.get(0).value()).isEqualTo("class-level:SingleRepeatableTestGrandChildClass");
     }
 
@@ -174,23 +184,23 @@ public class AnnotationUtilTest {
 
         list = findDeclared(TestClass.class.getMethod("directlyPresentRepeatableMulti"),
                             TestRepeatable.class);
-        assertThat(list.size()).isEqualTo(3);
+        assertThat(list).hasSize(3);
         assertThat(list.get(0).value()).isEqualTo("method-level:directlyPresentRepeatableMulti:1");
         assertThat(list.get(1).value()).isEqualTo("method-level:directlyPresentRepeatableMulti:2");
         assertThat(list.get(2).value()).isEqualTo("method-level:directlyPresentRepeatableMulti:3");
 
         list = findDeclared(TestClass.class, TestRepeatable.class);
-        assertThat(list.size()).isEqualTo(2);
+        assertThat(list).hasSize(2);
         assertThat(list.get(0).value()).isEqualTo("class-level:TestClass:Repeatable1");
         assertThat(list.get(1).value()).isEqualTo("class-level:TestClass:Repeatable2");
 
         list = findDeclared(TestChildClass.class, TestRepeatable.class);
-        assertThat(list.size()).isEqualTo(2);
+        assertThat(list).hasSize(2);
         assertThat(list.get(0).value()).isEqualTo("class-level:TestChildClass:Repeatable1");
         assertThat(list.get(1).value()).isEqualTo("class-level:TestChildClass:Repeatable2");
 
         list = findDeclared(TestGrandChildClass.class, TestRepeatable.class);
-        assertThat(list.size()).isEqualTo(2);
+        assertThat(list).hasSize(2);
         assertThat(list.get(0).value()).isEqualTo("class-level:TestGrandChildClass:Repeatable1");
         assertThat(list.get(1).value()).isEqualTo("class-level:TestGrandChildClass:Repeatable2");
     }
@@ -200,23 +210,23 @@ public class AnnotationUtilTest {
         List<TestAnnotation> list;
 
         list = findInherited(TestClass.class, TestAnnotation.class);
-        assertThat(list.size()).isOne();
+        assertThat(list).hasSize(1);
         assertThat(list.get(0).value()).isEqualTo("class-level:TestClass");
 
         list = findInherited(TestChildClass.class, TestAnnotation.class);
-        assertThat(list.size()).isEqualTo(2);
+        assertThat(list).hasSize(2);
         assertThat(list.get(0).value()).isEqualTo("class-level:TestChildClass");
         assertThat(list.get(1).value()).isEqualTo("class-level:TestClass");
 
         list = findInherited(TestGrandChildClass.class, TestAnnotation.class);
-        assertThat(list.size()).isEqualTo(3);
+        assertThat(list).hasSize(3);
         assertThat(list.get(0).value()).isEqualTo("class-level:TestGrandChildClass");
         assertThat(list.get(1).value()).isEqualTo("class-level:TestChildClass");
         assertThat(list.get(2).value()).isEqualTo("class-level:TestClass");
 
         list = find(TestGrandChildClass.class, TestAnnotation.class,
                     FindOption.LOOKUP_SUPER_CLASSES, FindOption.COLLECT_SUPER_CLASSES_FIRST);
-        assertThat(list.size()).isEqualTo(3);
+        assertThat(list).hasSize(3);
         assertThat(list.get(0).value()).isEqualTo("class-level:TestClass");
         assertThat(list.get(1).value()).isEqualTo("class-level:TestChildClass");
         assertThat(list.get(2).value()).isEqualTo("class-level:TestGrandChildClass");
@@ -227,23 +237,23 @@ public class AnnotationUtilTest {
         List<TestRepeatable> list;
 
         list = findInherited(SingleRepeatableTestClass.class, TestRepeatable.class);
-        assertThat(list.size()).isOne();
+        assertThat(list).hasSize(1);
         assertThat(list.get(0).value()).isEqualTo("class-level:SingleRepeatableTestClass");
 
         list = findInherited(SingleRepeatableTestChildClass.class, TestRepeatable.class);
-        assertThat(list.size()).isEqualTo(2);
+        assertThat(list).hasSize(2);
         assertThat(list.get(0).value()).isEqualTo("class-level:SingleRepeatableTestChildClass");
         assertThat(list.get(1).value()).isEqualTo("class-level:SingleRepeatableTestClass");
 
         list = findInherited(SingleRepeatableTestGrandChildClass.class, TestRepeatable.class);
-        assertThat(list.size()).isEqualTo(3);
+        assertThat(list).hasSize(3);
         assertThat(list.get(0).value()).isEqualTo("class-level:SingleRepeatableTestGrandChildClass");
         assertThat(list.get(1).value()).isEqualTo("class-level:SingleRepeatableTestChildClass");
         assertThat(list.get(2).value()).isEqualTo("class-level:SingleRepeatableTestClass");
 
         list = find(SingleRepeatableTestGrandChildClass.class, TestRepeatable.class,
                     FindOption.LOOKUP_SUPER_CLASSES, FindOption.COLLECT_SUPER_CLASSES_FIRST);
-        assertThat(list.size()).isEqualTo(3);
+        assertThat(list).hasSize(3);
         assertThat(list.get(0).value()).isEqualTo("class-level:SingleRepeatableTestClass");
         assertThat(list.get(1).value()).isEqualTo("class-level:SingleRepeatableTestChildClass");
         assertThat(list.get(2).value()).isEqualTo("class-level:SingleRepeatableTestGrandChildClass");
@@ -254,19 +264,19 @@ public class AnnotationUtilTest {
         List<TestRepeatable> list;
 
         list = findInherited(TestClass.class, TestRepeatable.class);
-        assertThat(list.size()).isEqualTo(2);
+        assertThat(list).hasSize(2);
         assertThat(list.get(0).value()).isEqualTo("class-level:TestClass:Repeatable1");
         assertThat(list.get(1).value()).isEqualTo("class-level:TestClass:Repeatable2");
 
         list = findInherited(TestChildClass.class, TestRepeatable.class);
-        assertThat(list.size()).isEqualTo(4);
+        assertThat(list).hasSize(4);
         assertThat(list.get(0).value()).isEqualTo("class-level:TestChildClass:Repeatable1");
         assertThat(list.get(1).value()).isEqualTo("class-level:TestChildClass:Repeatable2");
         assertThat(list.get(2).value()).isEqualTo("class-level:TestClass:Repeatable1");
         assertThat(list.get(3).value()).isEqualTo("class-level:TestClass:Repeatable2");
 
         list = findInherited(TestGrandChildClass.class, TestRepeatable.class);
-        assertThat(list.size()).isEqualTo(6);
+        assertThat(list).hasSize(6);
         assertThat(list.get(0).value()).isEqualTo("class-level:TestGrandChildClass:Repeatable1");
         assertThat(list.get(1).value()).isEqualTo("class-level:TestGrandChildClass:Repeatable2");
         assertThat(list.get(2).value()).isEqualTo("class-level:TestChildClass:Repeatable1");
@@ -276,7 +286,7 @@ public class AnnotationUtilTest {
 
         list = find(TestGrandChildClass.class, TestRepeatable.class,
                     FindOption.LOOKUP_SUPER_CLASSES, FindOption.COLLECT_SUPER_CLASSES_FIRST);
-        assertThat(list.size()).isEqualTo(6);
+        assertThat(list).hasSize(6);
         assertThat(list.get(0).value()).isEqualTo("class-level:TestClass:Repeatable1");
         assertThat(list.get(1).value()).isEqualTo("class-level:TestClass:Repeatable2");
         assertThat(list.get(2).value()).isEqualTo("class-level:TestChildClass:Repeatable1");
@@ -293,7 +303,7 @@ public class AnnotationUtilTest {
                                                      TestChildClass.class,
                                                      TestGrandChildClass.class)) {
             list = find(clazz, TestMetaAnnotation.class, EnumSet.of(FindOption.LOOKUP_META_ANNOTATIONS));
-            assertThat(list.size()).isEqualTo(2);
+            assertThat(list).hasSize(2);
             assertThat(list.get(0).value()).isEqualTo("TestRepeatables");   // From the container annotation.
             assertThat(list.get(1).value()).isEqualTo("TestAnnotation");
         }
@@ -302,7 +312,7 @@ public class AnnotationUtilTest {
                                                      SingleRepeatableTestChildClass.class,
                                                      SingleRepeatableTestGrandChildClass.class)) {
             list = find(clazz, TestMetaAnnotation.class, EnumSet.of(FindOption.LOOKUP_META_ANNOTATIONS));
-            assertThat(list.size()).isOne();
+            assertThat(list).hasSize(1);
             assertThat(list.get(0).value()).isEqualTo("TestRepeatable");
         }
     }
@@ -312,16 +322,16 @@ public class AnnotationUtilTest {
         List<TestMetaAnnotation> list;
 
         list = findAll(SingleRepeatableTestClass.class, TestMetaAnnotation.class);
-        assertThat(list.size()).isOne();
+        assertThat(list).hasSize(1);
         assertThat(list.get(0).value()).isEqualTo("TestRepeatable");
 
         list = findAll(SingleRepeatableTestChildClass.class, TestMetaAnnotation.class);
-        assertThat(list.size()).isEqualTo(2);
+        assertThat(list).hasSize(2);
         assertThat(list.get(0).value()).isEqualTo("TestRepeatable");
         assertThat(list.get(1).value()).isEqualTo("TestRepeatable");
 
         list = findAll(SingleRepeatableTestGrandChildClass.class, TestMetaAnnotation.class);
-        assertThat(list.size()).isEqualTo(3);
+        assertThat(list).hasSize(3);
         assertThat(list.get(0).value()).isEqualTo("TestRepeatable");
         assertThat(list.get(1).value()).isEqualTo("TestRepeatable");
         assertThat(list.get(2).value()).isEqualTo("TestRepeatable");
@@ -332,19 +342,19 @@ public class AnnotationUtilTest {
         List<TestMetaAnnotation> list;
 
         list = findAll(TestClass.class, TestMetaAnnotation.class);
-        assertThat(list.size()).isEqualTo(2);
+        assertThat(list).hasSize(2);
         assertThat(list.get(0).value()).isEqualTo("TestRepeatables");
         assertThat(list.get(1).value()).isEqualTo("TestAnnotation");
 
         list = findAll(TestChildClass.class, TestMetaAnnotation.class);
-        assertThat(list.size()).isEqualTo(4);
+        assertThat(list).hasSize(4);
         assertThat(list.get(0).value()).isEqualTo("TestRepeatables");
         assertThat(list.get(1).value()).isEqualTo("TestAnnotation");
         assertThat(list.get(2).value()).isEqualTo("TestRepeatables");
         assertThat(list.get(3).value()).isEqualTo("TestAnnotation");
 
         list = findAll(TestGrandChildClass.class, TestMetaAnnotation.class);
-        assertThat(list.size()).isEqualTo(6);
+        assertThat(list).hasSize(6);
         assertThat(list.get(0).value()).isEqualTo("TestRepeatables");
         assertThat(list.get(1).value()).isEqualTo("TestAnnotation");
         assertThat(list.get(2).value()).isEqualTo("TestRepeatables");
@@ -358,13 +368,13 @@ public class AnnotationUtilTest {
         List<TestAnnotation> list;
 
         list = findAll(TestClassWithIface.class, TestAnnotation.class);
-        assertThat(list.size()).isEqualTo(3);
+        assertThat(list).hasSize(3);
         assertThat(list.get(0).value()).isEqualTo("TestClassWithIface");
         assertThat(list.get(1).value()).isEqualTo("TestChildIface");
         assertThat(list.get(2).value()).isEqualTo("TestIface");
 
         list = findAll(TestChildClassWithIface.class, TestAnnotation.class);
-        assertThat(list.size()).isEqualTo(5);
+        assertThat(list).hasSize(5);
         assertThat(list.get(0).value()).isEqualTo("TestChildClassWithIface");
         assertThat(list.get(1).value()).isEqualTo("TestAnotherIface");
         assertThat(list.get(2).value()).isEqualTo("TestClassWithIface");
@@ -387,6 +397,17 @@ public class AnnotationUtilTest {
     }
 
     @Test
+    public void findAll_cyclic() throws Exception {
+        List<CyclicAnnotation> list = findAll(TestClassWithCyclicAnnotation.class, CyclicAnnotation.class);
+        assertThat(list).hasSize(1);
+        assertThat(list.get(0)).isInstanceOf(CyclicAnnotation.class);
+
+        list = findAll(TestClassWithCyclicAnnotation.class.getDeclaredMethod("foo"), CyclicAnnotation.class);
+        assertThat(list).hasSize(1);
+        assertThat(list.get(0)).isInstanceOf(CyclicAnnotation.class);
+    }
+
+    @Test
     public void cglibProxy() {
         final Enhancer enhancer = new Enhancer();
         enhancer.setSuperclass(TestGrandChildClass.class);
@@ -400,13 +421,13 @@ public class AnnotationUtilTest {
                         EnumSet.of(FindOption.LOOKUP_META_ANNOTATIONS))).isEmpty();
 
         final List<TestAnnotation> list1 = findAll(proxy.getClass(), TestAnnotation.class);
-        assertThat(list1.size()).isEqualTo(3);
+        assertThat(list1).hasSize(3);
         assertThat(list1.get(0).value()).isEqualTo("class-level:TestGrandChildClass");
         assertThat(list1.get(1).value()).isEqualTo("class-level:TestChildClass");
         assertThat(list1.get(2).value()).isEqualTo("class-level:TestClass");
 
         final List<TestMetaAnnotation> list2 = findAll(proxy.getClass(), TestMetaAnnotation.class);
-        assertThat(list2.size()).isEqualTo(6);
+        assertThat(list2).hasSize(6);
         assertThat(list2.get(0).value()).isEqualTo("TestRepeatables");
         assertThat(list2.get(1).value()).isEqualTo("TestAnnotation");
         assertThat(list2.get(2).value()).isEqualTo("TestRepeatables");
@@ -418,7 +439,7 @@ public class AnnotationUtilTest {
     @Test
     public void getAnnotations_declared() {
         final List<Annotation> list = getAnnotations(TestGrandChildClass.class);
-        assertThat(list.size()).isEqualTo(2);
+        assertThat(list).hasSize(2);
         assertThat(list.get(0)).isInstanceOf(TestRepeatables.class);
         assertThat(list.get(1)).isInstanceOf(TestAnnotation.class);
     }
@@ -427,7 +448,7 @@ public class AnnotationUtilTest {
     public void getAnnotations_inherited() {
         final List<Annotation> list =
                 getAnnotations(TestGrandChildClass.class, FindOption.LOOKUP_SUPER_CLASSES);
-        assertThat(list.size()).isEqualTo(6);
+        assertThat(list).hasSize(6);
         assertThat(list.get(0)).isInstanceOf(TestRepeatables.class);
         assertThat(list.get(1)).isInstanceOf(TestAnnotation.class);
         assertThat(list.get(2)).isInstanceOf(TestRepeatables.class);
@@ -439,16 +460,27 @@ public class AnnotationUtilTest {
     @Test
     public void getAnnotations_all() {
         final List<Annotation> list = getAllAnnotations(TestGrandChildClass.class);
-        assertThat(list.size()).isEqualTo(18);
-        for (int i = 0; i < 3 * 6; i += 6) {
-            assertThat(list.get(i)).isInstanceOf(TestMetaOfMetaAnnotation.class);
-            assertThat(list.get(i + 1)).isInstanceOf(TestMetaAnnotation.class);
-            assertThat(((TestMetaAnnotation) list.get(i + 1)).value()).isEqualTo("TestRepeatables");
-            assertThat(list.get(i + 2)).isInstanceOf(TestRepeatables.class);
-            assertThat(list.get(i + 3)).isInstanceOf(TestMetaOfMetaAnnotation.class);
-            assertThat(list.get(i + 4)).isInstanceOf(TestMetaAnnotation.class);
-            assertThat(((TestMetaAnnotation) list.get(i + 4)).value()).isEqualTo("TestAnnotation");
-            assertThat(list.get(i + 5)).isInstanceOf(TestAnnotation.class);
+        assertThat(list).hasSize(18);
+        for (int i = 0; i < 3 * 6;) {
+            assertThat(list.get(i++)).isInstanceOf(TestMetaOfMetaAnnotation.class);
+            assertThat(list.get(i)).isInstanceOf(TestMetaAnnotation.class);
+            assertThat(((TestMetaAnnotation) list.get(i++)).value()).isEqualTo("TestRepeatables");
+            assertThat(list.get(i++)).isInstanceOf(TestRepeatables.class);
+            assertThat(list.get(i++)).isInstanceOf(TestMetaOfMetaAnnotation.class);
+            assertThat(list.get(i)).isInstanceOf(TestMetaAnnotation.class);
+            assertThat(((TestMetaAnnotation) list.get(i++)).value()).isEqualTo("TestAnnotation");
+            assertThat(list.get(i++)).isInstanceOf(TestAnnotation.class);
         }
+    }
+
+    @Test
+    public void getAnnotations_all_cyclic() throws Exception {
+        List<Annotation> list = getAllAnnotations(TestClassWithCyclicAnnotation.class);
+        assertThat(list).hasSize(1);
+        assertThat(list.get(0)).isInstanceOf(CyclicAnnotation.class);
+
+        list = getAllAnnotations(TestClassWithCyclicAnnotation.class.getDeclaredMethod("foo"));
+        assertThat(list).hasSize(1);
+        assertThat(list.get(0)).isInstanceOf(CyclicAnnotation.class);
     }
 }


### PR DESCRIPTION
Motivation:

There is no cyclic reference detection implemented in `AnnotationUtil`,
which means an annotation like the following can trigger a
`StackOverflowError`:

    @Cyclic
    @Retention(RUNTIME)
    @interface Cyclic {}

This was not a problem before because we blacklisted well known JDK
classes that has cyclic references, but it does not work for other
classes.

Modifications:

- Added cyclic dependency detection in the traversal logic.
- Added a thread-local blacklist of the annotation types with cyclic
  dependencies.

Result:

- Annotation scanning is faster.
- Annotation scanning does not trigger a `StackOverflowException`.
- Fixes #1632
- Fixes #1633

/cc @iEAmi @tobias- 