### PR TITLE
Strip a leading slash in an `HttpFile` resource path

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/file/HttpFileBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/HttpFileBuilder.java
@@ -111,6 +111,13 @@ public abstract class HttpFileBuilder extends AbstractHttpFileBuilder<HttpFileBu
     public static HttpFileBuilder ofResource(ClassLoader classLoader, String path) {
         requireNonNull(classLoader, "classLoader");
         requireNonNull(path, "path");
+
+        // Strip the leading slash.
+        if (path.startsWith("/")) {
+            path = path.substring(1);
+        }
+
+        // Retrieve the resource URL.
         final URL url = classLoader.getResource(path);
         if (url == null || url.getPath().endsWith("/")) {
             // Non-existent resource.

--- a/core/src/test/java/com/linecorp/armeria/server/file/HttpFileTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/file/HttpFileTest.java
@@ -50,4 +50,12 @@ public class HttpFileTest {
         assertThat(headers.getAll(HttpHeaderNames.CACHE_CONTROL))
                 .containsExactly(ServerCacheControl.REVALIDATED.asHeaderValue());
     }
+
+    @Test
+    public void leadingSlashInResourcePath() throws Exception {
+        final HttpFile f = HttpFile.ofResource(ClassLoader.getSystemClassLoader(), "/java/lang/Object.class");
+        final HttpFileAttributes attrs = f.readAttributes();
+        assertThat(attrs).isNotNull();
+        assertThat(attrs.length()).isPositive();
+    }
 }


### PR DESCRIPTION
Motivation:

Unlike `ClassPathHttpVfs.get()`, `HttpFile.ofResource()` does not strip
a leading slash in a given path.

Modifications:

- Strip a leading slash in `HttpFileBuilder.ofResource()`

Result:

- Fixes #1650.