### PR TITLE
Add HTTP content encoding property to ArmeriaSettings

### DIFF
--- a/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaSettings.java
+++ b/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaSettings.java
@@ -47,6 +47,11 @@ import com.linecorp.armeria.server.metric.MetricCollectingService;
  *     key-store-password: "changeme"
  *     trust-store: "truststore.jks"
  *     trust-store-password: "changeme"
+ *   compression:
+ *     enabled: true
+ *     mime-types: text/*, application/json
+ *     excluded-user-agents: some-user-agent, another-user-agent
+ *     min-response-size: 1KB
  * }</pre>
  * TODO(ide) Adds virtualhost settings
  */
@@ -151,6 +156,93 @@ public class ArmeriaSettings {
     }
 
     /**
+     * Configurations for the HTTP content encoding.
+     */
+    public static class Compression {
+        /**
+         * Specifies whether the HTTP content encoding is enabled.
+         */
+        private boolean enabled;
+
+        /**
+         * The MIME Types of an HTTP response which are applicable for the HTTP content encoding.
+         */
+        private String[] mimeTypes = {
+                "text/html", "text/xml", "text/plain", "text/css", "text/javascript",
+                "application/javascript", "application/json", "application/xml"
+        };
+
+        /**
+         * The {@code "user-agent"} header values which are not applicable for the HTTP content encoding.
+         */
+        @Nullable
+        private String[] excludedUserAgents;
+
+        /**
+         * The minimum bytes for encoding the content of an HTTP response.
+         */
+        private String minResponseSize = "2048";
+
+        /**
+         * Returns {@code true} if the HTTP content encoding is enabled.
+         */
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        /**
+         * Sets whether the HTTP content encoding is enabled.
+         */
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        /**
+         * Returns the MIME Types of an HTTP response which are applicable for the HTTP content encoding.
+         */
+        public String[] getMimeTypes() {
+            return mimeTypes;
+        }
+
+        /**
+         * Sets the MIME Types of an HTTP response which are applicable for the HTTP content encoding.
+         */
+        public void setMimeTypes(String[] mimeTypes) {
+            this.mimeTypes = mimeTypes;
+        }
+
+        /**
+         * Returns the {@code "user-agent"} header values which are not applicable for the HTTP content
+         * encoding.
+         */
+        @Nullable
+        public String[] getExcludedUserAgents() {
+            return excludedUserAgents;
+        }
+
+        /**
+         * Sets the {@code "user-agent"} header values which are not applicable for the HTTP content encoding.
+         */
+        public void setExcludedUserAgents(String[] excludedUserAgents) {
+            this.excludedUserAgents = excludedUserAgents;
+        }
+
+        /**
+         * Returns the minimum bytes for encoding the content of an HTTP response.
+         */
+        public String getMinResponseSize() {
+            return minResponseSize;
+        }
+
+        /**
+         * Sets the minimum bytes for encoding the content of an HTTP response.
+         */
+        public void setMinResponseSize(String minResponseSize) {
+            this.minResponseSize = minResponseSize;
+        }
+    }
+
+    /**
      * The ports to listen on for requests. If not specified, will listen on
      * port 8080 for HTTP (not SSL).
      */
