### PR TITLE
Add TLS configuration support to spring-autoconfigure

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -88,6 +88,11 @@ This product contains a modified part of Netty, distributed by Netty.io:
   * License: licenses/LICENSE.netty.al20.txt (Apache License v2.0)
   * Homepage: https://netty.io/
 
+This product contains a modified part of Spring Boot, distributed by Pivotal Software, Inc:
+
+  * License: licenses/LICENSE.spring.al20.txt (Apache License v2.0)
+  * Homepage: https://spring.io/
+
 This product contains a modified part of Twitter Commons, distributed by Twitter, Inc:
 
   * License: license/LICENSE.twitter.al20.txt (Apache License v2.0)

--- a/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/internal/spring/ArmeriaConfigurationUtil.java
+++ b/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/internal/spring/ArmeriaConfigurationUtil.java
@@ -379,7 +379,7 @@ public final class ArmeriaConfigurationUtil {
 
             sb.tls(sslBuilder.build());
         } catch (Exception e) {
-            throw new IllegalStateException("Failed to configure TLS: " + e);
+            throw new IllegalStateException("Failed to configure TLS: " + e, e);
         }
     }
 

--- a/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/internal/spring/ArmeriaConfigurationUtil.java
+++ b/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/internal/spring/ArmeriaConfigurationUtil.java
@@ -367,7 +367,7 @@ public final class ArmeriaConfigurationUtil {
 
             final List<String> enabledProtocols = ssl.getEnabledProtocols();
             if (enabledProtocols != null) {
-                sslBuilder.protocols((String[]) enabledProtocols.toArray());
+                sslBuilder.protocols(enabledProtocols.toArray(new String[enabledProtocols.size()]));
             }
 
             final List<String> ciphers = ssl.getCiphers();

--- a/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/internal/spring/ArmeriaConfigurationUtil.java
+++ b/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/internal/spring/ArmeriaConfigurationUtil.java
@@ -15,13 +15,18 @@
  */
 package com.linecorp.armeria.internal.spring;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
 import static java.util.Objects.requireNonNull;
 
+import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.NetworkInterface;
 import java.net.SocketException;
+import java.net.URL;
 import java.net.UnknownHostException;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Enumeration;
@@ -32,12 +37,16 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.TrustManagerFactory;
 
 import org.apache.thrift.TBase;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.util.ResourceUtils;
 
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.json.MetricsModule;
@@ -68,12 +77,15 @@ import com.linecorp.armeria.spring.ArmeriaSettings;
 import com.linecorp.armeria.spring.ArmeriaSettings.Port;
 import com.linecorp.armeria.spring.HttpServiceRegistrationBean;
 import com.linecorp.armeria.spring.MeterIdPrefixFunctionFactory;
+import com.linecorp.armeria.spring.Ssl;
 import com.linecorp.armeria.spring.ThriftServiceRegistrationBean;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.micrometer.core.instrument.dropwizard.DropwizardMeterRegistry;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.netty.handler.ssl.ClientAuth;
+import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.util.NetUtil;
 import io.prometheus.client.CollectorRegistry;
 
@@ -145,6 +157,10 @@ public final class ArmeriaConfigurationUtil {
                             }
                         });
             }
+        }
+
+        if (settings.getSsl() != null) {
+            configureTls(server, settings.getSsl());
         }
     }
 
@@ -318,6 +334,105 @@ public final class ArmeriaConfigurationUtil {
 
         final CollectorRegistry prometheusRegistry = registry.getPrometheusRegistry();
         server.service(metricsPath, new PrometheusExpositionService(prometheusRegistry));
+    }
+
+    /**
+     * Adds SSL/TLS context to the specified {@link ServerBuilder}.
+     */
+    public static void configureTls(ServerBuilder sb, Ssl ssl) {
+        configureTls(sb, ssl, null, null);
+    }
+
+    /**
+     * Adds SSL/TLS context to the specified {@link ServerBuilder}.
+     */
+    public static void configureTls(ServerBuilder sb, Ssl ssl,
+                                    @Nullable Supplier<KeyStore> keyStoreSupplier,
+                                    @Nullable Supplier<KeyStore> trustStoreSupplier) {
+        try {
+            if (keyStoreSupplier == null && trustStoreSupplier == null &&
+                ssl.getKeyStore() == null && ssl.getTrustStore() == null) {
+                logger.warn("Configuring TLS with a self-signed certificate " +
+                            "because no key or trust store was specified");
+                sb.tlsSelfSigned();
+                return;
+            }
+
+            final SslContextBuilder sslBuilder = SslContextBuilder
+                    .forServer(getKeyManagerFactory(ssl, keyStoreSupplier))
+                    .trustManager(getTrustManagerFactory(ssl, trustStoreSupplier));
+
+            final List<String> enabledProtocols = ssl.getEnabledProtocols();
+            if (enabledProtocols != null) {
+                sslBuilder.protocols((String[]) enabledProtocols.toArray());
+            }
+
+            final List<String> ciphers = ssl.getCiphers();
+            if (ciphers != null) {
+                sslBuilder.ciphers(ImmutableList.copyOf(ciphers));
+            }
+
+            final ClientAuth clientAuth = ssl.getClientAuth();
+            if (clientAuth != null) {
+                sslBuilder.clientAuth(clientAuth);
+            }
+
+            sb.tls(sslBuilder.build());
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to configure TLS: " + e);
+        }
+    }
+
+    private static KeyManagerFactory getKeyManagerFactory(
+            Ssl ssl, @Nullable Supplier<KeyStore> sslStoreProvider) throws Exception {
+        final KeyStore store;
+        if (sslStoreProvider != null) {
+            store = sslStoreProvider.get();
+        } else {
+            store = loadKeyStore(ssl.getKeyStoreType(), ssl.getKeyStore(), ssl.getKeyStorePassword());
+        }
+
+        final KeyManagerFactory keyManagerFactory =
+                KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+
+        String keyPassword = ssl.getKeyPassword();
+        if (keyPassword == null) {
+            keyPassword = ssl.getKeyStorePassword();
+        }
+
+        keyManagerFactory.init(store, keyPassword != null ? keyPassword.toCharArray()
+                                                          : null);
+        return keyManagerFactory;
+    }
+
+    private static TrustManagerFactory getTrustManagerFactory(
+            Ssl ssl, @Nullable Supplier<KeyStore> sslStoreProvider) throws Exception {
+        final KeyStore store;
+        if (sslStoreProvider != null) {
+            store = sslStoreProvider.get();
+        } else {
+            store = loadKeyStore(ssl.getTrustStoreType(), ssl.getTrustStore(), ssl.getTrustStorePassword());
+        }
+
+        final TrustManagerFactory trustManagerFactory =
+                TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        trustManagerFactory.init(store);
+        return trustManagerFactory;
+    }
+
+    @Nullable
+    private static KeyStore loadKeyStore(
+            @Nullable String type,
+            @Nullable String resource,
+            @Nullable String password) throws IOException, GeneralSecurityException {
+        if (resource == null) {
+            return null;
+        }
+        final KeyStore store = KeyStore.getInstance(firstNonNull(type, "JKS"));
+        final URL url = ResourceUtils.getURL(resource);
+        store.load(url.openStream(), password != null ? password.toCharArray()
+                                                      : null);
+        return store;
     }
 
     private ArmeriaConfigurationUtil() {}

