### PR TITLE
allow for repeated method declarations

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/Types.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/Types.java
@@ -16,8 +16,8 @@
 
 package com.linecorp.armeria.internal;
 
-import java.util.HashSet;
 import java.util.Set;
+import java.util.TreeSet;
 
 /**
  * Provides various utility functions for Java types.
@@ -26,9 +26,20 @@ public final class Types {
 
     /**
      * Returns a set of all interfaces defined for {@code cls}.
+     * Interfaces are sorted from lowest to highest level (i.e. children before parents)
      */
-    public static Set<Class<?>> getAllInterfaces(Class<?> cls) {
-        final Set<Class<?>> interfacesFound = new HashSet<>();
+    public static TreeSet<Class<?>> getAllInterfaces(Class<?> cls) {
+        final TreeSet<Class<?>> interfacesFound = new TreeSet<>(
+            (c1, c2) -> {
+                if (c1.equals(c2)) {
+                    return 0;
+                } else if (c1.isAssignableFrom(c2)) {
+                    return 1;
+                } else {
+                    return -1;
+                }
+            }
+        );
         getAllInterfaces(cls, interfacesFound);
         return interfacesFound;
     }

--- a/thrift/src/main/java/com/linecorp/armeria/internal/thrift/ThriftServiceMetadata.java
+++ b/thrift/src/main/java/com/linecorp/armeria/internal/thrift/ThriftServiceMetadata.java
@@ -75,6 +75,7 @@ public final class ThriftServiceMetadata {
     private Set<Class<?>> init(@Nullable Object implementation, Iterable<Class<?>> candidateInterfaces) {
 
         // Build the map of method names and their corresponding process functions.
+        // If a method is defined multiple times, we take the first definition
         final Set<String> methodNames = new HashSet<>();
         final Set<Class<?>> interfaces = new HashSet<>();
 
@@ -174,7 +175,10 @@ public final class ThriftServiceMetadata {
 
     @SuppressWarnings("rawtypes")
     private void registerFunction(Set<String> methodNames, Class<?> iface, String name, Object func) {
-        checkDuplicateMethodName(methodNames, name);
+        if (methodNames.contains(name)) {
+            logger.warn("duplicate Thrift method name: " + name);
+            return;
+        }
         methodNames.add(name);
 
         try {
@@ -188,12 +192,6 @@ public final class ThriftServiceMetadata {
         } catch (Exception e) {
             throw new IllegalArgumentException("failed to retrieve function metadata: " +
                                                iface.getName() + '.' + name + "()", e);
-        }
-    }
-
-    private static void checkDuplicateMethodName(Set<String> methodNames, String name) {
-        if (methodNames.contains(name)) {
-            throw new IllegalArgumentException("duplicate Thrift method name: " + name);
         }
     }
 

--- a/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftServiceTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftServiceTest.java
@@ -52,6 +52,8 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.thrift.ThriftProtocolFactories;
 import com.linecorp.armeria.common.thrift.ThriftSerializationFormats;
+import com.linecorp.armeria.common.thrift.text.ChildRpcDebugService;
+import com.linecorp.armeria.common.thrift.text.Response;
 import com.linecorp.armeria.common.util.CompletionActions;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.server.ServiceRequestContext;
@@ -598,6 +600,12 @@ public class ThriftServiceTest {
 
         in.reset(res2.array(), res2.offset(), res2.length());
         assertThat(client2.recv_sort()).containsExactly(NAME_A, NAME_B, NAME_C);
+    }
+
+    @Test
+    public void testServiceInheritance() {
+        // This should not throw an exception
+        THttpService.of((ChildRpcDebugService.Iface)(a1, a2, details) -> new Response("asdf"));
     }
 
     // NB: By making this interface functional, we can use lambda expression to implement

--- a/thrift/src/test/thrift/RpcDebugTest.thrift
+++ b/thrift/src/test/thrift/RpcDebugTest.thrift
@@ -16,3 +16,6 @@ exception DebugException {
 service RpcDebugService {
   Response doDebug(1: string methodArg1, 2: i64 methodArg2, 3: RequestDetails details) throws (1: DebugException e),
 }
+
+service ChildRpcDebugService extends RpcDebugService {
+}

--- a/thrift0.11/src/test/thrift/RpcDebugTest.thrift
+++ b/thrift0.11/src/test/thrift/RpcDebugTest.thrift
@@ -16,3 +16,6 @@ exception DebugException {
 service RpcDebugService {
   Response doDebug(1: string methodArg1, 2: i64 methodArg2, 3: RequestDetails details) throws (1: DebugException e),
 }
+
+service ChildRpcDebugService extends RpcDebugService {
+}

--- a/thrift0.9/src/test/thrift/RpcDebugTest.thrift
+++ b/thrift0.9/src/test/thrift/RpcDebugTest.thrift
@@ -16,3 +16,6 @@ exception DebugException {
 service RpcDebugService {
   Response doDebug(1: string methodArg1, 2: i64 methodArg2, 3: RequestDetails details) throws (1: DebugException e),
 }
+
+service ChildRpcDebugService extends RpcDebugService {
+}


### PR DESCRIPTION
Motivation:

When a Thrift service inherits from another service, armeria incorrectly sees the inherited methods as duplicated.

Modifications:

* Accept multiple declarations of the same method, making sure to always take the most specific declaration

Example error:
```
Exception in thread "main" java.lang.IllegalArgumentException: duplicate Thrift method name: cancel
	at com.linecorp.armeria.internal.thrift.ThriftServiceMetadata.checkDuplicateMethodName(ThriftServiceMetadata.java:196)
	at com.linecorp.armeria.internal.thrift.ThriftServiceMetadata.registerFunction(ThriftServiceMetadata.java:177)
	at com.linecorp.armeria.internal.thrift.ThriftServiceMetadata.lambda$init$1(ThriftServiceMetadata.java:94)
	at java.util.HashMap.forEach(HashMap.java:1289)
	at java.util.Collections$UnmodifiableMap.forEach(Collections.java:1505)
	at com.linecorp.armeria.internal.thrift.ThriftServiceMetadata.init(ThriftServiceMetadata.java:93)
	at com.linecorp.armeria.internal.thrift.ThriftServiceMetadata.init(ThriftServiceMetadata.java:72)
	at com.linecorp.armeria.internal.thrift.ThriftServiceMetadata.<init>(ThriftServiceMetadata.java:60)
	at com.linecorp.armeria.server.thrift.ThriftServiceEntry.<init>(ThriftServiceEntry.java:49)
	at com.linecorp.armeria.internal.shaded.guava.collect.CollectCollectors.lambda$toImmutableMap$1(CollectCollectors.java:61)
	at java.util.stream.ReduceOps$3ReducingSink.accept(ReduceOps.java:169)
	at java.util.Iterator.forEachRemaining(Iterator.java:116)
	at java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1801)
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:481)
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471)
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708)
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:499)
	at com.linecorp.armeria.server.thrift.ThriftCallService.<init>(ThriftCallService.java:95)
	at com.linecorp.armeria.server.thrift.ThriftCallService.of(ThriftCallService.java:73)
	at com.linecorp.armeria.server.thrift.THttpService.ofFormats(THttpService.java:241)
	at com.linecorp.armeria.server.thrift.THttpService.ofFormats(THttpService.java:189)
	at com.liveramp.partner_stats_service.service.PartnerStatsServer.main(PartnerStatsServer.java:68)
```