### PR TITLE
Add start/stop parameters to StartStopSupport

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/util/StartStopSupport.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/StartStopSupport.java
@@ -35,10 +35,12 @@ import org.slf4j.LoggerFactory;
 /**
  * Provides asynchronous start-stop life cycle support.
  *
+ * @param <T> the type of the startup argument. Use {@link Void} if unused.
+ * @param <U> the type of the shutdown argument. Use {@link Void} if unused.
  * @param <V> the type of the startup result. Use {@link Void} if unused.
  * @param <L> the type of the life cycle event listener. Use {@link Void} if unused.
  */
-public abstract class StartStopSupport<V, L> implements AutoCloseable {
+public abstract class StartStopSupport<T, U, V, L> implements AutoCloseable {
 
     private static final Logger logger = LoggerFactory.getLogger(StartStopSupport.class);
 
@@ -53,7 +55,7 @@ public abstract class StartStopSupport<V, L> implements AutoCloseable {
     private final List<L> listeners = new CopyOnWriteArrayList<>();
     private volatile State state = State.STOPPED;
     /**
-     * The value is {@code V}-typed when STARTING/STARTED and {@link Void}-typed when STOPPING/STOPPED.
+     * This future is {@code V}-typed when STARTING/STARTED and {@link Void}-typed when STOPPING/STOPPED.
      */
     private CompletableFuture<?> future = completedFuture(null);
 
@@ -62,8 +64,8 @@ public abstract class StartStopSupport<V, L> implements AutoCloseable {
      *
      * @param executor the {@link Executor} which will be used for invoking the extension points of this class:
      *                 <ul>
-     *                   <li>{@link #doStart()}</li>
-     *                   <li>{@link #doStop()}</li>
+     *                   <li>{@link #doStart(Object)}</li>
+     *                   <li>{@link #doStop(Object)}</li>
      *                   <li>{@link #rollbackFailed(Throwable)}</li>
      *                   <li>{@link #notificationFailed(Object, Throwable)}</li>
      *                   <li>All listener notifications</li>
@@ -90,16 +92,34 @@ public abstract class StartStopSupport<V, L> implements AutoCloseable {
     }
 
     /**
-     * Begins the startup procedure by calling {@link #doStart()}, ensuring that neither {@link #doStart()}
-     * nor {@link #doStop()} is invoked concurrently. When the startup fails, {@link #stop()} will be
-     * invoked automatically to roll back the side effect caused by {@link #start(boolean)} and any exceptions
-     * that occurred during the rollback will be reported to {@link #rollbackFailed(Throwable)}.
+     * Begins the startup procedure without an argument by calling {@link #doStart(Object)}, ensuring that
+     * neither {@link #doStart(Object)} nor {@link #doStop(Object)} is invoked concurrently. When the startup
+     * fails, {@link #stop(Object)} will be invoked automatically to roll back the side effect caused by
+     * {@link #start(Object, boolean)} and any exceptions that occurred during the rollback will be reported
+     * to {@link #rollbackFailed(Throwable)}. This method is a shortcut of {@code start(null, failIfStarted)}.
      *
      * @param failIfStarted whether to fail the returned {@link CompletableFuture} with
      *                      an {@link IllegalStateException} when the startup procedure is already
      *                      in progress or done
      */
     public final synchronized CompletableFuture<V> start(boolean failIfStarted) {
+        return start(null, failIfStarted);
+    }
+
+    /**
+     * Begins the startup procedure by calling {@link #doStart(Object)}, ensuring that neither
+     * {@link #doStart(Object)} nor {@link #doStop(Object)} is invoked concurrently. When the startup fails,
+     * {@link #stop(Object)} will be invoked automatically to roll back the side effect caused by
+     * {@link #start(Object, boolean)} and any exceptions that occurred during the rollback will be reported
+     * to {@link #rollbackFailed(Throwable)}.
+     *
+     * @param arg           the argument to pass to {@link #doStart(Object)},
+     *                      or {@code null} to pass no argument.
+     * @param failIfStarted whether to fail the returned {@link CompletableFuture} with
+     *                      an {@link IllegalStateException} when the startup procedure is already
+     *                      in progress or done
+     */
+    public final synchronized CompletableFuture<V> start(@Nullable T arg, boolean failIfStarted) {
         switch (state) {
             case STARTING:
             case STARTED:
@@ -115,7 +135,7 @@ public abstract class StartStopSupport<V, L> implements AutoCloseable {
                 // A user called start() to restart, but not stopped completely yet.
                 // Try again once stopped.
                 return future.exceptionally(unused -> null)
-                             .thenComposeAsync(unused -> start(failIfStarted), executor);
+                             .thenComposeAsync(unused -> start(arg, failIfStarted), executor);
         }
 
         assert state == State.STOPPED : "state: " + state;
@@ -127,8 +147,8 @@ public abstract class StartStopSupport<V, L> implements AutoCloseable {
         try {
             executor.execute(() -> {
                 try {
-                    notifyListeners(State.STARTING, null);
-                    final CompletionStage<V> f = doStart();
+                    notifyListeners(State.STARTING, arg, null, null);
+                    final CompletionStage<V> f = doStart(arg);
                     if (f == null) {
                         throw new IllegalStateException("doStart() returned null.");
                     }
@@ -157,14 +177,14 @@ public abstract class StartStopSupport<V, L> implements AutoCloseable {
         final CompletableFuture<V> future = startFuture.handleAsync((result, cause) -> {
             if (cause != null) {
                 // Failed to start. Stop and complete with the start failure cause.
-                final CompletableFuture<Void> rollbackFuture = stop(true).exceptionally(stopCause -> {
+                final CompletableFuture<Void> rollbackFuture = stop(null, true).exceptionally(stopCause -> {
                     rollbackFailed(Exceptions.peel(stopCause));
                     return null;
                 });
 
                 return rollbackFuture.<V>thenCompose(unused -> exceptionallyCompletedFuture(cause));
             } else {
-                enter(State.STARTED, result);
+                enter(State.STARTED, arg, null, result);
                 return completedFuture(result);
             }
         }, executor).thenCompose(Function.identity());
@@ -174,20 +194,31 @@ public abstract class StartStopSupport<V, L> implements AutoCloseable {
     }
 
     /**
-     * Begins the shutdown procedure by calling {@link #doStop()}, ensuring that neither {@link #doStart()} nor
-     * {@link #doStop()} is invoked concurrently.
+     * Begins the shutdown procedure without an argument by calling {@link #doStop(Object)}, ensuring that
+     * neither {@link #doStart(Object)} nor {@link #doStop(Object)} is invoked concurrently. This method is
+     * a shortcut of {@code stop(null)}.
      */
     public final CompletableFuture<Void> stop() {
-        return stop(false);
+        return stop(null);
     }
 
-    private synchronized CompletableFuture<Void> stop(boolean rollback) {
+    /**
+     * Begins the shutdown procedure by calling {@link #doStop(Object)}, ensuring that neither
+     * {@link #doStart(Object)} nor {@link #doStop(Object)} is invoked concurrently.
+     *
+     * @param arg the argument to pass to {@link #doStop(Object)}, or {@code null} to pass no argument.
+     */
+    public final CompletableFuture<Void> stop(@Nullable U arg) {
+        return stop(arg, false);
+    }
+
+    private synchronized CompletableFuture<Void> stop(@Nullable U arg, boolean rollback) {
         switch (state) {
             case STARTING:
                 if (!rollback) {
                     // Try again once started.
                     return future.exceptionally(unused -> null) // Ignore the exception.
-                                 .thenComposeAsync(unused -> stop(), executor);
+                                 .thenComposeAsync(unused -> stop(arg), executor);
                 } else {
                     break;
                 }
@@ -207,8 +238,8 @@ public abstract class StartStopSupport<V, L> implements AutoCloseable {
         try {
             executor.execute(() -> {
                 try {
-                    notifyListeners(State.STOPPING, null);
-                    final CompletionStage<Void> f = doStop();
+                    notifyListeners(State.STOPPING, null, arg, null);
+                    final CompletionStage<Void> f = doStop(arg);
                     if (f == null) {
                         throw new IllegalStateException("doStop() returned null.");
                     }
@@ -235,14 +266,14 @@ public abstract class StartStopSupport<V, L> implements AutoCloseable {
         }
 
         final CompletableFuture<Void> future = stopFuture.whenCompleteAsync(
-                (unused1, cause) -> enter(State.STOPPED, null), executor);
+                (unused1, cause) -> enter(State.STOPPED, null, arg, null), executor);
         this.future = future;
         return future;
     }
 
     /**
-     * A synchronous version of {@link #stop()}. Exceptions occurred during shutdown are reported to
-     * {@link #closeFailed(Throwable)}.
+     * A synchronous version of {@link #stop(Object)}. Exceptions occurred during shutdown are reported to
+     * {@link #closeFailed(Throwable)}. No argument (i.e. {@code null}) is passed.
      */
     @Override
     public final void close() {
@@ -251,7 +282,7 @@ public abstract class StartStopSupport<V, L> implements AutoCloseable {
             if (state == State.STOPPED) {
                 return;
             }
-            f = stop();
+            f = stop(null);
         }
 
         boolean interrupted = false;
@@ -272,29 +303,30 @@ public abstract class StartStopSupport<V, L> implements AutoCloseable {
         }
     }
 
-    private void enter(State state, @Nullable V value) {
+    private void enter(State state, @Nullable T startArg, @Nullable U stopArg, @Nullable V startResult) {
         synchronized (this) {
             assert this.state != state : "transition to the same state: " + state;
             this.state = state;
         }
-        notifyListeners(state, value);
+        notifyListeners(state, startArg, stopArg, startResult);
     }
 
-    private void notifyListeners(State state, @Nullable V value) {
+    private void notifyListeners(State state, @Nullable T startArg, @Nullable U stopArg,
+                                 @Nullable V startResult) {
         for (L l : listeners) {
             try {
                 switch (state) {
                     case STARTING:
-                        notifyStarting(l);
+                        notifyStarting(l, startArg);
                         break;
                     case STARTED:
-                        notifyStarted(l, value);
+                        notifyStarted(l, startArg, startResult);
                         break;
                     case STOPPING:
-                        notifyStopping(l);
+                        notifyStopping(l, stopArg);
                         break;
                     case STOPPED:
-                        notifyStopped(l);
+                        notifyStopped(l, stopArg);
                         break;
                     default:
                         throw new Error("unknown state: " + state);
@@ -306,43 +338,58 @@ public abstract class StartStopSupport<V, L> implements AutoCloseable {
     }
 
     /**
-     * Invoked by {@link #start(boolean)} to perform the actual startup.
+     * Invoked by {@link #start(Object, boolean)} to perform the actual startup.
+     *
+     * @param arg the argument passed from {@link #start(Object, boolean)},
+     *            or {@code null} if no argument was specified.
      */
-    protected abstract CompletionStage<V> doStart() throws Exception;
+    protected abstract CompletionStage<V> doStart(@Nullable T arg) throws Exception;
 
     /**
-     * Invoked by {@link #stop()} to perform the actual startup, or indirectly by {@link #start(boolean)} when
-     * startup failed.
+     * Invoked by {@link #stop(Object)} to perform the actual startup, or indirectly by
+     * {@link #start(Object, boolean)} when startup failed.
+     *
+     * @param arg the argument passed from {@link #stop(Object)},
+     *            or {@code null} if no argument was specified.
      */
-    protected abstract CompletionStage<Void> doStop() throws Exception;
+    protected abstract CompletionStage<Void> doStop(@Nullable U arg) throws Exception;
 
     /**
      * Invoked when the startup procedure begins.
      *
      * @param listener the listener
+     * @param arg      the argument passed from {@link #start(Object, boolean)},
+     *                 or {@code null} if no argument was specified.
      */
-    protected void notifyStarting(L listener) throws Exception {}
+    protected void notifyStarting(L listener, @Nullable T arg) throws Exception {}
 
     /**
      * Invoked when the startup procedure is finished.
      *
      * @param listener the listener
+     * @param arg      the argument passed from {@link #start(Object, boolean)},
+     *                 or {@code null} if no argument was specified.
+     * @param result   the value of the {@link CompletionStage} returned by {@link #doStart(Object)}.
      */
-    protected void notifyStarted(L listener, @Nullable V value) throws Exception {}
+    protected void notifyStarted(L listener, @Nullable T arg, @Nullable V result) throws Exception {}
 
     /**
      * Invoked when the shutdown procedure begins.
      *
      * @param listener the listener
+     * @param arg      the argument passed from {@link #stop(Object)},
+     *                 or {@code null} if no argument was specified.
      */
-    protected void notifyStopping(L listener) throws Exception {}
+    protected void notifyStopping(L listener, @Nullable U arg) throws Exception {}
 
     /**
      * Invoked when the shutdown procedure is finished.
      *
      * @param listener the listener
+     * @param arg      the argument passed from {@link #stop(Object)},
+     *                 or {@code null} if no argument was specified.
      */
-    protected void notifyStopped(L listener) throws Exception {}
+    protected void notifyStopped(L listener, @Nullable U arg) throws Exception {}
 
     /**
      * Invoked when failed to stop during the rollback after startup failure.

--- a/core/src/main/java/com/linecorp/armeria/server/Server.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Server.java
@@ -87,7 +87,7 @@ public final class Server implements AutoCloseable {
     @Nullable
     private final DomainNameMapping<SslContext> sslContexts;
 
-    private final StartStopSupport<Void, ServerListener> startStop;
+    private final StartStopSupport<Void, Void, Void, ServerListener> startStop;
     private final Set<Channel> serverChannels = Collections.newSetFromMap(new ConcurrentHashMap<>());
     private final Map<InetSocketAddress, ServerPort> activePorts = new LinkedHashMap<>();
     private final ConnectionLimitingHandler connectionLimitingHandler;
@@ -263,7 +263,7 @@ public final class Server implements AutoCloseable {
                           .toString();
     }
 
-    private final class ServerStartStopSupport extends StartStopSupport<Void, ServerListener> {
+    private final class ServerStartStopSupport extends StartStopSupport<Void, Void, Void, ServerListener> {
 
         @Nullable
         private volatile GracefulShutdownSupport gracefulShutdownSupport;
@@ -273,7 +273,7 @@ public final class Server implements AutoCloseable {
         }
 
         @Override
-        protected CompletionStage<Void> doStart() {
+        protected CompletionStage<Void> doStart(@Nullable Void arg) {
             if (config().gracefulShutdownQuietPeriod().isZero()) {
                 gracefulShutdownSupport = GracefulShutdownSupport.createDisabled();
             } else {
@@ -352,7 +352,7 @@ public final class Server implements AutoCloseable {
         }
 
         @Override
-        protected CompletionStage<Void> doStop() {
+        protected CompletionStage<Void> doStop(@Nullable Void arg) {
             final CompletableFuture<Void> future = new CompletableFuture<>();
             final GracefulShutdownSupport gracefulShutdownSupport = this.gracefulShutdownSupport;
             if (gracefulShutdownSupport == null ||
@@ -426,7 +426,7 @@ public final class Server implements AutoCloseable {
                     workerShutdownFuture.addListener(unused5 -> {
                         // If starts to shutdown before initializing serverChannels, completes the future
                         // immediately.
-                        if (serverChannels.size() == 0) {
+                        if (serverChannels.isEmpty()) {
                             finishDoStop(future);
                             return;
                         }
@@ -469,22 +469,23 @@ public final class Server implements AutoCloseable {
         }
 
         @Override
-        protected void notifyStarting(ServerListener listener) throws Exception {
+        protected void notifyStarting(ServerListener listener, @Nullable Void arg) throws Exception {
             listener.serverStarting(Server.this);
         }
 
         @Override
-        protected void notifyStarted(ServerListener listener, @Nullable Void value) throws Exception {
+        protected void notifyStarted(ServerListener listener, @Nullable Void arg,
+                                     @Nullable Void result) throws Exception {
             listener.serverStarted(Server.this);
         }
 
         @Override
-        protected void notifyStopping(ServerListener listener) throws Exception {
+        protected void notifyStopping(ServerListener listener, @Nullable Void arg) throws Exception {
             listener.serverStopping(Server.this);
         }
 
         @Override
-        protected void notifyStopped(ServerListener listener) throws Exception {
+        protected void notifyStopped(ServerListener listener, @Nullable Void arg) throws Exception {
             listener.serverStopped(Server.this);
         }
 

--- a/core/src/test/java/com/linecorp/armeria/common/util/StartStopSupportTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/util/StartStopSupportTest.java
@@ -246,10 +246,10 @@ public class StartStopSupportTest {
             throw exception;
         }, stopTask);
 
-        assertThatThrownBy(() -> startStop.start(true).join())
+        assertThatThrownBy(() -> startStop.start(null, 1L, true).join())
                 .isInstanceOf(CompletionException.class)
                 .hasCause(exception);
-        verify(stopTask, times(1)).run(null);
+        verify(stopTask, times(1)).run(1L);
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/common/util/StartStopSupportTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/util/StartStopSupportTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
@@ -29,7 +30,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.util.EventListener;
-import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
@@ -38,6 +38,9 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+import javax.annotation.Nullable;
 
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.ClassRule;
@@ -66,31 +69,31 @@ public class StartStopSupportTest {
 
     @Test
     public void simpleStartStop() throws Throwable {
-        final Callable<String> startTask = SpiedCallable.of("foo");
-        final ThrowingCallable stopTask = mock(ThrowingCallable.class);
+        final StartTask startTask = SpiedStartTask.of("foo");
+        final StopTask stopTask = mock(StopTask.class);
         final StartStop startStop = new StartStop(startTask, stopTask);
 
         assertThat(startStop.toString()).isEqualTo("STOPPED");
-        assertThat(startStop.start(true).join()).isEqualTo("foo");
+        assertThat(startStop.start(1, true).join()).isEqualTo("foo");
         assertThat(startStop.toString()).isEqualTo("STARTED");
-        verify(startTask, times(1)).call();
-        verify(stopTask, never()).call();
+        verify(startTask, times(1)).run(1);
+        verify(stopTask, never()).run(any());
 
-        assertThat(startStop.stop().join()).isNull();
+        assertThat(startStop.stop(2L).join()).isNull();
         assertThat(startStop.toString()).isEqualTo("STOPPED");
-        verify(startTask, times(1)).call();
-        verify(stopTask, times(1)).call();
+        verify(startTask, times(1)).run(1);
+        verify(stopTask, times(1)).run(2L);
     }
 
     @Test
     public void startingWhileStarting() {
         final CountDownLatch startLatch = new CountDownLatch(2);
-        final StartStop startStop = new StartStop(() -> {
+        final StartStop startStop = new StartStop(arg -> {
             // Signal the main thread that it entered the STARTING state.
             startLatch.countDown();
             startLatch.await();
             return "bar";
-        }, () -> {});
+        }, arg -> null);
 
         // Enter the STARTING state.
         final CompletableFuture<String> startFuture = startStop.start(true);
@@ -112,7 +115,7 @@ public class StartStopSupportTest {
 
     @Test
     public void startingWhileStarted() {
-        final StartStop startStop = new StartStop(() -> "foo", () -> {});
+        final StartStop startStop = new StartStop(arg -> "foo", arg -> null);
 
         // Enter the STARTED state.
         final CompletableFuture<String> startFuture = startStop.start(true);
@@ -129,12 +132,13 @@ public class StartStopSupportTest {
 
     @Test
     public void startingWhileStopping() throws Throwable {
-        final Callable<String> startTask = SpiedCallable.of("bar");
+        final StartTask startTask = SpiedStartTask.of("bar");
         final CountDownLatch stopLatch = new CountDownLatch(2);
-        final StartStop startStop = new StartStop(startTask, () -> {
+        final StartStop startStop = new StartStop(startTask, arg -> {
             // Signal the main thread that it entered the STOPPING state.
             stopLatch.countDown();
             stopLatch.await();
+            return null;
         });
 
         // Enter the STOPPING state.
@@ -147,7 +151,7 @@ public class StartStopSupportTest {
         clearInvocations(startTask);
         final CompletableFuture<String> startFuture = startStop.start(true);
         repeat(() -> {
-            verify(startTask, never()).call();
+            verify(startTask, never()).run(any());
             assertThat(startFuture).isNotDone();
         });
 
@@ -157,14 +161,14 @@ public class StartStopSupportTest {
 
         // Now check that the startup procedure has been performed.
         assertThat(startFuture.join()).isEqualTo("bar");
-        verify(startTask, times(1)).call();
+        verify(startTask, times(1)).run(null);
     }
 
     @Test
     public void stoppingWhileStarting() throws Throwable {
-        final ThrowingCallable stopTask = mock(ThrowingCallable.class);
+        final StopTask stopTask = mock(StopTask.class);
         final CountDownLatch startLatch = new CountDownLatch(2);
-        final StartStop startStop = new StartStop(() -> {
+        final StartStop startStop = new StartStop(arg -> {
             // Signal the main thread that it entered the STARTING state.
             startLatch.countDown();
             startLatch.await();
@@ -178,7 +182,7 @@ public class StartStopSupportTest {
         // stop() should never complete until startup procedure is complete.
         final CompletableFuture<Void> stopFuture = startStop.stop();
         repeat(() -> {
-            verify(stopTask, never()).call();
+            verify(stopTask, never()).run(any());
             assertThat(stopFuture).isNotDone();
         });
 
@@ -188,34 +192,42 @@ public class StartStopSupportTest {
 
         // Now check that the shutdown procedure has been performed.
         assertThat(stopFuture.join()).isNull();
-        verify(stopTask, times(1)).call();
+        verify(stopTask, times(1)).run(null);
     }
 
     @Test
     public void stoppingWhileStopping() {
+        final AtomicLong stopArg = new AtomicLong();
         final CountDownLatch stopLatch = new CountDownLatch(2);
-        final StartStop startStop = new StartStop(() -> "bar", () -> {
+        final StartStop startStop = new StartStop(arg -> "bar", arg -> {
+            assertThat(arg).isNotNull();
+            stopArg.set(arg);
+
             // Signal the main thread that it entered the STOPPING state.
             stopLatch.countDown();
             stopLatch.await();
+            return null;
         });
 
         // Enter the STOPPING state.
         assertThat(startStop.start(true).join()).isEqualTo("bar");
-        final CompletableFuture<Void> stopFuture = startStop.stop();
+        final CompletableFuture<Void> stopFuture = startStop.stop(1L);
         await().until(() -> stopLatch.getCount() == 1);
 
         // stop() will return the previous future.
-        assertThat(startStop.stop()).isSameAs(stopFuture);
+        assertThat(startStop.stop(2L)).isSameAs(stopFuture);
 
         // Finish the shutdown procedure.
         stopLatch.countDown();
         assertThat(stopFuture.join()).isNull();
+
+        // Make sure doStop() was not called with the arguments of the late stop() call.
+        assertThat(stopArg).hasValue(1);
     }
 
     @Test
     public void stoppingWhileStopped() {
-        final StartStop startStop = new StartStop(() -> "foo", () -> {});
+        final StartStop startStop = new StartStop(arg -> "foo", arg -> null);
 
         // Enter the STOPPED state.
         assertThat(startStop.start(true).join()).isEqualTo("foo");
@@ -228,25 +240,25 @@ public class StartStopSupportTest {
 
     @Test
     public void rollback() throws Throwable {
-        final ThrowingCallable stopTask = mock(ThrowingCallable.class);
+        final StopTask stopTask = mock(StopTask.class);
         final Exception exception = new AnticipatedException();
-        final StartStop startStop = new StartStop(() -> {
+        final StartStop startStop = new StartStop(arg -> {
             throw exception;
         }, stopTask);
 
         assertThatThrownBy(() -> startStop.start(true).join())
                 .isInstanceOf(CompletionException.class)
                 .hasCause(exception);
-        verify(stopTask, times(1)).call();
+        verify(stopTask, times(1)).run(null);
     }
 
     @Test
     public void rollbackFailure() throws Throwable {
         final Exception startException = new AnticipatedException();
         final Exception stopException = new AnticipatedException();
-        final StartStop startStop = spy(new StartStop(() -> {
+        final StartStop startStop = spy(new StartStop(arg -> {
             throw startException;
-        }, () -> {
+        }, arg -> {
             throw stopException;
         }));
 
@@ -262,45 +274,48 @@ public class StartStopSupportTest {
         final CountDownLatch startLatch = new CountDownLatch(1);
         final CountDownLatch stopLatch = new CountDownLatch(1);
         final EventListener listener = mock(EventListener.class);
-        final StartStop startStop = spy(new StartStop(() -> {
+        final StartStop startStop = spy(new StartStop(arg -> {
             startLatch.await();
             return "bar";
-        }, stopLatch::await));
+        }, arg -> {
+            stopLatch.await();
+            return null;
+        }));
         startStop.addListener(listener);
 
-        final CompletableFuture<String> startFuture = startStop.start(true);
+        final CompletableFuture<String> startFuture = startStop.start(1, true);
         await().untilAsserted(() -> {
-            verify(startStop, times(1)).notifyStarting(listener);
-            verify(startStop, never()).notifyStarted(listener, "bar");
-            verify(startStop, never()).notifyStopping(listener);
-            verify(startStop, never()).notifyStopped(listener);
+            verify(startStop, times(1)).notifyStarting(listener, 1);
+            verify(startStop, never()).notifyStarted(same(listener), any(), any());
+            verify(startStop, never()).notifyStopping(same(listener), any());
+            verify(startStop, never()).notifyStopped(same(listener), any());
             assertThat(startFuture).isNotDone();
         });
 
         startLatch.countDown();
         await().untilAsserted(() -> {
-            verify(startStop, times(1)).notifyStarting(listener);
-            verify(startStop, times(1)).notifyStarted(listener, "bar");
-            verify(startStop, never()).notifyStopping(listener);
-            verify(startStop, never()).notifyStopped(listener);
+            verify(startStop, times(1)).notifyStarting(listener, 1);
+            verify(startStop, times(1)).notifyStarted(listener, 1, "bar");
+            verify(startStop, never()).notifyStopping(same(listener), any());
+            verify(startStop, never()).notifyStopped(same(listener), any());
             assertThat(startFuture).isCompletedWithValue("bar");
         });
 
-        final CompletableFuture<Void> stopFuture = startStop.stop();
+        final CompletableFuture<Void> stopFuture = startStop.stop(2L);
         await().untilAsserted(() -> {
-            verify(startStop, times(1)).notifyStarting(listener);
-            verify(startStop, times(1)).notifyStarted(listener, "bar");
-            verify(startStop, times(1)).notifyStopping(listener);
-            verify(startStop, never()).notifyStopped(listener);
+            verify(startStop, times(1)).notifyStarting(listener, 1);
+            verify(startStop, times(1)).notifyStarted(listener, 1, "bar");
+            verify(startStop, times(1)).notifyStopping(listener, 2L);
+            verify(startStop, never()).notifyStopped(same(listener), any());
             assertThat(stopFuture).isNotDone();
         });
 
         stopLatch.countDown();
         await().untilAsserted(() -> {
-            verify(startStop, times(1)).notifyStarting(listener);
-            verify(startStop, times(1)).notifyStarted(listener, "bar");
-            verify(startStop, times(1)).notifyStopping(listener);
-            verify(startStop, times(1)).notifyStopped(listener);
+            verify(startStop, times(1)).notifyStarting(listener, 1);
+            verify(startStop, times(1)).notifyStarted(listener, 1, "bar");
+            verify(startStop, times(1)).notifyStopping(listener, 2L);
+            verify(startStop, times(1)).notifyStopped(listener, 2L);
             assertThat(stopFuture).isCompletedWithValue(null);
         });
     }
@@ -309,8 +324,8 @@ public class StartStopSupportTest {
     public void listenerNotificationFailure() throws Exception {
         final EventListener listener = mock(EventListener.class);
         final Exception exception = new AnticipatedException();
-        final StartStop startStop = spy(new StartStop(() -> "foo", () -> {}));
-        doThrow(exception).when(startStop).notifyStarting(any());
+        final StartStop startStop = spy(new StartStop(arg -> "foo", arg -> null));
+        doThrow(exception).when(startStop).notifyStarting(any(), any());
 
         startStop.addListener(listener);
         assertThat(startStop.start(true).join()).isEqualTo("foo");
@@ -320,56 +335,56 @@ public class StartStopSupportTest {
     @Test
     public void listenerRemoval() throws Exception {
         final EventListener listener = mock(EventListener.class);
-        final StartStop startStop = spy(new StartStop(() -> "bar", () -> {}));
+        final StartStop startStop = spy(new StartStop(arg -> "bar", arg -> null));
         startStop.addListener(listener);
         startStop.removeListener(listener);
 
         assertThat(startStop.start(true).join()).isEqualTo("bar");
         assertThat(startStop.stop().join()).isNull();
 
-        verify(startStop, never()).notifyStarting(listener);
-        verify(startStop, never()).notifyStarted(listener, "bar");
-        verify(startStop, never()).notifyStopping(listener);
-        verify(startStop, never()).notifyStopped(listener);
+        verify(startStop, never()).notifyStarting(same(listener), any());
+        verify(startStop, never()).notifyStarted(same(listener), any(), any());
+        verify(startStop, never()).notifyStopping(same(listener), any());
+        verify(startStop, never()).notifyStopped(same(listener), any());
     }
 
     @Test
     public void close() {
-        final StartStop startStop = new StartStop(() -> "foo", () -> {});
+        final StartStop startStop = new StartStop(arg -> "foo", arg -> null);
         startStop.close();
     }
 
     @Test
     public void closeWhileStopped() throws Throwable {
-        final Callable<String> startTask = SpiedCallable.of("bar");
-        final ThrowingCallable stopTask = mock(ThrowingCallable.class);
+        final StartTask startTask = SpiedStartTask.of("bar");
+        final StopTask stopTask = mock(StopTask.class);
         final StartStop startStop = new StartStop(startTask, stopTask);
 
         for (int i = 0; i < 2; i++) { // Check twice to ensure idempotence.
             startStop.close();
-            verify(startTask, never()).call();
-            verify(stopTask, never()).call();
+            verify(startTask, never()).run(any());
+            verify(stopTask, never()).run(any());
         }
     }
 
     @Test
     public void closeWhileStarted() throws Throwable {
-        final Callable<String> startTask = SpiedCallable.of("foo");
-        final ThrowingCallable stopTask = mock(ThrowingCallable.class);
+        final StartTask startTask = SpiedStartTask.of("foo");
+        final StopTask stopTask = mock(StopTask.class);
         final StartStop startStop = new StartStop(startTask, stopTask);
         startStop.start(true).join();
 
         for (int i = 0; i < 2; i++) { // Check twice to ensure idempotence.
-            verify(startTask, times(1)).call();
+            verify(startTask, times(1)).run(null);
             startStop.close();
-            verify(stopTask, times(1)).call();
+            verify(stopTask, times(1)).run(null);
         }
     }
 
     @Test
     public void closeFailure() {
         final Exception exception = new AnticipatedException();
-        final StartStop startStop = spy(new StartStop(() -> "bar", () -> {
+        final StartStop startStop = spy(new StartStop(arg -> "bar", arg -> {
             throw exception;
         }));
         startStop.start(true).join();
@@ -384,10 +399,11 @@ public class StartStopSupportTest {
     public void interruptedWhileClosing() throws Throwable {
         final AtomicBoolean interrupted = new AtomicBoolean();
         final CountDownLatch stopLatch = new CountDownLatch(2);
-        final StartStop startStop = new StartStop(() -> "foo", () -> {
+        final StartStop startStop = new StartStop(arg -> "foo", arg -> {
             // Signal the main thread that it entered the STOPPING state.
             stopLatch.countDown();
             stopLatch.await();
+            return null;
         });
 
         // Enter the STOPPING state.
@@ -414,17 +430,18 @@ public class StartStopSupportTest {
 
     @Test
     public void doStartReturnsNull() throws Exception {
-        final StartStopSupport<Void, Void> startStop = new StartStopSupport<Void, Void>(rule.get()) {
-            @Override
-            protected CompletionStage<Void> doStart() throws Exception {
-                return null;
-            }
+        final StartStopSupport<Void, Void, Void, Void> startStop =
+                new StartStopSupport<Void, Void, Void, Void>(rule.get()) {
+                    @Override
+                    protected CompletionStage<Void> doStart(@Nullable Void arg) throws Exception {
+                        return null;
+                    }
 
-            @Override
-            protected CompletionStage<Void> doStop() throws Exception {
-                return CompletableFuture.completedFuture(null);
-            }
-        };
+                    @Override
+                    protected CompletionStage<Void> doStop(@Nullable Void arg) throws Exception {
+                        return CompletableFuture.completedFuture(null);
+                    }
+                };
 
         assertThatThrownBy(() -> startStop.start(true).join())
                 .isInstanceOf(CompletionException.class)
@@ -436,17 +453,18 @@ public class StartStopSupportTest {
 
     @Test
     public void doStopReturnsNull() throws Exception {
-        final StartStopSupport<String, Void> startStop = new StartStopSupport<String, Void>(rule.get()) {
-            @Override
-            protected CompletionStage<String> doStart() throws Exception {
-                return CompletableFuture.completedFuture("started");
-            }
+        final StartStopSupport<Void, Void, String, Void> startStop =
+                new StartStopSupport<Void, Void, String, Void>(rule.get()) {
+                    @Override
+                    protected CompletionStage<String> doStart(@Nullable Void arg) throws Exception {
+                        return CompletableFuture.completedFuture("started");
+                    }
 
-            @Override
-            protected CompletionStage<Void> doStop() throws Exception {
-                return null;
-            }
-        };
+                    @Override
+                    protected CompletionStage<Void> doStop(@Nullable Void arg) throws Exception {
+                        return null;
+                    }
+                };
 
         assertThat(startStop.start(true).join()).isEqualTo("started");
         assertThatThrownBy(() -> startStop.stop().join())
@@ -460,17 +478,18 @@ public class StartStopSupportTest {
     @Test
     public void rejectingExecutor() throws Exception {
         final Executor executor = mock(Executor.class);
-        final StartStopSupport<String, Void> startStop = new StartStopSupport<String, Void>(executor) {
-            @Override
-            protected CompletionStage<String> doStart() throws Exception {
-                return CompletableFuture.completedFuture("started");
-            }
+        final StartStopSupport<Void, Void, String, Void> startStop =
+                new StartStopSupport<Void, Void, String, Void>(executor) {
+                    @Override
+                    protected CompletionStage<String> doStart(@Nullable Void arg) throws Exception {
+                        return CompletableFuture.completedFuture("started");
+                    }
 
-            @Override
-            protected CompletionStage<Void> doStop() throws Exception {
-                return CompletableFuture.completedFuture(null);
-            }
-        };
+                    @Override
+                    protected CompletionStage<Void> doStop(@Nullable Void arg) throws Exception {
+                        return CompletableFuture.completedFuture(null);
+                    }
+                };
 
         // Rejected when starting.
         doThrow(new RejectedExecutionException()).when(executor).execute(any());
@@ -492,37 +511,30 @@ public class StartStopSupportTest {
                 .hasCauseInstanceOf(RejectedExecutionException.class);
     }
 
-    private static class StartStop extends StartStopSupport<String, EventListener> {
+    private static class StartStop extends StartStopSupport<Integer, Long, String, EventListener> {
 
-        private final Callable<String> startTask;
-        private final ThrowingCallable stopTask;
+        private final StartTask startTask;
+        private final StopTask stopTask;
 
-        StartStop(Callable<String> startTask, ThrowingCallable stopTask) {
+        StartStop(StartTask startTask, StopTask stopTask) {
             super(rule.get());
             this.startTask = startTask;
             this.stopTask = stopTask;
         }
 
         @Override
-        protected CompletionStage<String> doStart() throws Exception {
-            return execute(startTask);
+        protected CompletionStage<String> doStart(@Nullable Integer arg) throws Exception {
+            return execute(startTask, arg);
         }
 
         @Override
-        protected CompletionStage<Void> doStop() throws Exception {
-            return execute(() -> {
-                try {
-                    stopTask.call();
-                } catch (Throwable cause) {
-                    Exceptions.throwUnsafely(cause);
-                }
-                return null;
-            });
+        protected CompletionStage<Void> doStop(@Nullable Long arg) throws Exception {
+            return execute(stopTask, arg);
         }
 
-        private static <T> CompletionStage<T> execute(Callable<T> task) {
-            final CompletableFuture<T> future = new CompletableFuture<>();
-            rule.get().submit(task).addListener((FutureListener<T>) f -> {
+        private static <T, U> CompletionStage<U> execute(ThrowingFunction<T, U> task, @Nullable T arg) {
+            final CompletableFuture<U> future = new CompletableFuture<>();
+            rule.get().submit(() -> task.run(arg)).addListener((FutureListener<U>) f -> {
                 if (f.isSuccess()) {
                     future.complete(f.getNow());
                 } else {
@@ -544,25 +556,37 @@ public class StartStopSupportTest {
         } while (stopwatch.elapsed(TimeUnit.MILLISECONDS) < 1000);
     }
 
+    @FunctionalInterface
+    private interface ThrowingFunction<T, U> {
+        @Nullable
+        U run(@Nullable T arg) throws Exception;
+    }
+
+    @FunctionalInterface
+    private interface StartTask extends ThrowingFunction<Integer, String> {}
+
+    @FunctionalInterface
+    private interface StopTask extends ThrowingFunction<Long, Void> {}
+
     @SuppressWarnings({
             "checkstyle:FinalClass",
             "ClassWithOnlyPrivateConstructors"
     }) // Can't be final to spy on it.
-    private static class SpiedCallable implements Callable<String> {
+    private static class SpiedStartTask implements StartTask {
 
-        static Callable<String> of(String value) {
-            return spy(new SpiedCallable(value));
+        static SpiedStartTask of(String result) {
+            return spy(new SpiedStartTask(result));
         }
 
-        private final String value;
+        private final String result;
 
-        private SpiedCallable(String value) {
-            this.value = value;
+        private SpiedStartTask(String result) {
+            this.result = result;
         }
 
         @Override
-        public String call() throws Exception {
-            return value;
+        public String run(@Nullable Integer arg) throws Exception {
+            return result;
         }
     }
 }


### PR DESCRIPTION
Motivation:

A user sometimes wants to pass an argument when starting or stopping
something.

Modifications:

- Added two more type parameters to `StartStopSupport`.
- Added `StartStopSupport.start(arg, failIfStarted)`
- Added `StartStopSupport.stop(arg)`
- Modified the parameters of `StartStop.doStart()`, `doStop()` and
  listener notification methods.

Result:

- A user can pass a startup/shutdown argument when using
  `StartStopSupport`.
- `StartStopSupport` has breaking changes.