### PR TITLE
Update dependencies

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -3,7 +3,7 @@
 #
 
 cglib:
-  cglib: { version: '3.2.10' }
+  cglib: { version: '3.2.12' }
 
 ch.qos.logback:
   logback-classic:
@@ -115,7 +115,7 @@ gradle.plugin.net.davidecavestro:
 
 io.dropwizard.metrics:
   metrics-core:
-    version: &DROPWIZARD_VERSION '4.0.5'
+    version: &DROPWIZARD_VERSION '4.1.0'
     javadocs:
     - https://metrics.dropwizard.io/4.0.0/apidocs/
   metrics-json: { version: *DROPWIZARD_VERSION }
@@ -188,7 +188,7 @@ io.netty:
 
 io.projectreactor:
   reactor-core:
-    version: &REACTOR_VERSION '3.2.8.RELEASE'
+    version: &REACTOR_VERSION '3.2.9.RELEASE'
     javadocs:
     - https://projectreactor.io/docs/core/release/api/
   reactor-test: { version: *REACTOR_VERSION }
@@ -264,7 +264,7 @@ net.javacrumbs.json-unit:
   json-unit-fluent: { version: *JSON_UNIT_VERSION }
 
 net.sf.proguard:
-  proguard-gradle: { version: '6.1.0beta2' }
+  proguard-gradle: { version: '6.1.0' }
 
 net.shibboleth.utilities:
   java-support: { version: '7.3.0' }
@@ -346,7 +346,7 @@ org.dmonix.junit:
   zookeeper-junit: { version: '1.2' }
 
 org.eclipse.jetty:
-  apache-jsp: { version: &JETTY_VERSION '9.4.17.v20190418' }
+  apache-jsp: { version: &JETTY_VERSION '9.4.18.v20190429' }
   apache-jstl: { version: *JETTY_VERSION }
   jetty-annotations:
     version: *JETTY_VERSION

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4-all.zip
-distributionSha256Sum=f177768e7a032727e4338c8fd047f8f263e5bd283f67a7766c1ba4182c8455a6
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionSha256Sum=14cd15fc8cc8705bd69dcfa3c8fefb27eb7027f5de4b47a8b279218f76895a91
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- Dropwizard Metrics 4.0.5 -> 4.1.0
- Jetty 9.4.17 -> 9.4.18
- Project Reactor 3.2.8 -> 3.2.9
- Build
  - cglib 3.2.10 -> 3.2.12
  - Gradle 5.4 -> 5.4.1
  - ProGuard 6.1.0beta2 -> 6.1.0