@@ -208,6 +300,12 @@ public class ArmeriaSettings {
      */
     @Nullable
     private Ssl ssl;
+
+    /**
+     * Compression configuration that the {@link Server} uses.
+     */
+    @Nullable
+    private Compression compression;
 
     public List<Port> getPorts() {
         return ports;
@@ -269,7 +367,7 @@ public class ArmeriaSettings {
     }
 
     /**
-     * Returns the SSL that the {@link Server} uses.
+     * Returns the {@link Ssl} configuration that the {@link Server} uses.
      */
     @Nullable
     public Ssl getSsl() {
@@ -277,9 +375,24 @@ public class ArmeriaSettings {
     }
 
     /**
-     * Registers a {@link Ssl} that the {@link Server} uses.
+     * Sets the {@link Ssl} configuration that the {@link Server} uses.
      */
     public void setSsl(Ssl ssl) {
         this.ssl = ssl;
+    }
+
+    /**
+     * Returns the HTTP content encoding configuration that the {@link Server} uses.
+     */
+    @Nullable
+    public Compression getCompression() {
+        return compression;
+    }
+
+    /**
+     * Sets the HTTP content encoding configuration that the {@link Server} uses.
+     */
+    public void setCompression(Compression compression) {
+        this.compression = compression;
     }
 }

--- a/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaCompressionConfigurationTest.java
+++ b/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaCompressionConfigurationTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.spring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.DisableOnDebug;
+import org.junit.rules.TestRule;
+import org.junit.rules.Timeout;
+import org.junit.runner.RunWith;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.google.common.base.Strings;
+
+import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.annotation.Get;
+import com.linecorp.armeria.server.annotation.Param;
+import com.linecorp.armeria.spring.ArmeriaCompressionConfigurationTest.TestConfiguration;
+import com.linecorp.armeria.spring.ArmeriaSettings.Compression;
+
+/**
+ * This uses {@link ArmeriaAutoConfiguration} for integration tests.
+ * {@code application-compressionTest.yml} will be loaded with minimal settings to make it work.
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = TestConfiguration.class)
+@ActiveProfiles({ "local", "compressionTest" })
+@DirtiesContext
+public class ArmeriaCompressionConfigurationTest {
+
+    @SpringBootApplication
+    public static class TestConfiguration {
+        @Bean
+        public ArmeriaServerConfigurator armeriaServerConfigurator() {
+            return sb -> sb.annotatedService(new Object() {
+                @Get("/hello")
+                public String hello(@Param Optional<Integer> size) {
+                    return Strings.repeat("a", size.orElse(1));
+                }
+            });
+        }
+    }
+
+    @Rule
+    public TestRule globalTimeout = new DisableOnDebug(new Timeout(10, TimeUnit.SECONDS));
+
+    @Inject
+    @Nullable
+    private Server server;
+
+    @Inject
+    @Nullable
+    private ArmeriaSettings settings;
+
+    private String newUrl() {
+        assert server != null;
+        return server.activePort().map(p -> "http://127.0.0.1:" + p.localAddress().getPort())
+                     .orElseThrow(() -> new RuntimeException("Failed to get an active port."));
+    }
+
+    private static HttpRequest request(int sizeParam) {
+        return HttpRequest.of(HttpHeaders.of(HttpMethod.GET, "/hello?size=" + sizeParam)
+                                         .add(HttpHeaderNames.ACCEPT_ENCODING, "gzip"));
+    }
+
+    @Test
+    public void compressionConfiguration() {
+        assertThat(settings).isNotNull();
+        final Compression compression = settings.getCompression();
+        assertThat(compression).isNotNull();
+        assertThat(compression.isEnabled()).isTrue();
+        assertThat(compression.getMimeTypes()).containsExactly("text/*", "application/json");
+        assertThat(compression.getExcludedUserAgents())
+                .containsExactly("some-user-agent", "another-user-agent");
+        assertThat(compression.getMinResponseSize()).isEqualTo("1KB");
+    }
+
+    @Test
+    public void compressedResponse() {
+        final AggregatedHttpMessage msg =
+                HttpClient.of(newUrl()).execute(request(2048)).aggregate().join();
+        assertThat(msg.status()).isEqualTo(HttpStatus.OK);
+        assertThat(msg.headers().get(HttpHeaderNames.CONTENT_ENCODING)).isEqualTo("gzip");
+    }
+
+    @Test
+    public void nonCompressedResponse() {
+        final AggregatedHttpMessage msg =
+                HttpClient.of(newUrl()).execute(request(1023)).aggregate().join();
+        assertThat(msg.status()).isEqualTo(HttpStatus.OK);
+        assertThat(msg.headers().get(HttpHeaderNames.CONTENT_ENCODING)).isNull();
+    }
+}

--- a/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaSslConfigurationTest.java
+++ b/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaSslConfigurationTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 
 import org.junit.Rule;
@@ -58,7 +59,7 @@ import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 
 /**
  * This uses {@link ArmeriaAutoConfiguration} for integration tests.
- * application-sslTest.yml will be loaded with minimal settings to make it work.
+ * {@code application-sslTest.yml} will be loaded with minimal settings to make it work.
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = TestConfiguration.class)
@@ -96,9 +97,11 @@ public class ArmeriaSslConfigurationTest {
     public TestRule globalTimeout = new DisableOnDebug(new Timeout(10, TimeUnit.SECONDS));
 
     @Inject
+    @Nullable
     private Server server;
 
     private String newUrl(SessionProtocol protocol) {
+        assert server != null;
         final int port = server.activePorts().values().stream()
                                .filter(p1 -> p1.hasProtocol(protocol)).findAny()
                                .flatMap(p -> Optional.of(p.localAddress().getPort()))

--- a/spring/boot-autoconfigure/src/test/resources/config/application-compressionTest.yml
+++ b/spring/boot-autoconfigure/src/test/resources/config/application-compressionTest.yml
@@ -1,0 +1,9 @@
+armeria:
+  ports:
+    - port: 0
+      protocol: HTTP
+  compression:
+    enabled: true
+    mime-types: text/*, application/json
+    excluded-user-agents: some-user-agent, another-user-agent
+    minResponseSize: 1KB

--- a/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
+++ b/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
@@ -235,7 +235,7 @@ public class ArmeriaReactiveWebServerFactory extends AbstractReactiveWebServerFa
         }
 
         final ArmeriaSettings.Compression compression = settings.getCompression();
-        if (compression != null && compression.getEnabled()) {
+        if (compression != null && compression.isEnabled()) {
             sb.decorator(contentEncodingDecorator(compression.getMimeTypes(),
                                                   compression.getExcludedUserAgents(),
                                                   parseDataSize(compression.getMinResponseSize())));

--- a/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
+++ b/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
@@ -23,6 +23,8 @@ import static com.linecorp.armeria.internal.spring.ArmeriaConfigurationUtil.conf
 import static com.linecorp.armeria.internal.spring.ArmeriaConfigurationUtil.configureServerWithArmeriaSettings;
 import static com.linecorp.armeria.internal.spring.ArmeriaConfigurationUtil.configureThriftServices;
 import static com.linecorp.armeria.internal.spring.ArmeriaConfigurationUtil.configureTls;
+import static com.linecorp.armeria.internal.spring.ArmeriaConfigurationUtil.contentEncodingDecorator;
+import static com.linecorp.armeria.internal.spring.ArmeriaConfigurationUtil.parseDataSize;
 import static com.linecorp.armeria.spring.MeterIdPrefixFunctionFactory.DEFAULT;
 import static java.util.Objects.requireNonNull;
 
@@ -33,10 +35,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Function;
-import java.util.function.Predicate;
 import java.util.function.Supplier;
-import java.util.regex.Pattern;
 
 import javax.annotation.Nullable;
 
@@ -54,17 +53,11 @@ import org.springframework.http.server.reactive.HttpHandler;
 
 import com.google.common.collect.ImmutableList;
 
-import com.linecorp.armeria.common.HttpHeaderNames;
-import com.linecorp.armeria.common.HttpHeaders;
-import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.server.PathMapping;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
-import com.linecorp.armeria.server.Service;
-import com.linecorp.armeria.server.encoding.HttpEncodingService;
 import com.linecorp.armeria.server.healthcheck.HealthChecker;
 import com.linecorp.armeria.spring.AnnotatedServiceRegistrationBean;
 import com.linecorp.armeria.spring.ArmeriaServerConfigurator;
@@ -84,7 +77,6 @@ import reactor.core.Disposable;
  */
 public class ArmeriaReactiveWebServerFactory extends AbstractReactiveWebServerFactory {
     private static final Logger logger = LoggerFactory.getLogger(ArmeriaReactiveWebServerFactory.class);
-    private static final String[] EMPTY = new String[0];
 
     private final ConfigurableListableBeanFactory beanFactory;
 
@@ -185,7 +177,9 @@ public class ArmeriaReactiveWebServerFactory extends AbstractReactiveWebServerFa
 
         final Compression compression = getCompression();
         if (compression != null && compression.getEnabled()) {
-            sb.decorator(contentEncodingDecorator(compression));
+            sb.decorator(contentEncodingDecorator(compression.getMimeTypes(),
+                                                  compression.getExcludedUserAgents(),
+                                                  compression.getMinResponseSize().toBytes()));
         }
 
         findBean(ArmeriaSettings.class).ifPresent(settings -> configureArmeriaService(sb, settings));
@@ -217,39 +211,6 @@ public class ArmeriaReactiveWebServerFactory extends AbstractReactiveWebServerFa
         });
     }
 
