### PR TITLE
Add HttpHeaderNames.PREFER back

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/HttpHeaderNames.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpHeaderNames.java
@@ -52,6 +52,7 @@ public final class HttpHeaderNames {
     // - Added pseudo headers
     // - Added Accept-Patch
     // - Added Content-Base
+    // - Added Prefer
     // - Removed the ancient CSP headers
     //   - X-Content-Security-Policy
     //   - X-Content-Security-Policy-Report-Only
@@ -219,6 +220,10 @@ public final class HttpHeaderNames {
      * The HTTP {@code "Origin"} header field name.
      */
     public static final AsciiString ORIGIN = create("Origin");
+    /**
+     * The HTTP {@code "Prefer"} header field name.
+     */
+    public static final AsciiString PREFER = create("Prefer");
     /**
      * The HTTP {@code "Proxy-Authorization"} header field name.
      */


### PR DESCRIPTION
Motivation:

We removed `HttpHeaderNames.PREFER` by mistake at
35c8b7914ee2335b6400b178dcab5a33203ef0d9.

Modification:

- Add `HttpHeaderNames.PREFER` back.

Result:

- A past mistake is undone.
- Fixes #1664