### PR TITLE
Update dependencies and forks

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClientOptions.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientOptions.java
@@ -40,6 +40,7 @@ import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.logging.ContentPreviewerFactory;
 import com.linecorp.armeria.common.util.AbstractOptions;
+import com.linecorp.armeria.internal.ArmeriaHttpUtil;
 
 import io.netty.handler.codec.http2.HttpConversionUtil.ExtensionHeaderNames;
 import io.netty.util.AsciiString;
@@ -51,19 +52,19 @@ public final class ClientOptions extends AbstractOptions {
 
     private static final Long DEFAULT_DEFAULT_WRITE_TIMEOUT_MILLIS = Duration.ofSeconds(1).toMillis();
 
-    @SuppressWarnings("deprecation")
     private static final Collection<AsciiString> BLACKLISTED_HEADER_NAMES =
             Collections.unmodifiableCollection(Arrays.asList(
                     HttpHeaderNames.CONNECTION,
                     HttpHeaderNames.HOST,
-                    HttpHeaderNames.KEEP_ALIVE,
+                    HttpHeaderNames.HTTP2_SETTINGS,
                     HttpHeaderNames.METHOD,
                     HttpHeaderNames.PATH,
-                    HttpHeaderNames.PROXY_CONNECTION,
                     HttpHeaderNames.SCHEME,
                     HttpHeaderNames.STATUS,
                     HttpHeaderNames.TRANSFER_ENCODING,
                     HttpHeaderNames.UPGRADE,
+                    ArmeriaHttpUtil.HEADER_NAME_KEEP_ALIVE,
+                    ArmeriaHttpUtil.HEADER_NAME_PROXY_CONNECTION,
                     ExtensionHeaderNames.PATH.text(),
                     ExtensionHeaderNames.SCHEME.text(),
                     ExtensionHeaderNames.STREAM_DEPENDENCY_ID.text(),

--- a/core/src/main/java/com/linecorp/armeria/client/logging/LoggingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/logging/LoggingClient.java
@@ -115,7 +115,7 @@ public final class LoggingClient<I extends Request, O extends Response> extends 
              Function.identity(),
              Function.identity(),
              Function.identity(),
-             Sampler.always());
+             Sampler.ALWAYS_SAMPLE);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/HttpHeaderNames.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpHeaderNames.java
@@ -14,19 +14,17 @@
  * under the License.
  */
 /*
- * Copyright 2014 The Netty Project
+ * Copyright (C) 2011 The Guava Authors
  *
- * The Netty Project licenses this file to you under the Apache License,
- * version 2.0 (the "License"); you may not use this file except in compliance
- * with the License. You may obtain a copy of the License at:
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  *
- *   https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.linecorp.armeria.common;
 
@@ -42,389 +40,503 @@ import com.google.common.collect.ImmutableMap;
 import io.netty.util.AsciiString;
 
 /**
- * Standard HTTP header names.
+ * Contains constant definitions for the HTTP header field names.
  *
- * <p>These are all defined as lowercase to support HTTP/2 requirements while also not
- * violating HTTP/1.x requirements. New header names should always be lowercase.
+ * <p>All header names in this class are defined in lowercase to support HTTP/2 requirements while
+ * also not violating HTTP/1 requirements.</p>
  */
 public final class HttpHeaderNames {
 
-    // Forked from Netty at 4875a2aad4c82204caedb2d121fb5ef03c09fe44
+    // Forked from Guava 27.1 at 8e174e76971449665658a800af6dd350806cc934
+    // Changes:
+    // - Added pseudo headers
+    // - Added Accept-Patch
+    // - Added Content-Base
+    // - Removed the ancient CSP headers
+    //   - X-Content-Security-Policy
+    //   - X-Content-Security-Policy-Report-Only
+    //   - X-WebKit-CSP
+    //   - X-WebKit-CSP-Report-Only
+    // - Removed Sec-Metadata headers (too early to add)
+    //   - Sec-Fetch-Dest
+    //   - Sec-Fetch-Mode
+    //   - Sec-Fetch-Site
+    //   - Sec-Fetch-User
+    //   - Sec-Metadata
 
     // Pseudo-headers
 
     /**
-     * {@code ":method"}.
+     * The HTTP {@code ":method"} pseudo header field name.
      */
-    public static final AsciiString METHOD = AsciiString.cached(":method");
+    public static final AsciiString METHOD = create(":method");
     /**
-     * {@code ":scheme"}.
+     * The HTTP {@code ":scheme"} pseudo header field name.
      */
-    public static final AsciiString SCHEME = AsciiString.cached(":scheme");
+    public static final AsciiString SCHEME = create(":scheme");
     /**
-     * {@code ":authority"}.
+     * The HTTP {@code ":authority"} pseudo header field name.
      */
-    public static final AsciiString AUTHORITY = AsciiString.cached(":authority");
+    public static final AsciiString AUTHORITY = create(":authority");
     /**
-     * {@code ":path"}.
+     * The HTTP {@code ":path"} pseudo header field name.
      */
-    public static final AsciiString PATH = AsciiString.cached(":path");
+    public static final AsciiString PATH = create(":path");
     /**
-     * {@code ":status"}.
+     * The HTTP {@code ":status"} pseudo header field name.
      */
-    public static final AsciiString STATUS = AsciiString.cached(":status");
+    public static final AsciiString STATUS = create(":status");
 
-    // Ordinary headers
+    // HTTP Request and Response header fields
 
     /**
-     * {@code "accept"}.
+     * The HTTP {@code "Cache-Control"} header field name.
      */
-    public static final AsciiString ACCEPT = AsciiString.cached("accept");
+    public static final AsciiString CACHE_CONTROL = create("Cache-Control");
     /**
-     * {@code "accept-charset"}.
+     * The HTTP {@code "Content-Length"} header field name.
      */
-    public static final AsciiString ACCEPT_CHARSET = AsciiString.cached("accept-charset");
+    public static final AsciiString CONTENT_LENGTH = create("Content-Length");
     /**
-     * {@code "accept-encoding"}.
+     * The HTTP {@code "Content-Type"} header field name.
      */
-    public static final AsciiString ACCEPT_ENCODING = AsciiString.cached("accept-encoding");
+    public static final AsciiString CONTENT_TYPE = create("Content-Type");
     /**
-     * {@code "accept-language"}.
+     * The HTTP {@code "Date"} header field name.
      */
-    public static final AsciiString ACCEPT_LANGUAGE = AsciiString.cached("accept-language");
+    public static final AsciiString DATE = create("Date");
     /**
-     * {@code "accept-ranges"}.
+     * The HTTP {@code "Pragma"} header field name.
      */
-    public static final AsciiString ACCEPT_RANGES = AsciiString.cached("accept-ranges");
+    public static final AsciiString PRAGMA = create("Pragma");
     /**
-     * {@code "accept-patch"}.
+     * The HTTP {@code "Via"} header field name.
      */
-    public static final AsciiString ACCEPT_PATCH = AsciiString.cached("accept-patch");
+    public static final AsciiString VIA = create("Via");
     /**
-     * {@code "access-control-allow-credentials"}.
+     * The HTTP {@code "Warning"} header field name.
+     */
+    public static final AsciiString WARNING = create("Warning");
+
+    // HTTP Request header fields
+
+    /**
+     * The HTTP {@code "Accept"} header field name.
+     */
+    public static final AsciiString ACCEPT = create("Accept");
+    /**
+     * The HTTP {@code "Accept-Charset"} header field name.
+     */
+    public static final AsciiString ACCEPT_CHARSET = create("Accept-Charset");
+    /**
+     * The HTTP {@code "Accept-Encoding"} header field name.
+     */
+    public static final AsciiString ACCEPT_ENCODING = create("Accept-Encoding");
+    /**
+     * The HTTP {@code "Accept-Language"} header field name.
+     */
+    public static final AsciiString ACCEPT_LANGUAGE = create("Accept-Language");
+    /**
+     * The HTTP {@code "Access-Control-Request-Headers"} header field name.
+     */
+    public static final AsciiString ACCESS_CONTROL_REQUEST_HEADERS = create("Access-Control-Request-Headers");
+    /**
+     * The HTTP {@code "Access-Control-Request-Method"} header field name.
+     */
+    public static final AsciiString ACCESS_CONTROL_REQUEST_METHOD = create("Access-Control-Request-Method");
+    /**
+     * The HTTP {@code "Authorization"} header field name.
+     */
+    public static final AsciiString AUTHORIZATION = create("Authorization");
+    /**
+     * The HTTP {@code "Connection"} header field name.
+     */
+    public static final AsciiString CONNECTION = create("Connection");
+    /**
+     * The HTTP {@code "Cookie"} header field name.
+     */
+    public static final AsciiString COOKIE = create("Cookie");
+    /**
+     * The HTTP <a href="https://tools.ietf.org/html/rfc8470">{@code "Early-Data"}</a> header field
+     * name.
+     */
+    public static final AsciiString EARLY_DATA = create("Early-Data");
+    /**
+     * The HTTP {@code "Expect"} header field name.
+     */
+    public static final AsciiString EXPECT = create("Expect");
+    /**
+     * The HTTP {@code "From"} header field name.
+     */
+    public static final AsciiString FROM = create("From");
+    /**
+     * The HTTP <a href="https://tools.ietf.org/html/rfc7239">{@code "Forwarded"}</a> header field name.
+     */
+    public static final AsciiString FORWARDED = create("Forwarded");
+    /**
+     * The HTTP {@code "Follow-Only-When-Prerender-Shown"} header field name.
+     */
+    public static final AsciiString FOLLOW_ONLY_WHEN_PRERENDER_SHOWN =
+            create("Follow-Only-When-Prerender-Shown");
+    /**
+     * The HTTP {@code "Host"} header field name.
+     */
+    public static final AsciiString HOST = create("Host");
+    /**
+     * The HTTP <a href="https://tools.ietf.org/html/rfc7540#section-3.2.1">{@code "HTTP2-Settings"}
+     * </a> header field name.
+     */
+    public static final AsciiString HTTP2_SETTINGS = create("HTTP2-Settings");
+    /**
+     * The HTTP {@code "If-Match"} header field name.
+     */
+    public static final AsciiString IF_MATCH = create("If-Match");
+    /**
+     * The HTTP {@code "If-Modified-Since"} header field name.
+     */
+    public static final AsciiString IF_MODIFIED_SINCE = create("If-Modified-Since");
+    /**
+     * The HTTP {@code "If-None-Match"} header field name.
+     */
+    public static final AsciiString IF_NONE_MATCH = create("If-None-Match");
+    /**
+     * The HTTP {@code "If-Range"} header field name.
+     */
+    public static final AsciiString IF_RANGE = create("If-Range");
+    /**
+     * The HTTP {@code "If-Unmodified-Since"} header field name.
+     */
+    public static final AsciiString IF_UNMODIFIED_SINCE = create("If-Unmodified-Since");
+    /**
+     * The HTTP {@code "Last-Event-ID"} header field name.
+     */
+    public static final AsciiString LAST_EVENT_ID = create("Last-Event-ID");
+    /**
+     * The HTTP {@code "Max-Forwards"} header field name.
+     */
+    public static final AsciiString MAX_FORWARDS = create("Max-Forwards");
+    /**
+     * The HTTP {@code "Origin"} header field name.
+     */
+    public static final AsciiString ORIGIN = create("Origin");
+    /**
+     * The HTTP {@code "Proxy-Authorization"} header field name.
+     */
+    public static final AsciiString PROXY_AUTHORIZATION = create("Proxy-Authorization");
+    /**
+     * The HTTP {@code "Range"} header field name.
+     */
+    public static final AsciiString RANGE = create("Range");
+    /**
+     * The HTTP {@code "Referer"} header field name.
+     */
+    public static final AsciiString REFERER = create("Referer");
+    /**
+     * The HTTP <a href="https://www.w3.org/TR/referrer-policy/">{@code "Referrer-Policy"}</a> header
+     * field name.
+     */
+    public static final AsciiString REFERRER_POLICY = create("Referrer-Policy");
+
+    /**
+     * The HTTP <a href="https://www.w3.org/TR/service-workers/#update-algorithm">{@code
+     * Service-Worker}</a> header field name.
+     */
+    public static final AsciiString SERVICE_WORKER = create("Service-Worker");
+    /**
+     * The HTTP {@code "TE"} header field name.
+     */
+    public static final AsciiString TE = create("TE");
+    /**
+     * The HTTP {@code "Upgrade"} header field name.
+     */
+    public static final AsciiString UPGRADE = create("Upgrade");
+    /**
+     * The HTTP {@code "User-Agent"} header field name.
+     */
+    public static final AsciiString USER_AGENT = create("User-Agent");
+
+    // HTTP Response header fields
+
+    /**
+     * The HTTP {@code "Accept-Ranges"} header field name.
+     */
+    public static final AsciiString ACCEPT_RANGES = create("Accept-Ranges");
+    /**
+     * The HTTP {@code "Accept-Patch"} header field name.
+     */
+    public static final AsciiString ACCEPT_PATCH = create("Accept-Patch");
+    /**
+     * The HTTP {@code "Access-Control-Allow-Headers"} header field name.
+     */
+    public static final AsciiString ACCESS_CONTROL_ALLOW_HEADERS = create("Access-Control-Allow-Headers");
+    /**
+     * The HTTP {@code "Access-Control-Allow-Methods"} header field name.
+     */
+    public static final AsciiString ACCESS_CONTROL_ALLOW_METHODS = create("Access-Control-Allow-Methods");
+    /**
+     * The HTTP {@code "Access-Control-Allow-Origin"} header field name.
+     */
+    public static final AsciiString ACCESS_CONTROL_ALLOW_ORIGIN = create("Access-Control-Allow-Origin");
+    /**
+     * The HTTP {@code "Access-Control-Allow-Credentials"} header field name.
      */
     public static final AsciiString ACCESS_CONTROL_ALLOW_CREDENTIALS =
-            AsciiString.cached("access-control-allow-credentials");
+            create("Access-Control-Allow-Credentials");
     /**
-     * {@code "access-control-allow-headers"}.
+     * The HTTP {@code "Access-Control-Expose-Headers"} header field name.
      */
-    public static final AsciiString ACCESS_CONTROL_ALLOW_HEADERS =
-            AsciiString.cached("access-control-allow-headers");
+    public static final AsciiString ACCESS_CONTROL_EXPOSE_HEADERS = create("Access-Control-Expose-Headers");
     /**
-     * {@code "access-control-allow-methods"}.
+     * The HTTP {@code "Access-Control-Max-Age"} header field name.
      */
-    public static final AsciiString ACCESS_CONTROL_ALLOW_METHODS =
-            AsciiString.cached("access-control-allow-methods");
+    public static final AsciiString ACCESS_CONTROL_MAX_AGE = create("Access-Control-Max-Age");
     /**
-     * {@code "access-control-allow-origin"}.
+     * The HTTP {@code "Age"} header field name.
      */
-    public static final AsciiString ACCESS_CONTROL_ALLOW_ORIGIN =
-            AsciiString.cached("access-control-allow-origin");
+    public static final AsciiString AGE = create("Age");
     /**
-     * {@code "access-control-expose-headers"}.
+     * The HTTP {@code "Allow"} header field name.
      */
-    public static final AsciiString ACCESS_CONTROL_EXPOSE_HEADERS =
-            AsciiString.cached("access-control-expose-headers");
+    public static final AsciiString ALLOW = create("Allow");
     /**
-     * {@code "access-control-max-age"}.
+     * The HTTP {@code "Content-Base"} header field name.
      */
-    public static final AsciiString ACCESS_CONTROL_MAX_AGE = AsciiString.cached("access-control-max-age");
+    public static final AsciiString CONTENT_BASE = create("Content-Base");
     /**
-     * {@code "access-control-request-headers"}.
+     * The HTTP {@code "Content-Disposition"} header field name.
      */
-    public static final AsciiString ACCESS_CONTROL_REQUEST_HEADERS =
-            AsciiString.cached("access-control-request-headers");
+    public static final AsciiString CONTENT_DISPOSITION = create("Content-Disposition");
     /**
-     * {@code "access-control-request-method"}.
+     * The HTTP {@code "Content-Encoding"} header field name.
      */
-    public static final AsciiString ACCESS_CONTROL_REQUEST_METHOD =
-            AsciiString.cached("access-control-request-method");
+    public static final AsciiString CONTENT_ENCODING = create("Content-Encoding");
     /**
-     * {@code "age"}.
+     * The HTTP {@code "Content-Language"} header field name.
      */
-    public static final AsciiString AGE = AsciiString.cached("age");
+    public static final AsciiString CONTENT_LANGUAGE = create("Content-Language");
     /**
-     * {@code "allow"}.
+     * The HTTP {@code "Content-Location"} header field name.
      */
-    public static final AsciiString ALLOW = AsciiString.cached("allow");
+    public static final AsciiString CONTENT_LOCATION = create("Content-Location");
     /**
-     * {@code "authorization"}.
+     * The HTTP {@code "Content-MD5"} header field name.
      */
-    public static final AsciiString AUTHORIZATION = AsciiString.cached("authorization");
+    public static final AsciiString CONTENT_MD5 = create("Content-MD5");
     /**
-     * {@code "cache-control"}.
+     * The HTTP {@code "Content-Range"} header field name.
      */
-    public static final AsciiString CACHE_CONTROL = AsciiString.cached("cache-control");
+    public static final AsciiString CONTENT_RANGE = create("Content-Range");
     /**
-     * {@code "connection"}.
+     * The HTTP <a href="https://w3.org/TR/CSP/#content-security-policy-header-field">{@code
+     * Content-Security-Policy}</a> header field name.
      */
-    public static final AsciiString CONNECTION = AsciiString.cached("connection");
+    public static final AsciiString CONTENT_SECURITY_POLICY = create("Content-Security-Policy");
     /**
-     * {@code "content-base"}.
+     * The HTTP <a href="https://w3.org/TR/CSP/#content-security-policy-report-only-header-field">
+     * {@code "Content-Security-Policy-Report-Only"}</a> header field name.
      */
-    public static final AsciiString CONTENT_BASE = AsciiString.cached("content-base");
+    public static final AsciiString CONTENT_SECURITY_POLICY_REPORT_ONLY =
+            create("Content-Security-Policy-Report-Only");
     /**
-     * {@code "content-disposition"}.
+     * The HTTP {@code "ETag"} header field name.
      */
-    public static final AsciiString CONTENT_DISPOSITION = AsciiString.cached("content-disposition");
+    public static final AsciiString ETAG = create("ETag");
     /**
-     * {@code "content-encoding"}.
+     * The HTTP {@code "Expires"} header field name.
      */
-    public static final AsciiString CONTENT_ENCODING = AsciiString.cached("content-encoding");
+    public static final AsciiString EXPIRES = create("Expires");
     /**
-     * {@code "content-language"}.
+     * The HTTP {@code "Last-Modified"} header field name.
      */
-    public static final AsciiString CONTENT_LANGUAGE = AsciiString.cached("content-language");
+    public static final AsciiString LAST_MODIFIED = create("Last-Modified");
     /**
-     * {@code "content-length"}.
+     * The HTTP {@code "Link"} header field name.
      */
-    public static final AsciiString CONTENT_LENGTH = AsciiString.cached("content-length");
+    public static final AsciiString LINK = create("Link");
     /**
-     * {@code "content-location"}.
+     * The HTTP {@code "Location"} header field name.
      */
-    public static final AsciiString CONTENT_LOCATION = AsciiString.cached("content-location");
+    public static final AsciiString LOCATION = create("Location");
     /**
-     * {@code "content-md5"}.
+     * The HTTP <a href="https://googlechrome.github.io/OriginTrials/#header">{@code "Origin-Trial"}</a>
+     * header field name.
      */
-    public static final AsciiString CONTENT_MD5 = AsciiString.cached("content-md5");
+    public static final AsciiString ORIGIN_TRIAL = create("Origin-Trial");
     /**
-     * {@code "content-range"}.
+     * The HTTP {@code "P3P"} header field name. Limited browser support.
      */
-    public static final AsciiString CONTENT_RANGE = AsciiString.cached("content-range");
+    public static final AsciiString P3P = create("P3P");
     /**
-     * {@code "content-security-policy"}.
+     * The HTTP {@code "Proxy-Authenticate"} header field name.
      */
-    public static final AsciiString CONTENT_SECURITY_POLICY = AsciiString.cached("content-security-policy");
+    public static final AsciiString PROXY_AUTHENTICATE = create("Proxy-Authenticate");
     /**
-     * {@code "content-transfer-encoding"}.
+     * The HTTP {@code "Refresh"} header field name. Non-standard header supported by most browsers.
      */
-    public static final AsciiString CONTENT_TRANSFER_ENCODING = AsciiString.cached("content-transfer-encoding");
+    public static final AsciiString REFRESH = create("Refresh");
     /**
-     * {@code "content-type"}.
+     * The HTTP <a href="https://www.w3.org/TR/reporting/">{@code "Report-To"}</a> header field name.
      */
-    public static final AsciiString CONTENT_TYPE = AsciiString.cached("content-type");
+    public static final AsciiString REPORT_TO = create("Report-To");
     /**
-     * {@code "cookie"}.
+     * The HTTP {@code "Retry-After"} header field name.
      */
-    public static final AsciiString COOKIE = AsciiString.cached("cookie");
+    public static final AsciiString RETRY_AFTER = create("Retry-After");
     /**
-     * {@code "date"}.
+     * The HTTP {@code "Server"} header field name.
      */
-    public static final AsciiString DATE = AsciiString.cached("date");
+    public static final AsciiString SERVER = create("Server");
     /**
-     * {@code "etag"}.
+     * The HTTP <a href="https://www.w3.org/TR/server-timing/">{@code "Server-Timing"}</a> header field
+     * name.
      */
-    public static final AsciiString ETAG = AsciiString.cached("etag");
+    public static final AsciiString SERVER_TIMING = create("Server-Timing");
     /**
-     * {@code "expect"}.
+     * The HTTP <a href="https://www.w3.org/TR/service-workers/#update-algorithm">{@code
+     * Service-Worker-Allowed}</a> header field name.
      */
-    public static final AsciiString EXPECT = AsciiString.cached("expect");
+    public static final AsciiString SERVICE_WORKER_ALLOWED = create("Service-Worker-Allowed");
     /**
-     * {@code "expires"}.
+     * The HTTP {@code "Set-Cookie"} header field name.
      */
-    public static final AsciiString EXPIRES = AsciiString.cached("expires");
+    public static final AsciiString SET_COOKIE = create("Set-Cookie");
     /**
-     * {@code "forwarded"}.
+     * The HTTP {@code "Set-Cookie2"} header field name.
      */
-    public static final AsciiString FORWARDED = AsciiString.cached("forwarded");
+    public static final AsciiString SET_COOKIE2 = create("Set-Cookie2");
+
     /**
-     * {@code "from"}.
+     * The HTTP <a href="https://goo.gl/Dxx19N">{@code "SourceMap"}</a> header field name.
      */
-    public static final AsciiString FROM = AsciiString.cached("from");
+    public static final AsciiString SOURCE_MAP = create("SourceMap");
+
     /**
-     * {@code "host"}.
+     * The HTTP <a href="https://tools.ietf.org/html/rfc6797#section-6.1">{@code
+     * Strict-Transport-Security}</a> header field name.
      */
-    public static final AsciiString HOST = AsciiString.cached("host");
+    public static final AsciiString STRICT_TRANSPORT_SECURITY = create("Strict-Transport-Security");
     /**
-     * {@code "if-match"}.
+     * The HTTP <a href="https://www.w3.org/TR/resource-timing/#cross-origin-resources">{@code
+     * Timing-Allow-Origin}</a> header field name.
      */
-    public static final AsciiString IF_MATCH = AsciiString.cached("if-match");
+    public static final AsciiString TIMING_ALLOW_ORIGIN = create("Timing-Allow-Origin");
     /**
-     * {@code "if-modified-since"}.
+     * The HTTP {@code "Trailer"} header field name.
      */
-    public static final AsciiString IF_MODIFIED_SINCE = AsciiString.cached("if-modified-since");
+    public static final AsciiString TRAILER = create("Trailer");
     /**
-     * {@code "if-none-match"}.
+     * The HTTP {@code "Transfer-Encoding"} header field name.
      */
-    public static final AsciiString IF_NONE_MATCH = AsciiString.cached("if-none-match");
+    public static final AsciiString TRANSFER_ENCODING = create("Transfer-Encoding");
     /**
-     * {@code "if-range"}.
+     * The HTTP {@code "Vary"} header field name.
      */
-    public static final AsciiString IF_RANGE = AsciiString.cached("if-range");
+    public static final AsciiString VARY = create("Vary");
     /**
-     * {@code "if-unmodified-since"}.
+     * The HTTP {@code "WWW-Authenticate"} header field name.
      */
-    public static final AsciiString IF_UNMODIFIED_SINCE = AsciiString.cached("if-unmodified-since");
+    public static final AsciiString WWW_AUTHENTICATE = create("WWW-Authenticate");
+
+    // Common, non-standard HTTP header fields
+
     /**
-     * {@code "keep-alive"}.
+     * The HTTP {@code "DNT"} header field name.
+     */
+    public static final AsciiString DNT = create("DNT");
+    /**
+     * The HTTP {@code "X-Content-Type-Options"} header field name.
+     */
+    public static final AsciiString X_CONTENT_TYPE_OPTIONS = create("X-Content-Type-Options");
+    /**
+     * The HTTP {@code "X-Do-Not-Track"} header field name.
+     */
+    public static final AsciiString X_DO_NOT_TRACK = create("X-Do-Not-Track");
+    /**
+     * The HTTP {@code "X-Forwarded-For"} header field name (superseded by {@code "Forwarded"}).
+     */
+    public static final AsciiString X_FORWARDED_FOR = create("X-Forwarded-For");
+    /**
+     * The HTTP {@code "X-Forwarded-Proto"} header field name.
+     */
+    public static final AsciiString X_FORWARDED_PROTO = create("X-Forwarded-Proto");
+    /**
+     * The HTTP <a href="https://goo.gl/lQirAH">{@code "X-Forwarded-Host"}</a> header field name.
+     */
+    public static final AsciiString X_FORWARDED_HOST = create("X-Forwarded-Host");
+    /**
+     * The HTTP <a href="https://goo.gl/YtV2at">{@code "X-Forwarded-Port"}</a> header field name.
+     */
+    public static final AsciiString X_FORWARDED_PORT = create("X-Forwarded-Port");
+    /**
+     * The HTTP {@code "X-Frame-Options"} header field name.
+     */
+    public static final AsciiString X_FRAME_OPTIONS = create("X-Frame-Options");
+    /**
+     * The HTTP {@code "X-Powered-By"} header field name.
+     */
+    public static final AsciiString X_POWERED_BY = create("X-Powered-By");
+    /**
+     * The HTTP <a href="https://tools.ietf.org/html/rfc7469">{@code
+     * Public-Key-Pins}</a> header field name.
+     */
+    public static final AsciiString PUBLIC_KEY_PINS = create("Public-Key-Pins");
+    /**
+     * The HTTP <a href="https://tools.ietf.org/html/rfc7469">{@code
+     * Public-Key-Pins-Report-Only}</a> header field name.
+     */
+    public static final AsciiString PUBLIC_KEY_PINS_REPORT_ONLY = create("Public-Key-Pins-Report-Only");
+    /**
+     * The HTTP {@code "X-Requested-With"} header field name.
+     */
+    public static final AsciiString X_REQUESTED_WITH = create("X-Requested-With");
+    /**
+     * The HTTP {@code "X-User-IP"} header field name.
+     */
+    public static final AsciiString X_USER_IP = create("X-User-IP");
+    /**
+     * The HTTP <a href="https://goo.gl/VKpXxa">{@code "X-Download-Options"}</a> header field name.
      *
-     * @deprecated Use {@link #CONNECTION}.
+     * <p>When the new X-Download-Options header is present with the value {@code "noopen"}, the user is
+     * prevented from opening a file download directly; instead, they must first save the file
+     * locally.
      */
-    @Deprecated
-    public static final AsciiString KEEP_ALIVE = AsciiString.cached("keep-alive");
+    public static final AsciiString X_DOWNLOAD_OPTIONS = create("X-Download-Options");
     /**
-     * {@code "last-event-id"}.
+     * The HTTP {@code "X-XSS-Protection"} header field name.
      */
-    public static final AsciiString LAST_EVENT_ID = AsciiString.cached("last-event-id");
+    public static final AsciiString X_XSS_PROTECTION = create("X-XSS-Protection");
     /**
-     * {@code "last-modified"}.
+     * The HTTP <a
+     * href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-DNS-Prefetch-Control">{@code
+     * X-DNS-Prefetch-Control}</a> header controls DNS prefetch behavior. Value can be "on" or "off".
+     * By default, DNS prefetching is "on" for HTTP pages and "off" for HTTPS pages.
      */
-    public static final AsciiString LAST_MODIFIED = AsciiString.cached("last-modified");
+    public static final AsciiString X_DNS_PREFETCH_CONTROL = create("X-DNS-Prefetch-Control");
     /**
-     * {@code "link"}.
+     * The HTTP <a href="https://html.spec.whatwg.org/multipage/semantics.html#hyperlink-auditing">
+     * {@code "Ping-From"}</a> header field name.
      */
-    public static final AsciiString LINK = AsciiString.cached("link");
+    public static final AsciiString PING_FROM = create("Ping-From");
     /**
-     * {@code "location"}.
+     * The HTTP <a href="https://html.spec.whatwg.org/multipage/semantics.html#hyperlink-auditing">
+     * {@code "Ping-To"}</a> header field name.
      */
-    public static final AsciiString LOCATION = AsciiString.cached("location");
+    public static final AsciiString PING_TO = create("Ping-To");
     /**
-     * {@code "max-forwards"}.
+     * The HTTP <a href="https://tools.ietf.org/html/rfc8473">{@code
+     * Sec-Token-Binding}</a> header field name.
      */
-    public static final AsciiString MAX_FORWARDS = AsciiString.cached("max-forwards");
+    public static final AsciiString SEC_TOKEN_BINDING = create("Sec-Token-Binding");
     /**
-     * {@code "origin"}.
+     * The HTTP <a href="https://tools.ietf.org/html/draft-ietf-tokbind-ttrp">{@code
+     * Sec-Provided-Token-Binding-ID}</a> header field name.
      */
-    public static final AsciiString ORIGIN = AsciiString.cached("origin");
+    public static final AsciiString SEC_PROVIDED_TOKEN_BINDING_ID = create("Sec-Provided-Token-Binding-ID");
     /**
-     * {@code "pragma"}.
+     * The HTTP <a href="https://tools.ietf.org/html/draft-ietf-tokbind-ttrp">{@code
+     * Sec-Referred-Token-Binding-ID}</a> header field name.
      */
-    public static final AsciiString PRAGMA = AsciiString.cached("pragma");
-    /**
-     * {@code "prefer"}.
-     */
-    public static final AsciiString PREFER = AsciiString.cached("prefer");
-    /**
-     * {@code "proxy-authenticate"}.
-     */
-    public static final AsciiString PROXY_AUTHENTICATE = AsciiString.cached("proxy-authenticate");
-    /**
-     * {@code "proxy-authorization"}.
-     */
-    public static final AsciiString PROXY_AUTHORIZATION = AsciiString.cached("proxy-authorization");
-    /**
-     * {@code "proxy-connection"}.
-     *
-     * @deprecated Use {@link #CONNECTION}.
-     */
-    @Deprecated
-    public static final AsciiString PROXY_CONNECTION = AsciiString.cached("proxy-connection");
-    /**
-     * {@code "range"}.
-     */
-    public static final AsciiString RANGE = AsciiString.cached("range");
-    /**
-     * {@code "referer"}.
-     */
-    public static final AsciiString REFERER = AsciiString.cached("referer");
-    /**
-     * {@code "retry-after"}.
-     */
-    public static final AsciiString RETRY_AFTER = AsciiString.cached("retry-after");
-    /**
-     * {@code "sec-websocket-key1"}.
-     */
-    public static final AsciiString SEC_WEBSOCKET_KEY1 = AsciiString.cached("sec-websocket-key1");
-    /**
-     * {@code "sec-websocket-key2"}.
-     */
-    public static final AsciiString SEC_WEBSOCKET_KEY2 = AsciiString.cached("sec-websocket-key2");
-    /**
-     * {@code "sec-websocket-location"}.
-     */
-    public static final AsciiString SEC_WEBSOCKET_LOCATION = AsciiString.cached("sec-websocket-location");
-    /**
-     * {@code "sec-websocket-origin"}.
-     */
-    public static final AsciiString SEC_WEBSOCKET_ORIGIN = AsciiString.cached("sec-websocket-origin");
-    /**
-     * {@code "sec-websocket-protocol"}.
-     */
-    public static final AsciiString SEC_WEBSOCKET_PROTOCOL = AsciiString.cached("sec-websocket-protocol");
-    /**
-     * {@code "sec-websocket-version"}.
-     */
-    public static final AsciiString SEC_WEBSOCKET_VERSION = AsciiString.cached("sec-websocket-version");
-    /**
-     * {@code "sec-websocket-key"}.
-     */
-    public static final AsciiString SEC_WEBSOCKET_KEY = AsciiString.cached("sec-websocket-key");
-    /**
-     * {@code "sec-websocket-accept"}.
-     */
-    public static final AsciiString SEC_WEBSOCKET_ACCEPT = AsciiString.cached("sec-websocket-accept");
-    /**
-     * {@code "sec-websocket-protocol"}.
-     */
-    public static final AsciiString SEC_WEBSOCKET_EXTENSIONS = AsciiString.cached("sec-websocket-extensions");
-    /**
-     * {@code "server"}.
-     */
-    public static final AsciiString SERVER = AsciiString.cached("server");
-    /**
-     * {@code "set-cookie"}.
-     */
-    public static final AsciiString SET_COOKIE = AsciiString.cached("set-cookie");
-    /**
-     * {@code "set-cookie2"}.
-     */
-    public static final AsciiString SET_COOKIE2 = AsciiString.cached("set-cookie2");
-    /**
-     * {@code "te"}.
-     */
-    public static final AsciiString TE = AsciiString.cached("te");
-    /**
-     * {@code "trailer"}.
-     */
-    public static final AsciiString TRAILER = AsciiString.cached("trailer");
-    /**
-     * {@code "transfer-encoding"}.
-     */
-    public static final AsciiString TRANSFER_ENCODING = AsciiString.cached("transfer-encoding");
-    /**
-     * {@code "upgrade"}.
-     */
-    public static final AsciiString UPGRADE = AsciiString.cached("upgrade");
-    /**
-     * {@code "user-agent"}.
-     */
-    public static final AsciiString USER_AGENT = AsciiString.cached("user-agent");
-    /**
-     * {@code "vary"}.
-     */
-    public static final AsciiString VARY = AsciiString.cached("vary");
-    /**
-     * {@code "via"}.
-     */
-    public static final AsciiString VIA = AsciiString.cached("via");
-    /**
-     * {@code "warning"}.
-     */
-    public static final AsciiString WARNING = AsciiString.cached("warning");
-    /**
-     * {@code "websocket-location"}.
-     */
-    public static final AsciiString WEBSOCKET_LOCATION = AsciiString.cached("websocket-location");
-    /**
-     * {@code "websocket-origin"}.
-     */
-    public static final AsciiString WEBSOCKET_ORIGIN = AsciiString.cached("websocket-origin");
-    /**
-     * {@code "websocket-protocol"}.
-     */
-    public static final AsciiString WEBSOCKET_PROTOCOL = AsciiString.cached("websocket-protocol");
-    /**
-     * {@code "www-authenticate"}.
-     */
-    public static final AsciiString WWW_AUTHENTICATE = AsciiString.cached("www-authenticate");
-    /**
-     * {@code "x-forwarded-for"}.
-     */
-    public static final AsciiString X_FORWARDED_FOR = AsciiString.cached("x-forwarded-for");
-    /**
-     * {@code "x-frame-options"}.
-     */
-    public static final AsciiString X_FRAME_OPTIONS = AsciiString.cached("x-frame-options");
+    public static final AsciiString SEC_REFERRED_TOKEN_BINDING_ID = create("Sec-Referred-Token-Binding-ID");
 
     private static final Map<CharSequence, AsciiString> map;
 
@@ -448,7 +560,7 @@ public final class HttpHeaderNames {
     }
 
     /**
-     * Lower-cases and converts the specified header name into an {@link AsciiString}. If {@code name} is
+     * Lower-cases and converts the specified header name into an {@link AsciiString}. If {@code "name"} is
      * a known header name, this method will return a pre-instantiated {@link AsciiString} to reduce
      * the allocation rate of {@link AsciiString}.
      */
@@ -463,7 +575,7 @@ public final class HttpHeaderNames {
     }
 
     /**
-     * Lower-cases and converts the specified header name into an {@link AsciiString}. If {@code name} is
+     * Lower-cases and converts the specified header name into an {@link AsciiString}. If {@code "name"} is
      * a known header name, this method will return a pre-instantiated {@link AsciiString} to reduce
      * the allocation rate of {@link AsciiString}.
      */
@@ -471,6 +583,10 @@ public final class HttpHeaderNames {
         final AsciiString lowerCased = name.toLowerCase();
         final AsciiString cached = map.get(lowerCased);
         return cached != null ? cached : lowerCased;
+    }
+
+    private static AsciiString create(String name) {
+        return AsciiString.cached(Ascii.toLowerCase(name));
     }
 
     private HttpHeaderNames() {}

--- a/core/src/main/java/com/linecorp/armeria/common/HttpMethod.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpMethod.java
@@ -37,7 +37,7 @@ import static java.util.Objects.requireNonNull;
  */
 public enum HttpMethod {
 
-    // Forked from Netty at 93b144b7b4872ea623a378c75b92d33bea28ab51
+    // Forked from Netty 4.1.34 at ff7484864b1785103cbc62845ff3a392c93822b7
 
     /**
      * The OPTIONS method which represents a request for information about the communication options

--- a/core/src/main/java/com/linecorp/armeria/common/HttpStatusClass.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpStatusClass.java
@@ -37,7 +37,7 @@ import io.netty.util.AsciiString;
  */
 public enum HttpStatusClass {
 
-    // Forked from Netty at 4875a2aad4c82204caedb2d121fb5ef03c09fe44
+    // Forked from Netty 4.1.34 at 4875a2aad4c82204caedb2d121fb5ef03c09fe44
 
     /**
      * The informational class (1xx).

--- a/core/src/main/java/com/linecorp/armeria/common/MediaType.java
+++ b/core/src/main/java/com/linecorp/armeria/common/MediaType.java
@@ -92,7 +92,7 @@ import com.google.common.collect.Multimaps;
 @JsonDeserialize(using = MediaTypeJsonDeserializer.class)
 public final class MediaType {
 
-    // Forked from Guava at 9704538cd9aa8e4b783b824773cfc76290f572c2 (27.0)
+    // Forked from Guava 27.1 at 8e174e76971449665658a800af6dd350806cc934
 
     private static final String CHARSET_ATTRIBUTE = "charset";
     private static final ImmutableListMultimap<String, String> UTF_8_CONSTANT_PARAMETERS =
@@ -188,6 +188,11 @@ public final class MediaType {
     public static final MediaType TSV_UTF_8 = createConstantUtf8(TEXT_TYPE, "tab-separated-values");
 
     public static final MediaType VCARD_UTF_8 = createConstantUtf8(TEXT_TYPE, "vcard");
+
+    /**
+     * UTF-8 encoded <a href="https://en.wikipedia.org/wiki/Wireless_Markup_Language">Wireless Markup
+     * Language</a>.
+     */
     public static final MediaType WML_UTF_8 = createConstantUtf8(TEXT_TYPE, "vnd.wap.wml");
 
     /**
@@ -203,13 +208,16 @@ public final class MediaType {
      */
     public static final MediaType VTT_UTF_8 = createConstantUtf8(TEXT_TYPE, "vtt");
 
-    /* image types */
+    /**
+     * <a href="https://en.wikipedia.org/wiki/BMP_file_format">Bitmap file format</a> ({@code bmp}
+     * files).
+     */
     public static final MediaType BMP = createConstant(IMAGE_TYPE, "bmp");
 
     /**
-     * The media type for the <a href="http://en.wikipedia.org/wiki/Camera_Image_File_Format">Canon
-     * Image File Format</a> ({@code crw} files), a widely-used "raw image" format for cameras. It is
-     * found in {@code /etc/mime.types}, e.g. in <a href=
+     * The <a href="https://en.wikipedia.org/wiki/Camera_Image_File_Format">Canon Image File
+     * Format</a> ({@code crw} files), a widely-used "raw image" format for cameras. It is found in
+     * {@code /etc/mime.types}, e.g. in <a href=
      * "http://anonscm.debian.org/gitweb/?p=collab-maint/mime-support.git;a=blob;f=mime.types;hb=HEAD"
      * >Debian 3.48-1</a>.
      */
@@ -221,7 +229,7 @@ public final class MediaType {
     public static final MediaType PNG = createConstant(IMAGE_TYPE, "png");
 
     /**
-     * The media type for the Photoshop File Format ({@code psd} files) as defined by <a
+     * The Photoshop File Format ({@code psd} files) as defined by <a
      * href="http://www.iana.org/assignments/media-types/image/vnd.adobe.photoshop">IANA</a>, and
      * found in {@code /etc/mime.types}, e.g. <a
      * href="http://svn.apache.org/repos/asf/httpd/httpd/branches/1.3.x/conf/mime.types"></a> of the
@@ -239,6 +247,10 @@ public final class MediaType {
 
     public static final MediaType SVG_UTF_8 = createConstantUtf8(IMAGE_TYPE, "svg+xml");
     public static final MediaType TIFF = createConstant(IMAGE_TYPE, "tiff");
+
+    /**
+     * <a href="https://en.wikipedia.org/wiki/WebP">WebP image format</a>.
+     */
     public static final MediaType WEBP = createConstant(IMAGE_TYPE, "webp");
 
     /* audio types */
@@ -248,58 +260,54 @@ public final class MediaType {
     public static final MediaType WEBM_AUDIO = createConstant(AUDIO_TYPE, "webm");
 
     /**
-     * Media type for L16 audio, as defined by <a href="https://tools.ietf.org/html/rfc2586">RFC
-     * 2586</a>.
+     * L16 audio, as defined by <a href="https://tools.ietf.org/html/rfc2586">RFC 2586</a>.
      */
     public static final MediaType L16_AUDIO = createConstant(AUDIO_TYPE, "l16");
 
     /**
-     * Media type for L24 audio, as defined by <a href="https://tools.ietf.org/html/rfc3190">RFC
-     * 3190</a>.
+     * L24 audio, as defined by <a href="https://tools.ietf.org/html/rfc3190">RFC 3190</a>.
      */
     public static final MediaType L24_AUDIO = createConstant(AUDIO_TYPE, "l24");
 
     /**
-     * Media type for Basic Audio, as defined by <a
-     * href="http://tools.ietf.org/html/rfc2046#section-4.3">RFC 2046</a>.
+     * Basic Audio, as defined by <a href="http://tools.ietf.org/html/rfc2046#section-4.3">RFC
+     * 2046</a>.
      */
     public static final MediaType BASIC_AUDIO = createConstant(AUDIO_TYPE, "basic");
 
     /**
-     * Media type for Advanced Audio Coding. For more information, see <a
+     * Advanced Audio Coding. For more information, see <a
      * href="https://en.wikipedia.org/wiki/Advanced_Audio_Coding">Advanced Audio Coding</a>.
      */
     public static final MediaType AAC_AUDIO = createConstant(AUDIO_TYPE, "aac");
 
     /**
-     * Media type for Vorbis Audio, as defined by <a href="http://tools.ietf.org/html/rfc5215">RFC
-     * 5215</a>.
+     * Vorbis Audio, as defined by <a href="http://tools.ietf.org/html/rfc5215">RFC 5215</a>.
      */
     public static final MediaType VORBIS_AUDIO = createConstant(AUDIO_TYPE, "vorbis");
 
     /**
-     * Media type for Windows Media Audio. For more information, see <a
+     * Windows Media Audio. For more information, see <a
      * href="https://msdn.microsoft.com/en-us/library/windows/desktop/dd562994(v=vs.85).aspx">file
      * name extensions for Windows Media metafiles</a>.
      */
     public static final MediaType WMA_AUDIO = createConstant(AUDIO_TYPE, "x-ms-wma");
 
     /**
-     * Media type for Windows Media metafiles. For more information, see <a
+     * Windows Media metafiles. For more information, see <a
      * href="https://msdn.microsoft.com/en-us/library/windows/desktop/dd562994(v=vs.85).aspx">file
      * name extensions for Windows Media metafiles</a>.
      */
     public static final MediaType WAX_AUDIO = createConstant(AUDIO_TYPE, "x-ms-wax");
 
     /**
-     * Media type for Real Audio. For more information, see <a
+     * Real Audio. For more information, see <a
      * href="http://service.real.com/help/faq/rp8/configrp8win.html">this link</a>.
      */
     public static final MediaType VND_REAL_AUDIO = createConstant(AUDIO_TYPE, "vnd.rn-realaudio");
 
     /**
-     * Media type for WAVE format, as defined by <a href="https://tools.ietf.org/html/rfc2361">RFC
-     * 2361</a>.
+     * WAVE format, as defined by <a href="https://tools.ietf.org/html/rfc2361">RFC 2361</a>.
      */
     public static final MediaType VND_WAVE_AUDIO = createConstant(AUDIO_TYPE, "vnd.wave");
 
@@ -312,21 +320,21 @@ public final class MediaType {
     public static final MediaType WMV = createConstant(VIDEO_TYPE, "x-ms-wmv");
 
     /**
-     * Media type for Flash video. For more information, see <a href=
+     * Flash video. For more information, see <a href=
      * "http://help.adobe.com/en_US/ActionScript/3.0_ProgrammingAS3/WS5b3ccc516d4fbf351e63e3d118a9b90204-7d48.html"
      * >this link</a>.
      */
     public static final MediaType FLV_VIDEO = createConstant(VIDEO_TYPE, "x-flv");
 
     /**
-     * Media type for the 3GP multimedia container format. For more information, see <a
+     * The 3GP multimedia container format. For more information, see <a
      * href="ftp://www.3gpp.org/tsg_sa/TSG_SA/TSGS_23/Docs/PDF/SP-040065.pdf#page=10">3GPP TS
      * 26.244</a>.
      */
     public static final MediaType THREE_GPP_VIDEO = createConstant(VIDEO_TYPE, "3gpp");
 
     /**
-     * Media type for the 3G2 multimedia container format. For more information, see <a
+     * The 3G2 multimedia container format. For more information, see <a
      * href="http://www.3gpp2.org/Public_html/specs/C.S0050-B_v1.0_070521.pdf#page=16">3GPP2
      * C.S0050-B</a>.
      */
@@ -344,20 +352,19 @@ public final class MediaType {
     public static final MediaType BZIP2 = createConstant(APPLICATION_TYPE, "x-bzip2");
 
     /**
-     * Media type for <a href="https://www.dartlang.org/articles/embedding-in-html/">dart files</a>.
+     * Files in the <a href="https://www.dartlang.org/articles/embedding-in-html/">dart</a>.
      */
     public static final MediaType DART_UTF_8 = createConstantUtf8(APPLICATION_TYPE, "dart");
 
     /**
-     * Media type for <a href="https://goo.gl/2QoMvg">Apple Passbook</a>.
+     * <a href="https://goo.gl/2QoMvg">Apple Passbook</a>.
      */
     public static final MediaType APPLE_PASSBOOK =
             createConstant(APPLICATION_TYPE, "vnd.apple.pkpass");
 
     /**
-     * Media type for <a href="http://en.wikipedia.org/wiki/Embedded_OpenType">Embedded OpenType</a>
-     * fonts. This is <a
-     * href="http://www.iana.org/assignments/media-types/application/vnd.ms-fontobject">registered
+     * <a href="http://en.wikipedia.org/wiki/Embedded_OpenType">Embedded OpenType</a> fonts. This is
+     * <a href="http://www.iana.org/assignments/media-types/application/vnd.ms-fontobject">registered
      * </a> with the IANA.
      */
     public static final MediaType EOT = createConstant(APPLICATION_TYPE, "vnd.ms-fontobject");
@@ -394,8 +401,8 @@ public final class MediaType {
     public static final MediaType GZIP = createConstant(APPLICATION_TYPE, "x-gzip");
 
     /**
-     * Media type for the <a href="https://tools.ietf.org/html/draft-kelly-json-hal-08#section-3">JSON
-     * Hypertext Application Language (HAL) documents</a>.
+     * <a href="https://tools.ietf.org/html/draft-kelly-json-hal-08#section-3">JSON Hypertext
+     * Application Language (HAL) documents</a>.
      */
     public static final MediaType HAL_JSON = createConstant(APPLICATION_TYPE, "hal+json");
 
@@ -406,6 +413,18 @@ public final class MediaType {
      */
     public static final MediaType JAVASCRIPT_UTF_8 =
             createConstantUtf8(APPLICATION_TYPE, "javascript");
+
+    /**
+     * For <a href="https://tools.ietf.org/html/rfc7515">JWS or JWE objects using the Compact
+     * Serialization</a>.
+     */
+    public static final MediaType JOSE = createConstant(APPLICATION_TYPE, "jose");
+
+    /**
+     * For <a href="https://tools.ietf.org/html/rfc7515">JWS or JWE objects using the JSON
+     * Serialization</a>.
+     */
+    public static final MediaType JOSE_JSON = createConstant(APPLICATION_TYPE, "jose+json");
 
     public static final MediaType JSON_UTF_8 = createConstantUtf8(APPLICATION_TYPE, "json");
     public static final MediaType JSON = createConstant(APPLICATION_TYPE, "json");
@@ -424,56 +443,64 @@ public final class MediaType {
     public static final MediaType JSON_SEQ = createConstant(APPLICATION_TYPE, "json-seq");
 
     /**
-     * Media type for the <a href="http://www.w3.org/TR/appmanifest/">Manifest for a web
-     * application</a>.
+     * The <a href="http://www.w3.org/TR/appmanifest/">Manifest for a web application</a>.
      */
     public static final MediaType MANIFEST_JSON_UTF_8 =
             createConstantUtf8(APPLICATION_TYPE, "manifest+json");
 
     /**
-     * Media type for <a href="http://www.opengeospatial.org/standards/kml/">OGC KML (Keyhole Markup
-     * Language)</a>.
+     * <a href="http://www.opengeospatial.org/standards/kml/">OGC KML (Keyhole Markup Language)</a>.
      */
     public static final MediaType KML = createConstant(APPLICATION_TYPE, "vnd.google-earth.kml+xml");
 
     /**
-     * Media type for <a href="http://www.opengeospatial.org/standards/kml/">OGC KML (Keyhole Markup
-     * Language)</a>, compressed using the ZIP format into KMZ archives.
+     * <a href="http://www.opengeospatial.org/standards/kml/">OGC KML (Keyhole Markup Language)</a>,
+     * compressed using the ZIP format into KMZ archives.
      */
     public static final MediaType KMZ = createConstant(APPLICATION_TYPE, "vnd.google-earth.kmz");
 
     /**
-     * Media type for the <a href="https://tools.ietf.org/html/rfc4155">mbox database format</a>.
+     * The <a href="https://tools.ietf.org/html/rfc4155">mbox database format</a>.
      */
     public static final MediaType MBOX = createConstant(APPLICATION_TYPE, "mbox");
 
     /**
-     * Media type for <a href="http://goo.gl/1pGBFm">Apple over-the-air mobile configuration
-     * profiles</a>.
+     * <a href="http://goo.gl/1pGBFm">Apple over-the-air mobile configuration profiles</a>.
      */
     public static final MediaType APPLE_MOBILE_CONFIG =
             createConstant(APPLICATION_TYPE, "x-apple-aspen-config");
 
+    /** <a href="http://goo.gl/XDQ1h2">Microsoft Excel</a> spreadsheets. */
     public static final MediaType MICROSOFT_EXCEL = createConstant(APPLICATION_TYPE, "vnd.ms-excel");
+
+    /**
+     * <a href="http://goo.gl/XrTEqG">Microsoft Outlook</a> items.
+     */
+    public static final MediaType MICROSOFT_OUTLOOK =
+            createConstant(APPLICATION_TYPE, "vnd.ms-outlook");
+
+    /** <a href="http://goo.gl/XDQ1h2">Microsoft Powerpoint</a> presentations. */
     public static final MediaType MICROSOFT_POWERPOINT =
             createConstant(APPLICATION_TYPE, "vnd.ms-powerpoint");
+
+    /** <a href="http://goo.gl/XDQ1h2">Microsoft Word</a> documents. */
     public static final MediaType MICROSOFT_WORD = createConstant(APPLICATION_TYPE, "msword");
 
     /**
-     * Media type for WASM applications. For more information see <a
-     * href="https://webassembly.org/">the Web Assembly overview</a>.
+     * WASM applications. For more information see <a href="https://webassembly.org/">the Web Assembly
+     * overview</a>.
      */
     public static final MediaType WASM_APPLICATION = createConstant(APPLICATION_TYPE, "wasm");
 
     /**
-     * Media type for NaCl applications. For more information see <a
+     * NaCl applications. For more information see <a
      * href="https://developer.chrome.com/native-client/devguide/coding/application-structure">the
      * Developer Guide for Native Client Application Structure</a>.
      */
     public static final MediaType NACL_APPLICATION = createConstant(APPLICATION_TYPE, "x-nacl");
 
     /**
-     * Media type for NaCl portable applications. For more information see <a
+     * NaCl portable applications. For more information see <a
      * href="https://developer.chrome.com/native-client/devguide/coding/application-structure">the
      * Developer Guide for Native Client Application Structure</a>.
      */
@@ -506,11 +533,17 @@ public final class MediaType {
      */
     public static final MediaType PROTOBUF = createConstant(APPLICATION_TYPE, "protobuf");
 
+    /**
+     * <a href="https://en.wikipedia.org/wiki/RDF/XML">RDF/XML</a> documents, which are XML
+     * serializations of <a
+     * href="https://en.wikipedia.org/wiki/Resource_Description_Framework">Resource Description
+     * Framework</a> graphs.
+     */
     public static final MediaType RDF_XML_UTF_8 = createConstantUtf8(APPLICATION_TYPE, "rdf+xml");
+
     public static final MediaType RTF_UTF_8 = createConstantUtf8(APPLICATION_TYPE, "rtf");
     /**
-     * Media type for SFNT fonts (which includes <a
-     * href="http://en.wikipedia.org/wiki/TrueType/">TrueType</a> and <a
+     * SFNT fonts (which includes <a href="http://en.wikipedia.org/wiki/TrueType/">TrueType</a> and <a
      * href="http://en.wikipedia.org/wiki/OpenType/">OpenType</a> fonts). This is <a
      * href="http://www.iana.org/assignments/media-types/application/font-sfnt">registered</a> with
      * the IANA.
@@ -519,6 +552,11 @@ public final class MediaType {
 
     public static final MediaType SHOCKWAVE_FLASH =
             createConstant(APPLICATION_TYPE, "x-shockwave-flash");
+
+    /**
+     * {@code skp} files produced by the 3D Modeling software <a
+     * href="https://www.sketchup.com/">SketchUp</a>.
+     */
     public static final MediaType SKETCHUP = createConstant(APPLICATION_TYPE, "vnd.sketchup.skp");
     /**
      * As described in <a href="http://www.ietf.org/rfc/rfc3902.txt">RFC 3902</a>, this constant
@@ -532,25 +570,28 @@ public final class MediaType {
     public static final MediaType SOAP_XML_UTF_8 = createConstantUtf8(APPLICATION_TYPE, "soap+xml");
 
     public static final MediaType TAR = createConstant(APPLICATION_TYPE, "x-tar");
+
     /**
-     * Media type for the <a href="http://en.wikipedia.org/wiki/Web_Open_Font_Format">Web Open Font
-     * Format</a> (WOFF) <a href="http://www.w3.org/TR/WOFF/">defined</a> by the W3C. This is <a
+     * <a href="http://en.wikipedia.org/wiki/Web_Open_Font_Format">Web Open Font Format</a> (WOFF) <a
+     * href="http://www.w3.org/TR/WOFF/">defined</a> by the W3C. This is <a
      * href="http://www.iana.org/assignments/media-types/application/font-woff">registered</a> with
      * the IANA.
      */
     public static final MediaType WOFF = createConstant(APPLICATION_TYPE, "font-woff");
+
     /**
-     * Media type for the <a href="http://en.wikipedia.org/wiki/Web_Open_Font_Format">Web Open Font
-     * Format</a> (WOFF) version 2 <a href="https://www.w3.org/TR/WOFF2/">defined</a> by the W3C.
+     * <a href="http://en.wikipedia.org/wiki/Web_Open_Font_Format">Web Open Font Format</a> (WOFF)
+     * version 2 <a href="https://www.w3.org/TR/WOFF2/">defined</a> by the W3C.
      */
     public static final MediaType WOFF2 = createConstant(APPLICATION_TYPE, "font-woff2");
 
     public static final MediaType XHTML_UTF_8 = createConstantUtf8(APPLICATION_TYPE, "xhtml+xml");
+
     /**
-     * Media type for Extensible Resource Descriptors. This is not yet registered with the IANA, but
-     * it is specified by OASIS in the <a
-     * href="http://docs.oasis-open.org/xri/xrd/v1.0/cd02/xrd-1.0-cd02.html">XRD definition</a> and
-     * implemented in projects such as <a href="http://code.google.com/p/webfinger/">WebFinger</a>.
+     * Extensible Resource Descriptors. This is not yet registered with the IANA, but it is specified
+     * by OASIS in the <a href="http://docs.oasis-open.org/xri/xrd/v1.0/cd02/xrd-1.0-cd02.html">XRD
+     * definition</a> and implemented in projects such as <a
+     * href="http://code.google.com/p/webfinger/">WebFinger</a>.
      */
     public static final MediaType XRD_UTF_8 = createConstantUtf8(APPLICATION_TYPE, "xrd+xml");
 

--- a/core/src/main/java/com/linecorp/armeria/common/StringValueConverter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/StringValueConverter.java
@@ -44,8 +44,8 @@ import io.netty.handler.codec.ValueConverter;
  */
 final class StringValueConverter implements ValueConverter<String> {
 
-    // Forked from Netty at f755e584638e20a4ae62466dd4b7a14954650348 (CharSequenceConverter) and
-    // 942b993f2b9781ff2126ff92a6be5b975dfc72ed (DefaultHttpHeaders.HeaderValueConverter)
+    // Forked from Netty 4.1.34 at 1611acf4cee4481b89a2cf024ccf821de2dbf13c (CharSequenceValueConverter) and
+    // 4c64c98f348131e0792ba4a92ce3d0003237d56a (DefaultHttpHeaders.HeaderValueConverter)
 
     static final StringValueConverter INSTANCE = new StringValueConverter();
 
@@ -119,7 +119,10 @@ final class StringValueConverter implements ValueConverter<String> {
 
     @Override
     public byte convertToByte(String value) {
-        return (byte) value.charAt(0);
+        if (!value.isEmpty()) {
+            return (byte) value.charAt(0);
+        }
+        return Byte.parseByte(value);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/util/Version.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/Version.java
@@ -61,7 +61,7 @@ import com.google.common.io.Closeables;
  */
 public final class Version {
 
-    // Forked from Netty at d0912f27091e4548466df81f545c017a25c9d256
+    // Forked from Netty 4.1.34 at d0912f27091e4548466df81f545c017a25c9d256
 
     private static final String PROP_RESOURCE_PATH = "META-INF/com.linecorp.armeria.versions.properties";
 

--- a/core/src/main/java/com/linecorp/armeria/internal/ArmeriaHttpUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/ArmeriaHttpUtil.java
@@ -94,7 +94,7 @@ import io.netty.util.internal.StringUtil;
  */
 public final class ArmeriaHttpUtil {
 
-    // Forked from Netty at 7d213240ca768d6dd35ef2336b1fda757bd4df3c
+    // Forked from Netty 4.1.34 at 4921f62c8ab8205fd222439dcd1811760b05daf1
 
     /**
      * The default case-insensitive {@link AsciiString} hasher and comparator for HTTP/2 headers.
@@ -118,6 +118,16 @@ public final class ArmeriaHttpUtil {
      */
     public static final Charset HTTP_DEFAULT_CONTENT_CHARSET = StandardCharsets.ISO_8859_1;
 
+    /**
+     * The old {@code "keep-alive"} header which has been superceded by {@code "connection"}.
+     */
+    public static final AsciiString HEADER_NAME_KEEP_ALIVE = AsciiString.cached("keep-alive");
+
+    /**
+     * The old {@code "proxy-connection"} header which has been superceded by {@code "connection"}.
+     */
+    public static final AsciiString HEADER_NAME_PROXY_CONNECTION = AsciiString.cached("proxy-connection");
+
     private static final URI ROOT = URI.create("/");
 
     /**
@@ -137,12 +147,8 @@ public final class ArmeriaHttpUtil {
 
     static {
         HTTP_TO_HTTP2_HEADER_BLACKLIST.add(HttpHeaderNames.CONNECTION, EMPTY_STRING);
-        @SuppressWarnings("deprecation")
-        final AsciiString keepAlive = HttpHeaderNames.KEEP_ALIVE;
-        HTTP_TO_HTTP2_HEADER_BLACKLIST.add(keepAlive, EMPTY_STRING);
-        @SuppressWarnings("deprecation")
-        final AsciiString proxyConnection = HttpHeaderNames.PROXY_CONNECTION;
-        HTTP_TO_HTTP2_HEADER_BLACKLIST.add(proxyConnection, EMPTY_STRING);
+        HTTP_TO_HTTP2_HEADER_BLACKLIST.add(HEADER_NAME_KEEP_ALIVE, EMPTY_STRING);
+        HTTP_TO_HTTP2_HEADER_BLACKLIST.add(HEADER_NAME_PROXY_CONNECTION, EMPTY_STRING);
         HTTP_TO_HTTP2_HEADER_BLACKLIST.add(HttpHeaderNames.TRANSFER_ENCODING, EMPTY_STRING);
         HTTP_TO_HTTP2_HEADER_BLACKLIST.add(HttpHeaderNames.HOST, EMPTY_STRING);
         HTTP_TO_HTTP2_HEADER_BLACKLIST.add(HttpHeaderNames.UPGRADE, EMPTY_STRING);

--- a/core/src/main/java/com/linecorp/armeria/internal/DefaultAttributeMap.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/DefaultAttributeMap.java
@@ -59,7 +59,7 @@ import io.netty.util.AttributeMap;
  */
 public class DefaultAttributeMap implements AttributeMap {
 
-    // Forked from Netty at d0912f27091e4548466df81f545c017a25c9d256
+    // Forked from Netty 4.1.34 at 506f0d8f8c10e1b24924f7d992a726d7bdd2e486
 
     @SuppressWarnings("rawtypes")
     private static final AtomicReferenceFieldUpdater<DefaultAttributeMap, AtomicReferenceArray> updater =

--- a/core/src/main/java/com/linecorp/armeria/internal/Http1ClientCodec.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/Http1ClientCodec.java
@@ -71,7 +71,7 @@ import io.netty.util.ReferenceCountUtil;
 public class Http1ClientCodec extends CombinedChannelDuplexHandler<HttpResponseDecoder, HttpRequestEncoder>
         implements HttpClientUpgradeHandler.SourceCodec {
 
-    // Forked from Netty at e0bbff74f7097f000472785982ad86c0ce891567
+    // Forked from Netty 4.1.34 at e0bbff74f7097f000472785982ad86c0ce891567
     // - Made the class non-final so that we can intercept the close() request.
     // - Handle 1xx responses correctly, not just 100 and 101.
 

--- a/core/src/main/java/com/linecorp/armeria/internal/logging/CountingSampler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/logging/CountingSampler.java
@@ -33,12 +33,10 @@ import java.util.BitSet;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import com.google.common.math.IntMath;
-
 /**
  * This sampler is appropriate for low-traffic instrumentation (ex servers that each receive <100K
- * requests), or those who do not provision random trace ids. It not appropriate for collectors as
- * the sampling decision isn't idempotent (consistent based on trace id).
+ * requests), or those who do not provision random trace ids. It is not appropriate for collectors
+ * as the sampling decision isn't idempotent (consistent based on trace id).
  *
  * <h3>Implementation</h3>
  *
@@ -46,34 +44,79 @@ import com.google.common.math.IntMath;
  * that it is accurate in units of 100 traces. At runtime, this loops through the bitset, returning
  * the value according to a counter.
  *
- * <p>Forked from brave-core.
+ * <p>Forked from brave-core 5.6.3 at d4cbd86e1df75687339da6ec2964d42ab3a8cf14
  */
 final class CountingSampler extends Sampler {
-    private final BitSet sampleDecisions;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param rate 0 means never sample, 1 means always sample. Otherwise minimum sample rate is 0.01,
+     *             or 1% of traces
+     */
+    public static Sampler create(final float rate) {
+        if (rate == 0) {
+            return NEVER_SAMPLE;
+        }
+        if (rate == 1.0) {
+            return ALWAYS_SAMPLE;
+        }
+        if (rate < 0.01f || rate > 1) {
+            throw new IllegalArgumentException("rate should be between 0.01 and 1: was " + rate);
+        }
+        return new CountingSampler(rate);
+    }
+
     private final AtomicInteger counter;
+    private final BitSet sampleDecisions;
 
     /** Fills a bitset with decisions according to the supplied rate. */
     CountingSampler(float rate) {
-        counter = new AtomicInteger();
-
-        final int outOf100 = (int) (rate * 100.0f);
-        sampleDecisions = randomBitSet(100, outOf100, new Random());
+        this(rate, new Random());
     }
 
     /**
-     * Reservoir sampling algorithm borrowed from Stack Overflow.
-     * https://stackoverflow.com/questions/12817946/generate-a-random-bitset-with-n-1s
+     * Fills a bitset with decisions according to the supplied rate with the supplied {@link Random}.
      */
-    private static BitSet randomBitSet(int size, int cardinality, Random rnd) {
-        final BitSet result = new BitSet(size);
-        final int[] chosen = new int[cardinality];
+    CountingSampler(float rate, Random random) {
+        counter = new AtomicInteger();
+        int outOf100 = (int) (rate * 100.0f);
+        this.sampleDecisions = randomBitSet(100, outOf100, random);
+    }
+
+    /** loops over the pre-canned decisions, resetting to zero when it gets to the end. */
+    @Override
+    public boolean isSampled() {
+        return sampleDecisions.get(mod(counter.getAndIncrement(), 100));
+    }
+
+    @Override
+    public String toString() {
+        return "CountingSampler()";
+    }
+
+    /**
+     * Returns a non-negative mod.
+     */
+    static int mod(int dividend, int divisor) {
+        int result = dividend % divisor;
+        return result >= 0 ? result : divisor + result;
+    }
+
+    /**
+     * Reservoir sampling algorithm borrowed from <a href=
+     * "http://stackoverflow.com/questions/12817946/generate-a-random-bitset-with-n-1s">Stack Overflow</a>.
+     */
+    static BitSet randomBitSet(int size, int cardinality, Random rnd) {
+        BitSet result = new BitSet(size);
+        int[] chosen = new int[cardinality];
         int i;
         for (i = 0; i < cardinality; ++i) {
             chosen[i] = i;
             result.set(i);
         }
         for (; i < size; ++i) {
-            final int j = rnd.nextInt(i + 1);
+            int j = rnd.nextInt(i + 1);
             if (j < cardinality) {
                 result.clear(chosen[j]);
                 result.set(i);
@@ -81,14 +124,5 @@ final class CountingSampler extends Sampler {
             }
         }
         return result;
-    }
-
-    /**
-     * Returns true if the trace ID should be measured.
-     * Loops over the pre-canned decisions, resetting to zero when it gets to the end.
-     */
-    @Override
-    public boolean isSampled() {
-        return sampleDecisions.get(IntMath.mod(counter.getAndIncrement(), 100));
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/internal/logging/Sampler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/logging/Sampler.java
@@ -29,50 +29,46 @@
  */
 package com.linecorp.armeria.internal.logging;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 /**
  * Sampler is responsible for deciding if a particular trace should be "sampled", i.e. whether the
  * overhead of tracing will occur and/or if a trace will be reported to the collection tier.
  *
  * <p>Zipkin v1 uses before-the-fact sampling. This means that the decision to keep or drop the
  * trace is made before any work is measured, or annotations are added. As such, the input parameter
- * to zipkin v1 samplers is the trace ID (64-bit random number).
+ * to zipkin v1 samplers is the trace ID (lower 64-bits under the assumption all bits are random).
  *
  * <p>The instrumentation sampling decision happens once, at the root of the trace, and is
- * propagated downstream. For this reason, the decision needn't be consistent based on trace ID.
+ * propagated downstream. For this reason, the algorithm needn't be consistent based on trace ID.
  *
- * <p>Forked from brave-core.
+ * <p>Forked from brave-core 5.6.3 at 3be55b5cccf881104bdd80c93e97d2575b83952d
  */
 // abstract for factory-method support on Java language level 7
 public abstract class Sampler {
 
-    static final Sampler ALWAYS_SAMPLE = new Sampler() {
+    public static final Sampler ALWAYS_SAMPLE = new Sampler() {
         @Override
         public boolean isSampled() {
             return true;
         }
 
-        @Override
-        public String toString() {
+        @Override public String toString() {
             return "AlwaysSample";
         }
     };
 
-    static final Sampler NEVER_SAMPLE = new Sampler() {
+    public static final Sampler NEVER_SAMPLE = new Sampler() {
         @Override
         public boolean isSampled() {
             return false;
         }
 
-        @Override
-        public String toString() {
+        @Override public String toString() {
             return "NeverSample";
         }
     };
 
     /**
-     *  Returns true if a log should be recorded.
+     *  Returns true if a request should be recorded.
      */
     public abstract boolean isSampled();
 
@@ -82,25 +78,9 @@ public abstract class Sampler {
      * <p>The sampler returned is good for low volumes of traffic (<100K requests), as it is precise.
      * If you have high volumes of traffic, consider {@code BoundarySampler}.
      *
-     * @param rate 0 for no sampling, 1 for full sampling, or in [0.01, 1] for random sampling.
+     * @param rate minimum sample rate is 0.01, or 1% of traces
      */
     public static Sampler create(float rate) {
-        if (rate >= 1.0) {
-            return ALWAYS_SAMPLE;
-        }
-
-        if (rate == 0.0) {
-            return NEVER_SAMPLE;
-        }
-
-        checkArgument(rate >= 0.01f && rate < 1, "rate should be between 0.01 and 1: was %s", rate);
-        return new CountingSampler(rate);
-    }
-
-    /**
-     * Returns a {@link Sampler} for full sampling.
-     */
-    public static Sampler always() {
-        return ALWAYS_SAMPLE;
+        return CountingSampler.create(rate);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/logging/LoggingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/LoggingService.java
@@ -107,7 +107,7 @@ public final class LoggingService<I extends Request, O extends Response> extends
              Function.identity(),
              Function.identity(),
              Function.identity(),
-             Sampler.always());
+             Sampler.ALWAYS_SAMPLE);
     }
 
     /**

--- a/core/src/test/java/com/linecorp/armeria/common/MediaTypeTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/MediaTypeTest.java
@@ -79,7 +79,7 @@ import com.google.common.testing.NullPointerTester;
  */
 public class MediaTypeTest {
 
-    // Forked from Guava at abd0906f6ed288671b75aa6f828a6ba904fe4477 (24.0)
+    // Forked from Guava 27.1 at 7da42d206b81c8fe184f73a9314fd8ffcf565560
 
     @Test // reflection
     public void testParse_useConstants() throws Exception {

--- a/core/src/test/java/com/linecorp/armeria/internal/DefaultAttributeMapTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/DefaultAttributeMapTest.java
@@ -53,7 +53,7 @@ import io.netty.util.AttributeKey;
 
 public class DefaultAttributeMapTest {
 
-    // Forked from Netty at 2993760e9261f046db88a0e8ccf9edf4e9b0acad
+    // Forked from Netty 4.1.34 at 2993760e9261f046db88a0e8ccf9edf4e9b0acad
 
     private DefaultAttributeMap map;
 

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -13,9 +13,9 @@ ch.qos.logback:
 
 com.auth0:
   java-jwt:
-    version: '3.7.0'
+    version: '3.8.0'
     javadocs:
-    - https://static.javadoc.io/com.auth0/java-jwt/3.7.0/
+    - https://static.javadoc.io/com.auth0/java-jwt/3.8.0/
 
 com.fasterxml.jackson.core:
   jackson-annotations:
@@ -51,7 +51,7 @@ com.google.code.findbugs:
 
 com.google.guava:
   guava:
-    version: &GUAVA_VERSION '27.0.1-jre'
+    version: &GUAVA_VERSION '27.1-jre'
     exclusions:
     - com.google.errorprone:error_prone_annotations
     - com.google.j2objc:j2objc-annotations
@@ -167,7 +167,7 @@ io.micrometer:
 
 io.netty:
   netty-common:
-    version: &NETTY_VERSION '4.1.33.Final'
+    version: &NETTY_VERSION '4.1.34.Final'
     javadocs:
     - https://netty.io/4.1/api/
   netty-buffer: { version: *NETTY_VERSION }
@@ -182,7 +182,7 @@ io.netty:
   netty-transport: { version: *NETTY_VERSION }
   netty-transport-native-epoll: { version: *NETTY_VERSION }
   netty-transport-native-unix-common: { version: *NETTY_VERSION }
-  netty-tcnative-boringssl-static: { version: '2.0.20.Final' }
+  netty-tcnative-boringssl-static: { version: '2.0.22.Final' }
 
 io.projectreactor:
   reactor-core:
@@ -205,9 +205,9 @@ io.reactivex.rxjava2:
 
 io.zipkin.brave:
   brave:
-    version: '5.6.1'
+    version: '5.6.3'
     javadocs:
-    - https://static.javadoc.io/io.zipkin.brave/brave/5.6.1/
+    - https://static.javadoc.io/io.zipkin.brave/brave/5.6.3/
 
 it.unimi.dsi:
   fastutil:
@@ -241,7 +241,7 @@ me.champeau.gradle:
   jmh-gradle-plugin: { version: '0.4.8' }
 
 net.javacrumbs.json-unit:
-  json-unit: { version: &JSON_UNIT_VERSION '2.4.0' }
+  json-unit: { version: &JSON_UNIT_VERSION '2.5.0' }
   json-unit-fluent: { version: *JSON_UNIT_VERSION }
 
 net.sf.proguard:
@@ -305,7 +305,7 @@ org.apache.zookeeper:
     - org.slf4j:slf4j-log4j12
 
 org.assertj:
-  assertj-core: { version: '3.12.1' }
+  assertj-core: { version: '3.12.2' }
 
 org.awaitility:
   awaitility: { version: '3.1.6' }
@@ -360,7 +360,7 @@ org.jsoup:
   jsoup: { version: '1.11.3' }
 
 org.mockito:
-  mockito-core: { version: '2.25.0' }
+  mockito-core: { version: '2.25.1' }
 
 org.mortbay.jetty.alpn:
   jetty-alpn-agent: { version: '2.0.9' }

--- a/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/DefaultSslInfo.java
+++ b/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/DefaultSslInfo.java
@@ -49,7 +49,7 @@ import org.springframework.util.Assert;
  */
 final class DefaultSslInfo implements SslInfo {
 
-    // Forked from spring-web-5.0.8.RELEASE
+    // Forked from spring-web-5.1.5.RELEASE at 1e4a3a2370b9ded44a62155aea59c0d81c36149f
 
     @Nullable
     private final String sessionId;
@@ -107,7 +107,7 @@ final class DefaultSslInfo implements SslInfo {
         Certificate[] certificates;
         try {
             certificates = session.getPeerCertificates();
-        } catch (Exception ex) {
+        } catch (Throwable ex) {
             return null;
         }
 


### PR DESCRIPTION
- Dependencies
  - java-jwt 3.7.0 -> 3.8.0
  - Guava 27.0.1 -> 27.1
  - Netty 4.1.33 -> 4.1.34
    - Netty TCNative BoringSSL 2.0.20 -> 2.0.22
  - Brave 5.6.1 -> 5.6.3
  - Build:
    - json-unit 2.4.0 -> 2.5.0
    - AssertJ 3.12.1 -> 3.12.2
    - Mockito 2.25.0 -> 2.25.1
- Forks:
  - Updated `MediaType`
  - Updated `DefaultSslInfo`
  - Updated `StringValueConverter`
  - Updated `Sampler` and `CountingSampler`
  - `HttpHeaderNames` now forks from Guava's `HttpHeaders` instead of
    Netty's `HttpHeaderNames` because it has more recent HTTP headers
    which may be useful to service authors.
    - (Breaking) Some header names were removed, although it is very
      unlikely to be used by users:
      - `Keep-Alive`
      - `Proxy-Connection`
      - `Content-Transfer-Encoding`
    - `ClientOptions` now prohibits `HTTP2-Settings` header as well.