### PR TITLE
Make CORS policy to be applied to the specific paths

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceFactory.java
@@ -873,6 +873,11 @@ public final class AnnotatedHttpServiceFactory {
         }
 
         @Override
+        public boolean hasPathPatternOnly() {
+            return mapping.hasPathPatternOnly();
+        }
+
+        @Override
         public boolean equals(Object o) {
             if (this == o) {
                 return true;

--- a/core/src/main/java/com/linecorp/armeria/server/CatchAllPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/CatchAllPathMapping.java
@@ -63,6 +63,11 @@ final class CatchAllPathMapping extends AbstractPathMapping {
     }
 
     @Override
+    public boolean hasPathPatternOnly() {
+        return true;
+    }
+
+    @Override
     public String toString() {
         return "catchAll";
     }

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultPathMapping.java
@@ -182,6 +182,11 @@ final class DefaultPathMapping extends AbstractPathMapping {
     }
 
     @Override
+    public boolean hasPathPatternOnly() {
+        return true;
+    }
+
+    @Override
     protected PathMappingResult doApply(PathMappingContext mappingCtx) {
         final Matcher matcher = pattern.matcher(mappingCtx.path());
         if (!matcher.matches()) {

--- a/core/src/main/java/com/linecorp/armeria/server/ExactPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ExactPathMapping.java
@@ -71,6 +71,11 @@ final class ExactPathMapping extends AbstractPathMapping {
     }
 
     @Override
+    public boolean hasPathPatternOnly() {
+        return true;
+    }
+
+    @Override
     public int hashCode() {
         return meterTag.hashCode();
     }

--- a/core/src/main/java/com/linecorp/armeria/server/GlobPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/GlobPathMapping.java
@@ -118,6 +118,11 @@ final class GlobPathMapping extends AbstractPathMapping {
     }
 
     @Override
+    public boolean hasPathPatternOnly() {
+        return true;
+    }
+
+    @Override
     public int hashCode() {
         return strVal.hashCode();
     }

--- a/core/src/main/java/com/linecorp/armeria/server/HttpHeaderPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpHeaderPathMapping.java
@@ -202,6 +202,11 @@ final class HttpHeaderPathMapping implements PathMapping {
     }
 
     @Override
+    public boolean hasPathPatternOnly() {
+        return false;
+    }
+
+    @Override
     public String toString() {
         final StringBuilder buf = new StringBuilder();
         buf.append('[');

--- a/core/src/main/java/com/linecorp/armeria/server/PathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/PathMapping.java
@@ -144,7 +144,7 @@ public interface PathMapping {
      */
     static PathMapping ofPrefix(String pathPrefix, boolean stripPrefix) {
         requireNonNull(pathPrefix, "pathPrefix");
-        if ("/" .equals(pathPrefix)) {
+        if ("/".equals(pathPrefix)) {
             // Every path starts with '/'.
             return ofCatchAll();
         }

--- a/core/src/main/java/com/linecorp/armeria/server/PathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/PathMapping.java
@@ -270,8 +270,9 @@ public interface PathMapping {
 
     /**
      * Returns {@code true} if this {@link PathMapping} has only the path patterns as its condition.
+     * For example, the {@link PathMapping} created by {@link #withHttpHeaderInfo(Set, List, List)} has
+     * more conditions for mapping a path, such as HTTP methods, consumable types and producible types.
+     * In that case, {@code false} must be returned.
      */
-    default boolean hasPathPatternOnly() {
-        return false;
-    }
+    boolean hasPathPatternOnly();
 }

--- a/core/src/main/java/com/linecorp/armeria/server/PathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/PathMapping.java
@@ -144,7 +144,7 @@ public interface PathMapping {
      */
     static PathMapping ofPrefix(String pathPrefix, boolean stripPrefix) {
         requireNonNull(pathPrefix, "pathPrefix");
-        if ("/".equals(pathPrefix)) {
+        if ("/" .equals(pathPrefix)) {
             // Every path starts with '/'.
             return ofCatchAll();
         }
@@ -266,5 +266,12 @@ public interface PathMapping {
     default PathMapping withHttpHeaderInfo(Set<HttpMethod> supportedMethods,
                                            List<MediaType> consumeTypes, List<MediaType> produceTypes) {
         return new HttpHeaderPathMapping(this, supportedMethods, consumeTypes, produceTypes);
+    }
+
+    /**
+     * Returns {@code true} if this {@link PathMapping} has only the path patterns as its condition.
+     */
+    default boolean hasPathPatternOnly() {
+        return false;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/PrefixPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/PrefixPathMapping.java
@@ -80,6 +80,11 @@ final class PrefixPathMapping extends AbstractPathMapping {
     }
 
     @Override
+    public boolean hasPathPatternOnly() {
+        return true;
+    }
+
+    @Override
     public int hashCode() {
         return stripPrefix ? prefix.hashCode() : -prefix.hashCode();
     }

--- a/core/src/main/java/com/linecorp/armeria/server/RegexPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RegexPathMapping.java
@@ -113,6 +113,11 @@ final class RegexPathMapping extends AbstractPathMapping {
     }
 
     @Override
+    public boolean hasPathPatternOnly() {
+        return true;
+    }
+
+    @Override
     public int hashCode() {
         return meterTag.hashCode();
     }

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/decorator/CorsDecorator.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/decorator/CorsDecorator.java
@@ -43,6 +43,12 @@ public @interface CorsDecorator {
     String[] origins();
 
     /**
+     * The path patterns that this policy is supposed to be applied to. If unspecified, all paths would be
+     * accepted.
+     */
+    String[] pathPatterns() default {};
+
+    /**
      * The allowed HTTP request methods that should be returned in the
      * CORS {@code "Access-Control-Allow-Methods"} response header.
      *

--- a/core/src/main/java/com/linecorp/armeria/server/cors/AbstractCorsPolicyBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/AbstractCorsPolicyBuilder.java
@@ -131,7 +131,9 @@ abstract class AbstractCorsPolicyBuilder<B extends AbstractCorsPolicyBuilder> {
      *
      * @param pathMapping the {@link PathMapping} that this policy is supposed to be applied to
      * @return {@code this} to support method chaining.
-     * @throws IllegalArgumentException if the {@link PathMapping} has conditions beyond the path pattern
+     * @throws IllegalArgumentException if the {@link PathMapping} has conditions beyond the path pattern,
+     *                                  i.e. the {@link PathMapping} created by
+     *                                  {@link PathMapping#withHttpHeaderInfo(Set, List, List)}
      */
     public B pathMapping(PathMapping pathMapping) {
         requireNonNull(pathMapping, "pathMapping");

--- a/core/src/main/java/com/linecorp/armeria/server/cors/AbstractCorsPolicyBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/AbstractCorsPolicyBuilder.java
@@ -86,9 +86,8 @@ abstract class AbstractCorsPolicyBuilder<B extends AbstractCorsPolicyBuilder> {
     }
 
     B setConfig(CorsDecorator corsDecorator) {
-        if (corsDecorator.pathPatterns().length > 0) {
-            Arrays.stream(corsDecorator.pathPatterns()).forEach(this::pathMapping);
-        }
+        Arrays.stream(corsDecorator.pathPatterns()).forEach(this::pathMapping);
+
         if (corsDecorator.credentialsAllowed()) {
             allowCredentials();
         }

--- a/core/src/main/java/com/linecorp/armeria/server/cors/AbstractCorsPolicyBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/AbstractCorsPolicyBuilder.java
@@ -120,6 +120,7 @@ abstract class AbstractCorsPolicyBuilder<B extends AbstractCorsPolicyBuilder> {
      *
      * @param pathPattern the path pattern that this policy is supposed to be applied to
      * @return {@code this} to support method chaining.
+     * @throws IllegalArgumentException if the path pattern is not valid
      */
     public B pathMapping(String pathPattern) {
         return pathMapping(PathMapping.of(pathPattern));
@@ -130,9 +131,15 @@ abstract class AbstractCorsPolicyBuilder<B extends AbstractCorsPolicyBuilder> {
      *
      * @param pathMapping the {@link PathMapping} that this policy is supposed to be applied to
      * @return {@code this} to support method chaining.
+     * @throws IllegalArgumentException if the {@link PathMapping} has conditions beyond the path pattern
      */
     public B pathMapping(PathMapping pathMapping) {
-        pathMappings.add(requireNonNull(pathMapping, "pathMapping"));
+        requireNonNull(pathMapping, "pathMapping");
+        checkArgument(pathMapping.hasPathPatternOnly(),
+                      "pathMapping: %s " +
+                      "(expected: the path mapping which has only the path patterns as its condition)",
+                      pathMapping.getClass().getSimpleName());
+        pathMappings.add(pathMapping);
         return self();
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/cors/AbstractCorsPolicyBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/AbstractCorsPolicyBuilder.java
@@ -21,11 +21,13 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.util.Objects.requireNonNull;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -37,6 +39,7 @@ import com.google.common.collect.Iterables;
 
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.server.PathMapping;
 import com.linecorp.armeria.server.annotation.AdditionalHeader;
 import com.linecorp.armeria.server.annotation.decorator.CorsDecorator;
 import com.linecorp.armeria.server.cors.CorsConfig.ConstantValueSupplier;
@@ -52,6 +55,7 @@ import io.netty.util.AsciiString;
 @SuppressWarnings("rawtypes")
 abstract class AbstractCorsPolicyBuilder<B extends AbstractCorsPolicyBuilder> {
     private final Set<String> origins;
+    private final List<PathMapping> pathMappings = new ArrayList<>();
     private boolean credentialsAllowed;
     private boolean nullOriginAllowed;
     private long maxAge;
@@ -82,6 +86,9 @@ abstract class AbstractCorsPolicyBuilder<B extends AbstractCorsPolicyBuilder> {
     }
 
     B setConfig(CorsDecorator corsDecorator) {
+        if (corsDecorator.pathPatterns().length > 0) {
+            Arrays.stream(corsDecorator.pathPatterns()).forEach(this::pathMapping);
+        }
         if (corsDecorator.credentialsAllowed()) {
             allowCredentials();
         }
@@ -106,6 +113,27 @@ abstract class AbstractCorsPolicyBuilder<B extends AbstractCorsPolicyBuilder> {
         if (corsDecorator.maxAge() > 0) {
             maxAge(corsDecorator.maxAge());
         }
+        return self();
+    }
+
+    /**
+     * Adds a path pattern that this policy is supposed to be applied to.
+     *
+     * @param pathPattern the path pattern that this policy is supposed to be applied to
+     * @return {@code this} to support method chaining.
+     */
+    public B pathMapping(String pathPattern) {
+        return pathMapping(PathMapping.of(pathPattern));
+    }
+
+    /**
+     * Adds a {@link PathMapping} that this policy is supposed to be applied to.
+     *
+     * @param pathMapping the {@link PathMapping} that this policy is supposed to be applied to
+     * @return {@code this} to support method chaining.
+     */
+    public B pathMapping(PathMapping pathMapping) {
+        pathMappings.add(requireNonNull(pathMapping, "pathMapping"));
         return self();
     }
 
@@ -232,7 +260,7 @@ abstract class AbstractCorsPolicyBuilder<B extends AbstractCorsPolicyBuilder> {
      */
     public B allowRequestHeaders(CharSequence... headers) {
         requireNonNull(headers, "headers");
-        checkArgument(headers.length > 0,"headers should not be empty.");
+        checkArgument(headers.length > 0, "headers should not be empty.");
         for (int i = 0; i < headers.length; i++) {
             if (headers[i] == null) {
                 throw new NullPointerException("headers[" + i + ']');
@@ -255,7 +283,7 @@ abstract class AbstractCorsPolicyBuilder<B extends AbstractCorsPolicyBuilder> {
     public B preflightResponseHeader(CharSequence name, Object... values) {
         requireNonNull(name, "name");
         requireNonNull(values, "values");
-        checkArgument(values.length > 0,"values should not be empty.");
+        checkArgument(values.length > 0, "values should not be empty.");
         for (int i = 0; i < values.length; i++) {
             if (values[i] == null) {
                 throw new NullPointerException("values[" + i + ']');
@@ -328,14 +356,15 @@ abstract class AbstractCorsPolicyBuilder<B extends AbstractCorsPolicyBuilder> {
      * Returns a newly-created {@link CorsPolicy} based on the properties of this builder.
      */
     CorsPolicy build() {
-        return new CorsPolicy(origins, credentialsAllowed, maxAge, nullOriginAllowed,
+        return new CorsPolicy(origins, pathMappings, credentialsAllowed, maxAge, nullOriginAllowed,
                               exposedHeaders, allowedRequestHeaders, allowedRequestMethods,
                               preflightResponseHeadersDisabled, preflightResponseHeaders);
     }
 
     @Override
     public String toString() {
-        return CorsPolicy.toString(this, origins, nullOriginAllowed, credentialsAllowed, maxAge, exposedHeaders,
+        return CorsPolicy.toString(this, origins, pathMappings,
+                                   nullOriginAllowed, credentialsAllowed, maxAge, exposedHeaders,
                                    allowedRequestMethods, allowedRequestHeaders, preflightResponseHeaders);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/cors/ChainedCorsPolicyBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/ChainedCorsPolicyBuilder.java
@@ -44,7 +44,7 @@ public class ChainedCorsPolicyBuilder extends AbstractCorsPolicyBuilder<ChainedC
      * Returns the parent {@link CorsServiceBuilder}.
      */
     public CorsServiceBuilder and() {
-        return serviceBuilder;
+        return serviceBuilder.addPolicy(build());
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsPolicy.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsPolicy.java
@@ -20,6 +20,7 @@ import static com.linecorp.armeria.server.cors.CorsService.ANY_ORIGIN;
 
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -29,6 +30,7 @@ import javax.annotation.Nullable;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
@@ -37,6 +39,7 @@ import com.linecorp.armeria.common.DefaultHttpHeaders;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.server.PathMapping;
 import com.linecorp.armeria.server.cors.CorsConfig.ConstantValueSupplier;
 import com.linecorp.armeria.server.cors.CorsConfig.InstantValueSupplier;
 
@@ -50,6 +53,7 @@ public final class CorsPolicy {
     private static final String DELIMITER = ",";
     private static final Joiner HEADER_JOINER = Joiner.on(DELIMITER);
     private final Set<String> origins;
+    private final List<PathMapping> pathMappings;
     private final boolean credentialsAllowed;
     private final boolean nullOriginAllowed;
     private final long maxAge;
@@ -61,12 +65,13 @@ public final class CorsPolicy {
     private final String joinedAllowedRequestMethods;
     private final Map<AsciiString, Supplier<?>> preflightResponseHeaders;
 
-    CorsPolicy(Set<String> origins, boolean credentialsAllowed, long maxAge,
+    CorsPolicy(Set<String> origins, List<PathMapping> pathMappings, boolean credentialsAllowed, long maxAge,
                boolean nullOriginAllowed, Set<AsciiString> exposedHeaders,
                Set<AsciiString> allowedRequestHeaders, EnumSet<HttpMethod> allowedRequestMethods,
                boolean preflightResponseHeadersDisabled,
                Map<AsciiString, Supplier<?>> preflightResponseHeaders) {
         this.origins = ImmutableSet.copyOf(origins);
+        this.pathMappings = ImmutableList.copyOf(pathMappings);
         this.credentialsAllowed = credentialsAllowed;
         this.maxAge = maxAge;
         this.nullOriginAllowed = nullOriginAllowed;
@@ -103,6 +108,13 @@ public final class CorsPolicy {
      */
     public Set<String> origins() {
         return origins;
+    }
+
+    /**
+     * Returns the list of {@link PathMapping}s that this policy is supposed to be applied to.
+     */
+    public List<PathMapping> pathMappings() {
+        return pathMappings;
     }
 
     /**
@@ -258,11 +270,11 @@ public final class CorsPolicy {
 
     @Override
     public String toString() {
-        return toString(this, origins, nullOriginAllowed, credentialsAllowed, maxAge,
+        return toString(this, origins, pathMappings, nullOriginAllowed, credentialsAllowed, maxAge,
                         exposedHeaders, allowedRequestMethods, allowedRequestHeaders, preflightResponseHeaders);
     }
 
-    static String toString(Object obj, @Nullable Set<String> origins,
+    static String toString(Object obj, @Nullable Set<String> origins, List<PathMapping> pathMappings,
                            boolean nullOriginAllowed, boolean credentialsAllowed,
                            long maxAge, @Nullable Set<AsciiString> exposedHeaders,
                            @Nullable Set<HttpMethod> allowedRequestMethods,
@@ -271,6 +283,7 @@ public final class CorsPolicy {
         return MoreObjects.toStringHelper(obj)
                           .omitNullValues()
                           .add("origins", origins)
+                          .add("pathMappings", pathMappings)
                           .add("nullOriginAllowed", nullOriginAllowed)
                           .add("credentialsAllowed", credentialsAllowed)
                           .add("maxAge", maxAge)

--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsService.java
@@ -76,7 +76,7 @@ public final class CorsService extends SimpleDecoratingService<HttpRequest, Http
                 return handleCorsPreflight(ctx, req);
             }
             if (config.isShortCircuit() &&
-                config.getPolicy(req.headers().get(HttpHeaderNames.ORIGIN)) == null) {
+                config.getPolicy(req.headers().get(HttpHeaderNames.ORIGIN), ctx.pathMappingContext()) == null) {
                 return forbidden();
             }
         }
@@ -159,10 +159,11 @@ public final class CorsService extends SimpleDecoratingService<HttpRequest, Http
 
         final String origin = request.headers().get(HttpHeaderNames.ORIGIN);
         if (origin != null) {
-            final CorsPolicy policy = config.getPolicy(origin);
+            final CorsPolicy policy = config.getPolicy(origin, ctx.pathMappingContext());
             if (policy == null) {
                 logger.debug(
-                        "{} There is no CORS policy configured for the request origin '{}'.", ctx, origin);
+                        "{} There is no CORS policy configured for the request origin '{}' and the path '{}'.",
+                        ctx, origin, ctx.path());
                 return null;
             }
             if (NULL_ORIGIN.equals(origin)) {

--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsServiceBuilder.java
@@ -23,6 +23,7 @@ import static java.util.Objects.requireNonNull;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -141,7 +142,9 @@ public final class CorsServiceBuilder {
      * Adds a {@link PathMapping} that this policy is supposed to be applied to.
      *
      * @param pathMapping the {@link PathMapping} that this policy is supposed to be applied to
-     * @throws IllegalArgumentException if the {@link PathMapping} has conditions beyond the path pattern
+     * @throws IllegalArgumentException if the {@link PathMapping} has conditions beyond the path pattern,
+     *                                  i.e. the {@link PathMapping} created by
+     *                                  {@link PathMapping#withHttpHeaderInfo(Set, List, List)}
      */
     public CorsServiceBuilder pathMapping(PathMapping pathMapping) {
         firstPolicyBuilder.pathMapping(pathMapping);

--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsServiceBuilder.java
@@ -20,10 +20,9 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.linecorp.armeria.server.cors.CorsService.ANY_ORIGIN;
 import static java.util.Objects.requireNonNull;
 
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.List;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -34,6 +33,7 @@ import org.slf4j.LoggerFactory;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.server.PathMapping;
 import com.linecorp.armeria.server.Service;
 
 /**
@@ -70,8 +70,7 @@ public final class CorsServiceBuilder {
      * Creates a new builder with the specified origin.
      */
     public static CorsServiceBuilder forOrigin(String origin) {
-        requireNonNull(origin, "origin");
-        return forOrigins(origin);
+        return forOrigins(requireNonNull(origin, "origin"));
     }
 
     /**
@@ -92,8 +91,7 @@ public final class CorsServiceBuilder {
 
     final boolean anyOriginSupported;
     final ChainedCorsPolicyBuilder firstPolicyBuilder;
-    final Set<CorsPolicy> policies;
-    final Set<ChainedCorsPolicyBuilder> policyBuilders;
+    final List<CorsPolicy> policies = new ArrayList<>();
 
     boolean shortCircuit;
 
@@ -103,9 +101,7 @@ public final class CorsServiceBuilder {
      */
     CorsServiceBuilder(String... origins) {
         anyOriginSupported = false;
-        policies = new HashSet<>();
         firstPolicyBuilder = new ChainedCorsPolicyBuilder(this, origins);
-        policyBuilders = new HashSet<>();
     }
 
     /**
@@ -113,9 +109,7 @@ public final class CorsServiceBuilder {
      */
     CorsServiceBuilder() {
         anyOriginSupported = true;
-        policies = Collections.emptySet();
         firstPolicyBuilder = new ChainedCorsPolicyBuilder(this);
-        policyBuilders = Collections.emptySet();
     }
 
     private void ensureForNewPolicy() {
@@ -124,11 +118,27 @@ public final class CorsServiceBuilder {
     }
 
     /**
-     * Add a {@link CorsPolicy} instance in the service.
+     * Adds a {@link CorsPolicy} instance in the service.
      */
     public CorsServiceBuilder addPolicy(CorsPolicy policy) {
         ensureForNewPolicy();
         policies.add(policy);
+        return this;
+    }
+
+    /**
+     * Adds a path pattern that this policy is supposed to be applied to.
+     */
+    public CorsServiceBuilder pathMapping(String pathPattern) {
+        firstPolicyBuilder.pathMapping(pathPattern);
+        return this;
+    }
+
+    /**
+     * Adds a {@link PathMapping} that this policy is supposed to be applied to.
+     */
+    public CorsServiceBuilder pathMapping(PathMapping pathMapping) {
+        firstPolicyBuilder.pathMapping(pathMapping);
         return this;
     }
 
@@ -356,9 +366,7 @@ public final class CorsServiceBuilder {
      */
     public ChainedCorsPolicyBuilder andForOrigins(String... origins) {
         ensureForNewPolicy();
-        final ChainedCorsPolicyBuilder builder = new ChainedCorsPolicyBuilder(this, origins);
-        policyBuilders.add(builder);
-        return builder;
+        return new ChainedCorsPolicyBuilder(this, origins);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsServiceBuilder.java
@@ -128,6 +128,9 @@ public final class CorsServiceBuilder {
 
     /**
      * Adds a path pattern that this policy is supposed to be applied to.
+     *
+     * @param pathPattern the path pattern that this policy is supposed to be applied to
+     * @throws IllegalArgumentException if the path pattern is not valid
      */
     public CorsServiceBuilder pathMapping(String pathPattern) {
         firstPolicyBuilder.pathMapping(pathPattern);
@@ -136,6 +139,9 @@ public final class CorsServiceBuilder {
 
     /**
      * Adds a {@link PathMapping} that this policy is supposed to be applied to.
+     *
+     * @param pathMapping the {@link PathMapping} that this policy is supposed to be applied to
+     * @throws IllegalArgumentException if the {@link PathMapping} has conditions beyond the path pattern
      */
     public CorsServiceBuilder pathMapping(PathMapping pathMapping) {
         firstPolicyBuilder.pathMapping(pathMapping);

--- a/core/src/test/java/com/linecorp/armeria/server/cors/HttpServerCorsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/cors/HttpServerCorsTest.java
@@ -38,11 +38,13 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.server.AbstractHttpService;
 import com.linecorp.armeria.server.HttpService;
+import com.linecorp.armeria.server.PathMapping;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.annotation.AdditionalHeader;
 import com.linecorp.armeria.server.annotation.Get;
 import com.linecorp.armeria.server.annotation.Options;
+import com.linecorp.armeria.server.annotation.Param;
 import com.linecorp.armeria.server.annotation.Post;
 import com.linecorp.armeria.server.annotation.StatusCode;
 import com.linecorp.armeria.server.annotation.decorator.CorsDecorator;
@@ -66,6 +68,19 @@ public class HttpServerCorsTest {
         @StatusCode(200)
         @CorsDecorator(origins = "http://example2.com", exposedHeaders = "expose_header_2")
         public void duptest() {}
+    }
+
+    @CorsDecorator(
+            origins = "http://example.com",
+            pathPatterns = "glob:/**/configured",
+            allowedRequestMethods = HttpMethod.GET
+    )
+    private static class MyAnnotatedService2 {
+        @Get("/configured")
+        public void configured() {}
+
+        @Get("/not_configured")
+        public void notConfigured() {}
     }
 
     @ClassRule
@@ -192,6 +207,51 @@ public class HttpServerCorsTest {
             });
 
             sb.annotatedService("/cors7", new MyAnnotatedService());
+
+            sb.annotatedService("/cors8", new Object() {
+                @Get("/movies")
+                public void titles() {}
+
+                @Post("/movies/{title}")
+                public void addMovie(@Param String title) {}
+
+                @Get("/movies/{title}/actors")
+                public void actors(@Param String title) {}
+            }, CorsServiceBuilder.forOrigin("http://example.com")
+                                 // Note that configuring mappings for specific paths first because the
+                                 // policies will be visited in the configured order.
+                                 .pathMapping(PathMapping.of("glob:/**/actors"))
+                                 .allowRequestMethods(HttpMethod.GET, HttpMethod.POST)
+                                 .andForOrigin("http://example.com")
+                                 .pathMapping(PathMapping.of("/cors8/movies/{title}"))
+                                 .allowRequestMethods(HttpMethod.POST)
+                                 .andForOrigin("http://example.com")
+                                 .pathMapping(PathMapping.of("prefix:/cors8"))
+                                 .allowRequestMethods(HttpMethod.GET)
+                                 .and()
+                                 .newDecorator());
+
+            sb.annotatedService("/cors9", new Object() {
+                @Get("/movies")
+                public void titles() {}
+
+                @Post("/movies/{title}")
+                public void addMovie(@Param String title) {}
+
+                @Get("/movies/{title}/actors")
+                public void actors(@Param String title) {}
+            }, CorsServiceBuilder.forOrigin("http://example.com")
+                                 // Note that this prefix path mapping is configured first, so all preflight
+                                 // requests with a path starting with "/cors9/" will be matched.
+                                 .pathMapping(PathMapping.of("prefix:/cors9"))
+                                 .allowRequestMethods(HttpMethod.GET)
+                                 .andForOrigin("http://example.com")
+                                 .pathMapping(PathMapping.of("/cors9/movies/{title}"))
+                                 .allowRequestMethods(HttpMethod.POST)
+                                 .and()
+                                 .newDecorator());
+
+            sb.annotatedService("/cors10", new MyAnnotatedService2());
         }
     };
 
@@ -428,5 +488,55 @@ public class HttpServerCorsTest {
         final AggregatedHttpMessage response = preflightRequest(client, "/cors5/options", "http://example.com",
                                                                 "POST");
         assertEquals(HttpStatus.OK, response.status());
+    }
+
+    @Test
+    public void testPathMapping() {
+        final HttpClient client = client();
+        AggregatedHttpMessage msg;
+
+        msg = preflightRequest(client, "/cors8/movies", "http://example.com", "GET");
+        assertThat(msg.status()).isEqualTo(HttpStatus.OK);
+        assertThat(msg.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS)).isEqualTo("GET");
+
+        msg = preflightRequest(client, "/cors8/movies/InfinityWar", "http://example.com", "POST");
+        assertThat(msg.status()).isEqualTo(HttpStatus.OK);
+        assertThat(msg.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS)).isEqualTo("POST");
+
+        msg = preflightRequest(client, "/cors8/movies/InfinityWar/actors", "http://example.com", "GET");
+        assertThat(msg.status()).isEqualTo(HttpStatus.OK);
+        assertThat(msg.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS)).isEqualTo("GET,POST");
+    }
+
+    @Test
+    public void testPathMapping_order() {
+        final HttpClient client = client();
+        AggregatedHttpMessage msg;
+
+        msg = preflightRequest(client, "/cors9/movies", "http://example.com", "GET");
+        assertThat(msg.status()).isEqualTo(HttpStatus.OK);
+        assertThat(msg.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS)).isEqualTo("GET");
+
+        msg = preflightRequest(client, "/cors9/movies/InfinityWar", "http://example.com", "POST");
+        assertThat(msg.status()).isEqualTo(HttpStatus.OK);
+        assertThat(msg.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS)).isEqualTo("GET");
+
+        msg = preflightRequest(client, "/cors9/movies/InfinityWar/actors", "http://example.com", "GET");
+        assertThat(msg.status()).isEqualTo(HttpStatus.OK);
+        assertThat(msg.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS)).isEqualTo("GET");
+    }
+
+    @Test
+    public void testPathMapping_annotated() {
+        final HttpClient client = client();
+        AggregatedHttpMessage msg;
+
+        msg = preflightRequest(client, "/cors10/configured", "http://example.com", "GET");
+        assertThat(msg.status()).isEqualTo(HttpStatus.OK);
+        assertThat(msg.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS)).isEqualTo("GET");
+
+        msg = preflightRequest(client, "/cors10/not_configured", "http://example.com", "GET");
+        assertThat(msg.status()).isEqualTo(HttpStatus.OK);
+        assertThat(msg.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS)).isNull();
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/cors/HttpServerCorsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/cors/HttpServerCorsTest.java
@@ -26,6 +26,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.HttpClient;
@@ -538,5 +539,17 @@ public class HttpServerCorsTest {
         msg = preflightRequest(client, "/cors10/not_configured", "http://example.com", "GET");
         assertThat(msg.status()).isEqualTo(HttpStatus.OK);
         assertThat(msg.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS)).isNull();
+    }
+
+    @Test
+    public void notAllowedPathMapping() {
+        final CorsServiceBuilder builder = CorsServiceBuilder.forAnyOrigin();
+        assertThatThrownBy(() -> {
+            builder.pathMapping(PathMapping.of("/exact").withHttpHeaderInfo(ImmutableSet.of(HttpMethod.GET),
+                                                                            ImmutableList.of(),
+                                                                            ImmutableList.of()));
+        }).isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining(
+                  "(expected: the path mapping which has only the path patterns as its condition)");
     }
 }

--- a/site/src/sphinx/server-cors.rst
+++ b/site/src/sphinx/server-cors.rst
@@ -119,7 +119,7 @@ a policy is applied to, e.g.
 
 .. note::
 
-    Please refer to the :api:`PathMapping` in order to learn how to specify a path pattern you interest.
+    Please refer to the :api:`PathMapping` in order to learn how to specify a path pattern.
 
 Configuring CORS via annotation
 -------------------------------

--- a/site/src/sphinx/server-cors.rst
+++ b/site/src/sphinx/server-cors.rst
@@ -98,6 +98,29 @@ You can also directly add a :api:`CorsPolicy` created by a :api:`CorsPolicyBuild
                                             .build())
                               .newDecorator()));
 
+Applying a policy to the specific paths
+---------------------------------------
+To configure a policy to the specific paths, you can use ``pathMapping()`` methods in the
+:api:`CorsServiceBuilder` and :api:`ChainedCorsPolicyBuilder`. They can help you to adjust the scope that
+a policy is applied to, e.g.
+
+.. code-block:: java
+
+    HttpService myService = (ctx, req) -> ...;
+    ServerBuilder sb = new ServerBuilder().service("/message", myService.decorate(
+            CorsServiceBuilder.forOrigins("http://example.com")
+                              // CORS policy will be applied for the path that starts with '/message/web/api/'
+                              // or '/message/internal/web/api/'.
+                              .pathMapping(PathMapping.of("prefix:/message/web/api/"))
+                              // A shortcut of 'PathMapping.of(...)'.
+                              .pathMapping("prefix:/message/internal/web/api/")
+                              .allowRequestMethods(HttpMethod.POST, HttpMethod.GET)
+                              .newDecorator()));
+
+.. note::
+
+    Please refer to the :api:`PathMapping` in order to learn how to specify a path pattern you interest.
+
 Configuring CORS via annotation
 -------------------------------
 
@@ -150,4 +173,14 @@ Note that the :api:`@CorsDecorator` annotation specified at the method level tak
         public HttpResponse post() {
             return HttpResponse.of(HttpStatus.OK);
         }
+    }
+
+If you want to allow a CORS policy to the specific paths, you can use ``pathPatterns`` property:
+
+.. code-block:: java
+
+    // This policy will be applied only to the paths matched by the pattern.
+    @CorsDecorator(origins = "http://example.com", pathPatterns = "glob:/**/web/api", credentialsAllowed = true)
+    class MyAnnotatedService {
+        ...
     }


### PR DESCRIPTION
Motivation:
Currently, there is no way to apply a CORS policy to the specific paths. So it is hard for a user to configure different policies for different paths when the `Origin` domains are the same.
`@CorsDecorator` can handle this kind of situation because it can be specified on each methods in an annotated service, but using the annotation will be worked only if a user knows what origins are allowed at the compile time, which means that it's not suitable for configuring the origins dynamically. Also, it's only for the annotated services.
If the `CorsPolicy` has a `PathMapping` property, `CorsService` will be able to find a policy by using an `Origin` header value and the request path. Therefore, a user can apply CORS policies for different paths more convenient way.

Modifications:
- Added `boolean hasPathPatternOnly()` method to `PathMapping` interface, which describes whether the mapping has only path patterns as its condition.
- Added `pathMapping()` methods to `AbstractCorsPolicyBuilder` and `CorsServiceBuilder`.
  - Note that only the `PathMapping` that `PathMapping.hasPathPatternOnly()` returns `true` can be allowed.
- `CorsServiceBuilder` no longer keeps `ChainedCorsPolicyBuilder` list. It will be immediately built when its `and()` method is called. It's because the order of policies became important. The first configured path mapping must be evaluated first.
- Added `pathPatterns` property to `@CorsDecorator`.
- Updated `server-cors.rst`.

Result:
- A user can apply a CORS policy to the specific paths.
- Closes #1698.