### PR TITLE
Add InvalidResponseHeadersException

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/InvalidResponseException.java
+++ b/core/src/main/java/com/linecorp/armeria/client/InvalidResponseException.java
@@ -18,7 +18,7 @@ package com.linecorp.armeria.client;
 import javax.annotation.Nullable;
 
 /**
- * A {@link RuntimeException} raised when the client received a response with an unexpected status code.
+ * A {@link RuntimeException} raised when a client received an invalid response.
  */
 public class InvalidResponseException extends RuntimeException {
     private static final long serialVersionUID = 7789160689214376205L;

--- a/core/src/main/java/com/linecorp/armeria/client/InvalidResponseHeadersException.java
+++ b/core/src/main/java/com/linecorp/armeria/client/InvalidResponseHeadersException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 LINE Corporation
+ * Copyright 2019 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/core/src/main/java/com/linecorp/armeria/client/InvalidResponseHeadersException.java
+++ b/core/src/main/java/com/linecorp/armeria/client/InvalidResponseHeadersException.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2015 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client;
+
+import static java.util.Objects.requireNonNull;
+
+import javax.annotation.Nullable;
+
+import com.linecorp.armeria.common.HttpHeaders;
+
+/**
+ * An {@link InvalidResponseException} raised when a client received a response with invalid headers.
+ */
+public class InvalidResponseHeadersException extends InvalidResponseException {
+
+    private static final long serialVersionUID = -1349209911680323202L;
+
+    private final HttpHeaders headers;
+
+    /**
+     * Creates a new instance with the specified response {@link HttpHeaders}.
+     */
+    public InvalidResponseHeadersException(HttpHeaders headers) {
+        super(requireNonNull(headers, "headers").toString());
+        this.headers = HttpHeaders.copyOf(headers).asImmutable();
+    }
+
+    /**
+     * Creates a new instance with the specified response {@link HttpHeaders} and {@code cause}.
+     */
+    public InvalidResponseHeadersException(HttpHeaders headers, @Nullable Throwable cause) {
+        super(requireNonNull(headers, "headers").toString(), cause);
+        this.headers = HttpHeaders.copyOf(headers).asImmutable();
+    }
+
+    /**
+     * Creates a new instance with the specified response {@link HttpHeaders}, {@code cause},
+     * suppression enabled or disabled, and writable stack trace enabled or disabled.
+     */
+    protected InvalidResponseHeadersException(HttpHeaders headers, @Nullable Throwable cause,
+                                              boolean enableSuppression, boolean writableStackTrace) {
+        super(requireNonNull(headers, "headers").toString(), cause,
+              enableSuppression, writableStackTrace);
+        this.headers = HttpHeaders.copyOf(headers).asImmutable();
+    }
+
+    /**
+     * Returns the response {@link HttpHeaders} which triggered this exception.
+     */
+    public HttpHeaders headers() {
+        return headers;
+    }
+}

--- a/thrift/src/main/java/com/linecorp/armeria/client/thrift/THttpClientDelegate.java
+++ b/thrift/src/main/java/com/linecorp/armeria/client/thrift/THttpClientDelegate.java
@@ -41,7 +41,7 @@ import com.google.common.base.Strings;
 
 import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.client.ClientRequestContext;
-import com.linecorp.armeria.client.InvalidResponseException;
+import com.linecorp.armeria.client.InvalidResponseHeadersException;
 import com.linecorp.armeria.common.AggregatedHttpMessage;
 import com.linecorp.armeria.common.DefaultRpcResponse;
 import com.linecorp.armeria.common.HttpData;
@@ -133,7 +133,8 @@ final class THttpClientDelegate implements Client<RpcRequest, RpcResponse> {
 
                 final HttpStatus status = res.status();
                 if (status.code() != HttpStatus.OK.code()) {
-                    handlePreDecodeException(ctx, reply, func, new InvalidResponseException(status.toString()));
+                    handlePreDecodeException(ctx, reply, func,
+                                             new InvalidResponseHeadersException(res.headers()));
                     return null;
                 }
 

--- a/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftSerializationFormatsTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftSerializationFormatsTest.java
@@ -37,7 +37,7 @@ import org.junit.rules.ExpectedException;
 
 import com.linecorp.armeria.client.ClientOption;
 import com.linecorp.armeria.client.Clients;
-import com.linecorp.armeria.client.InvalidResponseException;
+import com.linecorp.armeria.client.InvalidResponseHeadersException;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.SerializationFormat;
@@ -122,8 +122,8 @@ public class ThriftSerializationFormatsTest {
     public void notAllowed() throws Exception {
         final HelloService.Iface client =
                 Clients.newClient(server.uri(TEXT, "/hellobinaryonly"), HelloService.Iface.class);
-        thrown.expect(InvalidResponseException.class);
-        thrown.expectMessage("415 Unsupported Media Type");
+        thrown.expect(InvalidResponseHeadersException.class);
+        thrown.expectMessage(":status=415");
         client.hello("Trustin");
     }
 
@@ -147,8 +147,8 @@ public class ThriftSerializationFormatsTest {
                 Clients.newClient(server.uri(TEXT, "/hello"),
                                   HelloService.Iface.class,
                                   ClientOption.HTTP_HEADERS.newValue(headers));
-        thrown.expect(InvalidResponseException.class);
-        thrown.expectMessage("406 Not Acceptable");
+        thrown.expect(InvalidResponseHeadersException.class);
+        thrown.expectMessage(":status=406");
         client.hello("Trustin");
     }
 


### PR DESCRIPTION
Motivation:

When a Thrift client throws an `InvalidResponseException`, a user need
to know the details about the response, such as HTTP status code.

Modifications:

- Added `InvalidResponseHeadersException` which extends
  `InvalidResponseException`
- Throw `InvalidResponseHeadersException` instead of
  `InvalidResponseException` where possible.

Result:

A user have enough information to determine the status of a Thrift
endpoint.