### PR TITLE
Introduce 'Copy as a curl command' button to a debug request window

### DIFF
--- a/docs-client/src/containers/MethodPage/DebugPage.tsx
+++ b/docs-client/src/containers/MethodPage/DebugPage.tsx
@@ -285,9 +285,7 @@ class DebugPage extends React.PureComponent<Props, State> {
   private onExport = () => {
     const escapeSingleQuote = (text: string) => text.replace(/'/g, `'\\''`);
 
-    const endpointPath = this.state.endpointPath; // annotated service only
     const additionalHeaders = this.state.additionalHeaders;
-    const queries = this.state.additionalQueries;
     const requestBody = this.state.requestBody;
 
     try {
@@ -315,7 +313,10 @@ class DebugPage extends React.PureComponent<Props, State> {
       }
 
       const httpMethod = method.httpMethod;
-      const [path, body] = transport.curlPathAndBody(
+      const endpoint = transport.findDebugMimeTypeEndpoint(method);
+      const path = endpoint.pathMapping;
+      const body = transport.getCurlBody(
+        endpoint,
         method,
         escapeSingleQuote(requestBody),
       );
@@ -323,10 +324,12 @@ class DebugPage extends React.PureComponent<Props, State> {
 
       if (this.props.isAnnotatedHttpService) {
         if (this.props.exactPathMapping) {
+          const queries = this.state.additionalQueries;
           uri =
             `'${host}${escapeSingleQuote(path)}` +
             `${queries.length > 0 ? `?${escapeSingleQuote(queries)}` : ''}'`;
         } else {
+          const endpointPath = this.state.endpointPath;
           this.validateEndpointPath(endpointPath);
           uri = `'${host}${escapeSingleQuote(endpointPath)}'`;
         }

--- a/docs-client/src/containers/MethodPage/DebugPage.tsx
+++ b/docs-client/src/containers/MethodPage/DebugPage.tsx
@@ -291,7 +291,7 @@ class DebugPage extends React.PureComponent<Props, State> {
       }
 
       const httpMethod = method.httpMethod;
-      const [path, body] = transport.curlPathAndBody(method, requestBody);
+      const [path, body] = transport.curlPathAndBody(method, requestBody.replace(/'/g, `'\\''`));
       let uri;
 
       if (this.props.isAnnotatedHttpService) {

--- a/docs-client/src/containers/MethodPage/DebugPage.tsx
+++ b/docs-client/src/containers/MethodPage/DebugPage.tsx
@@ -339,14 +339,14 @@ class DebugPage extends React.PureComponent<Props, State> {
         headers[docServiceDebug] = 'true';
       }
 
-      const header = Object.keys(headers)
+      const headerOptions = Object.keys(headers)
         .map((title) => {
-          return `-H '${title}:${headers[title]}'`;
+          return `-H '${title}: ${headers[title]}'`;
         })
         .join(' ');
 
       const curlCommand =
-        `curl -X${httpMethod} ${header} ${uri}` +
+        `curl -X${httpMethod} ${headerOptions} ${uri}` +
         `${this.props.useRequestBody ? ` -d '${body}'` : ''}`;
 
       DebugPage.copyTextToClipboard(curlCommand);

--- a/docs-client/src/containers/MethodPage/DebugPage.tsx
+++ b/docs-client/src/containers/MethodPage/DebugPage.tsx
@@ -17,10 +17,10 @@
 import Button from '@material-ui/core/Button';
 import Grid from '@material-ui/core/Grid';
 import IconButton from '@material-ui/core/IconButton';
-import Snackbar from "@material-ui/core/Snackbar";
+import Snackbar from '@material-ui/core/Snackbar';
 import Tooltip from '@material-ui/core/Tooltip';
 import Typography from '@material-ui/core/Typography';
-import CloseIcon from "@material-ui/icons/Close";
+import CloseIcon from '@material-ui/icons/Close';
 import DeleteSweepIcon from '@material-ui/icons/DeleteSweep';
 import FileCopyIcon from '@material-ui/icons/FileCopy';
 import React, { ChangeEvent } from 'react';
@@ -31,7 +31,7 @@ import githubGist from 'react-syntax-highlighter/styles/hljs/github-gist';
 import jsonMinify from 'jsonminify';
 import { RouteComponentProps } from 'react-router';
 import Section from '../../components/Section';
-import { docServiceDebug } from "../../lib/header-provider";
+import { docServiceDebug } from '../../lib/header-provider';
 import jsonPrettify from '../../lib/json-prettify';
 import { Method } from '../../lib/specification';
 import { TRANSPORTS } from '../../lib/transports';
@@ -176,16 +176,16 @@ class DebugPage extends React.PureComponent<Props, State> {
           <Grid item xs={12} sm={6}>
             <Tooltip title="Copy response">
               <IconButton
-                  onClick={this.onCopy}
-                  disabled={this.state.debugResponse.length == 0}
+                onClick={this.onCopy}
+                disabled={this.state.debugResponse.length === 0}
               >
                 <FileCopyIcon />
               </IconButton>
             </Tooltip>
             <Tooltip title="Clear response">
               <IconButton
-                  onClick={this.onClear}
-                  disabled={this.state.debugResponse.length == 0}
+                onClick={this.onClear}
+                disabled={this.state.debugResponse.length === 0}
               >
                 <DeleteSweepIcon />
               </IconButton>
@@ -200,18 +200,15 @@ class DebugPage extends React.PureComponent<Props, State> {
           </Grid>
         </Grid>
         <Snackbar
-            open={this.state.snackbarOpen}
-            message={this.state.snackbarMessage}
-            autoHideDuration={3000}
-            onClose={this.onSnackbarDismiss}
-            action={[
-              <IconButton
-                  color="inherit"
-                  onClick={this.onSnackbarDismiss}
-              >
-                <CloseIcon />
-              </IconButton>,
-            ]}
+          open={this.state.snackbarOpen}
+          message={this.state.snackbarMessage}
+          autoHideDuration={3000}
+          onClose={this.onSnackbarDismiss}
+          action={
+            <IconButton color="inherit" onClick={this.onSnackbarDismiss}>
+              <CloseIcon />
+            </IconButton>
+          }
         />
       </Section>
     );
@@ -302,12 +299,14 @@ class DebugPage extends React.PureComponent<Props, State> {
         DebugPage.validateJsonObject(additionalHeaders, 'headers');
       }
 
-      const headers = additionalHeaders && JSON.parse(additionalHeaders) || {};
+      const headers =
+        (additionalHeaders && JSON.parse(additionalHeaders)) || {};
 
       // window.location.origin may have compatibility issue
       // https://developer.mozilla.org/en-US/docs/Web/API/Window/location#Browser_compatibility
-      const host = `${window.location.protocol}//${window.location.hostname}`
-          + (window.location.port ? `:${window.location.port}` : '');
+      const host =
+        `${window.location.protocol}//${window.location.hostname}` +
+        `${window.location.port ? `:${window.location.port}` : ''}`;
 
       const method = this.props.method;
       const transport = TRANSPORTS.getDebugTransport(method);
@@ -316,13 +315,17 @@ class DebugPage extends React.PureComponent<Props, State> {
       }
 
       const httpMethod = method.httpMethod;
-      const [path, body] = transport.curlPathAndBody(method, escapeSingleQuote(requestBody));
+      const [path, body] = transport.curlPathAndBody(
+        method,
+        escapeSingleQuote(requestBody),
+      );
       let uri;
 
       if (this.props.isAnnotatedHttpService) {
         if (this.props.exactPathMapping) {
-          uri = `'${host}${escapeSingleQuote(path)}`;
-          + queries.length > 0 ? `?${escapeSingleQuote(queries)}'` : `'`;
+          uri =
+            `'${host}${escapeSingleQuote(path)}` +
+            `${queries.length > 0 ? `?${escapeSingleQuote(queries)}` : ''}'`;
         } else {
           this.validateEndpointPath(endpointPath);
           uri = `'${host}${escapeSingleQuote(endpointPath)}'`;
@@ -336,18 +339,21 @@ class DebugPage extends React.PureComponent<Props, State> {
         headers[docServiceDebug] = 'true';
       }
 
-      const header = Object.keys(headers).map((title) => {
-        return `-H '${title}:${headers[title]}'`;
-      }).join(' ');
+      const header = Object.keys(headers)
+        .map((title) => {
+          return `-H '${title}:${headers[title]}'`;
+        })
+        .join(' ');
 
-      const curlCommand = `curl -X${httpMethod} ${header} ${uri}`
-          + (this.props.useRequestBody ? ` -d '${body}'` : '');
+      const curlCommand =
+        `curl -X${httpMethod} ${header} ${uri}` +
+        `${this.props.useRequestBody ? ` -d '${body}'` : ''}`;
 
       DebugPage.copyTextToClipboard(curlCommand);
       this.showSnackbar('The curl command has been copied to the clipboard.');
     } catch (e) {
       this.setState({
-        debugResponse: e.toString()
+        debugResponse: e.toString(),
       });
     }
   };

--- a/docs-client/src/containers/MethodPage/DebugPage.tsx
+++ b/docs-client/src/containers/MethodPage/DebugPage.tsx
@@ -281,7 +281,7 @@ class DebugPage extends React.PureComponent<Props, State> {
     const response = this.state.debugResponse;
     if (response.length > 0) {
       DebugPage.copyTextToClipboard(response);
-      this.onSnackbarOpen('The response has been copied to the clipboard.');
+      this.showSnackbar('The response has been copied to the clipboard.');
     }
   };
 
@@ -344,7 +344,7 @@ class DebugPage extends React.PureComponent<Props, State> {
           + (this.props.useRequestBody ? ` -d '${body}'` : '');
 
       DebugPage.copyTextToClipboard(curlCommand);
-      this.onSnackbarOpen('The curl command has been copied to the clipboard.');
+      this.showSnackbar('The curl command has been copied to the clipboard.');
     } catch (e) {
       this.setState({
         debugResponse: e.toString()
@@ -426,7 +426,7 @@ class DebugPage extends React.PureComponent<Props, State> {
     this.executeRequest(params);
   };
 
-  private onSnackbarOpen = (text: string) => {
+  private showSnackbar = (text: string) => {
     this.setState({
       snackbarOpen: true,
       snackbarMessage: text,

--- a/docs-client/src/containers/MethodPage/DebugPage.tsx
+++ b/docs-client/src/containers/MethodPage/DebugPage.tsx
@@ -326,7 +326,7 @@ class DebugPage extends React.PureComponent<Props, State> {
         if (this.props.exactPathMapping) {
           const queries = this.state.additionalQueries;
           uri =
-            `'${host}${escapeSingleQuote(path)}` +
+            `'${host}${escapeSingleQuote(path.substring("exact:".length))}` +
             `${queries.length > 0 ? `?${escapeSingleQuote(queries)}` : ''}'`;
         } else {
           const endpointPath = this.state.endpointPath;

--- a/docs-client/src/containers/MethodPage/DebugPage.tsx
+++ b/docs-client/src/containers/MethodPage/DebugPage.tsx
@@ -175,12 +175,18 @@ class DebugPage extends React.PureComponent<Props, State> {
           </Grid>
           <Grid item xs={12} sm={6}>
             <Tooltip title="Copy response">
-              <IconButton onClick={this.onCopy}>
+              <IconButton
+                  onClick={this.onCopy}
+                  disabled={this.state.debugResponse.length == 0}
+              >
                 <FileCopyIcon />
               </IconButton>
             </Tooltip>
             <Tooltip title="Clear response">
-              <IconButton onClick={this.onClear}>
+              <IconButton
+                  onClick={this.onClear}
+                  disabled={this.state.debugResponse.length == 0}
+              >
                 <DeleteSweepIcon />
               </IconButton>
             </Tooltip>

--- a/docs-client/src/containers/MethodPage/DebugPage.tsx
+++ b/docs-client/src/containers/MethodPage/DebugPage.tsx
@@ -340,8 +340,8 @@ class DebugPage extends React.PureComponent<Props, State> {
       }
 
       const headerOptions = Object.keys(headers)
-        .map((title) => {
-          return `-H '${title}: ${headers[title]}'`;
+        .map((name) => {
+          return `-H '${name}: ${headers[name]}'`;
         })
         .join(' ');
 

--- a/docs-client/src/containers/MethodPage/DebugPage.tsx
+++ b/docs-client/src/containers/MethodPage/DebugPage.tsx
@@ -326,7 +326,7 @@ class DebugPage extends React.PureComponent<Props, State> {
         if (this.props.exactPathMapping) {
           const queries = this.state.additionalQueries;
           uri =
-            `'${host}${escapeSingleQuote(path.substring("exact:".length))}` +
+            `'${host}${escapeSingleQuote(path.substring('exact:'.length))}` +
             `${queries.length > 0 ? `?${escapeSingleQuote(queries)}` : ''}'`;
         } else {
           const endpointPath = this.state.endpointPath;

--- a/docs-client/src/containers/MethodPage/DebugPage.tsx
+++ b/docs-client/src/containers/MethodPage/DebugPage.tsx
@@ -321,7 +321,8 @@ class DebugPage extends React.PureComponent<Props, State> {
 
       if (this.props.isAnnotatedHttpService) {
         if (this.props.exactPathMapping) {
-          uri = `'${host}${escapeSingleQuote(path)}?${escapeSingleQuote(queries)}'`;
+          uri = `'${host}${escapeSingleQuote(path)}`;
+          + queries.length > 0 ? `?${escapeSingleQuote(queries)}'` : `'`;
         } else {
           this.validateEndpointPath(endpointPath);
           uri = `'${host}${escapeSingleQuote(endpointPath)}'`;

--- a/docs-client/src/containers/MethodPage/DebugPage.tsx
+++ b/docs-client/src/containers/MethodPage/DebugPage.tsx
@@ -280,6 +280,8 @@ class DebugPage extends React.PureComponent<Props, State> {
   };
 
   private onExport = () => {
+    const escapeSingleQuote = (text: string) => text.replace(/'/g, `'\\''`);
+
     const endpointPath = this.state.endpointPath; // annotated service only
     const additionalHeaders = this.state.additionalHeaders;
     const queries = this.state.additionalQueries;
@@ -308,18 +310,18 @@ class DebugPage extends React.PureComponent<Props, State> {
       }
 
       const httpMethod = method.httpMethod;
-      const [path, body] = transport.curlPathAndBody(method, requestBody.replace(/'/g, `'\\''`));
+      const [path, body] = transport.curlPathAndBody(method, escapeSingleQuote(requestBody));
       let uri;
 
       if (this.props.isAnnotatedHttpService) {
         if (this.props.exactPathMapping) {
-          uri = `'${host}${path}?${queries}'`;
+          uri = `'${host}${escapeSingleQuote(path)}?${escapeSingleQuote(queries)}'`;
         } else {
           this.validateEndpointPath(endpointPath);
-          uri = `'${host}${endpointPath}'`;
+          uri = `'${host}${escapeSingleQuote(endpointPath)}'`;
         }
       } else {
-        uri = `'${host}${path}'`;
+        uri = `'${host}${escapeSingleQuote(path)}'`;
       }
 
       headers['content-type'] = transport.getDebugMimeType();

--- a/docs-client/src/lib/transports/annotated-http.ts
+++ b/docs-client/src/lib/transports/annotated-http.ts
@@ -30,7 +30,7 @@ export default class AnnotatedHttpTransport extends Transport {
   }
 
   protected getCurlPath(endpoint: Endpoint): string {
-    return endpoint.pathMapping.substring("exact:".length);
+    return endpoint.pathMapping.substring('exact:'.length);
   }
 
   protected async doSend(

--- a/docs-client/src/lib/transports/annotated-http.ts
+++ b/docs-client/src/lib/transports/annotated-http.ts
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-import { Method } from '../specification';
+import { Endpoint, Method } from '../specification';
 
 import Transport from './transport';
 
@@ -23,6 +23,14 @@ export const ANNOTATED_HTTP_MIME_TYPE = 'application/json; charset=utf-8';
 export default class AnnotatedHttpTransport extends Transport {
   public supportsMimeType(mimeType: string): boolean {
     return mimeType === ANNOTATED_HTTP_MIME_TYPE;
+  }
+
+  public getDebugMimeType(): string {
+    return ANNOTATED_HTTP_MIME_TYPE;
+  }
+
+  protected getCurlPath(endpoint: Endpoint): string {
+    return endpoint.pathMapping.substring("exact:".length);
   }
 
   protected async doSend(

--- a/docs-client/src/lib/transports/annotated-http.ts
+++ b/docs-client/src/lib/transports/annotated-http.ts
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-import { Endpoint, Method } from '../specification';
+import { Method } from '../specification';
 
 import Transport from './transport';
 
@@ -27,10 +27,6 @@ export default class AnnotatedHttpTransport extends Transport {
 
   public getDebugMimeType(): string {
     return ANNOTATED_HTTP_MIME_TYPE;
-  }
-
-  protected getCurlPath(endpoint: Endpoint): string {
-    return endpoint.pathMapping.substring('exact:'.length);
   }
 
   protected async doSend(

--- a/docs-client/src/lib/transports/annotated-http.ts
+++ b/docs-client/src/lib/transports/annotated-http.ts
@@ -40,14 +40,7 @@ export default class AnnotatedHttpTransport extends Transport {
     endpointPath?: string,
     queries?: string,
   ): Promise<string> {
-    const endpoint = method.endpoints.find((ep) =>
-      ep.availableMimeTypes.includes(ANNOTATED_HTTP_MIME_TYPE),
-    );
-    if (!endpoint) {
-      throw new Error(
-        'Endpoint does not support annotated HTTP debug transport.',
-      );
-    }
+    const endpoint = this.findDebugMimeTypeEndpoint(method);
 
     const hdrs = new Headers();
     hdrs.set('content-type', ANNOTATED_HTTP_MIME_TYPE);

--- a/docs-client/src/lib/transports/grpc-unframed.ts
+++ b/docs-client/src/lib/transports/grpc-unframed.ts
@@ -38,13 +38,7 @@ export default class GrpcUnframedTransport extends Transport {
     if (!bodyJson) {
       throw new Error('A gRPC request must have body.');
     }
-
-    const endpoint = method.endpoints.find((ep) =>
-      ep.availableMimeTypes.includes(GRPC_UNFRAMED_MIME_TYPE),
-    );
-    if (!endpoint) {
-      throw new Error('Endpoint does not support gRPC debug transport.');
-    }
+    const endpoint = this.findDebugMimeTypeEndpoint(method);
 
     const hdrs = new Headers();
     hdrs.set('content-type', GRPC_UNFRAMED_MIME_TYPE);

--- a/docs-client/src/lib/transports/grpc-unframed.ts
+++ b/docs-client/src/lib/transports/grpc-unframed.ts
@@ -26,6 +26,10 @@ export default class GrpcUnframedTransport extends Transport {
     return mimeType === GRPC_UNFRAMED_MIME_TYPE;
   }
 
+  public getDebugMimeType(): string {
+    return GRPC_UNFRAMED_MIME_TYPE;
+  }
+
   protected async doSend(
     method: Method,
     headers: { [name: string]: string },

--- a/docs-client/src/lib/transports/thrift.ts
+++ b/docs-client/src/lib/transports/thrift.ts
@@ -42,7 +42,6 @@ export default class ThriftTransport extends Transport {
     if (!bodyJson) {
       throw new Error('A Thrift request must have body.');
     }
-
     const endpoint = this.findDebugMimeTypeEndpoint(method);
 
     const thriftMethod = ThriftTransport.thriftMethod(endpoint, method);

--- a/docs-client/src/lib/transports/thrift.ts
+++ b/docs-client/src/lib/transports/thrift.ts
@@ -21,6 +21,12 @@ import Transport from './transport';
 const TTEXT_MIME_TYPE = 'application/x-thrift; protocol=TTEXT';
 
 export default class ThriftTransport extends Transport {
+  private static thriftMethod(endpoint: Endpoint, method: Method) {
+    return endpoint.fragment
+      ? `${endpoint.fragment}:${method.name}`
+      : method.name;
+  }
+
   public supportsMimeType(mimeType: string): boolean {
     return mimeType === TTEXT_MIME_TYPE;
   }
@@ -29,7 +35,11 @@ export default class ThriftTransport extends Transport {
     return TTEXT_MIME_TYPE;
   }
 
-  protected getCurlBody(body: string, endpoint: Endpoint, method: Method): string {
+  protected getCurlBody(
+    body: string,
+    endpoint: Endpoint,
+    method: Method,
+  ): string {
     const thriftMethod = ThriftTransport.thriftMethod(endpoint, method);
     return `{"method":"${thriftMethod}", "type": "CALL", "args": ${body}}`;
   }
@@ -59,11 +69,5 @@ export default class ThriftTransport extends Transport {
     });
     const response = await httpResponse.text();
     return response.length > 0 ? response : 'Request sent to one-way function';
-  }
-
-  private static thriftMethod(endpoint: Endpoint, method: Method) {
-    return endpoint.fragment
-        ? `${endpoint.fragment}:${method.name}`
-        : method.name;
   }
 }

--- a/docs-client/src/lib/transports/thrift.ts
+++ b/docs-client/src/lib/transports/thrift.ts
@@ -35,11 +35,7 @@ export default class ThriftTransport extends Transport {
     return TTEXT_MIME_TYPE;
   }
 
-  protected getCurlBody(
-    body: string,
-    endpoint: Endpoint,
-    method: Method,
-  ): string {
+  public getCurlBody(endpoint: Endpoint, method: Method, body: string): string {
     const thriftMethod = ThriftTransport.thriftMethod(endpoint, method);
     return `{"method":"${thriftMethod}", "type": "CALL", "args": ${body}}`;
   }

--- a/docs-client/src/lib/transports/transport.ts
+++ b/docs-client/src/lib/transports/transport.ts
@@ -19,6 +19,10 @@ import { docServiceDebug, providers } from '../header-provider';
 import { Endpoint, Method } from '../specification';
 
 export default abstract class Transport {
+  public abstract supportsMimeType(mimeType: string): boolean;
+
+  public abstract getDebugMimeType(): string;
+
   public async send(
     method: Method,
     headers: { [name: string]: string },
@@ -49,15 +53,20 @@ export default abstract class Transport {
 
   public curlPathAndBody(method: Method, body: string): [string, string] {
     const endpoint = this.findDebugMimeTypeEndpoint(method);
-    return [this.getCurlPath(endpoint), this.getCurlBody(body, endpoint, method)];
+    return [
+      this.getCurlPath(endpoint),
+      this.getCurlBody(body, endpoint, method),
+    ];
   }
 
   protected findDebugMimeTypeEndpoint(method: Method): Endpoint {
     const endpoint = method.endpoints.find((ep) =>
-        ep.availableMimeTypes.includes(this.getDebugMimeType()),
+      ep.availableMimeTypes.includes(this.getDebugMimeType()),
     );
     if (!endpoint) {
-      throw new Error(`Endpoint does not support debug transport. MimeType: ${this.getDebugMimeType()}`);
+      throw new Error(
+        `Endpoint does not support debug transport. MimeType: ${this.getDebugMimeType()}`,
+      );
     }
     return endpoint;
   }
@@ -66,13 +75,13 @@ export default abstract class Transport {
     return endpoint.pathMapping;
   }
 
-  protected getCurlBody(body: string, _endpoint: Endpoint, _method: Method): string {
+  protected getCurlBody(
+    body: string,
+    _endpoint: Endpoint,
+    _method: Method,
+  ): string {
     return body;
   }
-
-  public abstract supportsMimeType(mimeType: string): boolean;
-
-  public abstract getDebugMimeType(): string;
 
   protected abstract doSend(
     method: Method,

--- a/docs-client/src/lib/transports/transport.ts
+++ b/docs-client/src/lib/transports/transport.ts
@@ -51,15 +51,7 @@ export default abstract class Transport {
     return this.doSend(method, filledHeaders, bodyJson, endpointPath, queries);
   }
 
-  public curlPathAndBody(method: Method, body: string): [string, string] {
-    const endpoint = this.findDebugMimeTypeEndpoint(method);
-    return [
-      this.getCurlPath(endpoint),
-      this.getCurlBody(body, endpoint, method),
-    ];
-  }
-
-  protected findDebugMimeTypeEndpoint(method: Method): Endpoint {
+  public findDebugMimeTypeEndpoint(method: Method): Endpoint {
     const endpoint = method.endpoints.find((ep) =>
       ep.availableMimeTypes.includes(this.getDebugMimeType()),
     );
@@ -71,14 +63,10 @@ export default abstract class Transport {
     return endpoint;
   }
 
-  protected getCurlPath(endpoint: Endpoint): string {
-    return endpoint.pathMapping;
-  }
-
-  protected getCurlBody(
-    body: string,
+  public getCurlBody(
     _endpoint: Endpoint,
     _method: Method,
+    body: string,
   ): string {
     return body;
   }

--- a/docs-client/src/lib/transports/transport.ts
+++ b/docs-client/src/lib/transports/transport.ts
@@ -49,10 +49,6 @@ export default abstract class Transport {
 
   public curlPathAndBody(method: Method, body: string): [string, string] {
     const endpoint = this.findDebugMimeTypeEndpoint(method);
-    if (!endpoint) {
-      throw new Error("Endpoint null");
-    }
-
     return [this.getCurlPath(endpoint), this.getCurlBody(body, endpoint, method)];
   }
 
@@ -61,7 +57,7 @@ export default abstract class Transport {
         ep.availableMimeTypes.includes(this.getDebugMimeType()),
     );
     if (!endpoint) {
-      throw new Error('Endpoint does not support debug transport.');
+      throw new Error(`Endpoint does not support debug transport. MimeType: ${this.getDebugMimeType()}`);
     }
     return endpoint;
   }


### PR DESCRIPTION
Motivation:

- Rarely, I want to copy a debug request to a curl command to put
additional headers to the request. Even if I can copy it from the dev
tools provided by browsers, opening them is annoying.

Modifications:

- Introduced a 'Copy as a curl command' button
  - It copies the converted command to the clipboard, but not intuitive...
- Added some methods to support curl export in `Transport` class
  - Each three transports has its own MIME type and body format to make
  a request in text

Result:

- Close #196


For your reference,

<kbd><img src="https://cl.ly/35f9d965b508/2019-04-28_20-57-08.png"></kbd>

<kbd><img src="https://cl.ly/d655bfd6042d/2019-04-28_20-58-26.png"></kbd>

<kbd><img src="https://cl.ly/387928a10807/2019-04-28_20-59-14.png"></kbd>