### PR TITLE
Enable to convert request body to expected result type regardless of content-type

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/annotation/ByteArrayRequestConverterFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/ByteArrayRequestConverterFunction.java
@@ -43,7 +43,7 @@ public class ByteArrayRequestConverterFunction implements RequestConverterFuncti
             if (array.length == length) {
                 return array;
             } else {
-                return Arrays.copyOf(array, length);
+                return Arrays.copyOfRange(array, request.content().offset(), length);
             }
         }
         if (expectedResultType == HttpData.class) {

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/ByteArrayRequestConverterFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/ByteArrayRequestConverterFunction.java
@@ -16,9 +16,10 @@
 
 package com.linecorp.armeria.server.annotation;
 
+import java.util.Arrays;
+
 import com.linecorp.armeria.common.AggregatedHttpMessage;
 import com.linecorp.armeria.common.HttpData;
-import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
 /**
@@ -36,17 +37,17 @@ public class ByteArrayRequestConverterFunction implements RequestConverterFuncti
     @Override
     public Object convertRequest(ServiceRequestContext ctx, AggregatedHttpMessage request,
                                  Class<?> expectedResultType) throws Exception {
-        final MediaType mediaType = request.contentType();
-        if (mediaType == null ||
-            mediaType.is(MediaType.OCTET_STREAM) ||
-            mediaType.is(MediaType.APPLICATION_BINARY)) {
-
-            if (expectedResultType == byte[].class) {
-                return request.content().array();
+        if (expectedResultType == byte[].class) {
+            final byte[] array = request.content().array();
+            final int length = request.content().length();
+            if (array.length == length) {
+                return array;
+            } else {
+                return Arrays.copyOf(array, length);
             }
-            if (expectedResultType == HttpData.class) {
-                return request.content();
-            }
+        }
+        if (expectedResultType == HttpData.class) {
+            return request.content();
         }
         return RequestConverterFunction.fallthrough();
     }

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/ByteArrayRequestConverterFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/ByteArrayRequestConverterFunction.java
@@ -37,17 +37,18 @@ public class ByteArrayRequestConverterFunction implements RequestConverterFuncti
     @Override
     public Object convertRequest(ServiceRequestContext ctx, AggregatedHttpMessage request,
                                  Class<?> expectedResultType) throws Exception {
+        final HttpData content = request.content();
         if (expectedResultType == byte[].class) {
-            final byte[] array = request.content().array();
-            final int length = request.content().length();
+            final byte[] array = content.array();
+            final int length = content.length();
             if (array.length == length) {
                 return array;
             } else {
-                return Arrays.copyOfRange(array, request.content().offset(), length);
+                return Arrays.copyOfRange(array, content.offset(), length);
             }
         }
         if (expectedResultType == HttpData.class) {
-            return request.content();
+            return content;
         }
         return RequestConverterFunction.fallthrough();
     }

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/JacksonRequestConverterFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/JacksonRequestConverterFunction.java
@@ -76,7 +76,8 @@ public class JacksonRequestConverterFunction implements RequestConverterFunction
                 } catch (JsonProcessingException e) {
                     if (expectedResultType == byte[].class ||
                         expectedResultType == HttpData.class ||
-                        expectedResultType == String.class) {
+                        expectedResultType == String.class ||
+                        expectedResultType == CharSequence.class) {
                         return RequestConverterFunction.fallthrough();
                     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/JacksonRequestConverterFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/JacksonRequestConverterFunction.java
@@ -75,7 +75,8 @@ public class JacksonRequestConverterFunction implements RequestConverterFunction
                     return reader.readValue(content);
                 } catch (JsonProcessingException e) {
                     if (expectedResultType == byte[].class ||
-                        expectedResultType == HttpData.class) {
+                        expectedResultType == HttpData.class ||
+                        expectedResultType == String.class) {
                         return RequestConverterFunction.fallthrough();
                     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/JacksonRequestConverterFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/JacksonRequestConverterFunction.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 
 import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
@@ -68,8 +69,11 @@ public class JacksonRequestConverterFunction implements RequestConverterFunction
         final MediaType contentType = request.contentType();
         if (contentType != null && (contentType.is(MediaType.JSON) ||
                                     contentType.subtype().endsWith("+json"))) {
-            if (expectedResultType == String.class) {
-                return request.content(contentType.charset().orElse(StandardCharsets.UTF_8));
+            if (expectedResultType == byte[].class) {
+                return request.content().array();
+            }
+            if (expectedResultType == HttpData.class) {
+                return request.content();
             }
 
             final ObjectReader reader = readers.computeIfAbsent(expectedResultType, mapper::readerFor);

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/JacksonRequestConverterFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/JacksonRequestConverterFunction.java
@@ -68,6 +68,10 @@ public class JacksonRequestConverterFunction implements RequestConverterFunction
         final MediaType contentType = request.contentType();
         if (contentType != null && (contentType.is(MediaType.JSON) ||
                                     contentType.subtype().endsWith("+json"))) {
+            if (expectedResultType == String.class) {
+                return request.content(contentType.charset().orElse(StandardCharsets.UTF_8));
+            }
+
             final ObjectReader reader = readers.computeIfAbsent(expectedResultType, mapper::readerFor);
             if (reader != null) {
                 final String content = request.content(contentType.charset().orElse(StandardCharsets.UTF_8));

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/StringRequestConverterFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/StringRequestConverterFunction.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.server.annotation;
 
+import java.nio.charset.Charset;
+
 import com.linecorp.armeria.common.AggregatedHttpMessage;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.internal.ArmeriaHttpUtil;
@@ -34,11 +36,14 @@ public class StringRequestConverterFunction implements RequestConverterFunction 
                                  Class<?> expectedResultType) throws Exception {
         if (expectedResultType == String.class ||
             expectedResultType == CharSequence.class) {
+            final Charset charset;
             final MediaType contentType = request.contentType();
-            if (contentType != null && contentType.is(MediaType.ANY_TEXT_TYPE)) {
-                return request.content(
-                        contentType.charset().orElse(ArmeriaHttpUtil.HTTP_DEFAULT_CONTENT_CHARSET));
+            if (contentType != null) {
+                charset = contentType.charset().orElse(ArmeriaHttpUtil.HTTP_DEFAULT_CONTENT_CHARSET);
+            } else {
+                charset = ArmeriaHttpUtil.HTTP_DEFAULT_CONTENT_CHARSET;
             }
+            return request.content(charset);
         }
         return RequestConverterFunction.fallthrough();
     }

--- a/core/src/test/java/com/linecorp/armeria/server/annotation/ByteArrayRequestConverterFunctionTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/annotation/ByteArrayRequestConverterFunctionTest.java
@@ -19,63 +19,37 @@ package com.linecorp.armeria.server.annotation;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.nio.charset.StandardCharsets;
-
 import org.junit.Test;
 import org.testng.Assert;
 
 import com.linecorp.armeria.common.AggregatedHttpMessage;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.MediaType;
-import com.linecorp.armeria.internal.FallthroughException;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
-public class JacksonRequestConverterFunctionTest {
+public class ByteArrayRequestConverterFunctionTest {
 
-    private static final RequestConverterFunction function = new JacksonRequestConverterFunction();
+    private static final RequestConverterFunction function = new ByteArrayRequestConverterFunction();
     private static final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
     private static final AggregatedHttpMessage req = mock(AggregatedHttpMessage.class);
 
     static final String JSON_TEXT = "{\"key\": \"value\"}";
 
-    @Test(expected = FallthroughException.class)
+    @Test
     public void jsonTextToByteArray() throws Exception {
         when(req.contentType()).thenReturn(MediaType.JSON);
-        when(req.content(StandardCharsets.UTF_8)).thenReturn(JSON_TEXT);
+        when(req.content()).thenReturn(HttpData.ofUtf8(JSON_TEXT));
 
-        function.convertRequest(ctx, req, byte[].class);
-    }
-
-    @Test(expected = FallthroughException.class)
-    public void jsonTextToHttpData() throws Exception {
-        when(req.contentType()).thenReturn(MediaType.JSON);
-        when(req.content(StandardCharsets.UTF_8)).thenReturn(JSON_TEXT);
-
-        function.convertRequest(ctx, req, HttpData.class);
-    }
-
-    @Test(expected = FallthroughException.class)
-    public void jsonTextToString() throws Exception {
-        when(req.contentType()).thenReturn(MediaType.JSON);
-        when(req.content(StandardCharsets.UTF_8)).thenReturn(JSON_TEXT);
-
-        function.convertRequest(ctx, req, String.class);
+        final Object result = function.convertRequest(ctx, req, byte[].class);
+        Assert.assertTrue(result instanceof byte[]);
     }
 
     @Test
-    public void jsonTextToJsonRequest() throws Exception {
+    public void jsonTextToHttpData() throws Exception {
         when(req.contentType()).thenReturn(MediaType.JSON);
-        when(req.content(StandardCharsets.UTF_8)).thenReturn(JSON_TEXT);
+        when(req.content()).thenReturn(HttpData.ofUtf8(JSON_TEXT));
 
-        final Object result = function.convertRequest(ctx, req, JsonRequest.class);
-        Assert.assertTrue(result instanceof JsonRequest);
-    }
-
-    static class JsonRequest {
-        private String key;
-
-        public void setKey(String key) {
-            this.key = key;
-        }
+        final Object result = function.convertRequest(ctx, req, HttpData.class);
+        Assert.assertTrue(result instanceof HttpData);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/annotation/ByteArrayRequestConverterFunctionTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/annotation/ByteArrayRequestConverterFunctionTest.java
@@ -16,11 +16,11 @@
 
 package com.linecorp.armeria.server.annotation;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.junit.Test;
-import org.testng.Assert;
 
 import com.linecorp.armeria.common.AggregatedHttpMessage;
 import com.linecorp.armeria.common.HttpData;
@@ -41,7 +41,7 @@ public class ByteArrayRequestConverterFunctionTest {
         when(req.content()).thenReturn(HttpData.ofUtf8(JSON_TEXT));
 
         final Object result = function.convertRequest(ctx, req, byte[].class);
-        Assert.assertTrue(result instanceof byte[]);
+        assertThat(result).isInstanceOf(byte[].class);
     }
 
     @Test
@@ -50,6 +50,6 @@ public class ByteArrayRequestConverterFunctionTest {
         when(req.content()).thenReturn(HttpData.ofUtf8(JSON_TEXT));
 
         final Object result = function.convertRequest(ctx, req, HttpData.class);
-        Assert.assertTrue(result instanceof HttpData);
+        assertThat(result).isInstanceOf(HttpData.class);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/annotation/JacksonRequestConverterFunctionTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/annotation/JacksonRequestConverterFunctionTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.testng.Assert;
 
 import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
@@ -33,27 +34,40 @@ public class JacksonRequestConverterFunctionTest {
     private static final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
     private static final AggregatedHttpMessage req = mock(AggregatedHttpMessage.class);
 
-    private static final String JSON_TEXT = "{\"key\": \"value\"}";
-
     @Test
-    public void jsonText_string() throws Exception {
-        when(req.contentType()).thenReturn(MediaType.JSON);
-        when(req.content(StandardCharsets.UTF_8)).thenReturn(JSON_TEXT);
+    public void jsonText_to_byteArray() throws Exception {
+        final String JSON_TEXT = "\"value\"";
 
-        final String result = (String) function.convertRequest(ctx, req, String.class);
-        Assert.assertEquals(result, JSON_TEXT);
+        when(req.contentType()).thenReturn(MediaType.JSON);
+        when(req.content()).thenReturn(HttpData.ofUtf8(JSON_TEXT));
+
+        final Object result = function.convertRequest(ctx, req, byte[].class);
+        Assert.assertTrue(result instanceof byte[]);
     }
 
     @Test
-    public void jsonText_otherType() throws Exception {
+    public void jsonText_to_httpData() throws Exception {
+        final String JSON_TEXT = "\"value\"";
+
+        when(req.contentType()).thenReturn(MediaType.JSON);
+        when(req.content()).thenReturn(HttpData.ofUtf8(JSON_TEXT));
+
+        final Object result = function.convertRequest(ctx, req, HttpData.class);
+        Assert.assertTrue(result instanceof HttpData);
+    }
+
+    @Test
+    public void jsonText_to_jsonRequest() throws Exception {
+        final String JSON_TEXT = "{\"key\": \"value\"}";
+
         when(req.contentType()).thenReturn(MediaType.JSON);
         when(req.content(StandardCharsets.UTF_8)).thenReturn(JSON_TEXT);
 
-        final Object result = function.convertRequest(ctx, req, Data.class);
-        Assert.assertTrue(result instanceof Data);
+        final Object result = function.convertRequest(ctx, req, JsonRequest.class);
+        Assert.assertTrue(result instanceof JsonRequest);
     }
 
-    static class Data {
+    static class JsonRequest {
         private String key;
 
         public void setKey(String key) {

--- a/core/src/test/java/com/linecorp/armeria/server/annotation/JacksonRequestConverterFunctionTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/annotation/JacksonRequestConverterFunctionTest.java
@@ -16,13 +16,13 @@
 
 package com.linecorp.armeria.server.annotation;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.nio.charset.StandardCharsets;
 
 import org.junit.Test;
-import org.testng.Assert;
 
 import com.linecorp.armeria.common.AggregatedHttpMessage;
 import com.linecorp.armeria.common.HttpData;
@@ -68,7 +68,7 @@ public class JacksonRequestConverterFunctionTest {
         when(req.content(StandardCharsets.UTF_8)).thenReturn(JSON_TEXT);
 
         final Object result = function.convertRequest(ctx, req, JsonRequest.class);
-        Assert.assertTrue(result instanceof JsonRequest);
+        assertThat(result).isInstanceOf(JsonRequest.class);
     }
 
     static class JsonRequest {

--- a/core/src/test/java/com/linecorp/armeria/server/annotation/JacksonRequestConverterFunctionTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/annotation/JacksonRequestConverterFunctionTest.java
@@ -13,6 +13,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+
 package com.linecorp.armeria.server.annotation;
 
 import static org.mockito.Mockito.mock;
@@ -26,6 +27,7 @@ import org.testng.Assert;
 import com.linecorp.armeria.common.AggregatedHttpMessage;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.internal.FallthroughException;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
 public class JacksonRequestConverterFunctionTest {
@@ -34,32 +36,26 @@ public class JacksonRequestConverterFunctionTest {
     private static final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
     private static final AggregatedHttpMessage req = mock(AggregatedHttpMessage.class);
 
-    @Test
-    public void jsonText_to_byteArray() throws Exception {
-        final String JSON_TEXT = "\"value\"";
+    static final String JSON_TEXT = "{\"key\": \"value\"}";
 
+    @Test(expected = FallthroughException.class)
+    public void jsonTextToByteArray() throws Exception {
         when(req.contentType()).thenReturn(MediaType.JSON);
-        when(req.content()).thenReturn(HttpData.ofUtf8(JSON_TEXT));
+        when(req.content(StandardCharsets.UTF_8)).thenReturn(JSON_TEXT);
 
-        final Object result = function.convertRequest(ctx, req, byte[].class);
-        Assert.assertTrue(result instanceof byte[]);
+        function.convertRequest(ctx, req, byte[].class);
+    }
+
+    @Test(expected = FallthroughException.class)
+    public void jsonTextToHttpData() throws Exception {
+        when(req.contentType()).thenReturn(MediaType.JSON);
+        when(req.content(StandardCharsets.UTF_8)).thenReturn(JSON_TEXT);
+
+        function.convertRequest(ctx, req, HttpData.class);
     }
 
     @Test
-    public void jsonText_to_httpData() throws Exception {
-        final String JSON_TEXT = "\"value\"";
-
-        when(req.contentType()).thenReturn(MediaType.JSON);
-        when(req.content()).thenReturn(HttpData.ofUtf8(JSON_TEXT));
-
-        final Object result = function.convertRequest(ctx, req, HttpData.class);
-        Assert.assertTrue(result instanceof HttpData);
-    }
-
-    @Test
-    public void jsonText_to_jsonRequest() throws Exception {
-        final String JSON_TEXT = "{\"key\": \"value\"}";
-
+    public void jsonTextToJsonRequest() throws Exception {
         when(req.contentType()).thenReturn(MediaType.JSON);
         when(req.content(StandardCharsets.UTF_8)).thenReturn(JSON_TEXT);
 

--- a/core/src/test/java/com/linecorp/armeria/server/annotation/JacksonRequestConverterFunctionTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/annotation/JacksonRequestConverterFunctionTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.annotation;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.Test;
+import org.testng.Assert;
+
+import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.server.ServiceRequestContext;
+
+public class JacksonRequestConverterFunctionTest {
+
+    private static final RequestConverterFunction function = new JacksonRequestConverterFunction();
+    private static final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
+    private static final AggregatedHttpMessage req = mock(AggregatedHttpMessage.class);
+
+    private static final String JSON_TEXT = "{\"key\": \"value\"}";
+
+    @Test
+    public void jsonText_string() throws Exception {
+        when(req.contentType()).thenReturn(MediaType.JSON);
+        when(req.content(StandardCharsets.UTF_8)).thenReturn(JSON_TEXT);
+
+        final String result = (String) function.convertRequest(ctx, req, String.class);
+        Assert.assertEquals(result, JSON_TEXT);
+    }
+
+    @Test
+    public void jsonText_otherType() throws Exception {
+        when(req.contentType()).thenReturn(MediaType.JSON);
+        when(req.content(StandardCharsets.UTF_8)).thenReturn(JSON_TEXT);
+
+        final Object result = function.convertRequest(ctx, req, Data.class);
+        Assert.assertTrue(result instanceof Data);
+    }
+
+    static class Data {
+        private String key;
+
+        public void setKey(String key) {
+            this.key = key;
+        }
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/annotation/StringRequestConverterFunctionTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/annotation/StringRequestConverterFunctionTest.java
@@ -16,11 +16,11 @@
 
 package com.linecorp.armeria.server.annotation;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.junit.Test;
-import org.testng.Assert;
 
 import com.linecorp.armeria.common.AggregatedHttpMessage;
 import com.linecorp.armeria.common.MediaType;
@@ -41,7 +41,7 @@ public class StringRequestConverterFunctionTest {
         when(req.content(ArmeriaHttpUtil.HTTP_DEFAULT_CONTENT_CHARSET)).thenReturn(JSON_TEXT);
 
         final Object result = function.convertRequest(ctx, req, String.class);
-        Assert.assertTrue(result instanceof String);
+        assertThat(result).isInstanceOf(String.class);
     }
 
     @Test
@@ -50,6 +50,6 @@ public class StringRequestConverterFunctionTest {
         when(req.content(ArmeriaHttpUtil.HTTP_DEFAULT_CONTENT_CHARSET)).thenReturn(JSON_TEXT);
 
         final Object result = function.convertRequest(ctx, req, CharSequence.class);
-        Assert.assertTrue(result instanceof CharSequence);
+        assertThat(result).isInstanceOf(CharSequence.class);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/annotation/StringRequestConverterFunctionTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/annotation/StringRequestConverterFunctionTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.annotation;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+import org.testng.Assert;
+
+import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.internal.ArmeriaHttpUtil;
+import com.linecorp.armeria.server.ServiceRequestContext;
+
+public class StringRequestConverterFunctionTest {
+
+    private static final RequestConverterFunction function = new StringRequestConverterFunction();
+    private static final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
+    private static final AggregatedHttpMessage req = mock(AggregatedHttpMessage.class);
+
+    static final String JSON_TEXT = "{\"a\": 1}";
+
+    @Test
+    public void jsonTextToString() throws Exception {
+        when(req.contentType()).thenReturn(MediaType.JSON);
+        when(req.content(ArmeriaHttpUtil.HTTP_DEFAULT_CONTENT_CHARSET)).thenReturn(JSON_TEXT);
+
+        final Object result = function.convertRequest(ctx, req, String.class);
+        Assert.assertTrue(result instanceof String);
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/annotation/StringRequestConverterFunctionTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/annotation/StringRequestConverterFunctionTest.java
@@ -43,4 +43,13 @@ public class StringRequestConverterFunctionTest {
         final Object result = function.convertRequest(ctx, req, String.class);
         Assert.assertTrue(result instanceof String);
     }
+
+    @Test
+    public void jsonTextToCharSequence() throws Exception {
+        when(req.contentType()).thenReturn(MediaType.JSON);
+        when(req.content(ArmeriaHttpUtil.HTTP_DEFAULT_CONTENT_CHARSET)).thenReturn(JSON_TEXT);
+
+        final Object result = function.convertRequest(ctx, req, CharSequence.class);
+        Assert.assertTrue(result instanceof CharSequence);
+    }
 }

--- a/site/src/sphinx/server-annotated-service.rst
+++ b/site/src/sphinx/server-annotated-service.rst
@@ -523,22 +523,25 @@ after your request converters, so you don't have to specify any :api:`@RequestCo
         public HttpResponse hello2(MyJsonRequest body) { ... }
 
         @Post("/hello3")
-        public HttpResponse hello2(String body) { ... }
+        public HttpResponse hello3(byte[] body) { ... }
+
+        @Post("/hello4")
+        public HttpResponse hello4(HttpData body) { ... }
 
         // StringRequestConverterFunction will work for the content type of any of 'text'.
-        @Post("/hello4")
-        public HttpResponse hello3(String body) { ... }
-
         @Post("/hello5")
-        public HttpResponse hello4(CharSequence body) { ... }
+        public HttpResponse hello5(String body) { ... }
+
+        @Post("/hello6")
+        public HttpResponse hello6(CharSequence body) { ... }
 
         // ByteArrayRequestConverterFunction will work for the content type of 'application/octet-stream',
         // 'application/binary' or none.
-        @Post("/hello6")
-        public HttpResponse hello5(byte[] body) { ... }
-
         @Post("/hello7")
-        public HttpResponse hello6(HttpData body) { ... }
+        public HttpResponse hello7(byte[] body) { ... }
+
+        @Post("/hello8")
+        public HttpResponse hello8(HttpData body) { ... }
     }
 
 Injecting value of parameters and HTTP headers into a Java object

--- a/site/src/sphinx/server-annotated-service.rst
+++ b/site/src/sphinx/server-annotated-service.rst
@@ -522,19 +522,22 @@ after your request converters, so you don't have to specify any :api:`@RequestCo
         @Post("/hello2")
         public HttpResponse hello2(MyJsonRequest body) { ... }
 
-        // StringRequestConverterFunction will work for the content type of any of 'text'.
         @Post("/hello3")
+        public HttpResponse hello2(String body) { ... }
+
+        // StringRequestConverterFunction will work for the content type of any of 'text'.
+        @Post("/hello4")
         public HttpResponse hello3(String body) { ... }
 
-        @Post("/hello4")
+        @Post("/hello5")
         public HttpResponse hello4(CharSequence body) { ... }
 
         // ByteArrayRequestConverterFunction will work for the content type of 'application/octet-stream',
         // 'application/binary' or none.
-        @Post("/hello5")
+        @Post("/hello6")
         public HttpResponse hello5(byte[] body) { ... }
 
-        @Post("/hello6")
+        @Post("/hello7")
         public HttpResponse hello6(HttpData body) { ... }
     }
 

--- a/site/src/sphinx/server-annotated-service.rst
+++ b/site/src/sphinx/server-annotated-service.rst
@@ -522,26 +522,19 @@ after your request converters, so you don't have to specify any :api:`@RequestCo
         @Post("/hello2")
         public HttpResponse hello2(MyJsonRequest body) { ... }
 
+        // StringRequestConverterFunction will work for regardless of the content type.
         @Post("/hello3")
-        public HttpResponse hello3(byte[] body) { ... }
+        public HttpResponse hello3(String body) { ... }
 
         @Post("/hello4")
-        public HttpResponse hello4(HttpData body) { ... }
+        public HttpResponse hello4(CharSequence body) { ... }
 
-        // StringRequestConverterFunction will work for the content type of any of 'text'.
+        // ByteArrayRequestConverterFunction will work for regardless of the content type.
         @Post("/hello5")
-        public HttpResponse hello5(String body) { ... }
+        public HttpResponse hello5(byte[] body) { ... }
 
         @Post("/hello6")
-        public HttpResponse hello6(CharSequence body) { ... }
-
-        // ByteArrayRequestConverterFunction will work for the content type of 'application/octet-stream',
-        // 'application/binary' or none.
-        @Post("/hello7")
-        public HttpResponse hello7(byte[] body) { ... }
-
-        @Post("/hello8")
-        public HttpResponse hello8(HttpData body) { ... }
+        public HttpResponse hello6(HttpData body) { ... }
     }
 
 Injecting value of parameters and HTTP headers into a Java object

--- a/site/src/sphinx/server-annotated-service.rst
+++ b/site/src/sphinx/server-annotated-service.rst
@@ -522,14 +522,14 @@ after your request converters, so you don't have to specify any :api:`@RequestCo
         @Post("/hello2")
         public HttpResponse hello2(MyJsonRequest body) { ... }
 
-        // StringRequestConverterFunction will work for regardless of the content type.
+        // StringRequestConverterFunction will work regardless of the content type.
         @Post("/hello3")
         public HttpResponse hello3(String body) { ... }
 
         @Post("/hello4")
         public HttpResponse hello4(CharSequence body) { ... }
 
-        // ByteArrayRequestConverterFunction will work for regardless of the content type.
+        // ByteArrayRequestConverterFunction will work regardless of the content type.
         @Post("/hello5")
         public HttpResponse hello5(byte[] body) { ... }
 


### PR DESCRIPTION
**Related-Issue:** https://github.com/line/armeria/issues/1584

**Motivation:**

Currently, it is possible to convert the request body to `byte[]`, `HttpData`, `String`, `CharSequence` only for a specific `content-type`.
If the converters can convert the body to `byte[]`, `HttpData`, `String`, `CharSequence` regardless of `content-type`, a user can easily convert the request body to specific result type what they want.

**Modification:**

- In `JacksonRequestConverterFunction`, pass the request to the next `RequestConverterFunction` if it failed to deserialize its content.
- In `ByteArrayRequestConverterFunction` and `StringRequestConverterFunction`, the request body can be converted to `expectedResultType` regardless of `content-type`.

**Result:**

A user can convert the request body to `byte[]`, `HttpData`, `String` and `CharSequence` regardless of `content-type`.