### PR TITLE
Add a link to armeria-examples repository in gRPC documents

### DIFF
--- a/site/src/sphinx/client-grpc.rst
+++ b/site/src/sphinx/client-grpc.rst
@@ -9,6 +9,10 @@
 Calling a gRPC service
 ======================
 
+.. note::
+
+    Visit `armeria-examples <https://github.com/line/armeria-examples>`_ to find a fully working example.
+
 Let's assume we have the following gRPC_ service definition, served at ``http://127.0.0.1:8080/``, just like
 what we used in :ref:`server-grpc`:
 

--- a/site/src/sphinx/server-grpc.rst
+++ b/site/src/sphinx/server-grpc.rst
@@ -9,6 +9,10 @@
 Running a gRPC service
 ======================
 
+.. note::
+
+    Visit `armeria-examples <https://github.com/line/armeria-examples>`_ to find a fully working example.
+
 Let's assume we have the following gRPC_ service definition:
 
 .. code-block:: protobuf


### PR DESCRIPTION
Motivation:
We missed the links when adding a gRPC example.