### PR TITLE
Use `Class.getDeclaredField()` instead of `getField()` when fetching Thrift metadata.

### DIFF
--- a/thrift/src/main/java/com/linecorp/armeria/internal/thrift/ThriftFunction.java
+++ b/thrift/src/main/java/com/linecorp/armeria/internal/thrift/ThriftFunction.java
@@ -102,7 +102,7 @@ public final class ThriftFunction {
                     continue;
                 }
 
-                final Class<?> fieldType = resultType.getDelaredField(fieldName).getType();
+                final Class<?> fieldType = resultType.getDeclaredField(fieldName).getType();
                 if (Throwable.class.isAssignableFrom(fieldType)) {
                     @SuppressWarnings("unchecked")
                     final Class<Throwable> exceptionFieldType = (Class<Throwable>) fieldType;

--- a/thrift/src/main/java/com/linecorp/armeria/internal/thrift/ThriftFunction.java
+++ b/thrift/src/main/java/com/linecorp/armeria/internal/thrift/ThriftFunction.java
@@ -102,7 +102,7 @@ public final class ThriftFunction {
                     continue;
                 }
 
-                final Class<?> fieldType = resultType.getField(fieldName).getType();
+                final Class<?> fieldType = resultType.getDelaredField(fieldName).getType();
                 if (Throwable.class.isAssignableFrom(fieldType)) {
                     @SuppressWarnings("unchecked")
                     final Class<Throwable> exceptionFieldType = (Class<Throwable>) fieldType;

--- a/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftServiceTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftServiceTest.java
@@ -52,8 +52,12 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.thrift.ThriftProtocolFactories;
 import com.linecorp.armeria.common.thrift.ThriftSerializationFormats;
+import com.linecorp.armeria.common.thrift.text.Response;
+import com.linecorp.armeria.common.thrift.text.RpcDebugService;
 import com.linecorp.armeria.common.util.CompletionActions;
 import com.linecorp.armeria.common.util.Exceptions;
+import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.ServiceRequestContextBuilder;
 import com.linecorp.armeria.service.test.thrift.main.BinaryService;
@@ -598,6 +602,19 @@ public class ThriftServiceTest {
 
         in.reset(res2.array(), res2.offset(), res2.length());
         assertThat(client2.recv_sort()).containsExactly(NAME_A, NAME_B, NAME_C);
+    }
+
+    @Test
+    public void testServiceThrowingException() {
+        Server server = new ServerBuilder()
+            .verboseResponses(true)
+            .service(
+                "/some_path",
+                THttpService.ofFormats(
+                    (RpcDebugService.Iface)(a1, a2, details) -> new Response("asdf"),
+                    ThriftSerializationFormats.COMPACT
+                )
+            ).build();
     }
 
     // NB: By making this interface functional, we can use lambda expression to implement

--- a/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftServiceTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftServiceTest.java
@@ -52,12 +52,8 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.thrift.ThriftProtocolFactories;
 import com.linecorp.armeria.common.thrift.ThriftSerializationFormats;
-import com.linecorp.armeria.common.thrift.text.Response;
-import com.linecorp.armeria.common.thrift.text.RpcDebugService;
 import com.linecorp.armeria.common.util.CompletionActions;
 import com.linecorp.armeria.common.util.Exceptions;
-import com.linecorp.armeria.server.Server;
-import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.ServiceRequestContextBuilder;
 import com.linecorp.armeria.service.test.thrift.main.BinaryService;
@@ -602,19 +598,6 @@ public class ThriftServiceTest {
 
         in.reset(res2.array(), res2.offset(), res2.length());
         assertThat(client2.recv_sort()).containsExactly(NAME_A, NAME_B, NAME_C);
-    }
-
-    @Test
-    public void testServiceThrowingException() {
-        Server server = new ServerBuilder()
-            .verboseResponses(true)
-            .service(
-                "/some_path",
-                THttpService.ofFormats(
-                    (RpcDebugService.Iface)(a1, a2, details) -> new Response("asdf"),
-                    ThriftSerializationFormats.COMPACT
-                )
-            ).build();
     }
 
     // NB: By making this interface functional, we can use lambda expression to implement


### PR DESCRIPTION
fixes https://github.com/line/armeria/issues/1728 ?

Was able to test this locally and confirm that it works.