### PR TITLE
Fix ByteBuf leak from Spring WebFlux integration

### DIFF
--- a/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpResponse.java
+++ b/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpResponse.java
@@ -208,7 +208,7 @@ final class ArmeriaServerHttpResponse implements ServerHttpResponse {
                 armeriaHeaders.add(HttpHeaderNames.SET_COOKIE, cookieValues);
             }
 
-            stateUpdater.set(this, State.COMMITTED);
+            state = State.COMMITTED;
         }));
 
         if (writeAction != null) {

--- a/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpResponse.java
+++ b/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpResponse.java
@@ -24,6 +24,7 @@ import java.util.concurrent.CompletableFuture;
 
 import javax.annotation.Nullable;
 
+import org.reactivestreams.Processor;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
@@ -208,7 +209,7 @@ final class ArmeriaServerHttpResponse extends AbstractServerHttpResponse {
      * when it is discarded, which might cause {@link ByteBuf} leak. This processor behaves similarly
      * but will release the cached object when the subscription is completed.
      */
-    private static final class HttpResponseProcessor implements Publisher<HttpObject>, Subscriber<HttpData> {
+    private static final class HttpResponseProcessor implements Processor<HttpData, HttpObject> {
 
         private enum State {
             INIT, HEADER_SENT, FIRST_CONTENT_SENT

--- a/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpResponse.java
+++ b/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpResponse.java
@@ -271,7 +271,7 @@ final class ArmeriaServerHttpResponse extends AbstractServerHttpResponse {
                 @Override
                 public void request(long n) {
                     if (!isValidDemand(n)) {
-                        releaseFirstContent();
+                        cancel();
                         return;
                     }
                     if (state == State.FIRST_CONTENT_SENT) {

--- a/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpResponse.java
+++ b/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpResponse.java
@@ -271,6 +271,7 @@ final class ArmeriaServerHttpResponse extends AbstractServerHttpResponse {
                 @Override
                 public void request(long n) {
                     if (!isValidDemand(n)) {
+                        releaseFirstContent();
                         return;
                     }
                     if (state == State.FIRST_CONTENT_SENT) {

--- a/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpResponseTest.java
+++ b/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpResponseTest.java
@@ -21,8 +21,12 @@ import static org.awaitility.Awaitility.await;
 
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
@@ -30,6 +34,7 @@ import org.springframework.http.ResponseCookie;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpObject;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.server.ServiceRequestContext;
@@ -234,5 +239,44 @@ public class ArmeriaServerHttpResponseTest {
                     .verify();
 
         await().until(() -> httpResponse.completionFuture().isDone());
+    }
+
+    @Test
+    public void requestInvalidDemand() throws Exception {
+        final CompletableFuture<HttpResponse> future = new CompletableFuture<>();
+        final ArmeriaServerHttpResponse response = response(ctx, future);
+        response.writeWith(Mono.just(DataBufferFactoryWrapper.DEFAULT.delegate().wrap("foo".getBytes())))
+                .then(Mono.defer(response::setComplete)).subscribe();
+        await().until(future::isDone);
+        assertThat(future.isCompletedExceptionally()).isFalse();
+
+        final AtomicBoolean completed = new AtomicBoolean();
+        final AtomicReference<Throwable> error = new AtomicReference<>();
+        future.get().subscribe(new Subscriber<HttpObject>() {
+            @Override
+            public void onSubscribe(Subscription s) {
+                s.request(0);
+            }
+
+            @Override
+            public void onNext(HttpObject httpObject) {
+                // Do nothing.
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                error.compareAndSet(null, t);
+                completed.set(true);
+            }
+
+            @Override
+            public void onComplete() {
+                completed.set(true);
+            }
+        });
+
+        await().untilTrue(completed);
+        assertThat(error.get()).isInstanceOf(IllegalArgumentException.class)
+                               .hasMessageContaining("Reactive Streams specification rule 3.9");
     }
 }

--- a/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ByteBufLeakTest.java
+++ b/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ByteBufLeakTest.java
@@ -150,8 +150,7 @@ public class ByteBufLeakTest {
         }
 
         // Wait until all request has been completed.
-        final long timeoutSeconds = System.getenv("CI") != null ? 30 : 10;
-        await().atMost(timeoutSeconds, TimeUnit.SECONDS).until(() -> completed.get() == 2 * 3);
+        await().atMost(30, TimeUnit.SECONDS).until(() -> completed.get() == 2 * 3);
 
         ensureAllBuffersAreReleased();
     }

--- a/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ByteBufLeakTest.java
+++ b/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ByteBufLeakTest.java
@@ -136,9 +136,9 @@ public class ByteBufLeakTest {
             }
         }
 
-        // The buffer allocation might be done after closing the socket. So waiting a little before
-        // checking the allocated buffers.
-        Thread.sleep(3000);
+        // The buffer allocation might be done after closing the socket. So waiting for the buffers
+        // allocated by "/mono" and "/flux" requests.
+        await().untilAsserted(() -> assertThat(allocatedBuffers).hasSize(2 * 3));
 
         ensureAllBuffersAreReleased();
     }

--- a/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ByteBufLeakTest.java
+++ b/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ByteBufLeakTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.spring.web.reactive;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.io.PrintWriter;
+import java.net.Socket;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.DisableOnDebug;
+import org.junit.rules.TestRule;
+import org.junit.rules.Timeout;
+import org.junit.runner.RunWith;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.buffer.DataBufferFactory;
+import org.springframework.core.io.buffer.NettyDataBuffer;
+import org.springframework.core.io.buffer.NettyDataBufferFactory;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.linecorp.armeria.client.HttpClient;
+
+import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.util.NetUtil;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+public class ByteBufLeakTest {
+
+    private static final Queue<NettyDataBuffer> allocatedBuffers = new ConcurrentLinkedQueue<>();
+
+    @SpringBootApplication
+    @Configuration
+    static class TestConfiguration {
+        @Bean
+        public DataBufferFactory dataBufferFactory() {
+            return new NettyDataBufferFactory(PooledByteBufAllocator.DEFAULT) {
+                // This method will be called when emitting string from Mono/Flux.
+                @Override
+                public NettyDataBuffer allocateBuffer(int initialCapacity) {
+                    final NettyDataBuffer buffer = super.allocateBuffer(initialCapacity);
+                    // Keep allocated buffers.
+                    allocatedBuffers.offer(buffer);
+                    return buffer;
+                }
+            };
+        }
+
+        @RestController
+        static class TestController {
+            @GetMapping("/mono")
+            Mono<String> mono() {
+                return Mono.just("hello, WebFlux!");
+            }
+
+            @GetMapping("/flux")
+            Flux<String> flux() {
+                return Flux.just("abc", "def", "ghi", "jkl", "mno");
+            }
+
+            @GetMapping("/empty")
+            Mono<String> empty() {
+                return Mono.empty();
+            }
+        }
+    }
+
+    @Rule
+    public TestRule globalTimeout = new DisableOnDebug(new Timeout(10, TimeUnit.SECONDS));
+
+    @LocalServerPort
+    int port;
+
+    @Test
+    public void confirmNoBufferLeak() throws Exception {
+        assert allocatedBuffers.isEmpty();
+        final HttpClient client = HttpClient.of("http://127.0.0.1:" + port);
+        for (int i = 0; i < 3; i++) {
+            assertThat(client.get("/mono").aggregate().join().contentUtf8())
+                    .isEqualTo("hello, WebFlux!");
+            assertThat(client.get("/flux").aggregate().join().contentUtf8())
+                    .isEqualTo("abcdefghijklmno");
+            assertThat(client.get("/empty").aggregate().join().contentUtf8())
+                    .isEmpty();
+        }
+
+        await().untilAsserted(this::makeSureReleasedAllAllocatedBuffers);
+    }
+
+    @Test
+    public void confirmNoBufferLeak_resetConnection() throws Exception {
+        assert allocatedBuffers.isEmpty();
+        for (int i = 0; i < 3 * 3; i++) {
+            try (Socket s = new Socket(NetUtil.LOCALHOST, port)) {
+                s.setSoLinger(true, 0);
+                final PrintWriter outWriter = new PrintWriter(s.getOutputStream(), false);
+                switch (i % 3) {
+                    case 0:
+                        outWriter.print("GET /mono HTTP/1.1\r\n\r\n");
+                        break;
+                    case 1:
+                        outWriter.print("GET /flux HTTP/1.1\r\n\r\n");
+                        break;
+                    case 2:
+                        outWriter.print("GET /empty HTTP/1.1\r\n\r\n");
+                        break;
+                }
+                outWriter.flush();
+            }
+        }
+
+        // The buffer allocation might be done after closing the socket. So waiting a little before
+        // checking the allocated buffers.
+        Thread.sleep(3000);
+
+        await().untilAsserted(this::makeSureReleasedAllAllocatedBuffers);
+    }
+
+    private void makeSureReleasedAllAllocatedBuffers() {
+        NettyDataBuffer buffer;
+        while ((buffer = allocatedBuffers.peek()) != null) {
+            assertThat(buffer.getNativeBuffer().refCnt()).isZero();
+            allocatedBuffers.poll();
+        }
+        assertThat(allocatedBuffers).isEmpty();
+    }
+}

--- a/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ByteBufLeakTest.java
+++ b/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ByteBufLeakTest.java
@@ -57,6 +57,8 @@ import reactor.core.publisher.Mono;
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 public class ByteBufLeakTest {
 
+    private static final long timeoutSeconds = 60;
+
     private static final AtomicInteger completed = new AtomicInteger();
     private static final Queue<NettyDataBuffer> allocatedBuffers = new ConcurrentLinkedQueue<>();
 
@@ -105,7 +107,7 @@ public class ByteBufLeakTest {
     }
 
     @Rule
-    public TestRule globalTimeout = new DisableOnDebug(new Timeout(10, TimeUnit.SECONDS));
+    public TestRule globalTimeout = new DisableOnDebug(new Timeout(timeoutSeconds, TimeUnit.SECONDS));
 
     @LocalServerPort
     int port;
@@ -150,7 +152,7 @@ public class ByteBufLeakTest {
         }
 
         // Wait until all request has been completed.
-        await().atMost(30, TimeUnit.SECONDS).until(() -> completed.get() == 2 * 3);
+        await().atMost(timeoutSeconds, TimeUnit.SECONDS).until(() -> completed.get() == 2 * 3);
 
         ensureAllBuffersAreReleased();
     }

--- a/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ByteBufLeakTest.java
+++ b/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ByteBufLeakTest.java
@@ -111,7 +111,7 @@ public class ByteBufLeakTest {
                     .isEmpty();
         }
 
-        await().untilAsserted(this::makeSureReleasedAllAllocatedBuffers);
+        ensureAllBuffersAreReleased();
     }
 
     @Test
@@ -140,15 +140,17 @@ public class ByteBufLeakTest {
         // checking the allocated buffers.
         Thread.sleep(3000);
 
-        await().untilAsserted(this::makeSureReleasedAllAllocatedBuffers);
+        ensureAllBuffersAreReleased();
     }
 
-    private void makeSureReleasedAllAllocatedBuffers() {
-        NettyDataBuffer buffer;
-        while ((buffer = allocatedBuffers.peek()) != null) {
-            assertThat(buffer.getNativeBuffer().refCnt()).isZero();
-            allocatedBuffers.poll();
-        }
-        assertThat(allocatedBuffers).isEmpty();
+    private void ensureAllBuffersAreReleased() {
+        await().untilAsserted(() -> {
+            NettyDataBuffer buffer;
+            while ((buffer = allocatedBuffers.peek()) != null) {
+                assertThat(buffer.getNativeBuffer().refCnt()).isZero();
+                allocatedBuffers.poll();
+            }
+            assertThat(allocatedBuffers).isEmpty();
+        });
     }
 }


### PR DESCRIPTION
Motivation:
 `ArmeriaServerHttpResponse`, especially its super class, `AbstractServerHttpResponse`, uses `ChannelSendOperator#WriteBarrier` when writing a response.
The `WriteBarrier` internally caches the first published object, but it does nothing when the cached object is discarded, which might cause `ByteBuf` leak.

Modifications:
- Do not inherit `AbstractServerHttpResponse` anymore, which causes mis-ordering of invoking `onNext` of `PublisherBasedHttpResponse`.
- Add `HttpResponseProcessor` between `PublisherBasedHttpResponse` and the content publisher.
  - It always requests one element to the publisher when subscribing, and then caches the first published object.
  - When a Spring controller returns `Mono`, it always received `request(unbounded)` signal internally, so we need to have a reference to the published object in order to release it when it is discarded.
- Add test for checking `ByteBuf` leak.

Result:
- No more `ByteBuf` leak.