### PR TITLE
Add more languages to Highlight.js

### DIFF
--- a/site/src/sphinx/_templates/layout.html
+++ b/site/src/sphinx/_templates/layout.html
@@ -16,6 +16,9 @@
   </div>
   <script type="text/javascript" src="{{ pathto('_static/add_badges.js', 1) }}"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/highlight.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/languages/gradle.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/languages/protobuf.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/languages/thrift.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/languages/yaml.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/highlightjs-line-numbers.js/2.6.0/highlightjs-line-numbers.min.js"></script>
   <script>

--- a/site/src/sphinx/advanced-saml.rst
+++ b/site/src/sphinx/advanced-saml.rst
@@ -39,7 +39,7 @@ For Maven:
 For Gradle:
 
 .. parsed-literal::
-    :class: highlight-groovy
+    :class: highlight-gradle
 
     dependencies {
         compile 'com.linecorp.armeria:saml:\ |release|\ '

--- a/site/src/sphinx/advanced-spring-webflux-integration.rst
+++ b/site/src/sphinx/advanced-spring-webflux-integration.rst
@@ -37,7 +37,7 @@ For Maven:
 For Gradle:
 
 .. parsed-literal::
-    :class: highlight-groovy
+    :class: highlight-gradle
 
     dependencies {
         compile 'com.linecorp.armeria:armeria-spring-boot-webflux-starter:\ |release|\ '

--- a/site/src/sphinx/server-annotated-service.rst
+++ b/site/src/sphinx/server-annotated-service.rst
@@ -181,7 +181,7 @@ option. In this case the variable name is used as the value.
 
     You can configure your build tool to add ``-parameters`` javac option as follows.
 
-    .. code-block:: groovy
+    .. code-block:: gradle
 
         // Gradle:
         tasks.withType(JavaCompile) {

--- a/site/src/sphinx/server-grpc.rst
+++ b/site/src/sphinx/server-grpc.rst
@@ -1,7 +1,6 @@
 .. _gRPC: https://grpc.io/
 .. _gRPC-Web: https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB.md
 .. _gRPC-Web-Client: https://github.com/improbable-eng/grpc-web
-.. _protobuf-gradle-plugin: https://github.com/google/protobuf-gradle-plugin
 .. _Protobuf-JSON: https://developers.google.com/protocol-buffers/docs/proto3#json
 .. _the gRPC-Java README: https://github.com/grpc/grpc-java/blob/master/README.md#download
 

--- a/site/src/sphinx/setup.rst
+++ b/site/src/sphinx/setup.rst
@@ -51,7 +51,7 @@ Setting up with Gradle
 You might want to use the following ``build.gradle`` as a starting point when you set up a new project:
 
 .. parsed-literal::
-    :class: highlight-groovy
+    :class: highlight-gradle
 
     apply plugin: 'java'
     apply plugin: 'idea'


### PR DESCRIPTION
.. because `thrift`, `gradle`, `protobuf` are not included in the common
languages.