-    private static Function<Service<HttpRequest, HttpResponse>,
-            HttpEncodingService> contentEncodingDecorator(Compression compression) {
-        final Predicate<MediaType> encodableContentTypePredicate;
-        final String[] mimeTypes = compression.getMimeTypes();
-        if (mimeTypes == null || mimeTypes.length == 0) {
-            encodableContentTypePredicate = contentType -> true;
-        } else {
-            final List<MediaType> encodableContentTypes =
-                    Arrays.stream(mimeTypes).map(MediaType::parse).collect(toImmutableList());
-            encodableContentTypePredicate = contentType ->
-                    encodableContentTypes.stream().anyMatch(contentType::is);
-        }
-
-        final Predicate<HttpHeaders> encodableRequestHeadersPredicate;
-        final String[] excludedUserAgents = compression.getExcludedUserAgents();
-        if (excludedUserAgents == null || excludedUserAgents.length == 0) {
-            encodableRequestHeadersPredicate = headers -> true;
-        } else {
-            final List<Pattern> patterns =
-                    Arrays.stream(excludedUserAgents).map(Pattern::compile).collect(toImmutableList());
-            encodableRequestHeadersPredicate = headers -> {
-                // No User-Agent header will be converted to an empty string.
-                final String userAgent = headers.get(HttpHeaderNames.USER_AGENT, "");
-                return patterns.stream().noneMatch(pattern -> pattern.matcher(userAgent).matches());
-            };
-        }
-
-        return delegate -> new HttpEncodingService(delegate,
-                                                   encodableContentTypePredicate,
-                                                   encodableRequestHeadersPredicate,
-                                                   compression.getMinResponseSize().toBytes());
-    }
-
     private void configureArmeriaService(ServerBuilder sb, ArmeriaSettings settings) {
         final MeterIdPrefixFunctionFactory meterIdPrefixFunctionFactory =
                 settings.isEnableMetrics() ? findBean(MeterIdPrefixFunctionFactory.class).orElse(DEFAULT)
@@ -271,6 +232,13 @@ public class ArmeriaReactiveWebServerFactory extends AbstractReactiveWebServerFa
                                            findBeans(HealthChecker.class));
         if (settings.getSsl() != null) {
             configureTls(sb, settings.getSsl());
+        }
+
+        final ArmeriaSettings.Compression compression = settings.getCompression();
+        if (compression != null && compression.getEnabled()) {
+            sb.decorator(contentEncodingDecorator(compression.getMimeTypes(),
+                                                  compression.getExcludedUserAgents(),
+                                                  parseDataSize(compression.getMinResponseSize())));
         }
     }
 


### PR DESCRIPTION
Motivation:
Currently, Spring framework provides `server.compression` property to configure HTTP content encoding,
but `ArmeriaSettings` doesn't provide it. So a user cannot configure it without fixing their code.

Modifications:
- Added `Compression` class to `ArmeriaSettings`, which is similar to the Spring's one.
  - We could not reuse the Spring's class because we need to support Spring Boot 1.x and 2.x.
- Moved `ArmeriaReactiveWebServerFactory#contentEncodingDecorator` to `ArmeriaConfigurationUtil` for sharing the method with `spring-boot-autoconfigure`.

Result:
- A user can configure HTTP content encoding with a Spring property file.