### PR TITLE
UnframedGrpcService now sends a response even there is no content to …

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcService.java
@@ -256,8 +256,7 @@ class UnframedGrpcService extends SimpleDecoratingService<HttpRequest, HttpRespo
                 new Listener() {
                     @Override
                     public void messageRead(ByteBufOrStream message) {
-                        // We know there is only one message in total, so don't bother with checking endOfStream
-                        // We also know that we don't support compression, so this is always a ByteBuffer.
+                        // We know that we don't support compression, so this is always a ByteBuffer.
                         final HttpData unframedContent = new ByteBufHttpData(message.buf(), true);
                         unframedHeaders.setInt(HttpHeaderNames.CONTENT_LENGTH, unframedContent.length());
                         res.complete(HttpResponse.of(unframedHeaders, unframedContent));
@@ -266,6 +265,8 @@ class UnframedGrpcService extends SimpleDecoratingService<HttpRequest, HttpRespo
                     @Override
                     public void endOfStream() {
                         if (!res.isDone()) {
+                            // If 'ResponseObserver.onCompleted()' is called without calling 'onNext()',
+                            // this callback would be invoked but 'messageRead' callback wouldn't.
                             res.complete(HttpResponse.of(unframedHeaders));
                         }
                     }

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcService.java
@@ -264,7 +264,11 @@ class UnframedGrpcService extends SimpleDecoratingService<HttpRequest, HttpRespo
                     }
 
                     @Override
-                    public void endOfStream() {}
+                    public void endOfStream() {
+                        if (!res.isDone()) {
+                            res.complete(HttpResponse.of(unframedHeaders));
+                        }
+                    }
                 },
                 // Max outbound message size is handled by the GrpcService, so we don't need to set it here.
                 Integer.MAX_VALUE,

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnframedGrpcServiceTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnframedGrpcServiceTest.java
@@ -61,7 +61,6 @@ public class UnframedGrpcServiceTest {
 
     private ServiceRequestContext ctx;
     private HttpRequest request;
-    private UnframedGrpcService unframedGrpcService;
 
     @Before
     public void setUp() {
@@ -73,7 +72,7 @@ public class UnframedGrpcServiceTest {
 
     @Test
     public void statusOk() throws Exception {
-        unframedGrpcService = buildUnframedGrpcService(testService);
+        final UnframedGrpcService unframedGrpcService = buildUnframedGrpcService(testService);
         final HttpResponse response = unframedGrpcService.serve(ctx, request);
         final AggregatedHttpMessage aggregatedHttpMessage = response.aggregate().get();
         assertThat(aggregatedHttpMessage.status()).isEqualTo(HttpStatus.OK);
@@ -86,7 +85,7 @@ public class UnframedGrpcServiceTest {
         doThrow(Status.CANCELLED.withDescription("grpc error message").asRuntimeException())
                 .when(spyTestService)
                 .emptyCall(any(), any());
-        unframedGrpcService = buildUnframedGrpcService(spyTestService);
+        final UnframedGrpcService unframedGrpcService = buildUnframedGrpcService(spyTestService);
         final HttpResponse response = unframedGrpcService.serve(ctx, request);
         final AggregatedHttpMessage aggregatedHttpMessage = response.aggregate().get();
         assertThat(aggregatedHttpMessage.status()).isEqualTo(HttpStatus.CLIENT_CLOSED_REQUEST);
@@ -98,7 +97,7 @@ public class UnframedGrpcServiceTest {
 
     @Test
     public void noContent() throws Exception {
-        unframedGrpcService = buildUnframedGrpcService(new TestServiceImplBase() {
+        final UnframedGrpcService unframedGrpcService = buildUnframedGrpcService(new TestServiceImplBase() {
             @Override
             public void emptyCall(Empty request, StreamObserver<Empty> responseObserver) {
                 // Note that 'responseObserver.onNext()' is not called.

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnframedGrpcServiceTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnframedGrpcServiceTest.java
@@ -38,6 +38,7 @@ import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.ServiceRequestContextBuilder;
 import com.linecorp.armeria.testing.common.EventLoopRule;
 
+import io.grpc.BindableService;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 
@@ -72,15 +73,7 @@ public class UnframedGrpcServiceTest {
 
     @Test
     public void statusOk() throws Exception {
-        unframedGrpcService =
-                (UnframedGrpcService) new GrpcServiceBuilder().addService(testService)
-                                                              .setMaxInboundMessageSizeBytes(MAX_MESSAGE_BYTES)
-                                                              .setMaxOutboundMessageSizeBytes(MAX_MESSAGE_BYTES)
-                                                              .supportedSerializationFormats(
-                                                                      GrpcSerializationFormats.values())
-                                                              .enableUnframedRequests(true)
-                                                              .build();
-
+        unframedGrpcService = buildUnframedGrpcService(testService);
         final HttpResponse response = unframedGrpcService.serve(ctx, request);
         final AggregatedHttpMessage aggregatedHttpMessage = response.aggregate().get();
         assertThat(aggregatedHttpMessage.status()).isEqualTo(HttpStatus.OK);
@@ -93,14 +86,7 @@ public class UnframedGrpcServiceTest {
         doThrow(Status.CANCELLED.withDescription("grpc error message").asRuntimeException())
                 .when(spyTestService)
                 .emptyCall(any(), any());
-        unframedGrpcService =
-                (UnframedGrpcService) new GrpcServiceBuilder().addService(spyTestService)
-                                                              .setMaxInboundMessageSizeBytes(MAX_MESSAGE_BYTES)
-                                                              .setMaxOutboundMessageSizeBytes(MAX_MESSAGE_BYTES)
-                                                              .supportedSerializationFormats(
-                                                                      GrpcSerializationFormats.values())
-                                                              .enableUnframedRequests(true)
-                                                              .build();
+        unframedGrpcService = buildUnframedGrpcService(spyTestService);
         final HttpResponse response = unframedGrpcService.serve(ctx, request);
         final AggregatedHttpMessage aggregatedHttpMessage = response.aggregate().get();
         assertThat(aggregatedHttpMessage.status()).isEqualTo(HttpStatus.CLIENT_CLOSED_REQUEST);
@@ -108,5 +94,30 @@ public class UnframedGrpcServiceTest {
                 .isEqualTo("http-status: 499, Client Closed Request\n" +
                            "Caused by: \n" +
                            "grpc-status: 1, CANCELLED, grpc error message");
+    }
+
+    @Test
+    public void noContent() throws Exception {
+        unframedGrpcService = buildUnframedGrpcService(new TestServiceImplBase() {
+            @Override
+            public void emptyCall(Empty request, StreamObserver<Empty> responseObserver) {
+                // Note that 'responseObserver.onNext()' is not called.
+                responseObserver.onCompleted();
+            }
+        });
+        final HttpResponse response = unframedGrpcService.serve(ctx, request);
+        final AggregatedHttpMessage aggregatedHttpMessage = response.aggregate().get();
+        assertThat(aggregatedHttpMessage.status()).isEqualTo(HttpStatus.OK);
+        assertThat(aggregatedHttpMessage.content().isEmpty()).isTrue();
+    }
+
+    private static UnframedGrpcService buildUnframedGrpcService(BindableService bindableService) {
+        return (UnframedGrpcService) new GrpcServiceBuilder()
+                .addService(bindableService)
+                .setMaxInboundMessageSizeBytes(MAX_MESSAGE_BYTES)
+                .setMaxOutboundMessageSizeBytes(MAX_MESSAGE_BYTES)
+                .supportedSerializationFormats(GrpcSerializationFormats.values())
+                .enableUnframedRequests(true)
+                .build();
     }
 }


### PR DESCRIPTION
…respond

Modifications:
- Made the future completed correctly with `HttpResponse` even if no message was read by `ArmeriaMessageDeframer`.

Result:
- Closes #1721