### PR TITLE
Fix a bug where `DnsEndpointGroup` does not respect search domains

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsAddressEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsAddressEndpointGroup.java
@@ -32,7 +32,6 @@ import com.linecorp.armeria.common.CommonPools;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
 import io.netty.channel.EventLoop;
-import io.netty.handler.codec.dns.DefaultDnsQuestion;
 import io.netty.handler.codec.dns.DnsQuestion;
 import io.netty.handler.codec.dns.DnsRawRecord;
 import io.netty.handler.codec.dns.DnsRecord;
@@ -107,14 +106,14 @@ public final class DnsAddressEndpointGroup extends DnsEndpointGroup {
             case IPV4_ONLY:
             case IPV4_PREFERRED:
             case IPV6_PREFERRED:
-                builder.add(new DefaultDnsQuestion(hostname, DnsRecordType.A));
+                builder.add(new DnsQuestionWithoutTrailingDot(hostname, DnsRecordType.A));
                 break;
         }
         switch (resolvedAddressTypes) {
             case IPV6_ONLY:
             case IPV4_PREFERRED:
             case IPV6_PREFERRED:
-                builder.add(new DefaultDnsQuestion(hostname, DnsRecordType.AAAA));
+                builder.add(new DnsQuestionWithoutTrailingDot(hostname, DnsRecordType.AAAA));
                 break;
         }
         return builder.build();

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsEndpointGroup.java
@@ -95,6 +95,7 @@ abstract class DnsEndpointGroup extends DynamicEndpointGroup {
         final DnsNameResolverBuilder resolverBuilder = new DnsNameResolverBuilder(eventLoop)
                 .channelType(TransportType.datagramChannelType(eventLoop.parent()))
                 .ttl(minTtl, maxTtl)
+                .traceEnabled(true)
                 .nameServerProvider(serverAddressStreamProvider);
 
         resolverConfigurator.accept(resolverBuilder);
@@ -133,7 +134,6 @@ abstract class DnsEndpointGroup extends DynamicEndpointGroup {
         } else {
             // Multiple queries
             logger.debug("{} Sending DNS queries", logPrefix);
-            @SuppressWarnings("unchecked")
             final Promise<List<DnsRecord>> aggregatedPromise = eventLoop.newPromise();
             final FutureListener<List<DnsRecord>> listener = new FutureListener<List<DnsRecord>>() {
                 private final List<DnsRecord> records = new ArrayList<>();

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsQuestionWithoutTrailingDot.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsQuestionWithoutTrailingDot.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client.endpoint.dns;
+
+import static java.util.Objects.requireNonNull;
+
+import java.net.IDN;
+
+import io.netty.handler.codec.dns.DnsQuestion;
+import io.netty.handler.codec.dns.DnsRecordType;
+
+/**
+ * A {@link DnsQuestion} implementation which does not append a dot (.) to the name.
+ */
+final class DnsQuestionWithoutTrailingDot implements DnsQuestion {
+
+    private final String name;
+    private final DnsRecordType type;
+
+    DnsQuestionWithoutTrailingDot(String name, DnsRecordType type) {
+        this.name = IDN.toASCII(requireNonNull(name, "name"));
+        this.type = requireNonNull(type, "type");
+    }
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public DnsRecordType type() {
+        return type;
+    }
+
+    @Override
+    public int dnsClass() {
+        return CLASS_IN;
+    }
+
+    @Override
+    public long timeToLive() {
+        return 0;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final DnsQuestionWithoutTrailingDot that = (DnsQuestionWithoutTrailingDot) o;
+        return type.equals(that.type) && name.equals(that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return name.hashCode() * 31 + type.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder buf = new StringBuilder(64);
+        buf.append("DnsQuestion(")
+           .append(name())
+           .append(" IN ")
+           .append(type().name())
+           .append(')');
+        return buf.toString();
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsServiceEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsServiceEndpointGroup.java
@@ -30,7 +30,6 @@ import com.linecorp.armeria.common.CommonPools;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
 import io.netty.channel.EventLoop;
-import io.netty.handler.codec.dns.DefaultDnsQuestion;
 import io.netty.handler.codec.dns.DefaultDnsRecordDecoder;
 import io.netty.handler.codec.dns.DnsRawRecord;
 import io.netty.handler.codec.dns.DnsRecord;
@@ -60,7 +59,7 @@ public final class DnsServiceEndpointGroup extends DnsEndpointGroup {
                             DnsServerAddressStreamProvider serverAddressStreamProvider,
                             Backoff backoff, String hostname) {
         super(eventLoop, minTtl, maxTtl, serverAddressStreamProvider, backoff,
-              ImmutableList.of(new DefaultDnsQuestion(hostname, DnsRecordType.SRV)),
+              ImmutableList.of(new DnsQuestionWithoutTrailingDot(hostname, DnsRecordType.SRV)),
               unused -> {});
         start();
     }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsTextEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsTextEndpointGroup.java
@@ -31,7 +31,6 @@ import com.linecorp.armeria.common.CommonPools;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
 import io.netty.channel.EventLoop;
-import io.netty.handler.codec.dns.DefaultDnsQuestion;
 import io.netty.handler.codec.dns.DnsRawRecord;
 import io.netty.handler.codec.dns.DnsRecord;
 import io.netty.handler.codec.dns.DnsRecordType;
@@ -62,7 +61,7 @@ public final class DnsTextEndpointGroup extends DnsEndpointGroup {
                          DnsServerAddressStreamProvider serverAddressStreamProvider,
                          Backoff backoff, String hostname, Function<byte[], Endpoint> mapping) {
         super(eventLoop, minTtl, maxTtl, serverAddressStreamProvider, backoff,
-              ImmutableList.of(new DefaultDnsQuestion(hostname, DnsRecordType.TXT)),
+              ImmutableList.of(new DnsQuestionWithoutTrailingDot(hostname, DnsRecordType.TXT)),
               unused -> {});
         this.mapping = mapping;
         start();


### PR DESCRIPTION
Motivation:

When using `Dns*EndpointGroup` in a system with search domains in
`/etc/resolv.conf`, the resolver should try all search domains until the
host name is resolved.

However, it treats the specified host name as a full domain name by
appending a dot (.) to the specified host name.

Modifications:

- Introduce a new `DnsQuestion` implementation called
  `DnsQuestionWithoutTrailingDot` which does not append a dot at the end
  of the host name.

Result:

- `Dns*EndpointGroup` respects the search domains in `/etc/resolv.conf`.
- Fixes #1694