### PR TITLE
Fix JSON parse on header in docs-client

### DIFF
--- a/docs-client/src/containers/MethodPage/index.tsx
+++ b/docs-client/src/containers/MethodPage/index.tsx
@@ -513,7 +513,7 @@ export default class MethodPage extends React.PureComponent<Props, State> {
     if (headers) {
       try {
         const parsedHeaders = JSON.parse(headers);
-        if (typeof params !== 'object') {
+        if (typeof parsedHeaders !== 'object') {
           this.setState({
             debugResponse: `HTTP headers must be a JSON object.\nYou entered: ${typeof parsedHeaders}`,
           });


### PR DESCRIPTION
Motivation:
When I try to use docs-client to simply test my API, I found that there
is a bug validation on header is not properly working.
I found that there is an error in onSubmit method. Armeria invokes
JSON.parse method to validate and parse user input header, but it does
not passed to conditional branch.

Modification:
I correct parsedHeader in checking branch onSubmit method.

------
I think this PR can resolve #1622 issue.