### PR TITLE
Log response bytes transferred when sending a server timeout response…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
@@ -389,6 +389,11 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject>, RequestTim
                 responseEncoder.writeHeaders(id, streamId, headers, false);
                 future = responseEncoder.writeData(id, streamId, content, true);
             }
+
+            if (!loggedResponseHeadersFirstBytesTransferred) {
+                logBuilder().responseFirstBytesTransferred();
+                loggedResponseHeadersFirstBytesTransferred = true;
+            }
         } else {
             // Wrote something already; we have to reset/cancel the stream.
             future = responseEncoder.writeReset(id, streamId, error);

--- a/zipkin/src/main/java/com/linecorp/armeria/client/tracing/HttpTracingClient.java
+++ b/zipkin/src/main/java/com/linecorp/armeria/client/tracing/HttpTracingClient.java
@@ -114,7 +114,12 @@ public class HttpTracingClient extends SimpleDecoratingClient<HttpRequest, HttpR
 
         ctx.log().addListener(log -> {
             SpanTags.logWireSend(span, log.requestFirstBytesTransferredTimeNanos(), log);
-            SpanTags.logWireReceive(span, log.responseFirstBytesTransferredTimeNanos(), log);
+
+            // If the client timed-out the request, we will have never received any response data at all.
+            if (log.isAvailable(RequestLogAvailability.RESPONSE_FIRST_BYTES_TRANSFERRED)) {
+                SpanTags.logWireReceive(span, log.responseFirstBytesTransferredTimeNanos(), log);
+            }
+
             finishSpan(span, log);
         }, RequestLogAvailability.COMPLETE);
 

--- a/zipkin/src/main/java/com/linecorp/armeria/server/tracing/HttpTracingService.java
+++ b/zipkin/src/main/java/com/linecorp/armeria/server/tracing/HttpTracingService.java
@@ -91,7 +91,12 @@ public class HttpTracingService extends SimpleDecoratingService<HttpRequest, Htt
 
         ctx.log().addListener(log -> {
             SpanTags.logWireReceive(span, log.requestFirstBytesTransferredTimeNanos(), log);
-            SpanTags.logWireSend(span, log.responseFirstBytesTransferredTimeNanos(), log);
+
+            // If the client timed-out the request, we will have never sent any response data at all.
+            if (log.isAvailable(RequestLogAvailability.RESPONSE_FIRST_BYTES_TRANSFERRED)) {
+                SpanTags.logWireSend(span, log.responseFirstBytesTransferredTimeNanos(), log);
+            }
+
             SpanContextUtil.closeSpan(span, log);
         }, RequestLogAvailability.COMPLETE);
 

--- a/zipkin/src/test/java/com/linecorp/armeria/it/tracing/HttpTracingIntegrationTest.java
+++ b/zipkin/src/test/java/com/linecorp/armeria/it/tracing/HttpTracingIntegrationTest.java
@@ -23,7 +23,9 @@ import static com.google.common.util.concurrent.Futures.transformAsync;
 import static com.linecorp.armeria.common.HttpStatus.OK;
 import static com.linecorp.armeria.common.thrift.ThriftSerializationFormats.BINARY;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -49,6 +51,8 @@ import com.google.common.util.concurrent.MoreExecutors;
 import com.linecorp.armeria.client.ClientBuilder;
 import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.client.InvalidResponseHeadersException;
+import com.linecorp.armeria.client.ResponseTimeoutException;
 import com.linecorp.armeria.client.tracing.HttpTracingClient;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
@@ -81,6 +85,8 @@ public class HttpTracingIntegrationTest {
 
     private HelloService.Iface fooClient;
     private HelloService.Iface fooClientWithoutTracing;
+    private HelloService.Iface timeoutClient;
+    private HelloService.Iface timeoutClientClientTimesOut;
     private HelloService.AsyncIface barClient;
     private HelloService.AsyncIface quxClient;
     private HelloService.Iface zipClient;
@@ -90,8 +96,12 @@ public class HttpTracingIntegrationTest {
     public final ServerRule server = new ServerRule() {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
+            // Our test that triggers a timeout will take a second to run. Hopefully it doesn't cause flakiness
+            // for being too short.
+            sb.requestTimeout(Duration.ofSeconds(1));
+
             sb.service("/foo", decorate("service/foo", THttpService.of(
-                    (AsyncIface) (name, resultHandler) ->
+                            (AsyncIface) (name, resultHandler) ->
                             barClient.hello("Miss. " + name, new DelegatingCallback(resultHandler)))));
 
             sb.service("/bar", decorate("service/bar", THttpService.of(
@@ -168,6 +178,10 @@ public class HttpTracingIntegrationTest {
                     return res;
                 }
             }));
+
+            sb.service("/timeout", decorate("service/timeout", THttpService.of(
+                    // This service never calls the handler and will timeout.
+                    (AsyncIface) (name, resultHandler) -> {})));
         }
     };
 
@@ -183,6 +197,13 @@ public class HttpTracingIntegrationTest {
         barClient = newClient("/bar");
         quxClient = newClient("/qux");
         poolHttpClient = HttpClient.of(server.uri("/"));
+        timeoutClient = new ClientBuilder(server.uri(BINARY, "/timeout"))
+                .decorator(HttpTracingClient.newDecorator(newTracing("client/timeout")))
+                .build(HelloService.Iface.class);
+        timeoutClientClientTimesOut = new ClientBuilder(server.uri(BINARY, "/timeout"))
+                .decorator(HttpTracingClient.newDecorator(newTracing("client/timeout")))
+                .responseTimeout(Duration.ofMillis(10))
+                .build(HelloService.Iface.class);
     }
 
     @After
@@ -362,6 +383,36 @@ public class HttpTracingIntegrationTest {
         assertThat(Arrays.stream(spans).map(Span::parentId)
                          .filter(Objects::nonNull)
                          .collect(toImmutableSet())).hasSize(1);
+    }
+
+    @Test(timeout = 10000)
+    public void testServerTimesOut() throws Exception {
+        assertThatThrownBy(() -> timeoutClient.hello("name"))
+                .isInstanceOf(InvalidResponseHeadersException.class);
+        final Span[] spans = spanReporter.take(2);
+
+        final Span serverSpan = findSpan(spans, "service/timeout");
+        final Span clientSpan = findSpan(spans, "client/timeout");
+
+        // Server timed out meaning it did still send a timeout response to the client and we have all
+        // annotations.
+        assertThat(serverSpan.annotations()).hasSize(2);
+        assertThat(clientSpan.annotations()).hasSize(2);
+    }
+
+    @Test(timeout = 10000)
+    public void testClientTimesOut() throws Exception {
+        assertThatThrownBy(() -> timeoutClientClientTimesOut.hello("name"))
+                .isInstanceOf(ResponseTimeoutException.class);
+        final Span[] spans = spanReporter.take(2);
+
+        final Span serverSpan = findSpan(spans, "service/timeout");
+        final Span clientSpan = findSpan(spans, "client/timeout");
+
+        // Client timed out, so no response data was ever sent from the server. There is no wire send in the
+        // server and no wire receive in the client.
+        assertThat(serverSpan.annotations()).hasSize(1);
+        assertThat(clientSpan.annotations()).hasSize(1);
     }
 
     private static Span findSpan(Span[] spans, String serviceName) {

--- a/zipkin/src/test/java/com/linecorp/armeria/it/tracing/HttpTracingIntegrationTest.java
+++ b/zipkin/src/test/java/com/linecorp/armeria/it/tracing/HttpTracingIntegrationTest.java
@@ -101,7 +101,7 @@ public class HttpTracingIntegrationTest {
             sb.requestTimeout(Duration.ofSeconds(1));
 
             sb.service("/foo", decorate("service/foo", THttpService.of(
-                            (AsyncIface) (name, resultHandler) ->
+                    (AsyncIface) (name, resultHandler) ->
                             barClient.hello("Miss. " + name, new DelegatingCallback(resultHandler)))));
 
             sb.service("/bar", decorate("service/bar", THttpService.of(


### PR DESCRIPTION
…, and don't try logging response bytes when a client timed out, therefore no response was sent.

Currently, if the server times out a request, it does send a timeout response, but does not call the log handler to indicate it sent bytes. Also, both tracing implementations try to log response bytes timing always, but if the client times out a request, there was never a response so this needs to actually be checked.

Fixes #1769 

/cc @adriancole 