### PR TITLE
Support SslContextBuilder customizer when configuring TLS with Server…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -41,11 +41,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executor;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
+import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLException;
 
 import org.slf4j.Logger;
@@ -76,6 +78,7 @@ import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.epoll.EpollChannelOption;
 import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.util.DomainNameMapping;
 import io.netty.util.DomainNameMappingBuilder;
 import io.netty.util.concurrent.GlobalEventExecutor;
@@ -731,6 +734,20 @@ public final class ServerBuilder {
 
     /**
      * Configures SSL or TLS of the default {@link VirtualHost} from the specified {@code keyCertChainFile},
+     * cleartext {@code keyFile} and {@code tlsCustomizer}.
+     *
+     * @throws IllegalStateException if the default {@link VirtualHost} has been set via
+     *                               {@link #defaultVirtualHost(VirtualHost)} already
+     */
+    public ServerBuilder tls(File keyCertChainFile, File keyFile,
+                             Consumer<SslContextBuilder> tlsCustomizer) throws SSLException {
+        defaultVirtualHostBuilderUpdated();
+        defaultVirtualHostBuilder.tls(keyCertChainFile, keyFile, tlsCustomizer);
+        return this;
+    }
+
+    /**
+     * Configures SSL or TLS of the default {@link VirtualHost} from the specified {@code keyCertChainFile},
      * {@code keyFile} and {@code keyPassword}.
      *
      * @throws IllegalStateException if the default {@link VirtualHost} has been set via
@@ -738,9 +755,38 @@ public final class ServerBuilder {
      */
     public ServerBuilder tls(
             File keyCertChainFile, File keyFile, @Nullable String keyPassword) throws SSLException {
-
         defaultVirtualHostBuilderUpdated();
         defaultVirtualHostBuilder.tls(keyCertChainFile, keyFile, keyPassword);
+        return this;
+    }
+
+    /**
+     * Configures SSL or TLS of the default {@link VirtualHost} from the specified {@code keyCertChainFile},
+     * {@code keyFile}, {@code keyPassword} and {@code tlsCustomizer}.
+     *
+     * @throws IllegalStateException if the default {@link VirtualHost} has been set via
+     *                               {@link #defaultVirtualHost(VirtualHost)} already
+     */
+    public ServerBuilder tls(
+            File keyCertChainFile, File keyFile, @Nullable String keyPassword,
+            Consumer<SslContextBuilder> tlsCustomizer) throws SSLException {
+        defaultVirtualHostBuilderUpdated();
+        defaultVirtualHostBuilder.tls(keyCertChainFile, keyFile, keyPassword, tlsCustomizer);
+        return this;
+    }
+
+    /**
+     * Configures SSL or TLS of the default {@link VirtualHost} from the specified {@code keyManagerFactory}
+     * and {@code tlsCustomizer}.
+     *
+     * @throws IllegalStateException if the default {@link VirtualHost} has been set via
+     *                               {@link #defaultVirtualHost(VirtualHost)} already
+     */
+    public ServerBuilder tls(KeyManagerFactory keyManagerFactory,
+                             Consumer<SslContextBuilder> tlsCustomizer) throws SSLException {
+
+        defaultVirtualHostBuilderUpdated();
+        defaultVirtualHostBuilder.tls(keyManagerFactory, tlsCustomizer);
         return this;
     }
 
@@ -895,7 +941,7 @@ public final class ServerBuilder {
     public ServerBuilder service(
             ServiceWithPathMappings<HttpRequest, HttpResponse> serviceWithPathMappings,
             Iterable<Function<? super Service<HttpRequest, HttpResponse>,
-                              ? extends Service<HttpRequest, HttpResponse>>> decorators) {
+                    ? extends Service<HttpRequest, HttpResponse>>> decorators) {
         defaultVirtualHostBuilderUpdated();
         defaultVirtualHostBuilder.service(serviceWithPathMappings, decorators);
         return this;
@@ -914,7 +960,7 @@ public final class ServerBuilder {
     public final ServerBuilder service(
             ServiceWithPathMappings<HttpRequest, HttpResponse> serviceWithPathMappings,
             Function<? super Service<HttpRequest, HttpResponse>,
-                     ? extends Service<HttpRequest, HttpResponse>>... decorators) {
+                    ? extends Service<HttpRequest, HttpResponse>>... decorators) {
         defaultVirtualHostBuilderUpdated();
         defaultVirtualHostBuilder.service(serviceWithPathMappings, decorators);
         return this;

--- a/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/internal/spring/ArmeriaConfigurationUtil.java
+++ b/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/internal/spring/ArmeriaConfigurationUtil.java
@@ -95,6 +95,7 @@ import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.micrometer.core.instrument.dropwizard.DropwizardMeterRegistry;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.netty.handler.ssl.ClientAuth;
+import io.netty.handler.ssl.SslProvider;
 import io.netty.handler.ssl.SupportedCipherSuiteFilter;
 import io.netty.util.NetUtil;
 import io.prometheus.client.CollectorRegistry;
@@ -389,6 +390,10 @@ public final class ArmeriaConfigurationUtil {
             sb.tls(keyManagerFactory, sslContextBuilder -> {
                 sslContextBuilder.trustManager(trustManagerFactory);
 
+                final SslProvider sslProvider = ssl.getProvider();
+                if (sslProvider != null) {
+                    sslContextBuilder.sslProvider(sslProvider);
+                }
                 final List<String> enabledProtocols = ssl.getEnabledProtocols();
                 if (enabledProtocols != null) {
                     sslContextBuilder.protocols(enabledProtocols.toArray(new String[enabledProtocols.size()]));

--- a/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/internal/spring/ArmeriaConfigurationUtil.java
+++ b/spring/boot-autoconfigure/src/main/java/com/linecorp/armeria/internal/spring/ArmeriaConfigurationUtil.java
@@ -63,7 +63,6 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.math.LongMath;
 
-import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpRequest;
@@ -96,8 +95,7 @@ import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.micrometer.core.instrument.dropwizard.DropwizardMeterRegistry;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.netty.handler.ssl.ClientAuth;
-import io.netty.handler.ssl.SslContextBuilder;
-import io.netty.handler.ssl.SslProvider;
+import io.netty.handler.ssl.SupportedCipherSuiteFilter;
 import io.netty.util.NetUtil;
 import io.prometheus.client.CollectorRegistry;
 
@@ -385,31 +383,26 @@ public final class ArmeriaConfigurationUtil {
                 return;
             }
 
-            final SslContextBuilder sslBuilder = SslContextBuilder
-                    .forServer(getKeyManagerFactory(ssl, keyStoreSupplier))
-                    .trustManager(getTrustManagerFactory(ssl, trustStoreSupplier));
-            final SslProvider sslProvider = ssl.getProvider() == null ?
-                                            Flags.useOpenSsl() ?
-                                            SslProvider.OPENSSL
-                                                               : SslProvider.JDK
-                                                                      : ssl.getProvider();
-            sslBuilder.sslProvider(sslProvider);
-            final List<String> enabledProtocols = ssl.getEnabledProtocols();
-            if (enabledProtocols != null) {
-                sslBuilder.protocols(enabledProtocols.toArray(new String[enabledProtocols.size()]));
-            }
+            final KeyManagerFactory keyManagerFactory = getKeyManagerFactory(ssl, keyStoreSupplier);
+            final TrustManagerFactory trustManagerFactory = getTrustManagerFactory(ssl, trustStoreSupplier);
 
-            final List<String> ciphers = ssl.getCiphers();
-            if (ciphers != null) {
-                sslBuilder.ciphers(ImmutableList.copyOf(ciphers));
-            }
+            sb.tls(keyManagerFactory, sslContextBuilder -> {
+                sslContextBuilder.trustManager(trustManagerFactory);
 
-            final ClientAuth clientAuth = ssl.getClientAuth();
-            if (clientAuth != null) {
-                sslBuilder.clientAuth(clientAuth);
-            }
-
-            sb.tls(sslBuilder.build());
+                final List<String> enabledProtocols = ssl.getEnabledProtocols();
+                if (enabledProtocols != null) {
+                    sslContextBuilder.protocols(enabledProtocols.toArray(new String[enabledProtocols.size()]));
+                }
+                final List<String> ciphers = ssl.getCiphers();
+                if (ciphers != null) {
+                    sslContextBuilder.ciphers(ImmutableList.copyOf(ciphers),
+                                              SupportedCipherSuiteFilter.INSTANCE);
+                }
+                final ClientAuth clientAuth = ssl.getClientAuth();
+                if (clientAuth != null) {
+                    sslContextBuilder.clientAuth(clientAuth);
+                }
+            });
         } catch (Exception e) {
             throw new IllegalStateException("Failed to configure TLS: " + e, e);
         }


### PR DESCRIPTION
…Builder

Motivation:
When configuring a TLS server, the server needs to configure some common part, for example, setting a `SslProvider` to the context depending on the `Flags.useOpenSsl()` property. But it should be done by a user implementation if the user builds a `SslContext` by themselves. It would be better provide a way to customize the `SslContext` after configuring common part by Armeria.

Modifications:
- Added the following methods to the `ServerBuilder` and `AbstractVirtualHostBuilder`:
  - `tls(File keyCertChainFile, File keyFile, Consumer<SslContextBuilder> tlsCustomizer)`
  - `tls(File keyCertChainFile, File keyFile, @Nullable String keyPassword, Consumer<SslContextBuilder> tlsCustomizer)`
  - `tls(KeyManagerFactory keyManagerFactory, Consumer<SslContextBuilder> tlsCustomizer)`
- Used `tls(KeyManagerFactory, Consumer<SslContextBuilder>)` when configuring TLS server with `spring-boot-autoconfigure` and `spring-boot-webflux-autoconfigure` module.

Result:
- Hopefully closes #1711.