### PR TITLE
Create event-loop threads that make Project Reactor happy.

### DIFF
--- a/benchmarks/src/jmh/java/com/linecorp/armeria/shared/EventLoopJmhExecutor.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/shared/EventLoopJmhExecutor.java
@@ -18,11 +18,12 @@ package com.linecorp.armeria.shared;
 
 import java.util.concurrent.Executor;
 
+import com.linecorp.armeria.common.util.EventLoopThreadFactory;
+
 import io.netty.channel.DefaultEventLoop;
 import io.netty.channel.DefaultEventLoopGroup;
 import io.netty.channel.EventLoop;
 import io.netty.channel.MultithreadEventLoopGroup;
-import io.netty.util.concurrent.DefaultThreadFactory;
 import io.netty.util.concurrent.FastThreadLocal;
 
 /**
@@ -53,7 +54,7 @@ public class EventLoopJmhExecutor extends MultithreadEventLoopGroup {
     }
 
     public EventLoopJmhExecutor(int numThreads, String threadPrefix) {
-        super(numThreads, new DefaultThreadFactory(threadPrefix));
+        super(numThreads, new EventLoopThreadFactory(threadPrefix));
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/CommonPools.java
+++ b/core/src/main/java/com/linecorp/armeria/common/CommonPools.java
@@ -23,10 +23,10 @@ import java.util.concurrent.TimeUnit;
 
 import com.linecorp.armeria.client.ClientFactoryBuilder;
 import com.linecorp.armeria.common.util.EventLoopGroups;
+import com.linecorp.armeria.common.util.EventLoopThreadFactory;
 import com.linecorp.armeria.server.ServerBuilder;
 
 import io.netty.channel.EventLoopGroup;
-import io.netty.util.concurrent.DefaultThreadFactory;
 
 /**
  * Provides the common shared thread pools and {@link EventLoopGroup}s which is used when not overridden.
@@ -41,7 +41,7 @@ public final class CommonPools {
         final ThreadPoolExecutor blockingTaskExecutor = new ThreadPoolExecutor(
                 Flags.numCommonBlockingTaskThreads(), Flags.numCommonBlockingTaskThreads(),
                 60, TimeUnit.SECONDS, new LinkedTransferQueue<>(),
-                new DefaultThreadFactory("armeria-common-blocking-tasks", true));
+                new EventLoopThreadFactory("armeria-common-blocking-tasks", true));
 
         blockingTaskExecutor.allowCoreThreadTimeOut(true);
         BLOCKING_TASK_EXECUTOR = blockingTaskExecutor;

--- a/core/src/main/java/com/linecorp/armeria/common/util/EventLoopGroups.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/EventLoopGroups.java
@@ -34,11 +34,12 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.channel.ServerChannel;
 import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.SocketChannel;
-import io.netty.util.concurrent.DefaultThreadFactory;
 import io.netty.util.concurrent.Future;
 
 /**
  * Provides methods that are useful for creating an {@link EventLoopGroup}.
+ *
+ * @see EventLoopThreadFactory
  */
 public final class EventLoopGroups {
 
@@ -88,7 +89,7 @@ public final class EventLoopGroups {
 
         final TransportType type = TransportType.detectTransportType();
         final String prefix = threadNamePrefix + '-' + type.lowerCasedName();
-        return newEventLoopGroup(numThreads, new DefaultThreadFactory(prefix, useDaemonThreads));
+        return newEventLoopGroup(numThreads, new EventLoopThreadFactory(prefix, useDaemonThreads));
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/util/EventLoopThread.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/EventLoopThread.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common.util;
+
+import io.netty.util.concurrent.FastThreadLocalThread;
+import reactor.core.scheduler.NonBlocking;
+
+/**
+ * A {@link FastThreadLocalThread} that implements {@link NonBlocking} tag interface to make Project Reactor
+ * happy.
+ */
+final class EventLoopThread extends FastThreadLocalThread implements NonBlocking {
+    EventLoopThread(ThreadGroup threadGroup, Runnable r, String name) {
+        super(threadGroup, r, name);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/common/util/EventLoopThreadFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/EventLoopThreadFactory.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.util;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.concurrent.ThreadFactory;
+
+import javax.annotation.Nullable;
+
+import io.netty.util.concurrent.DefaultThreadFactory;
+
+/**
+ * {@link ThreadFactory} that creates event loop threads.
+ *
+ * @see EventLoopGroups
+ */
+public final class EventLoopThreadFactory implements ThreadFactory {
+
+    // Note that we did not extend DefaultThreadFactory directly to hide it from the class hierarchy.
+    private final ThreadFactory delegate;
+
+    /**
+     * Creates a new factory that creates a non-daemon and normal-priority thread.
+     *
+     * @param threadNamePrefix the prefix of the names of the threads created by this factory.
+     */
+    public EventLoopThreadFactory(String threadNamePrefix) {
+        this(new EventLoopThreadFactoryImpl(requireNonNull(threadNamePrefix, "threadNamePrefix")));
+    }
+
+    /**
+     * Creates a new factory that creates a normal-priority thread.
+     *
+     * @param threadNamePrefix the prefix of the names of the threads created by this factory.
+     * @param daemon whether to create a daemon thread.
+     */
+    public EventLoopThreadFactory(String threadNamePrefix, boolean daemon) {
+        this(new EventLoopThreadFactoryImpl(requireNonNull(threadNamePrefix, "threadNamePrefix"), daemon));
+    }
+
+    /**
+     * Creates a new factory that creates a non-daemon thread.
+     *
+     * @param threadNamePrefix the prefix of the names of the threads created by this factory.
+     * @param priority the priority of the threads created by this factory.
+     */
+    public EventLoopThreadFactory(String threadNamePrefix, int priority) {
+        this(new EventLoopThreadFactoryImpl(requireNonNull(threadNamePrefix, "threadNamePrefix"), priority));
+    }
+
+    /**
+     * Creates a new factory.
+     *
+     * @param threadNamePrefix the prefix of the names of the threads created by this factory.
+     * @param daemon whether to create a daemon thread.
+     * @param priority the priority of the threads created by this factory.
+     */
+    public EventLoopThreadFactory(String threadNamePrefix, boolean daemon, int priority) {
+        this(new EventLoopThreadFactoryImpl(requireNonNull(threadNamePrefix, "threadNamePrefix"),
+                                            daemon, priority));
+    }
+
+    /**
+     * Creates a new factory.
+     *
+     * @param threadNamePrefix the prefix of the names of the threads created by this factory.
+     * @param daemon whether to create a daemon thread.
+     * @param priority the priority of the threads created by this factory.
+     * @param threadGroup the {@link ThreadGroup}.
+     */
+    public EventLoopThreadFactory(String threadNamePrefix, boolean daemon, int priority,
+                                  @Nullable ThreadGroup threadGroup) {
+        this(new EventLoopThreadFactoryImpl(requireNonNull(threadNamePrefix, "threadNamePrefix"),
+                                            daemon, priority, threadGroup));
+    }
+
+    private EventLoopThreadFactory(ThreadFactory delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Thread newThread(Runnable r) {
+        return delegate.newThread(r);
+    }
+
+    private static final class EventLoopThreadFactoryImpl extends DefaultThreadFactory {
+        EventLoopThreadFactoryImpl(String threadNamePrefix) {
+            super(threadNamePrefix);
+        }
+
+        EventLoopThreadFactoryImpl(String threadNamePrefix, boolean daemon) {
+            super(threadNamePrefix, daemon);
+        }
+
+        EventLoopThreadFactoryImpl(String threadNamePrefix, int priority) {
+            super(threadNamePrefix, priority);
+        }
+
+        EventLoopThreadFactoryImpl(String threadNamePrefix, boolean daemon, int priority) {
+            super(threadNamePrefix, daemon, priority);
+        }
+
+        EventLoopThreadFactoryImpl(String threadNamePrefix, boolean daemon, int priority,
+                                   @Nullable ThreadGroup threadGroup) {
+            super(threadNamePrefix, daemon, priority, threadGroup);
+        }
+
+        @Override
+        protected Thread newThread(Runnable r, String name) {
+            return new EventLoopThread(threadGroup, r, name);
+        }
+    }
+}

--- a/core/src/main/java/reactor/core/scheduler/NonBlocking.java
+++ b/core/src/main/java/reactor/core/scheduler/NonBlocking.java
@@ -1,0 +1,3 @@
+package reactor.core.scheduler;
+
+public interface NonBlocking {}

--- a/core/src/main/java/reactor/core/scheduler/package-info.java
+++ b/core/src/main/java/reactor/core/scheduler/package-info.java
@@ -13,9 +13,11 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package reactor.core.scheduler;
 
 /**
- * A dummy interface that makes Project Reactor recognize Armeria's event loop threads as non-blocking.
+ * Provides a dummy interface that makes Project Reactor recognize Armeria's event loop threads as non-blocking.
  */
-public interface NonBlocking {}
+@NonNullByDefault
+package reactor.core.scheduler;
+
+import com.linecorp.armeria.common.util.NonNullByDefault;

--- a/core/src/test/java/com/linecorp/armeria/server/GracefulShutdownSupportTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/GracefulShutdownSupportTest.java
@@ -40,7 +40,7 @@ import org.mockito.junit.MockitoRule;
 
 import com.google.common.base.Ticker;
 
-import io.netty.util.concurrent.DefaultThreadFactory;
+import com.linecorp.armeria.common.util.EventLoopThreadFactory;
 
 public class GracefulShutdownSupportTest {
 
@@ -59,7 +59,7 @@ public class GracefulShutdownSupportTest {
     public void setUp() {
         executor = new ThreadPoolExecutor(
                 0, 1, 1, TimeUnit.SECONDS, new LinkedTransferQueue<>(),
-                new DefaultThreadFactory(GracefulShutdownSupportTest.class, true));
+                new EventLoopThreadFactory("graceful-shutdown-test", true));
 
         support = GracefulShutdownSupport.create(Duration.ofNanos(QUIET_PERIOD_NANOS), executor, ticker);
     }

--- a/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
@@ -57,6 +57,7 @@ import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.metric.MeterIdPrefix;
 import com.linecorp.armeria.common.metric.PrometheusMeterRegistries;
 import com.linecorp.armeria.common.util.CompletionActions;
+import com.linecorp.armeria.common.util.EventLoopThreadFactory;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.internal.metric.MicrometerUtil;
 import com.linecorp.armeria.server.logging.LoggingService;
@@ -67,7 +68,6 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.netty.channel.ChannelOption;
 import io.netty.handler.codec.http.HttpStatusClass;
 import io.netty.util.concurrent.DefaultEventExecutorGroup;
-import io.netty.util.concurrent.DefaultThreadFactory;
 import io.netty.util.concurrent.EventExecutorGroup;
 import io.netty.util.concurrent.Future;
 
@@ -345,7 +345,7 @@ public class ServerTest {
     public void customStartStopExecutor() {
         final Queue<Thread> threads = new LinkedTransferQueue<>();
         final String prefix = getClass().getName() + "#customStartStopExecutor";
-        final ExecutorService executor = Executors.newSingleThreadExecutor(new DefaultThreadFactory(prefix));
+        final ExecutorService executor = Executors.newSingleThreadExecutor(new EventLoopThreadFactory(prefix));
         final Server server = new ServerBuilder()
                 .startStopExecutor(executor)
                 .service("/", (ctx, req) -> HttpResponse.of(200))

--- a/site/build.gradle
+++ b/site/build.gradle
@@ -81,7 +81,7 @@ task test(group: 'Verification',
                 'nested.classes.inherited.from.class.'
         ]
         def whitelistedPrefixes = ['java.', 'javax.']
-        def blacklistedPrefixes = [ 'com.linecorp.armeria.internal.' ] +
+        def blacklistedPrefixes = [ 'com.linecorp.armeria.internal.', 'reactor.core.scheduler.' ] +
                                   rootProject.ext.relocations.collect { it[1] + '.' }
         def errors = []
 


### PR DESCRIPTION
Motivation:

Project Reactor determines whether a thread is non-blocking or not by
checking if the thread implements a special tag interface `NonBlocking`.
Because our event loop threads do not implement it, Project Reactor's
`Schedulers.isInNonBlockingThread()` will return `false`.

Modification:

- Added `reactor.core.scheduler.NonBlocking` interface to `armeria-core`.
- Added `EventLoopThreadFactory` that creates an `EventLoopThread`.
- Added `EventLoopThread` which implements `NonBlocking`.
- Updated the existing code to use `EventLoopThreadFactory` instead of
  `DefaultThreadFactory` wherever possible.

Result:

- Project Reactor and its users are happy.
- We are a little bit unhappy due to ugliness of the fix.