### PR TITLE
Support non-JSON Spring Actuator responses

### DIFF
--- a/examples/spring-boot-minimal/build.gradle
+++ b/examples/spring-boot-minimal/build.gradle
@@ -20,6 +20,8 @@ dependencies {
     compileOnly 'org.springframework.boot:spring-boot-configuration-processor'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
+    runtime project(':spring:boot-actuator-starter')
+
     testCompile 'junit:junit'
     testCompile 'net.javacrumbs.json-unit:json-unit-fluent'
     testCompile 'org.springframework.boot:spring-boot-starter-test'

--- a/examples/spring-boot-tomcat/build.gradle
+++ b/examples/spring-boot-tomcat/build.gradle
@@ -22,6 +22,8 @@ dependencies {
     compileOnly 'org.springframework.boot:spring-boot-configuration-processor'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
+    runtime project(':spring:boot-actuator-starter')
+
     testCompile 'junit:junit'
     testCompile 'org.assertj:assertj-core'
     testCompile 'org.springframework.boot:spring-boot-starter-test'

--- a/examples/spring-boot-webflux/build.gradle
+++ b/examples/spring-boot-webflux/build.gradle
@@ -19,6 +19,8 @@ dependencies {
     compileOnly 'org.springframework.boot:spring-boot-configuration-processor'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
+    runtime project(':spring:boot-actuator-starter')
+
     testCompile 'junit:junit'
     testCompile 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/spring/boot-actuator-autoconfigure/build.gradle
+++ b/spring/boot-actuator-autoconfigure/build.gradle
@@ -1,5 +1,7 @@
 dependencies {
     compile 'org.springframework.boot:spring-boot-actuator-autoconfigure'
+    compile 'javax.inject:javax.inject'
+    compileOnly 'javax.validation:validation-api'
 
     testCompile 'org.springframework.boot:spring-boot-starter-actuator'
     testCompile 'org.springframework.boot:spring-boot-starter-test'

--- a/spring/boot-actuator-autoconfigure/build.gradle
+++ b/spring/boot-actuator-autoconfigure/build.gradle
@@ -6,6 +6,7 @@ dependencies {
     testCompile 'org.springframework.boot:spring-boot-starter-actuator'
     testCompile 'org.springframework.boot:spring-boot-starter-test'
     testCompile 'io.projectreactor:reactor-test'
+    testRuntime project(':spring:boot-starter')
 }
 
 // Copy common files from boot-autoconfigure module to gen-src directory in order to use them as a source set.

--- a/spring/boot-actuator-autoconfigure/build.gradle
+++ b/spring/boot-actuator-autoconfigure/build.gradle
@@ -1,9 +1,16 @@
 dependencies {
-    compile project(':spring:boot-autoconfigure')
-
     compile 'org.springframework.boot:spring-boot-actuator-autoconfigure'
 
-    testCompile project(':spring:boot-starter')
     testCompile 'org.springframework.boot:spring-boot-starter-actuator'
     testCompile 'org.springframework.boot:spring-boot-starter-test'
+    testCompile 'io.projectreactor:reactor-test'
 }
+
+// Copy common files from boot-autoconfigure module to gen-src directory in order to use them as a source set.
+task copyFiles(type: Copy) {
+    from "${rootProject.projectDir}/spring/boot-autoconfigure/src/main/java"
+    into "${project.ext.genSrcDir}/main/java"
+    include '**/ArmeriaServerConfigurator.java'
+}
+
+tasks.compileJava.dependsOn(copyFiles)

--- a/spring/boot-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/ArmeriaSpringActuatorAutoConfiguration.java
+++ b/spring/boot-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/ArmeriaSpringActuatorAutoConfiguration.java
@@ -122,7 +122,8 @@ public class ArmeriaSpringActuatorAutoConfiguration {
                         mediaTypes.getProduced()
                 );
                 sb.service(mapping, (ctx, req) -> {
-                    Map<String, Link> links = new EndpointLinksResolver(endpoints).resolveLinks(req.path());
+                    final Map<String, Link> links =
+                            new EndpointLinksResolver(endpoints).resolveLinks(req.path());
                     return HttpResponse.of(
                             HttpStatus.OK,
                             MediaType.JSON,

--- a/spring/boot-actuator-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring/boot-actuator-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+  com.linecorp.armeria.spring.actuate.ArmeriaSpringActuatorAutoConfiguration

--- a/spring/boot-actuator-autoconfigure/src/test/java/com/linecorp/armeria/spring/actuate/ArmeriaSpringActuatorAutoConfigurationTest.java
+++ b/spring/boot-actuator-autoconfigure/src/test/java/com/linecorp/armeria/spring/actuate/ArmeriaSpringActuatorAutoConfigurationTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 import javax.inject.Inject;
 
@@ -45,13 +46,21 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 
+import com.linecorp.armeria.client.ClientOptionsBuilder;
+import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.server.Server;
+
+import io.prometheus.client.exporter.common.TextFormat;
+import reactor.test.StepVerifier;
 
 /**
  * This uses {@link com.linecorp.armeria.spring.ArmeriaAutoConfiguration} for integration tests.
@@ -72,22 +81,17 @@ public class ArmeriaSpringActuatorAutoConfigurationTest {
     private static final String TEST_LOGGER_NAME = "com.linecorp.armeria.spring.actuate.testing.TestLogger";
 
     // We use this logger to test the /loggers endpoint, so set the name manually instead of using class name.
+    @SuppressWarnings("unused")
     private static final Logger TEST_LOGGER = LoggerFactory.getLogger(TEST_LOGGER_NAME);
 
     @SpringBootApplication
-    public static class TestConfiguration {
-    }
+    public static class TestConfiguration {}
 
     @Rule
     public TestRule globalTimeout = new DisableOnDebug(new Timeout(10, TimeUnit.SECONDS));
 
     @Inject
     private Server server;
-
-    private String newUrl(String scheme) {
-        final int port = server.activePort().get().localAddress().getPort();
-        return scheme + "://127.0.0.1:" + port;
-    }
 
     private HttpClient client;
 
@@ -96,32 +100,37 @@ public class ArmeriaSpringActuatorAutoConfigurationTest {
         client = HttpClient.of(newUrl("h2c"));
     }
 
+    private String newUrl(String scheme) {
+        final int port = server.activePort().get().localAddress().getPort();
+        return scheme + "://127.0.0.1:" + port;
+    }
+
     @Test
     public void testHealth() throws Exception {
-        AggregatedHttpMessage msg = client.get("/internal/actuator/health").aggregate().get();
-        assertThat(msg.status()).isEqualTo(HttpStatus.OK);
+        final AggregatedHttpMessage res = client.get("/internal/actuator/health").aggregate().get();
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
 
-        Map<String, Object> values = OBJECT_MAPPER.readValue(msg.content().array(), JSON_MAP);
+        final Map<String, Object> values = OBJECT_MAPPER.readValue(res.content().array(), JSON_MAP);
         assertThat(values).containsEntry("status", "UP");
     }
 
     @Test
     public void testLoggers() throws Exception {
-        String loggerPath = "/internal/actuator/loggers/" + TEST_LOGGER_NAME;
-        AggregatedHttpMessage msg = client.get(loggerPath).aggregate().get();
-        assertThat(msg.status()).isEqualTo(HttpStatus.OK);
+        final String loggerPath = "/internal/actuator/loggers/" + TEST_LOGGER_NAME;
+        AggregatedHttpMessage res = client.get(loggerPath).aggregate().get();
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
 
-        Map<String, Object> values = OBJECT_MAPPER.readValue(msg.content().array(), JSON_MAP);
+        Map<String, Object> values = OBJECT_MAPPER.readValue(res.content().array(), JSON_MAP);
         assertThat(values).containsEntry("effectiveLevel", "DEBUG");
 
-        msg = client.execute(HttpHeaders.of(HttpMethod.POST, loggerPath)
+        res = client.execute(HttpHeaders.of(HttpMethod.POST, loggerPath)
                                         .contentType(MediaType.JSON_UTF_8),
                           OBJECT_MAPPER.writeValueAsBytes(ImmutableMap.of("configuredLevel", "info")))
                     .aggregate().get();
-        assertThat(msg.status()).isEqualTo(HttpStatus.NO_CONTENT);
+        assertThat(res.status()).isEqualTo(HttpStatus.NO_CONTENT);
 
-        msg = client.get(loggerPath).aggregate().get();
-        values = OBJECT_MAPPER.readValue(msg.content().array(), JSON_MAP);
+        res = client.get(loggerPath).aggregate().get();
+        values = OBJECT_MAPPER.readValue(res.content().array(), JSON_MAP);
         assertThat(values).containsEntry("effectiveLevel", "INFO");
 
         client.post(loggerPath, OBJECT_MAPPER.writeValueAsBytes(ImmutableMap.of()))
@@ -129,31 +138,72 @@ public class ArmeriaSpringActuatorAutoConfigurationTest {
     }
 
     @Test
+    public void testPrometheus() throws Exception {
+        final AggregatedHttpMessage res = client.get("/internal/actuator/prometheus").aggregate().get();
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.contentType()).isEqualTo(MediaType.parse(TextFormat.CONTENT_TYPE_004));
+        assertThat(res.contentAscii()).startsWith("# HELP ");
+    }
+
+    @Test
+    public void testHeapdump() throws Exception {
+        final HttpClient client = Clients.newDerivedClient(this.client, options -> {
+            return new ClientOptionsBuilder(options).defaultMaxResponseLength(0).build();
+        });
+
+        final HttpResponse res = client.get("/internal/actuator/heapdump");
+        final AtomicLong remainingBytes = new AtomicLong();
+        StepVerifier.create(res)
+                    .assertNext(obj -> {
+                        assertThat(obj).isInstanceOf(HttpHeaders.class);
+                        final HttpHeaders headers = (HttpHeaders) obj;
+                        assertThat(headers.status()).isEqualTo(HttpStatus.OK);
+                        assertThat(headers.contentType()).isEqualTo(MediaType.OCTET_STREAM);
+                        assertThat(headers.get(HttpHeaderNames.CONTENT_DISPOSITION))
+                                .startsWith("attachment;filename=heapdump");
+                        final Long contentLength = headers.getLong(HttpHeaderNames.CONTENT_LENGTH);
+                        assertThat(contentLength).isPositive();
+                        remainingBytes.set(contentLength);
+                    })
+                    .thenConsumeWhile(obj -> {
+                        assertThat(obj).isInstanceOf(HttpData.class);
+                        final HttpData data = (HttpData) obj;
+                        final long newRemainingBytes = remainingBytes.addAndGet(-data.length());
+                        assertThat(newRemainingBytes).isNotNegative();
+                        return newRemainingBytes > 0; // Stop at the last HttpData.
+                    })
+                    .expectNextCount(1) // Skip the last HttpData.
+                    .verifyComplete();
+
+        assertThat(remainingBytes).hasValue(0);
+    }
+
+    @Test
     public void testLinks() throws Exception {
-        AggregatedHttpMessage msg = client.get("/internal/actuator").aggregate().get();
-        assertThat(msg.status()).isEqualTo(HttpStatus.OK);
-        Map<String, Object> values = OBJECT_MAPPER.readValue(msg.content().array(), JSON_MAP);
+        final AggregatedHttpMessage res = client.get("/internal/actuator").aggregate().get();
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        final Map<String, Object> values = OBJECT_MAPPER.readValue(res.content().array(), JSON_MAP);
         assertThat(values).containsKey("_links");
     }
 
     @Test
     public void testMissingMediaType() throws Exception {
-        String loggerPath = "/internal/actuator/loggers/" + TEST_LOGGER_NAME;
-        AggregatedHttpMessage msg =
+        final String loggerPath = "/internal/actuator/loggers/" + TEST_LOGGER_NAME;
+        final AggregatedHttpMessage res =
                 client.execute(HttpHeaders.of(HttpMethod.POST, loggerPath),
                                OBJECT_MAPPER.writeValueAsBytes(ImmutableMap.of("configuredLevel", "info")))
                       .aggregate().get();
-        assertThat(msg.status()).isEqualTo(HttpStatus.UNSUPPORTED_MEDIA_TYPE);
+        assertThat(res.status()).isEqualTo(HttpStatus.UNSUPPORTED_MEDIA_TYPE);
     }
 
     @Test
     public void testInvalidMediaType() throws Exception {
-        String loggerPath = "/internal/actuator/loggers/" + TEST_LOGGER_NAME;
-        AggregatedHttpMessage msg =
+        final String loggerPath = "/internal/actuator/loggers/" + TEST_LOGGER_NAME;
+        final AggregatedHttpMessage res =
                 client.execute(HttpHeaders.of(HttpMethod.POST, loggerPath)
                                           .contentType(MediaType.PROTOBUF),
                                OBJECT_MAPPER.writeValueAsBytes(ImmutableMap.of("configuredLevel", "info")))
                       .aggregate().get();
-        assertThat(msg.status()).isEqualTo(HttpStatus.UNSUPPORTED_MEDIA_TYPE);
+        assertThat(res.status()).isEqualTo(HttpStatus.UNSUPPORTED_MEDIA_TYPE);
     }
 }

--- a/spring/boot-actuator-starter/build.gradle
+++ b/spring/boot-actuator-starter/build.gradle
@@ -1,4 +1,3 @@
 dependencies {
     compile project(':spring:boot-actuator-autoconfigure')
-    compile project(':spring:boot-starter')
 }


### PR DESCRIPTION
Motivation:

Spring Actuator responses are not always JSON. It can be a plaintext or
even an octet stream.

Modifications:

- Respect the negotiated media type.
- Added support for a plaintext response represented as a `CharSequence`.
- Added support for a binary response represented as a `Resource`.
- Miscellaneous:
  - `msg` -> `req` or `res`
  - Added `final` wherever applicable.
  - Added missing `spring.factories` to `armeria-spring-boot-actuator-autoconfigure`.
  - Made all Spring Boot examples use our actuator implementation.
  - Fixed a packaging issue which made more than one `Server` 
    instantiated. (The fix originally written by @hyangtack)

Result:

- Fixes #1637
- A user can also retrieve the heap dump via the Actuator service.
- A user does not need to import `ArmeriaSpringActuatorAutoConfiguration`
  manually anymore.
- `Server` startup does not fail anymore when a user pulls both
  `armeria-spring-boot-actuator-starter` and
  `armeria-spring-boot-webflux-starter`.
