### PR TITLE
Do not set SO_KEEPALIVE socket option by default

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
@@ -116,7 +116,6 @@ public final class ClientFactoryBuilder {
      */
     public ClientFactoryBuilder() {
         connectTimeoutMillis(Flags.defaultConnectTimeoutMillis());
-        channelOption(ChannelOption.SO_KEEPALIVE, true);
     }
 
     /**


### PR DESCRIPTION
Motivation:

There's not really a need to set the `SO_KEEPALIVE` socket option in a
modern socket programming, because the keepalive interval is way longer
than what users usually want and it is often difficult to configure the
interval.

Modifications:

- Remove the code that sets `SO_KEEPALIVE` channel option on the client
  side.

Result:

We don't waste time setting an additional channel option.