### PR TITLE
Allow using wildcards with RequestContextExportingAppender

### DIFF
--- a/logback/src/main/java/com/linecorp/armeria/common/logback/BuiltInProperty.java
+++ b/logback/src/main/java/com/linecorp/armeria/common/logback/BuiltInProperty.java
@@ -15,10 +15,12 @@
  */
 package com.linecorp.armeria.common.logback;
 
-import java.util.ArrayList;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.regex.Pattern;
 
 import javax.net.ssl.SSLSession;
@@ -165,13 +167,10 @@ public enum BuiltInProperty {
     static List<BuiltInProperty> findByMdcKeyPattern(String mdcKeyPattern) {
         final Pattern pattern = Pattern.compile(
                 ("\\Q" + mdcKeyPattern + "\\E").replaceAll(WILDCARD_REGEX, "\\\\E.*\\\\Q"));
-        final List<BuiltInProperty> matchedBuiltInProperties = new ArrayList<>();
-        mdcKeyToEnum.forEach((mdcKey, property) -> {
-            if (pattern.matcher(mdcKey).matches()) {
-                matchedBuiltInProperties.add(property);
-            }
-        });
-        return matchedBuiltInProperties;
+        return mdcKeyToEnum.entrySet().stream()
+                           .filter(e -> pattern.matcher(e.getKey()).matches())
+                           .map(Entry::getValue)
+                           .collect(toImmutableList());
     }
 
     final String mdcKey;

--- a/logback/src/main/java/com/linecorp/armeria/common/logback/BuiltInProperty.java
+++ b/logback/src/main/java/com/linecorp/armeria/common/logback/BuiltInProperty.java
@@ -15,9 +15,11 @@
  */
 package com.linecorp.armeria.common.logback;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
-import java.util.Optional;
+import java.util.regex.Pattern;
 
 import javax.net.ssl.SSLSession;
 
@@ -149,6 +151,8 @@ public enum BuiltInProperty {
 
     private static final Map<String, BuiltInProperty> mdcKeyToEnum;
 
+    static final String WILDCARD_STR = "*";
+
     static {
         final ImmutableMap.Builder<String, BuiltInProperty> builder = ImmutableMap.builder();
         for (BuiltInProperty k : BuiltInProperty.values()) {
@@ -157,8 +161,16 @@ public enum BuiltInProperty {
         mdcKeyToEnum = builder.build();
     }
 
-    static Optional<BuiltInProperty> findByMdcKey(String mdcKey) {
-        return Optional.ofNullable(mdcKeyToEnum.get(mdcKey));
+    static List<BuiltInProperty> findByMdcKeyPattern(String mdcKeyPattern) {
+        final Pattern pattern = Pattern.compile(
+                ("\\Q" + mdcKeyPattern + "\\E").replace(WILDCARD_STR, "\\E.*\\Q"));
+        final List<BuiltInProperty> matchedBuiltInProperties = new ArrayList<>();
+        mdcKeyToEnum.forEach((mdcKey, property) -> {
+            if (pattern.matcher(mdcKey).matches()) {
+                matchedBuiltInProperties.add(property);
+            }
+        });
+        return matchedBuiltInProperties;
     }
 
     final String mdcKey;

--- a/logback/src/main/java/com/linecorp/armeria/common/logback/BuiltInProperty.java
+++ b/logback/src/main/java/com/linecorp/armeria/common/logback/BuiltInProperty.java
@@ -152,6 +152,7 @@ public enum BuiltInProperty {
     private static final Map<String, BuiltInProperty> mdcKeyToEnum;
 
     static final String WILDCARD_STR = "*";
+    static final String WILDCARD_REGEX = '\\' + WILDCARD_STR;
 
     static {
         final ImmutableMap.Builder<String, BuiltInProperty> builder = ImmutableMap.builder();
@@ -163,7 +164,7 @@ public enum BuiltInProperty {
 
     static List<BuiltInProperty> findByMdcKeyPattern(String mdcKeyPattern) {
         final Pattern pattern = Pattern.compile(
-                ("\\Q" + mdcKeyPattern + "\\E").replace(WILDCARD_STR, "\\E.*\\Q"));
+                ("\\Q" + mdcKeyPattern + "\\E").replaceAll(WILDCARD_REGEX, "\\\\E.*\\\\Q"));
         final List<BuiltInProperty> matchedBuiltInProperties = new ArrayList<>();
         mdcKeyToEnum.forEach((mdcKey, property) -> {
             if (pattern.matcher(mdcKey).matches()) {

--- a/logback/src/main/java/com/linecorp/armeria/common/logback/RequestContextExporterBuilder.java
+++ b/logback/src/main/java/com/linecorp/armeria/common/logback/RequestContextExporterBuilder.java
@@ -21,8 +21,8 @@ import static java.util.Objects.requireNonNull;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -117,9 +117,13 @@ final class RequestContextExporterBuilder {
     void export(String mdcKey) {
         requireNonNull(mdcKey, "mdcKey");
 
-        final Optional<BuiltInProperty> opt = BuiltInProperty.findByMdcKey(mdcKey);
-        if (opt.isPresent()) {
-            builtIns.add(opt.get());
+        final List<BuiltInProperty> builtInPropertyList = BuiltInProperty.findByMdcKeyPattern(mdcKey);
+        if (!builtInPropertyList.isEmpty()) {
+            builtIns.addAll(builtInPropertyList);
+            return;
+        }
+
+        if (mdcKey.contains(BuiltInProperty.WILDCARD_STR)) {
             return;
         }
 

--- a/logback/src/main/java/com/linecorp/armeria/common/logback/RequestContextExporterBuilder.java
+++ b/logback/src/main/java/com/linecorp/armeria/common/logback/RequestContextExporterBuilder.java
@@ -124,7 +124,7 @@ final class RequestContextExporterBuilder {
         }
 
         if (mdcKey.contains(BuiltInProperty.WILDCARD_STR)) {
-            return;
+            throw new IllegalArgumentException("Not found matched built-in properties. mdcKey: " + mdcKey);
         }
 
         if (mdcKey.startsWith(PREFIX_ATTRS)) {

--- a/logback/src/main/java/com/linecorp/armeria/common/logback/RequestContextExporterBuilder.java
+++ b/logback/src/main/java/com/linecorp/armeria/common/logback/RequestContextExporterBuilder.java
@@ -124,7 +124,7 @@ final class RequestContextExporterBuilder {
         }
 
         if (mdcKey.contains(BuiltInProperty.WILDCARD_STR)) {
-            throw new IllegalArgumentException("Not found matched built-in properties. mdcKey: " + mdcKey);
+            return;
         }
 
         if (mdcKey.startsWith(PREFIX_ATTRS)) {

--- a/logback/src/test/java/com/linecorp/armeria/common/logback/RequestContextExporterBuilderTest.java
+++ b/logback/src/test/java/com/linecorp/armeria/common/logback/RequestContextExporterBuilderTest.java
@@ -63,9 +63,11 @@ public class RequestContextExporterBuilderTest {
         assertThat(builder.getBuiltIns()).containsExactly(expectedProperties);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testExportWithNotMatchedWildcard() {
+    @Test
+    public void testExportAttrWithWildcard() throws Exception {
         final RequestContextExporterBuilder builder = new RequestContextExporterBuilder();
-        builder.export("*hoge*");
+        builder.export("attrs.*");
+        builder.export("attrs.my_attrs:MyAttribute");
+        assertEquals(1, builder.getAttributes().size());
     }
 }

--- a/logback/src/test/java/com/linecorp/armeria/common/logback/RequestContextExporterBuilderTest.java
+++ b/logback/src/test/java/com/linecorp/armeria/common/logback/RequestContextExporterBuilderTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.logback;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
+public class RequestContextExporterBuilderTest {
+
+    @Test
+    public void testExportBuiltInProperties() throws Exception {
+        final RequestContextExporterBuilder builder = new RequestContextExporterBuilder();
+        for (BuiltInProperty property : BuiltInProperty.values()) {
+            builder.export(property.mdcKey);
+        }
+        assertThat(builder.getBuiltIns()).containsExactly(BuiltInProperty.values());
+    }
+
+    @Test
+    public void testExportWithoutWildcards() throws Exception {
+        final RequestContextExporterBuilder builder = new RequestContextExporterBuilder();
+        builder.export(BuiltInProperty.REMOTE_HOST.mdcKey);
+        assertThat(builder.getBuiltIns()).containsExactly(BuiltInProperty.REMOTE_HOST);
+    }
+
+    @Test
+    public void testExportWithWildcards() throws Exception {
+        final RequestContextExporterBuilder builder = new RequestContextExporterBuilder();
+        final BuiltInProperty[] expectedProperties =
+                Arrays.stream(BuiltInProperty.values())
+                      .filter(p -> p.mdcKey.startsWith("req."))
+                      .toArray(BuiltInProperty[]::new);
+        builder.export("req.*");
+        assertThat(builder.getBuiltIns()).containsExactly(expectedProperties);
+    }
+
+    @Test
+    public void testExportAttrWithWildcard() throws Exception {
+        final RequestContextExporterBuilder builder = new RequestContextExporterBuilder();
+        builder.export("attrs.*");
+        builder.export("attrs.my_attrs:MyAttribute");
+        assertEquals(1, builder.getAttributes().size());
+    }
+}

--- a/logback/src/test/java/com/linecorp/armeria/common/logback/RequestContextExporterBuilderTest.java
+++ b/logback/src/test/java/com/linecorp/armeria/common/logback/RequestContextExporterBuilderTest.java
@@ -63,11 +63,9 @@ public class RequestContextExporterBuilderTest {
         assertThat(builder.getBuiltIns()).containsExactly(expectedProperties);
     }
 
-    @Test
-    public void testExportAttrWithWildcard() throws Exception {
+    @Test(expected = IllegalArgumentException.class)
+    public void testExportWithNotMatchedWildcard() {
         final RequestContextExporterBuilder builder = new RequestContextExporterBuilder();
-        builder.export("attrs.*");
-        builder.export("attrs.my_attrs:MyAttribute");
-        assertEquals(1, builder.getAttributes().size());
+        builder.export("*hoge*");
     }
 }

--- a/logback/src/test/java/com/linecorp/armeria/common/logback/RequestContextExporterBuilderTest.java
+++ b/logback/src/test/java/com/linecorp/armeria/common/logback/RequestContextExporterBuilderTest.java
@@ -42,13 +42,24 @@ public class RequestContextExporterBuilderTest {
     }
 
     @Test
-    public void testExportWithWildcards() throws Exception {
+    public void testExportWithWildcard() throws Exception {
         final RequestContextExporterBuilder builder = new RequestContextExporterBuilder();
         final BuiltInProperty[] expectedProperties =
                 Arrays.stream(BuiltInProperty.values())
                       .filter(p -> p.mdcKey.startsWith("req."))
                       .toArray(BuiltInProperty[]::new);
         builder.export("req.*");
+        assertThat(builder.getBuiltIns()).containsExactly(expectedProperties);
+    }
+
+    @Test
+    public void testExportWithWildcards() throws Exception {
+        final RequestContextExporterBuilder builder = new RequestContextExporterBuilder();
+        final BuiltInProperty[] expectedProperties =
+                Arrays.stream(BuiltInProperty.values())
+                      .filter(p -> p.mdcKey.contains("rpc"))
+                      .toArray(BuiltInProperty[]::new);
+        builder.export("*rpc*");
         assertThat(builder.getBuiltIns()).containsExactly(expectedProperties);
     }
 

--- a/site/src/sphinx/advanced-logging.rst
+++ b/site/src/sphinx/advanced-logging.rst
@@ -33,6 +33,9 @@ For example, the following configuration:
                  req.http_headers.user-agent,
                  attrs.some_value:com.example.AttrKeys#SOME_VALUE</exports>
         -->
+        <!-- ... or with wildcard:
+        <export>req.*</export>
+        -->
       </appender>
       ...
     </configuration>
@@ -64,6 +67,10 @@ Built-in properties
 -------------------
 A built-in property is a common property available for most requests. See the complete list of the built-in
 properties and their MDC keys at :api:`BuiltInProperty`.
+You can also use wildcard character ``*`` instead of listing all properties. For example:
+
+- ``"*"``
+- ``"req.*"``
 
 HTTP request and response headers
 ---------------------------------


### PR DESCRIPTION
For #489

I applied a wildcard `*` pattern about builtin properties. We can also adopt a wildcard about `headers` or `attrs`. But it can be caused some overhead to by logging.
I also specified to document that the wildcard applies only to the `builtin` property.