### PR TITLE
Fix to send a request only when the submit button is pressed in `DocS…

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpDocServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpDocServiceTest.java
@@ -336,7 +336,9 @@ public class AnnotatedHttpDocServiceTest {
         }
 
         @Get("prefix:/prefix")
-        public String prefix(ServiceRequestContext ctx) {
+        public String prefix(ServiceRequestContext ctx) throws InterruptedException {
+            // Added to check delayed response in browser.
+            Thread.sleep(500);
             return "prefix";
         }
 

--- a/docs-client/src/containers/MethodPage/DebugPage.tsx
+++ b/docs-client/src/containers/MethodPage/DebugPage.tsx
@@ -91,15 +91,11 @@ class DebugPage extends React.PureComponent<Props, State> {
 
   public componentDidMount() {
     this.initializeState();
-    this.executeRequest();
   }
 
   public componentDidUpdate(prevProps: Props) {
     if (this.props.match.params !== prevProps.match.params) {
       this.initializeState();
-    }
-    if (this.props.location.search !== prevProps.location.search) {
-      this.executeRequest();
     }
   }
 
@@ -258,6 +254,10 @@ class DebugPage extends React.PureComponent<Props, State> {
   };
 
   private onSubmit = () => {
+    this.setState({
+      debugResponse: '',
+    });
+
     const requestBody = this.state.requestBody;
     const endpointPath = this.state.endpointPath;
     const queries = this.state.additionalQueries;
@@ -317,8 +317,8 @@ class DebugPage extends React.PureComponent<Props, State> {
       this.props.history.push(
         `${this.props.location.pathname}${serializedParams}`,
       );
-      this.executeRequest();
     }
+    this.executeRequest(params);
   };
 
   private validateEndpointPath(endpointPath: string) {
@@ -411,12 +411,7 @@ class DebugPage extends React.PureComponent<Props, State> {
     });
   }
 
-  private async executeRequest() {
-    if (!this.props.location.search) {
-      return;
-    }
-    const params = new URLSearchParams(this.props.location.search);
-
+  private async executeRequest(params: URLSearchParams) {
     let requestBody;
     if (this.props.useRequestBody) {
       requestBody = params.get('request_body');


### PR DESCRIPTION
…ervice`

Motivation:
Currently, a request is sending automatically whenever the browser is rendered.
However, this could cause some security issues, so we have to change the default behavior.

Modifications:
- Change to send a request when a user pressed the submit button.
- Clear the response before sending a request so that you are able to know that the submit button is pressed.

Result:
- The request is no longer sent automatically.