### PR TITLE
Fill scheme and authority pseudo headers in the request decoder

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
@@ -303,8 +303,17 @@ public interface HttpRequest extends Request, StreamMessage<HttpObject> {
     static HttpRequest of(HttpRequest request, RequestHeaders newHeaders) {
         requireNonNull(request, "request");
         requireNonNull(newHeaders, "newHeaders");
+        if (request.headers() == newHeaders) {
+            // Just check the reference only to avoid heavy comparison.
+            return request;
+        }
+
         if (request instanceof HeaderOverridingHttpRequest) {
             request = ((HeaderOverridingHttpRequest) request).unwrap();
+        }
+
+        if (request.headers() == newHeaders) {
+            return request;
         }
 
         return new HeaderOverridingHttpRequest(request, newHeaders);

--- a/core/src/main/java/com/linecorp/armeria/internal/ArmeriaHttpUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/ArmeriaHttpUtil.java
@@ -42,6 +42,7 @@ import static io.netty.util.internal.StringUtil.isNullOrEmpty;
 import static io.netty.util.internal.StringUtil.length;
 import static java.util.Objects.requireNonNull;
 
+import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
@@ -74,7 +75,9 @@ import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.RequestHeadersBuilder;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.ResponseHeadersBuilder;
+import com.linecorp.armeria.server.ServerConfig;
 
+import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.DefaultHeaders;
 import io.netty.handler.codec.UnsupportedValueConverter;
 import io.netty.handler.codec.http.HttpHeaderValues;
@@ -513,20 +516,45 @@ public final class ArmeriaHttpUtil {
     }
 
     /**
+     * Converts the specified Netty HTTP/2 into Armeria HTTP/2 {@link RequestHeaders}.
+     */
+    public static RequestHeaders toArmeriaRequestHeaders(ChannelHandlerContext ctx, Http2Headers headers,
+                                                         boolean endOfStream, AsciiString scheme,
+                                                         ServerConfig cfg) {
+        final RequestHeadersBuilder builder = RequestHeaders.builder();
+        toArmeria(builder, headers, endOfStream);
+        // A CONNECT request might not have ":scheme". See https://tools.ietf.org/html/rfc7540#section-8.1.2.3
+        if (!builder.contains(HttpHeaderNames.SCHEME)) {
+            builder.add(HttpHeaderNames.SCHEME, scheme.toString());
+        }
+        if (!builder.contains(HttpHeaderNames.AUTHORITY)) {
+            final String defaultHostname = cfg.defaultVirtualHost().defaultHostname();
+            final int port = ((InetSocketAddress) ctx.channel().localAddress()).getPort();
+            builder.add(HttpHeaderNames.AUTHORITY, defaultHostname + ':' + port);
+        }
+        return builder.build();
+    }
+
+    /**
      * Converts the specified Netty HTTP/2 into Armeria HTTP/2 headers.
      */
     public static HttpHeaders toArmeria(Http2Headers headers, boolean request, boolean endOfStream) {
-        final HttpHeadersBuilder converted;
+        final HttpHeadersBuilder builder;
         if (request) {
-            converted = headers.contains(HttpHeaderNames.METHOD) ? RequestHeaders.builder()
-                                                                 : HttpHeaders.builder();
+            builder = headers.contains(HttpHeaderNames.METHOD) ? RequestHeaders.builder()
+                                                               : HttpHeaders.builder();
         } else {
-            converted = headers.contains(HttpHeaderNames.STATUS) ? ResponseHeaders.builder()
-                                                                 : HttpHeaders.builder();
+            builder = headers.contains(HttpHeaderNames.STATUS) ? ResponseHeaders.builder()
+                                                               : HttpHeaders.builder();
         }
 
-        converted.sizeHint(headers.size());
-        converted.endOfStream(endOfStream);
+        toArmeria(builder, headers, endOfStream);
+        return builder.build();
+    }
+
+    private static void toArmeria(HttpHeadersBuilder builder, Http2Headers headers, boolean endOfStream) {
+        builder.sizeHint(headers.size());
+        builder.endOfStream(endOfStream);
 
         StringJoiner cookieJoiner = null;
         for (Entry<CharSequence, CharSequence> e : headers) {
@@ -541,15 +569,13 @@ public final class ArmeriaHttpUtil {
                 }
                 COOKIE_SPLITTER.split(value).forEach(cookieJoiner::add);
             } else {
-                converted.add(name, convertHeaderValue(name, value));
+                builder.add(name, convertHeaderValue(name, value));
             }
         }
 
         if (cookieJoiner != null && cookieJoiner.length() != 0) {
-            converted.add(HttpHeaderNames.COOKIE, cookieJoiner.toString());
+            builder.add(HttpHeaderNames.COOKIE, cookieJoiner.toString());
         }
-
-        return converted.build();
     }
 
     /**
@@ -561,7 +587,8 @@ public final class ArmeriaHttpUtil {
      * </ul>
      * {@link ExtensionHeaderNames#PATH} is ignored and instead extracted from the {@code Request-Line}.
      */
-    public static RequestHeaders toArmeria(HttpRequest in) throws URISyntaxException {
+    public static RequestHeaders toArmeria(ChannelHandlerContext ctx, HttpRequest in,
+                                           ServerConfig cfg) throws URISyntaxException {
         final URI requestTargetUri = toUri(in);
 
         final io.netty.handler.codec.http.HttpHeaders inHeaders = in.headers();
@@ -576,6 +603,12 @@ public final class ArmeriaHttpUtil {
             // Attempt to take from HOST header before taking from the request-line
             final String host = inHeaders.getAsString(HttpHeaderNames.HOST);
             addHttp2Authority(host == null || host.isEmpty() ? requestTargetUri.getAuthority() : host, out);
+        }
+
+        if (out.authority() == null) {
+            final String defaultHostname = cfg.defaultVirtualHost().defaultHostname();
+            final int port = ((InetSocketAddress) ctx.channel().localAddress()).getPort();
+            out.add(HttpHeaderNames.AUTHORITY, defaultHostname + ':' + port);
         }
 
         // Add the HTTP headers which have not been consumed above

--- a/core/src/main/java/com/linecorp/armeria/internal/ArmeriaHttpUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/ArmeriaHttpUtil.java
@@ -519,13 +519,13 @@ public final class ArmeriaHttpUtil {
      * Converts the specified Netty HTTP/2 into Armeria HTTP/2 {@link RequestHeaders}.
      */
     public static RequestHeaders toArmeriaRequestHeaders(ChannelHandlerContext ctx, Http2Headers headers,
-                                                         boolean endOfStream, AsciiString scheme,
+                                                         boolean endOfStream, String scheme,
                                                          ServerConfig cfg) {
         final RequestHeadersBuilder builder = RequestHeaders.builder();
         toArmeria(builder, headers, endOfStream);
         // A CONNECT request might not have ":scheme". See https://tools.ietf.org/html/rfc7540#section-8.1.2.3
         if (!builder.contains(HttpHeaderNames.SCHEME)) {
-            builder.add(HttpHeaderNames.SCHEME, scheme.toString());
+            builder.add(HttpHeaderNames.SCHEME, scheme);
         }
         if (!builder.contains(HttpHeaderNames.AUTHORITY)) {
             final String defaultHostname = cfg.defaultVirtualHost().defaultHostname();

--- a/core/src/main/java/com/linecorp/armeria/server/Http1RequestDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http1RequestDecoder.java
@@ -171,7 +171,7 @@ final class Http1RequestDecoder extends ChannelDuplexHandler {
                     this.req = req = new DecodedHttpRequest(
                             ctx.channel().eventLoop(),
                             id, 1,
-                            ArmeriaHttpUtil.toArmeria(nettyReq),
+                            ArmeriaHttpUtil.toArmeria(ctx, nettyReq, cfg),
                             HttpUtil.isKeepAlive(nettyReq),
                             inboundTrafficController,
                             cfg.maxRequestLength());

--- a/core/src/main/java/com/linecorp/armeria/server/Http2RequestDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http2RequestDecoder.java
@@ -31,7 +31,6 @@ import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
-import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.internal.ArmeriaHttpUtil;
 import com.linecorp.armeria.internal.Http2GoAwayHandler;
 import com.linecorp.armeria.internal.InboundTrafficController;
@@ -70,15 +69,18 @@ final class Http2RequestDecoder extends Http2EventAdapter {
     private final ServerConfig cfg;
     private final Channel channel;
     private final Http2ConnectionEncoder writer;
+    private final AsciiString scheme;
+
     private final InboundTrafficController inboundTrafficController;
     private final Http2GoAwayHandler goAwayHandler;
     private final IntObjectMap<DecodedHttpRequest> requests = new IntObjectHashMap<>();
     private int nextId;
 
-    Http2RequestDecoder(ServerConfig cfg, Channel channel, Http2ConnectionEncoder writer) {
+    Http2RequestDecoder(ServerConfig cfg, Channel channel, Http2ConnectionEncoder writer, AsciiString scheme) {
         this.cfg = cfg;
         this.channel = channel;
         this.writer = writer;
+        this.scheme = scheme;
         inboundTrafficController =
                 InboundTrafficController.ofHttp2(channel, cfg.http2InitialConnectionWindowSize());
         goAwayHandler = new Http2GoAwayHandler();
@@ -130,7 +132,8 @@ final class Http2RequestDecoder extends Http2EventAdapter {
             }
 
             req = new DecodedHttpRequest(ctx.channel().eventLoop(), ++nextId, streamId,
-                                         (RequestHeaders) ArmeriaHttpUtil.toArmeria(headers, true, endOfStream),
+                                         ArmeriaHttpUtil.toArmeriaRequestHeaders(ctx, headers, endOfStream,
+                                                                                 scheme, cfg),
                                          true, inboundTrafficController, cfg.maxRequestLength());
 
             // Close the request early when it is sure that there will be

--- a/core/src/main/java/com/linecorp/armeria/server/Http2RequestDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http2RequestDecoder.java
@@ -69,14 +69,14 @@ final class Http2RequestDecoder extends Http2EventAdapter {
     private final ServerConfig cfg;
     private final Channel channel;
     private final Http2ConnectionEncoder writer;
-    private final AsciiString scheme;
+    private final String scheme;
 
     private final InboundTrafficController inboundTrafficController;
     private final Http2GoAwayHandler goAwayHandler;
     private final IntObjectMap<DecodedHttpRequest> requests = new IntObjectHashMap<>();
     private int nextId;
 
-    Http2RequestDecoder(ServerConfig cfg, Channel channel, Http2ConnectionEncoder writer, AsciiString scheme) {
+    Http2RequestDecoder(ServerConfig cfg, Channel channel, Http2ConnectionEncoder writer, String scheme) {
         this.cfg = cfg;
         this.channel = channel;
         this.writer = writer;

--- a/core/src/main/java/com/linecorp/armeria/server/Http2ServerConnectionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http2ServerConnectionHandler.java
@@ -23,6 +23,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http2.Http2ConnectionDecoder;
 import io.netty.handler.codec.http2.Http2ConnectionEncoder;
 import io.netty.handler.codec.http2.Http2Settings;
+import io.netty.util.AsciiString;
 
 final class Http2ServerConnectionHandler extends AbstractHttp2ConnectionHandler {
 
@@ -31,12 +32,12 @@ final class Http2ServerConnectionHandler extends AbstractHttp2ConnectionHandler 
 
     Http2ServerConnectionHandler(Http2ConnectionDecoder decoder, Http2ConnectionEncoder encoder,
                                  Http2Settings initialSettings, Channel channel, ServerConfig config,
-                                 GracefulShutdownSupport gracefulShutdownSupport) {
+                                 GracefulShutdownSupport gracefulShutdownSupport, AsciiString scheme) {
 
         super(decoder, encoder, initialSettings);
 
         this.gracefulShutdownSupport = gracefulShutdownSupport;
-        requestDecoder = new Http2RequestDecoder(config, channel, encoder());
+        requestDecoder = new Http2RequestDecoder(config, channel, encoder(), scheme);
         connection().addListener(requestDecoder);
         decoder().frameListener(requestDecoder);
 

--- a/core/src/main/java/com/linecorp/armeria/server/Http2ServerConnectionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http2ServerConnectionHandler.java
@@ -23,7 +23,6 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http2.Http2ConnectionDecoder;
 import io.netty.handler.codec.http2.Http2ConnectionEncoder;
 import io.netty.handler.codec.http2.Http2Settings;
-import io.netty.util.AsciiString;
 
 final class Http2ServerConnectionHandler extends AbstractHttp2ConnectionHandler {
 
@@ -32,7 +31,7 @@ final class Http2ServerConnectionHandler extends AbstractHttp2ConnectionHandler 
 
     Http2ServerConnectionHandler(Http2ConnectionDecoder decoder, Http2ConnectionEncoder encoder,
                                  Http2Settings initialSettings, Channel channel, ServerConfig config,
-                                 GracefulShutdownSupport gracefulShutdownSupport, AsciiString scheme) {
+                                 GracefulShutdownSupport gracefulShutdownSupport, String scheme) {
 
         super(decoder, encoder, initialSettings);
 

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
@@ -175,7 +175,7 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
         p.addLast(new Http2OrHttpHandler(proxiedAddresses));
     }
 
-    private Http2ConnectionHandler newHttp2ConnectionHandler(ChannelPipeline pipeline) {
+    private Http2ConnectionHandler newHttp2ConnectionHandler(ChannelPipeline pipeline, AsciiString scheme) {
 
         final Http2Connection conn = new DefaultHttp2Connection(true);
         final Http2FrameReader reader = new DefaultHttp2FrameReader(true);
@@ -185,7 +185,7 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
         final Http2ConnectionDecoder decoder = new DefaultHttp2ConnectionDecoder(conn, encoder, reader);
 
         return new Http2ServerConnectionHandler(
-                decoder, encoder, http2Settings(), pipeline.channel(), config, gracefulShutdownSupport);
+                decoder, encoder, http2Settings(), pipeline.channel(), config, gracefulShutdownSupport, scheme);
     }
 
     private Http2Settings http2Settings() {
@@ -374,7 +374,7 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
 
         private void addHttp2Handlers(ChannelHandlerContext ctx) {
             final ChannelPipeline p = ctx.pipeline();
-            p.addLast(newHttp2ConnectionHandler(p));
+            p.addLast(newHttp2ConnectionHandler(p, SCHEME_HTTPS));
             configureIdleTimeoutHandler(p);
             p.addLast(new HttpServerHandler(config, gracefulShutdownSupport, null,
                                             SessionProtocol.H2, proxiedAddresses));
@@ -475,7 +475,7 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
                         }
 
                         return new Http2ServerUpgradeCodec(
-                                newHttp2ConnectionHandler(p));
+                                newHttp2ConnectionHandler(p, SCHEME_HTTP));
                     },
                     UPGRADE_REQUEST_MAX_LENGTH));
 
@@ -485,7 +485,7 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
         private void configureHttp2(ChannelHandlerContext ctx) {
             final ChannelPipeline p = ctx.pipeline();
             assert name != null;
-            addAfter(p, name, newHttp2ConnectionHandler(p));
+            addAfter(p, name, newHttp2ConnectionHandler(p, SCHEME_HTTP));
         }
 
         private String addAfter(ChannelPipeline p, String baseName, ChannelHandler handler) {

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
@@ -185,7 +185,8 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
         final Http2ConnectionDecoder decoder = new DefaultHttp2ConnectionDecoder(conn, encoder, reader);
 
         return new Http2ServerConnectionHandler(
-                decoder, encoder, http2Settings(), pipeline.channel(), config, gracefulShutdownSupport, scheme);
+                decoder, encoder, http2Settings(), pipeline.channel(),
+                config, gracefulShutdownSupport, scheme.toString());
     }
 
     private Http2Settings http2Settings() {

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostServiceBindingBuilder.java
@@ -34,7 +34,7 @@ import com.linecorp.armeria.common.logging.ContentPreviewerFactory;
  * {@link VirtualHostBuilder#route()}. You can also configure a {@link Service} using
  * {@link VirtualHostBuilder#withRoute(Consumer)}.
  *
- * <p>Call {@link #service(Service)} to build the {@link Service} and return to the {@link VirtualHostBuilder}.
+ * <p>Call {@link #build(Service)} to build the {@link Service} and return to the {@link VirtualHostBuilder}.
  *
  * <pre>{@code
  * ServerBuilder sb = new ServerBuilder();
@@ -212,7 +212,7 @@ public final class VirtualHostServiceBindingBuilder extends AbstractServiceBindi
      *
      * @throws IllegalStateException if the path that the {@link Service} will be bound to is not specified
      */
-    public VirtualHostBuilder service(Service<HttpRequest, HttpResponse> service) {
+    public VirtualHostBuilder build(Service<HttpRequest, HttpResponse> service) {
         build0(service);
         return virtualHostBuilder;
     }

--- a/core/src/test/java/com/linecorp/armeria/internal/ArmeriaHttpUtilTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/ArmeriaHttpUtilTest.java
@@ -24,7 +24,10 @@ import static com.linecorp.armeria.internal.ArmeriaHttpUtil.toArmeria;
 import static com.linecorp.armeria.internal.ArmeriaHttpUtil.toNettyHttp1;
 import static com.linecorp.armeria.internal.ArmeriaHttpUtil.toNettyHttp2;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import java.net.InetSocketAddress;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.BiConsumer;
@@ -34,11 +37,18 @@ import org.junit.Test;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpHeadersBuilder;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.RequestHeadersBuilder;
 import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.ServerConfig;
 
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.DefaultHttpHeaders;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpVersion;
@@ -46,6 +56,7 @@ import io.netty.handler.codec.http2.DefaultHttp2Headers;
 import io.netty.handler.codec.http2.Http2Exception;
 import io.netty.handler.codec.http2.Http2Headers;
 import io.netty.handler.codec.http2.HttpConversionUtil.ExtensionHeaderNames;
+import io.netty.util.AsciiString;
 
 public class ArmeriaHttpUtilTest {
     @Test
@@ -130,7 +141,7 @@ public class ArmeriaHttpUtilTest {
         assertThat(values).hasSize(5)
                           .containsEntry("a", null)
                           .containsEntry("b", "c")
-                          .containsEntry("d",null)
+                          .containsEntry("d", null)
                           .containsEntry("e", "f")
                           .containsEntry("g", null);
     }
@@ -439,5 +450,33 @@ public class ArmeriaHttpUtilTest {
           .set(HttpHeaderNames.METHOD, "GET");
         assertThat(toArmeria(in, false, false)).isInstanceOf(ResponseHeaders.class)
                                                .isNotInstanceOf(RequestHeaders.class);
+    }
+
+    @Test
+    public void toArmeriaRequestHeaders() {
+        final Http2Headers in = new DefaultHttp2Headers().set("a", "b");
+
+        final InetSocketAddress socketAddress = new InetSocketAddress(36462);
+        final Channel channel = mock(Channel.class);
+        when(channel.localAddress()).thenReturn(socketAddress);
+
+        final ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+        when(ctx.channel()).thenReturn(channel);
+
+        in.set(HttpHeaderNames.METHOD, "GET")
+          .set(HttpHeaderNames.PATH, "/");
+        // Request headers without pseudo headers.
+        final RequestHeaders headers =
+                ArmeriaHttpUtil.toArmeriaRequestHeaders(ctx, in, false,
+                                                        AsciiString.cached("https"), serverConfig());
+        assertThat(headers.scheme()).isEqualTo("https");
+        assertThat(headers.authority()).isEqualTo("foo:36462");
+    }
+
+    private static ServerConfig serverConfig() {
+        final Server server = new ServerBuilder().defaultHostname("foo")
+                                                 .service("/", (ctx, req) -> HttpResponse.of(HttpStatus.OK))
+                                                 .build();
+        return server.config();
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/internal/ArmeriaHttpUtilTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/ArmeriaHttpUtilTest.java
@@ -56,7 +56,6 @@ import io.netty.handler.codec.http2.DefaultHttp2Headers;
 import io.netty.handler.codec.http2.Http2Exception;
 import io.netty.handler.codec.http2.Http2Headers;
 import io.netty.handler.codec.http2.HttpConversionUtil.ExtensionHeaderNames;
-import io.netty.util.AsciiString;
 
 public class ArmeriaHttpUtilTest {
     @Test
@@ -467,8 +466,7 @@ public class ArmeriaHttpUtilTest {
           .set(HttpHeaderNames.PATH, "/");
         // Request headers without pseudo headers.
         final RequestHeaders headers =
-                ArmeriaHttpUtil.toArmeriaRequestHeaders(ctx, in, false,
-                                                        AsciiString.cached("https"), serverConfig());
+                ArmeriaHttpUtil.toArmeriaRequestHeaders(ctx, in, false, "https", serverConfig());
         assertThat(headers.scheme()).isEqualTo("https");
         assertThat(headers.authority()).isEqualTo("foo:36462");
     }

--- a/core/src/test/java/com/linecorp/armeria/server/VirtualHostServiceBindingBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/VirtualHostServiceBindingBuilderTest.java
@@ -49,7 +49,7 @@ public class VirtualHostServiceBindingBuilderTest {
           .verboseResponses(true)
           .requestContentPreviewerFactory(requestFactory)
           .responseContentPreviewerFactory(responseFactory)
-          .service((ctx, req) -> HttpResponse.of(OK));
+          .build((ctx, req) -> HttpResponse.of(OK));
 
         final List<ServiceConfig> serviceConfigs = sb.build().serviceConfigs();
         assertThat(serviceConfigs.size()).isOne();
@@ -79,7 +79,7 @@ public class VirtualHostServiceBindingBuilderTest {
                    .requestTimeoutMillis(10)
                    .maxRequestLength(8192)
                    .verboseResponses(true)
-                   .service((ctx, req) -> HttpResponse.of(OK));
+                   .build((ctx, req) -> HttpResponse.of(OK));
         });
 
         final List<ServiceConfig> serviceConfigs = sb.build().serviceConfigs();

--- a/site/src/sphinx/advanced-structured-logging.rst
+++ b/site/src/sphinx/advanced-structured-logging.rst
@@ -291,7 +291,7 @@ You can enable it when you configure :api:`Server`, :api:`VirtualHost` or :api:`
     // Enable previewing the content with the maximum length of 100 for textual content.
     sb.contentPreview(100);
     ...
-    sb.withVirtualHost("http://example.com")
+    sb.virtualHost("http://example.com")
       // In this case, the property of virtual host takes precedence over that of server.
       .contentPreview(150);
     ...

--- a/site/src/sphinx/server-access-log.rst
+++ b/site/src/sphinx/server-access-log.rst
@@ -356,20 +356,20 @@ In this case, the mapper or logger you set for a specific :api:`VirtualHost` wil
 .. code-block:: java
 
     // Using the specific logger name.
-    sb.withVirtualHost("*.example.com")
+    sb.virtualHost("*.example.com")
       .accessLogger("com.example.my.access.logs")
       .and()
     ....
 
     // Using your own logger.
     Logger logger = LoggerFactory.getLogger("com.example2.my.access.logs");
-    sb.withVirtualHost("*.example2.com")
+    sb.virtualHost("*.example2.com")
       .accessLogger(Logger)
       .and()
     ....
 
     // Using the mapper which sets an access logger with the given VirtualHost instance.
-    sb.withVirtualHost("*.example3.com")
+    sb.virtualHost("*.example3.com")
       .accessLogger(virtualHost -> {
         // Return the logger.
         // Do not return null. Otherwise, it will raise an IllegalStateException.

--- a/site/src/sphinx/server-basics.rst
+++ b/site/src/sphinx/server-basics.rst
@@ -194,19 +194,17 @@ implementations that supports port unification:
 Virtual hosts
 -------------
 
-Use ``ServerBuilder.withVirtualHost()`` to configure `a name-based virtual host`_:
+Use ``ServerBuilder.virtualHost(...)`` to configure `a name-based virtual host`_:
 
 .. code-block:: java
 
-    import com.linecorp.armeria.server.VirtualHost;
-
     ServerBuilder sb = new ServerBuilder();
     // Configure foo.com.
-    sb.withVirtualHost("foo.com")
+    sb.virtualHost("foo.com")
       .service(...)
       .tls(...)
       .and() // Configure *.bar.com.
-      .withVirtualHost("*.bar.com")
+      .virtualHost("*.bar.com")
       .service(...)
       .tls(...)
       .and() // Configure the default virtual host.


### PR DESCRIPTION
Motivation:
We fill the `:scheme` and `:authority` header in `HttpServerHander`.
However, the `HttpHeaders` is immutable now, it's better to fill the headers when we build it.

Modification:
- Fii the `:scheme` and `:authority` header in `Http1RequestDecoder` and `Http2RequestDecoder`

Result:
- Fix #1773 