--- a/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/internal/spring/ArmeriaConfigurationUtil.java
+++ b/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/internal/spring/ArmeriaConfigurationUtil.java
@@ -349,6 +349,9 @@ public final class ArmeriaConfigurationUtil {
     public static void configureTls(ServerBuilder sb, Ssl ssl,
                                     @Nullable Supplier<KeyStore> keyStoreSupplier,
                                     @Nullable Supplier<KeyStore> trustStoreSupplier) {
+        if (!ssl.isEnabled()) {
+            return;
+        }
         try {
             if (keyStoreSupplier == null && trustStoreSupplier == null &&
                 ssl.getKeyStore() == null && ssl.getTrustStore() == null) {

--- a/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaSettings.java
+++ b/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaSettings.java
@@ -39,8 +39,16 @@ import com.linecorp.armeria.server.metric.MetricCollectingService;
  *     - ip: 127.0.0.1
  *       port: 8081
  *       protocol:HTTP
+ *     - port: 8443
+ *       protocol: HTTPS
+ *   ssl:
+ *   - key-alias: "host.name.com"
+ *     key-store: "keystore.jks"
+ *     key-store-password: "changeme"
+ *     trust-store: "truststore.jks"
+ *     trust-store-password: "changeme"
  * }</pre>
- * TODO(ide) Adds SSL and virtualhost settings
+ * TODO(ide) Adds virtualhost settings
  */
 @ConfigurationProperties(prefix = "armeria")
 @Validated
@@ -195,6 +203,12 @@ public class ArmeriaSettings {
      */
     private boolean enableMetrics = true;
 
+    /**
+     * SSL configuration that the {@link Server} uses.
+     */
+    @Nullable
+    private Ssl ssl;
+
     public List<Port> getPorts() {
         return ports;
     }
@@ -252,5 +266,20 @@ public class ArmeriaSettings {
 
     public void setEnableMetrics(boolean enableMetrics) {
         this.enableMetrics = enableMetrics;
+    }
+
+    /**
+     * Returns the SSL that the {@link Server} uses.
+     */
+    @Nullable
+    public Ssl getSsl() {
+        return ssl;
+    }
+
+    /**
+     * Registers a {@link Ssl} that the {@link Server} uses.
+     */
+    public void setSsl(Ssl ssl) {
+        this.ssl = ssl;
     }
 }

--- a/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaSettings.java
+++ b/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaSettings.java
@@ -42,7 +42,7 @@ import com.linecorp.armeria.server.metric.MetricCollectingService;
  *     - port: 8443
  *       protocol: HTTPS
  *   ssl:
- *   - key-alias: "host.name.com"
+ *     key-alias: "host.name.com"
  *     key-store: "keystore.jks"
  *     key-store-password: "changeme"
  *     trust-store: "truststore.jks"

--- a/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/Ssl.java
+++ b/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/Ssl.java
@@ -71,21 +71,24 @@ public class Ssl {
 
     private String trustStoreProvider;
 
-	/**
-	 * Return whether to enable SSL support.
-	 * @return whether to enable SSL support
-	 */
-	public boolean isEnabled() {
-		return this.enabled;
-	}
-
-	public Ssl setEnabled(boolean enabled) {
-		this.enabled = enabled;
-		return this;
-	}
+    /**
+     * Returns whether to enable SSL support.
+     * @return whether to enable SSL support
+     */
+    public boolean isEnabled() {
+        return this.enabled;
+    }
 
     /**
-     * Return Whether client authentication is not wanted ("none"), wanted ("want") or
+     * Enables (or disables) SSL support.
+     */
+    public Ssl setEnabled(boolean enabled) {
+        this.enabled = enabled;
+        return this;
+    }
+
+    /**
+     * Returns whether client authentication is not wanted ("none"), wanted ("want") or
      * needed ("need"). Requires a trust store.
      * @return the {@link ClientAuth} to use
      */
@@ -93,65 +96,81 @@ public class Ssl {
         return this.clientAuth;
     }
 
+    /**
+     * Sets whether the client authentication is not none ({@link ClientAuth#NONE}), optional
+     * ({@link ClientAuth#OPTIONAL}) or required ({@link ClientAuth#REQUIRE}).
+     */
     public Ssl setClientAuth(ClientAuth clientAuth) {
         this.clientAuth = clientAuth;
         return this;
     }
 
     /**
-     * Return the supported SSL ciphers.
+     * Returns the supported SSL ciphers.
      * @return the supported SSL ciphers
      */
     public List<String> getCiphers() {
         return this.ciphers;
     }
 
+    /**
+     * Sets the supported SSL ciphers.
+     */
     public Ssl setCiphers(List<String> ciphers) {
         this.ciphers = ciphers;
         return this;
     }
 
     /**
-     * Return the enabled SSL protocols.
+     * Returns the enabled SSL protocols.
      * @return the enabled SSL protocols.
      */
     public List<String> getEnabledProtocols() {
         return this.enabledProtocols;
     }
 
+    /**
+     * Sets the enabled SSL protocols.
+     */
     public Ssl setEnabledProtocols(List<String> enabledProtocols) {
         this.enabledProtocols = enabledProtocols;
         return this;
     }
 
     /**
-     * Return the alias that identifies the key in the key store.
+     * Returns the alias that identifies the key in the key store.
      * @return the key alias
      */
     public String getKeyAlias() {
         return this.keyAlias;
     }
 
+    /**
+     * Sets the alias  that identifies the key in the key store.
+     */
     public Ssl setKeyAlias(String keyAlias) {
         this.keyAlias = keyAlias;
         return this;
     }
 
     /**
-     * Return the password used to access the key in the key store.
+     * Returns the password used to access the key in the key store.
      * @return the key password
      */
     public String getKeyPassword() {
         return this.keyPassword;
     }
 
+    /**
+     * Sets the password used to access the key in the key store.
+     */
     public Ssl setKeyPassword(String keyPassword) {
         this.keyPassword = keyPassword;
         return this;
     }
 
     /**
-     * Return the path to the key store that holds the SSL certificate (typically a jks
+     * Returns the path to the key store that holds the SSL certificate (typically a jks
      * file).
      * @return the path to the key store
      */
@@ -159,97 +178,121 @@ public class Ssl {
         return this.keyStore;
     }
 
+    /**
+     * Sets the path to the key store that holds the SSL certificate (typically a jks file).
+     */
     public Ssl setKeyStore(String keyStore) {
         this.keyStore = keyStore;
         return this;
     }
 
     /**
-     * Return the password used to access the key store.
+     * Returns the password used to access the key store.
      * @return the key store password
      */
     public String getKeyStorePassword() {
         return this.keyStorePassword;
     }
 
+    /**
+     * Sets the password used to access the key store.
+     */
     public Ssl setKeyStorePassword(String keyStorePassword) {
         this.keyStorePassword = keyStorePassword;
         return this;
     }
 
     /**
-     * Return the type of the key store.
+     * Returns the type of the key store.
      * @return the key store type
      */
     public String getKeyStoreType() {
         return this.keyStoreType;
     }
 
+    /**
+     * Sets the type of the key store.
+     */
     public Ssl setKeyStoreType(String keyStoreType) {
         this.keyStoreType = keyStoreType;
         return this;
     }
 
     /**
-     * Return the provider for the key store.
+     * Returns the provider for the key store.
      * @return the key store provider
      */
     public String getKeyStoreProvider() {
         return this.keyStoreProvider;
     }
 
+    /**
+     * Sets the provider for the key store.
+     */
     public Ssl setKeyStoreProvider(String keyStoreProvider) {
         this.keyStoreProvider = keyStoreProvider;
         return this;
     }
 
     /**
-     * Return the trust store that holds SSL certificates.
+     * Returns the trust store that holds SSL certificates.
      * @return the trust store
      */
     public String getTrustStore() {
         return this.trustStore;
     }
 
+    /**
+     * Sets the trust store that holds SSL certificates.
+     */
     public Ssl setTrustStore(String trustStore) {
         this.trustStore = trustStore;
         return this;
     }
 
     /**
-     * Return the password used to access the trust store.
+     * Returns the password used to access the trust store.
      * @return the trust store password
      */
     public String getTrustStorePassword() {
         return this.trustStorePassword;
     }
 
+    /**
+     * Sets the password used to access the trust store.
+     */
     public Ssl setTrustStorePassword(String trustStorePassword) {
         this.trustStorePassword = trustStorePassword;
         return this;
     }
 
     /**
-     * Return the type of the trust store.
+     * Returns the type of the trust store.
      * @return the trust store type
      */
     public String getTrustStoreType() {
         return this.trustStoreType;
     }
 
+    /**
+     * Sets the type of the trust store.
+     */
     public Ssl setTrustStoreType(String trustStoreType) {
         this.trustStoreType = trustStoreType;
         return this;
     }
 
     /**
-     * Return the provider for the trust store.
+     * Returns the provider for the trust store.
      * @return the trust store provider
      */
     public String getTrustStoreProvider() {
         return this.trustStoreProvider;
     }
 
+    /**
+     * Sets the provider for the trust store.
+     */
     public Ssl setTrustStoreProvider(String trustStoreProvider) {
         this.trustStoreProvider = trustStoreProvider;
         return this;

--- a/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/Ssl.java
+++ b/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/Ssl.java
@@ -78,8 +78,9 @@ public class Ssl {
         return this.clientAuth;
     }
 
-    public void setClientAuth(ClientAuth clientAuth) {
+    public Ssl setClientAuth(ClientAuth clientAuth) {
         this.clientAuth = clientAuth;
+        return this;
     }
 
     /**
@@ -90,8 +91,9 @@ public class Ssl {
         return this.ciphers;
     }
 
-    public void setCiphers(List<String> ciphers) {
+    public Ssl setCiphers(List<String> ciphers) {
         this.ciphers = ciphers;
+        return this;
     }
 
     /**
@@ -102,8 +104,9 @@ public class Ssl {
         return this.enabledProtocols;
     }
 
-    public void setEnabledProtocols(List<String> enabledProtocols) {
+    public Ssl setEnabledProtocols(List<String> enabledProtocols) {
         this.enabledProtocols = enabledProtocols;
+        return this;
     }
 
     /**
@@ -114,8 +117,9 @@ public class Ssl {
         return this.keyAlias;
     }
 
-    public void setKeyAlias(String keyAlias) {
+    public Ssl setKeyAlias(String keyAlias) {
         this.keyAlias = keyAlias;
+        return this;
     }
 
     /**
@@ -126,8 +130,9 @@ public class Ssl {
         return this.keyPassword;
     }
 
-    public void setKeyPassword(String keyPassword) {
+    public Ssl setKeyPassword(String keyPassword) {
         this.keyPassword = keyPassword;
+        return this;
     }
 
     /**
@@ -139,8 +144,9 @@ public class Ssl {
         return this.keyStore;
     }
 
-    public void setKeyStore(String keyStore) {
+    public Ssl setKeyStore(String keyStore) {
         this.keyStore = keyStore;
+        return this;
     }
 
     /**
@@ -151,8 +157,9 @@ public class Ssl {
         return this.keyStorePassword;
     }
 
-    public void setKeyStorePassword(String keyStorePassword) {
+    public Ssl setKeyStorePassword(String keyStorePassword) {
         this.keyStorePassword = keyStorePassword;
+        return this;
     }
 
     /**
@@ -163,8 +170,9 @@ public class Ssl {
         return this.keyStoreType;
     }
 
-    public void setKeyStoreType(String keyStoreType) {
+    public Ssl setKeyStoreType(String keyStoreType) {
         this.keyStoreType = keyStoreType;
+        return this;
     }
 
     /**
@@ -175,8 +183,9 @@ public class Ssl {
         return this.keyStoreProvider;
     }
 
-    public void setKeyStoreProvider(String keyStoreProvider) {
+    public Ssl setKeyStoreProvider(String keyStoreProvider) {
         this.keyStoreProvider = keyStoreProvider;
+        return this;
     }
 
     /**
@@ -187,8 +196,9 @@ public class Ssl {
         return this.trustStore;
     }
 
-    public void setTrustStore(String trustStore) {
+    public Ssl setTrustStore(String trustStore) {
         this.trustStore = trustStore;
+        return this;
     }
 
     /**
@@ -199,8 +209,9 @@ public class Ssl {
         return this.trustStorePassword;
     }
 
-    public void setTrustStorePassword(String trustStorePassword) {
+    public Ssl setTrustStorePassword(String trustStorePassword) {
         this.trustStorePassword = trustStorePassword;
+        return this;
     }
 
     /**
@@ -211,8 +222,9 @@ public class Ssl {
         return this.trustStoreType;
     }
 
-    public void setTrustStoreType(String trustStoreType) {
+    public Ssl setTrustStoreType(String trustStoreType) {
         this.trustStoreType = trustStoreType;
+        return this;
     }
 
     /**
@@ -223,7 +235,8 @@ public class Ssl {
         return this.trustStoreProvider;
     }
 
-    public void setTrustStoreProvider(String trustStoreProvider) {
+    public Ssl setTrustStoreProvider(String trustStoreProvider) {
         this.trustStoreProvider = trustStoreProvider;
+        return this;
     }
 }

--- a/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/Ssl.java
+++ b/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/Ssl.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linecorp.armeria.spring;
+
+import java.util.List;
+
+import io.netty.handler.ssl.ClientAuth;
+
+/**
+ * Simple server-independent abstraction for SSL configuration.
+ *
+ * @author Andy Wilkinson
+ * @author Vladimir Tsanev
+ * @author Stephane Nicoll
+ */
+public class Ssl {
+    private ClientAuth clientAuth;
+
+    private List<String> ciphers;
+
+    private List<String> enabledProtocols;
+
+    private String keyAlias;
+
+    private String keyPassword;
+
+    private String keyStore;
+
+    private String keyStorePassword;
+
+    private String keyStoreType;
+
+    private String keyStoreProvider;
+
+    private String trustStore;
+
+    private String trustStorePassword;
+
+    private String trustStoreType;
+
+    private String trustStoreProvider;
+
+    /**
+     * Return Whether client authentication is not wanted ("none"), wanted ("want") or
+     * needed ("need"). Requires a trust store.
+     * @return the {@link ClientAuth} to use
+     */
+    public ClientAuth getClientAuth() {
+        return this.clientAuth;
+    }
+
+    public void setClientAuth(ClientAuth clientAuth) {
+        this.clientAuth = clientAuth;
+    }
+
+    /**
+     * Return the supported SSL ciphers.
+     * @return the supported SSL ciphers
+     */
+    public List<String> getCiphers() {
+        return this.ciphers;
+    }
+
+    public void setCiphers(List<String> ciphers) {
+        this.ciphers = ciphers;
+    }
+
+    /**
+     * Return the enabled SSL protocols.
+     * @return the enabled SSL protocols.
+     */
+    public List<String> getEnabledProtocols() {
+        return this.enabledProtocols;
+    }
+
+    public void setEnabledProtocols(List<String> enabledProtocols) {
+        this.enabledProtocols = enabledProtocols;
+    }
+
+    /**
+     * Return the alias that identifies the key in the key store.
+     * @return the key alias
+     */
+    public String getKeyAlias() {
+        return this.keyAlias;
+    }
+
+    public void setKeyAlias(String keyAlias) {
+        this.keyAlias = keyAlias;
+    }
+
+    /**
+     * Return the password used to access the key in the key store.
+     * @return the key password
+     */
+    public String getKeyPassword() {
+        return this.keyPassword;
+    }
+
+    public void setKeyPassword(String keyPassword) {
+        this.keyPassword = keyPassword;
+    }
+
+    /**
+     * Return the path to the key store that holds the SSL certificate (typically a jks
+     * file).
+     * @return the path to the key store
+     */
+    public String getKeyStore() {
+        return this.keyStore;
+    }
+
+    public void setKeyStore(String keyStore) {
+        this.keyStore = keyStore;
+    }
+
+    /**
+     * Return the password used to access the key store.
+     * @return the key store password
+     */
+    public String getKeyStorePassword() {
+        return this.keyStorePassword;
+    }
+
+    public void setKeyStorePassword(String keyStorePassword) {
+        this.keyStorePassword = keyStorePassword;
+    }
+
+    /**
+     * Return the type of the key store.
+     * @return the key store type
+     */
+    public String getKeyStoreType() {
+        return this.keyStoreType;
+    }
+
+    public void setKeyStoreType(String keyStoreType) {
+        this.keyStoreType = keyStoreType;
+    }
+
+    /**
+     * Return the provider for the key store.
+     * @return the key store provider
+     */
+    public String getKeyStoreProvider() {
+        return this.keyStoreProvider;
+    }
+
+    public void setKeyStoreProvider(String keyStoreProvider) {
+        this.keyStoreProvider = keyStoreProvider;
+    }
+
+    /**
+     * Return the trust store that holds SSL certificates.
+     * @return the trust store
+     */
+    public String getTrustStore() {
+        return this.trustStore;
+    }
+
+    public void setTrustStore(String trustStore) {
+        this.trustStore = trustStore;
+    }
+
+    /**
+     * Return the password used to access the trust store.
+     * @return the trust store password
+     */
+    public String getTrustStorePassword() {
+        return this.trustStorePassword;
+    }
+
+    public void setTrustStorePassword(String trustStorePassword) {
+        this.trustStorePassword = trustStorePassword;
+    }
+
+    /**
+     * Return the type of the trust store.
+     * @return the trust store type
+     */
+    public String getTrustStoreType() {
+        return this.trustStoreType;
+    }
+
+    public void setTrustStoreType(String trustStoreType) {
+        this.trustStoreType = trustStoreType;
+    }
+
+    /**
+     * Return the provider for the trust store.
+     * @return the trust store provider
+     */
+    public String getTrustStoreProvider() {
+        return this.trustStoreProvider;
+    }
+
+    public void setTrustStoreProvider(String trustStoreProvider) {
+        this.trustStoreProvider = trustStoreProvider;
+    }
+}

--- a/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/Ssl.java
+++ b/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/Ssl.java
@@ -12,7 +12,8 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations
  * under the License.
- *
+ */
+/*
  * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/Ssl.java
+++ b/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/Ssl.java
@@ -146,7 +146,7 @@ public class Ssl {
     }
 
     /**
-     * Sets the alias  that identifies the key in the key store.
+     * Sets the alias that identifies the key in the key store.
      */
     public Ssl setKeyAlias(String keyAlias) {
         this.keyAlias = keyAlias;

--- a/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/Ssl.java
+++ b/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/Ssl.java
@@ -43,6 +43,8 @@ import io.netty.handler.ssl.ClientAuth;
  * @author Stephane Nicoll
  */
 public class Ssl {
+    private boolean enabled = true;
+
     private ClientAuth clientAuth;
 
     private List<String> ciphers;
@@ -68,6 +70,19 @@ public class Ssl {
     private String trustStoreType;
 
     private String trustStoreProvider;
+
+	/**
+	 * Return whether to enable SSL support.
+	 * @return whether to enable SSL support
+	 */
+	public boolean isEnabled() {
+		return this.enabled;
+	}
+
+	public Ssl setEnabled(boolean enabled) {
+		this.enabled = enabled;
+		return this;
+	}
 
     /**
      * Return Whether client authentication is not wanted ("none"), wanted ("want") or

--- a/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaAutoConfigurationTest.java
+++ b/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaAutoConfigurationTest.java
@@ -34,6 +34,7 @@ import org.junit.runner.RunWith;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -76,17 +77,8 @@ import com.linecorp.armeria.spring.test.thrift.main.HelloService.hello_args;
 public class ArmeriaAutoConfigurationTest {
 
     @SpringBootApplication
+    @Import(ArmeriaOkServiceConfiguration.class)
     public static class TestConfiguration {
-
-        @Bean
-        public HttpServiceRegistrationBean okService() {
-            return new HttpServiceRegistrationBean()
-                    .setServiceName("okService")
-                    .setService(new OkService())
-                    .setPathMapping(PathMapping.ofExact("/ok"))
-                    .setDecorators(ImmutableList.of(LoggingService.newDecorator()));
-        }
-
         @Bean
         public AnnotatedServiceRegistrationBean annotatedService() {
             return new AnnotatedServiceRegistrationBean()
@@ -109,13 +101,6 @@ public class ArmeriaAutoConfigurationTest {
                     .setExampleRequests(Collections.singleton(new hello_args("nameVal")))
                     .setExampleHeaders(Collections.singleton(HttpHeaders.of(
                             HttpHeaderNames.of("x-additional-header"), "headerVal")));
-        }
-    }
-
-    public static class OkService extends AbstractHttpService {
-        @Override
-        protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) throws Exception {
-            return HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "ok");
         }
     }
 

--- a/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaAutoConfigurationTest.java
+++ b/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaAutoConfigurationTest.java
@@ -51,8 +51,6 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.RequestContext;
-import com.linecorp.armeria.server.AbstractHttpService;
-import com.linecorp.armeria.server.PathMapping;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerPort;
 import com.linecorp.armeria.server.ServiceRequestContext;

--- a/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaAutoConfigurationWithoutMeterTest.java
+++ b/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaAutoConfigurationWithoutMeterTest.java
@@ -29,22 +29,15 @@ import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.common.AggregatedHttpMessage;
-import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
-import com.linecorp.armeria.common.MediaType;
-import com.linecorp.armeria.server.AbstractHttpService;
-import com.linecorp.armeria.server.PathMapping;
 import com.linecorp.armeria.server.Server;
-import com.linecorp.armeria.server.ServiceRequestContext;
-import com.linecorp.armeria.server.logging.LoggingService;
 import com.linecorp.armeria.spring.ArmeriaAutoConfigurationWithoutMeterTest.NoMeterTestConfiguration;
 
 /**

--- a/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaMeterBindersConfigurationTest.java
+++ b/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaMeterBindersConfigurationTest.java
@@ -33,21 +33,12 @@ import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import com.linecorp.armeria.common.HttpRequest;
-import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.common.HttpStatus;
-import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.metric.MoreMeters;
-import com.linecorp.armeria.server.AbstractHttpService;
-import com.linecorp.armeria.server.PathMapping;
-import com.linecorp.armeria.server.ServiceRequestContext;
-import com.linecorp.armeria.server.logging.LoggingService;
 import com.linecorp.armeria.spring.ArmeriaMeterBindersConfigurationTest.TestConfiguration;
 
 import io.micrometer.core.instrument.MeterRegistry;

--- a/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaMeterBindersConfigurationTest.java
+++ b/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaMeterBindersConfigurationTest.java
@@ -34,6 +34,7 @@ import org.junit.runner.RunWith;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -58,21 +59,8 @@ import io.micrometer.core.instrument.MeterRegistry;
 public class ArmeriaMeterBindersConfigurationTest {
 
     @SpringBootApplication
+    @Import(ArmeriaOkServiceConfiguration.class)
     public static class TestConfiguration {
-
-        @Bean
-        public HttpServiceRegistrationBean okService() {
-            return new HttpServiceRegistrationBean()
-                    .setServiceName("okService")
-                    .setService(new AbstractHttpService() {
-                        @Override
-                        protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) {
-                            return HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "ok");
-                        }
-                    })
-                    .setPathMapping(PathMapping.ofExact("/ok"))
-                    .setDecorators(LoggingService.newDecorator());
-        }
     }
 
     @Rule

--- a/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaOkServiceConfiguration.java
+++ b/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaOkServiceConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 LINE Corporation
+ * Copyright 2019 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaOkServiceConfiguration.java
+++ b/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaOkServiceConfiguration.java
@@ -30,11 +30,8 @@ import com.linecorp.armeria.server.PathMapping;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.logging.LoggingService;
 
-/**
- *
- */
 @Configuration
-public class ArmeriaOkServiceConfiguration {
+class ArmeriaOkServiceConfiguration {
     @Bean
     public HttpServiceRegistrationBean okService() {
         return new HttpServiceRegistrationBean()

--- a/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaOkServiceConfiguration.java
+++ b/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaOkServiceConfiguration.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.spring;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.server.AbstractHttpService;
+import com.linecorp.armeria.server.PathMapping;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.logging.LoggingService;
+
+/**
+ *
+ */
+@Configuration
+public class ArmeriaOkServiceConfiguration {
+    @Bean
+    public HttpServiceRegistrationBean okService() {
+        return new HttpServiceRegistrationBean()
+                .setServiceName("okService")
+                .setService(new OkService())
+                .setPathMapping(PathMapping.ofExact("/ok"))
+                .setDecorators(ImmutableList.of(LoggingService.newDecorator()));
+    }
+
+    public static class OkService extends AbstractHttpService {
+        @Override
+        protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+            return HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "ok");
+        }
+    }
+}

--- a/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaOkServiceConfiguration.java
+++ b/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaOkServiceConfiguration.java
@@ -23,8 +23,6 @@ import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.common.HttpStatus;
-import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.server.AbstractHttpService;
 import com.linecorp.armeria.server.PathMapping;
 import com.linecorp.armeria.server.ServiceRequestContext;
@@ -44,7 +42,7 @@ class ArmeriaOkServiceConfiguration {
     public static class OkService extends AbstractHttpService {
         @Override
         protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) throws Exception {
-            return HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "ok");
+            return HttpResponse.of("ok");
         }
     }
 }

--- a/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaSslConfigurationTest.java
+++ b/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaSslConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 LINE Corporation
+ * Copyright 2019 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaSslConfigurationTest.java
+++ b/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaSslConfigurationTest.java
@@ -86,6 +86,12 @@ public class ArmeriaSslConfigurationTest {
         }
     }
 
+    private static final ClientFactory clientFactory =
+            new ClientFactoryBuilder()
+                    .sslContextCustomizer(b -> b.trustManager(InsecureTrustManagerFactory.INSTANCE))
+                    .addressResolverGroupFactory(eventLoopGroup -> MockAddressResolverGroup.localhost())
+                    .build();
+
     @Rule
     public TestRule globalTimeout = new DisableOnDebug(new Timeout(10, TimeUnit.SECONDS));
 
@@ -101,7 +107,7 @@ public class ArmeriaSslConfigurationTest {
     }
 
     private void verify(SessionProtocol protocol) {
-        final HttpResponse response = HttpClient.of(newUrl(protocol)).get("/ok");
+        final HttpResponse response = HttpClient.of(clientFactory, newUrl(protocol)).get("/ok");
 
         final AggregatedHttpMessage msg = response.aggregate().join();
         assertThat(msg.status()).isEqualTo(HttpStatus.OK);

--- a/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaSslConfigurationTest.java
+++ b/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaSslConfigurationTest.java
@@ -15,14 +15,10 @@
  */
 package com.linecorp.armeria.spring;
 
-import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Collection;
-import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
-import javax.annotation.Nullable;
 import javax.inject.Inject;
 
 import org.junit.Rule;
@@ -40,30 +36,18 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 import com.google.common.collect.ImmutableList;
 
-import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.common.AggregatedHttpMessage;
-import com.linecorp.armeria.common.HttpHeaderNames;
-import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
-import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.server.AbstractHttpService;
 import com.linecorp.armeria.server.PathMapping;
 import com.linecorp.armeria.server.Server;
-import com.linecorp.armeria.server.ServerPort;
 import com.linecorp.armeria.server.ServiceRequestContext;
-import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
-import com.linecorp.armeria.server.annotation.Get;
-import com.linecorp.armeria.server.annotation.ResponseConverterFunction;
-import com.linecorp.armeria.server.annotation.StringRequestConverterFunction;
 import com.linecorp.armeria.server.logging.LoggingService;
-import com.linecorp.armeria.server.thrift.THttpService;
 import com.linecorp.armeria.spring.ArmeriaAutoConfigurationTest.TestConfiguration;
-import com.linecorp.armeria.spring.test.thrift.main.HelloService;
-import com.linecorp.armeria.spring.test.thrift.main.HelloService.hello_args;
 
 /**
  * This uses {@link ArmeriaAutoConfiguration} for integration tests.

--- a/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaSslConfigurationTest.java
+++ b/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaSslConfigurationTest.java
@@ -108,9 +108,7 @@ public class ArmeriaSslConfigurationTest {
 
     @Test
     public void https() {
-        final HttpClient client = HttpClient.of(newUrl("https"));
-
-        final HttpResponse response = client.get("/ok");
+        final HttpResponse response = HttpClient.of(newUrl("https")).get("/ok");
 
         final AggregatedHttpMessage msg = response.aggregate().join();
         assertThat(msg.status()).isEqualTo(HttpStatus.OK);

--- a/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaSslConfigurationTest.java
+++ b/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaSslConfigurationTest.java
@@ -15,10 +15,14 @@
  */
 package com.linecorp.armeria.spring;
 
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 
 import org.junit.Rule;
@@ -30,35 +34,65 @@ import org.junit.runner.RunWith;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.server.AbstractHttpService;
 import com.linecorp.armeria.server.PathMapping;
 import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.ServerPort;
 import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
+import com.linecorp.armeria.server.annotation.Get;
+import com.linecorp.armeria.server.annotation.ResponseConverterFunction;
+import com.linecorp.armeria.server.annotation.StringRequestConverterFunction;
 import com.linecorp.armeria.server.logging.LoggingService;
-import com.linecorp.armeria.spring.ArmeriaAutoConfigurationWithoutMeterTest.NoMeterTestConfiguration;
+import com.linecorp.armeria.server.thrift.THttpService;
+import com.linecorp.armeria.spring.ArmeriaAutoConfigurationTest.TestConfiguration;
+import com.linecorp.armeria.spring.test.thrift.main.HelloService;
+import com.linecorp.armeria.spring.test.thrift.main.HelloService.hello_args;
 
 /**
  * This uses {@link ArmeriaAutoConfiguration} for integration tests.
- * application-autoConfTest.yml will be loaded with minimal settings to make it work.
+ * application-sslTest.yml will be loaded with minimal settings to make it work.
  */
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = NoMeterTestConfiguration.class)
-@ActiveProfiles({ "local", "autoConfTest" })
-public class ArmeriaAutoConfigurationWithoutMeterTest {
+@SpringBootTest(classes = TestConfiguration.class)
+@ActiveProfiles({ "local", "sslTest" })
+@DirtiesContext
+public class ArmeriaSslConfigurationTest {
 
     @SpringBootApplication
-    @Import(ArmeriaOkServiceConfiguration.class)
-    public static class NoMeterTestConfiguration {
+    public static class TestConfiguration {
+
+        @Bean
+        public HttpServiceRegistrationBean okService() {
+            return new HttpServiceRegistrationBean()
+                    .setServiceName("okService")
+                    .setService(new OkService())
+                    .setPathMapping(PathMapping.ofExact("/ok"))
+                    .setDecorators(ImmutableList.of(LoggingService.newDecorator()));
+        }
+    }
+
+    public static class OkService extends AbstractHttpService {
+        @Override
+        protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+            return HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "ok");
+        }
     }
 
     @Rule
@@ -73,12 +107,12 @@ public class ArmeriaAutoConfigurationWithoutMeterTest {
     }
 
     @Test
-    public void testHttpServiceRegistrationBean() throws Exception {
-        final HttpClient client = HttpClient.of(newUrl("h1c"));
+    public void https() {
+        final HttpClient client = HttpClient.of(newUrl("https"));
 
         final HttpResponse response = client.get("/ok");
 
-        final AggregatedHttpMessage msg = response.aggregate().get();
+        final AggregatedHttpMessage msg = response.aggregate().join();
         assertThat(msg.status()).isEqualTo(HttpStatus.OK);
         assertThat(msg.contentUtf8()).isEqualTo("ok");
     }

--- a/spring/boot-autoconfigure/src/test/resources/config/application-sslTest.yml
+++ b/spring/boot-autoconfigure/src/test/resources/config/application-sslTest.yml
@@ -1,0 +1,8 @@
+armeria:
+  ports:
+    - port: 0
+      protocol: HTTP
+    - port: 0
+      protocol: HTTPS
+  ssl:
+    use-self-signed-certification: true

--- a/spring/boot-autoconfigure/src/test/resources/config/application-sslTest.yml
+++ b/spring/boot-autoconfigure/src/test/resources/config/application-sslTest.yml
@@ -5,4 +5,4 @@ armeria:
     - port: 0
       protocol: HTTPS
   ssl:
-    use-self-signed-certification: true
+    enabled: true # Use self-signed certificate because no key-store configuration is specified.

--- a/spring/boot-webflux-autoconfigure/build.gradle
+++ b/spring/boot-webflux-autoconfigure/build.gradle
@@ -33,6 +33,7 @@ task copyFiles(type: Copy) {
     include '**/ArmeriaServerConfigurator.java'
     include '**/ArmeriaSettings.java'
     include '**/MeterIdPrefixFunctionFactory.java'
+    include '**/Ssl.java'
     include '**/ThriftServiceUtils.java'
 }
 

--- a/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
+++ b/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
@@ -105,6 +105,7 @@ public class ArmeriaReactiveWebServerFactory extends AbstractReactiveWebServerFa
             }
         }
         return new com.linecorp.armeria.spring.Ssl()
+                .setEnabled(ssl.isEnabled())
                 .setClientAuth(clientAuth)
                 .setCiphers(ImmutableList.copyOf(ssl.getCiphers()))
                 .setEnabledProtocols(ImmutableList.copyOf(ssl.getEnabledProtocols()))

--- a/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
+++ b/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
@@ -92,7 +92,7 @@ public class ArmeriaReactiveWebServerFactory extends AbstractReactiveWebServerFa
         this.beanFactory = requireNonNull(beanFactory, "beanFactory");
     }
 
-    private ArmeriaSettings.Ssl toArmeriaSslConfiguration(Ssl ssl) {
+    private com.linecorp.armeria.spring.Ssl toArmeriaSslConfiguration(Ssl ssl) {
         ClientAuth clientAuth = null;
         if (ssl.getClientAuth() != null) {
             switch (ssl.getClientAuth()) {
@@ -104,7 +104,7 @@ public class ArmeriaReactiveWebServerFactory extends AbstractReactiveWebServerFa
                     break;
             }
         }
-        return new ArmeriaSettings.Ssl()
+        return new com.linecorp.armeria.spring.Ssl()
                 .setClientAuth(clientAuth)
                 .setCiphers(ImmutableList.copyOf(ssl.getCiphers()))
                 .setEnabledProtocols(ImmutableList.copyOf(ssl.getEnabledProtocols()))

--- a/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
+++ b/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
@@ -15,7 +15,6 @@
  */
 package com.linecorp.armeria.spring.web.reactive;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.linecorp.armeria.internal.spring.ArmeriaConfigurationUtil.configureAnnotatedHttpServices;
@@ -23,15 +22,12 @@ import static com.linecorp.armeria.internal.spring.ArmeriaConfigurationUtil.conf
 import static com.linecorp.armeria.internal.spring.ArmeriaConfigurationUtil.configurePorts;
 import static com.linecorp.armeria.internal.spring.ArmeriaConfigurationUtil.configureServerWithArmeriaSettings;
 import static com.linecorp.armeria.internal.spring.ArmeriaConfigurationUtil.configureThriftServices;
+import static com.linecorp.armeria.internal.spring.ArmeriaConfigurationUtil.configureTls;
 import static com.linecorp.armeria.spring.MeterIdPrefixFunctionFactory.DEFAULT;
 import static java.util.Objects.requireNonNull;
 
-import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.net.URL;
-import java.security.GeneralSecurityException;
-import java.security.KeyStore;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -41,8 +37,6 @@ import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 import javax.annotation.Nullable;
-import javax.net.ssl.KeyManagerFactory;
-import javax.net.ssl.TrustManagerFactory;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,11 +46,9 @@ import org.springframework.boot.web.reactive.server.ReactiveWebServerFactory;
 import org.springframework.boot.web.server.Compression;
 import org.springframework.boot.web.server.Http2;
 import org.springframework.boot.web.server.Ssl;
-import org.springframework.boot.web.server.Ssl.ClientAuth;
 import org.springframework.boot.web.server.SslStoreProvider;
 import org.springframework.boot.web.server.WebServer;
 import org.springframework.http.server.reactive.HttpHandler;
-import org.springframework.util.ResourceUtils;
 
 import com.google.common.collect.ImmutableList;
 
@@ -82,7 +74,7 @@ import com.linecorp.armeria.spring.web.ArmeriaWebServer;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Metrics;
-import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.ClientAuth;
 import reactor.core.Disposable;
 
 /**
@@ -100,6 +92,34 @@ public class ArmeriaReactiveWebServerFactory extends AbstractReactiveWebServerFa
         this.beanFactory = requireNonNull(beanFactory, "beanFactory");
     }
 
+    private ArmeriaSettings.Ssl toArmeriaSslConfiguration(Ssl ssl) {
+        ClientAuth clientAuth = null;
+        if (ssl.getClientAuth() != null) {
+            switch (ssl.getClientAuth()) {
+                case NEED:
+                    clientAuth = ClientAuth.REQUIRE;
+                    break;
+                case WANT:
+                    clientAuth = ClientAuth.OPTIONAL;
+                    break;
+            }
+        }
+        return new ArmeriaSettings.Ssl()
+                .setClientAuth(clientAuth)
+                .setCiphers(ImmutableList.copyOf(ssl.getCiphers()))
+                .setEnabledProtocols(ImmutableList.copyOf(ssl.getEnabledProtocols()))
+                .setKeyAlias(ssl.getKeyAlias())
+                .setKeyPassword(ssl.getKeyPassword())
+                .setKeyStore(ssl.getKeyStore())
+                .setKeyStorePassword(ssl.getKeyStorePassword())
+                .setKeyStoreType(ssl.getKeyStoreType())
+                .setKeyStoreProvider(ssl.getKeyStoreProvider())
+                .setTrustStore(ssl.getTrustStore())
+                .setTrustStorePassword(ssl.getTrustStorePassword())
+                .setTrustStoreType(ssl.getTrustStoreType())
+                .setTrustStoreProvider(ssl.getTrustStoreProvider());
+    }
+
     @Override
     public WebServer getWebServer(HttpHandler httpHandler) {
         final ServerBuilder sb = new ServerBuilder();
@@ -108,7 +128,22 @@ public class ArmeriaReactiveWebServerFactory extends AbstractReactiveWebServerFa
         final Ssl ssl = getSsl();
         if (ssl != null) {
             if (ssl.isEnabled()) {
-                configureTls(sb, ssl, getSslStoreProvider());
+                SslStoreProvider provider = getSslStoreProvider();
+                configureTls(sb, toArmeriaSslConfiguration(ssl),
+                             () -> {
+                                 try {
+                                     return provider.getKeyStore();
+                                 } catch (Exception e) {
+                                     throw new IllegalStateException(e);
+                                 }
+                             },
+                             () -> {
+                                 try {
+                                     return provider.getTrustStore();
+                                 } catch (Exception e) {
+                                     throw new IllegalStateException(e);
+                                 }
+                             });
                 protocol = SessionProtocol.HTTPS;
             } else {
                 logger.warn("TLS configuration exists but it is disabled by 'enabled' property.");
@@ -218,6 +253,7 @@ public class ArmeriaReactiveWebServerFactory extends AbstractReactiveWebServerFa
         configureServerWithArmeriaSettings(sb, settings,
                                            findBean(MeterRegistry.class).orElse(Metrics.globalRegistry),
                                            findBeans(HealthChecker.class));
+        configureTls(sb, settings.getSsl());
     }
 
     private <T> Optional<T> findBean(Class<T> clazz) {
@@ -247,100 +283,5 @@ public class ArmeriaReactiveWebServerFactory extends AbstractReactiveWebServerFa
         checkArgument(port >= 0 && port <= 65535,
                       "port: %s (expected: 0[arbitrary port] or 1-65535)", port);
         return port;
-    }
-
-    private static void configureTls(ServerBuilder sb,
-                                     Ssl ssl, @Nullable SslStoreProvider sslStoreProvider) {
-        try {
-            if (sslStoreProvider == null &&
-                ssl.getKeyStore() == null && ssl.getTrustStore() == null) {
-                logger.warn("Configuring TLS with a self-signed certificate " +
-                            "because no key or trust store was specified");
-                sb.tlsSelfSigned();
-                return;
-            }
-
-            final SslContextBuilder sslBuilder = SslContextBuilder
-                    .forServer(getKeyManagerFactory(ssl, sslStoreProvider))
-                    .trustManager(getTrustManagerFactory(ssl, sslStoreProvider));
-
-            final String[] enabledProtocols = ssl.getEnabledProtocols();
-            if (enabledProtocols != null) {
-                sslBuilder.protocols(enabledProtocols.clone());
-            }
-
-            final String[] ciphers = ssl.getCiphers();
-            if (ciphers != null) {
-                sslBuilder.ciphers(ImmutableList.copyOf(ciphers));
-            }
-
-            final ClientAuth clientAuth = ssl.getClientAuth();
-            if (clientAuth != null) {
-                switch (clientAuth) {
-                    case NEED:
-                        sslBuilder.clientAuth(io.netty.handler.ssl.ClientAuth.REQUIRE);
-                        break;
-                    case WANT:
-                        sslBuilder.clientAuth(io.netty.handler.ssl.ClientAuth.OPTIONAL);
-                        break;
-                }
-            }
-
-            sb.tls(sslBuilder.build());
-        } catch (Exception e) {
-            throw new IllegalStateException("Failed to configure TLS: " + e);
-        }
-    }
-
-    private static KeyManagerFactory getKeyManagerFactory(
-            Ssl ssl, @Nullable SslStoreProvider sslStoreProvider) throws Exception {
-        final KeyStore store;
-        if (sslStoreProvider != null) {
-            store = sslStoreProvider.getKeyStore();
-        } else {
-            store = loadKeyStore(ssl.getKeyStoreType(), ssl.getKeyStore(), ssl.getKeyStorePassword());
-        }
-
-        final KeyManagerFactory keyManagerFactory =
-                KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
-
-        String keyPassword = ssl.getKeyPassword();
-        if (keyPassword == null) {
-            keyPassword = ssl.getKeyStorePassword();
-        }
-
-        keyManagerFactory.init(store, keyPassword != null ? keyPassword.toCharArray()
-                                                          : null);
-        return keyManagerFactory;
-    }
-
-    private static TrustManagerFactory getTrustManagerFactory(
-            Ssl ssl, @Nullable SslStoreProvider sslStoreProvider) throws Exception {
-        final KeyStore store;
-        if (sslStoreProvider != null) {
-            store = sslStoreProvider.getTrustStore();
-        } else {
-            store = loadKeyStore(ssl.getTrustStoreType(), ssl.getTrustStore(), ssl.getTrustStorePassword());
-        }
-
-        final TrustManagerFactory trustManagerFactory =
-                TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
-        trustManagerFactory.init(store);
-        return trustManagerFactory;
-    }
-
-    @Nullable
-    private static KeyStore loadKeyStore(
-            @Nullable String type,
-            @Nullable String resource,
-            @Nullable String password) throws IOException, GeneralSecurityException {
-        if (resource == null) {
-            return null;
-        }
-        final KeyStore store = KeyStore.getInstance(firstNonNull(type, "JKS"));
-        final URL url = ResourceUtils.getURL(resource);
-        store.load(url.openStream(), password != null ? password.toCharArray()
-                                                      : null);
-        return store;
     }
 }

--- a/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
+++ b/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
@@ -254,7 +254,9 @@ public class ArmeriaReactiveWebServerFactory extends AbstractReactiveWebServerFa
         configureServerWithArmeriaSettings(sb, settings,
                                            findBean(MeterRegistry.class).orElse(Metrics.globalRegistry),
                                            findBeans(HealthChecker.class));
-        configureTls(sb, settings.getSsl());
+        if (settings.getSsl() != null) {
+            configureTls(sb, settings.getSsl());
+        }
     }
 
     private <T> Optional<T> findBean(Class<T> clazz) {

--- a/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
+++ b/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
@@ -129,7 +129,7 @@ public class ArmeriaReactiveWebServerFactory extends AbstractReactiveWebServerFa
         final Ssl ssl = getSsl();
         if (ssl != null) {
             if (ssl.isEnabled()) {
-                SslStoreProvider provider = getSslStoreProvider();
+                final SslStoreProvider provider = getSslStoreProvider();
                 configureTls(sb, toArmeriaSslConfiguration(ssl),
                              () -> {
                                  try {


### PR DESCRIPTION
Changes:
- Fork Spring's Ssl to support both spring-boot1, spring-boot2.
- Move TLS configuration setup to boot-autoconfigure to allow to setup TLS at non-reactive servers

Results:
- Cloeses #1659 

TODO:
- [x] Update unit tests