### PR TITLE
Provide a way to get the duration that was taken to get a connection

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClientConnectionTimings.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientConnectionTimings.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.MoreObjects.ToStringHelper;
+
+import com.linecorp.armeria.common.Request;
+
+import io.netty.channel.Channel;
+import io.netty.util.AttributeKey;
+
+/**
+ * A holder class which has the start time and duration information about acquiring a connection
+ * before a client sends a {@link Request}.
+ */
+public final class ClientConnectionTimings {
+
+    public static final AttributeKey<ClientConnectionTimings> TIMINGS =
+            AttributeKey.valueOf(ClientConnectionTimings.class, "TIMINGS");
+
+    private final long acquiringConnectionStartMicros;
+    private final long acquiringConnectionDurationNanos;
+
+    private final long dnsResolutionDurationNanos;
+    private final long socketConnectDurationNanos;
+    private final long pendingAcquisitionDurationNanos;
+
+    ClientConnectionTimings(long acquiringConnectionStartMicros, long acquiringConnectionDurationNanos,
+                            long dnsResolutionDurationNanos, long socketConnectDurationNanos,
+                            long pendingAcquisitionDurationNanos) {
+        this.acquiringConnectionStartMicros = acquiringConnectionStartMicros;
+        this.acquiringConnectionDurationNanos = acquiringConnectionDurationNanos;
+        this.dnsResolutionDurationNanos = dnsResolutionDurationNanos;
+        this.socketConnectDurationNanos = socketConnectDurationNanos;
+        this.pendingAcquisitionDurationNanos = pendingAcquisitionDurationNanos;
+    }
+
+    /**
+     * Returns the time when acquiring a connection started, in micros since the epoch.
+     */
+    public long acquiringConnectionStartMicros() {
+        return acquiringConnectionStartMicros;
+    }
+
+    /**
+     * Returns the duration which was taken to get a connection, in nanoseconds. This value is greater than or
+     * equal to the sum of {@link #dnsResolutionDurationNanos()}, {@link #socketConnectDurationNanos()} and
+     * {@link #pendingAcquisitionDurationNanos()}.
+     */
+    public long acquiringConnectionDurationNanos() {
+        return acquiringConnectionDurationNanos;
+    }
+
+    /**
+     * Returns the duration which was taken to resolve a DNS address, in nanoseconds.
+     *
+     * @return the duration, or {@code -1} if there was no action to resolve DNS address.
+     */
+    public long dnsResolutionDurationNanos() {
+        return dnsResolutionDurationNanos;
+    }
+
+    /**
+     * Returns the duration which was taken to connect a {@link Channel} to the remote peer, in nanoseconds.
+     *
+     * @return the duration, or {@code -1} if there was no action to connect to the remote peer.
+     */
+    public long socketConnectDurationNanos() {
+        return socketConnectDurationNanos;
+    }
+
+    /**
+     * Returns the duration which was taken to get a pending connection, in nanoseconds. This applies
+     * only for HTTP/2.
+     *
+     * @return the duration, or {@code -1} if there was no action to get a pending connection.
+     */
+    public long pendingAcquisitionDurationNanos() {
+        return pendingAcquisitionDurationNanos;
+    }
+
+    @Override
+    public String toString() {
+        final ToStringHelper toStringHelper =
+                MoreObjects.toStringHelper(this)
+                           .add("acquiringConnectionStartMicros", acquiringConnectionStartMicros)
+                           .add("acquiringConnectionDurationNanos", acquiringConnectionDurationNanos);
+        if (dnsResolutionDurationNanos != -1) {
+            toStringHelper.add("dnsResolutionDurationNanos", dnsResolutionDurationNanos);
+        }
+        if (socketConnectDurationNanos != -1) {
+            toStringHelper.add("socketConnectDurationNanos", socketConnectDurationNanos);
+        }
+        if (pendingAcquisitionDurationNanos != -1) {
+            toStringHelper.add("pendingAcquisitionDurationNanos", pendingAcquisitionDurationNanos);
+        }
+
+        return toStringHelper.toString();
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/client/ClientConnectionTimings.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientConnectionTimings.java
@@ -224,8 +224,8 @@ public final class ClientConnectionTimings {
 
     @Override
     public String toString() {
-        // 1 + 37 + 37 + 31 + 29 + 31 + 29 + 36 + 34 + 46 * 4 + 16 * 4 + 1 = 514
-        final StringBuilder buf = new StringBuilder(514);
+        // 1 + 37 + 37 + 31 + 29 + 31 + 29 + 36 + 34 + 45 * 4 + 16 * 4 + 1 = 510
+        final StringBuilder buf = new StringBuilder(510);
         buf.append('{');
         buf.append("connectionAcquisitionStartTimeMicros=");
         TextFormatter.appendEpochMicros(buf, connectionAcquisitionStartTimeMicros);

--- a/core/src/main/java/com/linecorp/armeria/client/ClientConnectionTimings.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientConnectionTimings.java
@@ -30,7 +30,7 @@ import com.linecorp.armeria.common.util.TextFormatter;
 import io.netty.util.AttributeKey;
 
 /**
- * A holder class which has the timing information about a connection attempts before a client
+ * A holder class which has the timing information about a connection attempt before a client
  * sends a {@link Request}.
  */
 public final class ClientConnectionTimings {
@@ -50,7 +50,8 @@ public final class ClientConnectionTimings {
 
     /**
      * Returns {@link ClientConnectionTimings} from the specified {@link RequestContext} if exists.
-     * You can set a timings using {@link #setTo(RequestContext)}.
+     *
+     * @see #setTo(RequestContext)
      */
     @Nullable
     public static ClientConnectionTimings get(RequestContext ctx) {
@@ -63,7 +64,8 @@ public final class ClientConnectionTimings {
 
     /**
      * Returns {@link ClientConnectionTimings} from the specified {@link RequestLog} if exists.
-     * You can set a timings using {@link #setTo(RequestLog)}.
+     *
+     * @see #setTo(RequestLog)
      */
     @Nullable
     public static ClientConnectionTimings get(RequestLog log) {
@@ -90,7 +92,9 @@ public final class ClientConnectionTimings {
 
     /**
      * Sets this {@link ClientConnectionTimings} to the specified {@link RequestContext}.
-     * You can bring it back using {@link #get(RequestContext)}.
+     * Note that this method is intended for internal use. Do not use unless you really need to.
+     *
+     * @see #get(RequestContext)
      */
     public void setTo(RequestContext ctx) {
         requireNonNull(ctx, "ctx");
@@ -98,8 +102,10 @@ public final class ClientConnectionTimings {
     }
 
     /**
-     * Sets this {@link ClientConnectionTimings} to the specified {@link RequestContext}.
-     * You can bring it back using {@link #get(RequestLog)}.
+     * Sets this {@link ClientConnectionTimings} to the specified {@link RequestLog}.
+     * Note that this method is intended for internal use. Do not use unless you really need to.
+     *
+     * @see #get(RequestLog)
      */
     public void setTo(RequestLog log) {
         requireNonNull(log, "log");
@@ -107,14 +113,14 @@ public final class ClientConnectionTimings {
     }
 
     /**
-     * Returns the time when acquiring a connection started, in microseconds since the epoch.
+     * Returns the time when the client started to acquire a connection, in microseconds since the epoch.
      */
     public long connectionAcquisitionStartTimeMicros() {
         return connectionAcquisitionStartTimeMicros;
     }
 
     /**
-     * Returns the time when acquiring a connection started, in milliseconds since the epoch.
+     * Returns the time when the client started to acquire a connection, in milliseconds since the epoch.
      */
     public long connectionAcquisitionStartTimeMillis() {
         return TimeUnit.MICROSECONDS.toMillis(connectionAcquisitionStartTimeMicros);
@@ -130,7 +136,7 @@ public final class ClientConnectionTimings {
     }
 
     /**
-     * Returns the time when resolving a domain name started, in microseconds since the epoch.
+     * Returns the time when the client started to resolve a domain name, in microseconds since the epoch.
      *
      * @return the duration, or {@code -1} if there was no action to resolve a domain name.
      */
@@ -139,7 +145,7 @@ public final class ClientConnectionTimings {
     }
 
     /**
-     * Returns the time when resolving a domain name started, in milliseconds since the epoch.
+     * Returns the time when the client started to resolve a domain name, in milliseconds since the epoch.
      *
      * @return the duration, or {@code -1} if there was no action to resolve a domain name.
      */
@@ -160,7 +166,7 @@ public final class ClientConnectionTimings {
     }
 
     /**
-     * Returns the time when connecting to a remote peer started, in microseconds since the epoch.
+     * Returns the time when the client started to connect to a remote peer, in microseconds since the epoch.
      *
      * @return the duration, or {@code -1} if there was no action to connect to a remote peer.
      */
@@ -169,7 +175,7 @@ public final class ClientConnectionTimings {
     }
 
     /**
-     * Returns the time when connecting to a remote peer started, in milliseconds since the epoch.
+     * Returns the time when the client started to connect to a remote peer, in milliseconds since the epoch.
      *
      * @return the duration, or {@code -1} if there was no action to connect to a remote peer.
      */
@@ -190,7 +196,7 @@ public final class ClientConnectionTimings {
     }
 
     /**
-     * Returns the time when waiting for the completion of an existing connection attempt started,
+     * Returns the time when the client started to wait for the completion of an existing connection attempt,
      * in microseconds since the epoch.
      *
      * @return the duration, or {@code -1} if there was no action to get a pending connection.
@@ -200,7 +206,7 @@ public final class ClientConnectionTimings {
     }
 
     /**
-     * Returns the time when waiting for the completion of an existing connection attempt started,
+     * Returns the time when the client started to wait for the completion of an existing connection attempt,
      * in milliseconds since the epoch.
      *
      * @return the duration, or {@code -1} if there was no action to get a pending connection.

--- a/core/src/main/java/com/linecorp/armeria/client/ClientConnectionTimings.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientConnectionTimings.java
@@ -32,8 +32,8 @@ import com.linecorp.armeria.common.logging.RequestLog;
 import io.netty.util.AttributeKey;
 
 /**
- * A holder class which has the start time and duration information about acquiring a connection
- * before a client sends a {@link Request}.
+ * A holder class which has the timing information about a connection attempts before a client
+ * sends a {@link Request}.
  */
 public final class ClientConnectionTimings {
 
@@ -192,7 +192,7 @@ public final class ClientConnectionTimings {
     }
 
     /**
-     * Returns the time when waiting the completion of an ongoing connecting attempt started,
+     * Returns the time when waiting the completion of an existing connection attempt started,
      * in microseconds since the epoch.
      *
      * @return the duration, or {@code -1} if there was no action to get a pending connection.
@@ -202,7 +202,7 @@ public final class ClientConnectionTimings {
     }
 
     /**
-     * Returns the time when waiting the completion of an ongoing connecting attempt started,
+     * Returns the time when waiting the completion of an existing connection attempt started,
      * in milliseconds since the epoch.
      *
      * @return the duration, or {@code -1} if there was no action to get a pending connection.
@@ -215,7 +215,7 @@ public final class ClientConnectionTimings {
     }
 
     /**
-     * Returns the duration which was taken to wait the completion of an ongoing connecting attempt in order to
+     * Returns the duration which was taken to wait the completion of an existing connection attempt in order to
      * use one connection for HTTP/2.
      *
      * @return the duration, or {@code -1} if there was no action to get a pending connection.

--- a/core/src/main/java/com/linecorp/armeria/client/ClientConnectionTimings.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientConnectionTimings.java
@@ -22,6 +22,8 @@ import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nullable;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.logging.RequestLog;
@@ -37,6 +39,9 @@ public final class ClientConnectionTimings {
 
     private static final AttributeKey<ClientConnectionTimings> TIMINGS =
             AttributeKey.valueOf(ClientConnectionTimings.class, "TIMINGS");
+
+    @VisibleForTesting
+    static final int TO_STRING_BUILDER_CAPACITY = 466;
 
     private final long connectionAcquisitionStartTimeMicros;
     private final long connectionAcquisitionDurationNanos;
@@ -231,7 +236,7 @@ public final class ClientConnectionTimings {
     @Override
     public String toString() {
         // 33 + 31 + 26 + 23 + 26 + 23 + 31 + 28 + 45 * 4 + 16 * 4 + 1 = 466
-        final StringBuilder buf = new StringBuilder(466);
+        final StringBuilder buf = new StringBuilder(TO_STRING_BUILDER_CAPACITY);
         buf.append("{connectionAcquisitionStartTime=");
         TextFormatter.appendEpochMicros(buf, connectionAcquisitionStartTimeMicros);
         buf.append(", connectionAcquisitionDuration=");

--- a/core/src/main/java/com/linecorp/armeria/client/ClientConnectionTimings.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientConnectionTimings.java
@@ -138,7 +138,7 @@ public final class ClientConnectionTimings {
     /**
      * Returns the time when the client started to resolve a domain name, in microseconds since the epoch.
      *
-     * @return the duration, or {@code -1} if there was no action to resolve a domain name.
+     * @return the start time, or {@code -1} if there was no action to resolve a domain name.
      */
     public long dnsResolutionStartTimeMicros() {
         return dnsResolutionStartTimeMicros;
@@ -147,7 +147,7 @@ public final class ClientConnectionTimings {
     /**
      * Returns the time when the client started to resolve a domain name, in milliseconds since the epoch.
      *
-     * @return the duration, or {@code -1} if there was no action to resolve a domain name.
+     * @return the start time, or {@code -1} if there was no action to resolve a domain name.
      */
     public long dnsResolutionStartTimeMillis() {
         if (dnsResolutionStartTimeMicros >= 0) {
@@ -168,7 +168,7 @@ public final class ClientConnectionTimings {
     /**
      * Returns the time when the client started to connect to a remote peer, in microseconds since the epoch.
      *
-     * @return the duration, or {@code -1} if there was no action to connect to a remote peer.
+     * @return the start time, or {@code -1} if there was no action to connect to a remote peer.
      */
     public long socketConnectStartTimeMicros() {
         return socketConnectStartTimeMicros;
@@ -177,7 +177,7 @@ public final class ClientConnectionTimings {
     /**
      * Returns the time when the client started to connect to a remote peer, in milliseconds since the epoch.
      *
-     * @return the duration, or {@code -1} if there was no action to connect to a remote peer.
+     * @return the start time, or {@code -1} if there was no action to connect to a remote peer.
      */
     public long socketConnectStartTimeMillis() {
         if (socketConnectStartTimeMicros >= 0) {
@@ -199,7 +199,7 @@ public final class ClientConnectionTimings {
      * Returns the time when the client started to wait for the completion of an existing connection attempt,
      * in microseconds since the epoch.
      *
-     * @return the duration, or {@code -1} if there was no action to get a pending connection.
+     * @return the start time, or {@code -1} if there was no action to get a pending connection.
      */
     public long pendingAcquisitionStartTimeMicros() {
         return pendingAcquisitionStartTimeMicros;
@@ -209,7 +209,7 @@ public final class ClientConnectionTimings {
      * Returns the time when the client started to wait for the completion of an existing connection attempt,
      * in milliseconds since the epoch.
      *
-     * @return the duration, or {@code -1} if there was no action to get a pending connection.
+     * @return the start time, or {@code -1} if there was no action to get a pending connection.
      */
     public long pendingAcquisitionStartTimeMillis() {
         if (pendingAcquisitionStartTimeMicros >= 0) {
@@ -230,31 +230,30 @@ public final class ClientConnectionTimings {
 
     @Override
     public String toString() {
-        // 1 + 37 + 37 + 31 + 29 + 31 + 29 + 36 + 34 + 45 * 4 + 16 * 4 + 1 = 510
-        final StringBuilder buf = new StringBuilder(510);
-        buf.append('{');
-        buf.append("connectionAcquisitionStartTimeMicros=");
+        // 33 + 31 + 26 + 23 + 26 + 23 + 31 + 28 + 45 * 4 + 16 * 4 + 1 = 466
+        final StringBuilder buf = new StringBuilder(466);
+        buf.append("{connectionAcquisitionStartTime=");
         TextFormatter.appendEpochMicros(buf, connectionAcquisitionStartTimeMicros);
-        buf.append(", connectionAcquisitionDurationNanos=");
+        buf.append(", connectionAcquisitionDuration=");
         TextFormatter.appendElapsed(buf, connectionAcquisitionDurationNanos);
 
         if (dnsResolutionDurationNanos >= 0) {
-            buf.append(", dnsResolutionStartTimeMicros=");
+            buf.append(", dnsResolutionStartTime=");
             TextFormatter.appendEpochMicros(buf, dnsResolutionStartTimeMicros);
-            buf.append(", dnsResolutionDurationNanos=");
+            buf.append(", dnsResolutionDuration=");
             TextFormatter.appendElapsed(buf, dnsResolutionDurationNanos);
         }
 
         if (socketConnectDurationNanos >= 0) {
-            buf.append(", socketConnectStartTimeMicros=");
+            buf.append(", socketConnectStartTime=");
             TextFormatter.appendEpochMicros(buf, socketConnectStartTimeMicros);
-            buf.append(", socketConnectDurationNanos=");
+            buf.append(", socketConnectDuration=");
             TextFormatter.appendElapsed(buf, socketConnectDurationNanos);
         }
         if (pendingAcquisitionDurationNanos >= 0) {
-            buf.append(", pendingAcquisitionStartTimeMicros=");
+            buf.append(", pendingAcquisitionStartTime=");
             TextFormatter.appendEpochMicros(buf, pendingAcquisitionStartTimeMicros);
-            buf.append(", pendingAcquisitionDurationNanos=");
+            buf.append(", pendingAcquisitionDuration=");
             TextFormatter.appendElapsed(buf, pendingAcquisitionDurationNanos);
         }
         buf.append('}');

--- a/core/src/main/java/com/linecorp/armeria/client/ClientConnectionTimings.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientConnectionTimings.java
@@ -22,12 +22,10 @@ import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nullable;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.base.MoreObjects.ToStringHelper;
-
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.logging.RequestLog;
+import com.linecorp.armeria.common.util.TextFormatter;
 
 import io.netty.util.AttributeKey;
 
@@ -192,7 +190,7 @@ public final class ClientConnectionTimings {
     }
 
     /**
-     * Returns the time when waiting the completion of an existing connection attempt started,
+     * Returns the time when waiting for the completion of an existing connection attempt started,
      * in microseconds since the epoch.
      *
      * @return the duration, or {@code -1} if there was no action to get a pending connection.
@@ -202,7 +200,7 @@ public final class ClientConnectionTimings {
     }
 
     /**
-     * Returns the time when waiting the completion of an existing connection attempt started,
+     * Returns the time when waiting for the completion of an existing connection attempt started,
      * in milliseconds since the epoch.
      *
      * @return the duration, or {@code -1} if there was no action to get a pending connection.
@@ -215,8 +213,8 @@ public final class ClientConnectionTimings {
     }
 
     /**
-     * Returns the duration which was taken to wait the completion of an existing connection attempt in order to
-     * use one connection for HTTP/2.
+     * Returns the duration which was taken to wait for the completion of an existing connection attempt
+     * in order to use one connection for HTTP/2.
      *
      * @return the duration, or {@code -1} if there was no action to get a pending connection.
      */
@@ -226,23 +224,34 @@ public final class ClientConnectionTimings {
 
     @Override
     public String toString() {
-        final ToStringHelper toStringHelper =
-                MoreObjects.toStringHelper(this)
-                           .add("connectionAcquisitionStartTimeMicros", connectionAcquisitionStartTimeMicros)
-                           .add("connectionAcquisitionDurationNanos", connectionAcquisitionDurationNanos);
+        // 1 + 37 + 37 + 31 + 29 + 31 + 29 + 36 + 34 + 46 * 4 + 16 * 4 + 1 = 514
+        final StringBuilder buf = new StringBuilder(514);
+        buf.append('{');
+        buf.append("connectionAcquisitionStartTimeMicros=");
+        TextFormatter.appendEpochMicros(buf, connectionAcquisitionStartTimeMicros);
+        buf.append(", connectionAcquisitionDurationNanos=");
+        TextFormatter.appendElapsed(buf, connectionAcquisitionDurationNanos);
+
         if (dnsResolutionDurationNanos >= 0) {
-            toStringHelper.add("dnsResolutionStartTimeMicros", dnsResolutionStartTimeMicros);
-            toStringHelper.add("dnsResolutionDurationNanos", dnsResolutionDurationNanos);
-        }
-        if (socketConnectDurationNanos >= 0) {
-            toStringHelper.add("socketConnectStartTimeMicros", socketConnectStartTimeMicros);
-            toStringHelper.add("socketConnectDurationNanos", socketConnectDurationNanos);
-        }
-        if (pendingAcquisitionDurationNanos >= 0) {
-            toStringHelper.add("pendingAcquisitionStartTimeMicros", pendingAcquisitionStartTimeMicros);
-            toStringHelper.add("pendingAcquisitionDurationNanos", pendingAcquisitionDurationNanos);
+            buf.append(", dnsResolutionStartTimeMicros=");
+            TextFormatter.appendEpochMicros(buf, dnsResolutionStartTimeMicros);
+            buf.append(", dnsResolutionDurationNanos=");
+            TextFormatter.appendElapsed(buf, dnsResolutionDurationNanos);
         }
 
-        return toStringHelper.toString();
+        if (socketConnectDurationNanos >= 0) {
+            buf.append(", socketConnectStartTimeMicros=");
+            TextFormatter.appendEpochMicros(buf, socketConnectStartTimeMicros);
+            buf.append(", socketConnectDurationNanos=");
+            TextFormatter.appendElapsed(buf, socketConnectDurationNanos);
+        }
+        if (pendingAcquisitionDurationNanos >= 0) {
+            buf.append(", pendingAcquisitionStartTimeMicros=");
+            TextFormatter.appendEpochMicros(buf, pendingAcquisitionStartTimeMicros);
+            buf.append(", pendingAcquisitionDurationNanos=");
+            TextFormatter.appendElapsed(buf, pendingAcquisitionDurationNanos);
+        }
+        buf.append('}');
+        return buf.toString();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/ClientConnectionTimings.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientConnectionTimings.java
@@ -27,7 +27,6 @@ import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.logging.RequestLog;
 
-import io.netty.channel.Channel;
 import io.netty.util.AttributeKey;
 
 /**
@@ -151,7 +150,7 @@ public final class ClientConnectionTimings {
     }
 
     /**
-     * Returns the duration which was taken to connect a {@link Channel} to a remote peer, in nanoseconds.
+     * Returns the duration which was taken to connect to a remote peer, in nanoseconds.
      *
      * @return the duration, or {@code -1} if there was no action to connect to a remote peer.
      */
@@ -160,7 +159,8 @@ public final class ClientConnectionTimings {
     }
 
     /**
-     * Returns the time when connecting to a remote peer started, in microseconds since the epoch.
+     * Returns the time when waiting the completion of an ongoing connecting attempt started,
+     * in microseconds since the epoch.
      *
      * @return the duration, or {@code -1} if there was no action to connect to a remote peer.
      */
@@ -169,7 +169,7 @@ public final class ClientConnectionTimings {
     }
 
     /**
-     * Returns the duration which was taken to wait an ongoing connecting attempt is completed in order to
+     * Returns the duration which was taken to wait the completion of an ongoing connecting attempt in order to
      * use one connection for HTTP/2.
      *
      * @return the duration, or {@code -1} if there was no action to get a pending connection.

--- a/core/src/main/java/com/linecorp/armeria/client/ClientConnectionTimingsBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientConnectionTimingsBuilder.java
@@ -82,8 +82,8 @@ public final class ClientConnectionTimingsBuilder {
     }
 
     /**
-     * Sets the time when waiting the completion of an ongoing connecting attempt in order to use one connection
-     * for HTTP/2.
+     * Sets the time when waiting the completion of an existing connection attempt in order to use one
+     * connection for HTTP/2.
      */
     public ClientConnectionTimingsBuilder pendingAcquisitionStart() {
         pendingAcquisitionStartTimeMicros = SystemInfo.currentTimeMicros();
@@ -92,7 +92,7 @@ public final class ClientConnectionTimingsBuilder {
     }
 
     /**
-     * Sets the time when waiting an ongoing connecting attempt ends in order to use one connection
+     * Sets the time when waiting an existing connection attempt ends in order to use one connection
      * for HTTP/2.
      *
      * @throws IllegalStateException if {@link #pendingAcquisitionStart()} is not invoked before calling this.

--- a/core/src/main/java/com/linecorp/armeria/client/ClientConnectionTimingsBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientConnectionTimingsBuilder.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import com.google.common.annotations.VisibleForTesting;
+
+/**
+ * Builds a new {@link ClientConnectionTimings}.
+ */
+@VisibleForTesting
+public class ClientConnectionTimingsBuilder {
+
+    private final long acquiringConnectionStartMicros;
+    private final long acquiringConnectionStartNanos;
+
+    private long dnsResolutionEndNanos;
+    private long socketConnectStartNanos;
+    private long socketConnectEndNanos;
+    private long pendingAcquisitionStartNanos;
+    private long pendingAcquisitionEndNanos;
+
+    /**
+     * Creates a new instance.
+     */
+    @VisibleForTesting
+    public ClientConnectionTimingsBuilder(long acquiringConnectionStartMicros,
+                                          long acquiringConnectionStartNanos) {
+        this.acquiringConnectionStartMicros = acquiringConnectionStartMicros;
+        this.acquiringConnectionStartNanos = acquiringConnectionStartNanos;
+    }
+
+    void dnsResolutionEndNanos(long dnsResolutionEndNanos) {
+        this.dnsResolutionEndNanos = dnsResolutionEndNanos;
+    }
+
+    void socketConnectStartNanos(long socketConnectStartNanos) {
+        this.socketConnectStartNanos = socketConnectStartNanos;
+    }
+
+    void socketConnectEndNanos(long socketConnectEndNanos) {
+        this.socketConnectEndNanos = socketConnectEndNanos;
+    }
+
+    void pendingAcquisitionStartNanos(long pendingAcquisitionStartNanos) {
+        this.pendingAcquisitionStartNanos = pendingAcquisitionStartNanos;
+    }
+
+    void pendingAcquisitionEndNanos(long pendingAcquisitionEndNanos) {
+        this.pendingAcquisitionEndNanos = pendingAcquisitionEndNanos;
+    }
+
+    /**
+     * Returns a newly-created {@link ClientConnectionTimings} instance.
+     */
+    @VisibleForTesting
+    public ClientConnectionTimings build(long acquiringConnectionEndNanos) {
+        return new ClientConnectionTimings(
+                acquiringConnectionStartMicros,
+                acquiringConnectionEndNanos - acquiringConnectionStartNanos,
+                dnsResolutionEndNanos == 0 ? -1 : dnsResolutionEndNanos - acquiringConnectionStartNanos,
+                socketConnectEndNanos == 0 ? -1 : socketConnectEndNanos - socketConnectStartNanos,
+                pendingAcquisitionEndNanos == 0 ? -1 : pendingAcquisitionEndNanos -
+                                                       pendingAcquisitionStartNanos);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/client/ClientConnectionTimingsBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientConnectionTimingsBuilder.java
@@ -54,8 +54,9 @@ public final class ClientConnectionTimingsBuilder {
     }
 
     /**
-     * Sets the time when resolving a domain name ended. If this method is invoked, the creation time of this
-     * {@link ClientConnectionTimingsBuilder} is considered as the start time of resolving a domain name.
+     * Sets the time when the client ended to resolve a domain name. If this method is invoked, the creation
+     * time of this {@link ClientConnectionTimingsBuilder} is considered as the start time of
+     * resolving a domain name.
      */
     public ClientConnectionTimingsBuilder dnsResolutionEnd() {
         checkState(!dnsResolutionEndSet, "dnsResolutionEnd() is already called.");
@@ -65,7 +66,7 @@ public final class ClientConnectionTimingsBuilder {
     }
 
     /**
-     * Sets the time when connecting to a remote peer started.
+     * Sets the time when the client started to connect to a remote peer.
      */
     public ClientConnectionTimingsBuilder socketConnectStart() {
         socketConnectStartTimeMicros = SystemInfo.currentTimeMicros();
@@ -74,7 +75,7 @@ public final class ClientConnectionTimingsBuilder {
     }
 
     /**
-     * Sets the time when connecting to a remote peer ended.
+     * Sets the time when the client ended to connect to a remote peer.
      *
      * @throws IllegalStateException if {@link #socketConnectStart()} is not invoked before calling this.
      */
@@ -87,8 +88,8 @@ public final class ClientConnectionTimingsBuilder {
     }
 
     /**
-     * Sets the time when waiting for the completion of an existing connection attempt started in order to
-     * use one connection for HTTP/2.
+     * Sets the time when the client started to wait for the completion of an existing connection attempt
+     * in order to use one connection for HTTP/2.
      */
     public ClientConnectionTimingsBuilder pendingAcquisitionStart() {
         pendingAcquisitionStartTimeMicros = SystemInfo.currentTimeMicros();
@@ -97,8 +98,8 @@ public final class ClientConnectionTimingsBuilder {
     }
 
     /**
-     * Sets the time when waiting for an existing connection attempt ended in order to use one connection
-     * for HTTP/2.
+     * Sets the time when the client ended to wait for an existing connection attempt in order to use
+     * one connection for HTTP/2.
      *
      * @throws IllegalStateException if {@link #pendingAcquisitionStart()} is not invoked before calling this.
      */

--- a/core/src/main/java/com/linecorp/armeria/client/ClientConnectionTimingsBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientConnectionTimingsBuilder.java
@@ -25,17 +25,17 @@ import com.linecorp.armeria.common.util.SystemInfo;
  */
 public final class ClientConnectionTimingsBuilder {
 
-    private final long acquiringConnectionStartMicros;
-    private final long acquiringConnectionStartNanos;
+    private final long connectionAcquisitionStartTimeMicros;
+    private final long connectionAcquisitionStartNanos;
     private long dnsResolutionEndNanos;
     private boolean dnsResolutionEndSet;
 
-    private long socketConnectStartMicros;
+    private long socketConnectStartTimeMicros;
     private long socketConnectStartNanos;
     private long socketConnectEndNanos;
     private boolean socketConnectEndSet;
 
-    private long pendingAcquisitionStartMicros;
+    private long pendingAcquisitionStartTimeMicros;
     private long pendingAcquisitionStartNanos;
     private long pendingAcquisitionEndNanos;
     private boolean pendingAcquisitionEndSet;
@@ -44,8 +44,8 @@ public final class ClientConnectionTimingsBuilder {
      * Creates a new instance.
      */
     public ClientConnectionTimingsBuilder() {
-        acquiringConnectionStartMicros = SystemInfo.currentTimeMicros();
-        acquiringConnectionStartNanos = System.nanoTime();
+        connectionAcquisitionStartTimeMicros = SystemInfo.currentTimeMicros();
+        connectionAcquisitionStartNanos = System.nanoTime();
     }
 
     /**
@@ -63,7 +63,7 @@ public final class ClientConnectionTimingsBuilder {
      * Sets the time when connecting to a remote peer started.
      */
     public ClientConnectionTimingsBuilder socketConnectStart() {
-        socketConnectStartMicros = SystemInfo.currentTimeMicros();
+        socketConnectStartTimeMicros = SystemInfo.currentTimeMicros();
         socketConnectStartNanos = System.nanoTime();
         return this;
     }
@@ -74,7 +74,7 @@ public final class ClientConnectionTimingsBuilder {
      * @throws IllegalStateException if {@link #socketConnectStart()} is not invoked before calling this.
      */
     public ClientConnectionTimingsBuilder socketConnectEnd() {
-        checkState(socketConnectStartMicros >= 0, "socketConnectStart() is not called yet.");
+        checkState(socketConnectStartTimeMicros >= 0, "socketConnectStart() is not called yet.");
         checkState(!socketConnectEndSet, "socketConnectEnd() is already called.");
         socketConnectEndNanos = System.nanoTime();
         socketConnectEndSet = true;
@@ -86,7 +86,7 @@ public final class ClientConnectionTimingsBuilder {
      * for HTTP/2.
      */
     public ClientConnectionTimingsBuilder pendingAcquisitionStart() {
-        pendingAcquisitionStartMicros = SystemInfo.currentTimeMicros();
+        pendingAcquisitionStartTimeMicros = SystemInfo.currentTimeMicros();
         pendingAcquisitionStartNanos = System.nanoTime();
         return this;
     }
@@ -98,7 +98,7 @@ public final class ClientConnectionTimingsBuilder {
      * @throws IllegalStateException if {@link #pendingAcquisitionStart()} is not invoked before calling this.
      */
     public ClientConnectionTimingsBuilder pendingAcquisitionEnd() {
-        checkState(pendingAcquisitionStartMicros >= 0, "pendingAcquisitionStart() is not called yet.");
+        checkState(pendingAcquisitionStartTimeMicros >= 0, "pendingAcquisitionStart() is not called yet.");
         checkState(!pendingAcquisitionEndSet, "pendingAcquisitionEnd() is already called.");
         pendingAcquisitionEndNanos = System.nanoTime();
         pendingAcquisitionEndSet = true;
@@ -110,13 +110,13 @@ public final class ClientConnectionTimingsBuilder {
      */
     public ClientConnectionTimings build() {
         return new ClientConnectionTimings(
-                acquiringConnectionStartMicros,
-                System.nanoTime() - acquiringConnectionStartNanos,
-                dnsResolutionEndSet ? acquiringConnectionStartMicros : -1,
-                dnsResolutionEndSet ? dnsResolutionEndNanos - acquiringConnectionStartNanos : -1,
-                socketConnectEndSet ? socketConnectStartMicros : -1,
+                connectionAcquisitionStartTimeMicros,
+                System.nanoTime() - connectionAcquisitionStartNanos,
+                dnsResolutionEndSet ? connectionAcquisitionStartTimeMicros : -1,
+                dnsResolutionEndSet ? dnsResolutionEndNanos - connectionAcquisitionStartNanos : -1,
+                socketConnectEndSet ? socketConnectStartTimeMicros : -1,
                 socketConnectEndSet ? socketConnectEndNanos - socketConnectStartNanos : -1,
-                pendingAcquisitionEndSet ? pendingAcquisitionStartMicros : -1,
+                pendingAcquisitionEndSet ? pendingAcquisitionStartTimeMicros : -1,
                 pendingAcquisitionEndSet ? pendingAcquisitionEndNanos - pendingAcquisitionStartNanos : -1);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
@@ -265,9 +265,9 @@ final class HttpChannelPool implements AutoCloseable {
             return false;
         }
 
-        timingsBuilder.pendingAcquisitionStartNanos(System.nanoTime());
+        timingsBuilder.pendingAcquisitionStart();
         pendingAcquisition.handle((pch, cause) -> {
-            timingsBuilder.pendingAcquisitionEndNanos(System.nanoTime());
+            timingsBuilder.pendingAcquisitionEnd();
 
             if (cause == null) {
                 final SessionProtocol actualProtocol = pch.protocol();
@@ -299,8 +299,7 @@ final class HttpChannelPool implements AutoCloseable {
                          ClientConnectionTimingsBuilder timingsBuilder) {
 
         setPendingAcquisition(desiredProtocol, key, promise);
-
-        timingsBuilder.socketConnectStartNanos(System.nanoTime());
+        timingsBuilder.socketConnectStart();
 
         final InetSocketAddress remoteAddress;
         try {
@@ -385,7 +384,7 @@ final class HttpChannelPool implements AutoCloseable {
         assert future.isDone();
         removePendingAcquisition(desiredProtocol, key);
 
-        timingsBuilder.socketConnectEndNanos(System.nanoTime());
+        timingsBuilder.socketConnectEnd();
         try {
             if (future.isSuccess()) {
                 final Channel channel = future.getNow();

--- a/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
@@ -157,7 +157,7 @@ final class HttpChannelPool implements AutoCloseable {
      * Attempts to acquire a {@link Channel} which is matched by the specified condition immediately.
      *
      * @return {@code null} is there's no match left in the pool and thus a new connection has to be
-     *         requested via {@link #acquireLater(SessionProtocol, PoolKey)}.
+     *         requested via {@link #acquireLater(SessionProtocol, PoolKey, ClientConnectionTimingsBuilder)}.
      */
     @Nullable
     PooledChannel acquireNow(SessionProtocol desiredProtocol, PoolKey key) {
@@ -234,10 +234,11 @@ final class HttpChannelPool implements AutoCloseable {
      * Acquires a new {@link Channel} which is matched by the specified condition by making a connection
      * attempt or waiting for the current connection attempt in progress.
      */
-    CompletableFuture<PooledChannel> acquireLater(SessionProtocol desiredProtocol, PoolKey key) {
+    CompletableFuture<PooledChannel> acquireLater(SessionProtocol desiredProtocol, PoolKey key,
+                                                  ClientConnectionTimingsBuilder timingsBuilder) {
         final CompletableFuture<PooledChannel> promise = new CompletableFuture<>();
-        if (!usePendingAcquisition(desiredProtocol, key, promise)) {
-            connect(desiredProtocol, key, promise);
+        if (!usePendingAcquisition(desiredProtocol, key, promise, timingsBuilder)) {
+            connect(desiredProtocol, key, promise, timingsBuilder);
         }
         return promise;
     }
@@ -248,7 +249,8 @@ final class HttpChannelPool implements AutoCloseable {
      * @return {@code true} if succeeded to reuse the pending connection.
      */
     private boolean usePendingAcquisition(SessionProtocol desiredProtocol, PoolKey key,
-                                          CompletableFuture<PooledChannel> promise) {
+                                          CompletableFuture<PooledChannel> promise,
+                                          ClientConnectionTimingsBuilder timingsBuilder) {
 
         if (desiredProtocol == SessionProtocol.H1 || desiredProtocol == SessionProtocol.H1C) {
             // Can't use HTTP/1 connections because they will not be available in the pool until
@@ -263,7 +265,10 @@ final class HttpChannelPool implements AutoCloseable {
             return false;
         }
 
+        timingsBuilder.pendingAcquisitionStartNanos(System.nanoTime());
         pendingAcquisition.handle((pch, cause) -> {
+            timingsBuilder.pendingAcquisitionEndNanos(System.nanoTime());
+
             if (cause == null) {
                 final SessionProtocol actualProtocol = pch.protocol();
                 if (actualProtocol.isMultiplex()) {
@@ -277,12 +282,12 @@ final class HttpChannelPool implements AutoCloseable {
                     if (ch != null) {
                         promise.complete(ch);
                     } else {
-                        connect(actualProtocol, key, promise);
+                        connect(actualProtocol, key, promise, timingsBuilder);
                     }
                 }
             } else {
                 // The pending connection attempt has failed.
-                connect(desiredProtocol, key, promise);
+                connect(desiredProtocol, key, promise, timingsBuilder);
             }
             return null;
         });
@@ -290,16 +295,18 @@ final class HttpChannelPool implements AutoCloseable {
         return true;
     }
 
-    private void connect(SessionProtocol desiredProtocol, PoolKey key,
-                         CompletableFuture<PooledChannel> promise) {
+    private void connect(SessionProtocol desiredProtocol, PoolKey key, CompletableFuture<PooledChannel> promise,
+                         ClientConnectionTimingsBuilder timingsBuilder) {
 
         setPendingAcquisition(desiredProtocol, key, promise);
+
+        timingsBuilder.socketConnectStartNanos(System.nanoTime());
 
         final InetSocketAddress remoteAddress;
         try {
             remoteAddress = toRemoteAddress(key);
         } catch (UnknownHostException e) {
-            notifyConnect(desiredProtocol, key, eventLoop.newFailedFuture(e), promise);
+            notifyConnect(desiredProtocol, key, eventLoop.newFailedFuture(e), promise, timingsBuilder);
             return;
         }
 
@@ -309,7 +316,7 @@ final class HttpChannelPool implements AutoCloseable {
                           eventLoop.newFailedFuture(
                                   new SessionProtocolNegotiationException(
                                           desiredProtocol, "previously failed negotiation")),
-                          promise);
+                          promise, timingsBuilder);
             return;
         }
 
@@ -318,10 +325,10 @@ final class HttpChannelPool implements AutoCloseable {
         connect(remoteAddress, desiredProtocol, sessionPromise);
 
         if (sessionPromise.isDone()) {
-            notifyConnect(desiredProtocol, key, sessionPromise, promise);
+            notifyConnect(desiredProtocol, key, sessionPromise, promise, timingsBuilder);
         } else {
             sessionPromise.addListener((Future<Channel> future) -> {
-                notifyConnect(desiredProtocol, key, future, promise);
+                notifyConnect(desiredProtocol, key, future, promise, timingsBuilder);
             });
         }
     }
@@ -329,7 +336,8 @@ final class HttpChannelPool implements AutoCloseable {
     /**
      * A low-level operation that triggers a new connection attempt. Used only by:
      * <ul>
-     *   <li>{@link #connect(SessionProtocol, PoolKey, CompletableFuture)} - The pool has been exhausted.</li>
+     *   <li>{@link #connect(SessionProtocol, PoolKey, CompletableFuture, ClientConnectionTimingsBuilder)} -
+     *       The pool has been exhausted.</li>
      *   <li>{@link HttpSessionHandler} - HTTP/2 upgrade has failed.</li>
      * </ul>
      */
@@ -371,11 +379,13 @@ final class HttpChannelPool implements AutoCloseable {
         ch.pipeline().addLast(new HttpSessionHandler(this, ch, sessionPromise, timeoutFuture));
     }
 
-    private void notifyConnect(SessionProtocol desiredProtocol, PoolKey key,
-                               Future<Channel> future, CompletableFuture<PooledChannel> promise) {
+    private void notifyConnect(SessionProtocol desiredProtocol, PoolKey key, Future<Channel> future,
+                               CompletableFuture<PooledChannel> promise,
+                               ClientConnectionTimingsBuilder timingsBuilder) {
         assert future.isDone();
         removePendingAcquisition(desiredProtocol, key);
 
+        timingsBuilder.socketConnectEndNanos(System.nanoTime());
         try {
             if (future.isSuccess()) {
                 final Channel channel = future.getNow();

--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
@@ -1088,7 +1088,7 @@ public class DefaultRequestLog implements RequestLog, RequestLogBuilder {
         buf.append('{');
         if (isAvailable(flags, REQUEST_START)) {
             buf.append("startTime=");
-            TextFormatter.appendEpoch(buf, requestStartTimeMillis());
+            TextFormatter.appendEpochMicros(buf, requestStartTimeMicros());
 
             if (isAvailable(flags, REQUEST_END)) {
                 buf.append(", length=");
@@ -1160,7 +1160,7 @@ public class DefaultRequestLog implements RequestLog, RequestLogBuilder {
         buf.append('{');
         if (isAvailable(flags, RESPONSE_START)) {
             buf.append("startTime=");
-            TextFormatter.appendEpoch(buf, responseStartTimeMillis());
+            TextFormatter.appendEpochMicros(buf, responseStartTimeMicros());
 
             if (isAvailable(flags, RESPONSE_END)) {
                 buf.append(", length=");

--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
@@ -43,6 +43,7 @@ import java.util.function.Function;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLSession;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.client.ClientConnectionTimings;
@@ -75,7 +76,11 @@ public class DefaultRequestLog implements RequestLog, RequestLogBuilder {
     private static final int FLAGS_RESPONSE_END_WITHOUT_CONTENT =
             RESPONSE_END.setterFlags() & ~RESPONSE_CONTENT.setterFlags();
 
-    private static final int STRING_BUILDER_CAPACITY = 512;
+    @VisibleForTesting
+    static final int REQUEST_STRING_BUILDER_CAPACITY = 190;
+
+    @VisibleForTesting
+    static final int RESPONSE_STRING_BUILDER_CAPACITY = 203;
 
     private static final HttpHeaders DUMMY_REQUEST_HEADERS_HTTP =
             HttpHeaders.of().scheme("http").authority("?").method(HttpMethod.UNKNOWN).path("?").asImmutable();
@@ -1084,47 +1089,86 @@ public class DefaultRequestLog implements RequestLog, RequestLogBuilder {
             return requestStr;
         }
 
-        final StringBuilder buf = new StringBuilder(STRING_BUILDER_CAPACITY);
-        buf.append('{');
-        if (isAvailable(flags, REQUEST_START)) {
-            buf.append("startTime=");
-            TextFormatter.appendEpochMicros(buf, requestStartTimeMicros());
+        if (!isAvailable(flags, REQUEST_START)) {
+            requestStr = "{}";
+            requestStrFlags = flags;
+            return requestStr;
+        }
 
-            if (isAvailable(flags, REQUEST_END)) {
-                buf.append(", length=");
-                TextFormatter.appendSize(buf, requestLength);
-                buf.append(", duration=");
-                TextFormatter.appendElapsed(buf, requestDurationNanos());
-                if (requestCause != null) {
-                    buf.append(", cause=").append(requestCause);
-                }
-            }
+        int additionalCapacity = 0;
 
-            buf.append(", scheme=");
-            if (isAvailable(flags, SCHEME)) {
-                buf.append(scheme().uriText());
-            } else {
-                buf.append(SerializationFormat.UNKNOWN.uriText())
-                   .append('+')
-                   .append(sessionProtocol.uriText());
-            }
+        final String requestCauseString;
+        if (isAvailable(flags, REQUEST_END) && requestCause != null) {
+            requestCauseString = String.valueOf(requestCause);
+            additionalCapacity += requestCauseString.length();
+        } else {
+            requestCauseString = null;
+        }
 
-            if (isAvailable(flags, REQUEST_HEADERS)) {
-                buf.append(", headers=").append(headersSanitizer.apply(requestHeaders));
-            }
+        final String sanitizedHeaders;
+        if (isAvailable(flags, REQUEST_HEADERS)) {
+            sanitizedHeaders = String.valueOf(headersSanitizer.apply(requestHeaders));
+            additionalCapacity += sanitizedHeaders.length();
+        } else {
+            sanitizedHeaders = null;
+        }
 
-            if (isAvailable(flags, REQUEST_CONTENT) && requestContent != null) {
-                buf.append(", content=").append(contentSanitizer.apply(requestContent));
-            } else if (isAvailable(flags, REQUEST_END) && requestContentPreview != null) {
-                buf.append(", contentPreview=").append(requestContentPreview);
-            }
-
-            final HttpHeaders requestTrailers = this.requestTrailers;
-            if (!requestTrailers.isEmpty()) {
-                buf.append(", trailers=").append(trailersSanitizer.apply(requestTrailers));
+        final String sanitizedContent;
+        if (isAvailable(flags, REQUEST_CONTENT) && requestContent != null) {
+            sanitizedContent = String.valueOf(contentSanitizer.apply(requestContent));
+            additionalCapacity += sanitizedContent.length();
+        } else {
+            sanitizedContent = null;
+            if (isAvailable(flags, REQUEST_END) && requestContentPreview != null) {
+                additionalCapacity += requestContentPreview.length();
             }
         }
-        buf.append('}');
+
+        final String sanitizedTrailers;
+        if (!requestTrailers.isEmpty()) {
+            sanitizedTrailers = String.valueOf(trailersSanitizer.apply(requestTrailers));
+            additionalCapacity += sanitizedTrailers.length();
+        } else {
+            sanitizedTrailers = null;
+        }
+
+        final StringBuilder buf = new StringBuilder(REQUEST_STRING_BUILDER_CAPACITY + additionalCapacity);
+        buf.append("{startTime=");                                            // 11
+        TextFormatter.appendEpochMicros(buf, requestStartTimeMicros());       // 45
+
+        if (isAvailable(flags, REQUEST_END)) {
+            buf.append(", length=");                                          // 9
+            TextFormatter.appendSize(buf, requestLength);                     // 20 (When it's under 10GiB)
+            buf.append(", duration=");                                        // 11
+            TextFormatter.appendElapsed(buf, requestDurationNanos());         // 22 (When it's under 30 minutes)
+            if (requestCauseString != null) {
+                buf.append(", cause=").append(requestCauseString);            // 8
+            }
+        }
+
+        buf.append(", scheme=");                                              // 9
+        if (isAvailable(flags, SCHEME)) {
+            buf.append(scheme().uriText());                                   // 16 (ex. gproto-web+https)
+        } else {
+            buf.append(SerializationFormat.UNKNOWN.uriText())
+               .append('+')
+               .append(sessionProtocol.uriText());
+        }
+
+        if (isAvailable(flags, REQUEST_HEADERS)) {
+            buf.append(", headers=").append(sanitizedHeaders);                // 10
+        }
+
+        if (sanitizedContent != null) {                                       // 17
+            buf.append(", content=").append(sanitizedContent);
+        } else if (isAvailable(flags, REQUEST_END) && requestContentPreview != null) {
+            buf.append(", contentPreview=").append(requestContentPreview);
+        }
+
+        if (sanitizedTrailers != null) {
+            buf.append(", trailers=").append(sanitizedTrailers);              // 11
+        }
+        buf.append('}');                                                      // 1
 
         requestStr = buf.toString();
         requestStrFlags = flags;
@@ -1156,44 +1200,87 @@ public class DefaultRequestLog implements RequestLog, RequestLogBuilder {
             return responseStr;
         }
 
-        final StringBuilder buf = new StringBuilder(STRING_BUILDER_CAPACITY);
-        buf.append('{');
-        if (isAvailable(flags, RESPONSE_START)) {
-            buf.append("startTime=");
-            TextFormatter.appendEpochMicros(buf, responseStartTimeMicros());
+        if (!isAvailable(flags, RESPONSE_START)) {
+            responseStr = "{}";
+            responseStrFlags = flags;
+            return responseStr;
+        }
 
-            if (isAvailable(flags, RESPONSE_END)) {
-                buf.append(", length=");
-                TextFormatter.appendSize(buf, responseLength);
-                buf.append(", duration=");
-                TextFormatter.appendElapsed(buf, responseDurationNanos());
-                if (isAvailable(flags, REQUEST_START)) {
-                    buf.append(", totalDuration=");
-                    TextFormatter.appendElapsed(buf, totalDurationNanos());
-                }
-                if (responseCause != null) {
-                    buf.append(", cause=").append(responseCause);
-                }
-            }
+        int additionalCapacity = 0;
 
-            if (isAvailable(flags, RESPONSE_HEADERS)) {
-                buf.append(", headers=").append(headersSanitizer.apply(responseHeaders));
-            }
+        final String responseCauseString;
+        if (isAvailable(flags, RESPONSE_END) && responseCause != null) {
+            responseCauseString = String.valueOf(responseCause);
+            additionalCapacity += responseCauseString.length();
+        } else {
+            responseCauseString = null;
+        }
 
-            if (isAvailable(flags, RESPONSE_CONTENT) && responseContent != null) {
-                buf.append(", content=").append(contentSanitizer.apply(responseContent));
-            } else if (isAvailable(flags, RESPONSE_END) && responseContentPreview != null) {
-                buf.append(", contentPreview=").append(responseContentPreview);
-            }
+        final String sanitizedHeaders;
+        if (isAvailable(flags, RESPONSE_HEADERS)) {
+            sanitizedHeaders = String.valueOf(headersSanitizer.apply(responseHeaders));
+            additionalCapacity += sanitizedHeaders.length();
+        } else {
+            sanitizedHeaders = null;
+        }
 
-            final HttpHeaders responseTrailers = this.responseTrailers;
-            if (!responseTrailers.isEmpty()) {
-                buf.append(", trailers=").append(trailersSanitizer.apply(responseTrailers));
+        final String sanitizedContent;
+        if (isAvailable(flags, RESPONSE_CONTENT) && responseContent != null) {
+            sanitizedContent = String.valueOf(contentSanitizer.apply(responseContent));
+            additionalCapacity += sanitizedContent.length();
+        } else {
+            sanitizedContent = null;
+            if (isAvailable(flags, RESPONSE_END) && responseContentPreview != null) {
+                additionalCapacity += responseContentPreview.length();
             }
         }
-        buf.append('}');
+
+        final String sanitizedTrailers;
+        if (!responseTrailers.isEmpty()) {
+            sanitizedTrailers = String.valueOf(trailersSanitizer.apply(responseTrailers));
+            additionalCapacity += sanitizedTrailers.length();
+        } else {
+            sanitizedTrailers = null;
+        }
 
         final int numChildren = children != null ? children.size() : 0;
+        if (numChildren > 1) {
+            additionalCapacity += 21;
+        }
+
+        final StringBuilder buf = new StringBuilder(RESPONSE_STRING_BUILDER_CAPACITY + additionalCapacity);
+        buf.append("{startTime=");                                            // 11
+        TextFormatter.appendEpochMicros(buf, responseStartTimeMicros());      // 45
+
+        if (isAvailable(flags, RESPONSE_END)) {
+            buf.append(", length=");                                          // 9
+            TextFormatter.appendSize(buf, responseLength);                    // 20 (When it's under 10GiB)
+            buf.append(", duration=");                                        // 11
+            TextFormatter.appendElapsed(buf, responseDurationNanos());        // 22 (When it's under 30 minutes)
+            if (isAvailable(flags, REQUEST_START)) {
+                buf.append(", totalDuration=");                               // 16
+                TextFormatter.appendElapsed(buf, totalDurationNanos());       // 22 (When it's under 30 minutes)
+            }
+            if (responseCauseString != null) {
+                buf.append(", cause=").append(responseCauseString);           // 8
+            }
+        }
+
+        if (sanitizedHeaders != null) {
+            buf.append(", headers=").append(sanitizedHeaders);                // 10
+        }
+
+        if (sanitizedContent != null) {                                       // 17
+            buf.append(", content=").append(contentSanitizer.apply(responseContent));
+        } else if (isAvailable(flags, RESPONSE_END) && responseContentPreview != null) {
+            buf.append(", contentPreview=").append(responseContentPreview);
+        }
+
+        if (sanitizedTrailers != null) {
+            buf.append(", trailers=").append(sanitizedTrailers);              // 11
+        }
+        buf.append('}');                                                      // 1
+
         if (numChildren > 1) {
             // Append only when there were retries which the numChildren is greater than 1.
             buf.append(", {totalAttempts=");

--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
@@ -182,6 +182,11 @@ public class DefaultRequestLog implements RequestLog, RequestLogBuilder {
     }
 
     @Override
+    public Iterator<Attribute<?>> attrs() {
+        return ctx.attrs();
+    }
+
+    @Override
     public void addChild(RequestLog child) {
         checkState(!hasLastChild, "last child is already added");
         requireNonNull(child, "child");
@@ -195,9 +200,9 @@ public class DefaultRequestLog implements RequestLog, RequestLogBuilder {
 
     private void propagateRequestSideLog(RequestLog child) {
         child.addListener(log -> {
-                              if (log.hasAttr(ClientConnectionTimings.TIMINGS)) {
-                                  attr(ClientConnectionTimings.TIMINGS)
-                                          .set(log.attr(ClientConnectionTimings.TIMINGS).get());
+                              final ClientConnectionTimings timings = ClientConnectionTimings.get(log);
+                              if (timings != null) {
+                                  timings.setTo(this);
                               }
                               startRequest0(log.channel(), log.sessionProtocol(), null,
                                             log.requestStartTimeNanos(), log.requestStartTimeMicros(), true);

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestLog.java
@@ -46,6 +46,7 @@ import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
 
 import io.netty.channel.Channel;
+import io.netty.util.AttributeMap;
 
 /**
  * A set of informational properties collected while processing a {@link Request} and its {@link Response}.
@@ -59,7 +60,7 @@ import io.netty.channel.Channel;
  * @see RequestLogAvailability
  * @see RequestLogListener
  */
-public interface RequestLog {
+public interface RequestLog extends AttributeMap {
 
     /**
      * Returns the list of child {@link RequestLog}s, ordered by the time it was added.

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestLog.java
@@ -20,6 +20,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.net.InetSocketAddress;
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
@@ -46,6 +47,7 @@ import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
 
 import io.netty.channel.Channel;
+import io.netty.util.Attribute;
 import io.netty.util.AttributeMap;
 
 /**
@@ -61,6 +63,11 @@ import io.netty.util.AttributeMap;
  * @see RequestLogListener
  */
 public interface RequestLog extends AttributeMap {
+
+    /**
+     * Returns all {@link Attribute}s set in this log.
+     */
+    Iterator<Attribute<?>> attrs();
 
     /**
      * Returns the list of child {@link RequestLog}s, ordered by the time it was added.
@@ -198,14 +205,14 @@ public interface RequestLog extends AttributeMap {
     }
 
     /**
-     * Returns the time when the processing of the request started, in micros since the epoch.
+     * Returns the time when the processing of the request started, in microseconds since the epoch.
      *
      * @throws RequestLogAvailabilityException if this property is not available yet
      */
     long requestStartTimeMicros();
 
     /**
-     * Returns the time when the processing of the request started, in millis since the epoch.
+     * Returns the time when the processing of the request started, in milliseconds since the epoch.
      *
      * @throws RequestLogAvailabilityException if this property is not available yet
      */
@@ -259,14 +266,14 @@ public interface RequestLog extends AttributeMap {
     Throwable requestCause();
 
     /**
-     * Returns the time when the processing of the response started, in micros since the epoch.
+     * Returns the time when the processing of the response started, in microseconds since the epoch.
      *
      * @throws RequestLogAvailabilityException if this property is not available yet
      */
     long responseStartTimeMicros();
 
     /**
-     * Returns the time when the processing of the response started, in millis since the epoch.
+     * Returns the time when the processing of the response started, in milliseconds since the epoch.
      *
      * @throws RequestLogAvailabilityException if this property is not available yet
      */

--- a/core/src/main/java/com/linecorp/armeria/common/util/TextFormatter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/TextFormatter.java
@@ -138,8 +138,8 @@ public final class TextFormatter {
      * @return the human readable string representation of the given epoch time
      */
     public static StringBuilder epoch(long timeMillis) {
-        // 24 (human readable part) + 3 (parens) + 19 (max digits of a long integer)
-        final StringBuilder buf = new StringBuilder(46);
+        // 24 (human readable part) + 2 (parens) + 19 (max digits of a long integer)
+        final StringBuilder buf = new StringBuilder(45);
         appendEpoch(buf, timeMillis);
         return buf;
     }
@@ -164,8 +164,8 @@ public final class TextFormatter {
      * @return the human readable string representation of the given epoch time
      */
     public static StringBuilder epochMicro(long timeMicros) {
-        // 24 (human readable part) + 3 (parens) + 19 (max digits of a long integer)
-        final StringBuilder buf = new StringBuilder(46);
+        // 24 (human readable part) + 2 (parens) + 19 (max digits of a long integer)
+        final StringBuilder buf = new StringBuilder(45);
         appendEpochMicros(buf, timeMicros);
         return buf;
     }

--- a/core/src/main/java/com/linecorp/armeria/common/util/TextFormatter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/TextFormatter.java
@@ -121,8 +121,8 @@ public final class TextFormatter {
                                           .withZone(ZoneId.of("GMT"));
 
     /**
-     * Formats the given epoch time to typical human-readable format "yyyy-MM-dd'T'HH_mm:ss.SSSX" and appends
-     * it to the specified {@link StringBuilder}.
+     * Formats the given epoch time in milliseconds to typical human-readable format
+     * "yyyy-MM-dd'T'HH_mm:ss.SSSZ" and appends it to the specified {@link StringBuilder}.
      */
     public static void appendEpoch(StringBuilder buf, long timeMillis) {
         buf.append(dateTimeFormatter.format(Instant.ofEpochMilli(timeMillis)))
@@ -130,9 +130,10 @@ public final class TextFormatter {
     }
 
     /**
-     * Formats the given epoch time to typical human-readable format "yyyy-MM-dd'T'HH:mm:ss.SSSX"
+     * Formats the given epoch time in milliseconds to typical human-readable format
+     * "yyyy-MM-dd'T'HH:mm:ss.SSSZ".
      *
-     * @param timeMillis epoch time in ms
+     * @param timeMillis epoch time in milliseconds
      *
      * @return the human readable string representation of the given epoch time
      */
@@ -140,6 +141,32 @@ public final class TextFormatter {
         // 24 (human readable part) + 3 (parens) + 19 (max digits of a long integer)
         final StringBuilder buf = new StringBuilder(46);
         appendEpoch(buf, timeMillis);
+        return buf;
+    }
+
+    /**
+     * Formats the given epoch time in microseconds to typical human-readable format
+     * "yyyy-MM-dd'T'HH_mm:ss.SSSZ" and appends it to the specified {@link StringBuilder}.
+     */
+    public static void appendEpochMicros(StringBuilder buf, long timeMicros) {
+        final long secs = Math.floorDiv(timeMicros, 1_000_000);
+        final long nanos = Math.floorMod(timeMicros, 1_000_000) * 1000;
+        buf.append(dateTimeFormatter.format(Instant.ofEpochSecond(secs, nanos)))
+           .append('(').append(timeMicros).append(')');
+    }
+
+    /**
+     * Formats the given epoch time in microseconds to typical human-readable format
+     * "yyyy-MM-dd'T'HH:mm:ss.SSSZ".
+     *
+     * @param timeMicros epoch time in microseconds
+     *
+     * @return the human readable string representation of the given epoch time
+     */
+    public static StringBuilder epochMicro(long timeMicros) {
+        // 24 (human readable part) + 3 (parens) + 19 (max digits of a long integer)
+        final StringBuilder buf = new StringBuilder(46);
+        appendEpochMicros(buf, timeMicros);
         return buf;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/util/TextFormatter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/TextFormatter.java
@@ -20,6 +20,7 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.util.Locale;
+import java.util.concurrent.TimeUnit;
 
 /**
  * A utility class to format things as a {@link String} with ease.
@@ -122,8 +123,29 @@ public final class TextFormatter {
 
     /**
      * Formats the given epoch time in milliseconds to typical human-readable format
-     * "yyyy-MM-dd'T'HH_mm:ss.SSSZ" and appends it to the specified {@link StringBuilder}.
+     * "yyyy-MM-dd'T'HH:mm:ss.SSSX".
+     *
+     * @deprecated Use {@link #epochMillis(long)}.
+     *
+     * @param timeMillis epoch time in milliseconds
+     *
+     * @return the human readable string representation of the given epoch time
      */
+    @Deprecated
+    public static StringBuilder epoch(long timeMillis) {
+        // 24 (human readable part) + 2 (parens) + 19 (max digits of a long integer)
+        final StringBuilder buf = new StringBuilder(45);
+        appendEpochMillis(buf, timeMillis);
+        return buf;
+    }
+
+    /**
+     * Formats the given epoch time in milliseconds to typical human-readable format
+     * "yyyy-MM-dd'T'HH_mm:ss.SSSX" and appends it to the specified {@link StringBuilder}.
+     *
+     * @deprecated Use {@link #appendEpochMillis(StringBuilder, long)}.
+     */
+    @Deprecated
     public static void appendEpoch(StringBuilder buf, long timeMillis) {
         buf.append(dateTimeFormatter.format(Instant.ofEpochMilli(timeMillis)))
            .append('(').append(timeMillis).append(')');
@@ -131,33 +153,31 @@ public final class TextFormatter {
 
     /**
      * Formats the given epoch time in milliseconds to typical human-readable format
-     * "yyyy-MM-dd'T'HH:mm:ss.SSSZ".
+     * "yyyy-MM-dd'T'HH:mm:ss.SSSX".
      *
      * @param timeMillis epoch time in milliseconds
      *
      * @return the human readable string representation of the given epoch time
      */
-    public static StringBuilder epoch(long timeMillis) {
+    public static StringBuilder epochMillis(long timeMillis) {
         // 24 (human readable part) + 2 (parens) + 19 (max digits of a long integer)
         final StringBuilder buf = new StringBuilder(45);
-        appendEpoch(buf, timeMillis);
+        appendEpochMillis(buf, timeMillis);
         return buf;
     }
 
     /**
-     * Formats the given epoch time in microseconds to typical human-readable format
-     * "yyyy-MM-dd'T'HH_mm:ss.SSSZ" and appends it to the specified {@link StringBuilder}.
+     * Formats the given epoch time in milliseconds to typical human-readable format
+     * "yyyy-MM-dd'T'HH_mm:ss.SSSX" and appends it to the specified {@link StringBuilder}.
      */
-    public static void appendEpochMicros(StringBuilder buf, long timeMicros) {
-        final long secs = Math.floorDiv(timeMicros, 1_000_000);
-        final long nanos = Math.floorMod(timeMicros, 1_000_000) * 1000;
-        buf.append(dateTimeFormatter.format(Instant.ofEpochSecond(secs, nanos)))
-           .append('(').append(timeMicros).append(')');
+    public static void appendEpochMillis(StringBuilder buf, long timeMillis) {
+        buf.append(dateTimeFormatter.format(Instant.ofEpochMilli(timeMillis)))
+           .append('(').append(timeMillis).append(')');
     }
 
     /**
      * Formats the given epoch time in microseconds to typical human-readable format
-     * "yyyy-MM-dd'T'HH:mm:ss.SSSZ".
+     * "yyyy-MM-dd'T'HH:mm:ss.SSSX".
      *
      * @param timeMicros epoch time in microseconds
      *
@@ -168,5 +188,14 @@ public final class TextFormatter {
         final StringBuilder buf = new StringBuilder(45);
         appendEpochMicros(buf, timeMicros);
         return buf;
+    }
+
+    /**
+     * Formats the given epoch time in microseconds to typical human-readable format
+     * "yyyy-MM-dd'T'HH_mm:ss.SSSX" and appends it to the specified {@link StringBuilder}.
+     */
+    public static void appendEpochMicros(StringBuilder buf, long timeMicros) {
+        buf.append(dateTimeFormatter.format(Instant.ofEpochMilli(TimeUnit.MICROSECONDS.toMillis(timeMicros))))
+           .append('(').append(timeMicros).append(')');
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/internal/metric/RequestMetricSupport.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/metric/RequestMetricSupport.java
@@ -104,9 +104,8 @@ public final class RequestMetricSupport {
         updateMetrics(log, metrics);
         final ClientConnectionTimings timings = ClientConnectionTimings.get(log);
         if (timings != null) {
-            metrics.connectionAcquisitionDuration().record(
-                    timings.connectionAcquisitionDurationNanos(),
-                    TimeUnit.NANOSECONDS);
+            metrics.connectionAcquisitionDuration().record(timings.connectionAcquisitionDurationNanos(),
+                                                           TimeUnit.NANOSECONDS);
             final long dnsResolutionDurationNanos = timings.dnsResolutionDurationNanos();
             if (dnsResolutionDurationNanos >= 0) {
                 metrics.dnsResolutionDuration().record(dnsResolutionDurationNanos, TimeUnit.NANOSECONDS);

--- a/core/src/main/java/com/linecorp/armeria/internal/metric/RequestMetricSupport.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/metric/RequestMetricSupport.java
@@ -104,8 +104,8 @@ public final class RequestMetricSupport {
         updateMetrics(log, metrics);
         final ClientConnectionTimings timings = ClientConnectionTimings.get(log);
         if (timings != null) {
-            metrics.acquiringConnectionDuration().record(
-                    timings.acquiringConnectionDurationNanos(),
+            metrics.connectionAcquisitionDuration().record(
+                    timings.connectionAcquisitionDurationNanos(),
                     TimeUnit.NANOSECONDS);
             final long dnsResolutionDurationNanos = timings.dnsResolutionDurationNanos();
             if (dnsResolutionDurationNanos >= 0) {
@@ -197,7 +197,7 @@ public final class RequestMetricSupport {
     private interface ClientRequestMetrics extends RequestMetrics {
         Counter actualRequests();
 
-        Timer acquiringConnectionDuration();
+        Timer connectionAcquisitionDuration();
 
         Timer dnsResolutionDuration();
 
@@ -289,7 +289,7 @@ public final class RequestMetricSupport {
         private final MeterRegistry parent;
         private final MeterIdPrefix idPrefix;
 
-        private final Timer acquiringConnectionDuration;
+        private final Timer connectionAcquisitionDuration;
         private final Timer dnsResolutionDuration;
         private final Timer socketConnectDuration;
         private final Timer pendingAcquisitionDuration;
@@ -305,8 +305,8 @@ public final class RequestMetricSupport {
             this.parent = parent;
             this.idPrefix = idPrefix;
 
-            acquiringConnectionDuration = newTimer(
-                    parent, idPrefix.name("acquiringConnectionDuration"), idPrefix.tags());
+            connectionAcquisitionDuration = newTimer(
+                    parent, idPrefix.name("connectionAcquisitionDuration"), idPrefix.tags());
             dnsResolutionDuration = newTimer(parent, idPrefix.name("dnsResolutionDuration"), idPrefix.tags());
             socketConnectDuration = newTimer(parent, idPrefix.name("socketConnectDuration"), idPrefix.tags());
             pendingAcquisitionDuration = newTimer(
@@ -332,8 +332,8 @@ public final class RequestMetricSupport {
         }
 
         @Override
-        public Timer acquiringConnectionDuration() {
-            return acquiringConnectionDuration;
+        public Timer connectionAcquisitionDuration() {
+            return connectionAcquisitionDuration;
         }
 
         @Override

--- a/core/src/main/java/com/linecorp/armeria/server/logging/structured/StructuredLog.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/structured/StructuredLog.java
@@ -102,7 +102,7 @@ public abstract class StructuredLog {
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
-                          .add("timestamp", TextFormatter.epoch(timestampMillis))
+                          .add("timestamp", TextFormatter.epochMillis(timestampMillis))
                           .add("responseTime", TextFormatter.elapsed(responseTimeNanos))
                           .add("requestSize", TextFormatter.size(requestSize))
                           .add("responseSize", TextFormatter.size(responseSize))

--- a/core/src/test/java/com/linecorp/armeria/client/ClientConnectionTimingsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientConnectionTimingsTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import static com.linecorp.armeria.client.ClientConnectionTimings.TO_STRING_BUILDER_CAPACITY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class ClientConnectionTimingsTest {
+
+    @Test
+    public void toStringBuilderCapacity() {
+        final ClientConnectionTimings timings = new ClientConnectionTimingsBuilder()
+                .dnsResolutionEnd()
+                .pendingAcquisitionStart()
+                .pendingAcquisitionEnd()
+                .socketConnectStart()
+                .socketConnectEnd()
+                .build();
+
+        assertThat(timings.toString().length()).isLessThanOrEqualTo(TO_STRING_BUILDER_CAPACITY);
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientWithRequestLogTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientWithRequestLogTest.java
@@ -98,7 +98,7 @@ public class HttpClientWithRequestLogTest {
         final HttpClient client = new HttpClientBuilder("http://unresolved.armeria.com")
                 .decorator(new ExceptionHoldingDecorator())
                 .decorator((delegate, ctx, req) -> {
-                    ctx.log().addListener(log -> ref.set(connectionTimings(log)),
+                    ctx.log().addListener(log -> ref.set(ClientConnectionTimings.get(log)),
                                           RequestLogAvailability.REQUEST_START);
                     return delegate.execute(ctx, req);
                 })
@@ -129,7 +129,7 @@ public class HttpClientWithRequestLogTest {
         final HttpClient client = new HttpClientBuilder("http://127.0.0.1:1")
                 .decorator(new ExceptionHoldingDecorator())
                 .decorator((delegate, ctx, req) -> {
-                    ctx.log().addListener(log -> ref.set(connectionTimings(log)),
+                    ctx.log().addListener(log -> ref.set(ClientConnectionTimings.get(log)),
                                           RequestLogAvailability.REQUEST_START);
                     return delegate.execute(ctx, req);
                 })
@@ -151,10 +151,6 @@ public class HttpClientWithRequestLogTest {
         await().untilAsserted(() -> assertThat(
                 responseCauseHolder.get()).hasCauseInstanceOf(ConnectException.class));
         await().untilAsserted(() -> assertThat(req.isComplete()).isTrue());
-    }
-
-    private static ClientConnectionTimings connectionTimings(RequestLog log) {
-        return log.attr(ClientConnectionTimings.TIMINGS).get();
     }
 
     private static class ExceptionHoldingDecorator

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientWithRequestLogTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientWithRequestLogTest.java
@@ -109,10 +109,10 @@ public class HttpClientWithRequestLogTest {
 
         await().untilAsserted(() -> assertThat(ref.get()).isNotNull());
         final ClientConnectionTimings timings = ref.get();
-        assertThat(timings.acquiringConnectionStartMicros()).isGreaterThan(0);
+        assertThat(timings.acquiringConnectionStartMicros()).isPositive();
 
         final long dnsResolutionDurationNanos = timings.dnsResolutionDurationNanos();
-        assertThat(dnsResolutionDurationNanos).isGreaterThan(0);
+        assertThat(dnsResolutionDurationNanos).isPositive();
         assertThat(timings.acquiringConnectionDurationNanos())
                 .isGreaterThanOrEqualTo(dnsResolutionDurationNanos);
 
@@ -140,10 +140,10 @@ public class HttpClientWithRequestLogTest {
 
         await().untilAsserted(() -> assertThat(ref.get()).isNotNull());
         final ClientConnectionTimings timings = ref.get();
-        assertThat(timings.acquiringConnectionStartMicros()).isGreaterThan(0);
+        assertThat(timings.acquiringConnectionStartMicros()).isPositive();
 
         final long connectDurationNanos = timings.socketConnectDurationNanos();
-        assertThat(connectDurationNanos).isGreaterThan(0);
+        assertThat(connectDurationNanos).isPositive();
         assertThat(timings.acquiringConnectionDurationNanos()).isGreaterThanOrEqualTo(connectDurationNanos);
 
         await().untilAsserted(() -> assertThat(

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientWithRequestLogTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientWithRequestLogTest.java
@@ -109,11 +109,11 @@ public class HttpClientWithRequestLogTest {
 
         await().untilAsserted(() -> assertThat(ref.get()).isNotNull());
         final ClientConnectionTimings timings = ref.get();
-        assertThat(timings.acquiringConnectionStartMicros()).isPositive();
+        assertThat(timings.connectionAcquisitionStartTimeMicros()).isPositive();
 
         final long dnsResolutionDurationNanos = timings.dnsResolutionDurationNanos();
         assertThat(dnsResolutionDurationNanos).isPositive();
-        assertThat(timings.acquiringConnectionDurationNanos())
+        assertThat(timings.connectionAcquisitionDurationNanos())
                 .isGreaterThanOrEqualTo(dnsResolutionDurationNanos);
 
         await().untilAsserted(() -> assertThat(requestCauseHolder.get()).isNotNull());
@@ -140,11 +140,11 @@ public class HttpClientWithRequestLogTest {
 
         await().untilAsserted(() -> assertThat(ref.get()).isNotNull());
         final ClientConnectionTimings timings = ref.get();
-        assertThat(timings.acquiringConnectionStartMicros()).isPositive();
+        assertThat(timings.connectionAcquisitionStartTimeMicros()).isPositive();
 
         final long connectDurationNanos = timings.socketConnectDurationNanos();
         assertThat(connectDurationNanos).isPositive();
-        assertThat(timings.acquiringConnectionDurationNanos()).isGreaterThanOrEqualTo(connectDurationNanos);
+        assertThat(timings.connectionAcquisitionDurationNanos()).isGreaterThanOrEqualTo(connectDurationNanos);
 
         await().untilAsserted(() -> assertThat(
                 requestCauseHolder.get()).hasCauseInstanceOf(ConnectException.class));

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientWithRequestLogTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientWithRequestLogTest.java
@@ -93,10 +93,28 @@ public class HttpClientWithRequestLogTest {
 
     @Test
     public void unresolvedUri() {
-        final HttpClient client = new HttpClientBuilder("http://unresolved.armeria.com").decorator(
-                new ExceptionHoldingDecorator()).build();
+        final AtomicReference<ClientConnectionTimings> ref = new AtomicReference<>();
+
+        final HttpClient client = new HttpClientBuilder("http://unresolved.armeria.com")
+                .decorator(new ExceptionHoldingDecorator())
+                .decorator((delegate, ctx, req) -> {
+                    ctx.log().addListener(log -> ref.set(connectionTimings(log)),
+                                          RequestLogAvailability.REQUEST_START);
+                    return delegate.execute(ctx, req);
+                })
+                .build();
+
         final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/");
         assertThatThrownBy(() -> client.execute(req).aggregate().get()).isInstanceOf(Exception.class);
+
+        await().untilAsserted(() -> assertThat(ref.get()).isNotNull());
+        final ClientConnectionTimings timings = ref.get();
+        assertThat(timings.acquiringConnectionStartMicros()).isGreaterThan(0);
+
+        final long dnsResolutionDurationNanos = timings.dnsResolutionDurationNanos();
+        assertThat(dnsResolutionDurationNanos).isGreaterThan(0);
+        assertThat(timings.acquiringConnectionDurationNanos())
+                .isGreaterThanOrEqualTo(dnsResolutionDurationNanos);
 
         await().untilAsserted(() -> assertThat(requestCauseHolder.get()).isNotNull());
         await().untilAsserted(() -> assertThat(responseCauseHolder.get()).isNotNull());
@@ -105,18 +123,38 @@ public class HttpClientWithRequestLogTest {
 
     @Test
     public void connectionError() {
+        final AtomicReference<ClientConnectionTimings> ref = new AtomicReference<>();
+
         // According to rfc7805, TCP port number 1 is not used so a connection error always happens.
         final HttpClient client = new HttpClientBuilder("http://127.0.0.1:1")
-                .decorator(new ExceptionHoldingDecorator()).build();
+                .decorator(new ExceptionHoldingDecorator())
+                .decorator((delegate, ctx, req) -> {
+                    ctx.log().addListener(log -> ref.set(connectionTimings(log)),
+                                          RequestLogAvailability.REQUEST_START);
+                    return delegate.execute(ctx, req);
+                })
+                .build();
         final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/");
         assertThatThrownBy(() -> client.execute(req).aggregate().get())
                 .hasCauseInstanceOf(ConnectException.class);
+
+        await().untilAsserted(() -> assertThat(ref.get()).isNotNull());
+        final ClientConnectionTimings timings = ref.get();
+        assertThat(timings.acquiringConnectionStartMicros()).isGreaterThan(0);
+
+        final long connectDurationNanos = timings.socketConnectDurationNanos();
+        assertThat(connectDurationNanos).isGreaterThan(0);
+        assertThat(timings.acquiringConnectionDurationNanos()).isGreaterThanOrEqualTo(connectDurationNanos);
 
         await().untilAsserted(() -> assertThat(
                 requestCauseHolder.get()).hasCauseInstanceOf(ConnectException.class));
         await().untilAsserted(() -> assertThat(
                 responseCauseHolder.get()).hasCauseInstanceOf(ConnectException.class));
         await().untilAsserted(() -> assertThat(req.isComplete()).isTrue());
+    }
+
+    private static ClientConnectionTimings connectionTimings(RequestLog log) {
+        return log.attr(ClientConnectionTimings.TIMINGS).get();
     }
 
     private static class ExceptionHoldingDecorator

--- a/core/src/test/java/com/linecorp/armeria/common/logging/DefaultRequestLogTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/logging/DefaultRequestLogTest.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.common.logging;
 
+import static com.linecorp.armeria.common.logging.DefaultRequestLog.REQUEST_STRING_BUILDER_CAPACITY;
+import static com.linecorp.armeria.common.logging.DefaultRequestLog.RESPONSE_STRING_BUILDER_CAPACITY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
@@ -27,9 +29,14 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.ClientRequestContextBuilder;
+import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.RpcResponse;
@@ -40,6 +47,13 @@ import com.linecorp.armeria.testing.internal.AnticipatedException;
 import io.netty.channel.Channel;
 
 public class DefaultRequestLogTest {
+
+    private static final String VERY_LONG_STRING =
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut " +
+            "labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco " +
+            "laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in " +
+            "voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat " +
+            "non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
 
     @Rule
     public MockitoRule mocks = MockitoJUnit.rule();
@@ -178,5 +192,59 @@ public class DefaultRequestLogTest {
         child.endResponse(new AnticipatedException("Oops!"));
         assertThat(log.responseDurationNanos()).isEqualTo(child.responseDurationNanos());
         assertThat(log.totalDurationNanos()).isEqualTo(child.totalDurationNanos());
+    }
+
+    @Test
+    public void toStringRequestBuilderCapacity() {
+        final HttpHeaders reqHeaders = HttpHeaders.of(HttpMethod.GET, "/armeria/awesome");
+        final HttpRequest req = HttpRequest.of(
+                AggregatedHttpMessage.of(reqHeaders, HttpData.ofUtf8(VERY_LONG_STRING)));
+        final ClientRequestContext ctx = ClientRequestContextBuilder.of(req).build();
+
+        final RequestLogBuilder logBuilder = ctx.logBuilder();
+        logBuilder.requestLength(1000000000);
+        logBuilder.requestContentPreview(VERY_LONG_STRING);
+
+        final HttpHeaders requestTrailers = HttpHeaders.of(HttpHeaderNames.CONTENT_MD5, VERY_LONG_STRING);
+        logBuilder.requestTrailers(requestTrailers);
+
+        final IllegalArgumentException cause = new IllegalArgumentException(VERY_LONG_STRING);
+        logBuilder.endRequest(cause);
+
+        assertThat(ctx.log().toStringRequestOnly().length()).isLessThanOrEqualTo(
+                REQUEST_STRING_BUILDER_CAPACITY +
+                reqHeaders.toString().length() +
+                VERY_LONG_STRING.length() +
+                requestTrailers.toString().length() +
+                cause.toString().length());
+    }
+
+    @Test
+    public void toStringResponseBuilderCapacity() {
+        final HttpRequest req = HttpRequest.of(
+                AggregatedHttpMessage.of(HttpHeaders.of(HttpMethod.GET, "/armeria/awesome"),
+                                         HttpData.ofUtf8(VERY_LONG_STRING)));
+        final ClientRequestContext ctx = ClientRequestContextBuilder.of(req).build();
+        final RequestLogBuilder logBuilder = ctx.logBuilder();
+        logBuilder.endRequest();
+
+        final HttpHeaders resHeaders = HttpHeaders.of(200);
+        logBuilder.responseHeaders(resHeaders);
+
+        logBuilder.responseLength(1000000000);
+        logBuilder.responseContentPreview(VERY_LONG_STRING);
+
+        final HttpHeaders responseTrailers = HttpHeaders.of(HttpHeaderNames.CONTENT_MD5, VERY_LONG_STRING);
+        logBuilder.responseTrailers(responseTrailers);
+
+        final IllegalArgumentException cause = new IllegalArgumentException(VERY_LONG_STRING);
+        logBuilder.endResponse(cause);
+
+        assertThat(ctx.log().toStringResponseOnly().length()).isLessThanOrEqualTo(
+                RESPONSE_STRING_BUILDER_CAPACITY +
+                resHeaders.toString().length() +
+                VERY_LONG_STRING.length() +
+                responseTrailers.toString().length() +
+                cause.toString().length());
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/common/util/TextFormatterTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/util/TextFormatterTest.java
@@ -49,7 +49,7 @@ public class TextFormatterTest {
 
     @Test
     public void testFormatEpoch() throws Exception {
-        assertThat(TextFormatter.epoch(1478601399123L).toString())
+        assertThat(TextFormatter.epochMillis(1478601399123L).toString())
                 .isEqualTo("2016-11-08T10:36:39.123Z(1478601399123)");
         assertThat(TextFormatter.epochMicro(1478601399123235L).toString())
                 .isEqualTo("2016-11-08T10:36:39.123Z(1478601399123235)");

--- a/core/src/test/java/com/linecorp/armeria/common/util/TextFormatterTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/util/TextFormatterTest.java
@@ -51,5 +51,7 @@ public class TextFormatterTest {
     public void testFormatEpoch() throws Exception {
         assertThat(TextFormatter.epoch(1478601399123L).toString())
                 .isEqualTo("2016-11-08T10:36:39.123Z(1478601399123)");
+        assertThat(TextFormatter.epochMicro(1478601399123235L).toString())
+                .isEqualTo("2016-11-08T10:36:39.123Z(1478601399123235)");
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/internal/metric/RequestMetricSupportTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/metric/RequestMetricSupportTest.java
@@ -72,7 +72,7 @@ public class RequestMetricSupportTest {
                                                1.0)
                                 .containsEntry("foo.requests#count{httpStatus=200,method=POST,result=failure}",
                                                0.0)
-                                .containsEntry("foo.acquiringConnectionDuration#count{httpStatus=200," +
+                                .containsEntry("foo.connectionAcquisitionDuration#count{httpStatus=200," +
                                                "method=POST}", 1.0)
                                 .containsEntry("foo.dnsResolutionDuration#count{httpStatus=200," +
                                                "method=POST}", 1.0)
@@ -148,7 +148,7 @@ public class RequestMetricSupportTest {
                                                1.0)
                                 .containsEntry("foo.actualRequests#count{httpStatus=500,method=POST}",
                                                2.0)
-                                .containsEntry("foo.acquiringConnectionDuration#count{httpStatus=500," +
+                                .containsEntry("foo.connectionAcquisitionDuration#count{httpStatus=500," +
                                                "method=POST}", 1.0)
                                 .containsEntry("foo.dnsResolutionDuration#count{httpStatus=500," +
                                                "method=POST}", 1.0)

--- a/core/src/test/java/com/linecorp/armeria/internal/metric/RequestMetricSupportTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/metric/RequestMetricSupportTest.java
@@ -21,9 +21,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
 
+import com.linecorp.armeria.client.ClientConnectionTimings;
+import com.linecorp.armeria.client.ClientConnectionTimingsBuilder;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.ClientRequestContextBuilder;
 import com.linecorp.armeria.client.Endpoint;
@@ -50,6 +53,9 @@ public class RequestMetricSupportTest {
         final MeterRegistry registry = PrometheusMeterRegistries.newRegistry();
         final ClientRequestContext ctx = setupClientRequestCtx(registry);
 
+        ctx.attr(ClientConnectionTimings.TIMINGS).set(
+                new ClientConnectionTimingsBuilder(1, TimeUnit.MILLISECONDS.toNanos(1))
+                        .build(TimeUnit.MILLISECONDS.toNanos(2)));
         ctx.logBuilder().requestHeaders(HttpHeaders.of(HttpMethod.POST, "/foo"));
         ctx.logBuilder().requestFirstBytesTransferred();
         ctx.logBuilder().requestContent(null, null);
@@ -70,6 +76,10 @@ public class RequestMetricSupportTest {
                                                1.0)
                                 .containsEntry("foo.requests#count{httpStatus=200,method=POST,result=failure}",
                                                0.0)
+                                .containsEntry("foo.acquiringConnectionDuration#count{httpStatus=200," +
+                                               "method=POST}", 1.0)
+                                .containsEntry("foo.acquiringConnectionDuration#total{httpStatus=200," +
+                                               "method=POST}", 0.001)
                                 .containsEntry("foo.requestLength#count{httpStatus=200,method=POST}", 1.0)
                                 .containsEntry("foo.requestLength#total{httpStatus=200,method=POST}", 123.0)
                                 .containsEntry("foo.responseDuration#count{httpStatus=200,method=POST}", 1.0)
@@ -128,6 +138,10 @@ public class RequestMetricSupportTest {
                                                1.0)
                                 .containsEntry("foo.actualRequests#count{httpStatus=500,method=POST}",
                                                2.0)
+                                .containsEntry("foo.acquiringConnectionDuration#count{httpStatus=500," +
+                                               "method=POST}", 1.0)
+                                .containsEntry("foo.acquiringConnectionDuration#total{httpStatus=500," +
+                                               "method=POST}", 0.001)
                                 .containsEntry("foo.requestLength#count{httpStatus=500,method=POST}", 1.0)
                                 .containsEntry("foo.requestLength#total{httpStatus=500,method=POST}", 123.0)
                                 .containsEntry("foo.responseDuration#count{httpStatus=500,method=POST}", 1.0)
@@ -202,6 +216,9 @@ public class RequestMetricSupportTest {
         final ClientRequestContext derivedCtx = ctx.newDerivedContext();
         ctx.logBuilder().addChild(derivedCtx.log());
 
+        derivedCtx.attr(ClientConnectionTimings.TIMINGS).set(
+                new ClientConnectionTimingsBuilder(1, TimeUnit.MILLISECONDS.toNanos(1))
+                        .build(TimeUnit.MILLISECONDS.toNanos(2)));
         derivedCtx.logBuilder().requestHeaders(HttpHeaders.of(HttpMethod.POST, "/foo"));
         derivedCtx.logBuilder().requestFirstBytesTransferred();
         derivedCtx.logBuilder().requestContent(null, null);

--- a/logback/src/main/java/com/linecorp/armeria/common/logback/RequestContextExportingAppender.java
+++ b/logback/src/main/java/com/linecorp/armeria/common/logback/RequestContextExportingAppender.java
@@ -51,7 +51,7 @@ import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
  * A <a href="https://logback.qos.ch/">Logback</a> {@link Appender} that exports the properties of the current
  * {@link RequestContext} to {@link MDC}.
  *
- * <p>Read '<a href="https://line.github.io/armeria/server-basics.html">Logging contextual information</a>'
+ * <p>Read '<a href="https://line.github.io/armeria/advanced-logging.html">Logging contextual information</a>'
  * for more information.
  */
 public class RequestContextExportingAppender extends UnsynchronizedAppenderBase<ILoggingEvent>

--- a/site/src/sphinx/advanced-custom-attributes.rst
+++ b/site/src/sphinx/advanced-custom-attributes.rst
@@ -5,7 +5,7 @@ RequestContext custom attributes
 
 When you are using multiple decorators, you might want to pass some value to the next decorator.
 You can do this by attaching attributes to a :api:`RequestContext`. To attach an attribute,
-you need to define ``AttributeKey`` first:
+you need to define an ``AttributeKey`` first:
 
 .. code-block:: java
 

--- a/site/src/sphinx/advanced-custom-attributes.rst
+++ b/site/src/sphinx/advanced-custom-attributes.rst
@@ -4,8 +4,8 @@ RequestContext custom attributes
 ================================
 
 When you are using multiple decorators, you might want to pass some value to the next decorator.
-You can do this by attaching attributes to a :api:`RequestContext`. To attach attributes,
-you need to define attributeKey first:
+You can do this by attaching attributes to a :api:`RequestContext`. To attach an attribute,
+you need to define ``AttributeKey`` first:
 
 .. code-block:: java
 

--- a/site/src/sphinx/advanced-custom-attributes.rst
+++ b/site/src/sphinx/advanced-custom-attributes.rst
@@ -1,0 +1,58 @@
+.. _advanced-custom-attribute:
+
+RequestContext custom attributes
+================================
+
+When you are using multiple decorators, you might want to pass some value to the next decorator.
+You can do this by attaching attributes to a :api:`RequestContext`. To attach attributes,
+you need to define attributeKey first:
+
+.. code-block:: java
+
+    import io.netty.util.AttributeKey;
+
+    public final class MyAttributeKeys {
+        public static final AttributeKey<Integer> INT_ATTR =
+                AttributeKey.valueOf(MyAttributeKeys.class, "INT_ATTR");
+        public static final AttributeKey<MyBean> BEAN_ATTR =
+                AttributeKey.valueOf(MyAttributeKeys.class, "BEAN_ATTR");
+        ...
+    }
+
+Then, you can access them via ``RequestContext.attr(AttributeKey)``:
+
+.. code-block:: java
+
+    // Setting
+    ctx.attr(INT_ATTR).set(42);
+    MyBean myBean = new MyBean();
+    ctx.attr(BEAN_ATTR).set(new MyBean());
+
+    // Getting
+    Integer i = ctx.attr(INT_ATTR).get(); // i == 42
+    MyBean bean = ctx.attr(BEAN_ATTR).get(); // bean == myBean
+
+You can also iterate over all the attributes in a context using ``RequestContext.attrs()``:
+
+.. code-block:: java
+
+    for (Attribute<?> a : ctx.attrs()) {
+        System.err.println(a.key() + ": " + a.get());
+    }
+
+If you are only interested in checking whether an attribute exists or not, you should use
+``RequestContext.hasAttr(AttributeKey)``. It does not perform any allocation for a non-existent attribute
+unlike ``RequestContext.attr(AttributeKey)`` does:
+
+.. code-block:: java
+
+    if (ctx.hasAttr(INT_ATTR)) {
+        int i = ctx.attr(INT_ATTR).get();
+        ...
+    }
+
+.. note::
+
+    You can do this using :api:`RequestLog` as well. If you invoke ``RequestLog.attr(AttributeKey)``,
+    ``RequestLog.attrs()`` and ``RequestLog.hasAttr(AttributeKey)``, the :api:`RequestLog` simply delegates
+    the call to the :api:`RequestContext` that it belongs to.

--- a/site/src/sphinx/advanced-custom-attributes.rst
+++ b/site/src/sphinx/advanced-custom-attributes.rst
@@ -1,7 +1,7 @@
 .. _advanced-custom-attribute:
 
-RequestContext custom attributes
-================================
+``RequestContext`` custom attributes
+====================================
 
 When you are using multiple decorators, you might want to pass some value to the next decorator.
 You can do this by attaching attributes to a :api:`RequestContext`. To attach an attribute,

--- a/site/src/sphinx/advanced-logging.rst
+++ b/site/src/sphinx/advanced-logging.rst
@@ -77,7 +77,7 @@ request and response. The MDC key of the exported header is ``"req.http_headers.
 Custom attributes
 -----------------
 A user can attach an arbitrary custom attribute to a :api:`RequestContext` by using
-``RequestContext.attr(...).set(...)`` to store the information associated with the request being handled.
+:ref:`advanced-custom-attribute` to store the information associated with the request being handled.
 :api:`RequestContextExportingAppender` can export such attributes to the `MDC`_ property map as well.
 
 Unlike other property types, you need to specify the full name of an attribute as well as its alias.

--- a/site/src/sphinx/advanced-structured-logging.rst
+++ b/site/src/sphinx/advanced-structured-logging.rst
@@ -10,8 +10,11 @@ What properties can be retrieved?
 ---------------------------------
 :api:`RequestLog` provides various properties recorded while handling a request:
 
-+----------------------------------------------------------------------------------------------------+
-| Request properties                                                                                 |
+Request properties
+^^^^^^^^^^^^^^^^^^
+
++-----------------------------+----------------------------------------------------------------------+
+| Property                    | Description                                                          |
 +=============================+======================================================================+
 | ``requestStartTimeMicros``  | when the request processing started, in microseconds since the       |
 |                             | epoch (01-Jan-1970 00:00:00 UTC)                                     |
@@ -39,8 +42,11 @@ What properties can be retrieved?
 | ``requestContentPreview``   | the preview of the request content                                   |
 +-----------------------------+----------------------------------------------------------------------+
 
-+----------------------------------------------------------------------------------------------------+
-| Response properties                                                                                |
+Response properties
+^^^^^^^^^^^^^^^^^^^
+
++-----------------------------+----------------------------------------------------------------------+
+| Property                    | Description                                                          |
 +=============================+======================================================================+
 | ``responseStartTimeMicros`` | when the response processing started, in microseconds since the      |
 |                             | epoch (01-Jan-1970 00:00:00 UTC)                                     |
@@ -63,36 +69,38 @@ What properties can be retrieved?
 | ``responseContentPreview``  | the preview of the response content                                  |
 +-----------------------------+----------------------------------------------------------------------+
 
-Client connection timing
-^^^^^^^^^^^^^^^^^^^^^^^^
+Client connection timing properties
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-+--------------------------------------------------------------------------------------------------------------+
-| Client connection timing properties                                                                          |
++------------------------------------------+-------------------------------------------------------------------+
+| Property                                 | Description                                                       |
 +==========================================+===================================================================+
-| ``dnsResolutionStartTimeMicros``         | when the client started to resolve a domain name, in microseconds |
+| ``connectionAcquisitionStartTimeMicros`` | when the client started to acquire a connection, in microseconds  |
 |                                          | since the epoch (01-Jan-1970 00:00:00 UTC)                        |
++------------------------------------------+-------------------------------------------------------------------+
+| ``connectionAcquisitionDurationNanos``   | the duration took to get a connection (i.e. the total duration)   |
++------------------------------------------+-------------------------------------------------------------------+
+| ``dnsResolutionStartTimeMicros``         | when the client started to resolve a domain name, in microseconds |
+|                                          | since the epoch (01-Jan-1970 00:00:00 UTC), ``-1`` if DNS lookup  |
+|                                          | did not occur                                                     |
 +------------------------------------------+-------------------------------------------------------------------+
 | ``dnsResolutionDurationNanos``           | the duration took to resolve a domain name, ``-1`` if DNS lookup  |
 |                                          | did not occur                                                     |
 +------------------------------------------+-------------------------------------------------------------------+
 | ``socketConnectStartTimeMicros``         | when the client started to connect to a remote peer, in           |
-|                                          | microseconds since the epoch (01-Jan-1970 00:00:00 UTC)           |
+|                                          | microseconds since the epoch (01-Jan-1970 00:00:00 UTC), ``-1``   |
+|                                          | if socket connection attempt did not occur                        |
 +------------------------------------------+-------------------------------------------------------------------+
 | ``socketConnectDurationNanos``           | the duration took to connect to a remote peer, ``-1`` if socket   |
 |                                          | connection attempt did not occur                                  |
 +------------------------------------------+-------------------------------------------------------------------+
 | ``pendingAcquisitionStartTimeMicros``    | when the client started to wait for the completion of an existing |
 |                                          | connection attempt, in microseconds since the                     |
-|                                          | epoch (01-Jan-1970 00:00:00 UTC)                                  |
+|                                          | epoch (01-Jan-1970 00:00:00 UTC), ``-1`` if waiting did not occur |
 +------------------------------------------+-------------------------------------------------------------------+
 | ``pendingAcquisitionDurationNanos``      | the duration took to wait for the completion of an existing       |
 |                                          | connection attempt to use one connection in HTTP/2, ``-1`` if     |
 |                                          | waiting did not occur                                             |
-+------------------------------------------+-------------------------------------------------------------------+
-| ``connectionAcquisitionStartTimeMicros`` | when the client started to acquire a connection, in microseconds  |
-|                                          | since the epoch (01-Jan-1970 00:00:00 UTC)                        |
-+------------------------------------------+-------------------------------------------------------------------+
-| ``connectionAcquisitionDurationNanos``   | the duration took to get a connection (i.e. the total duration)   |
 +------------------------------------------+-------------------------------------------------------------------+
 
 The total duration is the sum of ``dnsResolutionDurationNanos``, ``socketConnectDurationNanos`` and
@@ -104,7 +112,6 @@ These are some of the scenarios how the total duration is composed of:
        .. uml::
 
            @startditaa(--no-separation, --no-shadows)
-
            +---------------------------------------------------------------+                               #1
            :<---------------------connectionAcquisition------------------->|
            +---------------------------------------------------------------+
@@ -122,13 +129,11 @@ These are some of the scenarios how the total duration is composed of:
        .. uml::
 
            @startditaa(--no-separation, --no-shadows)
-
            +-----------------------------+                                                                 #2
            :<---connectionAcquisition--->|
            +-----------------------------+
            :<-----pendingAcquisition---->|
            +-----------------------------+
-
            @enduml
 
     3. Connecting to the remote peer with the resolved IP address after the existing connection attempt is
@@ -137,7 +142,6 @@ These are some of the scenarios how the total duration is composed of:
        .. uml::
 
            @startditaa(--no-separation, --no-shadows)
-
            +------------------------------------------------------------------------------------------+    #3
            :<-----------------------------------connectionAcquisition-------------------------------->|
            +------------------------------------------------------------------------------------------+

--- a/site/src/sphinx/advanced-structured-logging.rst
+++ b/site/src/sphinx/advanced-structured-logging.rst
@@ -69,27 +69,28 @@ Client connection timing
 +--------------------------------------------------------------------------------------------------------------+
 | Client connection timing properties                                                                          |
 +==========================================+===================================================================+
-| ``dnsResolutionStartTimeMicros``         | when resolving a domain name started, in microseconds since the   |
-|                                          | epoch (01-Jan-1970 00:00:00 UTC)                                  |
+| ``dnsResolutionStartTimeMicros``         | when the client started to resolve a domain name, in microseconds |
+|                                          | since the epoch (01-Jan-1970 00:00:00 UTC)                        |
 +------------------------------------------+-------------------------------------------------------------------+
 | ``dnsResolutionDurationNanos``           | the duration took to resolve a domain name, ``-1`` if DNS lookup  |
 |                                          | did not occur                                                     |
 +------------------------------------------+-------------------------------------------------------------------+
-| ``socketConnectStartTimeMicros``         | when connecting to a remote peer started, in microseconds since   |
-|                                          | the epoch (01-Jan-1970 00:00:00 UTC)                              |
+| ``socketConnectStartTimeMicros``         | when the client started to connect to a remote peer, in           |
+|                                          | microseconds since the epoch (01-Jan-1970 00:00:00 UTC)           |
 +------------------------------------------+-------------------------------------------------------------------+
 | ``socketConnectDurationNanos``           | the duration took to connect to a remote peer, ``-1`` if socket   |
 |                                          | connection attempt did not occur                                  |
 +------------------------------------------+-------------------------------------------------------------------+
-| ``pendingAcquisitionStartTimeMicros``    | when waiting for the completion of an existing connection attempt |
-|                                          | the epoch (01-Jan-1970 00:00:00 UTC)                              |
+| ``pendingAcquisitionStartTimeMicros``    | when the client started to wait for the completion of an existing |
+|                                          | connection attempt, in microseconds since the                     |
+|                                          | epoch (01-Jan-1970 00:00:00 UTC)                                  |
 +------------------------------------------+-------------------------------------------------------------------+
 | ``pendingAcquisitionDurationNanos``      | the duration took to wait for the completion of an existing       |
 |                                          | connection attempt to use one connection in HTTP/2, ``-1`` if     |
 |                                          | waiting did not occur                                             |
 +------------------------------------------+-------------------------------------------------------------------+
-| ``connectionAcquisitionStartTimeMicros`` | when acquiring a connection started, in microseconds since the    |
-|                                          | epoch (01-Jan-1970 00:00:00 UTC)                                  |
+| ``connectionAcquisitionStartTimeMicros`` | when the client started to acquire a connection, in microseconds  |
+|                                          | since the epoch (01-Jan-1970 00:00:00 UTC)                        |
 +------------------------------------------+-------------------------------------------------------------------+
 | ``connectionAcquisitionDurationNanos``   | the duration took to get a connection (i.e. the total duration)   |
 +------------------------------------------+-------------------------------------------------------------------+
@@ -115,8 +116,8 @@ These are some of the scenarios how the total duration is composed of:
 
     2. Waiting for the connection to be established, since there's an existing connection attempt, to use one
     connection in HTTP/2. (Note that, if you create a client with an IP address, ``dnsResolution`` did not
-    occur. Also note that, there's no ``socketConnect`` because the client just wait for the connection and
-    use it.)
+    occur. Also note that, there's no ``socketConnect`` because the client just waits for the connection and
+    uses it.)
 
        .. uml::
 

--- a/site/src/sphinx/advanced-structured-logging.rst
+++ b/site/src/sphinx/advanced-structured-logging.rst
@@ -96,10 +96,7 @@ Client connection timing
 
 The total duration is the sum of ``dnsResolutionDurationNanos``, ``socketConnectDurationNanos`` and
 ``pendingAcquisitionDurationNanos``. They may or may not occur depending on circumstances.
-For example, if you specify an IP address while creating a client, ``dnsResolutionDurationNanos`` is ``-1``
-since the client doesn't have to resolve a domain name. Likewise, ``socketConnectDurationNanos`` is ``-1``
-if the client reuses the connection which was established before. These are some of the scenarios how
-``connectionAcquisitionDurationNanos`` is composed of:
+These are some of the scenarios how the total duration is composed of:
 
     1. Resolving a domain name and connecting to the remote peer.
 
@@ -116,20 +113,21 @@ if the client reuses the connection which was established before. These are some
                                            +-------------------------------+
            @endditaa
 
-    2. Resolving a domain name and waiting, since there's existing connection attempt with same IP address,
-    to use one connection in HTTP/2.
+    2. Waiting for the connection to be established, since there's an existing connection attempt, to use one
+    connection in HTTP/2. (Note that, if you create a client with an IP address, ``dnsResolution`` did not
+    occur. Also note that, there's no ``socketConnect`` because the client just wait for the connection and
+    use it.)
 
        .. uml::
 
            @startditaa(--no-separation, --no-shadows)
 
-           +----------------------------------------------------------+                                    #2
-           :<---------------------connectionAcquisition-------------->|
-           +----------------------------------------------------------+
-           :<--------dnsResolution-------->|
-           +-------------------------------+--------------------------+
-                                           :<---pendingAcquisition--->|
-                                           +--------------------------+
+           +-----------------------------+                                                                 #2
+           :<---connectionAcquisition--->|
+           +-----------------------------+
+           :<-----pendingAcquisition---->|
+           +-----------------------------+
+
            @enduml
 
     3. Connecting to the remote peer with the resolved IP address after the existing connection attempt is

--- a/site/src/sphinx/advanced-unit-testing.rst
+++ b/site/src/sphinx/advanced-unit-testing.rst
@@ -14,90 +14,90 @@ object easily:
 
 .. code-block:: java
 
-   import org.junit.Before;
-   import org.junit.Test;
+    import org.junit.Before;
+    import org.junit.Test;
 
-   import com.linecorp.armeria.common.HttpRequest;
-   import com.linecorp.armeria.common.HttpResponse;
-   import com.linecorp.armeria.common.AggregatedHttpMessage;
-   import com.linecorp.armeria.client.ClientRequestContext;
-   import com.linecorp.armeria.server.ServiceRequestContext;
+    import com.linecorp.armeria.common.HttpRequest;
+    import com.linecorp.armeria.common.HttpResponse;
+    import com.linecorp.armeria.common.AggregatedHttpMessage;
+    import com.linecorp.armeria.client.ClientRequestContext;
+    import com.linecorp.armeria.server.ServiceRequestContext;
 
-   public class MyJUnit4Test {
+    public class MyJUnit4Test {
 
-       private MyClient client;
-       private MyService service;
+        private MyClient client;
+        private MyService service;
 
-       @Before
-       public void setUp() {
-           client = ...;
-           service = ...;
-       }
+        @Before
+        public void setUp() {
+            client = ...;
+            service = ...;
+        }
 
-       @Test
-       public void testClient() throws Exception {
-           // Given
-           HttpRequest req = HttpRequest.of(HttpMethod.GET, "/greet?name=foo");
-           ClientRequestContext cctx = ClientRequestContext.of(req);
+        @Test
+        public void testClient() throws Exception {
+            // Given
+            HttpRequest req = HttpRequest.of(HttpMethod.GET, "/greet?name=foo");
+            ClientRequestContext cctx = ClientRequestContext.of(req);
 
-           // When
-           HttpResponse res = client.execute(cctx, req);
+            // When
+            HttpResponse res = client.execute(cctx, req);
 
-           // Then
-           AggregatedHttpMessage aggregatedRes = res.aggregate().get();
-           assertEquals(200, aggregatedRes.status().code());
-       }
+            // Then
+            AggregatedHttpMessage aggregatedRes = res.aggregate().get();
+            assertEquals(200, aggregatedRes.status().code());
+        }
 
-       @Test
-       public void testService() throws Exception {
-           // Given
-           HttpRequest req = HttpRequest.of(HttpMethod.POST, "/greet",
-                                            MediaType.JSON_UTF_8,
-                                            "{ \"name\": \"foo\" }");
-           ServiceRequestContext sctx = ServiceRequestContext.of(req);
+        @Test
+        public void testService() throws Exception {
+            // Given
+            HttpRequest req = HttpRequest.of(HttpMethod.POST, "/greet",
+                                             MediaType.JSON_UTF_8,
+                                             "{ \"name\": \"foo\" }");
+            ServiceRequestContext sctx = ServiceRequestContext.of(req);
 
-           // When
-           HttpResponse res = service.serve(sctx, req);
+            // When
+            HttpResponse res = service.serve(sctx, req);
 
-           // Then
-           AggregatedHttpMessage aggregatedRes = res.aggregate().get();
-           assertEquals(200, aggregatedRes.status().code());
-       }
-   }
+            // Then
+            AggregatedHttpMessage aggregatedRes = res.aggregate().get();
+            assertEquals(200, aggregatedRes.status().code());
+        }
+    }
 
 Although the fake context returned by ``ClientRequestContext.of()`` and ``ServiceRequestContext.of()`` will
 provide sensible defaults, you can override its default properties using a builder:
 
 .. code-block:: java
 
-   import java.net.InetAddress;
-   import java.net.InetSocketAddress;
-   import java.util.Map;
+    import java.net.InetAddress;
+    import java.net.InetSocketAddress;
+    import java.util.Map;
 
-   import com.linecorp.armeria.common.SessionProtocol;
-   import com.linecorp.armeria.client.ClientRequestContextBuilder;
-   import com.linecorp.armeria.server.PathMappingResult;
-   import com.linecorp.armeria.server.ServiceRequestContextBuilder;
+    import com.linecorp.armeria.common.SessionProtocol;
+    import com.linecorp.armeria.client.ClientRequestContextBuilder;
+    import com.linecorp.armeria.server.PathMappingResult;
+    import com.linecorp.armeria.server.ServiceRequestContextBuilder;
 
-   HttpRequest req = HttpRequest.of(...);
+    HttpRequest req = HttpRequest.of(...);
 
-   ClientRequestContext cctx =
-           ClientRequestContextBuilder.of(req)
-                                      .sessionProtocol(SessionProtocol.H1C)
-                                      .remoteAddress(new InetSocketAddress("192.168.0.2", 443))
-                                      .build();
-
-   PathMappingResult mappingResult =
-           PathMappingResult.of("/mapped/path",                // Mapped path
-                                "foo=bar&baz=qux",             // Query string
-                                Map.of("pathParam1", "value1", // Path parameters
-                                       "pathParam2", "value2"));
-
-   ServiceRequestContext sctx =
-           ServiceRequestContextBuilder.of(req)
-                                       .clientAddress(InetAddress.getByName("192.168.1.2"))
-                                       .pathMappingResult(mappingResult);
+    ClientRequestContext cctx =
+            ClientRequestContextBuilder.of(req)
+                                       .sessionProtocol(SessionProtocol.H1C)
+                                       .remoteAddress(new InetSocketAddress("192.168.0.2", 443))
                                        .build();
+
+    PathMappingResult mappingResult =
+            PathMappingResult.of("/mapped/path",                // Mapped path
+                                 "foo=bar&baz=qux",             // Query string
+                                 Map.of("pathParam1", "value1", // Path parameters
+                                        "pathParam2", "value2"));
+
+    ServiceRequestContext sctx =
+            ServiceRequestContextBuilder.of(req)
+                                        .clientAddress(InetAddress.getByName("192.168.1.2"))
+                                        .pathMappingResult(mappingResult);
+                                        .build();
 
 Using a fake context to emulate an incoming request
 ---------------------------------------------------
@@ -115,27 +115,27 @@ The following example shows how to emit a fake request every minute:
 
 .. code-block:: java
 
-   import java.util.concurrent.ScheduledExecutorService;
-   import java.util.concurrent.TimeUnit;
+    import java.util.concurrent.ScheduledExecutorService;
+    import java.util.concurrent.TimeUnit;
 
-   import com.linecorp.armeria.server.HttpService;
+    import com.linecorp.armeria.server.HttpService;
 
-   ScheduledExecutorService executor = ...;
-   HttpService sessionManagementService = (ctx, req) -> ...;
+    ScheduledExecutorService executor = ...;
+    HttpService sessionManagementService = (ctx, req) -> ...;
 
-   // Send a session expiration request to the session management service
-   // every minute.
-   executor.scheduleWithFixedDelay(() -> {
-       HttpRequest req = HttpRequest.of(HttpMethod.POST, "/expire_stall_sessions");
-       ServiceRequestContext ctx = ServiceRequestContext.of(req);
-       try {
-           HttpResponse res = sessionManagementService.servce(ctx, req);
-           AggregatedHttpMessage aggregatedRes = res.aggregate().get();
-           if (aggregatedRes.status().code() != 200) {
-               System.err.println("Failed to expire stall sessions: " +
-                                  aggregatedRes);
-           }
-       } catch (Exception e) {
-           e.printStackTrace();
-       }
-   }, 1, 1, TimeUnit.MINUTES);
+    // Send a session expiration request to the session management service
+    // every minute.
+    executor.scheduleWithFixedDelay(() -> {
+        HttpRequest req = HttpRequest.of(HttpMethod.POST, "/expire_stall_sessions");
+        ServiceRequestContext ctx = ServiceRequestContext.of(req);
+        try {
+            HttpResponse res = sessionManagementService.servce(ctx, req);
+            AggregatedHttpMessage aggregatedRes = res.aggregate().get();
+            if (aggregatedRes.status().code() != 200) {
+                System.err.println("Failed to expire stall sessions: " +
+                                   aggregatedRes);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }, 1, 1, TimeUnit.MINUTES);

--- a/site/src/sphinx/advanced.rst
+++ b/site/src/sphinx/advanced.rst
@@ -8,6 +8,7 @@ Advanced topics
 
     advanced-logging
     advanced-structured-logging
+    advanced-custom-attributes
     advanced-structured-logging-kafka
     advanced-unit-testing
     advanced-production-checklist

--- a/site/src/sphinx/client-decorator.rst
+++ b/site/src/sphinx/client-decorator.rst
@@ -66,3 +66,4 @@ See also
 --------
 
 - :ref:`server-decorator`
+- :ref:`advanced-custom-attribute`

--- a/site/src/sphinx/server-decorator.rst
+++ b/site/src/sphinx/server-decorator.rst
@@ -221,3 +221,4 @@ See also
 --------
 
 - :ref:`client-decorator`
+- :ref:`advanced-custom-attribute`

--- a/thrift/src/main/java/com/linecorp/armeria/server/thrift/ThriftStructuredLog.java
+++ b/thrift/src/main/java/com/linecorp/armeria/server/thrift/ThriftStructuredLog.java
@@ -142,7 +142,7 @@ public class ThriftStructuredLog extends StructuredLog {
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
-                          .add("timestamp", TextFormatter.epoch(timestampMillis()))
+                          .add("timestamp", TextFormatter.epochMillis(timestampMillis()))
                           .add("responseTime", TextFormatter.elapsed(responseTimeNanos()))
                           .add("requestSize", TextFormatter.size(requestSize()))
                           .add("responseSize", TextFormatter.size(responseSize()))


### PR DESCRIPTION
Motivation:
Currently, there's no way to get the duration for getting a connection. If you use HTTP/2,
getting the duration might be useless because, most of the time, you will share just one connection which was established beforehand. (So the duration is very short.) If you use HTTP/1.1, however,
you might need the value due to the nature of HTTP/1.1 which sends just one request at a time. (You need as many connections as you send requests concurrently.)

Modifications:
- Make `RequestLog` extends `AttributeMap` so that you can easily get the attributes from the log.
- Add `ClientConnectionTimings` and it's builder which has the timing information about a connection attempt. The timings are the start time and duration of:
  - `connectionAcquisition`
  - `dnsResolution`
  - `socketConnect`
  - `pendingAcquisition`
- Add the timing values to the client request metric.
- Miscellaneous
  - Calculate the length of request and response in `DefaultRequestLog` to use as the initial value of the `StringBuilder` for efficiency.
  - Deprecate `TextFormatter.epoch()` and `TextFormatter.appendEpoch()`, add
 `TextFormatter.epochMillis()`, `TextFormatter.appendEpochMillis()`, `TextFormatter.epochMicros()` and `TextFormatter.appendEpochMicros()`.

Result:
- Close #1678
- You can get the timing information about a connection attempt.