### PR TITLE
Link to https://go.java/ instead of https://java.oracle.com/

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Visit [the official web site](https://line.github.io/armeria/) for more informat
 # Armeria
 
 _Armeria_ is an open-source asynchronous RPC/API client/server library built on top of
-[Java 8](https://java.oracle.com/), [Netty 4.1](https://netty.io/), [HTTP/2](https://http2.github.io/),
+[Java 8](https://go.java/), [Netty 4.1](https://netty.io/), [HTTP/2](https://http2.github.io/),
 [Thrift](https://thrift.apache.org/) and [gRPC](https://grpc.io/). Its primary goal is to help engineers build
 high-performance asynchronous microservices that use HTTP/2 as a session layer protocol.
 

--- a/site/src/sphinx/index.rst
+++ b/site/src/sphinx/index.rst
@@ -3,7 +3,7 @@
 .. _`gRPC`: https://grpc.io/
 .. _`HTTP/2`: https://http2.github.io/
 .. _`HTTP/2 connection preface`: https://tools.ietf.org/html/rfc7540#section-3.5
-.. _`Java 8`: https://java.oracle.com/
+.. _`Java 8`: https://go.java/
 .. _`LINE Corporation`: https://linecorp.com/en/
 .. _`Netty`: https://netty.io/
 .. _`Reactive Streams`: http://www.reactive-streams.org/


### PR DESCRIPTION
.. because it just looks better.