### PR TITLE
Allow non-armeria trace context for clients which may be used outside…

### DIFF
--- a/zipkin/src/test/java/com/linecorp/armeria/client/tracing/HttpTracingClientTest.java
+++ b/zipkin/src/test/java/com/linecorp/armeria/client/tracing/HttpTracingClientTest.java
@@ -17,7 +17,6 @@
 package com.linecorp.armeria.client.tracing;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.same;
@@ -67,12 +66,8 @@ public class HttpTracingClientTest {
     }
 
     @Test
-    public void newDecorator_shouldFailFastWhenRequestContextCurrentTraceContextNotConfigured() {
-        assertThatThrownBy(() -> HttpTracingClient.newDecorator(Tracing.newBuilder().build()))
-                .isInstanceOf(IllegalStateException.class).hasMessage(
-                "Tracing.currentTraceContext is not a RequestContextCurrentTraceContext scope. " +
-                "Please call Tracing.Builder.currentTraceContext(RequestContextCurrentTraceContext.INSTANCE)."
-        );
+    public void newDecorator_shouldWorkWhenRequestContextCurrentTraceContextNotConfigured() {
+        HttpTracingClient.newDecorator(Tracing.newBuilder().build());
     }
 
     @Test


### PR DESCRIPTION
… of armeria servers.

While it's never a good idea to use the default `CurrentTraceContext` for an armeria server, I think it can be for an armeria client which is being used outside of an armeria server in a blocking way. Though I could be missing a corner case too since tracing is hard.

/cc @adriancole 

Fixes #1767 
