### PR TITLE
Make `RedirectService` preserve the query string by default

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/RedirectService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RedirectService.java
@@ -274,9 +274,7 @@ public class RedirectService extends AbstractHttpService {
             return location;
         }
 
-        final StringBuilder buf = new StringBuilder(location.length() + query.length() + 1);
-        buf.append(location).append('?').append(query);
-        return buf.toString();
+        return location + '?' + query;
     }
 
     @Override
@@ -308,6 +306,7 @@ public class RedirectService extends AbstractHttpService {
 
     private static String populatePatternParams(String pathPattern, Map<String, String> pathParams) {
         for (Entry<String, String> e : pathParams.entrySet()) {
+            @SuppressWarnings("RegExpRedundantEscape")
             final String tokenPattern = "\\{" + e.getKey() + "\\}|:" + e.getKey();
             pathPattern = pathPattern.replaceAll(tokenPattern, e.getValue());
         }

--- a/core/src/main/java/com/linecorp/armeria/server/RedirectService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RedirectService.java
@@ -34,28 +34,91 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 
 /**
- * An {@link HttpService} that implements an HTTP redirection.
+ * An {@link HttpService} that sends a redirect response such as {@code "307 Temporary Redirect"}.
+ * You have to specify a template or a {@link Function} that generates the value of the {@code "Location"}
+ * header.
  *
- * <p>This class will redirect requests from its bound {@link Service} path pattern
- * to a new location pattern. Currently only these patterns are supported:
+ * <h3>Using a location template</h3>
+ *
+ * <p>You can choose one of the following template styles where the path parameters are substituted with
+ * the values retrieved from {@link ServiceRequestContext#pathParam(String)}:</p>
+ *
  * <ul>
- *   <li>{@code /new} (no path parameters)</li>
- *   <li>{@code /new/{var1}} (curly-brace style parameters)</li>
- *   <li>{@code /new/:var1/new/:var2} (colon style parameters)</li>
- *   <li>{@code http://host/new} (full URL without path parameters)</li>
- *   <li>{@code http://host/new/{var1}} (full URL with curly-brace style parameters)</li>
- *   <li>{@code http://host/new/:var1/new/:var2} (full URL with colon style parameters)</li>
+ *   <li>{@code /new} (no path parameters)
+ *     <pre>{@code
+ *     ServerBuilder sb = new ServerBuilder();
+ *     // e.g. /old -> /new
+ *     sb.service("/old", new RedirectService("/new");
+ *     }</pre>
+ *   </li>
+ *   <li>{@code /new/{var}} (curly-brace style parameters)
+ *     <pre>{@code
+ *     // e.g. /old/foo -> /new/foo
+ *     sb.service("/old/{var}", new RedirectService("/new/{var}");
+ *     }</pre>
+ *   </li>
+ *   <li>{@code /new/:var1/:var2} (colon style parameters)
+ *     <pre>{@code
+ *     // e.g. /old/foo/bar -> /new/foo/bar
+ *     sb.service("/old/:var1/:var2", new RedirectService("/new/:var1/:var2"));
+ *     }</pre>
+ *   </li>
+ *   <li>{@code http://host/new} (full URL without path parameters)
+ *     <pre>{@code
+ *     // e.g. /old -> http://host/new
+ *     sb.service("/old", new RedirectService("http://host/new"));
+ *     }</pre>
+ *   </li>
+ *   <li>{@code http://host/new/{var}} (full URL with curly-brace style parameters)
+ *     <pre>{@code
+ *     // e.g. /old/foo -> http://host/new/foo
+ *     sb.service("/old/{var}", new RedirectService("http://host/new/{var}"));
+ *     }</pre>
+ *   </li>
+ *   <li>{@code http://host/new/:var1/:var2} (full URL with colon style parameters)
+ *     <pre>{@code
+ *     // e.g. /old/foo/bar -> http://host/new/foo/bar
+ *     sb.service("/old/:var1/:var2", new RedirectService("http://host/new/:var1/:var2"));
+ *     }</pre>
+ *   </li>
  * </ul>
- * The {@link RedirectService} will return {@link HttpStatus#TEMPORARY_REDIRECT 307 Temporary Redirect}
- * by default.
- * <pre>{@code
- * ServerBuilder sb = ...;
- * sb.service("/old/", new RedirectService("/new"));
- * sb.service("/old/{var}", new RedirectService("/new/{var}"));
- * sb.service("/old/{var}", new RedirectService(ctx -> "/new/" + ctx.pathParam("var")));
  *
- * sb.service("/old/{var}", new RedirectService(HttpStatus.MOVED_PERMANENTLY, "/new/{var}"));
- * sb.service("/old/{var}", new RedirectService("http://user:name@localhost:8080/search/{var}"));
+ * <h3>Using a location function</h3>
+ *
+ * <p>You can also specify a custom function to generate a location which cannot be generated with a location
+ * template:</p>
+ *
+ * <pre>{@code
+ * ServerBuilder sb = new ServerBuilder();
+ * // e.g. /foo/bar -> /NNNNNN/foo_bar
+ * sb.service("/:var1/:var2", new RedirectService(ctx -> {
+ *     String name = ctx.pathParam("var1") + "_" + ctx.pathParam("var2");
+ *     return String.format("/%d/%s", name.hashCode(), name);
+ * });
+ * }</pre>
+ *
+ * <h3>Specifying an alternative status code</h3>
+ *
+ * <p>By default, {@link RedirectService} responds with {@link HttpStatus#TEMPORARY_REDIRECT 307 Temporary
+ * Redirect} status. You can specify alternative status such as {@link HttpStatus#MOVED_PERMANENTLY 301 Moved
+ * Permanently} when calling the constructor.</p>
+ *
+ * <h3>Preserving a query string (or not)</h3>
+ *
+ * <p>By default, {@link RedirectService} preserves the query string in the request URI when generating
+ * a new location. For example, if you bound {@code new RedirectService("/new")} at {@code "/old"},
+ * a request to {@code "/old?foo=bar"} will be redirected to {@code "/new?foo=bar"}. You can disable
+ * this behavior by specifying {@code false} for the {@code preserveQueryString} parameter
+ * when constructing the service.</p>
+ *
+ * <p>Note that {@link RedirectService} will not append the query string if the generated location already
+ * contains a query string, regardless of the {@code preserveQueryString} parameter value. For example,
+ * the following location function never preserves the original query string:</p>
+ *
+ * <pre>{@code
+ * ServiceBuilder sb = new ServiceBuilder();
+ * // /old?foo=bar -> /new?redirected=1 (?foo=bar is ignored.)
+ * sb.service("/old", new RedirectService("/new?redirected=1"));
  * }</pre>
  */
 public class RedirectService extends AbstractHttpService {
@@ -67,20 +130,45 @@ public class RedirectService extends AbstractHttpService {
 
     private final HttpStatus httpStatus;
     private final Function<? super ServiceRequestContext, String> locationFunction;
+    private final boolean preserveQueryString;
 
     @Nullable
     private Set<String> paramNames;
 
     /**
      * Creates a new instance that redirects to the location constructed with the specified
-     * {@code locationPattern}.
+     * {@code locationPattern}, preserving the query string in the request URI.
      *
      * @param locationPattern the location pattern that is used to generate a redirect location.
      *
      * @throws IllegalArgumentException if the specified {@code locationPattern} is unsupported or invalid
      */
     public RedirectService(String locationPattern) {
-        this(HttpStatus.TEMPORARY_REDIRECT, locationPattern);
+        this(locationPattern, true);
+    }
+
+    /**
+     * Creates a new instance that redirects to the location constructed with the specified
+     * {@code locationPattern}.
+     *
+     * @param locationPattern the location pattern that is used to generate a redirect location.
+     * @param preserveQueryString whether to preserve the query string in the generated redirect location.
+     *
+     * @throws IllegalArgumentException if the specified {@code locationPattern} is unsupported or invalid
+     */
+    public RedirectService(String locationPattern, boolean preserveQueryString) {
+        this(HttpStatus.TEMPORARY_REDIRECT, locationPattern, preserveQueryString);
+    }
+
+    /**
+     * Creates a new instance that redirects to the location returned by {@code locationFunction},
+     * preserving the query string in the request URI.
+     *
+     * @param locationFunction a {@link Function} that takes a {@link ServiceRequestContext}
+     *                         and returns a new location.
+     */
+    public RedirectService(Function<? super ServiceRequestContext, String> locationFunction) {
+        this(locationFunction, true);
     }
 
     /**
@@ -88,9 +176,24 @@ public class RedirectService extends AbstractHttpService {
      *
      * @param locationFunction a {@link Function} that takes a {@link ServiceRequestContext}
      *                         and returns a new location.
+     * @param preserveQueryString whether to preserve the query string in the generated redirect location.
      */
-    public RedirectService(Function<? super ServiceRequestContext, String> locationFunction) {
-        this(HttpStatus.TEMPORARY_REDIRECT, locationFunction);
+    public RedirectService(Function<? super ServiceRequestContext, String> locationFunction,
+                           boolean preserveQueryString) {
+        this(HttpStatus.TEMPORARY_REDIRECT, locationFunction, preserveQueryString);
+    }
+
+    /**
+     * Creates a new instance that redirects to the location constructed with the specified
+     * {@code locationPattern}, preserving the query string in the request URI.
+     *
+     * @param redirectStatus the {@link HttpStatus} that the {@link Service} will return.
+     * @param locationPattern the location pattern that is used to generate a redirect location.
+     *
+     * @throws IllegalArgumentException if the specified {@code locationPattern} is unsupported or invalid
+     */
+    public RedirectService(HttpStatus redirectStatus, String locationPattern) {
+        this(redirectStatus, locationPattern, true);
     }
 
     /**
@@ -99,11 +202,12 @@ public class RedirectService extends AbstractHttpService {
      *
      * @param redirectStatus the {@link HttpStatus} that the {@link Service} will return.
      * @param locationPattern the location pattern that is used to generate a redirect location.
+     * @param preserveQueryString whether to preserve the query string in the generated redirect location.
      *
      * @throws IllegalArgumentException if the specified {@code locationPattern} is unsupported or invalid
      */
-    public RedirectService(HttpStatus redirectStatus, String locationPattern) {
-        this(redirectStatus, toLocationFunction(locationPattern));
+    public RedirectService(HttpStatus redirectStatus, String locationPattern, boolean preserveQueryString) {
+        this(redirectStatus, toLocationFunction(locationPattern), preserveQueryString);
 
         final Matcher m = PATTERN_PARAMS_START.matcher(locationPattern);
         if (m.find()) {
@@ -112,7 +216,8 @@ public class RedirectService extends AbstractHttpService {
     }
 
     /**
-     * Creates a new instance that redirects to the location returned by {@code locationFunction}.
+     * Creates a new instance that redirects to the location returned by {@code locationFunction},
+     * preserving the query string in the request URI.
      *
      * @param redirectStatus the {@link HttpStatus} that the {@link Service} will return.
      * @param locationFunction a {@link Function} that takes a {@link ServiceRequestContext}
@@ -120,6 +225,20 @@ public class RedirectService extends AbstractHttpService {
      */
     public RedirectService(HttpStatus redirectStatus,
                            Function<? super ServiceRequestContext, String> locationFunction) {
+        this(redirectStatus, locationFunction, true);
+    }
+
+    /**
+     * Creates a new instance that redirects to the location returned by {@code locationFunction}.
+     *
+     * @param redirectStatus the {@link HttpStatus} that the {@link Service} will return.
+     * @param locationFunction a {@link Function} that takes a {@link ServiceRequestContext}
+     *                         and returns a new location.
+     * @param preserveQueryString whether to preserve the query string in the generated redirect location.
+     */
+    public RedirectService(HttpStatus redirectStatus,
+                           Function<? super ServiceRequestContext, String> locationFunction,
+                           boolean preserveQueryString) {
         requireNonNull(redirectStatus, "redirectStatus");
         requireNonNull(locationFunction, "locationFunction");
         if (redirectStatus.compareTo(HttpStatus.MULTIPLE_CHOICES) < 0 ||
@@ -128,16 +247,36 @@ public class RedirectService extends AbstractHttpService {
         }
         httpStatus = redirectStatus;
         this.locationFunction = locationFunction;
+        this.preserveQueryString = preserveQueryString;
     }
 
     /**
      * NB: For now we redirect all methods.
      */
     @Override
-    public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req)
-            throws Exception {
+    public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+        String location = locationFunction.apply(ctx);
+        requireNonNull(location, "locationFunction returned null.");
+
+        if (preserveQueryString) {
+            location = appendQueryString(ctx, location);
+        }
+
         return HttpResponse.of(HttpHeaders.of(httpStatus)
-                .set(HttpHeaderNames.LOCATION, locationFunction.apply(ctx)));
+                                          .set(HttpHeaderNames.LOCATION, location));
+    }
+
+    private static String appendQueryString(ServiceRequestContext ctx, String location) {
+        final String query = ctx.query();
+        if (query == null || location.lastIndexOf('?') >= 0) {
+            // The request URI does not have a query string or
+            // The new location includes a query string already.
+            return location;
+        }
+
+        final StringBuilder buf = new StringBuilder(location.length() + query.length() + 1);
+        buf.append(location).append('?').append(query);
+        return buf.toString();
     }
 
     @Override
@@ -169,8 +308,7 @@ public class RedirectService extends AbstractHttpService {
 
     private static String populatePatternParams(String pathPattern, Map<String, String> pathParams) {
         for (Entry<String, String> e : pathParams.entrySet()) {
-            final String tokenPattern = "\\{" + e.getKey() + "\\}|:" + e
-                    .getKey();
+            final String tokenPattern = "\\{" + e.getKey() + "\\}|:" + e.getKey();
             pathPattern = pathPattern.replaceAll(tokenPattern, e.getValue());
         }
         return pathPattern;


### PR DESCRIPTION
Motivation:

When redirecting, a user would want to preserve the query string in the
original request URI, by appending it to the end of the new location.

Modifications:

- Make `RedirectService` preserve the query string by default.
  - Note: the query string is not appended if the new location already
    contains a query string.
- Add `preserveQueryString` parameter to the constructors of
  `RedirectService` so that a user can go back to the old behavior.
- Update the class documentation of `RedirectService`.

Result:

- Fixes #1725
- Less surprising behavior.