### PR TITLE
Provide a way to create a client with an Endpoint rather than with a URI

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/AbstractClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/AbstractClientFactory.java
@@ -22,6 +22,8 @@ import java.net.URI;
 import java.util.Optional;
 import java.util.Set;
 
+import javax.annotation.Nullable;
+
 import com.linecorp.armeria.common.Scheme;
 
 /**
@@ -42,29 +44,12 @@ public abstract class AbstractClientFactory implements ClientFactory {
         return newClient(URI.create(uri), clientType, options);
     }
 
-    /**
-     * Creates a new client that connects to the specified {@link URI} using the default
-     * {@link ClientFactory}.
-     *
-     * @param uri the URI of the server endpoint
-     * @param clientType the type of the new client
-     * @param options the {@link ClientOptionValue}s
-     */
     @Override
     public final <T> T newClient(URI uri, Class<T> clientType, ClientOptionValue<?>... options) {
         requireNonNull(options, "options");
         return newClient(uri, clientType, ClientOptions.of(options));
     }
 
-    /**
-     * Creates a new client that connects to the specified {@link Endpoint} with the {@link Scheme} using
-     * the default {@link ClientFactory}.
-     *
-     * @param scheme the {@link Scheme} for the {@code endpoint}
-     * @param endpoint the server {@link Endpoint}
-     * @param clientType the type of the new client
-     * @param options the {@link ClientOptionValue}s
-     */
     @Override
     public final <T> T newClient(Scheme scheme, Endpoint endpoint, Class<T> clientType,
                                  ClientOptionValue<?>... options) {
@@ -74,15 +59,6 @@ public abstract class AbstractClientFactory implements ClientFactory {
         return newClient(scheme, endpoint, clientType, ClientOptions.of(options));
     }
 
-    /**
-     * Creates a new client that connects to the specified {@link Endpoint} with the {@link Scheme} using
-     * the default {@link ClientFactory}.
-     *
-     * @param scheme the {@link Scheme} for the {@code endpoint}
-     * @param endpoint the server {@link Endpoint}
-     * @param clientType the type of the new client
-     * @param options the {@link ClientOptions}
-     */
     @Override
     public final <T> T newClient(Scheme scheme, Endpoint endpoint, Class<T> clientType, ClientOptions options) {
         requireNonNull(scheme, "scheme");
@@ -91,22 +67,11 @@ public abstract class AbstractClientFactory implements ClientFactory {
         return newClient(scheme, endpoint, "", clientType, options);
     }
 
-    /**
-     * Creates a new client that connects to the specified {@link Endpoint} with the {@link Scheme}
-     * and {@code path} using the default {@link ClientFactory}.
-     *
-     * @param scheme the {@link Scheme} for the {@code endpoint}
-     * @param endpoint the server {@link Endpoint}
-     * @param path the service {@code path}
-     * @param clientType the type of the new client
-     * @param options the {@link ClientOptionValue}s
-     */
     @Override
-    public final <T> T newClient(Scheme scheme, Endpoint endpoint, String path, Class<T> clientType,
+    public final <T> T newClient(Scheme scheme, Endpoint endpoint, @Nullable String path, Class<T> clientType,
                                  ClientOptionValue<?>... options) {
         requireNonNull(scheme, "scheme");
         requireNonNull(endpoint, "endpoint");
-        requireNonNull(path, "path");
         requireNonNull(options, "options");
         return newClient(scheme, endpoint, path, clientType, ClientOptions.of(options));
     }

--- a/core/src/main/java/com/linecorp/armeria/client/AbstractClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/AbstractClientFactory.java
@@ -111,10 +111,10 @@ public abstract class AbstractClientFactory implements ClientFactory {
     }
 
     /**
-     * Makes sure the scheme of the specified {@link Scheme} is supported by this {@link ClientFactory}.
+     * Makes sure the specified {@link Scheme} is supported by this {@link ClientFactory}.
      *
      * @param scheme the {@link Scheme} of the server endpoint
-     * @return the supported {@link Scheme}
+     * @return the {@link Scheme}
      *
      * @throws IllegalArgumentException if the {@link Scheme} is not supported by this {@link ClientFactory}
      */

--- a/core/src/main/java/com/linecorp/armeria/client/AbstractClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/AbstractClientFactory.java
@@ -75,6 +75,43 @@ public abstract class AbstractClientFactory implements ClientFactory {
     }
 
     /**
+     * Creates a new client that connects to the specified {@link Endpoint} with the {@link Scheme} using
+     * the default {@link ClientFactory}.
+     *
+     * @param scheme the {@link Scheme} for the {@code endpoint}
+     * @param endpoint the server {@link Endpoint}
+     * @param clientType the type of the new client
+     * @param options the {@link ClientOptions}
+     */
+    @Override
+    public final <T> T newClient(Scheme scheme, Endpoint endpoint, Class<T> clientType, ClientOptions options) {
+        requireNonNull(scheme, "scheme");
+        requireNonNull(endpoint, "endpoint");
+        requireNonNull(options, "options");
+        return newClient(scheme, endpoint, "", clientType, options);
+    }
+
+    /**
+     * Creates a new client that connects to the specified {@link Endpoint} with the {@link Scheme}
+     * and {@code path} using the default {@link ClientFactory}.
+     *
+     * @param scheme the {@link Scheme} for the {@code endpoint}
+     * @param endpoint the server {@link Endpoint}
+     * @param path the service {@code path}
+     * @param clientType the type of the new client
+     * @param options the {@link ClientOptionValue}s
+     */
+    @Override
+    public final <T> T newClient(Scheme scheme, Endpoint endpoint, String path, Class<T> clientType,
+                                 ClientOptionValue<?>... options) {
+        requireNonNull(scheme, "scheme");
+        requireNonNull(endpoint, "endpoint");
+        requireNonNull(path, "path");
+        requireNonNull(options, "options");
+        return newClient(scheme, endpoint, path, clientType, ClientOptions.of(options));
+    }
+
+    /**
      * Makes sure the scheme of the specified {@link URI} is supported by this {@link ClientFactory}.
      *
      * @param uri the {@link URI} of the server endpoint

--- a/core/src/main/java/com/linecorp/armeria/client/AbstractClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/AbstractClientFactory.java
@@ -42,10 +42,36 @@ public abstract class AbstractClientFactory implements ClientFactory {
         return newClient(URI.create(uri), clientType, options);
     }
 
+    /**
+     * Creates a new client that connects to the specified {@link URI} using the default
+     * {@link ClientFactory}.
+     *
+     * @param uri the URI of the server endpoint
+     * @param clientType the type of the new client
+     * @param options the {@link ClientOptionValue}s
+     */
     @Override
     public final <T> T newClient(URI uri, Class<T> clientType, ClientOptionValue<?>... options) {
         requireNonNull(options, "options");
         return newClient(uri, clientType, ClientOptions.of(options));
+    }
+
+    /**
+     * Creates a new client that connects to the specified {@link Endpoint} with the {@link Scheme} using
+     * the default {@link ClientFactory}.
+     *
+     * @param scheme the {@link Scheme} for the {@code endpoint}
+     * @param endpoint the server {@link Endpoint}
+     * @param clientType the type of the new client
+     * @param options the {@link ClientOptionValue}s
+     */
+    @Override
+    public final <T> T newClient(Scheme scheme, Endpoint endpoint, Class<T> clientType,
+                                 ClientOptionValue<?>... options) {
+        requireNonNull(scheme, "scheme");
+        requireNonNull(endpoint, "endpoint");
+        requireNonNull(options, "options");
+        return newClient(scheme, endpoint, clientType, ClientOptions.of(options));
     }
 
     /**
@@ -82,6 +108,26 @@ public abstract class AbstractClientFactory implements ClientFactory {
         }
 
         return parsedScheme;
+    }
+
+    /**
+     * Makes sure the scheme of the specified {@link Scheme} is supported by this {@link ClientFactory}.
+     *
+     * @param scheme the {@link Scheme} of the server endpoint
+     * @return the supported {@link Scheme}
+     *
+     * @throws IllegalArgumentException if the {@link Scheme} is not supported by this {@link ClientFactory}
+     */
+    protected final Scheme validateScheme(Scheme scheme) {
+        requireNonNull(scheme, "scheme");
+
+        final Set<Scheme> supportedSchemes = supportedSchemes();
+        if (!supportedSchemes.contains(scheme)) {
+            throw new IllegalArgumentException(
+                    "Unsupported scheme: " + scheme + " (expected: " + supportedSchemes + ')');
+        }
+
+        return scheme;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/AbstractClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/AbstractClientFactory.java
@@ -34,6 +34,7 @@ public abstract class AbstractClientFactory implements ClientFactory {
     @Override
     public final <T> T newClient(String uri, Class<T> clientType, ClientOptionValue<?>... options) {
         requireNonNull(uri, "uri");
+        requireNonNull(clientType, "clientType");
         requireNonNull(options, "options");
         return newClient(URI.create(uri), clientType, ClientOptions.of(options));
     }
@@ -41,11 +42,15 @@ public abstract class AbstractClientFactory implements ClientFactory {
     @Override
     public final <T> T newClient(String uri, Class<T> clientType, ClientOptions options) {
         requireNonNull(uri, "uri");
+        requireNonNull(clientType, "clientType");
+        requireNonNull(options, "options");
         return newClient(URI.create(uri), clientType, options);
     }
 
     @Override
     public final <T> T newClient(URI uri, Class<T> clientType, ClientOptionValue<?>... options) {
+        requireNonNull(uri, "uri");
+        requireNonNull(clientType, "clientType");
         requireNonNull(options, "options");
         return newClient(uri, clientType, ClientOptions.of(options));
     }
@@ -55,6 +60,7 @@ public abstract class AbstractClientFactory implements ClientFactory {
                                  ClientOptionValue<?>... options) {
         requireNonNull(scheme, "scheme");
         requireNonNull(endpoint, "endpoint");
+        requireNonNull(clientType, "clientType");
         requireNonNull(options, "options");
         return newClient(scheme, endpoint, clientType, ClientOptions.of(options));
     }
@@ -63,8 +69,9 @@ public abstract class AbstractClientFactory implements ClientFactory {
     public final <T> T newClient(Scheme scheme, Endpoint endpoint, Class<T> clientType, ClientOptions options) {
         requireNonNull(scheme, "scheme");
         requireNonNull(endpoint, "endpoint");
+        requireNonNull(clientType, "clientType");
         requireNonNull(options, "options");
-        return newClient(scheme, endpoint, "", clientType, options);
+        return newClient(scheme, endpoint, null, clientType, options);
     }
 
     @Override
@@ -72,6 +79,7 @@ public abstract class AbstractClientFactory implements ClientFactory {
                                  ClientOptionValue<?>... options) {
         requireNonNull(scheme, "scheme");
         requireNonNull(endpoint, "endpoint");
+        requireNonNull(clientType, "clientType");
         requireNonNull(options, "options");
         return newClient(scheme, endpoint, path, clientType, ClientOptions.of(options));
     }

--- a/core/src/main/java/com/linecorp/armeria/client/ClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientBuilder.java
@@ -61,6 +61,8 @@ public final class ClientBuilder extends AbstractClientOptionsBuilder<ClientBuil
     private final Scheme scheme;
     @Nullable
     private final Endpoint endpoint;
+    @Nullable
+    private final String path;
     private ClientFactory factory = ClientFactory.DEFAULT;
 
     /**
@@ -74,7 +76,7 @@ public final class ClientBuilder extends AbstractClientOptionsBuilder<ClientBuil
      * Creates a new {@link ClientBuilder} that builds the client that connects to the specified {@link URI}.
      */
     public ClientBuilder(URI uri) {
-        this(requireNonNull(uri), null, null);
+        this(requireNonNull(uri, "uri"), null, null, null);
     }
 
     /**
@@ -107,13 +109,48 @@ public final class ClientBuilder extends AbstractClientOptionsBuilder<ClientBuil
      * {@link Endpoint} with the {@link Scheme}.
      */
     public ClientBuilder(Scheme scheme, Endpoint endpoint) {
-        this(null, requireNonNull(scheme, "scheme"), requireNonNull(endpoint, "endpoint"));
+        this(null, requireNonNull(scheme, "scheme"), requireNonNull(endpoint, "endpoint"), "");
     }
 
-    private ClientBuilder(URI uri, Scheme scheme, Endpoint endpoint) {
+    /**
+     * Creates a new {@link ClientBuilder} that builds the client that connects to the specified
+     * {@link Endpoint} with the {@link SessionProtocol}, {@link SerializationFormat}, and {@code path}.
+     */
+    public ClientBuilder(SessionProtocol protocol, SerializationFormat format, Endpoint endpoint, String path) {
+        this(Scheme.of(format, protocol), requireNonNull(endpoint, "endpoint"), requireNonNull(path, "path"));
+    }
+
+    /**
+     * Creates a new {@link ClientBuilder} that builds the HTTP client that connects to the specified
+     * {@link Endpoint} with the {@link SessionProtocol} and {@code path}.
+     */
+    public ClientBuilder(SessionProtocol protocol, Endpoint endpoint, String path) {
+        this(requireNonNull(protocol, "protocol"), SerializationFormat.NONE,
+             requireNonNull(endpoint, "endpoint"), requireNonNull(path, "path"));
+    }
+
+    /**
+     * Creates a new {@link ClientBuilder} that builds the client that connects to the specified
+     * {@link Endpoint} with the {@code scheme} and {@code path}.
+     */
+    public ClientBuilder(String scheme, Endpoint endpoint, String path) {
+        this(Scheme.parse(scheme), requireNonNull(endpoint, "endpoint"), requireNonNull(path, "path"));
+    }
+
+    /**
+     * Creates a new {@link ClientBuilder} that builds the client that connects to the specified
+     * {@link Endpoint} with the {@link Scheme} and {@code path}.
+     */
+    public ClientBuilder(Scheme scheme, Endpoint endpoint, String path) {
+        this(null, requireNonNull(scheme, "scheme"), requireNonNull(endpoint, "endpoint"),
+             requireNonNull(path, "path"));
+    }
+
+    private ClientBuilder(URI uri, Scheme scheme, Endpoint endpoint, String path) {
         this.uri = uri;
         this.scheme = scheme;
         this.endpoint = endpoint;
+        this.path = path;
     }
 
     /**
@@ -138,7 +175,7 @@ public final class ClientBuilder extends AbstractClientOptionsBuilder<ClientBuil
         if (uri != null) {
             return factory.newClient(uri, clientType, buildOptions());
         } else {
-            return factory.newClient(scheme, endpoint, clientType, buildOptions());
+            return factory.newClient(scheme, endpoint, path, clientType, buildOptions());
         }
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/ClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientBuilder.java
@@ -56,11 +56,11 @@ import com.linecorp.armeria.common.SessionProtocol;
 public final class ClientBuilder extends AbstractClientOptionsBuilder<ClientBuilder> {
 
     @Nullable
-    private URI uri;
+    private final URI uri;
     @Nullable
-    private Scheme scheme;
+    private final Scheme scheme;
     @Nullable
-    private Endpoint endpoint;
+    private final Endpoint endpoint;
     private ClientFactory factory = ClientFactory.DEFAULT;
 
     /**
@@ -74,7 +74,7 @@ public final class ClientBuilder extends AbstractClientOptionsBuilder<ClientBuil
      * Creates a new {@link ClientBuilder} that builds the client that connects to the specified {@link URI}.
      */
     public ClientBuilder(URI uri) {
-        this.uri = requireNonNull(uri, "uri");
+        this(requireNonNull(uri), null, null);
     }
 
     /**
@@ -86,7 +86,7 @@ public final class ClientBuilder extends AbstractClientOptionsBuilder<ClientBuil
     }
 
     /**
-     * Creates a new {@link ClientBuilder} that builds the client that connects to the specified
+     * Creates a new {@link ClientBuilder} that builds the HTTP client that connects to the specified
      * {@link Endpoint} with the {@link SessionProtocol}.
      */
     public ClientBuilder(SessionProtocol protocol, Endpoint endpoint) {
@@ -107,8 +107,13 @@ public final class ClientBuilder extends AbstractClientOptionsBuilder<ClientBuil
      * {@link Endpoint} with the {@link Scheme}.
      */
     public ClientBuilder(Scheme scheme, Endpoint endpoint) {
-        this.scheme = requireNonNull(scheme, "scheme");
-        this.endpoint = requireNonNull(endpoint, "endpoint");
+        this(null, requireNonNull(scheme, "scheme"), requireNonNull(endpoint, "endpoint"));
+    }
+
+    private ClientBuilder(URI uri, Scheme scheme, Endpoint endpoint) {
+        this.uri = uri;
+        this.scheme = scheme;
+        this.endpoint = endpoint;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/ClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientBuilder.java
@@ -60,6 +60,14 @@ public final class ClientBuilder extends AbstractClientOptionsBuilder<ClientBuil
     }
 
     /**
+     * Creates a new {@link ClientBuilder} that builds the client that connects to
+     * the specified {@link Endpoint} with {@code scheme}.
+     */
+    public ClientBuilder(String scheme, Endpoint endpoint) {
+        this(requireNonNull(endpoint, "endpoint").toURI(scheme));
+    }
+
+    /**
      * Creates a new {@link ClientBuilder} that builds the client that connects to the specified {@link URI}.
      */
     public ClientBuilder(URI uri) {

--- a/core/src/main/java/com/linecorp/armeria/client/ClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientBuilder.java
@@ -175,7 +175,7 @@ public final class ClientBuilder extends AbstractClientOptionsBuilder<ClientBuil
         if (endpoint == null) {
             throw new IllegalStateException(
                     getClass().getSimpleName() + " must be created with an " + Endpoint.class.getSimpleName() +
-                    " to call this method");
+                    " to call this method.");
         }
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/ClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientBuilder.java
@@ -89,7 +89,7 @@ public final class ClientBuilder extends AbstractClientOptionsBuilder<ClientBuil
      * {@link Endpoint} with the {@code scheme}.
      */
     public ClientBuilder(String scheme, Endpoint endpoint) {
-        this(Scheme.parse(scheme), requireNonNull(endpoint, "endpoint"));
+        this(Scheme.parse(requireNonNull(scheme, "scheme")), requireNonNull(endpoint, "endpoint"));
     }
 
     /**
@@ -105,7 +105,7 @@ public final class ClientBuilder extends AbstractClientOptionsBuilder<ClientBuil
      * {@link Endpoint} with the {@link SessionProtocol}.
      */
     public ClientBuilder(SessionProtocol protocol, Endpoint endpoint) {
-        this(null, null, requireNonNull(protocol, "sessionProtocol"), requireNonNull(endpoint, "endpoint"));
+        this(null, null, requireNonNull(protocol, "protocol"), requireNonNull(endpoint, "endpoint"));
     }
 
     private ClientBuilder(@Nullable URI uri, @Nullable Scheme scheme, @Nullable SessionProtocol protocol,
@@ -173,7 +173,9 @@ public final class ClientBuilder extends AbstractClientOptionsBuilder<ClientBuil
 
     private void ensureEndpoint() {
         if (endpoint == null) {
-            throw new IllegalStateException("endpoint is not given");
+            throw new IllegalStateException(
+                    getClass().getSimpleName() + " must be created with an " + Endpoint.class.getSimpleName() +
+                    " to call this method");
         }
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/ClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientBuilder.java
@@ -86,7 +86,7 @@ public final class ClientBuilder extends AbstractClientOptionsBuilder<ClientBuil
 
     /**
      * Creates a new {@link ClientBuilder} that builds the client that connects to the specified
-     * {@link Endpoint} with the {@code Scheme}.
+     * {@link Endpoint} with the {@code scheme}.
      */
     public ClientBuilder(String scheme, Endpoint endpoint) {
         this(Scheme.parse(scheme), requireNonNull(endpoint, "endpoint"));
@@ -114,8 +114,6 @@ public final class ClientBuilder extends AbstractClientOptionsBuilder<ClientBuil
         this.scheme = scheme;
         this.protocol = protocol;
         this.endpoint = endpoint;
-
-        checkArguments();
     }
 
     /**
@@ -145,7 +143,7 @@ public final class ClientBuilder extends AbstractClientOptionsBuilder<ClientBuil
             throw new IllegalStateException("scheme is already given");
         }
 
-        this.format = requireNonNull(format, "serializationFormat");
+        this.format = requireNonNull(format, "format");
         return this;
     }
 
@@ -159,7 +157,6 @@ public final class ClientBuilder extends AbstractClientOptionsBuilder<ClientBuil
      */
     public <T> T build(Class<T> clientType) {
         requireNonNull(clientType, "clientType");
-        checkArguments();
 
         if (uri != null) {
             return factory.newClient(uri, clientType, buildOptions());
@@ -171,21 +168,7 @@ public final class ClientBuilder extends AbstractClientOptionsBuilder<ClientBuil
     }
 
     private Scheme scheme() {
-        return scheme == null ? Scheme.of(format, requireNonNull(protocol)) : scheme;
-    }
-
-    private void checkArguments() {
-        if (uri != null) {
-            return;
-        }
-
-        if (endpoint == null) {
-            throw new IllegalStateException("both uri and endpoint are not given");
-        }
-
-        if (scheme == null && protocol == null) {
-            throw new IllegalStateException("both scheme and protocol are not given");
-        }
+        return scheme == null ? Scheme.of(format, protocol) : scheme;
     }
 
     private void ensureEndpoint() {

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactory.java
@@ -21,6 +21,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 
+import javax.annotation.Nullable;
+
 import org.slf4j.LoggerFactory;
 
 import com.linecorp.armeria.common.Scheme;
@@ -130,8 +132,7 @@ public interface ClientFactory extends AutoCloseable {
     <T> T newClient(String uri, Class<T> clientType, ClientOptions options);
 
     /**
-     * Creates a new client that connects to the specified {@link URI} using the default
-     * {@link ClientFactory}.
+     * Creates a new client that connects to the specified {@link URI}.
      *
      * @param uri the URI of the server endpoint
      * @param clientType the type of the new client
@@ -140,8 +141,7 @@ public interface ClientFactory extends AutoCloseable {
     <T> T newClient(URI uri, Class<T> clientType, ClientOptionValue<?>... options);
 
     /**
-     * Creates a new client that connects to the specified {@link URI} using the default
-     * {@link ClientFactory}.
+     * Creates a new client that connects to the specified {@link URI}.
      *
      * @param uri the URI of the server endpoint
      * @param clientType the type of the new client
@@ -150,8 +150,7 @@ public interface ClientFactory extends AutoCloseable {
     <T> T newClient(URI uri, Class<T> clientType, ClientOptions options);
 
     /**
-     * Creates a new client that connects to the specified {@link Endpoint} with the {@link Scheme} using
-     * the default {@link ClientFactory}.
+     * Creates a new client that connects to the specified {@link Endpoint} with the {@link Scheme}.
      *
      * @param scheme the {@link Scheme} for the {@code endpoint}
      * @param endpoint the server {@link Endpoint}
@@ -161,8 +160,7 @@ public interface ClientFactory extends AutoCloseable {
     <T> T newClient(Scheme scheme, Endpoint endpoint, Class<T> clientType, ClientOptionValue<?>... options);
 
     /**
-     * Creates a new client that connects to the specified {@link Endpoint} with the {@link Scheme} using
-     * the default {@link ClientFactory}.
+     * Creates a new client that connects to the specified {@link Endpoint} with the {@link Scheme}.
      *
      * @param scheme the {@link Scheme} for the {@code endpoint}
      * @param endpoint the server {@link Endpoint}
@@ -173,7 +171,7 @@ public interface ClientFactory extends AutoCloseable {
 
     /**
      * Creates a new client that connects to the specified {@link Endpoint} with the {@link Scheme}
-     * and {@code path} using the default {@link ClientFactory}.
+     * and {@code path}.
      *
      * @param scheme the {@link Scheme} for the {@code endpoint}
      * @param endpoint the server {@link Endpoint}
@@ -181,12 +179,12 @@ public interface ClientFactory extends AutoCloseable {
      * @param clientType the type of the new client
      * @param options the {@link ClientOptionValue}s
      */
-    <T> T newClient(Scheme scheme, Endpoint endpoint, String path, Class<T> clientType,
+    <T> T newClient(Scheme scheme, Endpoint endpoint, @Nullable String path, Class<T> clientType,
                     ClientOptionValue<?>... options);
 
     /**
      * Creates a new client that connects to the specified {@link Endpoint} with the {@link Scheme}
-     * and {@code path} using the default {@link ClientFactory}.
+     * and {@code path}.
      *
      * @param scheme the {@link Scheme} for the {@code endpoint}
      * @param endpoint the server {@link Endpoint}
@@ -194,7 +192,8 @@ public interface ClientFactory extends AutoCloseable {
      * @param clientType the type of the new client
      * @param options the {@link ClientOptions}
      */
-    <T> T newClient(Scheme scheme, Endpoint endpoint, String path, Class<T> clientType, ClientOptions options);
+    <T> T newClient(Scheme scheme, Endpoint endpoint, @Nullable String path, Class<T> clientType,
+                    ClientOptions options);
 
     /**
      * Returns the {@link ClientBuilderParams} held in {@code client}. This is used when creating a new derived

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactory.java
@@ -112,6 +112,28 @@ public interface ClientFactory extends AutoCloseable {
     void setMeterRegistry(MeterRegistry meterRegistry);
 
     /**
+     * Creates a new client that connects to the specified {@link Endpoint} with the {@link Scheme} using
+     * the default {@link ClientFactory}.
+     *
+     * @param scheme the {@link Scheme} for the {@code endpoint}
+     * @param endpoint the server {@link Endpoint}
+     * @param clientType the type of the new client
+     * @param options the {@link ClientOptionValue}s
+     */
+    <T> T newClient(Scheme scheme, Endpoint endpoint, Class<T> clientType, ClientOptionValue<?>... options);
+
+    /**
+     * Creates a new client that connects to the specified {@link Endpoint} with the {@link Scheme} using
+     * the default {@link ClientFactory}.
+     *
+     * @param scheme the {@link Scheme} for the {@code endpoint}
+     * @param endpoint the server {@link Endpoint}
+     * @param clientType the type of the new client
+     * @param options the {@link ClientOptions}
+     */
+    <T> T newClient(Scheme scheme, Endpoint endpoint, Class<T> clientType, ClientOptions options);
+
+    /**
      * Creates a new client that connects to the specified {@code uri}.
      *
      * @param uri the URI of the server endpoint

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactory.java
@@ -112,28 +112,6 @@ public interface ClientFactory extends AutoCloseable {
     void setMeterRegistry(MeterRegistry meterRegistry);
 
     /**
-     * Creates a new client that connects to the specified {@link Endpoint} with the {@link Scheme} using
-     * the default {@link ClientFactory}.
-     *
-     * @param scheme the {@link Scheme} for the {@code endpoint}
-     * @param endpoint the server {@link Endpoint}
-     * @param clientType the type of the new client
-     * @param options the {@link ClientOptionValue}s
-     */
-    <T> T newClient(Scheme scheme, Endpoint endpoint, Class<T> clientType, ClientOptionValue<?>... options);
-
-    /**
-     * Creates a new client that connects to the specified {@link Endpoint} with the {@link Scheme} using
-     * the default {@link ClientFactory}.
-     *
-     * @param scheme the {@link Scheme} for the {@code endpoint}
-     * @param endpoint the server {@link Endpoint}
-     * @param clientType the type of the new client
-     * @param options the {@link ClientOptions}
-     */
-    <T> T newClient(Scheme scheme, Endpoint endpoint, Class<T> clientType, ClientOptions options);
-
-    /**
      * Creates a new client that connects to the specified {@code uri}.
      *
      * @param uri the URI of the server endpoint
@@ -170,6 +148,53 @@ public interface ClientFactory extends AutoCloseable {
      * @param options the {@link ClientOptions}
      */
     <T> T newClient(URI uri, Class<T> clientType, ClientOptions options);
+
+    /**
+     * Creates a new client that connects to the specified {@link Endpoint} with the {@link Scheme} using
+     * the default {@link ClientFactory}.
+     *
+     * @param scheme the {@link Scheme} for the {@code endpoint}
+     * @param endpoint the server {@link Endpoint}
+     * @param clientType the type of the new client
+     * @param options the {@link ClientOptionValue}s
+     */
+    <T> T newClient(Scheme scheme, Endpoint endpoint, Class<T> clientType, ClientOptionValue<?>... options);
+
+    /**
+     * Creates a new client that connects to the specified {@link Endpoint} with the {@link Scheme} using
+     * the default {@link ClientFactory}.
+     *
+     * @param scheme the {@link Scheme} for the {@code endpoint}
+     * @param endpoint the server {@link Endpoint}
+     * @param clientType the type of the new client
+     * @param options the {@link ClientOptions}
+     */
+    <T> T newClient(Scheme scheme, Endpoint endpoint, Class<T> clientType, ClientOptions options);
+
+    /**
+     * Creates a new client that connects to the specified {@link Endpoint} with the {@link Scheme}
+     * and {@code path} using the default {@link ClientFactory}.
+     *
+     * @param scheme the {@link Scheme} for the {@code endpoint}
+     * @param endpoint the server {@link Endpoint}
+     * @param path the service {@code path}
+     * @param clientType the type of the new client
+     * @param options the {@link ClientOptionValue}s
+     */
+    <T> T newClient(Scheme scheme, Endpoint endpoint, String path, Class<T> clientType,
+                    ClientOptionValue<?>... options);
+
+    /**
+     * Creates a new client that connects to the specified {@link Endpoint} with the {@link Scheme}
+     * and {@code path} using the default {@link ClientFactory}.
+     *
+     * @param scheme the {@link Scheme} for the {@code endpoint}
+     * @param endpoint the server {@link Endpoint}
+     * @param path the service {@code path}
+     * @param clientType the type of the new client
+     * @param options the {@link ClientOptions}
+     */
+    <T> T newClient(Scheme scheme, Endpoint endpoint, String path, Class<T> clientType, ClientOptions options);
 
     /**
      * Returns the {@link ClientBuilderParams} held in {@code client}. This is used when creating a new derived

--- a/core/src/main/java/com/linecorp/armeria/client/Clients.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Clients.java
@@ -205,46 +205,6 @@ public final class Clients {
     }
 
     /**
-     * Creates a new client that connects to the specified {@link Endpoint} with the {@link SessionProtocol},
-     * {@link SerializationFormat}, and {@code path} using the default {@link ClientFactory}.
-     *
-     * @param protocol the session protocol
-     * @param format the {@link SerializationFormat} for remote procedure call
-     * @param endpoint the server {@link Endpoint}
-     * @param path the service {@code path}
-     * @param clientType the type of the new client
-     * @param options the {@link ClientOptionValue}s
-     *
-     * @throws IllegalArgumentException if the scheme of the specified {@link SessionProtocol} and
-     *                                  {@link SerializationFormat}, or the specified {@code clientType} is
-     *                                  unsupported for the scheme
-     */
-    public static <T> T newClient(SessionProtocol protocol, SerializationFormat format, Endpoint endpoint,
-                                  String path, Class<T> clientType, ClientOptionValue<?>... options) {
-        return newClient(ClientFactory.DEFAULT, protocol, format, endpoint, path, clientType, options);
-    }
-
-    /**
-     * Creates a new client that connects to the specified {@link Endpoint} with the {@link SessionProtocol},
-     * {@link SerializationFormat}, and {@code path} using the default {@link ClientFactory}.
-     *
-     * @param protocol the session protocol
-     * @param format the {@link SerializationFormat} for remote procedure call
-     * @param endpoint the server {@link Endpoint}
-     * @param path the service {@code path}
-     * @param clientType the type of the new client
-     * @param options the {@link ClientOptions}
-     *
-     * @throws IllegalArgumentException if the scheme of the specified {@link SessionProtocol} and
-     *                                  {@link SerializationFormat}, or the specified {@code clientType} is
-     *                                  unsupported for the scheme
-     */
-    public static <T> T newClient(SessionProtocol protocol, SerializationFormat format, Endpoint endpoint,
-                                  String path, Class<T> clientType, ClientOptions options) {
-        return newClient(ClientFactory.DEFAULT, protocol, format, endpoint, path, clientType, options);
-    }
-
-    /**
      * Creates a new client that connects to the specified {@link Endpoint} with the {@link SessionProtocol} and
      * the {@link SerializationFormat} using the specified {@link ClientFactory}.
      *
@@ -285,49 +245,6 @@ public final class Clients {
     }
 
     /**
-     * Creates a new client that connects to the specified {@link Endpoint} with the {@link SessionProtocol},
-     * {@link SerializationFormat}, and {@code path} using the specified {@link ClientFactory}.
-     *
-     * @param factory an alternative {@link ClientFactory}
-     * @param protocol the session protocol
-     * @param format the {@link SerializationFormat} for remote procedure call
-     * @param endpoint the server {@link Endpoint}
-     * @param path the service {@code path}
-     * @param clientType the type of the new client
-     * @param options the {@link ClientOptionValue}s
-     *
-     * @throws IllegalArgumentException if the scheme of the specified {@link SessionProtocol} and
-     *                                  {@link SerializationFormat}, or the specified {@code clientType} is
-     *                                  unsupported for the scheme
-     */
-    public static <T> T newClient(ClientFactory factory, SessionProtocol protocol, SerializationFormat format,
-                                  Endpoint endpoint, String path, Class<T> clientType,
-                                  ClientOptionValue<?>... options) {
-        return newClient(factory, Scheme.of(format, protocol), endpoint, path, clientType, options);
-    }
-
-    /**
-     * Creates a new client that connects to the specified {@link Endpoint} with the {@link SessionProtocol},
-     * {@link SerializationFormat}, and {@code path} using the specified {@link ClientFactory}.
-     *
-     * @param factory an alternative {@link ClientFactory}
-     * @param protocol the session protocol
-     * @param format the {@link SerializationFormat} for remote procedure call
-     * @param endpoint the server {@link Endpoint}
-     * @param path the service {@code path}
-     * @param clientType the type of the new client
-     * @param options the {@link ClientOptions}
-     *
-     * @throws IllegalArgumentException if the scheme of the specified {@link SessionProtocol} and
-     *                                  {@link SerializationFormat}, or the specified {@code clientType} is
-     *                                  unsupported for the scheme
-     */
-    public static <T> T newClient(ClientFactory factory, SessionProtocol protocol, SerializationFormat format,
-                                  Endpoint endpoint, String path, Class<T> clientType, ClientOptions options) {
-        return newClient(factory, Scheme.of(format, protocol), endpoint, path, clientType, options);
-    }
-
-    /**
      * Creates a new client that connects to the specified {@link Endpoint} with the {@link Scheme} using
      * the default {@link ClientFactory}.
      *
@@ -359,42 +276,6 @@ public final class Clients {
     public static <T> T newClient(Scheme scheme, Endpoint endpoint, Class<T> clientType,
                                   ClientOptions options) {
         return newClient(ClientFactory.DEFAULT, scheme, endpoint, clientType, options);
-    }
-
-    /**
-     * Creates a new client that connects to the specified {@link Endpoint} with the {@link Scheme}
-     * and {@code path} using the default {@link ClientFactory}.
-     *
-     * @param scheme the {@link Scheme}
-     * @param endpoint the server {@link Endpoint}
-     * @param path the service {@code path}
-     * @param clientType the type of the new client
-     * @param options the {@link ClientOptionValue}s
-     *
-     * @throws IllegalArgumentException if the specified {@link Scheme} or the specified {@code clientType} is
-     *                                  unsupported for the scheme
-     */
-    public static <T> T newClient(Scheme scheme, Endpoint endpoint, String path,
-                                  Class<T> clientType, ClientOptionValue<?>... options) {
-        return newClient(ClientFactory.DEFAULT, scheme, endpoint, path, clientType, options);
-    }
-
-    /**
-     * Creates a new client that connects to the specified {@link Endpoint} with the {@link Scheme}
-     * and {@code path} using the default {@link ClientFactory}.
-     *
-     * @param scheme the {@link Scheme}
-     * @param endpoint the server {@link Endpoint}
-     * @param path the service {@code path}
-     * @param clientType the type of the new client
-     * @param options the {@link ClientOptionValue}s
-     *
-     * @throws IllegalArgumentException if the specified {@link Scheme} or the specified {@code clientType} is
-     *                                  unsupported for the scheme
-     */
-    public static <T> T newClient(Scheme scheme, Endpoint endpoint, String path,
-                                  Class<T> clientType, ClientOptions options) {
-        return newClient(ClientFactory.DEFAULT, scheme, endpoint, path, clientType, options);
     }
 
     /**
@@ -431,44 +312,6 @@ public final class Clients {
     public static <T> T newClient(ClientFactory factory, Scheme scheme, Endpoint endpoint, Class<T> clientType,
                                   ClientOptions options) {
         return new ClientBuilder(scheme, endpoint).factory(factory).options(options).build(clientType);
-    }
-
-    /**
-     * Creates a new client that connects to the specified {@link Endpoint} with the {@link Scheme}
-     * and {@code path} using the specified {@link ClientFactory}.
-     *
-     * @param factory an alternative {@link ClientFactory}
-     * @param scheme the {@link Scheme}
-     * @param endpoint the server {@link Endpoint}
-     * @param path the service {@code path}
-     * @param clientType the type of the new client
-     * @param options the {@link ClientOptionValue}s
-     *
-     * @throws IllegalArgumentException if the specified {@link Scheme} or the specified {@code clientType} is
-     *                                  unsupported for the scheme
-     */
-    public static <T> T newClient(ClientFactory factory, Scheme scheme, Endpoint endpoint, String path,
-                                  Class<T> clientType, ClientOptionValue<?>... options) {
-        return new ClientBuilder(scheme, endpoint, path).factory(factory).options(options).build(clientType);
-    }
-
-    /**
-     * Creates a new client that connects to the specified {@link Endpoint} with the {@link Scheme}
-     * and {@code path} using the specified {@link ClientFactory}.
-     *
-     * @param factory an alternative {@link ClientFactory}
-     * @param scheme the {@link Scheme}
-     * @param endpoint the server {@link Endpoint}
-     * @param path the service {@code path}
-     * @param clientType the type of the new client
-     * @param options the {@link ClientOptions}
-     *
-     * @throws IllegalArgumentException if the specified {@link Scheme} or the specified {@code clientType} is
-     *                                  unsupported for the scheme
-     */
-    public static <T> T newClient(ClientFactory factory, Scheme scheme, Endpoint endpoint, String path,
-                                  Class<T> clientType, ClientOptions options) {
-        return new ClientBuilder(scheme, endpoint, path).factory(factory).options(options).build(clientType);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/Clients.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Clients.java
@@ -26,6 +26,9 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.Scheme;
+import com.linecorp.armeria.common.SerializationFormat;
+import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.util.SafeCloseable;
 
 /**
@@ -161,6 +164,154 @@ public final class Clients {
      */
     public static <T> T newClient(ClientFactory factory, URI uri, Class<T> clientType, ClientOptions options) {
         return new ClientBuilder(uri).factory(factory).options(options).build(clientType);
+    }
+
+    /**
+     * Creates a new client that connects to the specified {@link Endpoint} with the {@link SessionProtocol} and
+     * the {@link SerializationFormat} using the default {@link ClientFactory}.
+     *
+     * @param protocol the session protocol
+     * @param format the {@link SerializationFormat} for remote procedure call
+     * @param endpoint the server {@link Endpoint}
+     * @param clientType the type of the new client
+     * @param options the {@link ClientOptionValue}s
+     *
+     * @throws IllegalArgumentException if the scheme of the specified {@link SessionProtocol} and
+     *                                     {@link SerializationFormat}, or the specified {@code clientType} is
+     *                                     unsupported for the scheme
+     */
+    public static <T> T newClient(SessionProtocol protocol, SerializationFormat format, Endpoint endpoint,
+                                  Class<T> clientType, ClientOptionValue<?>... options) {
+        return newClient(ClientFactory.DEFAULT, protocol, format, endpoint, clientType, options);
+    }
+
+    /**
+     * Creates a new client that connects to the specified {@link Endpoint} with the {@link SessionProtocol} and
+     * the {@link SerializationFormat} using the default {@link ClientFactory}.
+     *
+     * @param protocol the session protocol
+     * @param format the {@link SerializationFormat} for remote procedure call
+     * @param endpoint the server {@link Endpoint}
+     * @param clientType the type of the new client
+     * @param options the {@link ClientOptions}
+     *
+     * @throws IllegalArgumentException if the scheme of the specified {@link SessionProtocol} and
+     *                                     {@link SerializationFormat}, or the specified {@code clientType} is
+     *                                     unsupported for the scheme
+     */
+    public static <T> T newClient(SessionProtocol protocol, SerializationFormat format, Endpoint endpoint,
+                                  Class<T> clientType, ClientOptions options) {
+        return newClient(ClientFactory.DEFAULT, protocol, format, endpoint, clientType, options);
+    }
+
+    /**
+     * Creates a new client that connects to the specified {@link Endpoint} with the {@link SessionProtocol} and
+     * the {@link SerializationFormat} using an alternative {@link ClientFactory}.
+     *
+     * @param factory an alternative {@link ClientFactory}
+     * @param protocol the session protocol
+     * @param format the {@link SerializationFormat} for remote procedure call
+     * @param endpoint the server {@link Endpoint}
+     * @param clientType the type of the new client
+     * @param options the {@link ClientOptionValue}s
+     *
+     * @throws IllegalArgumentException if the scheme of the specified {@link SessionProtocol} and
+     *                                     {@link SerializationFormat}, or the specified {@code clientType} is
+     *                                     unsupported for the scheme
+     */
+    public static <T> T newClient(ClientFactory factory, SessionProtocol protocol, SerializationFormat format,
+                                  Endpoint endpoint, Class<T> clientType, ClientOptionValue<?>... options) {
+        return newClient(factory, Scheme.of(format, protocol), endpoint, clientType, options);
+    }
+
+    /**
+     * Creates a new client that connects to the specified {@link Endpoint} with the {@link SessionProtocol} and
+     * the {@link SerializationFormat} using an alternative {@link ClientFactory}.
+     *
+     * @param factory an alternative {@link ClientFactory}
+     * @param protocol the session protocol
+     * @param format the {@link SerializationFormat} for remote procedure call
+     * @param endpoint the server {@link Endpoint}
+     * @param clientType the type of the new client
+     * @param options the {@link ClientOptions}
+     *
+     * @throws IllegalArgumentException if the scheme of the specified {@link SessionProtocol} and
+     *                                     {@link SerializationFormat}, or the specified {@code clientType} is
+     *                                     unsupported for the scheme
+     */
+    public static <T> T newClient(ClientFactory factory, SessionProtocol protocol, SerializationFormat format,
+                                  Endpoint endpoint, Class<T> clientType, ClientOptions options) {
+        return newClient(factory, Scheme.of(format, protocol), endpoint, clientType, options);
+    }
+
+    /**
+     * Creates a new client that connects to the specified {@link Endpoint} with the {@link Scheme} using
+     * the default {@link ClientFactory}.
+     *
+     * @param scheme the {@link Scheme}
+     * @param endpoint the server {@link Endpoint}
+     * @param clientType the type of the new client
+     * @param options the {@link ClientOptionValue}s
+     *
+     * @throws IllegalArgumentException if the specified {@link Scheme} or the specified {@code clientType} is
+     *                                     unsupported for the scheme
+     */
+    public static <T> T newClient(Scheme scheme, Endpoint endpoint, Class<T> clientType,
+                                  ClientOptionValue<?>... options) {
+        return newClient(ClientFactory.DEFAULT, scheme, endpoint, clientType, options);
+    }
+
+    /**
+     * Creates a new client that connects to the specified {@link Endpoint} with the {@link Scheme} using
+     * the default {@link ClientFactory}.
+     *
+     * @param scheme the {@link Scheme}
+     * @param endpoint the server {@link Endpoint}
+     * @param clientType the type of the new client
+     * @param options the {@link ClientOptions}
+     *
+     * @throws IllegalArgumentException if the specified {@link Scheme} or the specified {@code clientType} is
+     *                                     unsupported for the scheme
+     */
+    public static <T> T newClient(Scheme scheme, Endpoint endpoint, Class<T> clientType,
+                                  ClientOptions options) {
+        return newClient(ClientFactory.DEFAULT, scheme, endpoint, clientType, options);
+    }
+
+    /**
+     * Creates a new client that connects to the specified {@link Endpoint} with the {@link Scheme} using
+     * an alternative {@link ClientFactory}.
+     *
+     * @param factory an alternative {@link ClientFactory}
+     * @param scheme the {@link Scheme}
+     * @param endpoint the server {@link Endpoint}
+     * @param clientType the type of the new client
+     * @param options the {@link ClientOptionValue}s
+     *
+     * @throws IllegalArgumentException if the specified {@link Scheme} or the specified {@code clientType} is
+     *                                     unsupported for the scheme
+     */
+    public static <T> T newClient(ClientFactory factory, Scheme scheme, Endpoint endpoint, Class<T> clientType,
+                                  ClientOptionValue<?>... options) {
+        return new ClientBuilder(scheme, endpoint).factory(factory).options(options).build(clientType);
+    }
+
+    /**
+     * Creates a new client that connects to the specified {@link Endpoint} with the {@link Scheme} using
+     * an alternative {@link ClientFactory}.
+     *
+     * @param factory an alternative {@link ClientFactory}
+     * @param scheme the {@link Scheme}
+     * @param endpoint the server {@link Endpoint}
+     * @param clientType the type of the new client
+     * @param options the {@link ClientOptions}
+     *
+     * @throws IllegalArgumentException if the specified {@link Scheme} or the specified {@code clientType} is
+     *                                     unsupported for the scheme
+     */
+    public static <T> T newClient(ClientFactory factory, Scheme scheme, Endpoint endpoint, Class<T> clientType,
+                                  ClientOptions options) {
+        return new ClientBuilder(scheme, endpoint).factory(factory).options(options).build(clientType);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/Clients.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Clients.java
@@ -90,7 +90,7 @@ public final class Clients {
      * Creates a new client that connects to the specified {@code uri} using the specified
      * {@link ClientFactory}.
      *
-     * @param factory the specified {@link ClientFactory}
+     * @param factory an alternative {@link ClientFactory}
      * @param uri the URI of the server endpoint
      * @param clientType the type of the new client
      * @param options the {@link ClientOptions}
@@ -137,7 +137,7 @@ public final class Clients {
      * Creates a new client that connects to the specified {@link URI} using the specified
      * {@link ClientFactory}.
      *
-     * @param factory the specified {@link ClientFactory}
+     * @param factory an alternative {@link ClientFactory}
      * @param uri the URI of the server endpoint
      * @param clientType the type of the new client
      * @param options the {@link ClientOptionValue}s
@@ -154,7 +154,7 @@ public final class Clients {
      * Creates a new client that connects to the specified {@link URI} using the specified
      * {@link ClientFactory}.
      *
-     * @param factory the specified {@link ClientFactory}
+     * @param factory an alternative {@link ClientFactory}
      * @param uri the URI of the server endpoint
      * @param clientType the type of the new client
      * @param options the {@link ClientOptions}
@@ -208,7 +208,7 @@ public final class Clients {
      * Creates a new client that connects to the specified {@link Endpoint} with the {@link SessionProtocol} and
      * the {@link SerializationFormat} using the specified {@link ClientFactory}.
      *
-     * @param factory the specified {@link ClientFactory}
+     * @param factory an alternative {@link ClientFactory}
      * @param protocol the session protocol
      * @param format the {@link SerializationFormat} for remote procedure call
      * @param endpoint the server {@link Endpoint}
@@ -228,7 +228,7 @@ public final class Clients {
      * Creates a new client that connects to the specified {@link Endpoint} with the {@link SessionProtocol} and
      * the {@link SerializationFormat} using the specified {@link ClientFactory}.
      *
-     * @param factory the specified {@link ClientFactory}
+     * @param factory an alternative {@link ClientFactory}
      * @param protocol the session protocol
      * @param format the {@link SerializationFormat} for remote procedure call
      * @param endpoint the server {@link Endpoint}
@@ -282,7 +282,7 @@ public final class Clients {
      * Creates a new client that connects to the specified {@link Endpoint} with the {@link Scheme} using
      * the specified {@link ClientFactory}.
      *
-     * @param factory the specified {@link ClientFactory}
+     * @param factory an alternative {@link ClientFactory}
      * @param scheme the {@link Scheme}
      * @param endpoint the server {@link Endpoint}
      * @param clientType the type of the new client
@@ -300,7 +300,7 @@ public final class Clients {
      * Creates a new client that connects to the specified {@link Endpoint} with the {@link Scheme} using
      * the specified {@link ClientFactory}.
      *
-     * @param factory the specified {@link ClientFactory}
+     * @param factory an alternative {@link ClientFactory}
      * @param scheme the {@link Scheme}
      * @param endpoint the server {@link Endpoint}
      * @param clientType the type of the new client

--- a/core/src/main/java/com/linecorp/armeria/client/Clients.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Clients.java
@@ -205,6 +205,46 @@ public final class Clients {
     }
 
     /**
+     * Creates a new client that connects to the specified {@link Endpoint} with the {@link SessionProtocol},
+     * {@link SerializationFormat}, and {@code path} using the default {@link ClientFactory}.
+     *
+     * @param protocol the session protocol
+     * @param format the {@link SerializationFormat} for remote procedure call
+     * @param endpoint the server {@link Endpoint}
+     * @param path the service {@code path}
+     * @param clientType the type of the new client
+     * @param options the {@link ClientOptionValue}s
+     *
+     * @throws IllegalArgumentException if the scheme of the specified {@link SessionProtocol} and
+     *                                  {@link SerializationFormat}, or the specified {@code clientType} is
+     *                                  unsupported for the scheme
+     */
+    public static <T> T newClient(SessionProtocol protocol, SerializationFormat format, Endpoint endpoint,
+                                  String path, Class<T> clientType, ClientOptionValue<?>... options) {
+        return newClient(ClientFactory.DEFAULT, protocol, format, endpoint, path, clientType, options);
+    }
+
+    /**
+     * Creates a new client that connects to the specified {@link Endpoint} with the {@link SessionProtocol},
+     * {@link SerializationFormat}, and {@code path} using the default {@link ClientFactory}.
+     *
+     * @param protocol the session protocol
+     * @param format the {@link SerializationFormat} for remote procedure call
+     * @param endpoint the server {@link Endpoint}
+     * @param path the service {@code path}
+     * @param clientType the type of the new client
+     * @param options the {@link ClientOptions}
+     *
+     * @throws IllegalArgumentException if the scheme of the specified {@link SessionProtocol} and
+     *                                  {@link SerializationFormat}, or the specified {@code clientType} is
+     *                                  unsupported for the scheme
+     */
+    public static <T> T newClient(SessionProtocol protocol, SerializationFormat format, Endpoint endpoint,
+                                  String path, Class<T> clientType, ClientOptions options) {
+        return newClient(ClientFactory.DEFAULT, protocol, format, endpoint, path, clientType, options);
+    }
+
+    /**
      * Creates a new client that connects to the specified {@link Endpoint} with the {@link SessionProtocol} and
      * the {@link SerializationFormat} using the specified {@link ClientFactory}.
      *
@@ -245,6 +285,49 @@ public final class Clients {
     }
 
     /**
+     * Creates a new client that connects to the specified {@link Endpoint} with the {@link SessionProtocol},
+     * {@link SerializationFormat}, and {@code path} using the specified {@link ClientFactory}.
+     *
+     * @param factory an alternative {@link ClientFactory}
+     * @param protocol the session protocol
+     * @param format the {@link SerializationFormat} for remote procedure call
+     * @param endpoint the server {@link Endpoint}
+     * @param path the service {@code path}
+     * @param clientType the type of the new client
+     * @param options the {@link ClientOptionValue}s
+     *
+     * @throws IllegalArgumentException if the scheme of the specified {@link SessionProtocol} and
+     *                                  {@link SerializationFormat}, or the specified {@code clientType} is
+     *                                  unsupported for the scheme
+     */
+    public static <T> T newClient(ClientFactory factory, SessionProtocol protocol, SerializationFormat format,
+                                  Endpoint endpoint, String path, Class<T> clientType,
+                                  ClientOptionValue<?>... options) {
+        return newClient(factory, Scheme.of(format, protocol), endpoint, path, clientType, options);
+    }
+
+    /**
+     * Creates a new client that connects to the specified {@link Endpoint} with the {@link SessionProtocol},
+     * {@link SerializationFormat}, and {@code path} using the specified {@link ClientFactory}.
+     *
+     * @param factory an alternative {@link ClientFactory}
+     * @param protocol the session protocol
+     * @param format the {@link SerializationFormat} for remote procedure call
+     * @param endpoint the server {@link Endpoint}
+     * @param path the service {@code path}
+     * @param clientType the type of the new client
+     * @param options the {@link ClientOptions}
+     *
+     * @throws IllegalArgumentException if the scheme of the specified {@link SessionProtocol} and
+     *                                  {@link SerializationFormat}, or the specified {@code clientType} is
+     *                                  unsupported for the scheme
+     */
+    public static <T> T newClient(ClientFactory factory, SessionProtocol protocol, SerializationFormat format,
+                                  Endpoint endpoint, String path, Class<T> clientType, ClientOptions options) {
+        return newClient(factory, Scheme.of(format, protocol), endpoint, path, clientType, options);
+    }
+
+    /**
      * Creates a new client that connects to the specified {@link Endpoint} with the {@link Scheme} using
      * the default {@link ClientFactory}.
      *
@@ -276,6 +359,42 @@ public final class Clients {
     public static <T> T newClient(Scheme scheme, Endpoint endpoint, Class<T> clientType,
                                   ClientOptions options) {
         return newClient(ClientFactory.DEFAULT, scheme, endpoint, clientType, options);
+    }
+
+    /**
+     * Creates a new client that connects to the specified {@link Endpoint} with the {@link Scheme}
+     * and {@code path} using the default {@link ClientFactory}.
+     *
+     * @param scheme the {@link Scheme}
+     * @param endpoint the server {@link Endpoint}
+     * @param path the service {@code path}
+     * @param clientType the type of the new client
+     * @param options the {@link ClientOptionValue}s
+     *
+     * @throws IllegalArgumentException if the specified {@link Scheme} or the specified {@code clientType} is
+     *                                  unsupported for the scheme
+     */
+    public static <T> T newClient(Scheme scheme, Endpoint endpoint, String path,
+                                  Class<T> clientType, ClientOptionValue<?>... options) {
+        return newClient(ClientFactory.DEFAULT, scheme, endpoint, path, clientType, options);
+    }
+
+    /**
+     * Creates a new client that connects to the specified {@link Endpoint} with the {@link Scheme}
+     * and {@code path} using the default {@link ClientFactory}.
+     *
+     * @param scheme the {@link Scheme}
+     * @param endpoint the server {@link Endpoint}
+     * @param path the service {@code path}
+     * @param clientType the type of the new client
+     * @param options the {@link ClientOptionValue}s
+     *
+     * @throws IllegalArgumentException if the specified {@link Scheme} or the specified {@code clientType} is
+     *                                  unsupported for the scheme
+     */
+    public static <T> T newClient(Scheme scheme, Endpoint endpoint, String path,
+                                  Class<T> clientType, ClientOptions options) {
+        return newClient(ClientFactory.DEFAULT, scheme, endpoint, path, clientType, options);
     }
 
     /**
@@ -312,6 +431,44 @@ public final class Clients {
     public static <T> T newClient(ClientFactory factory, Scheme scheme, Endpoint endpoint, Class<T> clientType,
                                   ClientOptions options) {
         return new ClientBuilder(scheme, endpoint).factory(factory).options(options).build(clientType);
+    }
+
+    /**
+     * Creates a new client that connects to the specified {@link Endpoint} with the {@link Scheme}
+     * and {@code path} using the specified {@link ClientFactory}.
+     *
+     * @param factory an alternative {@link ClientFactory}
+     * @param scheme the {@link Scheme}
+     * @param endpoint the server {@link Endpoint}
+     * @param path the service {@code path}
+     * @param clientType the type of the new client
+     * @param options the {@link ClientOptionValue}s
+     *
+     * @throws IllegalArgumentException if the specified {@link Scheme} or the specified {@code clientType} is
+     *                                  unsupported for the scheme
+     */
+    public static <T> T newClient(ClientFactory factory, Scheme scheme, Endpoint endpoint, String path,
+                                  Class<T> clientType, ClientOptionValue<?>... options) {
+        return new ClientBuilder(scheme, endpoint, path).factory(factory).options(options).build(clientType);
+    }
+
+    /**
+     * Creates a new client that connects to the specified {@link Endpoint} with the {@link Scheme}
+     * and {@code path} using the specified {@link ClientFactory}.
+     *
+     * @param factory an alternative {@link ClientFactory}
+     * @param scheme the {@link Scheme}
+     * @param endpoint the server {@link Endpoint}
+     * @param path the service {@code path}
+     * @param clientType the type of the new client
+     * @param options the {@link ClientOptions}
+     *
+     * @throws IllegalArgumentException if the specified {@link Scheme} or the specified {@code clientType} is
+     *                                  unsupported for the scheme
+     */
+    public static <T> T newClient(ClientFactory factory, Scheme scheme, Endpoint endpoint, String path,
+                                  Class<T> clientType, ClientOptions options) {
+        return new ClientBuilder(scheme, endpoint, path).factory(factory).options(options).build(clientType);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/Clients.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Clients.java
@@ -69,10 +69,10 @@ public final class Clients {
     }
 
     /**
-     * Creates a new client that connects to the specified {@code uri} using an alternative
+     * Creates a new client that connects to the specified {@code uri} using the specified
      * {@link ClientFactory}.
      *
-     * @param factory an alternative {@link ClientFactory}
+     * @param factory the specified {@link ClientFactory}
      * @param uri the URI of the server endpoint
      * @param clientType the type of the new client
      * @param options the {@link ClientOptionValue}s
@@ -87,10 +87,10 @@ public final class Clients {
     }
 
     /**
-     * Creates a new client that connects to the specified {@code uri} using an alternative
+     * Creates a new client that connects to the specified {@code uri} using the specified
      * {@link ClientFactory}.
      *
-     * @param factory an alternative {@link ClientFactory}
+     * @param factory the specified {@link ClientFactory}
      * @param uri the URI of the server endpoint
      * @param clientType the type of the new client
      * @param options the {@link ClientOptions}
@@ -134,10 +134,10 @@ public final class Clients {
     }
 
     /**
-     * Creates a new client that connects to the specified {@link URI} using an alternative
+     * Creates a new client that connects to the specified {@link URI} using the specified
      * {@link ClientFactory}.
      *
-     * @param factory an alternative {@link ClientFactory}
+     * @param factory the specified {@link ClientFactory}
      * @param uri the URI of the server endpoint
      * @param clientType the type of the new client
      * @param options the {@link ClientOptionValue}s
@@ -151,10 +151,10 @@ public final class Clients {
     }
 
     /**
-     * Creates a new client that connects to the specified {@link URI} using an alternative
+     * Creates a new client that connects to the specified {@link URI} using the specified
      * {@link ClientFactory}.
      *
-     * @param factory an alternative {@link ClientFactory}
+     * @param factory the specified {@link ClientFactory}
      * @param uri the URI of the server endpoint
      * @param clientType the type of the new client
      * @param options the {@link ClientOptions}
@@ -206,9 +206,9 @@ public final class Clients {
 
     /**
      * Creates a new client that connects to the specified {@link Endpoint} with the {@link SessionProtocol} and
-     * the {@link SerializationFormat} using an alternative {@link ClientFactory}.
+     * the {@link SerializationFormat} using the specified {@link ClientFactory}.
      *
-     * @param factory an alternative {@link ClientFactory}
+     * @param factory the specified {@link ClientFactory}
      * @param protocol the session protocol
      * @param format the {@link SerializationFormat} for remote procedure call
      * @param endpoint the server {@link Endpoint}
@@ -226,9 +226,9 @@ public final class Clients {
 
     /**
      * Creates a new client that connects to the specified {@link Endpoint} with the {@link SessionProtocol} and
-     * the {@link SerializationFormat} using an alternative {@link ClientFactory}.
+     * the {@link SerializationFormat} using the specified {@link ClientFactory}.
      *
-     * @param factory an alternative {@link ClientFactory}
+     * @param factory the specified {@link ClientFactory}
      * @param protocol the session protocol
      * @param format the {@link SerializationFormat} for remote procedure call
      * @param endpoint the server {@link Endpoint}
@@ -280,9 +280,9 @@ public final class Clients {
 
     /**
      * Creates a new client that connects to the specified {@link Endpoint} with the {@link Scheme} using
-     * an alternative {@link ClientFactory}.
+     * the specified {@link ClientFactory}.
      *
-     * @param factory an alternative {@link ClientFactory}
+     * @param factory the specified {@link ClientFactory}
      * @param scheme the {@link Scheme}
      * @param endpoint the server {@link Endpoint}
      * @param clientType the type of the new client
@@ -298,9 +298,9 @@ public final class Clients {
 
     /**
      * Creates a new client that connects to the specified {@link Endpoint} with the {@link Scheme} using
-     * an alternative {@link ClientFactory}.
+     * the specified {@link ClientFactory}.
      *
-     * @param factory an alternative {@link ClientFactory}
+     * @param factory the specified {@link ClientFactory}
      * @param scheme the {@link Scheme}
      * @param endpoint the server {@link Endpoint}
      * @param clientType the type of the new client

--- a/core/src/main/java/com/linecorp/armeria/client/Clients.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Clients.java
@@ -47,7 +47,7 @@ public final class Clients {
      * @param options the {@link ClientOptionValue}s
      *
      * @throws IllegalArgumentException if the scheme of the specified {@code uri} or
-     *                                     the specified {@code clientType} is unsupported for the scheme
+     *                                  the specified {@code clientType} is unsupported for the scheme
      */
     public static <T> T newClient(String uri, Class<T> clientType, ClientOptionValue<?>... options) {
         return newClient(ClientFactory.DEFAULT, uri, clientType, options);
@@ -62,7 +62,7 @@ public final class Clients {
      * @param options the {@link ClientOptions}
      *
      * @throws IllegalArgumentException if the scheme of the specified {@code uri} or
-     *                                     the specified {@code clientType} is unsupported for the scheme
+     *                                  the specified {@code clientType} is unsupported for the scheme
      */
     public static <T> T newClient(String uri, Class<T> clientType, ClientOptions options) {
         return newClient(ClientFactory.DEFAULT, uri, clientType, options);
@@ -78,7 +78,7 @@ public final class Clients {
      * @param options the {@link ClientOptionValue}s
      *
      * @throws IllegalArgumentException if the scheme of the specified {@code uri} or
-     *                                     the specified {@code clientType} is unsupported for the scheme
+     *                                  the specified {@code clientType} is unsupported for the scheme
      */
     public static <T> T newClient(ClientFactory factory, String uri,
                                   Class<T> clientType, ClientOptionValue<?>... options) {
@@ -96,7 +96,7 @@ public final class Clients {
      * @param options the {@link ClientOptions}
      *
      * @throws IllegalArgumentException if the scheme of the specified {@code uri} or
-     *                                     the specified {@code clientType} is unsupported for the scheme
+     *                                  the specified {@code clientType} is unsupported for the scheme
      */
     public static <T> T newClient(ClientFactory factory, String uri,
                                   Class<T> clientType, ClientOptions options) {
@@ -112,7 +112,7 @@ public final class Clients {
      * @param options the {@link ClientOptionValue}s
      *
      * @throws IllegalArgumentException if the scheme of the specified {@code uri} or
-     *                                     the specified {@code clientType} is unsupported for the scheme
+     *                                  the specified {@code clientType} is unsupported for the scheme
      */
     public static <T> T newClient(URI uri, Class<T> clientType, ClientOptionValue<?>... options) {
         return newClient(ClientFactory.DEFAULT, uri, clientType, options);
@@ -127,7 +127,7 @@ public final class Clients {
      * @param options the {@link ClientOptions}
      *
      * @throws IllegalArgumentException if the scheme of the specified {@code uri} or
-     *                                     the specified {@code clientType} is unsupported for the scheme
+     *                                  the specified {@code clientType} is unsupported for the scheme
      */
     public static <T> T newClient(URI uri, Class<T> clientType, ClientOptions options) {
         return newClient(ClientFactory.DEFAULT, uri, clientType, options);
@@ -143,7 +143,7 @@ public final class Clients {
      * @param options the {@link ClientOptionValue}s
      *
      * @throws IllegalArgumentException if the scheme of the specified {@code uri} or
-     *                                     the specified {@code clientType} is unsupported for the scheme
+     *                                  the specified {@code clientType} is unsupported for the scheme
      */
     public static <T> T newClient(ClientFactory factory, URI uri, Class<T> clientType,
                                   ClientOptionValue<?>... options) {
@@ -160,7 +160,7 @@ public final class Clients {
      * @param options the {@link ClientOptions}
      *
      * @throws IllegalArgumentException if the scheme of the specified {@code uri} or
-     *                                     the specified {@code clientType} is unsupported for the scheme
+     *                                  the specified {@code clientType} is unsupported for the scheme
      */
     public static <T> T newClient(ClientFactory factory, URI uri, Class<T> clientType, ClientOptions options) {
         return new ClientBuilder(uri).factory(factory).options(options).build(clientType);
@@ -177,8 +177,8 @@ public final class Clients {
      * @param options the {@link ClientOptionValue}s
      *
      * @throws IllegalArgumentException if the scheme of the specified {@link SessionProtocol} and
-     *                                     {@link SerializationFormat}, or the specified {@code clientType} is
-     *                                     unsupported for the scheme
+     *                                  {@link SerializationFormat}, or the specified {@code clientType} is
+     *                                  unsupported for the scheme
      */
     public static <T> T newClient(SessionProtocol protocol, SerializationFormat format, Endpoint endpoint,
                                   Class<T> clientType, ClientOptionValue<?>... options) {
@@ -196,8 +196,8 @@ public final class Clients {
      * @param options the {@link ClientOptions}
      *
      * @throws IllegalArgumentException if the scheme of the specified {@link SessionProtocol} and
-     *                                     {@link SerializationFormat}, or the specified {@code clientType} is
-     *                                     unsupported for the scheme
+     *                                  {@link SerializationFormat}, or the specified {@code clientType} is
+     *                                  unsupported for the scheme
      */
     public static <T> T newClient(SessionProtocol protocol, SerializationFormat format, Endpoint endpoint,
                                   Class<T> clientType, ClientOptions options) {
@@ -216,8 +216,8 @@ public final class Clients {
      * @param options the {@link ClientOptionValue}s
      *
      * @throws IllegalArgumentException if the scheme of the specified {@link SessionProtocol} and
-     *                                     {@link SerializationFormat}, or the specified {@code clientType} is
-     *                                     unsupported for the scheme
+     *                                  {@link SerializationFormat}, or the specified {@code clientType} is
+     *                                  unsupported for the scheme
      */
     public static <T> T newClient(ClientFactory factory, SessionProtocol protocol, SerializationFormat format,
                                   Endpoint endpoint, Class<T> clientType, ClientOptionValue<?>... options) {
@@ -236,8 +236,8 @@ public final class Clients {
      * @param options the {@link ClientOptions}
      *
      * @throws IllegalArgumentException if the scheme of the specified {@link SessionProtocol} and
-     *                                     {@link SerializationFormat}, or the specified {@code clientType} is
-     *                                     unsupported for the scheme
+     *                                  {@link SerializationFormat}, or the specified {@code clientType} is
+     *                                  unsupported for the scheme
      */
     public static <T> T newClient(ClientFactory factory, SessionProtocol protocol, SerializationFormat format,
                                   Endpoint endpoint, Class<T> clientType, ClientOptions options) {
@@ -254,7 +254,7 @@ public final class Clients {
      * @param options the {@link ClientOptionValue}s
      *
      * @throws IllegalArgumentException if the specified {@link Scheme} or the specified {@code clientType} is
-     *                                     unsupported for the scheme
+     *                                  unsupported for the scheme
      */
     public static <T> T newClient(Scheme scheme, Endpoint endpoint, Class<T> clientType,
                                   ClientOptionValue<?>... options) {
@@ -271,7 +271,7 @@ public final class Clients {
      * @param options the {@link ClientOptions}
      *
      * @throws IllegalArgumentException if the specified {@link Scheme} or the specified {@code clientType} is
-     *                                     unsupported for the scheme
+     *                                  unsupported for the scheme
      */
     public static <T> T newClient(Scheme scheme, Endpoint endpoint, Class<T> clientType,
                                   ClientOptions options) {
@@ -289,7 +289,7 @@ public final class Clients {
      * @param options the {@link ClientOptionValue}s
      *
      * @throws IllegalArgumentException if the specified {@link Scheme} or the specified {@code clientType} is
-     *                                     unsupported for the scheme
+     *                                  unsupported for the scheme
      */
     public static <T> T newClient(ClientFactory factory, Scheme scheme, Endpoint endpoint, Class<T> clientType,
                                   ClientOptionValue<?>... options) {
@@ -307,7 +307,7 @@ public final class Clients {
      * @param options the {@link ClientOptions}
      *
      * @throws IllegalArgumentException if the specified {@link Scheme} or the specified {@code clientType} is
-     *                                     unsupported for the scheme
+     *                                  unsupported for the scheme
      */
     public static <T> T newClient(ClientFactory factory, Scheme scheme, Endpoint endpoint, Class<T> clientType,
                                   ClientOptions options) {

--- a/core/src/main/java/com/linecorp/armeria/client/Clients.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Clients.java
@@ -72,7 +72,7 @@ public final class Clients {
      * Creates a new client that connects to the specified {@code uri} using the specified
      * {@link ClientFactory}.
      *
-     * @param factory the specified {@link ClientFactory}
+     * @param factory an alternative {@link ClientFactory}
      * @param uri the URI of the server endpoint
      * @param clientType the type of the new client
      * @param options the {@link ClientOptionValue}s

--- a/core/src/main/java/com/linecorp/armeria/client/DecoratingClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DecoratingClientFactory.java
@@ -87,8 +87,9 @@ public class DecoratingClientFactory extends AbstractClientFactory {
     }
 
     @Override
-    public <T> T newClient(Scheme scheme, Endpoint endpoint, Class<T> clientType, ClientOptions options) {
-        return delegate().newClient(scheme, endpoint, clientType, options);
+    public <T> T newClient(Scheme scheme, Endpoint endpoint, String path, Class<T> clientType,
+                           ClientOptions options) {
+        return delegate().newClient(scheme, endpoint, path, clientType, options);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/DecoratingClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DecoratingClientFactory.java
@@ -23,6 +23,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 
+import javax.annotation.Nullable;
+
 import com.linecorp.armeria.common.Scheme;
 import com.linecorp.armeria.common.util.ReleasableHolder;
 
@@ -87,7 +89,7 @@ public class DecoratingClientFactory extends AbstractClientFactory {
     }
 
     @Override
-    public <T> T newClient(Scheme scheme, Endpoint endpoint, String path, Class<T> clientType,
+    public <T> T newClient(Scheme scheme, Endpoint endpoint, @Nullable String path, Class<T> clientType,
                            ClientOptions options) {
         return delegate().newClient(scheme, endpoint, path, clientType, options);
     }

--- a/core/src/main/java/com/linecorp/armeria/client/DecoratingClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DecoratingClientFactory.java
@@ -87,6 +87,11 @@ public class DecoratingClientFactory extends AbstractClientFactory {
     }
 
     @Override
+    public <T> T newClient(Scheme scheme, Endpoint endpoint, Class<T> clientType, ClientOptions options) {
+        return delegate().newClient(scheme, endpoint, clientType, options);
+    }
+
+    @Override
     public <T> Optional<ClientBuilderParams> clientBuilderParams(T client) {
         return delegate().clientBuilderParams(client);
     }

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientFactory.java
@@ -129,6 +129,12 @@ final class DefaultClientFactory extends AbstractClientFactory {
     }
 
     @Override
+    public <T> T newClient(Scheme scheme, Endpoint endpoint, Class<T> clientType, ClientOptions options) {
+        final Scheme validatedScheme = validateScheme(scheme);
+        return clientFactories.get(validatedScheme).newClient(validatedScheme, endpoint, clientType, options);
+    }
+
+    @Override
     public <T> Optional<ClientBuilderParams> clientBuilderParams(T client) {
         for (ClientFactory factory : clientFactories.values()) {
             final Optional<ClientBuilderParams> params = factory.clientBuilderParams(client);

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientFactory.java
@@ -25,6 +25,8 @@ import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.function.Supplier;
 
+import javax.annotation.Nullable;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -129,7 +131,7 @@ final class DefaultClientFactory extends AbstractClientFactory {
     }
 
     @Override
-    public <T> T newClient(Scheme scheme, Endpoint endpoint, String path, Class<T> clientType,
+    public <T> T newClient(Scheme scheme, Endpoint endpoint, @Nullable String path, Class<T> clientType,
                            ClientOptions options) {
         final Scheme validatedScheme = validateScheme(scheme);
         return clientFactories.get(validatedScheme)

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientFactory.java
@@ -129,9 +129,11 @@ final class DefaultClientFactory extends AbstractClientFactory {
     }
 
     @Override
-    public <T> T newClient(Scheme scheme, Endpoint endpoint, Class<T> clientType, ClientOptions options) {
+    public <T> T newClient(Scheme scheme, Endpoint endpoint, String path, Class<T> clientType,
+                           ClientOptions options) {
         final Scheme validatedScheme = validateScheme(scheme);
-        return clientFactories.get(validatedScheme).newClient(validatedScheme, endpoint, clientType, options);
+        return clientFactories.get(validatedScheme)
+                              .newClient(validatedScheme, endpoint, path, clientType, options);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
@@ -422,8 +422,16 @@ public final class Endpoint implements Comparable<Endpoint> {
 
         if (isGroup()) {
             authority = "group:" + groupName;
+        } else if (port != 0) {
+            if (hostType == HostType.IPv6_ONLY) {
+                authority = '[' + host() + "]:" + port;
+            } else {
+                authority = host() + ':' + port;
+            }
+        } else if (hostType == HostType.IPv6_ONLY) {
+            authority = '[' + host() + ']';
         } else {
-            authority = buildAuthority(host(), port);
+            authority = host();
         }
 
         return this.authority = authority;
@@ -467,30 +475,7 @@ public final class Endpoint implements Comparable<Endpoint> {
     public URI toUri(Scheme scheme) {
         requireNonNull(scheme, "scheme");
 
-        final String authority;
-        if (isGroup()) {
-            authority = "group:" + groupName;
-        } else {
-            authority = buildAuthority(hasIpAddr() ? ipAddr() : host(), port);
-        }
-
-        return URI.create(scheme.uriText() + "://" + authority);
-    }
-
-    private static String buildAuthority(String host, int port) {
-        if (port != 0) {
-            if (NetUtil.isValidIpV6Address(host)) {
-                return '[' + host + "]:" + port;
-            } else {
-                return host + ':' + port;
-            }
-        } else {
-            if (NetUtil.isValidIpV6Address(host)) {
-                return '[' + host + ']';
-            } else {
-                return host;
-            }
-        }
+        return URI.create(scheme.uriText() + "://" + authority());
     }
 
     private void ensureGroup() {

--- a/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
@@ -433,6 +433,32 @@ public final class Endpoint implements Comparable<Endpoint> {
         return this.authority = authority;
     }
 
+    /**
+     * Converts this endpoint into a URI string.
+     *
+     * @return the URI string
+     */
+    public String toURI() {
+        final String authority;
+
+        if (ipAddr == null) {
+            authority = authority();
+        } else if (port == 0) {
+            if (NetUtil.isValidIpV4Address(ipAddr)) {
+                authority = ipAddr;
+            } else {
+                authority = '[' + ipAddr + ']';
+            }
+        } else {
+            if (NetUtil.isValidIpV4Address(ipAddr)) {
+                authority = ipAddr + ':' + port;
+            } else {
+                authority = '[' + ipAddr + "]:" + port;
+            }
+        }
+        return "http://" + authority;
+    }
+
     private void ensureGroup() {
         if (!isGroup()) {
             throw new IllegalStateException("not a group endpoint");

--- a/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
@@ -21,6 +21,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.net.StandardProtocolFamily;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Comparator;
 import java.util.Objects;
 
@@ -507,7 +508,7 @@ public final class Endpoint implements Comparable<Endpoint> {
      */
     public URI toUri(Scheme scheme) {
         requireNonNull(scheme, "scheme");
-        return toUri(scheme, "");
+        return toUri(scheme, null);
     }
 
     /**
@@ -518,19 +519,13 @@ public final class Endpoint implements Comparable<Endpoint> {
      *
      * @return the URI
      */
-    public URI toUri(Scheme scheme, String path) {
+    public URI toUri(Scheme scheme, @Nullable String path) {
         requireNonNull(scheme, "scheme");
-        requireNonNull(path, "path");
-
-        if (path.isEmpty()) {
-            return URI.create(scheme.uriText() + "://" + authority());
+        try {
+            return new URI(scheme.uriText(), authority(), path, null, null);
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException(e.getMessage(), e);
         }
-
-        if (!path.startsWith("/")) {
-            path = '/' + path;
-        }
-
-        return URI.create(scheme.uriText() + "://" + authority() + path);
     }
 
     private void ensureGroup() {

--- a/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
@@ -438,7 +438,7 @@ public final class Endpoint implements Comparable<Endpoint> {
     }
 
     /**
-     * Converts this endpoint into a URI using the {@code scheme}.
+     * Converts this endpoint into an URI using the {@code scheme}.
      *
      * @param scheme the {@code scheme} for {@link URI}.
      *
@@ -451,7 +451,22 @@ public final class Endpoint implements Comparable<Endpoint> {
     }
 
     /**
-     * Converts this endpoint into a URI using the {@link SessionProtocol} and {@link SerializationFormat}.
+     * Converts this endpoint into an URI using the {@code scheme} and {@code path}.
+     *
+     * @param scheme the {@code scheme} for {@link URI}.
+     * @param path the {@code path} for {@link URI}.
+     *
+     * @return the URI
+     */
+    public URI toUri(String scheme, String path) {
+        requireNonNull(scheme, "scheme");
+        requireNonNull(path, "path");
+
+        return toUri(Scheme.parse(scheme), path);
+    }
+
+    /**
+     * Converts this endpoint into an URI using the {@link SessionProtocol} and {@link SerializationFormat}.
      *
      * @param sessionProtocol the {@link SessionProtocol} for {@link URI}.
      * @param serializationFormat the {@link SerializationFormat} for {@link URI}
@@ -466,7 +481,25 @@ public final class Endpoint implements Comparable<Endpoint> {
     }
 
     /**
-     * Converts this endpoint into a URI using the {@link Scheme}.
+     * Converts this endpoint into an URI using the {@link SessionProtocol}, {@link SerializationFormat}
+     * and {@code path}.
+     *
+     * @param sessionProtocol the {@link SessionProtocol} for {@link URI}.
+     * @param serializationFormat the {@link SerializationFormat} for {@link URI}
+     * @param path the {@code path} for {@link URI}.
+     *
+     * @return the URI
+     */
+    public URI toUri(SessionProtocol sessionProtocol, SerializationFormat serializationFormat, String path) {
+        requireNonNull(serializationFormat, "serializationFormat");
+        requireNonNull(sessionProtocol, "sessionProtocol");
+        requireNonNull(path, "path");
+
+        return toUri(Scheme.of(serializationFormat, sessionProtocol), path);
+    }
+
+    /**
+     * Converts this endpoint into an URI using the {@link Scheme}.
      *
      * @param scheme the {@link Scheme} for {@link URI}.
      *
@@ -474,8 +507,30 @@ public final class Endpoint implements Comparable<Endpoint> {
      */
     public URI toUri(Scheme scheme) {
         requireNonNull(scheme, "scheme");
+        return toUri(scheme, "");
+    }
 
-        return URI.create(scheme.uriText() + "://" + authority());
+    /**
+     * Converts this endpoint into an URI using the {@link Scheme} and the {@code path}.
+     *
+     * @param scheme the {@link Scheme} for {@link URI}.
+     * @param path the {@code path} for {@link URI}.
+     *
+     * @return the URI
+     */
+    public URI toUri(Scheme scheme, String path) {
+        requireNonNull(scheme, "scheme");
+        requireNonNull(path, "path");
+
+        if (path.isEmpty()) {
+            return URI.create(scheme.uriText() + "://" + authority());
+        }
+
+        if (!path.startsWith("/")) {
+            path = '/' + path;
+        }
+
+        return URI.create(scheme.uriText() + "://" + authority() + path);
     }
 
     private void ensureGroup() {

--- a/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
@@ -439,7 +439,7 @@ public final class Endpoint implements Comparable<Endpoint> {
     }
 
     /**
-     * Converts this endpoint into an URI using the {@code scheme}.
+     * Converts this endpoint into a URI using the {@code scheme}.
      *
      * @param scheme the {@code scheme} for {@link URI}.
      *
@@ -452,7 +452,7 @@ public final class Endpoint implements Comparable<Endpoint> {
     }
 
     /**
-     * Converts this endpoint into an URI using the {@code scheme} and {@code path}.
+     * Converts this endpoint into a URI using the {@code scheme} and {@code path}.
      *
      * @param scheme the {@code scheme} for {@link URI}.
      * @param path the {@code path} for {@link URI}.
@@ -467,7 +467,7 @@ public final class Endpoint implements Comparable<Endpoint> {
     }
 
     /**
-     * Converts this endpoint into an URI using the {@link SessionProtocol} and {@link SerializationFormat}.
+     * Converts this endpoint into a URI using the {@link SessionProtocol} and {@link SerializationFormat}.
      *
      * @param sessionProtocol the {@link SessionProtocol} for {@link URI}.
      * @param serializationFormat the {@link SerializationFormat} for {@link URI}
@@ -482,7 +482,7 @@ public final class Endpoint implements Comparable<Endpoint> {
     }
 
     /**
-     * Converts this endpoint into an URI using the {@link SessionProtocol}, {@link SerializationFormat}
+     * Converts this endpoint into a URI using the {@link SessionProtocol}, {@link SerializationFormat}
      * and {@code path}.
      *
      * @param sessionProtocol the {@link SessionProtocol} for {@link URI}.
@@ -500,7 +500,7 @@ public final class Endpoint implements Comparable<Endpoint> {
     }
 
     /**
-     * Converts this endpoint into an URI using the {@link Scheme}.
+     * Converts this endpoint into a URI using the {@link Scheme}.
      *
      * @param scheme the {@link Scheme} for {@link URI}.
      *
@@ -512,7 +512,7 @@ public final class Endpoint implements Comparable<Endpoint> {
     }
 
     /**
-     * Converts this endpoint into an URI using the {@link Scheme} and the {@code path}.
+     * Converts this endpoint into a URI using the {@link Scheme} and the {@code path}.
      *
      * @param scheme the {@link Scheme} for {@link URI}.
      * @param path the {@code path} for {@link URI}.

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClient.java
@@ -16,8 +16,6 @@
 
 package com.linecorp.armeria.client;
 
-import static java.util.Objects.requireNonNull;
-
 import java.net.URI;
 import java.nio.charset.Charset;
 
@@ -27,6 +25,9 @@ import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.common.Scheme;
+import com.linecorp.armeria.common.SerializationFormat;
+import com.linecorp.armeria.common.SessionProtocol;
 
 /**
  * An HTTP client.
@@ -142,58 +143,57 @@ public interface HttpClient extends ClientBuilderParams {
     }
 
     /**
-     * Creates a new HTTP client that connects to the specified {@link Endpoint} with {@code scheme}
+     * Creates a new HTTP client that connects to the specified {@link Endpoint} with {@link SessionProtocol}
      * using the default {@link ClientFactory}.
      *
-     * @param scheme a scheme of URI
+     * @param protocol the {@link SessionProtocol} of the {@link Endpoint}
      * @param endpoint the server {@link Endpoint}
      * @param options the {@link ClientOptionValue}s
      */
-    static HttpClient of(String scheme, Endpoint endpoint, ClientOptionValue<?>... options) {
-        requireNonNull(endpoint, "endpoint");
-        return of(ClientFactory.DEFAULT, endpoint.toURI(scheme), options);
+    static HttpClient of(SessionProtocol protocol, Endpoint endpoint, ClientOptionValue<?>... options) {
+        return of(ClientFactory.DEFAULT, protocol, endpoint, ClientOptions.of(options));
     }
 
     /**
-     * Creates a new HTTP client that connects to the specified {@link Endpoint} with {@code scheme}
+     * Creates a new HTTP client that connects to the specified {@link Endpoint} with {@link SessionProtocol}
      * using the default {@link ClientFactory}.
      *
-     * @param scheme a scheme of URI
+     * @param protocol the {@link SessionProtocol} of the {@link Endpoint}
      * @param endpoint the server {@link Endpoint}
      * @param options the {@link ClientOptions}
      */
-    static HttpClient of(String scheme, Endpoint endpoint, ClientOptions options) {
-        requireNonNull(endpoint, "endpoint");
-        return of(ClientFactory.DEFAULT, endpoint.toURI(scheme), options);
+    static HttpClient of(SessionProtocol protocol, Endpoint endpoint, ClientOptions options) {
+        return of(ClientFactory.DEFAULT, protocol, endpoint, options);
     }
 
     /**
-     * Creates a new HTTP client that connects to the specified {@link Endpoint} with {@code scheme}
+     * Creates a new HTTP client that connects to the specified {@link Endpoint} with {@link SessionProtocol}
      * using an alternative {@link ClientFactory}.
      *
      * @param factory an alternative {@link ClientFactory}
-     * @param scheme a scheme of URI
+     * @param protocol the {@link SessionProtocol} of the {@link Endpoint}
      * @param endpoint the server {@link Endpoint}
      * @param options the {@link ClientOptionValue}s
      */
-    static HttpClient of(ClientFactory factory, String scheme, Endpoint endpoint,
+    static HttpClient of(ClientFactory factory, SessionProtocol protocol, Endpoint endpoint,
                          ClientOptionValue<?>... options) {
-        requireNonNull(endpoint, "endpoint");
-        return of(factory, endpoint.toURI(scheme), options);
+        return new HttpClientBuilder(Scheme.of(SerializationFormat.NONE, protocol), endpoint)
+                .factory(factory).options(options).build();
     }
 
     /**
-     * Creates a new HTTP client that connects to the specified {@link Endpoint} with {@code scheme}
+     * Creates a new HTTP client that connects to the specified {@link Endpoint} with {@link SessionProtocol}
      * using an alternative {@link ClientFactory}.
      *
      * @param factory an alternative {@link ClientFactory}
-     * @param scheme a scheme of URI
+     * @param protocol the {@link SessionProtocol} of the {@link Endpoint}
      * @param endpoint the server {@link Endpoint}
      * @param options the {@link ClientOptions}
      */
-    static HttpClient of(ClientFactory factory, String scheme, Endpoint endpoint, ClientOptions options) {
-        requireNonNull(endpoint, "endpoint");
-        return of(factory, endpoint.toURI(scheme), options);
+    static HttpClient of(ClientFactory factory, SessionProtocol protocol, Endpoint endpoint,
+                         ClientOptions options) {
+        return new HttpClientBuilder(Scheme.of(SerializationFormat.NONE, protocol), endpoint)
+                .factory(factory).options(options).build();
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClient.java
@@ -140,6 +140,52 @@ public interface HttpClient extends ClientBuilderParams {
     }
 
     /**
+     * Creates a new HTTP client that connects to the specified {@link Endpoint} using the default
+     * {@link ClientFactory}.
+     *
+     * @param endpoint the URI of the server endpoint {@link Endpoint}
+     * @param options the {@link ClientOptionValue}s
+     */
+    static HttpClient of(Endpoint endpoint, ClientOptionValue<?>... options) {
+        return of(ClientFactory.DEFAULT, endpoint.toURI(), options);
+    }
+
+    /**
+     * Creates a new HTTP client that connects to the specified {@link Endpoint} using the default
+     * {@link ClientFactory}.
+     *
+     * @param endpoint the URI of the server endpoint {@link Endpoint}
+     * @param options the {@link ClientOptions}
+     */
+    static HttpClient of(Endpoint endpoint, ClientOptions options) {
+        return of(ClientFactory.DEFAULT, endpoint.toURI(), options);
+    }
+
+    /**
+     * Creates a new HTTP client that connects to the specified {@link Endpoint} using an alternative
+     * {@link ClientFactory}.
+     *
+     * @param factory an alternative {@link ClientFactory}
+     * @param endpoint the server endpoint {@link Endpoint}
+     * @param options the {@link ClientOptionValue}s
+     */
+    static HttpClient of(ClientFactory factory, Endpoint endpoint, ClientOptionValue<?>... options) {
+        return new HttpClientBuilder(endpoint.toURI()).factory(factory).options(options).build();
+    }
+
+    /**
+     * Creates a new HTTP client that connects to the specified {@link Endpoint} using an alternative
+     * {@link ClientFactory}.
+     *
+     * @param factory an alternative {@link ClientFactory}
+     * @param endpoint the server endpoint {@link Endpoint}
+     * @param options the {@link ClientOptions}
+     */
+    static HttpClient of(ClientFactory factory, Endpoint endpoint, ClientOptions options) {
+        return new HttpClientBuilder(endpoint.toURI()).factory(factory).options(options).build();
+    }
+
+    /**
      * Sends the specified HTTP request.
      */
     HttpResponse execute(HttpRequest req);

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClient.java
@@ -149,7 +149,7 @@ public interface HttpClient extends ClientBuilderParams {
      * @param options the {@link ClientOptionValue}s
      */
     static HttpClient of(SessionProtocol protocol, Endpoint endpoint, ClientOptionValue<?>... options) {
-        return of(ClientFactory.DEFAULT, protocol, endpoint, ClientOptions.of(options));
+        return of(ClientFactory.DEFAULT, protocol, endpoint, options);
     }
 
     /**
@@ -162,6 +162,33 @@ public interface HttpClient extends ClientBuilderParams {
      */
     static HttpClient of(SessionProtocol protocol, Endpoint endpoint, ClientOptions options) {
         return of(ClientFactory.DEFAULT, protocol, endpoint, options);
+    }
+
+    /**
+     * Creates a new HTTP client that connects to the specified {@link Endpoint} with
+     * the {@link SessionProtocol} and {@code path} using the default {@link ClientFactory}.
+     *
+     * @param protocol the {@link SessionProtocol} of the {@link Endpoint}
+     * @param endpoint the server {@link Endpoint}
+     * @param path the service {@code path}
+     * @param options the {@link ClientOptionValue}s
+     */
+    static HttpClient of(SessionProtocol protocol, Endpoint endpoint, String path,
+                         ClientOptionValue<?>... options) {
+        return of(ClientFactory.DEFAULT, protocol, endpoint, path, options);
+    }
+
+    /**
+     * Creates a new HTTP client that connects to the specified {@link Endpoint} with
+     * the {@link SessionProtocol} and {@code path} using the default {@link ClientFactory}.
+     *
+     * @param protocol the {@link SessionProtocol} of the {@link Endpoint}
+     * @param endpoint the server {@link Endpoint}
+     * @param path the service {@code path}
+     * @param options the {@link ClientOptionValue}s
+     */
+    static HttpClient of(SessionProtocol protocol, Endpoint endpoint, String path, ClientOptions options) {
+        return of(ClientFactory.DEFAULT, protocol, endpoint, path, options);
     }
 
     /**
@@ -190,6 +217,36 @@ public interface HttpClient extends ClientBuilderParams {
     static HttpClient of(ClientFactory factory, SessionProtocol protocol, Endpoint endpoint,
                          ClientOptions options) {
         return new HttpClientBuilder(protocol, endpoint).factory(factory).options(options).build();
+    }
+
+    /**
+     * Creates a new HTTP client that connects to the specified {@link Endpoint} with
+     * the {@link SessionProtocol} and {@code path} using an alternative {@link ClientFactory}.
+     *
+     * @param factory an alternative {@link ClientFactory}
+     * @param protocol the {@link SessionProtocol} of the {@link Endpoint}
+     * @param endpoint the server {@link Endpoint}
+     * @param path the service {@code path}
+     * @param options the {@link ClientOptionValue}s
+     */
+    static HttpClient of(ClientFactory factory, SessionProtocol protocol, Endpoint endpoint, String path,
+                         ClientOptionValue<?>... options) {
+        return new HttpClientBuilder(protocol, endpoint, path).factory(factory).options(options).build();
+    }
+
+    /**
+     * Creates a new HTTP client that connects to the specified {@link Endpoint} with
+     * the {@link SessionProtocol} and {@code path} using an alternative {@link ClientFactory}.
+     *
+     * @param factory an alternative {@link ClientFactory}
+     * @param protocol the {@link SessionProtocol} of the {@link Endpoint}
+     * @param endpoint the server {@link Endpoint}
+     * @param path the service {@code path}
+     * @param options the {@link ClientOptions}
+     */
+    static HttpClient of(ClientFactory factory, SessionProtocol protocol, Endpoint endpoint, String path,
+                         ClientOptions options) {
+        return new HttpClientBuilder(protocol, endpoint, path).factory(factory).options(options).build();
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClient.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.client;
 
+import static java.util.Objects.requireNonNull;
+
 import java.net.URI;
 import java.nio.charset.Charset;
 
@@ -140,49 +142,58 @@ public interface HttpClient extends ClientBuilderParams {
     }
 
     /**
-     * Creates a new HTTP client that connects to the specified {@link Endpoint} using the default
-     * {@link ClientFactory}.
+     * Creates a new HTTP client that connects to the specified {@link Endpoint} with {@code scheme}
+     * using the default {@link ClientFactory}.
      *
-     * @param endpoint the URI of the server endpoint {@link Endpoint}
+     * @param scheme a scheme of URI
+     * @param endpoint the server {@link Endpoint}
      * @param options the {@link ClientOptionValue}s
      */
-    static HttpClient of(Endpoint endpoint, ClientOptionValue<?>... options) {
-        return of(ClientFactory.DEFAULT, endpoint.toURI(), options);
+    static HttpClient of(String scheme, Endpoint endpoint, ClientOptionValue<?>... options) {
+        requireNonNull(endpoint, "endpoint");
+        return of(ClientFactory.DEFAULT, endpoint.toURI(scheme), options);
     }
 
     /**
-     * Creates a new HTTP client that connects to the specified {@link Endpoint} using the default
-     * {@link ClientFactory}.
+     * Creates a new HTTP client that connects to the specified {@link Endpoint} with {@code scheme}
+     * using the default {@link ClientFactory}.
      *
-     * @param endpoint the URI of the server endpoint {@link Endpoint}
+     * @param scheme a scheme of URI
+     * @param endpoint the server {@link Endpoint}
      * @param options the {@link ClientOptions}
      */
-    static HttpClient of(Endpoint endpoint, ClientOptions options) {
-        return of(ClientFactory.DEFAULT, endpoint.toURI(), options);
+    static HttpClient of(String scheme, Endpoint endpoint, ClientOptions options) {
+        requireNonNull(endpoint, "endpoint");
+        return of(ClientFactory.DEFAULT, endpoint.toURI(scheme), options);
     }
 
     /**
-     * Creates a new HTTP client that connects to the specified {@link Endpoint} using an alternative
-     * {@link ClientFactory}.
+     * Creates a new HTTP client that connects to the specified {@link Endpoint} with {@code scheme}
+     * using an alternative {@link ClientFactory}.
      *
      * @param factory an alternative {@link ClientFactory}
-     * @param endpoint the server endpoint {@link Endpoint}
+     * @param scheme a scheme of URI
+     * @param endpoint the server {@link Endpoint}
      * @param options the {@link ClientOptionValue}s
      */
-    static HttpClient of(ClientFactory factory, Endpoint endpoint, ClientOptionValue<?>... options) {
-        return new HttpClientBuilder(endpoint.toURI()).factory(factory).options(options).build();
+    static HttpClient of(ClientFactory factory, String scheme, Endpoint endpoint,
+                         ClientOptionValue<?>... options) {
+        requireNonNull(endpoint, "endpoint");
+        return new HttpClientBuilder(endpoint.toURI(scheme)).factory(factory).options(options).build();
     }
 
     /**
-     * Creates a new HTTP client that connects to the specified {@link Endpoint} using an alternative
-     * {@link ClientFactory}.
+     * Creates a new HTTP client that connects to the specified {@link Endpoint} with {@code scheme}
+     * using an alternative {@link ClientFactory}.
      *
      * @param factory an alternative {@link ClientFactory}
-     * @param endpoint the server endpoint {@link Endpoint}
+     * @param scheme a scheme of URI
+     * @param endpoint the server {@link Endpoint}
      * @param options the {@link ClientOptions}
      */
-    static HttpClient of(ClientFactory factory, Endpoint endpoint, ClientOptions options) {
-        return new HttpClientBuilder(endpoint.toURI()).factory(factory).options(options).build();
+    static HttpClient of(ClientFactory factory, String scheme, Endpoint endpoint, ClientOptions options) {
+        requireNonNull(endpoint, "endpoint");
+        return new HttpClientBuilder(endpoint.toURI(scheme)).factory(factory).options(options).build();
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClient.java
@@ -25,8 +25,6 @@ import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.RequestHeaders;
-import com.linecorp.armeria.common.Scheme;
-import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.SessionProtocol;
 
 /**
@@ -177,8 +175,7 @@ public interface HttpClient extends ClientBuilderParams {
      */
     static HttpClient of(ClientFactory factory, SessionProtocol protocol, Endpoint endpoint,
                          ClientOptionValue<?>... options) {
-        return new HttpClientBuilder(Scheme.of(SerializationFormat.NONE, protocol), endpoint)
-                .factory(factory).options(options).build();
+        return new HttpClientBuilder(protocol, endpoint).factory(factory).options(options).build();
     }
 
     /**
@@ -192,8 +189,7 @@ public interface HttpClient extends ClientBuilderParams {
      */
     static HttpClient of(ClientFactory factory, SessionProtocol protocol, Endpoint endpoint,
                          ClientOptions options) {
-        return new HttpClientBuilder(Scheme.of(SerializationFormat.NONE, protocol), endpoint)
-                .factory(factory).options(options).build();
+        return new HttpClientBuilder(protocol, endpoint).factory(factory).options(options).build();
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClient.java
@@ -166,33 +166,6 @@ public interface HttpClient extends ClientBuilderParams {
 
     /**
      * Creates a new HTTP client that connects to the specified {@link Endpoint} with
-     * the {@link SessionProtocol} and {@code path} using the default {@link ClientFactory}.
-     *
-     * @param protocol the {@link SessionProtocol} of the {@link Endpoint}
-     * @param endpoint the server {@link Endpoint}
-     * @param path the service {@code path}
-     * @param options the {@link ClientOptionValue}s
-     */
-    static HttpClient of(SessionProtocol protocol, Endpoint endpoint, String path,
-                         ClientOptionValue<?>... options) {
-        return of(ClientFactory.DEFAULT, protocol, endpoint, path, options);
-    }
-
-    /**
-     * Creates a new HTTP client that connects to the specified {@link Endpoint} with
-     * the {@link SessionProtocol} and {@code path} using the default {@link ClientFactory}.
-     *
-     * @param protocol the {@link SessionProtocol} of the {@link Endpoint}
-     * @param endpoint the server {@link Endpoint}
-     * @param path the service {@code path}
-     * @param options the {@link ClientOptionValue}s
-     */
-    static HttpClient of(SessionProtocol protocol, Endpoint endpoint, String path, ClientOptions options) {
-        return of(ClientFactory.DEFAULT, protocol, endpoint, path, options);
-    }
-
-    /**
-     * Creates a new HTTP client that connects to the specified {@link Endpoint} with
      * the {@link SessionProtocol} using an alternative {@link ClientFactory}.
      *
      * @param factory an alternative {@link ClientFactory}
@@ -217,36 +190,6 @@ public interface HttpClient extends ClientBuilderParams {
     static HttpClient of(ClientFactory factory, SessionProtocol protocol, Endpoint endpoint,
                          ClientOptions options) {
         return new HttpClientBuilder(protocol, endpoint).factory(factory).options(options).build();
-    }
-
-    /**
-     * Creates a new HTTP client that connects to the specified {@link Endpoint} with
-     * the {@link SessionProtocol} and {@code path} using an alternative {@link ClientFactory}.
-     *
-     * @param factory an alternative {@link ClientFactory}
-     * @param protocol the {@link SessionProtocol} of the {@link Endpoint}
-     * @param endpoint the server {@link Endpoint}
-     * @param path the service {@code path}
-     * @param options the {@link ClientOptionValue}s
-     */
-    static HttpClient of(ClientFactory factory, SessionProtocol protocol, Endpoint endpoint, String path,
-                         ClientOptionValue<?>... options) {
-        return new HttpClientBuilder(protocol, endpoint, path).factory(factory).options(options).build();
-    }
-
-    /**
-     * Creates a new HTTP client that connects to the specified {@link Endpoint} with
-     * the {@link SessionProtocol} and {@code path} using an alternative {@link ClientFactory}.
-     *
-     * @param factory an alternative {@link ClientFactory}
-     * @param protocol the {@link SessionProtocol} of the {@link Endpoint}
-     * @param endpoint the server {@link Endpoint}
-     * @param path the service {@code path}
-     * @param options the {@link ClientOptions}
-     */
-    static HttpClient of(ClientFactory factory, SessionProtocol protocol, Endpoint endpoint, String path,
-                         ClientOptions options) {
-        return new HttpClientBuilder(protocol, endpoint, path).factory(factory).options(options).build();
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClient.java
@@ -179,7 +179,7 @@ public interface HttpClient extends ClientBuilderParams {
     static HttpClient of(ClientFactory factory, String scheme, Endpoint endpoint,
                          ClientOptionValue<?>... options) {
         requireNonNull(endpoint, "endpoint");
-        return new HttpClientBuilder(endpoint.toURI(scheme)).factory(factory).options(options).build();
+        return of(factory, endpoint.toURI(scheme), options);
     }
 
     /**
@@ -193,7 +193,7 @@ public interface HttpClient extends ClientBuilderParams {
      */
     static HttpClient of(ClientFactory factory, String scheme, Endpoint endpoint, ClientOptions options) {
         requireNonNull(endpoint, "endpoint");
-        return new HttpClientBuilder(endpoint.toURI(scheme)).factory(factory).options(options).build();
+        return of(factory, endpoint.toURI(scheme), options);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClient.java
@@ -141,8 +141,8 @@ public interface HttpClient extends ClientBuilderParams {
     }
 
     /**
-     * Creates a new HTTP client that connects to the specified {@link Endpoint} with {@link SessionProtocol}
-     * using the default {@link ClientFactory}.
+     * Creates a new HTTP client that connects to the specified {@link Endpoint} with
+     * the {@link SessionProtocol} using the default {@link ClientFactory}.
      *
      * @param protocol the {@link SessionProtocol} of the {@link Endpoint}
      * @param endpoint the server {@link Endpoint}
@@ -153,8 +153,8 @@ public interface HttpClient extends ClientBuilderParams {
     }
 
     /**
-     * Creates a new HTTP client that connects to the specified {@link Endpoint} with {@link SessionProtocol}
-     * using the default {@link ClientFactory}.
+     * Creates a new HTTP client that connects to the specified {@link Endpoint} with
+     * the {@link SessionProtocol} using the default {@link ClientFactory}.
      *
      * @param protocol the {@link SessionProtocol} of the {@link Endpoint}
      * @param endpoint the server {@link Endpoint}
@@ -165,8 +165,8 @@ public interface HttpClient extends ClientBuilderParams {
     }
 
     /**
-     * Creates a new HTTP client that connects to the specified {@link Endpoint} with {@link SessionProtocol}
-     * using an alternative {@link ClientFactory}.
+     * Creates a new HTTP client that connects to the specified {@link Endpoint} with
+     * the {@link SessionProtocol} using an alternative {@link ClientFactory}.
      *
      * @param factory an alternative {@link ClientFactory}
      * @param protocol the {@link SessionProtocol} of the {@link Endpoint}
@@ -179,8 +179,8 @@ public interface HttpClient extends ClientBuilderParams {
     }
 
     /**
-     * Creates a new HTTP client that connects to the specified {@link Endpoint} with {@link SessionProtocol}
-     * using an alternative {@link ClientFactory}.
+     * Creates a new HTTP client that connects to the specified {@link Endpoint} with
+     * the {@link SessionProtocol} using an alternative {@link ClientFactory}.
      *
      * @param factory an alternative {@link ClientFactory}
      * @param protocol the {@link SessionProtocol} of the {@link Endpoint}

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientBuilder.java
@@ -48,6 +48,16 @@ public final class HttpClientBuilder extends AbstractClientOptionsBuilder<HttpCl
     /**
      * Creates a new instance.
      *
+     * @throws IllegalArgumentException if the {@code scheme} is not one of the fields
+     *                                  in {@link SessionProtocol}
+     */
+    public HttpClientBuilder(String scheme, Endpoint endpoint) {
+        this(requireNonNull(endpoint).toURI(scheme));
+    }
+
+    /**
+     * Creates a new instance.
+     *
      * @throws IllegalArgumentException if the scheme of the uri is not one of the fields
      *                                  in {@link SessionProtocol}
      */

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientBuilder.java
@@ -41,6 +41,8 @@ public final class HttpClientBuilder extends AbstractClientOptionsBuilder<HttpCl
     private final Scheme scheme;
     @Nullable
     private final Endpoint endpoint;
+    @Nullable
+    private final String path;
     private ClientFactory factory = ClientFactory.DEFAULT;
 
     /**
@@ -64,6 +66,7 @@ public final class HttpClientBuilder extends AbstractClientOptionsBuilder<HttpCl
         this.uri = URI.create(SerializationFormat.NONE + "+" + uri);
         scheme = null;
         endpoint = null;
+        path = null;
     }
 
     /**
@@ -73,6 +76,16 @@ public final class HttpClientBuilder extends AbstractClientOptionsBuilder<HttpCl
      *                                  in {@link SessionProtocol}
      */
     public HttpClientBuilder(SessionProtocol sessionProtocol, Endpoint endpoint) {
+        this(sessionProtocol, endpoint, "");
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @throws IllegalArgumentException if the {@code sessionProtocol} is not one of the fields
+     *                                  in {@link SessionProtocol}
+     */
+    public HttpClientBuilder(SessionProtocol sessionProtocol, Endpoint endpoint, String path) {
         final Scheme scheme = Scheme.of(SerializationFormat.NONE, sessionProtocol);
         if (scheme == null) {
             throw new IllegalArgumentException("scheme: " + SerializationFormat.NONE.uriText() + '+' +
@@ -82,6 +95,7 @@ public final class HttpClientBuilder extends AbstractClientOptionsBuilder<HttpCl
         uri = null;
         this.scheme = scheme;
         this.endpoint = requireNonNull(endpoint, "endpoint");
+        this.path = path;
     }
 
     private static void validateScheme(String scheme) {
@@ -113,7 +127,7 @@ public final class HttpClientBuilder extends AbstractClientOptionsBuilder<HttpCl
         if (uri != null) {
             return factory.newClient(uri, HttpClient.class, buildOptions());
         } else {
-            return factory.newClient(scheme, endpoint, HttpClient.class, buildOptions());
+            return factory.newClient(scheme, endpoint, path, HttpClient.class, buildOptions());
         }
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientBuilder.java
@@ -36,11 +36,11 @@ import com.linecorp.armeria.common.SessionProtocol;
 public final class HttpClientBuilder extends AbstractClientOptionsBuilder<HttpClientBuilder> {
 
     @Nullable
-    private URI uri;
+    private final URI uri;
     @Nullable
-    private Scheme scheme;
+    private final Scheme scheme;
     @Nullable
-    private Endpoint endpoint;
+    private final Endpoint endpoint;
     private ClientFactory factory = ClientFactory.DEFAULT;
 
     /**
@@ -62,16 +62,25 @@ public final class HttpClientBuilder extends AbstractClientOptionsBuilder<HttpCl
     public HttpClientBuilder(URI uri) {
         validateScheme(requireNonNull(uri, "uri").getScheme());
         this.uri = URI.create(SerializationFormat.NONE + "+" + uri);
+        scheme = null;
+        endpoint = null;
     }
 
     /**
      * Creates a new instance.
      *
-     * @throws IllegalArgumentException if the {@link Scheme} is not one of the fields
+     * @throws IllegalArgumentException if the {@code sessionProtocol} is not one of the fields
      *                                  in {@link SessionProtocol}
      */
-    public HttpClientBuilder(Scheme scheme, Endpoint endpoint) {
-        this.scheme = requireNonNull(scheme, "scheme");
+    public HttpClientBuilder(SessionProtocol sessionProtocol, Endpoint endpoint) {
+        final Scheme scheme = Scheme.of(SerializationFormat.NONE, sessionProtocol);
+        if (scheme == null) {
+            throw new IllegalArgumentException("scheme: " + SerializationFormat.NONE.uriText() + '+' +
+                                               sessionProtocol.uriText() + " is unsupported");
+        }
+
+        uri = null;
+        this.scheme = scheme;
         this.endpoint = requireNonNull(endpoint, "endpoint");
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientBuilder.java
@@ -76,7 +76,7 @@ public final class HttpClientBuilder extends AbstractClientOptionsBuilder<HttpCl
      *                                  in {@link SessionProtocol}
      */
     public HttpClientBuilder(SessionProtocol sessionProtocol, Endpoint endpoint) {
-        validateScheme(requireNonNull(sessionProtocol).uriText());
+        validateScheme(requireNonNull(sessionProtocol, "sessionProtocol").uriText());
 
         uri = null;
         scheme = Scheme.of(SerializationFormat.NONE, sessionProtocol);

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientFactory.java
@@ -31,6 +31,8 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import javax.annotation.Nullable;
+
 import com.google.common.collect.MapMaker;
 
 import com.linecorp.armeria.common.HttpRequest;
@@ -228,7 +230,7 @@ final class HttpClientFactory extends AbstractClientFactory {
     }
 
     @Override
-    public <T> T newClient(Scheme scheme, Endpoint endpoint, String path, Class<T> clientType,
+    public <T> T newClient(Scheme scheme, Endpoint endpoint, @Nullable String path, Class<T> clientType,
                            ClientOptions options) {
         final URI uri = endpoint.toUri(scheme, path);
         return newClient(uri, scheme, endpoint, clientType, options);

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientFactory.java
@@ -220,17 +220,17 @@ final class HttpClientFactory extends AbstractClientFactory {
     }
 
     @Override
-    public <T> T newClient(Scheme scheme, Endpoint endpoint, Class<T> clientType, ClientOptions options) {
-        final URI uri = endpoint.toUri(scheme);
+    public <T> T newClient(URI uri, Class<T> clientType, ClientOptions options) {
+        final Scheme scheme = validateScheme(uri);
+        final Endpoint endpoint = newEndpoint(uri);
 
         return newClient(uri, scheme, endpoint, clientType, options);
     }
 
     @Override
-    public <T> T newClient(URI uri, Class<T> clientType, ClientOptions options) {
-        final Scheme scheme = validateScheme(uri);
-        final Endpoint endpoint = newEndpoint(uri);
-
+    public <T> T newClient(Scheme scheme, Endpoint endpoint, String path, Class<T> clientType,
+                           ClientOptions options) {
+        final URI uri = endpoint.toUri(scheme, path);
         return newClient(uri, scheme, endpoint, clientType, options);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientFactory.java
@@ -220,9 +220,22 @@ final class HttpClientFactory extends AbstractClientFactory {
     }
 
     @Override
+    public <T> T newClient(Scheme scheme, Endpoint endpoint, Class<T> clientType, ClientOptions options) {
+        final URI uri = endpoint.toUri(scheme);
+
+        return newClient(uri, scheme, endpoint, clientType, options);
+    }
+
+    @Override
     public <T> T newClient(URI uri, Class<T> clientType, ClientOptions options) {
         final Scheme scheme = validateScheme(uri);
+        final Endpoint endpoint = newEndpoint(uri);
 
+        return newClient(uri, scheme, endpoint, clientType, options);
+    }
+
+    private <T> T newClient(URI uri, Scheme scheme, Endpoint endpoint, Class<T> clientType,
+                            ClientOptions options) {
         validateClientType(clientType);
 
         final Client<HttpRequest, HttpResponse> delegate = options.decoration().decorate(
@@ -233,8 +246,6 @@ final class HttpClientFactory extends AbstractClientFactory {
             final T castClient = (T) delegate;
             return castClient;
         }
-
-        final Endpoint endpoint = newEndpoint(uri);
 
         if (clientType == HttpClient.class) {
             final HttpClient client = newHttpClient(uri, scheme, endpoint, options, delegate);

--- a/core/src/test/java/com/linecorp/armeria/client/EndpointTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/EndpointTest.java
@@ -122,21 +122,21 @@ public class EndpointTest {
         assertThat(foo.ipAddr()).isEqualTo("192.168.0.1");
         assertThat(foo.ipFamily()).isEqualTo(StandardProtocolFamily.INET);
         assertThat(foo.hasIpAddr()).isTrue();
-        assertThat(foo.toUri("none+http").toString()).isEqualTo("none+http://192.168.0.1");
+        assertThat(foo.toUri("none+http").toString()).isEqualTo("none+http://foo.com");
         assertThat(foo.withIpAddr(null).ipAddr()).isNull();
         assertThat(foo.withIpAddr(null).toUri("none+http").toString()).isEqualTo("none+http://foo.com");
         assertThat(foo.withIpAddr("::1").authority()).isEqualTo("foo.com");
         assertThat(foo.withIpAddr("::1").ipAddr()).isEqualTo("::1");
         assertThat(foo.withIpAddr("::1").ipFamily()).isEqualTo(StandardProtocolFamily.INET6);
         assertThat(foo.withIpAddr("::1").hasIpAddr()).isTrue();
-        assertThat(foo.withIpAddr("::1").toUri("none+http").toString()).isEqualTo("none+http://[::1]");
+        assertThat(foo.withIpAddr("::1").toUri("none+http").toString()).isEqualTo("none+http://foo.com");
         assertThat(foo.withIpAddr("192.168.0.1")).isSameAs(foo);
         assertThat(foo.withIpAddr("192.168.0.2").authority()).isEqualTo("foo.com");
         assertThat(foo.withIpAddr("192.168.0.2").ipAddr()).isEqualTo("192.168.0.2");
         assertThat(foo.withIpAddr("192.168.0.2").ipFamily()).isEqualTo(StandardProtocolFamily.INET);
         assertThat(foo.withIpAddr("192.168.0.2").hasIpAddr()).isTrue();
         assertThat(foo.withIpAddr("192.168.0.2").toUri("none+http").toString())
-                .isEqualTo("none+http://192.168.0.2");
+                .isEqualTo("none+http://foo.com");
 
         assertThatThrownBy(() -> foo.withIpAddr("no-ip")).isInstanceOf(IllegalArgumentException.class);
     }
@@ -222,7 +222,7 @@ public class EndpointTest {
         assertThat(e.host()).isEqualTo("foo");
         assertThat(e.ipAddr()).isEqualTo("::1");
         assertThat(e.ipFamily()).isEqualTo(StandardProtocolFamily.INET6);
-        assertThat(e.toUri("none+http").toString()).isEqualTo("none+http://[::1]");
+        assertThat(e.toUri("none+http").toString()).isEqualTo("none+http://foo");
     }
 
     @Test
@@ -271,11 +271,11 @@ public class EndpointTest {
 
         final Endpoint ipv6WithHostName = Endpoint.of("google.com").withIpAddr("[::1]");
         assertThat(ipv6WithHostName.toUri("none+h2").toString())
-                .isEqualTo("none+h2://[::1]");
+                .isEqualTo("none+h2://google.com");
         assertThat(ipv6WithHostName.toUri(SessionProtocol.H2, SerializationFormat.NONE).toString())
-                .isEqualTo("none+h2://[::1]");
+                .isEqualTo("none+h2://google.com");
         assertThat(ipv6WithHostName.withDefaultPort(80).toUri("none+h2").toString())
-                .isEqualTo("none+h2://[::1]:80");
+                .isEqualTo("none+h2://google.com:80");
 
         assertThatThrownBy(() -> group.toUri("http://www.badguys.com"))
                 .isInstanceOf(IllegalArgumentException.class);

--- a/core/src/test/java/com/linecorp/armeria/client/EndpointTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/EndpointTest.java
@@ -277,6 +277,12 @@ public class EndpointTest {
         assertThat(ipv6WithHostName.withDefaultPort(80).toUri("none+h2").toString())
                 .isEqualTo("none+h2://google.com:80");
 
+        final Endpoint naver = Endpoint.of("naver.com");
+        assertThat(naver.toUri("none+https", "/hello").toString())
+                .isEqualTo("none+https://naver.com/hello");
+        assertThat(naver.toUri(SessionProtocol.HTTPS, SerializationFormat.NONE, "hello").toString())
+                .isEqualTo("none+https://naver.com/hello");
+
         assertThatThrownBy(() -> group.toUri("http://www.badguys.com"))
                 .isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(() -> group.toUri(SessionProtocol.H1, SerializationFormat.THRIFT_JSON))

--- a/core/src/test/java/com/linecorp/armeria/client/EndpointTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/EndpointTest.java
@@ -33,14 +33,16 @@ public class EndpointTest {
         assertThat(foo.ipAddr()).isNull();
         assertThat(foo.ipFamily()).isNull();
         assertThat(foo.hasIpAddr()).isFalse();
+        assertThat(foo.toURI()).isEqualTo("http://foo");
 
         final Endpoint bar = Endpoint.parse("bar:80");
         assertThat(bar).isEqualTo(Endpoint.of("bar", 80));
         assertThat(bar.port()).isEqualTo(80);
-        assertThat(foo.weight()).isEqualTo(1000);
-        assertThat(foo.ipAddr()).isNull();
-        assertThat(foo.ipFamily()).isNull();
-        assertThat(foo.hasIpAddr()).isFalse();
+        assertThat(bar.weight()).isEqualTo(1000);
+        assertThat(bar.ipAddr()).isNull();
+        assertThat(bar.ipFamily()).isNull();
+        assertThat(bar.hasIpAddr()).isFalse();
+        assertThat(bar.toURI()).isEqualTo("http://bar:80");
 
         assertThat(Endpoint.parse("group:foo")).isEqualTo(Endpoint.ofGroup("foo"));
     }
@@ -51,6 +53,7 @@ public class EndpointTest {
         assertThat(foo.isGroup()).isTrue();
         assertThat(foo.groupName()).isEqualTo("foo");
         assertThat(foo.authority()).isEqualTo("group:foo");
+        assertThat(foo.toURI()).isEqualTo("http://group:foo");
 
         assertThatThrownBy(foo::host).isInstanceOf(IllegalStateException.class);
         assertThatThrownBy(foo::ipAddr).isInstanceOf(IllegalStateException.class);
@@ -72,6 +75,7 @@ public class EndpointTest {
         assertThat(foo.weight()).isEqualTo(1000);
         assertThat(foo.authority()).isEqualTo("foo.com");
         assertThat(foo.withIpAddr(null)).isSameAs(foo);
+        assertThat(foo.toURI()).isEqualTo("http://foo.com");
 
         assertThatThrownBy(foo::port).isInstanceOf(IllegalStateException.class);
         assertThatThrownBy(foo::groupName).isInstanceOf(IllegalStateException.class);
@@ -91,6 +95,7 @@ public class EndpointTest {
         assertThat(foo.withDefaultPort(42)).isSameAs(foo);
         assertThat(foo.weight()).isEqualTo(1000);
         assertThat(foo.authority()).isEqualTo("foo.com:80");
+        assertThat(foo.toURI()).isEqualTo("http://foo.com:80");
 
         assertThatThrownBy(foo::groupName).isInstanceOf(IllegalStateException.class);
     }
@@ -113,16 +118,23 @@ public class EndpointTest {
         assertThat(foo.ipAddr()).isEqualTo("192.168.0.1");
         assertThat(foo.ipFamily()).isEqualTo(StandardProtocolFamily.INET);
         assertThat(foo.hasIpAddr()).isTrue();
+        assertThat(foo.toURI()).isEqualTo("http://192.168.0.1");
+
         assertThat(foo.withIpAddr(null).ipAddr()).isNull();
+        assertThat(foo.withIpAddr(null).toURI()).isEqualTo("http://foo.com");
+
         assertThat(foo.withIpAddr("::1").authority()).isEqualTo("foo.com");
         assertThat(foo.withIpAddr("::1").ipAddr()).isEqualTo("::1");
         assertThat(foo.withIpAddr("::1").ipFamily()).isEqualTo(StandardProtocolFamily.INET6);
         assertThat(foo.withIpAddr("::1").hasIpAddr()).isTrue();
+        assertThat(foo.withIpAddr("::1").toURI()).isEqualTo("http://[::1]");
+
         assertThat(foo.withIpAddr("192.168.0.1")).isSameAs(foo);
         assertThat(foo.withIpAddr("192.168.0.2").authority()).isEqualTo("foo.com");
         assertThat(foo.withIpAddr("192.168.0.2").ipAddr()).isEqualTo("192.168.0.2");
         assertThat(foo.withIpAddr("192.168.0.2").ipFamily()).isEqualTo(StandardProtocolFamily.INET);
         assertThat(foo.withIpAddr("192.168.0.2").hasIpAddr()).isTrue();
+        assertThat(foo.withIpAddr("192.168.0.2").toURI()).isEqualTo("http://192.168.0.2");
 
         assertThatThrownBy(() -> foo.withIpAddr("no-ip")).isInstanceOf(IllegalArgumentException.class);
     }
@@ -143,6 +155,7 @@ public class EndpointTest {
         assertThat(a.ipFamily()).isEqualTo(StandardProtocolFamily.INET);
         assertThat(a.hasIpAddr()).isTrue();
         assertThat(a.authority()).isEqualTo("192.168.0.1");
+        assertThat(a.toURI()).isEqualTo("http://192.168.0.1");
         assertThatThrownBy(() -> a.withIpAddr(null)).isInstanceOf(IllegalStateException.class);
         assertThat(a.withIpAddr("192.168.0.1")).isSameAs(a);
         assertThat(a.withIpAddr("192.168.0.2")).isEqualTo(Endpoint.of("192.168.0.2"));
@@ -159,6 +172,7 @@ public class EndpointTest {
         assertThat(a.hasIpAddr()).isTrue();
         assertThat(a.port()).isEqualTo(80);
         assertThat(a.authority()).isEqualTo("192.168.0.1:80");
+        assertThat(a.toURI()).isEqualTo("http://192.168.0.1:80");
     }
 
     @Test
@@ -169,6 +183,7 @@ public class EndpointTest {
         assertThat(a.ipFamily()).isEqualTo(StandardProtocolFamily.INET6);
         assertThat(a.hasIpAddr()).isTrue();
         assertThat(a.authority()).isEqualTo("[::1]");
+        assertThat(a.toURI()).isEqualTo("http://[::1]");
         assertThatThrownBy(() -> a.withIpAddr(null)).isInstanceOf(IllegalStateException.class);
         assertThat(a.withIpAddr("::1")).isSameAs(a);
         assertThat(a.withIpAddr("::2")).isEqualTo(Endpoint.of("::2"));
@@ -181,6 +196,7 @@ public class EndpointTest {
         assertThat(b.ipFamily()).isEqualTo(StandardProtocolFamily.INET6);
         assertThat(b.hasIpAddr()).isTrue();
         assertThat(b.authority()).isEqualTo("[::1]:80");
+        assertThat(b.toURI()).isEqualTo("http://[::1]:80");
 
         // Surrounding '[' and ']' should be handled correctly.
         final Endpoint c = Endpoint.of("[::1]");
@@ -189,6 +205,7 @@ public class EndpointTest {
         assertThat(c.ipFamily()).isEqualTo(StandardProtocolFamily.INET6);
         assertThat(c.hasIpAddr()).isTrue();
         assertThat(c.authority()).isEqualTo("[::1]");
+        assertThat(c.toURI()).isEqualTo("http://[::1]");
 
         final Endpoint d = Endpoint.of("[::1]", 80);
         assertThat(d.host()).isEqualTo("::1");
@@ -196,12 +213,14 @@ public class EndpointTest {
         assertThat(d.ipFamily()).isEqualTo(StandardProtocolFamily.INET6);
         assertThat(d.hasIpAddr()).isTrue();
         assertThat(d.authority()).isEqualTo("[::1]:80");
+        assertThat(d.toURI()).isEqualTo("http://[::1]:80");
 
         // withIpAddr() should handle surrounding '[' and ']' correctly.
         final Endpoint e = Endpoint.of("foo").withIpAddr("[::1]");
         assertThat(e.host()).isEqualTo("foo");
         assertThat(e.ipAddr()).isEqualTo("::1");
         assertThat(e.ipFamily()).isEqualTo(StandardProtocolFamily.INET6);
+        assertThat(e.toURI()).isEqualTo("http://[::1]");
     }
 
     @Test
@@ -213,6 +232,7 @@ public class EndpointTest {
         assertThat(a.hasIpAddr()).isTrue();
         assertThat(a.port()).isEqualTo(80);
         assertThat(a.authority()).isEqualTo("[::1]:80");
+        assertThat(a.toURI()).isEqualTo("http://[::1]:80");
     }
 
     @Test
@@ -221,6 +241,15 @@ public class EndpointTest {
         final String authority1 = foo.authority();
         final String authority2 = foo.authority();
         assertThat(authority1).isSameAs(authority2);
+    }
+
+    @Test
+    public void toURI() {
+        assertThat(Endpoint.ofGroup("a").toURI()).isEqualTo("http://group:a");
+        assertThat(Endpoint.of("192.168.0.1", 80).toURI()).isEqualTo("http://192.168.0.1:80");
+        assertThat(Endpoint.of("192.168.0.1").toURI()).isEqualTo("http://192.168.0.1");
+        assertThat(Endpoint.of("[::1]", 80).toURI()).isEqualTo("http://[::1]:80");
+        assertThat(Endpoint.of("[::1]").toURI()).isEqualTo("http://[::1]");
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/client/EndpointTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/EndpointTest.java
@@ -33,7 +33,7 @@ public class EndpointTest {
         assertThat(foo.ipAddr()).isNull();
         assertThat(foo.ipFamily()).isNull();
         assertThat(foo.hasIpAddr()).isFalse();
-        assertThat(foo.toURI()).isEqualTo("http://foo");
+        assertThat(foo.toURI("http").toString()).isEqualTo("http://foo");
 
         final Endpoint bar = Endpoint.parse("bar:80");
         assertThat(bar).isEqualTo(Endpoint.of("bar", 80));
@@ -42,7 +42,7 @@ public class EndpointTest {
         assertThat(bar.ipAddr()).isNull();
         assertThat(bar.ipFamily()).isNull();
         assertThat(bar.hasIpAddr()).isFalse();
-        assertThat(bar.toURI()).isEqualTo("http://bar:80");
+        assertThat(bar.toURI("http").toString()).isEqualTo("http://bar:80");
 
         assertThat(Endpoint.parse("group:foo")).isEqualTo(Endpoint.ofGroup("foo"));
     }
@@ -53,7 +53,7 @@ public class EndpointTest {
         assertThat(foo.isGroup()).isTrue();
         assertThat(foo.groupName()).isEqualTo("foo");
         assertThat(foo.authority()).isEqualTo("group:foo");
-        assertThat(foo.toURI()).isEqualTo("http://group:foo");
+        assertThat(foo.toURI("http").toString()).isEqualTo("http://group:foo");
 
         assertThatThrownBy(foo::host).isInstanceOf(IllegalStateException.class);
         assertThatThrownBy(foo::ipAddr).isInstanceOf(IllegalStateException.class);
@@ -75,7 +75,7 @@ public class EndpointTest {
         assertThat(foo.weight()).isEqualTo(1000);
         assertThat(foo.authority()).isEqualTo("foo.com");
         assertThat(foo.withIpAddr(null)).isSameAs(foo);
-        assertThat(foo.toURI()).isEqualTo("http://foo.com");
+        assertThat(foo.toURI("http").toString()).isEqualTo("http://foo.com");
 
         assertThatThrownBy(foo::port).isInstanceOf(IllegalStateException.class);
         assertThatThrownBy(foo::groupName).isInstanceOf(IllegalStateException.class);
@@ -95,7 +95,7 @@ public class EndpointTest {
         assertThat(foo.withDefaultPort(42)).isSameAs(foo);
         assertThat(foo.weight()).isEqualTo(1000);
         assertThat(foo.authority()).isEqualTo("foo.com:80");
-        assertThat(foo.toURI()).isEqualTo("http://foo.com:80");
+        assertThat(foo.toURI("http").toString()).isEqualTo("http://foo.com:80");
 
         assertThatThrownBy(foo::groupName).isInstanceOf(IllegalStateException.class);
     }
@@ -118,23 +118,21 @@ public class EndpointTest {
         assertThat(foo.ipAddr()).isEqualTo("192.168.0.1");
         assertThat(foo.ipFamily()).isEqualTo(StandardProtocolFamily.INET);
         assertThat(foo.hasIpAddr()).isTrue();
-        assertThat(foo.toURI()).isEqualTo("http://192.168.0.1");
-
+        assertThat(foo.toURI("http").toString()).isEqualTo("http://192.168.0.1");
         assertThat(foo.withIpAddr(null).ipAddr()).isNull();
-        assertThat(foo.withIpAddr(null).toURI()).isEqualTo("http://foo.com");
-
+        assertThat(foo.withIpAddr(null).toURI("http").toString()).isEqualTo("http://foo.com");
         assertThat(foo.withIpAddr("::1").authority()).isEqualTo("foo.com");
         assertThat(foo.withIpAddr("::1").ipAddr()).isEqualTo("::1");
         assertThat(foo.withIpAddr("::1").ipFamily()).isEqualTo(StandardProtocolFamily.INET6);
         assertThat(foo.withIpAddr("::1").hasIpAddr()).isTrue();
-        assertThat(foo.withIpAddr("::1").toURI()).isEqualTo("http://[::1]");
-
+        assertThat(foo.withIpAddr("::1").toURI("http").toString()).isEqualTo("http://[::1]");
         assertThat(foo.withIpAddr("192.168.0.1")).isSameAs(foo);
         assertThat(foo.withIpAddr("192.168.0.2").authority()).isEqualTo("foo.com");
         assertThat(foo.withIpAddr("192.168.0.2").ipAddr()).isEqualTo("192.168.0.2");
         assertThat(foo.withIpAddr("192.168.0.2").ipFamily()).isEqualTo(StandardProtocolFamily.INET);
         assertThat(foo.withIpAddr("192.168.0.2").hasIpAddr()).isTrue();
-        assertThat(foo.withIpAddr("192.168.0.2").toURI()).isEqualTo("http://192.168.0.2");
+        assertThat(foo.withIpAddr("192.168.0.2").toURI("http").toString())
+                .isEqualTo("http://192.168.0.2");
 
         assertThatThrownBy(() -> foo.withIpAddr("no-ip")).isInstanceOf(IllegalArgumentException.class);
     }
@@ -155,7 +153,7 @@ public class EndpointTest {
         assertThat(a.ipFamily()).isEqualTo(StandardProtocolFamily.INET);
         assertThat(a.hasIpAddr()).isTrue();
         assertThat(a.authority()).isEqualTo("192.168.0.1");
-        assertThat(a.toURI()).isEqualTo("http://192.168.0.1");
+        assertThat(a.toURI("http").toString()).isEqualTo("http://192.168.0.1");
         assertThatThrownBy(() -> a.withIpAddr(null)).isInstanceOf(IllegalStateException.class);
         assertThat(a.withIpAddr("192.168.0.1")).isSameAs(a);
         assertThat(a.withIpAddr("192.168.0.2")).isEqualTo(Endpoint.of("192.168.0.2"));
@@ -172,7 +170,7 @@ public class EndpointTest {
         assertThat(a.hasIpAddr()).isTrue();
         assertThat(a.port()).isEqualTo(80);
         assertThat(a.authority()).isEqualTo("192.168.0.1:80");
-        assertThat(a.toURI()).isEqualTo("http://192.168.0.1:80");
+        assertThat(a.toURI("http").toString()).isEqualTo("http://192.168.0.1:80");
     }
 
     @Test
@@ -183,7 +181,7 @@ public class EndpointTest {
         assertThat(a.ipFamily()).isEqualTo(StandardProtocolFamily.INET6);
         assertThat(a.hasIpAddr()).isTrue();
         assertThat(a.authority()).isEqualTo("[::1]");
-        assertThat(a.toURI()).isEqualTo("http://[::1]");
+        assertThat(a.toURI("http").toString()).isEqualTo("http://[::1]");
         assertThatThrownBy(() -> a.withIpAddr(null)).isInstanceOf(IllegalStateException.class);
         assertThat(a.withIpAddr("::1")).isSameAs(a);
         assertThat(a.withIpAddr("::2")).isEqualTo(Endpoint.of("::2"));
@@ -196,7 +194,7 @@ public class EndpointTest {
         assertThat(b.ipFamily()).isEqualTo(StandardProtocolFamily.INET6);
         assertThat(b.hasIpAddr()).isTrue();
         assertThat(b.authority()).isEqualTo("[::1]:80");
-        assertThat(b.toURI()).isEqualTo("http://[::1]:80");
+        assertThat(b.toURI("http").toString()).isEqualTo("http://[::1]:80");
 
         // Surrounding '[' and ']' should be handled correctly.
         final Endpoint c = Endpoint.of("[::1]");
@@ -205,7 +203,7 @@ public class EndpointTest {
         assertThat(c.ipFamily()).isEqualTo(StandardProtocolFamily.INET6);
         assertThat(c.hasIpAddr()).isTrue();
         assertThat(c.authority()).isEqualTo("[::1]");
-        assertThat(c.toURI()).isEqualTo("http://[::1]");
+        assertThat(c.toURI("http").toString()).isEqualTo("http://[::1]");
 
         final Endpoint d = Endpoint.of("[::1]", 80);
         assertThat(d.host()).isEqualTo("::1");
@@ -213,14 +211,14 @@ public class EndpointTest {
         assertThat(d.ipFamily()).isEqualTo(StandardProtocolFamily.INET6);
         assertThat(d.hasIpAddr()).isTrue();
         assertThat(d.authority()).isEqualTo("[::1]:80");
-        assertThat(d.toURI()).isEqualTo("http://[::1]:80");
+        assertThat(d.toURI("http").toString()).isEqualTo("http://[::1]:80");
 
         // withIpAddr() should handle surrounding '[' and ']' correctly.
         final Endpoint e = Endpoint.of("foo").withIpAddr("[::1]");
         assertThat(e.host()).isEqualTo("foo");
         assertThat(e.ipAddr()).isEqualTo("::1");
         assertThat(e.ipFamily()).isEqualTo(StandardProtocolFamily.INET6);
-        assertThat(e.toURI()).isEqualTo("http://[::1]");
+        assertThat(e.toURI("http").toString()).isEqualTo("http://[::1]");
     }
 
     @Test
@@ -232,7 +230,7 @@ public class EndpointTest {
         assertThat(a.hasIpAddr()).isTrue();
         assertThat(a.port()).isEqualTo(80);
         assertThat(a.authority()).isEqualTo("[::1]:80");
-        assertThat(a.toURI()).isEqualTo("http://[::1]:80");
+        assertThat(a.toURI("http").toString()).isEqualTo("http://[::1]:80");
     }
 
     @Test
@@ -245,11 +243,27 @@ public class EndpointTest {
 
     @Test
     public void toURI() {
-        assertThat(Endpoint.ofGroup("a").toURI()).isEqualTo("http://group:a");
-        assertThat(Endpoint.of("192.168.0.1", 80).toURI()).isEqualTo("http://192.168.0.1:80");
-        assertThat(Endpoint.of("192.168.0.1").toURI()).isEqualTo("http://192.168.0.1");
-        assertThat(Endpoint.of("[::1]", 80).toURI()).isEqualTo("http://[::1]:80");
-        assertThat(Endpoint.of("[::1]").toURI()).isEqualTo("http://[::1]");
+        final Endpoint group = Endpoint.ofGroup("a");
+        assertThat(group.toURI("http").toString()).isEqualTo("http://group:a");
+        assertThat(group.toURI("https").toString()).isEqualTo("https://group:a");
+
+        final Endpoint router = Endpoint.of("192.168.0.1");
+        assertThat(router.toURI("h1").toString()).isEqualTo("h1://192.168.0.1");
+        assertThat(router.toURI("h1c").toString()).isEqualTo("h1c://192.168.0.1");
+        assertThat(router.withDefaultPort(80).toURI("h1c").toString())
+                .isEqualTo("h1c://192.168.0.1:80");
+
+        final Endpoint google = Endpoint.of("google.com");
+        assertThat(google.toURI("http").toString()).isEqualTo("http://google.com");
+        assertThat(google.withDefaultPort(80).toURI("http").toString()).isEqualTo("http://google.com:80");
+
+        assertThat(google.toURI("https").toString()).isEqualTo("https://google.com");
+        assertThat(google.withDefaultPort(80).toURI("https").toString()).isEqualTo("https://google.com:80");
+
+        final Endpoint ipv6WithHostName = Endpoint.of("google.com").withIpAddr("[::1]");
+        assertThat(ipv6WithHostName.toURI("http").toString()).isEqualTo("http://[::1]");
+        assertThat(ipv6WithHostName.withDefaultPort(80).toURI("http").toString())
+                .isEqualTo("http://[::1]:80");
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/client/EndpointTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/EndpointTest.java
@@ -33,7 +33,7 @@ public class EndpointTest {
         assertThat(foo.ipAddr()).isNull();
         assertThat(foo.ipFamily()).isNull();
         assertThat(foo.hasIpAddr()).isFalse();
-        assertThat(foo.toURI("http").toString()).isEqualTo("http://foo");
+        assertThat(foo.toUri("none+http").toString()).isEqualTo("none+http://foo");
 
         final Endpoint bar = Endpoint.parse("bar:80");
         assertThat(bar).isEqualTo(Endpoint.of("bar", 80));
@@ -42,7 +42,7 @@ public class EndpointTest {
         assertThat(bar.ipAddr()).isNull();
         assertThat(bar.ipFamily()).isNull();
         assertThat(bar.hasIpAddr()).isFalse();
-        assertThat(bar.toURI("http").toString()).isEqualTo("http://bar:80");
+        assertThat(bar.toUri("none+http").toString()).isEqualTo("none+http://bar:80");
 
         assertThat(Endpoint.parse("group:foo")).isEqualTo(Endpoint.ofGroup("foo"));
     }
@@ -53,7 +53,7 @@ public class EndpointTest {
         assertThat(foo.isGroup()).isTrue();
         assertThat(foo.groupName()).isEqualTo("foo");
         assertThat(foo.authority()).isEqualTo("group:foo");
-        assertThat(foo.toURI("http").toString()).isEqualTo("http://group:foo");
+        assertThat(foo.toUri("none+http").toString()).isEqualTo("none+http://group:foo");
 
         assertThatThrownBy(foo::host).isInstanceOf(IllegalStateException.class);
         assertThatThrownBy(foo::ipAddr).isInstanceOf(IllegalStateException.class);
@@ -75,7 +75,7 @@ public class EndpointTest {
         assertThat(foo.weight()).isEqualTo(1000);
         assertThat(foo.authority()).isEqualTo("foo.com");
         assertThat(foo.withIpAddr(null)).isSameAs(foo);
-        assertThat(foo.toURI("http").toString()).isEqualTo("http://foo.com");
+        assertThat(foo.toUri("none+http").toString()).isEqualTo("none+http://foo.com");
 
         assertThatThrownBy(foo::port).isInstanceOf(IllegalStateException.class);
         assertThatThrownBy(foo::groupName).isInstanceOf(IllegalStateException.class);
@@ -95,7 +95,7 @@ public class EndpointTest {
         assertThat(foo.withDefaultPort(42)).isSameAs(foo);
         assertThat(foo.weight()).isEqualTo(1000);
         assertThat(foo.authority()).isEqualTo("foo.com:80");
-        assertThat(foo.toURI("http").toString()).isEqualTo("http://foo.com:80");
+        assertThat(foo.toUri("none+http").toString()).isEqualTo("none+http://foo.com:80");
 
         assertThatThrownBy(foo::groupName).isInstanceOf(IllegalStateException.class);
     }
@@ -118,21 +118,21 @@ public class EndpointTest {
         assertThat(foo.ipAddr()).isEqualTo("192.168.0.1");
         assertThat(foo.ipFamily()).isEqualTo(StandardProtocolFamily.INET);
         assertThat(foo.hasIpAddr()).isTrue();
-        assertThat(foo.toURI("http").toString()).isEqualTo("http://192.168.0.1");
+        assertThat(foo.toUri("none+http").toString()).isEqualTo("none+http://192.168.0.1");
         assertThat(foo.withIpAddr(null).ipAddr()).isNull();
-        assertThat(foo.withIpAddr(null).toURI("http").toString()).isEqualTo("http://foo.com");
+        assertThat(foo.withIpAddr(null).toUri("none+http").toString()).isEqualTo("none+http://foo.com");
         assertThat(foo.withIpAddr("::1").authority()).isEqualTo("foo.com");
         assertThat(foo.withIpAddr("::1").ipAddr()).isEqualTo("::1");
         assertThat(foo.withIpAddr("::1").ipFamily()).isEqualTo(StandardProtocolFamily.INET6);
         assertThat(foo.withIpAddr("::1").hasIpAddr()).isTrue();
-        assertThat(foo.withIpAddr("::1").toURI("http").toString()).isEqualTo("http://[::1]");
+        assertThat(foo.withIpAddr("::1").toUri("none+http").toString()).isEqualTo("none+http://[::1]");
         assertThat(foo.withIpAddr("192.168.0.1")).isSameAs(foo);
         assertThat(foo.withIpAddr("192.168.0.2").authority()).isEqualTo("foo.com");
         assertThat(foo.withIpAddr("192.168.0.2").ipAddr()).isEqualTo("192.168.0.2");
         assertThat(foo.withIpAddr("192.168.0.2").ipFamily()).isEqualTo(StandardProtocolFamily.INET);
         assertThat(foo.withIpAddr("192.168.0.2").hasIpAddr()).isTrue();
-        assertThat(foo.withIpAddr("192.168.0.2").toURI("http").toString())
-                .isEqualTo("http://192.168.0.2");
+        assertThat(foo.withIpAddr("192.168.0.2").toUri("none+http").toString())
+                .isEqualTo("none+http://192.168.0.2");
 
         assertThatThrownBy(() -> foo.withIpAddr("no-ip")).isInstanceOf(IllegalArgumentException.class);
     }
@@ -153,7 +153,7 @@ public class EndpointTest {
         assertThat(a.ipFamily()).isEqualTo(StandardProtocolFamily.INET);
         assertThat(a.hasIpAddr()).isTrue();
         assertThat(a.authority()).isEqualTo("192.168.0.1");
-        assertThat(a.toURI("http").toString()).isEqualTo("http://192.168.0.1");
+        assertThat(a.toUri("none+http").toString()).isEqualTo("none+http://192.168.0.1");
         assertThatThrownBy(() -> a.withIpAddr(null)).isInstanceOf(IllegalStateException.class);
         assertThat(a.withIpAddr("192.168.0.1")).isSameAs(a);
         assertThat(a.withIpAddr("192.168.0.2")).isEqualTo(Endpoint.of("192.168.0.2"));
@@ -170,7 +170,7 @@ public class EndpointTest {
         assertThat(a.hasIpAddr()).isTrue();
         assertThat(a.port()).isEqualTo(80);
         assertThat(a.authority()).isEqualTo("192.168.0.1:80");
-        assertThat(a.toURI("http").toString()).isEqualTo("http://192.168.0.1:80");
+        assertThat(a.toUri("none+http").toString()).isEqualTo("none+http://192.168.0.1:80");
     }
 
     @Test
@@ -181,7 +181,7 @@ public class EndpointTest {
         assertThat(a.ipFamily()).isEqualTo(StandardProtocolFamily.INET6);
         assertThat(a.hasIpAddr()).isTrue();
         assertThat(a.authority()).isEqualTo("[::1]");
-        assertThat(a.toURI("http").toString()).isEqualTo("http://[::1]");
+        assertThat(a.toUri("none+http").toString()).isEqualTo("none+http://[::1]");
         assertThatThrownBy(() -> a.withIpAddr(null)).isInstanceOf(IllegalStateException.class);
         assertThat(a.withIpAddr("::1")).isSameAs(a);
         assertThat(a.withIpAddr("::2")).isEqualTo(Endpoint.of("::2"));
@@ -194,7 +194,7 @@ public class EndpointTest {
         assertThat(b.ipFamily()).isEqualTo(StandardProtocolFamily.INET6);
         assertThat(b.hasIpAddr()).isTrue();
         assertThat(b.authority()).isEqualTo("[::1]:80");
-        assertThat(b.toURI("http").toString()).isEqualTo("http://[::1]:80");
+        assertThat(b.toUri("none+http").toString()).isEqualTo("none+http://[::1]:80");
 
         // Surrounding '[' and ']' should be handled correctly.
         final Endpoint c = Endpoint.of("[::1]");
@@ -203,7 +203,7 @@ public class EndpointTest {
         assertThat(c.ipFamily()).isEqualTo(StandardProtocolFamily.INET6);
         assertThat(c.hasIpAddr()).isTrue();
         assertThat(c.authority()).isEqualTo("[::1]");
-        assertThat(c.toURI("http").toString()).isEqualTo("http://[::1]");
+        assertThat(c.toUri("none+http").toString()).isEqualTo("none+http://[::1]");
 
         final Endpoint d = Endpoint.of("[::1]", 80);
         assertThat(d.host()).isEqualTo("::1");
@@ -211,14 +211,14 @@ public class EndpointTest {
         assertThat(d.ipFamily()).isEqualTo(StandardProtocolFamily.INET6);
         assertThat(d.hasIpAddr()).isTrue();
         assertThat(d.authority()).isEqualTo("[::1]:80");
-        assertThat(d.toURI("http").toString()).isEqualTo("http://[::1]:80");
+        assertThat(d.toUri("none+http").toString()).isEqualTo("none+http://[::1]:80");
 
         // withIpAddr() should handle surrounding '[' and ']' correctly.
         final Endpoint e = Endpoint.of("foo").withIpAddr("[::1]");
         assertThat(e.host()).isEqualTo("foo");
         assertThat(e.ipAddr()).isEqualTo("::1");
         assertThat(e.ipFamily()).isEqualTo(StandardProtocolFamily.INET6);
-        assertThat(e.toURI("http").toString()).isEqualTo("http://[::1]");
+        assertThat(e.toUri("none+http").toString()).isEqualTo("none+http://[::1]");
     }
 
     @Test
@@ -230,7 +230,7 @@ public class EndpointTest {
         assertThat(a.hasIpAddr()).isTrue();
         assertThat(a.port()).isEqualTo(80);
         assertThat(a.authority()).isEqualTo("[::1]:80");
-        assertThat(a.toURI("http").toString()).isEqualTo("http://[::1]:80");
+        assertThat(a.toUri("none+http").toString()).isEqualTo("none+http://[::1]:80");
     }
 
     @Test
@@ -244,26 +244,28 @@ public class EndpointTest {
     @Test
     public void toURI() {
         final Endpoint group = Endpoint.ofGroup("a");
-        assertThat(group.toURI("http").toString()).isEqualTo("http://group:a");
-        assertThat(group.toURI("https").toString()).isEqualTo("https://group:a");
+        assertThat(group.toUri("none+http").toString()).isEqualTo("none+http://group:a");
+        assertThat(group.toUri("none+https").toString()).isEqualTo("none+https://group:a");
 
         final Endpoint router = Endpoint.of("192.168.0.1");
-        assertThat(router.toURI("h1").toString()).isEqualTo("h1://192.168.0.1");
-        assertThat(router.toURI("h1c").toString()).isEqualTo("h1c://192.168.0.1");
-        assertThat(router.withDefaultPort(80).toURI("h1c").toString())
-                .isEqualTo("h1c://192.168.0.1:80");
+        assertThat(router.toUri("none+h1").toString()).isEqualTo("none+h1://192.168.0.1");
+        assertThat(router.toUri("none+h1c").toString()).isEqualTo("none+h1c://192.168.0.1");
+        assertThat(router.withDefaultPort(80).toUri("none+h1c").toString())
+                .isEqualTo("none+h1c://192.168.0.1:80");
 
         final Endpoint google = Endpoint.of("google.com");
-        assertThat(google.toURI("http").toString()).isEqualTo("http://google.com");
-        assertThat(google.withDefaultPort(80).toURI("http").toString()).isEqualTo("http://google.com:80");
+        assertThat(google.toUri("none+http").toString()).isEqualTo("none+http://google.com");
+        assertThat(google.withDefaultPort(80).toUri("none+http").toString())
+                .isEqualTo("none+http://google.com:80");
 
-        assertThat(google.toURI("https").toString()).isEqualTo("https://google.com");
-        assertThat(google.withDefaultPort(80).toURI("https").toString()).isEqualTo("https://google.com:80");
+        assertThat(google.toUri("none+https").toString()).isEqualTo("none+https://google.com");
+        assertThat(google.withDefaultPort(80).toUri("none+https").toString())
+                .isEqualTo("none+https://google.com:80");
 
         final Endpoint ipv6WithHostName = Endpoint.of("google.com").withIpAddr("[::1]");
-        assertThat(ipv6WithHostName.toURI("http").toString()).isEqualTo("http://[::1]");
-        assertThat(ipv6WithHostName.withDefaultPort(80).toURI("http").toString())
-                .isEqualTo("http://[::1]:80");
+        assertThat(ipv6WithHostName.toUri("none+http").toString()).isEqualTo("none+http://[::1]");
+        assertThat(ipv6WithHostName.withDefaultPort(80).toUri("none+http").toString())
+                .isEqualTo("none+http://[::1]:80");
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/client/EndpointTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/EndpointTest.java
@@ -280,7 +280,7 @@ public class EndpointTest {
         final Endpoint naver = Endpoint.of("naver.com");
         assertThat(naver.toUri("none+https", "/hello").toString())
                 .isEqualTo("none+https://naver.com/hello");
-        assertThat(naver.toUri(SessionProtocol.HTTPS, SerializationFormat.NONE, "hello").toString())
+        assertThat(naver.toUri(SessionProtocol.HTTPS, SerializationFormat.NONE, "/hello").toString())
                 .isEqualTo("none+https://naver.com/hello");
 
         assertThatThrownBy(() -> group.toUri("http://www.badguys.com"))

--- a/core/src/test/java/com/linecorp/armeria/client/EndpointTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/EndpointTest.java
@@ -248,15 +248,15 @@ public class EndpointTest {
     @Test
     public void toUri() {
         final Endpoint group = Endpoint.ofGroup("a");
-        assertThat(group.toUri("none+http").toString())
-                .isEqualTo("none+http://group:a");
+        assertThat(group.toUri("http").toString())
+                .isEqualTo("http://group:a");
         assertThat(group.toUri(Scheme.of(SerializationFormat.NONE, SessionProtocol.HTTP)).toString())
                 .isEqualTo("none+http://group:a");
 
         final Endpoint router = Endpoint.of("192.168.0.1");
         assertThat(router.toUri("none+h1").toString())
                 .isEqualTo("none+h1://192.168.0.1");
-        assertThat(group.toUri(SessionProtocol.H1, SerializationFormat.NONE).toString())
+        assertThat(group.toUri(SessionProtocol.H1).toString())
                 .isEqualTo("none+h1://group:a");
         assertThat(router.withDefaultPort(80).toUri("none+h1").toString())
                 .isEqualTo("none+h1://192.168.0.1:80");
@@ -264,7 +264,7 @@ public class EndpointTest {
         final Endpoint google = Endpoint.of("google.com");
         assertThat(google.toUri("none+https").toString())
                 .isEqualTo("none+https://google.com");
-        assertThat(google.toUri(SessionProtocol.HTTPS, SerializationFormat.of("none")).toString())
+        assertThat(google.toUri(SessionProtocol.HTTPS).toString())
                 .isEqualTo("none+https://google.com");
         assertThat(google.withDefaultPort(80).toUri("none+https").toString())
                 .isEqualTo("none+https://google.com:80");
@@ -272,7 +272,7 @@ public class EndpointTest {
         final Endpoint ipv6WithHostName = Endpoint.of("google.com").withIpAddr("[::1]");
         assertThat(ipv6WithHostName.toUri("none+h2").toString())
                 .isEqualTo("none+h2://google.com");
-        assertThat(ipv6WithHostName.toUri(SessionProtocol.H2, SerializationFormat.NONE).toString())
+        assertThat(ipv6WithHostName.toUri(SessionProtocol.H2).toString())
                 .isEqualTo("none+h2://google.com");
         assertThat(ipv6WithHostName.withDefaultPort(80).toUri("none+h2").toString())
                 .isEqualTo("none+h2://google.com:80");
@@ -280,12 +280,15 @@ public class EndpointTest {
         final Endpoint naver = Endpoint.of("naver.com");
         assertThat(naver.toUri("none+https", "/hello").toString())
                 .isEqualTo("none+https://naver.com/hello");
-        assertThat(naver.toUri(SessionProtocol.HTTPS, SerializationFormat.NONE, "/hello").toString())
+        assertThat(naver.toUri(SessionProtocol.HTTPS, "/hello").toString())
                 .isEqualTo("none+https://naver.com/hello");
+
+        assertThat(naver.toUri("https", ""))
+                .isEqualTo(naver.toUri("https", null));
 
         assertThatThrownBy(() -> group.toUri("http://www.badguys.com"))
                 .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> group.toUri(SessionProtocol.H1, SerializationFormat.THRIFT_JSON))
+        assertThatThrownBy(() -> group.toUri(Scheme.of(SerializationFormat.THRIFT_JSON, SessionProtocol.H1)))
                 .isInstanceOf(NullPointerException.class);
     }
 

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientIntegrationTest.java
@@ -624,70 +624,54 @@ class HttpClientIntegrationTest {
     }
 
     @Test
-    void givenHttpClient_thenBuildClient() throws Exception {
-        final URI uri = URI.create(server.httpUri("/"));
-        final Endpoint endpoint = Endpoint.of(uri.getHost()).withDefaultPort(uri.getPort());
-
-        final HttpClient client = HttpClient.of(SessionProtocol.HTTP, endpoint);
-
-        final AggregatedHttpMessage response = client.get("/hello/world").aggregate().get();
-
-        assertEquals("success", response.contentUtf8());
-    }
-
-    @Test
-    void givenHttpClinetBuilder_thenBuildClient() throws Exception {
-        final URI uri = URI.create(server.httpUri("/"));
-        final Endpoint endpoint = Endpoint.of(uri.getHost()).withDefaultPort(uri.getPort());
-
-        final HttpClient client = new HttpClientBuilder(SessionProtocol.HTTP, endpoint).build();
-
-        final AggregatedHttpMessage response = client.get("/hello/world").aggregate().get();
-
-        assertEquals("success", response.contentUtf8());
-    }
-
-    @Test
-    void givenClientFactory_thenBuildClient() throws Exception {
-        final URI uri = URI.create(server.httpUri("/"));
-        final Endpoint endpoint = Endpoint.of(uri.getHost())
-                                          .withDefaultPort(uri.getPort());
-
-        final Scheme scheme = Scheme.of(SerializationFormat.NONE, SessionProtocol.HTTP);
-        final ClientFactory factory = new ClientFactoryBuilder().build();
-        final HttpClient client = factory.newClient(scheme, endpoint, HttpClient.class);
-
-        final AggregatedHttpMessage response = client.get("/hello/world").aggregate().get();
-
-        assertEquals("success", response.contentUtf8());
-    }
-
-    @Test
     void givenClients_thenBuildClient() throws Exception {
-        final URI uri = URI.create(server.httpUri("/"));
-        final Endpoint endpoint = Endpoint.of(uri.getHost())
-                                          .withDefaultPort(uri.getPort());
-
+        final Endpoint endpoint = newEndpoint();
         final Scheme scheme = Scheme.of(SerializationFormat.NONE, SessionProtocol.HTTP);
-        final HttpClient client = Clients.newClient(scheme, endpoint, HttpClient.class);
 
-        final AggregatedHttpMessage response = client.get("/hello/world").aggregate().get();
+        // with ClientOptionValues
+        HttpClient client = Clients.newClient(scheme, endpoint, HttpClient.class);
+        AggregatedHttpMessage response = client.get("/hello/world").aggregate().get();
+
+        assertEquals("success", response.contentUtf8());
+
+        // with ClientOptions
+        client = Clients.newClient(scheme, endpoint, HttpClient.class, ClientOptions.DEFAULT);
+        response = client.get("/hello/world").aggregate().get();
+
+        assertEquals("success", response.contentUtf8());
+
+        // with Path and ClientOptions
+        client = Clients.newClient(scheme, endpoint, "/hello", HttpClient.class, ClientOptions.DEFAULT);
+        response = client.get("/world").aggregate().get();
 
         assertEquals("success", response.contentUtf8());
     }
 
     @Test
-    void givenClientBuilder_thenBuildClient() throws Exception {
-        final URI uri = URI.create(server.httpUri("/"));
-        final Endpoint endpoint = Endpoint.of(uri.getHost())
-                                          .withDefaultPort(uri.getPort());
+    void givenHttpClient_thenBuildClient() throws Exception {
+        final Endpoint endpoint = newEndpoint();
 
-        final ClientFactory factory = new ClientFactoryBuilder().build();
-        final HttpClient client = new ClientBuilder("none+http", endpoint).factory(factory)
-                                                                          .build(HttpClient.class);
-
-        final AggregatedHttpMessage response = client.get("/hello/world").aggregate().get();
+        // with ClientOptionValues
+        HttpClient client = HttpClient.of(SessionProtocol.HTTP, endpoint);
+        AggregatedHttpMessage response = client.get("/hello/world").aggregate().get();
 
         assertEquals("success", response.contentUtf8());
+
+        // with ClientOptions
+        client = HttpClient.of(SessionProtocol.HTTP, endpoint, ClientOptions.DEFAULT);
+        response = client.get("/hello/world").aggregate().get();
+
+        assertEquals("success", response.contentUtf8());
+
+        // with Path and ClientOptions
+        client = HttpClient.of(SessionProtocol.HTTP, endpoint, "hello", ClientOptions.DEFAULT);
+        response = client.get("/world").aggregate().get();
+
+        assertEquals("success", response.contentUtf8());
+    }
+
+    private static Endpoint newEndpoint() {
+        final URI uri = URI.create(server.httpUri("/"));
+        return Endpoint.of(uri.getHost()).withDefaultPort(uri.getPort());
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientIntegrationTest.java
@@ -699,7 +699,7 @@ class HttpClientIntegrationTest {
     }
 
     private static void checkGetRequest(String path, HttpClient client) throws Exception {
-        final AggregatedHttpMessage response = client.get(path).aggregate().get();
+        final AggregatedHttpResponse response = client.get(path).aggregate().get();
         assertEquals("success", response.contentUtf8());
     }
 

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientIntegrationTest.java
@@ -626,115 +626,76 @@ class HttpClientIntegrationTest {
     @Test
     void givenClients_thenBuildClient() throws Exception {
         final Endpoint endpoint = newEndpoint();
+        final ClientFactory factory = new ClientFactoryBuilder().build();
 
-        // with ClientOptionValues
-        HttpClient client = Clients.newClient(SessionProtocol.HTTP, SerializationFormat.NONE, endpoint,
-                                              HttpClient.class);
+        HttpClient client = Clients.newClient(factory, SessionProtocol.HTTP, SerializationFormat.NONE,
+                                              endpoint, HttpClient.class);
         checkGetRequest("/hello/world", client);
 
-        // with ClientOptions
+        client = Clients.newClient(factory, SessionProtocol.HTTP, SerializationFormat.NONE, endpoint,
+                                   HttpClient.class, ClientOptions.DEFAULT);
+        checkGetRequest("/hello/world", client);
+
+        client = Clients.newClient(SessionProtocol.HTTP, SerializationFormat.NONE, endpoint, HttpClient.class);
+        checkGetRequest("/hello/world", client);
+
         client = Clients.newClient(SessionProtocol.HTTP, SerializationFormat.NONE, endpoint, HttpClient.class,
                                    ClientOptions.DEFAULT);
         checkGetRequest("/hello/world", client);
-
-        // with Path and ClientOptionValues
-        client = Clients.newClient(SessionProtocol.HTTP, SerializationFormat.NONE, endpoint, "/hello",
-                                   HttpClient.class);
-        checkGetRequest("/world", client);
-
-        // with Path and ClientOptions
-        client = Clients.newClient(SessionProtocol.HTTP, SerializationFormat.NONE, endpoint, "/hello",
-                                   HttpClient.class, ClientOptions.DEFAULT);
-        checkGetRequest("/world", client);
-    }
-
-    @Test
-    void givenClients_whenSchemeExist_thenBuildClient() throws Exception {
-        final Endpoint endpoint = newEndpoint();
-        final Scheme scheme = Scheme.of(SerializationFormat.NONE, SessionProtocol.HTTP);
-
-        // with ClientOptionValues
-        HttpClient client = Clients.newClient(scheme, endpoint, HttpClient.class);
-        checkGetRequest("/hello/world", client);
-
-        // with ClientOptions
-        client = Clients.newClient(scheme, endpoint, HttpClient.class, ClientOptions.DEFAULT);
-        checkGetRequest("/hello/world", client);
-
-        // with Path and ClientOptionValues
-        client = Clients.newClient(scheme, endpoint, "/hello", HttpClient.class);
-        checkGetRequest("/world", client);
-
-        // with Path and ClientOptions
-        client = Clients.newClient(scheme, endpoint, "/hello", HttpClient.class, ClientOptions.DEFAULT);
-        checkGetRequest("/world", client);
     }
 
     @Test
     void givenHttpClient_thenBuildClient() throws Exception {
         final Endpoint endpoint = newEndpoint();
+        final ClientFactory factory = new ClientFactoryBuilder().build();
 
-        // with ClientOptionValues
-        HttpClient client = HttpClient.of(SessionProtocol.HTTP, endpoint);
+        HttpClient client = HttpClient.of(factory, SessionProtocol.HTTP, endpoint);
         checkGetRequest("/hello/world", client);
 
-        // with ClientOptions
+        client = HttpClient.of(factory, SessionProtocol.HTTP, endpoint, ClientOptions.DEFAULT);
+        checkGetRequest("/hello/world", client);
+
+        client = HttpClient.of(SessionProtocol.HTTP, endpoint);
+        checkGetRequest("/hello/world", client);
+
         client = HttpClient.of(SessionProtocol.HTTP, endpoint, ClientOptions.DEFAULT);
         checkGetRequest("/hello/world", client);
-
-        // with Path and ClientOptionValues
-        client = HttpClient.of(SessionProtocol.HTTP, endpoint, "hello");
-        checkGetRequest("/world", client);
-
-        // with Path and ClientOptions
-        client = HttpClient.of(SessionProtocol.HTTP, endpoint, "hello", ClientOptions.DEFAULT);
-        checkGetRequest("/world", client);
     }
 
     @Test
     void givenClientBuilder_thenBuildClient() throws Exception {
         final Endpoint endpoint = newEndpoint();
-
-        HttpClient client = new ClientBuilder(SessionProtocol.HTTP, SerializationFormat.NONE, endpoint)
-                .build(HttpClient.class);
-        checkGetRequest("/hello/world", client);
-
-        client = new ClientBuilder(SessionProtocol.HTTP, endpoint).build(HttpClient.class);
-        checkGetRequest("/hello/world", client);
-
-        client = new ClientBuilder(SessionProtocol.HTTP, SerializationFormat.NONE, endpoint, "/hello")
-                .build(HttpClient.class);
-        checkGetRequest("/world", client);
-
-        client = new ClientBuilder(SessionProtocol.HTTP, endpoint, "/hello").build(HttpClient.class);
-        checkGetRequest("/world", client);
-    }
-
-    @Test
-    void givenClientBuilder_whenSchemeExist_thenBuildClient() throws Exception {
-        final Endpoint endpoint = newEndpoint();
-        final Scheme scheme = Scheme.of(SerializationFormat.NONE, SessionProtocol.HTTP);
-
-        HttpClient client = new ClientBuilder(scheme, endpoint).build(HttpClient.class);
-        checkGetRequest("/hello/world", client);
-
-        client = new ClientBuilder("none+http", endpoint).build(HttpClient.class);
-        checkGetRequest("/hello/world", client);
-
-        client = new ClientBuilder(scheme, endpoint, "/hello").build(HttpClient.class);
-        checkGetRequest("/world", client);
-
-        client = new ClientBuilder("none+http", endpoint, "/hello").build(HttpClient.class);
-        checkGetRequest("/world", client);
-    }
-
-    @Test
-    void givenHttpClientFactory_whenClientTypeNotHttp_thenThrowIllegalArgument() throws Exception {
-        final Endpoint endpoint = newEndpoint();
         final ClientFactory factory = new ClientFactoryBuilder().build();
 
-        assertThatThrownBy(() -> factory.newClient(Scheme.of(SerializationFormat.NONE, SessionProtocol.HTTP),
-                                                   endpoint, null));
+        HttpClient client = new ClientBuilder(SessionProtocol.HTTP, endpoint)
+                .serializationFormat(SerializationFormat.NONE)
+                .factory(factory)
+                .build(HttpClient.class);
+        checkGetRequest("/hello/world", client);
+
+        client = new ClientBuilder(SessionProtocol.HTTP, endpoint)
+                .build(HttpClient.class);
+        checkGetRequest("/hello/world", client);
+
+        client = new ClientBuilder("none+http", endpoint)
+                .path("/hello")
+                .build(HttpClient.class);
+        checkGetRequest("/world", client);
+
+        client = new ClientBuilder(Scheme.of(SerializationFormat.NONE, SessionProtocol.HTTP), endpoint)
+                .path("/hello")
+                .build(HttpClient.class);
+        checkGetRequest("/world", client);
+
+        client = new ClientBuilder(SessionProtocol.HTTP, endpoint)
+                .serializationFormat(SerializationFormat.NONE)
+                .path("/hello")
+                .build(HttpClient.class);
+        checkGetRequest("/world", client);
+
+        assertThatThrownBy(() -> new ClientBuilder("none+http", endpoint)
+                .serializationFormat(SerializationFormat.NONE)
+                .build(HttpClient.class));
     }
 
     private static void checkGetRequest(String path, HttpClient client) throws Exception {

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientFactory.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientFactory.java
@@ -27,6 +27,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 
+import javax.annotation.Nullable;
+
 import org.curioswitch.common.protobuf.json.MessageMarshaller;
 
 import com.google.common.base.Strings;
@@ -89,7 +91,7 @@ final class GrpcClientFactory extends DecoratingClientFactory {
     }
 
     @Override
-    public <T> T newClient(Scheme scheme, Endpoint endpoint, String path, Class<T> clientType,
+    public <T> T newClient(Scheme scheme, Endpoint endpoint, @Nullable String path, Class<T> clientType,
                            ClientOptions options) {
         final URI uri = endpoint.toUri(scheme, path);
 

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientFactory.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientFactory.java
@@ -38,6 +38,7 @@ import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.ClientOptions;
 import com.linecorp.armeria.client.DecoratingClientFactory;
 import com.linecorp.armeria.client.DefaultClientBuilderParams;
+import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.Scheme;
@@ -82,6 +83,20 @@ final class GrpcClientFactory extends DecoratingClientFactory {
     @Override
     public <T> T newClient(URI uri, Class<T> clientType, ClientOptions options) {
         final Scheme scheme = validateScheme(uri);
+        final Endpoint endpoint = newEndpoint(uri);
+
+        return newClient(uri, scheme, endpoint, clientType, options);
+    }
+
+    @Override
+    public <T> T newClient(Scheme scheme, Endpoint endpoint, Class<T> clientType, ClientOptions options) {
+        final URI uri = endpoint.toUri(scheme);
+
+        return newClient(uri, scheme, endpoint, clientType, options);
+    }
+
+    private <T> T newClient(URI uri, Scheme scheme, Endpoint endpoint, Class<T> clientType,
+                            ClientOptions options) {
         final SerializationFormat serializationFormat = scheme.serializationFormat();
         final Class<?> stubClass = clientType.getEnclosingClass();
         if (stubClass == null) {
@@ -128,7 +143,7 @@ final class GrpcClientFactory extends DecoratingClientFactory {
                 httpClient,
                 meterRegistry(),
                 scheme.sessionProtocol(),
-                newEndpoint(uri),
+                endpoint,
                 serializationFormat,
                 jsonMarshaller);
 

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientFactory.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientFactory.java
@@ -89,8 +89,9 @@ final class GrpcClientFactory extends DecoratingClientFactory {
     }
 
     @Override
-    public <T> T newClient(Scheme scheme, Endpoint endpoint, Class<T> clientType, ClientOptions options) {
-        final URI uri = endpoint.toUri(scheme);
+    public <T> T newClient(Scheme scheme, Endpoint endpoint, String path, Class<T> clientType,
+                           ClientOptions options) {
+        final URI uri = endpoint.toUri(scheme, path);
 
         return newClient(uri, scheme, endpoint, clientType, options);
     }

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientTest.java
@@ -57,6 +57,7 @@ import com.linecorp.armeria.client.ClientBuilder;
 import com.linecorp.armeria.client.ClientOption;
 import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.DecoratingClientFunction;
+import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.ResponseTimeoutException;
 import com.linecorp.armeria.client.logging.LoggingClientBuilder;
 import com.linecorp.armeria.common.FilteredHttpResponse;
@@ -176,7 +177,7 @@ public class GrpcClientTest {
                 .decorator(new LoggingClientBuilder().newDecorator())
                 .decorator(requestLogRecorder)
                 .build(TestServiceBlockingStub.class);
-        asyncStub = new ClientBuilder("gproto+" + uri.getScheme() + "://" + uri.getAuthority())
+        asyncStub = new ClientBuilder("gproto+" + uri.getScheme(), Endpoint.of(uri.getHost(), uri.getPort()))
                 .decorator(new LoggingClientBuilder().newDecorator())
                 .decorator(requestLogRecorder)
                 .build(TestServiceStub.class);

--- a/thrift/src/main/java/com/linecorp/armeria/client/thrift/THttpClientFactory.java
+++ b/thrift/src/main/java/com/linecorp/armeria/client/thrift/THttpClientFactory.java
@@ -30,6 +30,7 @@ import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.ClientOptions;
 import com.linecorp.armeria.client.DecoratingClientFactory;
 import com.linecorp.armeria.client.DefaultClientBuilderParams;
+import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.RpcRequest;
@@ -71,8 +72,22 @@ final class THttpClientFactory extends DecoratingClientFactory {
     }
 
     @Override
+    public <T> T newClient(Scheme scheme, Endpoint endpoint, Class<T> clientType, ClientOptions options) {
+        final URI uri = endpoint.toUri(scheme);
+
+        return newClient(uri, scheme, endpoint, clientType, options);
+    }
+
+    @Override
     public <T> T newClient(URI uri, Class<T> clientType, ClientOptions options) {
         final Scheme scheme = validateScheme(uri);
+        final Endpoint endpoint = newEndpoint(uri);
+
+        return newClient(uri, scheme, endpoint, clientType, options);
+    }
+
+    private <T> T newClient(URI uri, Scheme scheme, Endpoint endpoint, Class<T> clientType,
+                            ClientOptions options) {
         final SerializationFormat serializationFormat = scheme.serializationFormat();
 
         final Client<RpcRequest, RpcResponse> delegate = options.decoration().decorate(
@@ -85,13 +100,13 @@ final class THttpClientFactory extends DecoratingClientFactory {
             @SuppressWarnings("unchecked")
             final T client = (T) new DefaultTHttpClient(
                     new DefaultClientBuilderParams(this, uri, THttpClient.class, options),
-                    delegate, meterRegistry(), scheme.sessionProtocol(), newEndpoint(uri));
+                    delegate, meterRegistry(), scheme.sessionProtocol(), endpoint);
             return client;
         } else {
             // Create a THttpClient without path.
             final THttpClient thriftClient = new DefaultTHttpClient(
                     new DefaultClientBuilderParams(this, pathlessUri(uri), THttpClient.class, options),
-                    delegate, meterRegistry(), scheme.sessionProtocol(), newEndpoint(uri));
+                    delegate, meterRegistry(), scheme.sessionProtocol(), endpoint);
 
             @SuppressWarnings("unchecked")
             final T client = (T) Proxy.newProxyInstance(

--- a/thrift/src/main/java/com/linecorp/armeria/client/thrift/THttpClientFactory.java
+++ b/thrift/src/main/java/com/linecorp/armeria/client/thrift/THttpClientFactory.java
@@ -23,6 +23,8 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Set;
 
+import javax.annotation.Nullable;
+
 import com.google.common.collect.ImmutableSet;
 
 import com.linecorp.armeria.client.Client;
@@ -80,7 +82,7 @@ final class THttpClientFactory extends DecoratingClientFactory {
     }
 
     @Override
-    public <T> T newClient(Scheme scheme, Endpoint endpoint, String path, Class<T> clientType,
+    public <T> T newClient(Scheme scheme, Endpoint endpoint, @Nullable String path, Class<T> clientType,
                            ClientOptions options) {
         final URI uri = endpoint.toUri(scheme, path);
 

--- a/thrift/src/main/java/com/linecorp/armeria/client/thrift/THttpClientFactory.java
+++ b/thrift/src/main/java/com/linecorp/armeria/client/thrift/THttpClientFactory.java
@@ -72,16 +72,17 @@ final class THttpClientFactory extends DecoratingClientFactory {
     }
 
     @Override
-    public <T> T newClient(Scheme scheme, Endpoint endpoint, Class<T> clientType, ClientOptions options) {
-        final URI uri = endpoint.toUri(scheme);
+    public <T> T newClient(URI uri, Class<T> clientType, ClientOptions options) {
+        final Scheme scheme = validateScheme(uri);
+        final Endpoint endpoint = newEndpoint(uri);
 
         return newClient(uri, scheme, endpoint, clientType, options);
     }
 
     @Override
-    public <T> T newClient(URI uri, Class<T> clientType, ClientOptions options) {
-        final Scheme scheme = validateScheme(uri);
-        final Endpoint endpoint = newEndpoint(uri);
+    public <T> T newClient(Scheme scheme, Endpoint endpoint, String path, Class<T> clientType,
+                           ClientOptions options) {
+        final URI uri = endpoint.toUri(scheme, path);
 
         return newClient(uri, scheme, endpoint, clientType, options);
     }

--- a/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftSerializationFormatsTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftSerializationFormatsTest.java
@@ -36,13 +36,14 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import com.linecorp.armeria.client.ClientBuilder;
 import com.linecorp.armeria.client.ClientOption;
-import com.linecorp.armeria.client.ClientOptions;
 import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.InvalidResponseHeadersException;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.Scheme;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.server.ServerBuilder;
@@ -177,27 +178,15 @@ public class ThriftSerializationFormatsTest {
 
     @Test
     public void givenClients_whenBinary_thenBuildClient() throws Exception {
-        // with ClientOptionValues
-        HelloService.Iface client = Clients.newClient(SessionProtocol.HTTP, BINARY, newEndpoint(BINARY),
-                                                      "/hello", HelloService.Iface.class);
+        HelloService.Iface client =
+                new ClientBuilder(Scheme.of(BINARY, SessionProtocol.HTTP), newEndpoint(BINARY))
+                        .path("/hello")
+                        .build(HelloService.Iface.class);
         assertThat(client.hello("Trustin")).isEqualTo("Hello, Trustin!");
 
-        // with ClientOptions
-        client = Clients.newClient(SessionProtocol.HTTP, BINARY, newEndpoint(BINARY), "/hello",
-                                   HelloService.Iface.class, ClientOptions.DEFAULT);
-        assertThat(client.hello("Trustin")).isEqualTo("Hello, Trustin!");
-    }
-
-    @Test
-    public void givenClients_whenText_thenBuildClient() throws Exception {
-        // with ClientOptionValues
-        HelloService.Iface client = Clients.newClient(SessionProtocol.HTTP, TEXT, newEndpoint(TEXT),
-                                                      "/hello", HelloService.Iface.class);
-        assertThat(client.hello("Trustin")).isEqualTo("Hello, Trustin!");
-
-        // with ClientOptions
-        client = Clients.newClient(SessionProtocol.HTTP, TEXT, newEndpoint(TEXT), "/hello",
-                                   HelloService.Iface.class, ClientOptions.DEFAULT);
+        client = new ClientBuilder(Scheme.of(TEXT, SessionProtocol.HTTP), newEndpoint(TEXT))
+                .path("/hello")
+                .build(HelloService.Iface.class);
         assertThat(client.hello("Trustin")).isEqualTo("Hello, Trustin!");
     }
 


### PR DESCRIPTION
   Motivation:
   - Current HttpClient only allow string or URI object for argument,
     but Endpoint is commonly use for handling URI. For convenience,
     HttpClient can accept Endpoint as argument.

   Modification:
   - Add Endpoint argument to HttpClient creation methods.

   Result:
   - HttpClient can be created with Endpoint instead of string or URI.