### PR TITLE
Fix `http.url` Zipkin span tag and add `http.protocol` and `http.serfmt`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/SessionProtocol.java
+++ b/core/src/main/java/com/linecorp/armeria/common/SessionProtocol.java
@@ -21,9 +21,11 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import com.google.common.base.Ascii;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Sets;
 
 /**
  * Session-level protocol that provides facilities such as framing and flow control.
@@ -58,6 +60,10 @@ public enum SessionProtocol {
      */
     PROXY("proxy", false, false, 0);
 
+    private static final Set<SessionProtocol> HTTP_VALUES = Sets.immutableEnumSet(HTTP, H1C, H2C);
+
+    private static final Set<SessionProtocol> HTTPS_VALUES = Sets.immutableEnumSet(HTTPS, H1, H2);
+
     private static final Map<String, SessionProtocol> uriTextToProtocols;
 
     static {
@@ -87,6 +93,26 @@ public enum SessionProtocol {
     public static Optional<SessionProtocol> find(String uriText) {
         uriText = Ascii.toLowerCase(requireNonNull(uriText, "uriText"));
         return Optional.ofNullable(uriTextToProtocols.get(uriText));
+    }
+
+    /**
+     * Returns an immutable {@link Set} that contains {@link #HTTP}, {@link #H1C} and {@link #H2C}.
+     * Note that it does not contain HTTPS protocols such as {@link #HTTPS}, {@link #H1} and {@link #H2}.
+     *
+     * @see #httpsValues()
+     */
+    public static Set<SessionProtocol> httpValues() {
+        return HTTP_VALUES;
+    }
+
+    /**
+     * Returns an immutable {@link Set} that contains {@link #HTTPS}, {@link #H1} and {@link #H2}.
+     * Note that it does not contain HTTP protocols such as {@link #HTTP}, {@link #H1C} and {@link #H2C}.
+     *
+     * @see #httpValues()
+     */
+    public static Set<SessionProtocol> httpsValues() {
+        return HTTPS_VALUES;
     }
 
     private final String uriText;

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
@@ -34,8 +34,6 @@ import javax.net.ssl.SSLException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.collect.Iterables;
-
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.internal.ChannelUtil;
@@ -137,7 +135,7 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
     private void configurePipeline(ChannelPipeline p, Set<SessionProtocol> protocols,
                                    @Nullable ProxiedAddresses proxiedAddresses) {
         if (protocols.size() == 1) {
-            switch (Iterables.getFirst(protocols, null)) {
+            switch (protocols.iterator().next()) {
                 case HTTP:
                     configureHttp(p, proxiedAddresses);
                     break;

--- a/zipkin/src/main/java/com/linecorp/armeria/internal/tracing/SpanTags.java
+++ b/zipkin/src/main/java/com/linecorp/armeria/internal/tracing/SpanTags.java
@@ -83,16 +83,23 @@ public final class SpanTags {
 
     private static String generateUrl(Scheme scheme, String authority, String path, @Nullable String query) {
         final SessionProtocol sessionProtocol = scheme.sessionProtocol();
-        final StringBuilder uriBuilder = new StringBuilder();
+        final String uriScheme;
         if (SessionProtocol.httpValues().contains(sessionProtocol)) {
-            uriBuilder.append("http://");
+            uriScheme = "http://";
         } else if (SessionProtocol.httpsValues().contains(sessionProtocol)) {
-            uriBuilder.append("https://");
+            uriScheme = "https://";
         } else {
-            uriBuilder.append(sessionProtocol.uriText()).append("://");
+            uriScheme = sessionProtocol.uriText() + "://";
         }
 
-        uriBuilder.append(authority).append(path);
+        final StringBuilder uriBuilder = new StringBuilder(
+                uriScheme.length() + authority.length() + path.length() +
+                (query != null ? query.length() + 1 : 0));
+
+        uriBuilder.append(uriScheme)
+                  .append(authority)
+                  .append(path);
+
         if (query != null) {
             uriBuilder.append('?').append(query);
         }

--- a/zipkin/src/main/java/com/linecorp/armeria/internal/tracing/SpanTags.java
+++ b/zipkin/src/main/java/com/linecorp/armeria/internal/tracing/SpanTags.java
@@ -22,6 +22,7 @@ import javax.annotation.Nullable;
 
 import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.Scheme;
+import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.logging.RequestLog;
 
@@ -52,8 +53,12 @@ public final class SpanTags {
             .tag("http.path", path)
             .tag("http.url", generateUrl(scheme, authority, path, log.query()))
             .tag("http.status_code", log.status().codeAsText())
-            .tag("http.protocol", scheme.sessionProtocol().uriText())
-            .tag("http.serfmt", scheme.serializationFormat().uriText());
+            .tag("http.protocol", scheme.sessionProtocol().uriText());
+
+        final SerializationFormat serFmt = scheme.serializationFormat();
+        if (serFmt != SerializationFormat.NONE) {
+            span.tag("http.serfmt", serFmt.uriText());
+        }
 
         final Throwable responseCause = log.responseCause();
         if (responseCause != null) {

--- a/zipkin/src/test/java/com/linecorp/armeria/client/tracing/HttpTracingClientTest.java
+++ b/zipkin/src/test/java/com/linecorp/armeria/client/tracing/HttpTracingClientTest.java
@@ -111,8 +111,7 @@ public class HttpTracingClientTest {
                                .containsEntry("http.path", "/hello/armeria")
                                .containsEntry("http.status_code", "200")
                                .containsEntry("http.url", "http://foo.com/hello/armeria")
-                               .containsEntry("http.protocol", "h2c")
-                               .containsEntry("http.serfmt", "none");
+                               .containsEntry("http.protocol", "h2c");
 
         // check service name
         assertThat(span.localServiceName()).isEqualTo(TEST_SERVICE);
@@ -141,8 +140,7 @@ public class HttpTracingClientTest {
                                .containsEntry("http.path", "/hello/armeria")
                                .containsEntry("http.status_code", "200")
                                .containsEntry("http.url", "http://foo.com/hello/armeria")
-                               .containsEntry("http.protocol", "h2c")
-                               .containsEntry("http.serfmt", "none");
+                               .containsEntry("http.protocol", "h2c");
 
         // check service name
         assertThat(span.localServiceName()).isEqualTo(TEST_SERVICE);

--- a/zipkin/src/test/java/com/linecorp/armeria/client/tracing/HttpTracingClientTest.java
+++ b/zipkin/src/test/java/com/linecorp/armeria/client/tracing/HttpTracingClientTest.java
@@ -33,8 +33,6 @@ import javax.annotation.Nullable;
 import org.junit.After;
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableMap;
-
 import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.ClientRequestContextBuilder;
@@ -108,12 +106,13 @@ public class HttpTracingClientTest {
         assertThat(span.annotations()).hasSize(2);
 
         // check tags
-        assertThat(span.tags()).containsAllEntriesOf(ImmutableMap.of(
-                "http.host", "foo.com",
-                "http.method", "POST",
-                "http.path", "/hello/armeria",
-                "http.status_code", "200",
-                "http.url", "none+h2c://foo.com/hello/armeria"));
+        assertThat(span.tags()).containsEntry("http.host", "foo.com")
+                               .containsEntry("http.method", "POST")
+                               .containsEntry("http.path", "/hello/armeria")
+                               .containsEntry("http.status_code", "200")
+                               .containsEntry("http.url", "http://foo.com/hello/armeria")
+                               .containsEntry("http.protocol", "h2c")
+                               .containsEntry("http.serfmt", "none");
 
         // check service name
         assertThat(span.localServiceName()).isEqualTo(TEST_SERVICE);
@@ -137,12 +136,13 @@ public class HttpTracingClientTest {
         final Span span = reporter.spans().take();
 
         // check tags
-        assertThat(span.tags()).containsAllEntriesOf(ImmutableMap.of(
-                "http.host", "foo.com",
-                "http.method", "POST",
-                "http.path", "/hello/armeria",
-                "http.status_code", "200",
-                "http.url", "none+h2c://foo.com/hello/armeria"));
+        assertThat(span.tags()).containsEntry("http.host", "foo.com")
+                               .containsEntry("http.method", "POST")
+                               .containsEntry("http.path", "/hello/armeria")
+                               .containsEntry("http.status_code", "200")
+                               .containsEntry("http.url", "http://foo.com/hello/armeria")
+                               .containsEntry("http.protocol", "h2c")
+                               .containsEntry("http.serfmt", "none");
 
         // check service name
         assertThat(span.localServiceName()).isEqualTo(TEST_SERVICE);

--- a/zipkin/src/test/java/com/linecorp/armeria/internal/tracing/SpanTagsTest.java
+++ b/zipkin/src/test/java/com/linecorp/armeria/internal/tracing/SpanTagsTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.internal.tracing;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.notNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.function.Consumer;
+
+import javax.net.ssl.SSLSession;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.common.RpcRequest;
+import com.linecorp.armeria.common.SerializationFormat;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.logging.RequestLogBuilder;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.ServiceRequestContextBuilder;
+
+import brave.Span;
+
+class SpanTagsTest {
+
+    @Test
+    void http() {
+        final Span span = mockSpan();
+        final HttpRequest req = HttpRequest.of(RequestHeaders.of(HttpMethod.POST, "/post",
+                                                                 HttpHeaderNames.AUTHORITY, "foo.com"));
+        final ServiceRequestContext ctx = newContext(req, SessionProtocol.H2C, 200);
+
+        SpanTags.addTags(span, ctx.log());
+
+        verify(span, times(1)).tag("http.host", "foo.com");
+        verify(span, times(1)).tag("http.method", "POST");
+        verify(span, times(1)).tag("http.path", "/post");
+        verify(span, times(1)).tag("http.url", "http://foo.com/post");
+        verify(span, times(1)).tag("http.status_code", "200");
+        verify(span, times(1)).tag("http.protocol", "h2c");
+        verify(span, times(1)).tag(eq("address.remote"), notNull());
+        verify(span, times(1)).tag(eq("address.local"), notNull());
+        verifyNoMoreInteractions(span);
+    }
+
+    @Test
+    void https() {
+        final Span span = mockSpan();
+        final HttpRequest req = HttpRequest.of(RequestHeaders.of(HttpMethod.GET, "/get",
+                                                                 HttpHeaderNames.AUTHORITY, "bar.com"));
+        final ServiceRequestContext ctx = newContext(req, SessionProtocol.H2, 404);
+
+        SpanTags.addTags(span, ctx.log());
+
+        verify(span, times(1)).tag("http.host", "bar.com");
+        verify(span, times(1)).tag("http.method", "GET");
+        verify(span, times(1)).tag("http.path", "/get");
+        verify(span, times(1)).tag("http.url", "https://bar.com/get");
+        verify(span, times(1)).tag("http.status_code", "404");
+        verify(span, times(1)).tag("http.protocol", "h2");
+        verify(span, times(1)).tag(eq("address.remote"), notNull());
+        verify(span, times(1)).tag(eq("address.local"), notNull());
+        verifyNoMoreInteractions(span);
+    }
+
+    @Test
+    void rpc() {
+        final Span span = mockSpan();
+        final HttpRequest req = HttpRequest.of(RequestHeaders.of(HttpMethod.POST, "/rpc",
+                                                                 HttpHeaderNames.AUTHORITY, "call.com"));
+        final ServiceRequestContext ctx = newContext(req, SessionProtocol.H2C, 200, logBuilder -> {
+            logBuilder.serializationFormat(SerializationFormat.UNKNOWN);
+            logBuilder.requestContent(RpcRequest.of(Object.class, "someMethod"), null);
+        });
+
+        SpanTags.addTags(span, ctx.log());
+
+        verify(span, times(1)).tag("http.host", "call.com");
+        verify(span, times(1)).tag("http.method", "POST");
+        verify(span, times(1)).tag("http.path", "/rpc");
+        verify(span, times(1)).tag("http.url", "http://call.com/rpc");
+        verify(span, times(1)).tag("http.status_code", "200");
+        verify(span, times(1)).tag("http.protocol", "h2c");
+        verify(span, times(1)).tag("http.serfmt", "unknown");
+        verify(span, times(1)).tag(eq("address.remote"), notNull());
+        verify(span, times(1)).tag(eq("address.local"), notNull());
+        verify(span, times(1)).name("someMethod");
+        verifyNoMoreInteractions(span);
+    }
+
+    @Test
+    void error() {
+        final Span span = mockSpan();
+        final HttpRequest req = HttpRequest.of(RequestHeaders.of(HttpMethod.CONNECT, "/error",
+                                                                 HttpHeaderNames.AUTHORITY, "oops.com"));
+        final ServiceRequestContext ctx = newContext(req, SessionProtocol.H2C, 0, logBuilder -> {
+            logBuilder.endResponse(new Exception("oops"));
+        });
+
+        SpanTags.addTags(span, ctx.log());
+
+        verify(span, times(1)).tag("http.host", "oops.com");
+        verify(span, times(1)).tag("http.method", "CONNECT");
+        verify(span, times(1)).tag("http.path", "/error");
+        verify(span, times(1)).tag("http.url", "http://oops.com/error");
+        verify(span, times(1)).tag("http.status_code", "0");
+        verify(span, times(1)).tag("http.protocol", "h2c");
+        verify(span, times(1)).tag("error", "java.lang.Exception: oops");
+        verify(span, times(1)).tag(eq("address.remote"), notNull());
+        verify(span, times(1)).tag(eq("address.local"), notNull());
+        verifyNoMoreInteractions(span);
+    }
+
+    private static Span mockSpan() {
+        final Span span = mock(Span.class);
+        when(span.tag(any(), any())).thenReturn(span);
+        return span;
+    }
+
+    private static ServiceRequestContext newContext(HttpRequest req, SessionProtocol protocol, int statusCode) {
+        return newContext(req, protocol, statusCode, logBuilder -> {});
+    }
+
+    private static ServiceRequestContext newContext(HttpRequest req, SessionProtocol protocol, int statusCode,
+                                                    Consumer<RequestLogBuilder> logBuilderCustomizer) {
+        final ServiceRequestContextBuilder builder = ServiceRequestContextBuilder.of(req);
+        builder.sessionProtocol(protocol);
+        if (protocol.isTls()) {
+            builder.sslSession(mock(SSLSession.class));
+        }
+        final ServiceRequestContext ctx = builder.build();
+        final RequestLogBuilder logBuilder = ctx.logBuilder();
+        logBuilderCustomizer.accept(logBuilder);
+        logBuilder.endRequest();
+        logBuilder.responseHeaders(ResponseHeaders.of(statusCode));
+        logBuilder.endResponse();
+        return ctx;
+    }
+}

--- a/zipkin/src/test/java/com/linecorp/armeria/server/tracing/HttpTracingServiceTest.java
+++ b/zipkin/src/test/java/com/linecorp/armeria/server/tracing/HttpTracingServiceTest.java
@@ -100,8 +100,7 @@ public class HttpTracingServiceTest {
                                .containsEntry("http.path", "/hello/trustin")
                                .containsEntry("http.status_code", "200")
                                .containsEntry("http.url", "http://foo.com/hello/trustin")
-                               .containsEntry("http.protocol", "h2c")
-                               .containsEntry("http.serfmt", "none");
+                               .containsEntry("http.protocol", "h2c");
 
         // check service name
         assertThat(span.localServiceName()).isEqualTo(TEST_SERVICE);

--- a/zipkin/src/test/java/com/linecorp/armeria/server/tracing/HttpTracingServiceTest.java
+++ b/zipkin/src/test/java/com/linecorp/armeria/server/tracing/HttpTracingServiceTest.java
@@ -29,8 +29,6 @@ import java.util.concurrent.TimeUnit;
 import org.junit.After;
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableMap;
-
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
@@ -97,12 +95,13 @@ public class HttpTracingServiceTest {
         assertThat(span.annotations()).hasSize(2);
 
         // check tags
-        assertThat(span.tags()).containsAllEntriesOf(ImmutableMap.of(
-                "http.host", "foo.com",
-                "http.method", "POST",
-                "http.path", "/hello/trustin",
-                "http.status_code", "200",
-                "http.url", "none+h2c://foo.com/hello/trustin"));
+        assertThat(span.tags()).containsEntry("http.host", "foo.com")
+                               .containsEntry("http.method", "POST")
+                               .containsEntry("http.path", "/hello/trustin")
+                               .containsEntry("http.status_code", "200")
+                               .containsEntry("http.url", "http://foo.com/hello/trustin")
+                               .containsEntry("http.protocol", "h2c")
+                               .containsEntry("http.serfmt", "none");
 
         // check service name
         assertThat(span.localServiceName()).isEqualTo(TEST_SERVICE);


### PR DESCRIPTION
Motivation:

The Zipkin span tag `http.url` has to be a valid addressable URL that
starts with `http://` or `https://`. We currently use `Scheme.uriText()`
which may be surprising to users.

Modifications:

- Make sure `http.url` starts with `http://` or `https://` for HTTP(S)
  endpoints.
- Add `http.protocol` and `http.serfmt`.

Result:

Less surprising behavior.