### PR TITLE
Allow SettableHealthChecker to have chained invocation.

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/HttpHealthCheckService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/HttpHealthCheckService.java
@@ -103,7 +103,7 @@ public class HttpHealthCheckService extends AbstractHttpService
      */
     public HttpHealthCheckService(Iterable<? extends HealthChecker> healthCheckers) {
         this.healthCheckers = ImmutableList.copyOf(requireNonNull(healthCheckers, "healthCheckers"));
-        serverHealth = new SettableHealthChecker();
+        serverHealth = new SettableHealthChecker(false);
         serverHealthUpdater = new ServerHealthUpdater();
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/SettableHealthChecker.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/SettableHealthChecker.java
@@ -36,7 +36,7 @@ public final class SettableHealthChecker implements HealthChecker {
     }
 
     /**
-     * Constructs a new {@link SettableHealthChecker} which starts out the specified health state and can be
+     * Constructs a new {@link SettableHealthChecker} which starts out in the specified health state and can be
      * changed using {@link #setHealthy(boolean)}.
      */
     public SettableHealthChecker(boolean isHealthy) {

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/SettableHealthChecker.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/SettableHealthChecker.java
@@ -27,6 +27,22 @@ public final class SettableHealthChecker implements HealthChecker {
 
     private volatile boolean isHealthy;
 
+    /**
+     * Constructs a new {@link SettableHealthChecker} which starts out in a healthy state and can be changed
+     * using {@link #setHealthy(boolean)}.
+     */
+    public SettableHealthChecker() {
+        this(true);
+    }
+
+    /**
+     * Constructs a new {@link SettableHealthChecker} which starts out the specified health state and can be
+     * changed using {@link #setHealthy(boolean)}.
+     */
+    public SettableHealthChecker(boolean isHealthy) {
+        this.isHealthy = isHealthy;
+    }
+
     @Override
     public boolean isHealthy() {
         return isHealthy;

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/SettableHealthChecker.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/SettableHealthChecker.java
@@ -35,8 +35,9 @@ public final class SettableHealthChecker implements HealthChecker {
     /**
      * Sets if the {@link Server} is healthy or not.
      */
-    public void setHealthy(boolean isHealthy) {
+    public SettableHealthChecker setHealthy(boolean isHealthy) {
         this.isHealthy = isHealthy;
+        return this;
     }
 
     @Override

--- a/core/src/test/java/com/linecorp/armeria/server/healthcheck/SettableHealthCheckerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/healthcheck/SettableHealthCheckerTest.java
@@ -25,6 +25,12 @@ public class SettableHealthCheckerTest {
     @Test
     public void justCreated() {
         final SettableHealthChecker checker = new SettableHealthChecker();
+        assertTrue(checker.isHealthy());
+    }
+
+    @Test
+    public void justCreatedExplicit() {
+        final SettableHealthChecker checker = new SettableHealthChecker(false);
         assertFalse(checker.isHealthy());
     }
 


### PR DESCRIPTION
Currently, it can sometimes be inconvenient that a `SettableHealthChecker` can't have `setHealthy` called fluently. This is mainly because the default is `false` though - it might be good to consider whether the default should be `true`, in which case this change becomes less useful.