### PR TITLE
Update dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.google.gradle:osdetector-gradle-plugin:1.6.2'
-        classpath 'io.spring.gradle:dependency-management-plugin:1.0.6.RELEASE'
+        classpath 'io.spring.gradle:dependency-management-plugin:1.0.7.RELEASE'
     }
 }
 

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -33,9 +33,9 @@ com.fasterxml.jackson.core:
 
 com.github.ben-manes.caffeine:
   caffeine:
-    version: '2.6.2'
+    version: '2.7.0'
     javadocs:
-    - https://static.javadoc.io/com.github.ben-manes.caffeine/caffeine/2.6.2/
+    - https://static.javadoc.io/com.github.ben-manes.caffeine/caffeine/2.7.0/
     relocations:
     - from: com.github.benmanes.caffeine
       to: com.linecorp.armeria.internal.shaded.caffeine
@@ -44,7 +44,7 @@ com.github.jengelman.gradle.plugins:
   shadow: { version: '4.0.4' }
 
 com.google.api:
-  gax-grpc: { version: '1.39.0' }
+  gax-grpc: { version: '1.42.0' }
 
 com.google.code.findbugs:
   jsr305: { version: '3.0.2' }
@@ -82,10 +82,11 @@ com.google.j2objc:
   j2objc-annotations: { version: '1.3' }
 
 # Ensure that we use the same Protobuf version as what gRPC depends on.
-# See: https://search.maven.org/search?q=g:io.grpc%20AND%20a:grpc-protobuf&core=gav
+# See: https://github.com/grpc/grpc-java/blob/master/build.gradle
+#      (Switch to the right tag and look for 'protobufVersion' and 'protocVersion'.)
 com.google.protobuf:
-  protoc: { version: '3.5.1-1' }
-  protobuf-java: { version: &PROTOBUF_VERSION '3.5.1' }
+  protoc: { version: '3.6.1' }
+  protobuf-java: { version: &PROTOBUF_VERSION '3.6.1' }
   protobuf-java-util: { version: *PROTOBUF_VERSION }
   protobuf-gradle-plugin: { version: '0.8.8' }
 
@@ -93,7 +94,7 @@ com.moowork.gradle:
   gradle-node-plugin: { version: '1.2.0' }
 
 com.puppycrawl.tools:
-  checkstyle: { version: '8.17' }
+  checkstyle: { version: '8.18' }
 
 com.spotify:
   completable-futures:
@@ -122,7 +123,7 @@ io.dropwizard.metrics:
 # Ensure to update the Protobuf version in this file when updating gRPC.
 io.grpc:
   grpc-core:
-    version: &GRPC_VERSION '1.18.0'
+    version: &GRPC_VERSION '1.19.0'
     javadocs:
     - https://grpc.io/grpc-java/javadoc/
     - https://developers.google.com/protocol-buffers/docs/reference/java/
@@ -198,7 +199,7 @@ io.prometheus:
 
 io.reactivex.rxjava2:
   rxjava:
-    version: '2.2.6'
+    version: '2.2.7'
     javadocs:
     - http://reactivex.io/RxJava/2.x/javadoc/
 
@@ -251,9 +252,9 @@ net.shibboleth.utilities:
 
 org.apache.curator:
   curator-recipes:
-    version: '4.1.0'
+    version: '4.2.0'
     javadocs:
-    - https://static.javadoc.io/org.apache.curator/curator-recipes/4.1.0/
+    - https://static.javadoc.io/org.apache.curator/curator-recipes/4.2.0/
     exclusions:
     - org.apache.zookeeper:zookeeper
 
@@ -304,7 +305,7 @@ org.apache.zookeeper:
     - org.slf4j:slf4j-log4j12
 
 org.assertj:
-  assertj-core: { version: '3.12.0' }
+  assertj-core: { version: '3.12.1' }
 
 org.awaitility:
   awaitility: { version: '3.1.6' }
@@ -326,7 +327,7 @@ org.dmonix.junit:
   zookeeper-junit: { version: '1.2' }
 
 org.eclipse.jetty:
-  apache-jsp: { version: &JETTY_VERSION '9.4.14.v20181114' }
+  apache-jsp: { version: &JETTY_VERSION '9.4.15.v20190215' }
   apache-jstl: { version: *JETTY_VERSION }
   jetty-annotations:
     version: *JETTY_VERSION
@@ -346,7 +347,7 @@ org.eclipse.jetty.http2:
   http2-server: { version: *JETTY_VERSION }
 
 org.hibernate.validator:
-  hibernate-validator: { version: '6.0.14.Final' }
+  hibernate-validator: { version: '6.0.15.Final' }
 
 org.jctools:
   jctools-core:
@@ -359,7 +360,7 @@ org.jsoup:
   jsoup: { version: '1.11.3' }
 
 org.mockito:
-  mockito-core: { version: '2.24.0' }
+  mockito-core: { version: '2.25.0' }
 
 org.mortbay.jetty.alpn:
   jetty-alpn-agent: { version: '2.0.9' }
@@ -392,7 +393,7 @@ org.reflections:
       to: com.linecorp.armeria.internal.shaded.reflections
 
 org.slf4j:
-  jcl-over-slf4j: { version: &SLF4J_VERSION '1.7.25' }
+  jcl-over-slf4j: { version: &SLF4J_VERSION '1.7.26' }
   jul-to-slf4j: { version: *SLF4J_VERSION }
   log4j-over-slf4j: { version: *SLF4J_VERSION }
   slf4j-api:
@@ -403,7 +404,7 @@ org.slf4j:
 
 org.springframework.boot:
   spring-boot-starter:
-    version: &SPRING_BOOT_VERSION '2.1.2.RELEASE'
+    version: &SPRING_BOOT_VERSION '2.1.3.RELEASE'
     javadocs:
     - https://docs.spring.io/spring/docs/current/javadoc-api/
   spring-boot-actuator-autoconfigure: { version: *SPRING_BOOT_VERSION }


### PR DESCRIPTION
- Caffeine 2.6.2 -> 2.7.0
- Curator 4.1.0 -> 4.2.0
- gRPC 1.18.0 -> 1.19.0
- Hibernate Validator 6.0.14 -> 6.0.15
- Jetty 9.4.14 -> 9.4.15
- protobuf-java 3.5.1 -> 3.6.1
- RxJava 2.2.6 -> 2.2.7
- SLF4J 1.7.25 -> 1.7.26
- Spring Boot 2.1.2 -> 2.1.3
- Build
  - AssertJ 3.12.0 -> 3.12.1
  - Checkstyle 8.17 -> 8.18
  - dependency-management-plugin 1.0.6 -> 1.0.7
  - gax-grpc 1.42.0
  - Mockito 2.24.0 -> 2.25.0
  - protoc 3.5.1-1 -> 3.6.1