### PR TITLE
Don't use address for service name

### DIFF
--- a/zipkin/src/main/java/com/linecorp/armeria/client/tracing/HttpTracingClient.java
+++ b/zipkin/src/main/java/com/linecorp/armeria/client/tracing/HttpTracingClient.java
@@ -25,8 +25,6 @@ import java.util.function.Function;
 
 import javax.annotation.Nullable;
 
-import com.google.common.base.Strings;
-
 import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.SimpleDecoratingClient;
@@ -125,7 +123,6 @@ public class HttpTracingClient extends SimpleDecoratingClient<HttpRequest, HttpR
     }
 
     private void setRemoteEndpoint(Span span, RequestLog log) {
-
         final SocketAddress remoteAddress = log.context().remoteAddress();
         final InetAddress address;
         final int port;
@@ -137,22 +134,7 @@ public class HttpTracingClient extends SimpleDecoratingClient<HttpRequest, HttpR
             address = null;
             port = 0;
         }
-
-        final String remoteServiceName;
-        if (this.remoteServiceName != null) {
-            remoteServiceName = this.remoteServiceName;
-        } else {
-            final String authority = log.requestHeaders().authority();
-            if (!"?".equals(authority)) {
-                remoteServiceName = authority;
-            } else if (address != null) {
-                remoteServiceName = String.valueOf(remoteAddress);
-            } else {
-                remoteServiceName = null;
-            }
-        }
-
-        if (!Strings.isNullOrEmpty(remoteServiceName)) {
+        if (remoteServiceName != null) {
             span.remoteServiceName(remoteServiceName);
         }
         if (address != null) {

--- a/zipkin/src/test/java/com/linecorp/armeria/client/tracing/HttpTracingClientTest.java
+++ b/zipkin/src/test/java/com/linecorp/armeria/client/tracing/HttpTracingClientTest.java
@@ -115,7 +115,7 @@ public class HttpTracingClientTest {
         assertThat(span.localServiceName()).isEqualTo(TEST_SERVICE);
 
         // check remote service name
-        assertThat(span.remoteServiceName()).isEqualTo("foo.com");
+        assertThat(span.remoteServiceName()).isEqualTo(null);
     }
 
     @Test(timeout = 20000)


### PR DESCRIPTION
In most cases, address can not be used in place of service name.
The namespace of service name is polluted.
If `remoteEndpoint.serviceName` is not set, it should not be set to span.

Related PR: #835 #1235 