### PR TITLE
DefaultPathMapping now generates the correct regex pattern for a path…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/DefaultPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultPathMapping.java
@@ -30,6 +30,7 @@ import java.util.regex.Pattern;
 
 import javax.annotation.Nullable;
 
+import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableSet;
 
 /**
@@ -45,6 +46,8 @@ final class DefaultPathMapping extends AbstractPathMapping {
     private static final Pattern VALID_PATTERN = Pattern.compile("(/[^/{}:]+|/:[^/{}]+|/\\{[^/{}]+})+/?");
 
     private static final String[] EMPTY_NAMES = new String[0];
+
+    private static final Splitter PATH_SPLITTER = Splitter.on('/');
 
     /**
      * The original path pattern specified in the constructor.
@@ -100,7 +103,7 @@ final class DefaultPathMapping extends AbstractPathMapping {
         final StringJoiner patternJoiner = new StringJoiner("/");
         final StringJoiner skeletonJoiner = new StringJoiner("/");
         final List<String> paramNames = new ArrayList<>();
-        for (String token : pathPattern.split("/")) {
+        for (String token : PATH_SPLITTER.split(pathPattern)) {
             final String paramName = paramName(token);
             if (paramName == null) {
                 // If the given token is a constant, do not manipulate it.

--- a/core/src/test/java/com/linecorp/armeria/server/DefaultPathMappingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/DefaultPathMappingTest.java
@@ -63,6 +63,15 @@ public class DefaultPathMappingTest {
     }
 
     @Test
+    public void testPathEndsWithSlash() throws Exception {
+        final DefaultPathMapping ppe = new DefaultPathMapping("/service/{value}/");
+        final PathMappingResult result = ppe.apply(create("/service/hello/", null));
+
+        assertThat(result.isPresent()).isTrue();
+        assertThat(result.path()).isEqualTo("/service/hello/");
+    }
+
+    @Test
     public void testNumericPathParamNames() {
         final DefaultPathMapping m = new DefaultPathMapping("/{0}/{1}/{2}");
         assertThat(m.paramNames()).containsExactlyInAnyOrder("0", "1", "2");


### PR DESCRIPTION
… ending with a slash

Modifications:
- Used `Splitter` other than `String.split()` method, in order not to ignore the slash on the last index of the path.

Result:
- Closes #1730