### PR TITLE
Prevent double `CorsService` decoration

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsDecoratorFactoryFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsDecoratorFactoryFunction.java
@@ -36,6 +36,14 @@ public final class CorsDecoratorFactoryFunction implements DecoratorFactoryFunct
         requireNonNull(parameter, "parameter");
         final CorsServiceBuilder cb = CorsServiceBuilder.forOrigins(parameter.origins());
         cb.firstPolicyBuilder.setConfig(parameter);
-        return cb.newDecorator();
+
+        final Function<Service<HttpRequest, HttpResponse>, CorsService> decorator = cb.newDecorator();
+        return service -> {
+            if (service.as(CorsService.class).isPresent()) {
+                return service;
+            } else {
+                return decorator.apply(service);
+            }
+        };
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsDecoratorsFactoryFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsDecoratorsFactoryFunction.java
@@ -49,7 +49,15 @@ public final class CorsDecoratorsFactoryFunction implements DecoratorFactoryFunc
             builder.setConfig(policies[i]);
             cb.addPolicy(builder.build());
         }
-        return cb.newDecorator();
+
+        final Function<Service<HttpRequest, HttpResponse>, CorsService> decorator = cb.newDecorator();
+        return service -> {
+            if (service.as(CorsService.class).isPresent()) {
+                return service;
+            } else {
+                return decorator.apply(service);
+            }
+        };
     }
 
     private static void ensureValidConfig(CorsDecorators conf) {

--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsServiceBuilder.java
@@ -351,6 +351,12 @@ public final class CorsServiceBuilder {
      * Returns a newly-created {@link CorsService} based on the properties of this builder.
      */
     public CorsService build(Service<HttpRequest, HttpResponse> delegate) {
+        if (delegate.as(CorsService.class).isPresent()) {
+            throw new IllegalArgumentException(
+                    "decorated with a " + CorsService.class.getSimpleName() + " already: " +
+                    delegate);
+        }
+
         return new CorsService(delegate, new CorsConfig(this));
     }
 
@@ -358,14 +364,8 @@ public final class CorsServiceBuilder {
      * Returns a newly-created decorator that decorates a {@link Service} with a new {@link CorsService}
      * based on the properties of this builder.
      */
-    public Function<Service<HttpRequest, HttpResponse>,
-            ? extends Service<HttpRequest, HttpResponse>> newDecorator() {
-        return s -> {
-            if (s.as(CorsService.class).isPresent()) {
-                return s;
-            }
-            return build(s);
-        };
+    public Function<Service<HttpRequest, HttpResponse>, CorsService> newDecorator() {
+        return this::build;
     }
 
     /**

--- a/core/src/test/java/com/linecorp/armeria/server/cors/HttpServerCorsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/cors/HttpServerCorsTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 import java.util.Arrays;
+import java.util.function.Function;
 
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -41,6 +42,7 @@ import com.linecorp.armeria.server.AbstractHttpService;
 import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.PathMapping;
 import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.annotation.AdditionalHeader;
 import com.linecorp.armeria.server.annotation.Get;
@@ -338,6 +340,15 @@ public class HttpServerCorsTest {
                 IllegalArgumentException.class);
         assertThatThrownBy(() -> CorsServiceBuilder.forAnyOrigin().allowRequestHeaders()).isInstanceOf(
                 IllegalArgumentException.class);
+
+        // Ensure double decoration is prohibited.
+        assertThatThrownBy(() -> {
+            final Function<Service<HttpRequest, HttpResponse>, CorsService> decorator =
+                    CorsServiceBuilder.forAnyOrigin().newDecorator();
+            final HttpService service = (ctx, req) -> HttpResponse.of("OK");
+            service.decorate(decorator).decorate(decorator);
+        }).isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("decorated with a CorsService already");
     }
 
     // Makes sure if null origin supported CorsService works properly and it finds the CORS policy


### PR DESCRIPTION
Motivation:

Currently, the decorator function returned by
`CorsServiceBuilder.newDecorator()` does not perform any decoration at
all when a given `Service` is decorated with a `CorsService` already.
This is a confusing behavior which throws user's configuration
unexpectedly.

Modifications:

- Make `CorsServiceBuilder.build()` reject double decoration.
- Move the logic that ignores the CORS policy at a higher level to
  `CorsDecorator(s)FactoryFunction`.

Result:

- Less surprising behavior.