### PR TITLE
`RoutingTrie` can now handle a trailing slash correctly

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/RoutingTrie.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RoutingTrie.java
@@ -127,9 +127,13 @@ final class RoutingTrie<V> {
             case PARAMETER:
                 // Consume characters until the delimiter '/' as a path variable.
                 final int delim = path.indexOf('/', begin);
-                if (delim < 0 || path.length() == delim + 1) {
-                    // No more delimiter, or ends with delimiter.
+                if (delim < 0) {
+                    // No more delimiter.
                     return node;
+                }
+                if (path.length() == delim + 1) {
+                    final Node<V> trailingSlashNode = node.child('/');
+                    return trailingSlashNode != null ? trailingSlashNode : node;
                 }
                 next = delim;
                 break;

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerPathTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerPathTest.java
@@ -49,6 +49,19 @@ public class HttpServerPathTest {
                 }
             });
 
+            // '/another/foo/' and '/another/foo' should be differently handled.
+            sb.service("/another/{id}/", new AbstractHttpService() {
+                @Override
+                protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) {
+                    return HttpResponse.of(HttpStatus.OK);
+                }
+            }).service("/another/{id}", new AbstractHttpService() {
+                @Override
+                protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) {
+                    return HttpResponse.of(HttpStatus.NO_CONTENT);
+                }
+            });
+
             sb.serviceUnder("/", new AbstractHttpService() {
                 @Override
                 protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) {
@@ -71,6 +84,8 @@ public class HttpServerPathTest {
         TEST_URLS.put("/service//test//////a/?flag=hello", HttpStatus.OK);
         TEST_URLS.put("/service/foo:bar", HttpStatus.OK);
         TEST_URLS.put("/service/foo::::::bar", HttpStatus.OK);
+        TEST_URLS.put("/another/foo/", HttpStatus.OK);
+        TEST_URLS.put("/another/foo", HttpStatus.NO_CONTENT);
         TEST_URLS.put("/cache/v1.0/rnd_team/get/krisjey:56578015655:1223", HttpStatus.OK);
 
         TEST_URLS.put("/signout/56578015655?crumb=s-1475829101-cec4230588-%E2%98%83", HttpStatus.OK);


### PR DESCRIPTION
Motivation:
- #1735 made `DefaultPathMapping` generate a correct path pattern with a trailing slash,
  but the `RoutingTrie` hasn't still handled the trailing slash correctly.

Modifications:
- Made `RoutingTrie` handle the trailing slash correctly.

Result:
- A service can be correctly mapped to the path with a trailing slash.