### PR TITLE
Ensure to close HttpResponseWrapper on the channel event loop

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.client;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -70,8 +71,8 @@ abstract class HttpResponseDecoder {
             int id, @Nullable HttpRequest req, DecodedHttpResponse res, RequestLogBuilder logBuilder,
             long responseTimeoutMillis, long maxContentLength) {
 
-        final HttpResponseWrapper newRes =
-                new HttpResponseWrapper(req, res, logBuilder, responseTimeoutMillis, maxContentLength);
+        final HttpResponseWrapper newRes = new HttpResponseWrapper(channel.eventLoop(), req, res, logBuilder,
+                                                                   responseTimeoutMillis, maxContentLength);
         final HttpResponseWrapper oldRes = responses.put(id, newRes);
 
         assert oldRes == null : "addResponse(" + id + ", " + res + ", " + responseTimeoutMillis + "): " +
@@ -133,6 +134,7 @@ abstract class HttpResponseDecoder {
             DONE
         }
 
+        private final EventLoop eventLoop;
         @Nullable
         private final HttpRequest request;
         private final DecodedHttpResponse delegate;
@@ -146,8 +148,9 @@ abstract class HttpResponseDecoder {
 
         private State state = State.WAIT_NON_INFORMATIONAL;
 
-        HttpResponseWrapper(@Nullable HttpRequest request, DecodedHttpResponse delegate,
+        HttpResponseWrapper(EventLoop eventLoop, @Nullable HttpRequest request, DecodedHttpResponse delegate,
                             RequestLogBuilder logBuilder, long responseTimeoutMillis, long maxContentLength) {
+            this.eventLoop = eventLoop;
             this.request = request;
             this.delegate = delegate;
             this.logBuilder = logBuilder;
@@ -254,8 +257,19 @@ abstract class HttpResponseDecoder {
             return delegate.onDemand(task);
         }
 
+        /**
+         * Note that this method can be called from outside of the event loop because it will be called
+         * by the {@link CompletableFuture#handle(BiFunction)} method when the future of
+         * the delegate (i.e. {@link DecodedHttpResponse}) is completed. Please refer to
+         * {@link Http1ResponseDecoder#addResponse} and {@link Http2ResponseDecoder#addResponse}
+         * where calling this method.
+         */
         void onSubscriptionCancelled() {
-            close(null, this::cancelAction);
+            if (eventLoop.inEventLoop()) {
+                close(null, this::cancelAction);
+            } else {
+                eventLoop.execute(() -> close(null, this::cancelAction));
+            }
         }
 
         @Override

--- a/core/src/test/java/com/linecorp/armeria/client/HttpResponseDecoderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpResponseDecoderTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.channels.Channel;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linecorp.armeria.client.HttpResponseDecoder.HttpResponseWrapper;
+import com.linecorp.armeria.client.retry.Backoff;
+import com.linecorp.armeria.client.retry.RetryStrategy;
+import com.linecorp.armeria.client.retry.RetryingHttpClientBuilder;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.logging.RequestLogAvailability;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.testing.server.ServerRule;
+
+public class HttpResponseDecoderTest {
+    private static final Logger logger = LoggerFactory.getLogger(HttpResponseDecoderTest.class);
+
+    @ClassRule
+    public static ServerRule rule = new ServerRule() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.service("/", (ctx, req) -> HttpResponse.of("Hello, Armeria!"));
+        }
+    };
+
+    /**
+     * This test would be passed because the {@code cancelAction} method of the {@link HttpResponseWrapper} is
+     * invoked in the event loop of the {@link Channel}.
+     */
+    @Test
+    public void confirmResponseStartAndEndInTheSameThread() throws InterruptedException {
+        final AtomicBoolean failed = new AtomicBoolean();
+        final Backoff backoff = Backoff.exponential(200, 1000).withJitter(0.2);
+        final RetryStrategy strategy = (ctx, cause) -> CompletableFuture.completedFuture(backoff);
+        final HttpClient client = new HttpClientBuilder("h1c://127.0.0.1:" + rule.httpPort())
+                // This increases the execution duration of 'endResponse0' of the DefaultRequestLog,
+                // which means that we have more chance to reproduce the bug if two threads are racing
+                // for notifying RESPONSE_END to listeners.
+                .contentPreview(100)
+                // In order to use a different thread to send a request.
+                .decorator(new RetryingHttpClientBuilder(strategy).maxTotalAttempts(2).newDecorator())
+                .decorator((delegate, ctx, req) -> {
+                    final AtomicReference<Thread> responseStartedThread = new AtomicReference<>();
+                    ctx.log().addListener(log -> {
+                        responseStartedThread.set(Thread.currentThread());
+                        if (!ctx.eventLoop().inEventLoop()) {
+                            // Actually we don't expect this situation, but it is prepared for the case.
+                            logger.error("{} Response started in another thread: {} != {}",
+                                         ctx, ctx.eventLoop(), Thread.currentThread());
+                            failed.set(true);
+                        }
+                    }, RequestLogAvailability.RESPONSE_START);
+                    ctx.log().addListener(log -> {
+                        final Thread thread = responseStartedThread.get();
+                        if (thread != null && thread != Thread.currentThread()) {
+                            logger.error("{} Response ended in another thread: {} != {}",
+                                         ctx, thread, Thread.currentThread());
+                            failed.set(true);
+                        }
+                    }, RequestLogAvailability.RESPONSE_END);
+                    return delegate.execute(ctx, req);
+                })
+                .build();
+
+        // Execute it as much as we can in order to confirm that there's no problem.
+        final int n = 1000;
+        final CountDownLatch latch = new CountDownLatch(n);
+        for (int i = 0; i < n; i++) {
+            client.execute(HttpRequest.of(HttpMethod.GET, "/")).aggregate()
+                  .handle((unused1, unused2) -> {
+                      latch.countDown();
+                      return null;
+                  });
+        }
+
+        latch.await(System.getenv("CI") != null ? 60 : 10, TimeUnit.SECONDS);
+        assertThat(failed.get()).isFalse();
+    }
+}


### PR DESCRIPTION
Motivation:
There's chance to close `HttpResponseWrapper` on an event loop which is different from the channel event loop.
It is definitely not intended action, and it can cause `IllegalReferenceCountException` due to double-free if a user configured a content previewer.

Modifications:
- Used channel event loop when closing the `HttpResponseWrapper`.

Result:
- No more `IllegalReferenceCountException`.