### PR TITLE
Add a flag that can dump available ciphers on startup.

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.common;
 
 import java.io.IOException;
 import java.nio.channels.ClosedChannelException;
+import java.security.cert.CertificateException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -38,6 +39,7 @@ import com.github.benmanes.caffeine.cache.CaffeineSpec;
 import com.google.common.base.Ascii;
 import com.google.common.base.CharMatcher;
 import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.client.ClientFactoryBuilder;
 import com.linecorp.armeria.client.retry.Backoff;
@@ -50,10 +52,15 @@ import com.linecorp.armeria.server.ServiceConfig;
 import com.linecorp.armeria.server.annotation.ExceptionHandler;
 import com.linecorp.armeria.server.annotation.ExceptionVerbosity;
 
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.epoll.Epoll;
 import io.netty.handler.codec.http2.Http2CodecUtil;
 import io.netty.handler.codec.http2.Http2Exception;
+import io.netty.handler.codec.http2.Http2SecurityUtil;
 import io.netty.handler.ssl.OpenSsl;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.util.SelfSignedCertificate;
+import io.netty.util.ReferenceCountUtil;
 
 /**
  * The system properties that affect Armeria's runtime behavior.
@@ -80,6 +87,8 @@ public final class Flags {
 
     private static final boolean USE_OPENSSL = getBoolean("useOpenSsl", OpenSsl.isAvailable(),
                                                           value -> OpenSsl.isAvailable() || !value);
+
+    private static final boolean DUMP_OPENSSL_INFO = getBoolean("dumpOpenSslInfo", false);
 
     private static final int DEFAULT_MAX_NUM_CONNECTIONS = Integer.MAX_VALUE;
     private static final int MAX_NUM_CONNECTIONS =
@@ -270,6 +279,23 @@ public final class Flags {
             logger.info("Using OpenSSL: {}, 0x{}",
                         OpenSsl.versionString(),
                         Long.toHexString(OpenSsl.version() & 0xFFFFFFFFL));
+
+            if (dumpOpenSslInfo()) {
+                try {
+                    SSLEngine engine = SslContextBuilder
+                            .forClient()
+                            .ciphers(Http2SecurityUtil.CIPHERS)
+                            .build()
+                            .newEngine(ByteBufAllocator.DEFAULT);
+                    logger.info("All available SSL protocols: {}",
+                                ImmutableList.copyOf(engine.getSupportedProtocols()));
+                    ReferenceCountUtil.release(engine);
+                } catch (SSLException e) {
+                    // Just skip it if it doesn't work for some reason.
+                }
+                logger.info("All available SSL ciphers: {}", OpenSsl.availableJavaCipherSuites());
+                logger.info("Default enabled SSL ciphers: {}", Http2SecurityUtil.CIPHERS);
+            }
         }
     }
 
@@ -350,6 +376,17 @@ public final class Flags {
      */
     public static boolean useOpenSsl() {
         return USE_OPENSSL;
+    }
+
+    /**
+     * Returns whether information about the OpenSSL environment should be dumped when first starting the
+     * application, including supported ciphers.
+     *
+     * <p>This flag is disabled by default. Specify the {@code -Dcom.linecorp.armeria.dumpOpenSslInfo=true} JVM
+     * option to enable it.
+     */
+    public static boolean dumpOpenSslInfo() {
+        return DUMP_OPENSSL_INFO;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -18,7 +18,6 @@ package com.linecorp.armeria.common;
 
 import java.io.IOException;
 import java.nio.channels.ClosedChannelException;
-import java.security.cert.CertificateException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -59,7 +58,6 @@ import io.netty.handler.codec.http2.Http2Exception;
 import io.netty.handler.codec.http2.Http2SecurityUtil;
 import io.netty.handler.ssl.OpenSsl;
 import io.netty.handler.ssl.SslContextBuilder;
-import io.netty.handler.ssl.util.SelfSignedCertificate;
 import io.netty.util.ReferenceCountUtil;
 
 /**
@@ -282,7 +280,7 @@ public final class Flags {
 
             if (dumpOpenSslInfo()) {
                 try {
-                    SSLEngine engine = SslContextBuilder
+                    final SSLEngine engine = SslContextBuilder
                             .forClient()
                             .ciphers(Http2SecurityUtil.CIPHERS)
                             .build()


### PR DESCRIPTION
Currently it is very difficult to know what ciphers are supported by a given armeria-based server that uses OpenSSL (JDK users can look at JDK's documentation) because OpenSSL may be boring, or system, depending on configuration, and the version always changes. This PR adds a flag to dump information about ciphers so users can see the exact ciphers that would be used in their environment.

I tried also using `getEnabledProtocols` to see what protocols are enabled by default, but it always seems to return SSLV2 and TLS1, 1.1, even though when I use `testssl.sh`, it always only shows TLS1.2, so for now I haven't tried logging that since I don't know how to get the right value.

`-Dcom.linecorp.armeria.dumpOpenSslInfo=true`

For #1711 