### PR TITLE
Add `boolean shutdownOnStop` parameter to `ServerBuilder.blockingTaskExecutor()`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/InterminableExecutorService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/InterminableExecutorService.java
@@ -33,6 +33,10 @@ final class InterminableExecutorService implements ExecutorService {
         this.executor = executor;
     }
 
+    ExecutorService getExecutorService() {
+        return executor;
+    }
+
     @Override
     public void shutdown() {
         throw new UnsupportedOperationException();

--- a/core/src/main/java/com/linecorp/armeria/server/Server.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Server.java
@@ -469,12 +469,12 @@ public final class Server implements AutoCloseable {
                     while (!executor.isTerminated()) {
                         try {
                             executor.awaitTermination(1, TimeUnit.DAYS);
-                        } catch (InterruptedException e) {
-                            Thread.currentThread().interrupt();
+                        } catch (InterruptedException ignore) {
+                            // Do nothing.
                         }
                     }
                 } catch (Exception e) {
-                    logger.warn("Failed to shutdown the {}:", executor, e);
+                    logger.warn("Failed to shutdown the blockingTaskExecutor: {}", executor, e);
                 }
             }
 

--- a/core/src/main/java/com/linecorp/armeria/server/Server.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Server.java
@@ -457,11 +457,11 @@ public final class Server implements AutoCloseable {
         private void finishDoStop(CompletableFuture<Void> future) {
             if (config.shutdownBlockingTaskExecutorOnStop()) {
                 final ExecutorService executor;
-                if (config.blockingTaskExecutor() instanceof InterminableExecutorService) {
-                    executor =
-                            ((InterminableExecutorService) config.blockingTaskExecutor()).getExecutorService();
+                final ExecutorService blockingTaskExecutor = config.blockingTaskExecutor();
+                if (blockingTaskExecutor instanceof InterminableExecutorService) {
+                    executor = ((InterminableExecutorService) blockingTaskExecutor).getExecutorService();
                 } else {
-                    executor = config.blockingTaskExecutor();
+                    executor = blockingTaskExecutor;
                 }
 
                 try {

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -652,7 +652,7 @@ public final class ServerBuilder {
      */
     @Deprecated
     public ServerBuilder blockingTaskExecutor(Executor blockingTaskExecutor) {
-        this.blockingTaskExecutor = requireNonNull(blockingTaskExecutor, "blockingTaskExecutor");
+        blockingTaskExecutor(blockingTaskExecutor, false);
         return this;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -652,8 +652,7 @@ public final class ServerBuilder {
      */
     @Deprecated
     public ServerBuilder blockingTaskExecutor(Executor blockingTaskExecutor) {
-        blockingTaskExecutor(blockingTaskExecutor, false);
-        return this;
+        return blockingTaskExecutor(blockingTaskExecutor, false);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -177,6 +177,7 @@ public final class ServerBuilder {
     private Duration gracefulShutdownQuietPeriod = DEFAULT_GRACEFUL_SHUTDOWN_QUIET_PERIOD;
     private Duration gracefulShutdownTimeout = DEFAULT_GRACEFUL_SHUTDOWN_TIMEOUT;
     private Executor blockingTaskExecutor = CommonPools.blockingTaskExecutor();
+    private boolean shutdownBlockingTaskExecutorOnStop;
     private MeterRegistry meterRegistry = Metrics.globalRegistry;
     private String serviceLoggerPrefix = DEFAULT_SERVICE_LOGGER_PREFIX;
     private AccessLogWriter accessLogWriter = AccessLogWriter.disabled();
@@ -645,9 +646,25 @@ public final class ServerBuilder {
     /**
      * Sets the {@link Executor} dedicated to the execution of blocking tasks or invocations.
      * If not set, {@linkplain CommonPools#blockingTaskExecutor() the common pool} is used.
+     *
+     * @deprecated Use {@link #blockingTaskExecutor(Executor, boolean)}.
+     *
      */
+    @Deprecated
     public ServerBuilder blockingTaskExecutor(Executor blockingTaskExecutor) {
         this.blockingTaskExecutor = requireNonNull(blockingTaskExecutor, "blockingTaskExecutor");
+        return this;
+    }
+
+    /**
+     * Sets the {@link Executor} dedicated to the execution of blocking tasks or invocations.
+     * If not set, {@linkplain CommonPools#blockingTaskExecutor() the common pool} is used.
+     *
+     * @param shutdownOnStop whether to shut down the {@link Executor} when the {@link Server} stops
+     */
+    public ServerBuilder blockingTaskExecutor(Executor blockingTaskExecutor, boolean shutdownOnStop) {
+        this.blockingTaskExecutor = requireNonNull(blockingTaskExecutor, "blockingTaskExecutor");
+        shutdownBlockingTaskExecutorOnStop = shutdownOnStop;
         return this;
     }
 
@@ -1376,7 +1393,8 @@ public final class ServerBuilder {
                 http2InitialConnectionWindowSize, http2InitialStreamWindowSize, http2MaxStreamsPerConnection,
                 http2MaxFrameSize, http2MaxHeaderListSize,
                 http1MaxInitialLineLength, http1MaxHeaderSize, http1MaxChunkSize,
-                gracefulShutdownQuietPeriod, gracefulShutdownTimeout, blockingTaskExecutor,
+                gracefulShutdownQuietPeriod, gracefulShutdownTimeout,
+                blockingTaskExecutor, shutdownBlockingTaskExecutorOnStop,
                 meterRegistry, serviceLoggerPrefix, accessLogWriter, shutdownAccessLogWriterOnStop,
                 proxyProtocolMaxTlvSize, channelOptions, childChannelOptions,
                 clientAddressSources, clientAddressTrustedProxyFilter, clientAddressFilter), sslContexts);
@@ -1470,7 +1488,8 @@ public final class ServerBuilder {
                 http2MaxStreamsPerConnection, http2MaxFrameSize, http2MaxHeaderListSize,
                 http1MaxInitialLineLength, http1MaxHeaderSize, http1MaxChunkSize,
                 proxyProtocolMaxTlvSize, gracefulShutdownQuietPeriod, gracefulShutdownTimeout,
-                blockingTaskExecutor, meterRegistry, serviceLoggerPrefix,
+                blockingTaskExecutor, shutdownBlockingTaskExecutorOnStop,
+                meterRegistry, serviceLoggerPrefix,
                 accessLogWriter, shutdownAccessLogWriterOnStop,
                 channelOptions, childChannelOptions,
                 clientAddressSources, clientAddressTrustedProxyFilter, clientAddressFilter

--- a/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
@@ -83,6 +83,7 @@ public final class ServerConfig {
     private final Duration gracefulShutdownTimeout;
 
     private final ExecutorService blockingTaskExecutor;
+    private final boolean shutdownBlockingTaskExecutorOnStop;
 
     private final MeterRegistry meterRegistry;
 
@@ -113,7 +114,8 @@ public final class ServerConfig {
             long http2MaxStreamsPerConnection, int http2MaxFrameSize, long http2MaxHeaderListSize,
             int http1MaxInitialLineLength, int http1MaxHeaderSize, int http1MaxChunkSize,
             Duration gracefulShutdownQuietPeriod, Duration gracefulShutdownTimeout,
-            Executor blockingTaskExecutor, MeterRegistry meterRegistry, String serviceLoggerPrefix,
+            Executor blockingTaskExecutor, boolean shutdownBlockingTaskExecutorOnStop,
+            MeterRegistry meterRegistry, String serviceLoggerPrefix,
             AccessLogWriter accessLogWriter, boolean shutdownAccessLogWriterOnStop, int proxyProtocolMaxTlvSize,
             Map<ChannelOption<?>, Object> channelOptions,
             Map<ChannelOption<?>, Object> childChannelOptions,
@@ -158,6 +160,7 @@ public final class ServerConfig {
         } else {
             this.blockingTaskExecutor = new ExecutorBasedExecutorService(blockingTaskExecutor);
         }
+        this.shutdownBlockingTaskExecutorOnStop = shutdownBlockingTaskExecutorOnStop;
 
         this.meterRegistry = requireNonNull(meterRegistry, "meterRegistry");
         this.serviceLoggerPrefix = ServiceConfig.validateLoggerName(serviceLoggerPrefix, "serviceLoggerPrefix");
@@ -531,6 +534,13 @@ public final class ServerConfig {
     }
 
     /**
+     * Returns whether the worker {@link Executor} is shut down when the {@link Server} stops.
+     */
+    public boolean shutdownBlockingTaskExecutorOnStop() {
+        return shutdownBlockingTaskExecutorOnStop;
+    }
+
+    /**
      * Returns the {@link MeterRegistry} that collects various stats.
      */
     public MeterRegistry meterRegistry() {
@@ -601,7 +611,8 @@ public final class ServerConfig {
                     http2MaxStreamsPerConnection(), http2MaxFrameSize(), http2MaxHeaderListSize(),
                     http1MaxInitialLineLength(), http1MaxHeaderSize(), http1MaxChunkSize(),
                     proxyProtocolMaxTlvSize(), gracefulShutdownQuietPeriod(), gracefulShutdownTimeout(),
-                    blockingTaskExecutor(), meterRegistry(), serviceLoggerPrefix(),
+                    blockingTaskExecutor(), shutdownBlockingTaskExecutorOnStop(),
+                    meterRegistry(), serviceLoggerPrefix(),
                     accessLogWriter(), shutdownAccessLogWriterOnStop(),
                     channelOptions(), childChannelOptions(),
                     clientAddressSources(), clientAddressTrustedProxyFilter(), clientAddressFilter()
@@ -621,7 +632,8 @@ public final class ServerConfig {
             long http2MaxHeaderListSize, long http1MaxInitialLineLength, long http1MaxHeaderSize,
             long http1MaxChunkSize, int proxyProtocolMaxTlvSize,
             Duration gracefulShutdownQuietPeriod, Duration gracefulShutdownTimeout,
-            Executor blockingTaskExecutor, @Nullable MeterRegistry meterRegistry, String serviceLoggerPrefix,
+            Executor blockingTaskExecutor, boolean shutdownBlockingTaskExecutorOnStop,
+            @Nullable MeterRegistry meterRegistry, String serviceLoggerPrefix,
             AccessLogWriter accessLogWriter, boolean shutdownAccessLogWriterOnStop,
             Map<ChannelOption<?>, ?> channelOptions, Map<ChannelOption<?>, ?> childChannelOptions,
             List<ClientAddressSource> clientAddressSources,
@@ -708,6 +720,8 @@ public final class ServerConfig {
         buf.append(gracefulShutdownTimeout);
         buf.append(", blockingTaskExecutor: ");
         buf.append(blockingTaskExecutor);
+        buf.append(", shutdownBlockingTaskExecutorOnStop: ");
+        buf.append(shutdownBlockingTaskExecutorOnStop);
         if (meterRegistry != null) {
             buf.append(", meterRegistry: ");
             buf.append(meterRegistry);

--- a/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
@@ -369,7 +369,7 @@ public class ServerTest {
                 .service("/", (ctx, req) -> HttpResponse.of(200))
                 .build();
 
-        server.start().thenApply(unused -> Thread.currentThread()).join();
+        server.start().join();
 
         executor.execute(() -> {
             try {
@@ -379,7 +379,7 @@ public class ServerTest {
             }
         });
 
-        server.stop().thenApply(unused -> Thread.currentThread()).join();
+        server.stop().join();
 
         assertThat(server.config().blockingTaskExecutor().isShutdown()).isTrue();
         assertThat(server.config().blockingTaskExecutor().isTerminated()).isTrue();
@@ -394,7 +394,7 @@ public class ServerTest {
                 .service("/", (ctx, req) -> HttpResponse.of(200))
                 .build();
 
-        server.start().thenApply(unused -> Thread.currentThread()).join();
+        server.start().join();
 
         executor.execute(() -> {
             try {
@@ -404,7 +404,7 @@ public class ServerTest {
             }
         });
 
-        server.stop().thenApply(unused -> Thread.currentThread()).join();
+        server.stop().join();
 
         assertThat(server.config().blockingTaskExecutor().isShutdown()).isFalse();
         assertThat(server.config().blockingTaskExecutor().isTerminated()).isFalse();

--- a/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftServiceTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftServiceTest.java
@@ -637,7 +637,7 @@ public class ThriftServiceTest {
                                             .eventLoop(eventLoop.get())
                                             .serverConfigurator(builder -> {
                                                 builder.blockingTaskExecutor(ImmediateEventExecutor.INSTANCE,
-                                                                             true);
+                                                                             false);
                                                 builder.verboseResponses(true);
                                             })
                                             .build();

--- a/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftServiceTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftServiceTest.java
@@ -636,7 +636,8 @@ public class ThriftServiceTest {
                 ServiceRequestContextBuilder.of(req)
                                             .eventLoop(eventLoop.get())
                                             .serverConfigurator(builder -> {
-                                                builder.blockingTaskExecutor(ImmediateEventExecutor.INSTANCE);
+                                                builder.blockingTaskExecutor(ImmediateEventExecutor.INSTANCE,
+                                                                             true);
                                                 builder.verboseResponses(true);
                                             })
                                             .build();


### PR DESCRIPTION
Hi :)
I added `ServerBuilder.blockingTaskExecutor(Executor, boolean[shutdownOnStop])`, but I don't know how to using `shutdownOnStop`.

Modifications:
- Deprecate `ServerBuilder.blockingTaskExecutor(Executor)`
- Add `ServerBuilder.blockingTaskExecutor(Executor, boolean[shutdownOnStop])`

Result:
- Fix #1685

\- This is my first PR at Armenia that might be insufficient, Please advise the insufficient part.