### PR TITLE
Set 0.5 to the default failure rate threshold of a circuit breaker

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerBuilder.java
@@ -34,17 +34,17 @@ public final class CircuitBreakerBuilder {
 
     private static final class Defaults {
 
-        private static final double FAILURE_RATE_THRESHOLD = 0.8;
+        private static final double FAILURE_RATE_THRESHOLD = 0.5;
 
         private static final long MINIMUM_REQUEST_THRESHOLD = 10;
 
-        private static final Duration TRIAL_REQUEST_INTERVAL = Duration.ofSeconds(3);
+        private static final int TRIAL_REQUEST_INTERVAL_SECONDS = 3;
 
-        private static final Duration CIRCUIT_OPEN_WINDOW = Duration.ofSeconds(10);
+        private static final int CIRCUIT_OPEN_WINDOW_SECONDS = 10;
 
-        private static final Duration COUNTER_SLIDING_WINDOW = Duration.ofSeconds(20);
+        private static final int COUNTER_SLIDING_WINDOW_SECONDS = 20;
 
-        private static final Duration COUNTER_UPDATE_INTERVAL = Duration.ofSeconds(1);
+        private static final int COUNTER_UPDATE_INTERVAL_SECONDS = 1;
 
         private static final Ticker TICKER = Ticker.systemTicker();
     }
@@ -55,13 +55,13 @@ public final class CircuitBreakerBuilder {
 
     private long minimumRequestThreshold = Defaults.MINIMUM_REQUEST_THRESHOLD;
 
-    private Duration trialRequestInterval = Defaults.TRIAL_REQUEST_INTERVAL;
+    private Duration trialRequestInterval = Duration.ofSeconds(Defaults.TRIAL_REQUEST_INTERVAL_SECONDS);
 
-    private Duration circuitOpenWindow = Defaults.CIRCUIT_OPEN_WINDOW;
+    private Duration circuitOpenWindow = Duration.ofSeconds(Defaults.CIRCUIT_OPEN_WINDOW_SECONDS);
 
-    private Duration counterSlidingWindow = Defaults.COUNTER_SLIDING_WINDOW;
+    private Duration counterSlidingWindow = Duration.ofSeconds(Defaults.COUNTER_SLIDING_WINDOW_SECONDS);
 
-    private Duration counterUpdateInterval = Defaults.COUNTER_UPDATE_INTERVAL;
+    private Duration counterUpdateInterval = Duration.ofSeconds(Defaults.COUNTER_UPDATE_INTERVAL_SECONDS);
 
     private Ticker ticker = Defaults.TICKER;
 
@@ -89,6 +89,7 @@ public final class CircuitBreakerBuilder {
 
     /**
      * Sets the threshold of failure rate to detect a remote service fault.
+     * Defaults to {@value Defaults#FAILURE_RATE_THRESHOLD} if unspecified.
      *
      * @param failureRateThreshold The rate between 0 (exclusive) and 1 (inclusive)
      */
@@ -103,6 +104,7 @@ public final class CircuitBreakerBuilder {
 
     /**
      * Sets the minimum number of requests within a time window necessary to detect a remote service fault.
+     * Defaults to {@value Defaults#MINIMUM_REQUEST_THRESHOLD} if unspecified.
      */
     public CircuitBreakerBuilder minimumRequestThreshold(long minimumRequestThreshold) {
         if (minimumRequestThreshold < 0) {
@@ -115,6 +117,7 @@ public final class CircuitBreakerBuilder {
 
     /**
      * Sets the trial request interval in HALF_OPEN state.
+     * Defaults to {@value Defaults#TRIAL_REQUEST_INTERVAL_SECONDS} seconds if unspecified.
      */
     public CircuitBreakerBuilder trialRequestInterval(Duration trialRequestInterval) {
         requireNonNull(trialRequestInterval, "trialRequestInterval");
@@ -127,7 +130,8 @@ public final class CircuitBreakerBuilder {
     }
 
     /**
-     * Sets the trial request interval in HALF_OPEN state.
+     * Sets the trial request interval in HALF_OPEN state in milliseconds.
+     * Defaults to {@value Defaults#TRIAL_REQUEST_INTERVAL_SECONDS} seconds if unspecified.
      */
     public CircuitBreakerBuilder trialRequestIntervalMillis(long trialRequestIntervalMillis) {
         trialRequestInterval(Duration.ofMillis(trialRequestIntervalMillis));
@@ -136,6 +140,7 @@ public final class CircuitBreakerBuilder {
 
     /**
      * Sets the duration of OPEN state.
+     * Defaults to {@value Defaults#CIRCUIT_OPEN_WINDOW_SECONDS} seconds if unspecified.
      */
     public CircuitBreakerBuilder circuitOpenWindow(Duration circuitOpenWindow) {
         requireNonNull(circuitOpenWindow, "circuitOpenWindow");
@@ -148,7 +153,8 @@ public final class CircuitBreakerBuilder {
     }
 
     /**
-     * Sets the duration of OPEN state.
+     * Sets the duration of OPEN state in milliseconds.
+     * Defaults to {@value Defaults#CIRCUIT_OPEN_WINDOW_SECONDS} seconds if unspecified.
      */
     public CircuitBreakerBuilder circuitOpenWindowMillis(long circuitOpenWindowMillis) {
         circuitOpenWindow(Duration.ofMillis(circuitOpenWindowMillis));
@@ -157,6 +163,7 @@ public final class CircuitBreakerBuilder {
 
     /**
      * Sets the time length of sliding window to accumulate the count of events.
+     * Defaults to {@value Defaults#COUNTER_SLIDING_WINDOW_SECONDS} seconds if unspecified.
      */
     public CircuitBreakerBuilder counterSlidingWindow(Duration counterSlidingWindow) {
         requireNonNull(counterSlidingWindow, "counterSlidingWindow");
@@ -169,7 +176,8 @@ public final class CircuitBreakerBuilder {
     }
 
     /**
-     * Sets the time length of sliding window to accumulate the count of events.
+     * Sets the time length of sliding window to accumulate the count of events, in milliseconds.
+     * Defaults to {@value Defaults#COUNTER_SLIDING_WINDOW_SECONDS} seconds if unspecified.
      */
     public CircuitBreakerBuilder counterSlidingWindowMillis(long counterSlidingWindowMillis) {
         counterSlidingWindow(Duration.ofMillis(counterSlidingWindowMillis));
@@ -178,6 +186,7 @@ public final class CircuitBreakerBuilder {
 
     /**
      * Sets the interval that a circuit breaker can see the latest accumulated count of events.
+     * Defaults to {@value Defaults#COUNTER_UPDATE_INTERVAL_SECONDS} second if unspecified.
      */
     public CircuitBreakerBuilder counterUpdateInterval(Duration counterUpdateInterval) {
         requireNonNull(counterUpdateInterval, "counterUpdateInterval");
@@ -190,7 +199,8 @@ public final class CircuitBreakerBuilder {
     }
 
     /**
-     * Sets the interval that a circuit breaker can see the latest accumulated count of events.
+     * Sets the interval that a circuit breaker can see the latest accumulated count of events, in milliseconds.
+     * Defaults to {@value Defaults#COUNTER_UPDATE_INTERVAL_SECONDS} second if unspecified.
      */
     public CircuitBreakerBuilder counterUpdateIntervalMillis(long counterUpdateIntervalMillis) {
         counterUpdateInterval(Duration.ofMillis(counterUpdateIntervalMillis));

--- a/site/src/sphinx/client-circuit-breaker.rst
+++ b/site/src/sphinx/client-circuit-breaker.rst
@@ -280,7 +280,7 @@ If you use :api:`CircuitBreakerBuilder`, you can configure the parameters which 
 
   - The threshold that changes :api:`CircuitBreaker`'s state to ``OPEN`` when the number of failed
     :apiplural:`Request` divided by the number of total :apiplural:`Request` exceeds it.
-    The default value is ``0.2``.
+    The default value is ``0.5``.
 
 - ``minimumRequestThreshold``:
 


### PR DESCRIPTION
Motivation:

The default failure rate threshold of a circuit breaker is written
inconsistently between documentation (0.2) and implementation (0.8).

Modifications:

- Use consistent default value - 0.5.

Result:

- Fixes documentation error.
- (Breaking) Uses more widely adopted default failure rate threshold.