### PR TITLE
Return pooled buffers from HTTP decoded responses when requested.

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/encoding/DeflateStreamDecoderFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/encoding/DeflateStreamDecoderFactory.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.client.encoding;
 
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.handler.codec.compression.ZlibWrapper;
 
 /**
@@ -29,7 +30,7 @@ public class DeflateStreamDecoderFactory implements StreamDecoderFactory {
     }
 
     @Override
-    public StreamDecoder newDecoder() {
-        return new ZlibStreamDecoder(ZlibWrapper.ZLIB);
+    public StreamDecoder newDecoder(ByteBufAllocator alloc) {
+        return new ZlibStreamDecoder(ZlibWrapper.ZLIB, alloc);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/encoding/GzipStreamDecoderFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/encoding/GzipStreamDecoderFactory.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.client.encoding;
 
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.handler.codec.compression.ZlibWrapper;
 
 /**
@@ -29,7 +30,7 @@ public class GzipStreamDecoderFactory implements StreamDecoderFactory {
     }
 
     @Override
-    public StreamDecoder newDecoder() {
-        return new ZlibStreamDecoder(ZlibWrapper.GZIP);
+    public StreamDecoder newDecoder(ByteBufAllocator alloc) {
+        return new ZlibStreamDecoder(ZlibWrapper.GZIP, alloc);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/encoding/HttpDecodedResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/client/encoding/HttpDecodedResponse.java
@@ -32,20 +32,25 @@ import com.linecorp.armeria.common.HttpObject;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.internal.ArmeriaHttpUtil;
 
+import io.netty.buffer.ByteBufAllocator;
+
 /**
  * A {@link FilteredHttpResponse} that applies HTTP decoding to {@link HttpObject}s as they are published.
  */
 class HttpDecodedResponse extends FilteredHttpResponse {
 
     private final Map<String, StreamDecoderFactory> availableDecoders;
+    private final ByteBufAllocator alloc;
 
     @Nullable
     private StreamDecoder responseDecoder;
     private boolean headersReceived;
 
-    HttpDecodedResponse(HttpResponse delegate, Map<String, StreamDecoderFactory> availableDecoders) {
+    HttpDecodedResponse(HttpResponse delegate, Map<String, StreamDecoderFactory> availableDecoders,
+                        ByteBufAllocator alloc) {
         super(delegate);
         this.availableDecoders = availableDecoders;
+        this.alloc = alloc;
     }
 
     @Override
@@ -78,7 +83,7 @@ class HttpDecodedResponse extends FilteredHttpResponse {
                 // If the server returned an encoding we don't support (shouldn't happen since we set
                 // Accept-Encoding), decoding will be skipped which is ok.
                 if (decoderFactory != null) {
-                    responseDecoder = decoderFactory.newDecoder();
+                    responseDecoder = decoderFactory.newDecoder(alloc);
                 }
             }
 

--- a/core/src/main/java/com/linecorp/armeria/client/encoding/HttpDecodedResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/client/encoding/HttpDecodedResponse.java
@@ -48,7 +48,7 @@ class HttpDecodedResponse extends FilteredHttpResponse {
 
     HttpDecodedResponse(HttpResponse delegate, Map<String, StreamDecoderFactory> availableDecoders,
                         ByteBufAllocator alloc) {
-        super(delegate);
+        super(delegate, false);
         this.availableDecoders = availableDecoders;
         this.alloc = alloc;
     }

--- a/core/src/main/java/com/linecorp/armeria/client/encoding/HttpDecodedResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/client/encoding/HttpDecodedResponse.java
@@ -48,7 +48,7 @@ class HttpDecodedResponse extends FilteredHttpResponse {
 
     HttpDecodedResponse(HttpResponse delegate, Map<String, StreamDecoderFactory> availableDecoders,
                         ByteBufAllocator alloc) {
-        super(delegate, false);
+        super(delegate, true);
         this.availableDecoders = availableDecoders;
         this.alloc = alloc;
     }

--- a/core/src/main/java/com/linecorp/armeria/client/encoding/HttpDecodingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/encoding/HttpDecodingClient.java
@@ -90,6 +90,6 @@ public final class HttpDecodingClient extends SimpleDecoratingClient<HttpRequest
         ctx.updateRequest(req);
 
         final HttpResponse res = delegate().execute(ctx, req);
-        return new HttpDecodedResponse(res, decoderFactories);
+        return new HttpDecodedResponse(res, decoderFactories, ctx.alloc());
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/encoding/StreamDecoderFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/encoding/StreamDecoderFactory.java
@@ -18,6 +18,8 @@ package com.linecorp.armeria.client.encoding;
 
 import com.linecorp.armeria.common.HttpResponse;
 
+import io.netty.buffer.ByteBufAllocator;
+
 /**
  * An interface that constructs a new {@link StreamDecoder} for a given Content-Encoding header value.
  * A new decoder is valid for the lifetime of an {@link HttpResponse}.
@@ -32,6 +34,7 @@ public interface StreamDecoderFactory {
     /**
      * Construct a new {@link StreamDecoder} to use to decode an
      * {@link HttpResponse}.
+     * @param alloc
      */
-    StreamDecoder newDecoder();
+    StreamDecoder newDecoder(ByteBufAllocator alloc);
 }

--- a/core/src/main/java/com/linecorp/armeria/client/encoding/StreamDecoderFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/encoding/StreamDecoderFactory.java
@@ -32,9 +32,7 @@ public interface StreamDecoderFactory {
     String encodingHeaderValue();
 
     /**
-     * Construct a new {@link StreamDecoder} to use to decode an
-     * {@link HttpResponse}.
-     * @param alloc
+     * Construct a new {@link StreamDecoder} to use to decode an {@link HttpResponse}.
      */
     StreamDecoder newDecoder(ByteBufAllocator alloc);
 }

--- a/core/src/main/java/com/linecorp/armeria/client/encoding/ZlibStreamDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/encoding/ZlibStreamDecoder.java
@@ -17,11 +17,12 @@
 package com.linecorp.armeria.client.encoding;
 
 import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.unsafe.ByteBufHttpData;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.ByteBufHolder;
 import io.netty.buffer.ByteBufUtil;
-import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.compression.ZlibCodecFactory;
@@ -34,34 +35,41 @@ import io.netty.handler.codec.compression.ZlibWrapper;
 class ZlibStreamDecoder implements StreamDecoder {
 
     private final EmbeddedChannel decoder;
+    private final ByteBufAllocator alloc;
 
-    ZlibStreamDecoder(ZlibWrapper zlibWrapper) {
+    private boolean withPooledObjects;
+
+    ZlibStreamDecoder(ZlibWrapper zlibWrapper, ByteBufAllocator alloc) {
         decoder = new EmbeddedChannel(false, ZlibCodecFactory.newZlibDecoder(zlibWrapper));
+        this.alloc = alloc;
     }
 
     @Override
     public HttpData decode(HttpData obj) {
         if (obj instanceof ByteBufHolder) {
             decoder.writeInbound(((ByteBufHolder) obj).content());
+
+            // We go ahead and return a pooled object if any one of the inputs were pooled.
+            withPooledObjects = true;
         } else {
             final ByteBuf compressed = Unpooled.wrappedBuffer(obj.array(), obj.offset(), obj.length());
             decoder.writeInbound(compressed);
         }
-        return HttpData.of(fetchDecoderOutput());
+        return fetchDecoderOutput();
     }
 
     @Override
     public HttpData finish() {
         if (decoder.finish()) {
-            return HttpData.of(fetchDecoderOutput());
+            return fetchDecoderOutput();
         } else {
             return HttpData.EMPTY_DATA;
         }
     }
 
     // Mostly copied from netty's HttpContentDecoder.
-    private byte[] fetchDecoderOutput() {
-        final CompositeByteBuf decoded = Unpooled.compositeBuffer();
+    private HttpData fetchDecoderOutput() {
+        ByteBuf decoded = null;
         for (;;) {
             final ByteBuf buf = decoder.readInbound();
             if (buf == null) {
@@ -71,10 +79,27 @@ class ZlibStreamDecoder implements StreamDecoder {
                 buf.release();
                 continue;
             }
-            decoded.addComponent(true, buf);
+            if (decoded == null) {
+                decoded = buf;
+            } else {
+                try {
+                    decoded.writeBytes(buf);
+                } finally {
+                    buf.release();
+                }
+            }
         }
-        final byte[] ret = ByteBufUtil.getBytes(decoded);
-        decoded.release();
-        return ret;
+
+        if (decoded == null) {
+            return HttpData.EMPTY_DATA;
+        }
+
+        if (withPooledObjects) {
+            return new ByteBufHttpData(decoded, false);
+        } else {
+            final byte[] ret = ByteBufUtil.getBytes(decoded);
+            decoded.release();
+            return HttpData.of(ret);
+        }
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/encoding/ZlibStreamDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/encoding/ZlibStreamDecoder.java
@@ -35,13 +35,12 @@ import io.netty.handler.codec.compression.ZlibWrapper;
 class ZlibStreamDecoder implements StreamDecoder {
 
     private final EmbeddedChannel decoder;
-    private final ByteBufAllocator alloc;
 
     private boolean withPooledObjects;
 
     ZlibStreamDecoder(ZlibWrapper zlibWrapper, ByteBufAllocator alloc) {
         decoder = new EmbeddedChannel(false, ZlibCodecFactory.newZlibDecoder(zlibWrapper));
-        this.alloc = alloc;
+        decoder.config().setAllocator(alloc);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/stream/FilteredStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/FilteredStreamMessage.java
@@ -45,7 +45,7 @@ public abstract class FilteredStreamMessage<T, U> implements StreamMessage<U> {
     private static final Logger logger = LoggerFactory.getLogger(FilteredStreamMessage.class);
 
     private final StreamMessage<T> delegate;
-    private final boolean withPooledObjects;
+    private final boolean filterSupportsPooledObjects;
 
     /**
      * Creates a new {@link FilteredStreamMessage} that filters objects published by {@code delegate}
@@ -66,7 +66,7 @@ public abstract class FilteredStreamMessage<T, U> implements StreamMessage<U> {
     protected FilteredStreamMessage(StreamMessage<T> delegate, boolean withPooledObjects) {
         requireNonNull(delegate, "delegate");
         this.delegate = delegate;
-        this.withPooledObjects = withPooledObjects;
+        this.filterSupportsPooledObjects = withPooledObjects;
     }
 
     /**
@@ -117,20 +117,20 @@ public abstract class FilteredStreamMessage<T, U> implements StreamMessage<U> {
     @Override
     public void subscribe(Subscriber<? super U> subscriber) {
         requireNonNull(subscriber, "subscriber");
-        delegate.subscribe(new FilteringSubscriber(subscriber));
+        delegate.subscribe(new FilteringSubscriber(subscriber, false));
     }
 
     @Override
     public void subscribe(Subscriber<? super U> subscriber, boolean withPooledObjects) {
         requireNonNull(subscriber, "subscriber");
-        delegate.subscribe(new FilteringSubscriber(subscriber), withPooledObjects);
+        delegate.subscribe(new FilteringSubscriber(subscriber, withPooledObjects), withPooledObjects);
     }
 
     @Override
     public void subscribe(Subscriber<? super U> subscriber, EventExecutor executor) {
         requireNonNull(subscriber, "subscriber");
         requireNonNull(executor, "executor");
-        delegate.subscribe(new FilteringSubscriber(subscriber), executor);
+        delegate.subscribe(new FilteringSubscriber(subscriber, false), executor);
     }
 
     @Override
@@ -138,7 +138,7 @@ public abstract class FilteredStreamMessage<T, U> implements StreamMessage<U> {
                           boolean withPooledObjects) {
         requireNonNull(subscriber, "subscriber");
         requireNonNull(executor, "executor");
-        delegate.subscribe(new FilteringSubscriber(subscriber), executor, withPooledObjects);
+        delegate.subscribe(new FilteringSubscriber(subscriber, withPooledObjects), executor, withPooledObjects);
     }
 
     @Override
@@ -154,7 +154,7 @@ public abstract class FilteredStreamMessage<T, U> implements StreamMessage<U> {
     @Override
     public CompletableFuture<List<U>> drainAll(boolean withPooledObjects) {
         final StreamMessageDrainer<U> drainer = new StreamMessageDrainer<>(withPooledObjects);
-        delegate.subscribe(new FilteringSubscriber(drainer), withPooledObjects);
+        delegate.subscribe(new FilteringSubscriber(drainer, withPooledObjects), withPooledObjects);
         return drainer.future();
     }
 
@@ -163,7 +163,7 @@ public abstract class FilteredStreamMessage<T, U> implements StreamMessage<U> {
         requireNonNull(executor, "executor");
 
         final StreamMessageDrainer<U> drainer = new StreamMessageDrainer<>(withPooledObjects);
-        delegate.subscribe(new FilteringSubscriber(drainer), executor, withPooledObjects);
+        delegate.subscribe(new FilteringSubscriber(drainer, withPooledObjects), executor, withPooledObjects);
         return drainer.future();
     }
 
@@ -175,10 +175,12 @@ public abstract class FilteredStreamMessage<T, U> implements StreamMessage<U> {
     private final class FilteringSubscriber implements Subscriber<T> {
 
         private final Subscriber<? super U> delegate;
+        private final boolean subscribedWithPooledObjects;
 
-        FilteringSubscriber(Subscriber<? super U> delegate) {
+        FilteringSubscriber(Subscriber<? super U> delegate, boolean subscribedWithPooledObjects) {
             requireNonNull(delegate, "delegate");
             this.delegate = delegate;
+            this.subscribedWithPooledObjects = subscribedWithPooledObjects;
         }
 
         @Override
@@ -190,10 +192,14 @@ public abstract class FilteredStreamMessage<T, U> implements StreamMessage<U> {
         @Override
         public void onNext(T o) {
             ReferenceCountUtil.touch(o);
-            if (!withPooledObjects) {
+            if (!filterSupportsPooledObjects) {
                 o = PooledObjects.toUnpooled(o);
             }
-            delegate.onNext(filter(o));
+            U filtered = filter(o);
+            if (!subscribedWithPooledObjects) {
+                filtered = PooledObjects.toUnpooled(filtered);
+            }
+            delegate.onNext(filtered);
         }
 
         @Override

--- a/core/src/main/java/com/linecorp/armeria/common/stream/FilteredStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/FilteredStreamMessage.java
@@ -64,8 +64,7 @@ public abstract class FilteredStreamMessage<T, U> implements StreamMessage<U> {
      *                          this means, use {@link #FilteredStreamMessage(StreamMessage)}.
      */
     protected FilteredStreamMessage(StreamMessage<T> delegate, boolean withPooledObjects) {
-        requireNonNull(delegate, "delegate");
-        this.delegate = delegate;
+        this.delegate = requireNonNull(delegate, "delegate");
         this.filterSupportsPooledObjects = withPooledObjects;
     }
 

--- a/core/src/test/java/com/linecorp/armeria/client/encoding/AbstractStreamDecoderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/encoding/AbstractStreamDecoderTest.java
@@ -48,14 +48,7 @@ abstract class AbstractStreamDecoderTest {
     abstract StreamDecoder newDecoder();
 
     @Test
-    public void unpooledBuffers() {
-        final StreamDecoder decoder = newDecoder();
-        HttpData data = decoder.decode(HttpData.of(PAYLOAD));
-        assertThat(data).isNotInstanceOf(ByteBufHolder.class);
-    }
-
-    @Test
-    public void pooledBuffers() {
+    public void notEmpty() {
         final StreamDecoder decoder = newDecoder();
         final ByteBuf buf = ByteBufAllocator.DEFAULT.buffer();
         buf.writeBytes(PAYLOAD);

--- a/core/src/test/java/com/linecorp/armeria/client/encoding/AbstractStreamDecoderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/encoding/AbstractStreamDecoderTest.java
@@ -17,22 +17,68 @@ package com.linecorp.armeria.client.encoding;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.zip.Deflater;
+import java.util.zip.DeflaterOutputStream;
+
 import org.junit.Test;
 
+import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.unsafe.ByteBufHttpData;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.ByteBufHolder;
 
 abstract class AbstractStreamDecoderTest {
+
+    private static final byte[] PAYLOAD;
+    static {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        try (DeflaterOutputStream zip = new DeflaterOutputStream(bos, new Deflater(-1, true))) {
+            zip.write(new byte[] { 1, 2, 3, 4, 5 });
+        } catch (IOException e) {
+            throw new Error(e);
+        }
+        PAYLOAD = bos.toByteArray();
+    }
 
     abstract StreamDecoder newDecoder();
 
     @Test
-    public void decodedBufferShouldNotLeak() {
+    public void unpooledBuffers() {
         final StreamDecoder decoder = newDecoder();
-        final ByteBuf buf = Unpooled.buffer();
-        decoder.decode(new ByteBufHttpData(buf, false));
+        HttpData data = decoder.decode(HttpData.of(PAYLOAD));
+        assertThat(data).isNotInstanceOf(ByteBufHolder.class);
+    }
+
+    @Test
+    public void pooledBuffers() {
+        final StreamDecoder decoder = newDecoder();
+        final ByteBuf buf = ByteBufAllocator.DEFAULT.buffer();
+        buf.writeBytes(PAYLOAD);
+        HttpData data = decoder.decode(new ByteBufHttpData(buf, false));
         assertThat(buf.refCnt()).isZero();
+        assertThat(data).isInstanceOfSatisfying(ByteBufHolder.class, d -> assertThat(d.refCnt()).isEqualTo(1));
+        ((ByteBufHolder) data).release();
+    }
+
+    @Test
+    public void empty_unpooled() {
+        final StreamDecoder decoder = newDecoder();
+        HttpData data = decoder.decode(HttpData.EMPTY_DATA);
+        assertThat(data).isNotInstanceOf(ByteBufHolder.class);
+    }
+    @Test
+    public void empty_pooled() {
+        final StreamDecoder decoder = newDecoder();
+        final ByteBuf buf = ByteBufAllocator.DEFAULT.buffer();
+        HttpData data = decoder.decode(new ByteBufHttpData(buf, false));
+        assertThat(buf.refCnt()).isZero();
+
+        // Even for a pooled empty input, the result is unpooled since there's no point in pooling empty
+        // buffers.
+        assertThat(data).isNotInstanceOf(ByteBufHolder.class);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/encoding/AbstractStreamDecoderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/encoding/AbstractStreamDecoderTest.java
@@ -34,6 +34,7 @@ import io.netty.buffer.ByteBufHolder;
 abstract class AbstractStreamDecoderTest {
 
     private static final byte[] PAYLOAD;
+
     static {
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         try (DeflaterOutputStream zip = new DeflaterOutputStream(bos, new Deflater(-1, true))) {
@@ -70,6 +71,7 @@ abstract class AbstractStreamDecoderTest {
         HttpData data = decoder.decode(HttpData.EMPTY_DATA);
         assertThat(data).isNotInstanceOf(ByteBufHolder.class);
     }
+
     @Test
     public void empty_pooled() {
         final StreamDecoder decoder = newDecoder();

--- a/core/src/test/java/com/linecorp/armeria/client/encoding/HttpDecodedResponseTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/encoding/HttpDecodedResponseTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.encoding;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.zip.GZIPOutputStream;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.unsafe.ByteBufHttpData;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.UnpooledHeapByteBuf;
+
+public class HttpDecodedResponseTest {
+
+    private static final Map<String, StreamDecoderFactory> DECODERS =
+            ImmutableMap.of("gzip", new GzipStreamDecoderFactory());
+
+    private static final ResponseHeaders RESPONSE_HEADERS =
+            ResponseHeaders.of(HttpStatus.OK, HttpHeaderNames.CONTENT_ENCODING, "gzip");
+
+    private static final byte[] PAYLOAD;
+
+    static {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        try (GZIPOutputStream gos = new GZIPOutputStream(bos)) {
+            gos.write("hello".getBytes(StandardCharsets.UTF_8));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        PAYLOAD = bos.toByteArray();
+    }
+
+    @Test
+    public void unpooledPayload_unpooledDrain() {
+        HttpData payload = HttpData.of(PAYLOAD);
+        HttpResponse delegate = HttpResponse.of(RESPONSE_HEADERS, payload);
+        HttpResponse decoded = new HttpDecodedResponse(delegate, DECODERS, ByteBufAllocator.DEFAULT);
+        ByteBuf buf = responseBuf(decoded, false);
+
+        assertThat(buf).isInstanceOf(UnpooledHeapByteBuf.class);
+    }
+
+    @Test
+    public void pooledPayload_unpooledDrain() {
+        ByteBufHttpData payload = new ByteBufHttpData(
+                ByteBufAllocator.DEFAULT.buffer().writeBytes(PAYLOAD), true);
+        HttpResponse delegate = HttpResponse.of(RESPONSE_HEADERS, payload);
+        HttpResponse decoded = new HttpDecodedResponse(delegate, DECODERS, ByteBufAllocator.DEFAULT);
+        ByteBuf buf = responseBuf(decoded, false);
+
+        assertThat(buf).isInstanceOf(UnpooledHeapByteBuf.class);
+        assertThat(payload.refCnt()).isZero();
+    }
+
+    // Users that request pooled objects still always need to be ok with unpooled ones.
+    @Test
+    public void unpooledPayload_pooledDrain() {
+        HttpData payload = HttpData.of(PAYLOAD);
+        HttpResponse delegate = HttpResponse.of(RESPONSE_HEADERS, payload);
+        HttpResponse decoded = new HttpDecodedResponse(delegate, DECODERS, ByteBufAllocator.DEFAULT);
+        ByteBuf buf = responseBuf(decoded, true);
+
+        assertThat(buf).isNotInstanceOf(UnpooledHeapByteBuf.class);
+    }
+
+    @Test
+    public void pooledPayload_pooledDrain() {
+        ByteBufHttpData payload = new ByteBufHttpData(
+                ByteBufAllocator.DEFAULT.buffer().writeBytes(PAYLOAD), true);
+        HttpResponse delegate = HttpResponse.of(RESPONSE_HEADERS, payload);
+        HttpResponse decoded = new HttpDecodedResponse(delegate, DECODERS, ByteBufAllocator.DEFAULT);
+        ByteBuf buf = responseBuf(decoded, true);
+
+        assertThat(buf).isNotInstanceOf(UnpooledHeapByteBuf.class);
+        assertThat(payload.refCnt()).isZero();
+    }
+
+    private static ByteBuf responseBuf(HttpResponse decoded, boolean withPooledObjects) {
+        return decoded.drainAll(withPooledObjects).join().stream()
+                .filter(o -> o instanceof ByteBufHttpData)
+                .map(o -> ((ByteBufHttpData) o).content())
+                .findFirst()
+                .get();
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/client/encoding/HttpDecodedResponseTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/encoding/HttpDecodedResponseTest.java
@@ -51,8 +51,8 @@ public class HttpDecodedResponseTest {
     private static final byte[] PAYLOAD;
 
     static {
-        ByteArrayOutputStream bos = new ByteArrayOutputStream();
-        try (GZIPOutputStream gos = new GZIPOutputStream(bos)) {
+        final ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        try (final GZIPOutputStream gos = new GZIPOutputStream(bos)) {
             gos.write("hello".getBytes(StandardCharsets.UTF_8));
         } catch (IOException e) {
             throw new UncheckedIOException(e);
@@ -62,21 +62,21 @@ public class HttpDecodedResponseTest {
 
     @Test
     public void unpooledPayload_unpooledDrain() {
-        HttpData payload = HttpData.of(PAYLOAD);
-        HttpResponse delegate = HttpResponse.of(RESPONSE_HEADERS, payload);
-        HttpResponse decoded = new HttpDecodedResponse(delegate, DECODERS, ByteBufAllocator.DEFAULT);
-        ByteBuf buf = responseBuf(decoded, false);
+        final HttpData payload = HttpData.of(PAYLOAD);
+        final HttpResponse delegate = HttpResponse.of(RESPONSE_HEADERS, payload);
+        final HttpResponse decoded = new HttpDecodedResponse(delegate, DECODERS, ByteBufAllocator.DEFAULT);
+        final ByteBuf buf = responseBuf(decoded, false);
 
         assertThat(buf).isInstanceOf(UnpooledHeapByteBuf.class);
     }
 
     @Test
     public void pooledPayload_unpooledDrain() {
-        ByteBufHttpData payload = new ByteBufHttpData(
+        final ByteBufHttpData payload = new ByteBufHttpData(
                 ByteBufAllocator.DEFAULT.buffer().writeBytes(PAYLOAD), true);
-        HttpResponse delegate = HttpResponse.of(RESPONSE_HEADERS, payload);
-        HttpResponse decoded = new HttpDecodedResponse(delegate, DECODERS, ByteBufAllocator.DEFAULT);
-        ByteBuf buf = responseBuf(decoded, false);
+        final HttpResponse delegate = HttpResponse.of(RESPONSE_HEADERS, payload);
+        final HttpResponse decoded = new HttpDecodedResponse(delegate, DECODERS, ByteBufAllocator.DEFAULT);
+        final ByteBuf buf = responseBuf(decoded, false);
 
         assertThat(buf).isInstanceOf(UnpooledHeapByteBuf.class);
         assertThat(payload.refCnt()).isZero();
@@ -85,21 +85,21 @@ public class HttpDecodedResponseTest {
     // Users that request pooled objects still always need to be ok with unpooled ones.
     @Test
     public void unpooledPayload_pooledDrain() {
-        HttpData payload = HttpData.of(PAYLOAD);
-        HttpResponse delegate = HttpResponse.of(RESPONSE_HEADERS, payload);
-        HttpResponse decoded = new HttpDecodedResponse(delegate, DECODERS, ByteBufAllocator.DEFAULT);
-        ByteBuf buf = responseBuf(decoded, true);
+        final HttpData payload = HttpData.of(PAYLOAD);
+        final HttpResponse delegate = HttpResponse.of(RESPONSE_HEADERS, payload);
+        final HttpResponse decoded = new HttpDecodedResponse(delegate, DECODERS, ByteBufAllocator.DEFAULT);
+        final ByteBuf buf = responseBuf(decoded, true);
 
         assertThat(buf).isNotInstanceOf(UnpooledHeapByteBuf.class);
     }
 
     @Test
     public void pooledPayload_pooledDrain() {
-        ByteBufHttpData payload = new ByteBufHttpData(
+        final ByteBufHttpData payload = new ByteBufHttpData(
                 ByteBufAllocator.DEFAULT.buffer().writeBytes(PAYLOAD), true);
-        HttpResponse delegate = HttpResponse.of(RESPONSE_HEADERS, payload);
-        HttpResponse decoded = new HttpDecodedResponse(delegate, DECODERS, ByteBufAllocator.DEFAULT);
-        ByteBuf buf = responseBuf(decoded, true);
+        final HttpResponse delegate = HttpResponse.of(RESPONSE_HEADERS, payload);
+        final HttpResponse decoded = new HttpDecodedResponse(delegate, DECODERS, ByteBufAllocator.DEFAULT);
+        final ByteBuf buf = responseBuf(decoded, true);
 
         assertThat(buf).isNotInstanceOf(UnpooledHeapByteBuf.class);
         assertThat(payload.refCnt()).isZero();

--- a/core/src/test/java/com/linecorp/armeria/client/encoding/HttpDecodedResponseTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/encoding/HttpDecodedResponseTest.java
@@ -52,7 +52,7 @@ public class HttpDecodedResponseTest {
 
     static {
         final ByteArrayOutputStream bos = new ByteArrayOutputStream();
-        try (final GZIPOutputStream gos = new GZIPOutputStream(bos)) {
+        try (GZIPOutputStream gos = new GZIPOutputStream(bos)) {
             gos.write("hello".getBytes(StandardCharsets.UTF_8));
         } catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/core/src/test/java/com/linecorp/armeria/client/encoding/ZlibStreamDecoderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/encoding/ZlibStreamDecoderTest.java
@@ -15,11 +15,12 @@
  */
 package com.linecorp.armeria.client.encoding;
 
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.handler.codec.compression.ZlibWrapper;
 
 public class ZlibStreamDecoderTest extends AbstractStreamDecoderTest {
     @Override
     StreamDecoder newDecoder() {
-        return new ZlibStreamDecoder(ZlibWrapper.NONE);
+        return new ZlibStreamDecoder(ZlibWrapper.NONE, ByteBufAllocator.DEFAULT);
     }
 }


### PR DESCRIPTION
Currently, HTTP decoding always returns unpooled data, even if a user requested pooled objects. This allows HTTP decoding to return pooled objects if any of the inputs were pooled, which indicates the user requested pooled objects.

Also added a minor optimization for the common case where calls to get the decoded output only return one buffer.

Came up in https://github.com/apache/incubator-zipkin/pull/2595

/cc @adriancole 