### PR TITLE
Consolidate SSL logic and enable TLSv1.3 by default.

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
@@ -42,7 +42,6 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Ascii;
 
-import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.HttpObject;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.logging.RequestLogBuilder;
@@ -50,6 +49,7 @@ import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.internal.ChannelUtil;
 import com.linecorp.armeria.internal.Http1ClientCodec;
 import com.linecorp.armeria.internal.ReadSuppressingHandler;
+import com.linecorp.armeria.internal.SslContextUtil;
 import com.linecorp.armeria.internal.TrafficLoggingHandler;
 
 import io.netty.buffer.ByteBuf;
@@ -87,17 +87,13 @@ import io.netty.handler.codec.http2.Http2ConnectionEncoder;
 import io.netty.handler.codec.http2.Http2Exception;
 import io.netty.handler.codec.http2.Http2FrameReader;
 import io.netty.handler.codec.http2.Http2FrameWriter;
-import io.netty.handler.codec.http2.Http2SecurityUtil;
 import io.netty.handler.codec.http2.Http2Settings;
 import io.netty.handler.flush.FlushConsolidationHandler;
-import io.netty.handler.ssl.ApplicationProtocolConfig;
 import io.netty.handler.ssl.ApplicationProtocolNames;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.ssl.SslHandshakeCompletionEvent;
-import io.netty.handler.ssl.SslProvider;
-import io.netty.handler.ssl.SupportedCipherSuiteFilter;
 import io.netty.util.AsciiString;
 import io.netty.util.ReferenceCountUtil;
 
@@ -141,24 +137,9 @@ final class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
             try {
                 final SslContextBuilder builder = SslContextBuilder.forClient();
 
-                builder.sslProvider(
-                        Flags.useOpenSsl() ? SslProvider.OPENSSL : SslProvider.JDK);
+                SslContextUtil.configureDefaults(builder, httpPreference == HttpPreference.HTTP1_REQUIRED);
                 clientFactory.sslContextCustomizer().accept(builder);
 
-                if (httpPreference == HttpPreference.HTTP2_REQUIRED ||
-                    httpPreference == HttpPreference.HTTP2_PREFERRED) {
-
-                    builder.ciphers(Http2SecurityUtil.CIPHERS, SupportedCipherSuiteFilter.INSTANCE)
-                           .applicationProtocolConfig(new ApplicationProtocolConfig(
-                                   ApplicationProtocolConfig.Protocol.ALPN,
-                                   // NO_ADVERTISE is currently the only mode supported by both OpenSsl and
-                                   // JDK providers.
-                                   ApplicationProtocolConfig.SelectorFailureBehavior.NO_ADVERTISE,
-                                   // ACCEPT is currently the only mode supported by both OpenSsl and JDK
-                                   // providers.
-                                   ApplicationProtocolConfig.SelectedListenerFailureBehavior.ACCEPT,
-                                   ApplicationProtocolNames.HTTP_2));
-                }
                 sslCtx = builder.build();
             } catch (SSLException e) {
                 throw new IllegalStateException("failed to create an SslContext", e);

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
@@ -136,10 +136,9 @@ final class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
         if (sessionProtocol.isTls()) {
             try {
                 final SslContextBuilder builder = SslContextBuilder.forClient();
-
-                SslContextUtil.configureDefaults(builder, httpPreference == HttpPreference.HTTP1_REQUIRED);
-                clientFactory.sslContextCustomizer().accept(builder);
-
+                SslContextUtil.configureDefaults(builder,
+                                                 httpPreference == HttpPreference.HTTP1_REQUIRED,
+                                                 clientFactory.sslContextCustomizer());
                 sslCtx = builder.build();
             } catch (SSLException e) {
                 throw new IllegalStateException("failed to create an SslContext", e);

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
@@ -134,15 +134,9 @@ final class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
         }
 
         if (sessionProtocol.isTls()) {
-            try {
-                final SslContextBuilder builder = SslContextBuilder.forClient();
-                SslContextUtil.configureDefaults(builder,
-                                                 httpPreference == HttpPreference.HTTP1_REQUIRED,
-                                                 clientFactory.sslContextCustomizer());
-                sslCtx = builder.build();
-            } catch (SSLException e) {
-                throw new IllegalStateException("failed to create an SslContext", e);
-            }
+            sslCtx = SslContextUtil.createSslContext(SslContextBuilder::forClient,
+                                                     httpPreference == HttpPreference.HTTP1_REQUIRED,
+                                                     clientFactory.sslContextCustomizer());
         } else {
             sslCtx = null;
         }

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -280,19 +280,14 @@ public final class Flags {
                         Long.toHexString(OpenSsl.version() & 0xFFFFFFFFL));
 
             if (dumpOpenSslInfo()) {
-                try {
-                    final SSLEngine engine = SslContextBuilder
-                            .forClient()
-                            .ciphers(Http2SecurityUtil.CIPHERS)
-                            .build()
-                            .newEngine(ByteBufAllocator.DEFAULT);
-                    logger.info("All available SSL protocols: {}",
-                                ImmutableList.copyOf(engine.getSupportedProtocols()));
-                    logger.info("Default enabled SSL protocols: {}", SslContextUtil.DEFAULT_PROTOCOLS);
-                    ReferenceCountUtil.release(engine);
-                } catch (SSLException e) {
-                    // Just skip it if it doesn't work for some reason.
-                }
+                final SSLEngine engine = SslContextUtil.createSslContext(
+                        SslContextBuilder::forClient,
+                        false,
+                        unused -> {}).newEngine(ByteBufAllocator.DEFAULT);
+                logger.info("All available SSL protocols: {}",
+                            ImmutableList.copyOf(engine.getSupportedProtocols()));
+                logger.info("Default enabled SSL protocols: {}", SslContextUtil.DEFAULT_PROTOCOLS);
+                ReferenceCountUtil.release(engine);
                 logger.info("All available SSL ciphers: {}", OpenSsl.availableJavaCipherSuites());
                 logger.info("Default enabled SSL ciphers: {}", SslContextUtil.DEFAULT_CIPHERS);
             }

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -56,7 +56,6 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.epoll.Epoll;
 import io.netty.handler.codec.http2.Http2CodecUtil;
 import io.netty.handler.codec.http2.Http2Exception;
-import io.netty.handler.codec.http2.Http2SecurityUtil;
 import io.netty.handler.ssl.OpenSsl;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.util.ReferenceCountUtil;

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -45,6 +45,7 @@ import com.linecorp.armeria.client.retry.Backoff;
 import com.linecorp.armeria.client.retry.RetryingHttpClient;
 import com.linecorp.armeria.client.retry.RetryingRpcClient;
 import com.linecorp.armeria.common.util.Exceptions;
+import com.linecorp.armeria.internal.SslContextUtil;
 import com.linecorp.armeria.server.PathMappingContext;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.ServiceConfig;
@@ -287,12 +288,13 @@ public final class Flags {
                             .newEngine(ByteBufAllocator.DEFAULT);
                     logger.info("All available SSL protocols: {}",
                                 ImmutableList.copyOf(engine.getSupportedProtocols()));
+                    logger.info("Default enabled SSL protocols: {}", SslContextUtil.DEFAULT_PROTOCOLS);
                     ReferenceCountUtil.release(engine);
                 } catch (SSLException e) {
                     // Just skip it if it doesn't work for some reason.
                 }
                 logger.info("All available SSL ciphers: {}", OpenSsl.availableJavaCipherSuites());
-                logger.info("Default enabled SSL ciphers: {}", Http2SecurityUtil.CIPHERS);
+                logger.info("Default enabled SSL ciphers: {}", SslContextUtil.DEFAULT_CIPHERS);
             }
         }
     }

--- a/core/src/main/java/com/linecorp/armeria/internal/SslContextUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/SslContextUtil.java
@@ -81,7 +81,7 @@ public final class SslContextUtil {
 
         userCustomizer.accept(builder);
 
-        // We call user customization logic before setting ALPN to make sure they don't break
+        // We called user customization logic before setting ALPN to make sure they don't break
         // compatibility with HTTP/2.
         if (!forceHttp1) {
             builder.applicationProtocolConfig(ALPN_CONFIG);

--- a/core/src/main/java/com/linecorp/armeria/internal/SslContextUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/SslContextUtil.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal;
+
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.common.Flags;
+
+import io.netty.handler.codec.http2.Http2SecurityUtil;
+import io.netty.handler.ssl.ApplicationProtocolConfig;
+import io.netty.handler.ssl.ApplicationProtocolConfig.Protocol;
+import io.netty.handler.ssl.ApplicationProtocolConfig.SelectedListenerFailureBehavior;
+import io.netty.handler.ssl.ApplicationProtocolConfig.SelectorFailureBehavior;
+import io.netty.handler.ssl.ApplicationProtocolNames;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.SslProvider;
+import io.netty.handler.ssl.SupportedCipherSuiteFilter;
+
+/**
+ * Utilities for configuring {@link SslContextBuilder}.
+ */
+public final class SslContextUtil {
+
+    private static final ApplicationProtocolConfig ALPN_CONFIG = new ApplicationProtocolConfig(
+            Protocol.ALPN,
+            // NO_ADVERTISE is currently the only mode supported by both OpenSsl and JDK providers.
+            SelectorFailureBehavior.NO_ADVERTISE,
+            // ACCEPT is currently the only mode supported by both OpenSsl and JDK providers.
+            SelectedListenerFailureBehavior.ACCEPT,
+            ApplicationProtocolNames.HTTP_2,
+            ApplicationProtocolNames.HTTP_1_1);
+
+    // OpenSSL's default enabled TLSv1.3 ciphers as documented at https://wiki.openssl.org/index.php/TLS1.3
+    private static final List<String> TLS_V13_CIPHERS = ImmutableList.of("TLS_AES_256_GCM_SHA384" ,
+                                                                         "TLS_CHACHA20_POLY1305_SHA256",
+                                                                         "TLS_AES_128_GCM_SHA256");
+
+    public static final List<String> DEFAULT_CIPHERS = ImmutableList.<String>builder()
+            .addAll(TLS_V13_CIPHERS)
+            .addAll(Http2SecurityUtil.CIPHERS)
+            .build();
+
+    public static final List<String> DEFAULT_PROTOCOLS = ImmutableList.of("TLSv1.3", "TLSv1.2");
+
+    /**
+     * Configures a {@link SslContextBuilder} with Armeria's defaults, enabling support for HTTP/2, TLSv1.3, and
+     * TLSv1.2.
+     */
+    public static void configureDefaults(SslContextBuilder sslContext, boolean forceHttp1) {
+        sslContext.sslProvider(Flags.useOpenSsl() ? SslProvider.OPENSSL : SslProvider.JDK)
+                  .protocols(DEFAULT_PROTOCOLS.toArray(new String[0]))
+                  .ciphers(DEFAULT_CIPHERS, SupportedCipherSuiteFilter.INSTANCE);
+        if (!forceHttp1) {
+            sslContext.applicationProtocolConfig(ALPN_CONFIG);
+        }
+    }
+
+    private SslContextUtil() {}
+}

--- a/core/src/main/java/com/linecorp/armeria/internal/SslContextUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/SslContextUtil.java
@@ -47,7 +47,7 @@ public final class SslContextUtil {
             ApplicationProtocolNames.HTTP_1_1);
 
     // OpenSSL's default enabled TLSv1.3 ciphers as documented at https://wiki.openssl.org/index.php/TLS1.3
-    private static final List<String> TLS_V13_CIPHERS = ImmutableList.of("TLS_AES_256_GCM_SHA384" ,
+    private static final List<String> TLS_V13_CIPHERS = ImmutableList.of("TLS_AES_256_GCM_SHA384",
                                                                          "TLS_CHACHA20_POLY1305_SHA256",
                                                                          "TLS_AES_128_GCM_SHA256");
 

--- a/core/src/main/java/com/linecorp/armeria/internal/SslContextUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/SslContextUtil.java
@@ -17,9 +17,14 @@
 package com.linecorp.armeria.internal;
 
 import java.util.List;
+import java.util.Set;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import javax.net.ssl.SSLException;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 import com.linecorp.armeria.common.Flags;
 
@@ -29,6 +34,7 @@ import io.netty.handler.ssl.ApplicationProtocolConfig.Protocol;
 import io.netty.handler.ssl.ApplicationProtocolConfig.SelectedListenerFailureBehavior;
 import io.netty.handler.ssl.ApplicationProtocolConfig.SelectorFailureBehavior;
 import io.netty.handler.ssl.ApplicationProtocolNames;
+import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslProvider;
 import io.netty.handler.ssl.SupportedCipherSuiteFilter;
@@ -60,24 +66,340 @@ public final class SslContextUtil {
     public static final List<String> DEFAULT_PROTOCOLS = ImmutableList.of("TLSv1.3", "TLSv1.2");
 
     /**
-     * Configures a {@link SslContextBuilder} with Armeria's defaults, enabling support for HTTP/2, TLSv1.3, and
+     * Creates a {@link SslContext} with Armeria's defaults, enabling support for HTTP/2, TLSv1.3, and
      * TLSv1.2.
      */
-    public static void configureDefaults(SslContextBuilder sslContext,
-                                         boolean forceHttp1,
-                                         Consumer<? super SslContextBuilder> userCustomizer) {
-        sslContext.sslProvider(Flags.useOpenSsl() ? SslProvider.OPENSSL : SslProvider.JDK)
+    public static SslContext createSslContext(Supplier<SslContextBuilder> sslContextSupplier,
+                                              boolean forceHttp1,
+                                              Consumer<? super SslContextBuilder> userCustomizer) {
+        final SslContextBuilder builder = sslContextSupplier.get();
+
+        builder.sslProvider(Flags.useOpenSsl() ? SslProvider.OPENSSL : SslProvider.JDK)
                   .protocols(DEFAULT_PROTOCOLS.toArray(new String[0]));
 
-        // We call user customization logic before setting ciphers and ALPN to make sure they don't break
-        // compatibility with HTTP/2.
-        userCustomizer.accept(sslContext);
+        builder.ciphers(DEFAULT_CIPHERS, SupportedCipherSuiteFilter.INSTANCE);
 
-        sslContext.ciphers(DEFAULT_CIPHERS, SupportedCipherSuiteFilter.INSTANCE);
+        userCustomizer.accept(builder);
+
+        // We call user customization logic before setting ALPN to make sure they don't break
+        // compatibility with HTTP/2.
         if (!forceHttp1) {
-            sslContext.applicationProtocolConfig(ALPN_CONFIG);
+            builder.applicationProtocolConfig(ALPN_CONFIG);
+        }
+
+        final SslContext sslContext;
+        try {
+            sslContext = builder.build();
+        } catch (SSLException e) {
+            throw new IllegalStateException("Could not initialize SSL context. Ensure that netty-tcnative is " +
+                                            "on the path, this is running on Java 11+, or user customization " +
+                                            "of the SSL context is supported by the environment.", e);
+        }
+
+        if (!forceHttp1) {
+            validateHttp2Ciphers(ImmutableSet.copyOf(sslContext.cipherSuites()));
+        }
+
+        return sslContext;
+    }
+
+    private static void validateHttp2Ciphers(Set<String> ciphers) {
+        if (!ciphers.contains("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")) {
+            throw new IllegalStateException("Attempting to configure a server or HTTP/2 client without the " +
+                                            "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 cipher enabled. This " +
+                                            "cipher must be enabled for HTTP/2 support.");
+        }
+
+        for (String cipher : ciphers) {
+            if (HTTP2_BLACKLISTED_CIPHERS.contains(cipher)) {
+                throw new IllegalStateException(
+                        "Attempted to configure a server or HTTP/2 client with a TLS cipher that is not " +
+                        "allowed. Please remove any ciphers from the HTTP/2 cipher blacklist " +
+                        "https://httpwg.org/specs/rfc7540.html#BadCipherSuites");
+            }
         }
     }
+
+    // https://httpwg.org/specs/rfc7540.html#BadCipherSuites
+    private static final Set<String> HTTP2_BLACKLISTED_CIPHERS =
+            ImmutableSet.of(
+                    "TLS_NULL_WITH_NULL_NULL",
+                    "TLS_RSA_WITH_NULL_MD5",
+                    "TLS_RSA_WITH_NULL_SHA",
+                    "TLS_RSA_EXPORT_WITH_RC4_40_MD5",
+                    "TLS_RSA_WITH_RC4_128_MD5",
+                    "TLS_RSA_WITH_RC4_128_SHA",
+                    "TLS_RSA_EXPORT_WITH_RC2_CBC_40_MD5",
+                    "TLS_RSA_WITH_IDEA_CBC_SHA",
+                    "TLS_RSA_EXPORT_WITH_DES40_CBC_SHA",
+                    "TLS_RSA_WITH_DES_CBC_SHA",
+                    "TLS_RSA_WITH_3DES_EDE_CBC_SHA",
+                    "TLS_DH_DSS_EXPORT_WITH_DES40_CBC_SHA",
+                    "TLS_DH_DSS_WITH_DES_CBC_SHA",
+                    "TLS_DH_DSS_WITH_3DES_EDE_CBC_SHA",
+                    "TLS_DH_RSA_EXPORT_WITH_DES40_CBC_SHA",
+                    "TLS_DH_RSA_WITH_DES_CBC_SHA",
+                    "TLS_DH_RSA_WITH_3DES_EDE_CBC_SHA",
+                    "TLS_DHE_DSS_EXPORT_WITH_DES40_CBC_SHA",
+                    "TLS_DHE_DSS_WITH_DES_CBC_SHA",
+                    "TLS_DHE_DSS_WITH_3DES_EDE_CBC_SHA",
+                    "TLS_DHE_RSA_EXPORT_WITH_DES40_CBC_SHA",
+                    "TLS_DHE_RSA_WITH_DES_CBC_SHA",
+                    "TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA",
+                    "TLS_DH_anon_EXPORT_WITH_RC4_40_MD5",
+                    "TLS_DH_anon_WITH_RC4_128_MD5",
+                    "TLS_DH_anon_EXPORT_WITH_DES40_CBC_SHA",
+                    "TLS_DH_anon_WITH_DES_CBC_SHA",
+                    "TLS_DH_anon_WITH_3DES_EDE_CBC_SHA",
+                    "TLS_KRB5_WITH_DES_CBC_SHA",
+                    "TLS_KRB5_WITH_3DES_EDE_CBC_SHA",
+                    "TLS_KRB5_WITH_RC4_128_SHA",
+                    "TLS_KRB5_WITH_IDEA_CBC_SHA",
+                    "TLS_KRB5_WITH_DES_CBC_MD5",
+                    "TLS_KRB5_WITH_3DES_EDE_CBC_MD5",
+                    "TLS_KRB5_WITH_RC4_128_MD5",
+                    "TLS_KRB5_WITH_IDEA_CBC_MD5",
+                    "TLS_KRB5_EXPORT_WITH_DES_CBC_40_SHA",
+                    "TLS_KRB5_EXPORT_WITH_RC2_CBC_40_SHA",
+                    "TLS_KRB5_EXPORT_WITH_RC4_40_SHA",
+                    "TLS_KRB5_EXPORT_WITH_DES_CBC_40_MD5",
+                    "TLS_KRB5_EXPORT_WITH_RC2_CBC_40_MD5",
+                    "TLS_KRB5_EXPORT_WITH_RC4_40_MD5",
+                    "TLS_PSK_WITH_NULL_SHA",
+                    "TLS_DHE_PSK_WITH_NULL_SHA",
+                    "TLS_RSA_PSK_WITH_NULL_SHA",
+                    "TLS_RSA_WITH_AES_128_CBC_SHA",
+                    "TLS_DH_DSS_WITH_AES_128_CBC_SHA",
+                    "TLS_DH_RSA_WITH_AES_128_CBC_SHA",
+                    "TLS_DHE_DSS_WITH_AES_128_CBC_SHA",
+                    "TLS_DHE_RSA_WITH_AES_128_CBC_SHA",
+                    "TLS_DH_anon_WITH_AES_128_CBC_SHA",
+                    "TLS_RSA_WITH_AES_256_CBC_SHA",
+                    "TLS_DH_DSS_WITH_AES_256_CBC_SHA",
+                    "TLS_DH_RSA_WITH_AES_256_CBC_SHA",
+                    "TLS_DHE_DSS_WITH_AES_256_CBC_SHA",
+                    "TLS_DHE_RSA_WITH_AES_256_CBC_SHA",
+                    "TLS_DH_anon_WITH_AES_256_CBC_SHA",
+                    "TLS_RSA_WITH_NULL_SHA256",
+                    "TLS_RSA_WITH_AES_128_CBC_SHA256",
+                    "TLS_RSA_WITH_AES_256_CBC_SHA256",
+                    "TLS_DH_DSS_WITH_AES_128_CBC_SHA256",
+                    "TLS_DH_RSA_WITH_AES_128_CBC_SHA256",
+                    "TLS_DHE_DSS_WITH_AES_128_CBC_SHA256",
+                    "TLS_RSA_WITH_CAMELLIA_128_CBC_SHA",
+                    "TLS_DH_DSS_WITH_CAMELLIA_128_CBC_SHA",
+                    "TLS_DH_RSA_WITH_CAMELLIA_128_CBC_SHA",
+                    "TLS_DHE_DSS_WITH_CAMELLIA_128_CBC_SHA",
+                    "TLS_DHE_RSA_WITH_CAMELLIA_128_CBC_SHA",
+                    "TLS_DH_anon_WITH_CAMELLIA_128_CBC_SHA",
+                    "TLS_DHE_RSA_WITH_AES_128_CBC_SHA256",
+                    "TLS_DH_DSS_WITH_AES_256_CBC_SHA256",
+                    "TLS_DH_RSA_WITH_AES_256_CBC_SHA256",
+                    "TLS_DHE_DSS_WITH_AES_256_CBC_SHA256",
+                    "TLS_DHE_RSA_WITH_AES_256_CBC_SHA256",
+                    "TLS_DH_anon_WITH_AES_128_CBC_SHA256",
+                    "TLS_DH_anon_WITH_AES_256_CBC_SHA256",
+                    "TLS_RSA_WITH_CAMELLIA_256_CBC_SHA",
+                    "TLS_DH_DSS_WITH_CAMELLIA_256_CBC_SHA",
+                    "TLS_DH_RSA_WITH_CAMELLIA_256_CBC_SHA",
+                    "TLS_DHE_DSS_WITH_CAMELLIA_256_CBC_SHA",
+                    "TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA",
+                    "TLS_DH_anon_WITH_CAMELLIA_256_CBC_SHA",
+                    "TLS_PSK_WITH_RC4_128_SHA",
+                    "TLS_PSK_WITH_3DES_EDE_CBC_SHA",
+                    "TLS_PSK_WITH_AES_128_CBC_SHA",
+                    "TLS_PSK_WITH_AES_256_CBC_SHA",
+                    "TLS_DHE_PSK_WITH_RC4_128_SHA",
+                    "TLS_DHE_PSK_WITH_3DES_EDE_CBC_SHA",
+                    "TLS_DHE_PSK_WITH_AES_128_CBC_SHA",
+                    "TLS_DHE_PSK_WITH_AES_256_CBC_SHA",
+                    "TLS_RSA_PSK_WITH_RC4_128_SHA",
+                    "TLS_RSA_PSK_WITH_3DES_EDE_CBC_SHA",
+                    "TLS_RSA_PSK_WITH_AES_128_CBC_SHA",
+                    "TLS_RSA_PSK_WITH_AES_256_CBC_SHA",
+                    "TLS_RSA_WITH_SEED_CBC_SHA",
+                    "TLS_DH_DSS_WITH_SEED_CBC_SHA",
+                    "TLS_DH_RSA_WITH_SEED_CBC_SHA",
+                    "TLS_DHE_DSS_WITH_SEED_CBC_SHA",
+                    "TLS_DHE_RSA_WITH_SEED_CBC_SHA",
+                    "TLS_DH_anon_WITH_SEED_CBC_SHA",
+                    "TLS_RSA_WITH_AES_128_GCM_SHA256",
+                    "TLS_RSA_WITH_AES_256_GCM_SHA384",
+                    "TLS_DH_RSA_WITH_AES_128_GCM_SHA256",
+                    "TLS_DH_RSA_WITH_AES_256_GCM_SHA384",
+                    "TLS_DH_DSS_WITH_AES_128_GCM_SHA256",
+                    "TLS_DH_DSS_WITH_AES_256_GCM_SHA384",
+                    "TLS_DH_anon_WITH_AES_128_GCM_SHA256",
+                    "TLS_DH_anon_WITH_AES_256_GCM_SHA384",
+                    "TLS_PSK_WITH_AES_128_GCM_SHA256",
+                    "TLS_PSK_WITH_AES_256_GCM_SHA384",
+                    "TLS_RSA_PSK_WITH_AES_128_GCM_SHA256",
+                    "TLS_RSA_PSK_WITH_AES_256_GCM_SHA384",
+                    "TLS_PSK_WITH_AES_128_CBC_SHA256",
+                    "TLS_PSK_WITH_AES_256_CBC_SHA384",
+                    "TLS_PSK_WITH_NULL_SHA256",
+                    "TLS_PSK_WITH_NULL_SHA384",
+                    "TLS_DHE_PSK_WITH_AES_128_CBC_SHA256",
+                    "TLS_DHE_PSK_WITH_AES_256_CBC_SHA384",
+                    "TLS_DHE_PSK_WITH_NULL_SHA256",
+                    "TLS_DHE_PSK_WITH_NULL_SHA384",
+                    "TLS_RSA_PSK_WITH_AES_128_CBC_SHA256",
+                    "TLS_RSA_PSK_WITH_AES_256_CBC_SHA384",
+                    "TLS_RSA_PSK_WITH_NULL_SHA256",
+                    "TLS_RSA_PSK_WITH_NULL_SHA384",
+                    "TLS_RSA_WITH_CAMELLIA_128_CBC_SHA256",
+                    "TLS_DH_DSS_WITH_CAMELLIA_128_CBC_SHA256",
+                    "TLS_DH_RSA_WITH_CAMELLIA_128_CBC_SHA256",
+                    "TLS_DHE_DSS_WITH_CAMELLIA_128_CBC_SHA256",
+                    "TLS_DHE_RSA_WITH_CAMELLIA_128_CBC_SHA256",
+                    "TLS_DH_anon_WITH_CAMELLIA_128_CBC_SHA256",
+                    "TLS_RSA_WITH_CAMELLIA_256_CBC_SHA256",
+                    "TLS_DH_DSS_WITH_CAMELLIA_256_CBC_SHA256",
+                    "TLS_DH_RSA_WITH_CAMELLIA_256_CBC_SHA256",
+                    "TLS_DHE_DSS_WITH_CAMELLIA_256_CBC_SHA256",
+                    "TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA256",
+                    "TLS_DH_anon_WITH_CAMELLIA_256_CBC_SHA256",
+                    "TLS_EMPTY_RENEGOTIATION_INFO_SCSV",
+                    "TLS_ECDH_ECDSA_WITH_NULL_SHA",
+                    "TLS_ECDH_ECDSA_WITH_RC4_128_SHA",
+                    "TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA",
+                    "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA",
+                    "TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA",
+                    "TLS_ECDHE_ECDSA_WITH_NULL_SHA",
+                    "TLS_ECDHE_ECDSA_WITH_RC4_128_SHA",
+                    "TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA",
+                    "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
+                    "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA",
+                    "TLS_ECDH_RSA_WITH_NULL_SHA",
+                    "TLS_ECDH_RSA_WITH_RC4_128_SHA",
+                    "TLS_ECDH_RSA_WITH_3DES_EDE_CBC_SHA",
+                    "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA",
+                    "TLS_ECDH_RSA_WITH_AES_256_CBC_SHA",
+                    "TLS_ECDHE_RSA_WITH_NULL_SHA",
+                    "TLS_ECDHE_RSA_WITH_RC4_128_SHA",
+                    "TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA",
+                    "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
+                    "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
+                    "TLS_ECDH_anon_WITH_NULL_SHA",
+                    "TLS_ECDH_anon_WITH_RC4_128_SHA",
+                    "TLS_ECDH_anon_WITH_3DES_EDE_CBC_SHA",
+                    "TLS_ECDH_anon_WITH_AES_128_CBC_SHA",
+                    "TLS_ECDH_anon_WITH_AES_256_CBC_SHA",
+                    "TLS_SRP_SHA_WITH_3DES_EDE_CBC_SHA",
+                    "TLS_SRP_SHA_RSA_WITH_3DES_EDE_CBC_SHA",
+                    "TLS_SRP_SHA_DSS_WITH_3DES_EDE_CBC_SHA",
+                    "TLS_SRP_SHA_WITH_AES_128_CBC_SHA",
+                    "TLS_SRP_SHA_RSA_WITH_AES_128_CBC_SHA",
+                    "TLS_SRP_SHA_DSS_WITH_AES_128_CBC_SHA",
+                    "TLS_SRP_SHA_WITH_AES_256_CBC_SHA",
+                    "TLS_SRP_SHA_RSA_WITH_AES_256_CBC_SHA",
+                    "TLS_SRP_SHA_DSS_WITH_AES_256_CBC_SHA",
+                    "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256",
+                    "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384",
+                    "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256",
+                    "TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384",
+                    "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
+                    "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384",
+                    "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256",
+                    "TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384",
+                    "TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256",
+                    "TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384",
+                    "TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256",
+                    "TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384",
+                    "TLS_ECDHE_PSK_WITH_RC4_128_SHA",
+                    "TLS_ECDHE_PSK_WITH_3DES_EDE_CBC_SHA",
+                    "TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA",
+                    "TLS_ECDHE_PSK_WITH_AES_256_CBC_SHA",
+                    "TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA256",
+                    "TLS_ECDHE_PSK_WITH_AES_256_CBC_SHA384",
+                    "TLS_ECDHE_PSK_WITH_NULL_SHA",
+                    "TLS_ECDHE_PSK_WITH_NULL_SHA256",
+                    "TLS_ECDHE_PSK_WITH_NULL_SHA384",
+                    "TLS_RSA_WITH_ARIA_128_CBC_SHA256",
+                    "TLS_RSA_WITH_ARIA_256_CBC_SHA384",
+                    "TLS_DH_DSS_WITH_ARIA_128_CBC_SHA256",
+                    "TLS_DH_DSS_WITH_ARIA_256_CBC_SHA384",
+                    "TLS_DH_RSA_WITH_ARIA_128_CBC_SHA256",
+                    "TLS_DH_RSA_WITH_ARIA_256_CBC_SHA384",
+                    "TLS_DHE_DSS_WITH_ARIA_128_CBC_SHA256",
+                    "TLS_DHE_DSS_WITH_ARIA_256_CBC_SHA384",
+                    "TLS_DHE_RSA_WITH_ARIA_128_CBC_SHA256",
+                    "TLS_DHE_RSA_WITH_ARIA_256_CBC_SHA384",
+                    "TLS_DH_anon_WITH_ARIA_128_CBC_SHA256",
+                    "TLS_DH_anon_WITH_ARIA_256_CBC_SHA384",
+                    "TLS_ECDHE_ECDSA_WITH_ARIA_128_CBC_SHA256",
+                    "TLS_ECDHE_ECDSA_WITH_ARIA_256_CBC_SHA384",
+                    "TLS_ECDH_ECDSA_WITH_ARIA_128_CBC_SHA256",
+                    "TLS_ECDH_ECDSA_WITH_ARIA_256_CBC_SHA384",
+                    "TLS_ECDHE_RSA_WITH_ARIA_128_CBC_SHA256",
+                    "TLS_ECDHE_RSA_WITH_ARIA_256_CBC_SHA384",
+                    "TLS_ECDH_RSA_WITH_ARIA_128_CBC_SHA256",
+                    "TLS_ECDH_RSA_WITH_ARIA_256_CBC_SHA384",
+                    "TLS_RSA_WITH_ARIA_128_GCM_SHA256",
+                    "TLS_RSA_WITH_ARIA_256_GCM_SHA384",
+                    "TLS_DH_RSA_WITH_ARIA_128_GCM_SHA256",
+                    "TLS_DH_RSA_WITH_ARIA_256_GCM_SHA384",
+                    "TLS_DH_DSS_WITH_ARIA_128_GCM_SHA256",
+                    "TLS_DH_DSS_WITH_ARIA_256_GCM_SHA384",
+                    "TLS_DH_anon_WITH_ARIA_128_GCM_SHA256",
+                    "TLS_DH_anon_WITH_ARIA_256_GCM_SHA384",
+                    "TLS_ECDH_ECDSA_WITH_ARIA_128_GCM_SHA256",
+                    "TLS_ECDH_ECDSA_WITH_ARIA_256_GCM_SHA384",
+                    "TLS_ECDH_RSA_WITH_ARIA_128_GCM_SHA256",
+                    "TLS_ECDH_RSA_WITH_ARIA_256_GCM_SHA384",
+                    "TLS_PSK_WITH_ARIA_128_CBC_SHA256",
+                    "TLS_PSK_WITH_ARIA_256_CBC_SHA384",
+                    "TLS_DHE_PSK_WITH_ARIA_128_CBC_SHA256",
+                    "TLS_DHE_PSK_WITH_ARIA_256_CBC_SHA384",
+                    "TLS_RSA_PSK_WITH_ARIA_128_CBC_SHA256",
+                    "TLS_RSA_PSK_WITH_ARIA_256_CBC_SHA384",
+                    "TLS_PSK_WITH_ARIA_128_GCM_SHA256",
+                    "TLS_PSK_WITH_ARIA_256_GCM_SHA384",
+                    "TLS_RSA_PSK_WITH_ARIA_128_GCM_SHA256",
+                    "TLS_RSA_PSK_WITH_ARIA_256_GCM_SHA384",
+                    "TLS_ECDHE_PSK_WITH_ARIA_128_CBC_SHA256",
+                    "TLS_ECDHE_PSK_WITH_ARIA_256_CBC_SHA384",
+                    "TLS_ECDHE_ECDSA_WITH_CAMELLIA_128_CBC_SHA256",
+                    "TLS_ECDHE_ECDSA_WITH_CAMELLIA_256_CBC_SHA384",
+                    "TLS_ECDH_ECDSA_WITH_CAMELLIA_128_CBC_SHA256",
+                    "TLS_ECDH_ECDSA_WITH_CAMELLIA_256_CBC_SHA384",
+                    "TLS_ECDHE_RSA_WITH_CAMELLIA_128_CBC_SHA256",
+                    "TLS_ECDHE_RSA_WITH_CAMELLIA_256_CBC_SHA384",
+                    "TLS_ECDH_RSA_WITH_CAMELLIA_128_CBC_SHA256",
+                    "TLS_ECDH_RSA_WITH_CAMELLIA_256_CBC_SHA384",
+                    "TLS_RSA_WITH_CAMELLIA_128_GCM_SHA256",
+                    "TLS_RSA_WITH_CAMELLIA_256_GCM_SHA384",
+                    "TLS_DH_RSA_WITH_CAMELLIA_128_GCM_SHA256",
+                    "TLS_DH_RSA_WITH_CAMELLIA_256_GCM_SHA384",
+                    "TLS_DH_DSS_WITH_CAMELLIA_128_GCM_SHA256",
+                    "TLS_DH_DSS_WITH_CAMELLIA_256_GCM_SHA384",
+                    "TLS_DH_anon_WITH_CAMELLIA_128_GCM_SHA256",
+                    "TLS_DH_anon_WITH_CAMELLIA_256_GCM_SHA384",
+                    "TLS_ECDH_ECDSA_WITH_CAMELLIA_128_GCM_SHA256",
+                    "TLS_ECDH_ECDSA_WITH_CAMELLIA_256_GCM_SHA384",
+                    "TLS_ECDH_RSA_WITH_CAMELLIA_128_GCM_SHA256",
+                    "TLS_ECDH_RSA_WITH_CAMELLIA_256_GCM_SHA384",
+                    "TLS_PSK_WITH_CAMELLIA_128_GCM_SHA256",
+                    "TLS_PSK_WITH_CAMELLIA_256_GCM_SHA384",
+                    "TLS_RSA_PSK_WITH_CAMELLIA_128_GCM_SHA256",
+                    "TLS_RSA_PSK_WITH_CAMELLIA_256_GCM_SHA384",
+                    "TLS_PSK_WITH_CAMELLIA_128_CBC_SHA256",
+                    "TLS_PSK_WITH_CAMELLIA_256_CBC_SHA384",
+                    "TLS_DHE_PSK_WITH_CAMELLIA_128_CBC_SHA256",
+                    "TLS_DHE_PSK_WITH_CAMELLIA_256_CBC_SHA384",
+                    "TLS_RSA_PSK_WITH_CAMELLIA_128_CBC_SHA256",
+                    "TLS_RSA_PSK_WITH_CAMELLIA_256_CBC_SHA384",
+                    "TLS_ECDHE_PSK_WITH_CAMELLIA_128_CBC_SHA256",
+                    "TLS_ECDHE_PSK_WITH_CAMELLIA_256_CBC_SHA384",
+                    "TLS_RSA_WITH_AES_128_CCM",
+                    "TLS_RSA_WITH_AES_256_CCM",
+                    "TLS_RSA_WITH_AES_128_CCM_8",
+                    "TLS_RSA_WITH_AES_256_CCM_8",
+                    "TLS_PSK_WITH_AES_128_CCM",
+                    "TLS_PSK_WITH_AES_256_CCM",
+                    "TLS_PSK_WITH_AES_128_CCM_8",
+                    "TLS_PSK_WITH_AES_256_CCM_8"
+            );
 
     private SslContextUtil() {}
 }

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
@@ -250,10 +250,7 @@ public final class VirtualHostBuilder {
         try {
             return BouncyCastleKeyFactoryProvider.call(() -> {
                 final SslContextBuilder builder = builderSupplier.get();
-
-                SslContextUtil.configureDefaults(builder, false);
-                tlsCustomizer.accept(builder);
-
+                SslContextUtil.configureDefaults(builder, false, tlsCustomizer);
                 return builder.build();
             });
         } catch (RuntimeException | SSLException e) {

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
@@ -248,11 +248,8 @@ public final class VirtualHostBuilder {
             Supplier<SslContextBuilder> builderSupplier,
             Consumer<SslContextBuilder> tlsCustomizer) throws SSLException {
         try {
-            return BouncyCastleKeyFactoryProvider.call(() -> {
-                final SslContextBuilder builder = builderSupplier.get();
-                SslContextUtil.configureDefaults(builder, false, tlsCustomizer);
-                return builder.build();
-            });
+            return BouncyCastleKeyFactoryProvider.call(() -> SslContextUtil.createSslContext(
+                    builderSupplier, false, tlsCustomizer));
         } catch (RuntimeException | SSLException e) {
             throw e;
         } catch (Exception e) {

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
@@ -46,7 +46,6 @@ import org.slf4j.LoggerFactory;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 
-import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.MediaType;
@@ -56,6 +55,7 @@ import com.linecorp.armeria.common.logging.ContentPreviewer;
 import com.linecorp.armeria.common.logging.ContentPreviewerFactory;
 import com.linecorp.armeria.common.util.SystemInfo;
 import com.linecorp.armeria.internal.ArmeriaHttpUtil;
+import com.linecorp.armeria.internal.SslContextUtil;
 import com.linecorp.armeria.internal.annotation.AnnotatedHttpServiceElement;
 import com.linecorp.armeria.internal.annotation.AnnotatedHttpServiceFactory;
 import com.linecorp.armeria.internal.crypto.BouncyCastleKeyFactoryProvider;
@@ -63,7 +63,6 @@ import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
 import com.linecorp.armeria.server.annotation.RequestConverterFunction;
 import com.linecorp.armeria.server.annotation.ResponseConverterFunction;
 
-import io.netty.handler.codec.http2.Http2SecurityUtil;
 import io.netty.handler.ssl.ApplicationProtocolConfig;
 import io.netty.handler.ssl.ApplicationProtocolConfig.Protocol;
 import io.netty.handler.ssl.ApplicationProtocolConfig.SelectedListenerFailureBehavior;
@@ -71,8 +70,6 @@ import io.netty.handler.ssl.ApplicationProtocolConfig.SelectorFailureBehavior;
 import io.netty.handler.ssl.ApplicationProtocolNames;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
-import io.netty.handler.ssl.SslProvider;
-import io.netty.handler.ssl.SupportedCipherSuiteFilter;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 
 /**
@@ -254,10 +251,7 @@ public final class VirtualHostBuilder {
             return BouncyCastleKeyFactoryProvider.call(() -> {
                 final SslContextBuilder builder = builderSupplier.get();
 
-                builder.sslProvider(Flags.useOpenSsl() ? SslProvider.OPENSSL : SslProvider.JDK);
-                builder.ciphers(Http2SecurityUtil.CIPHERS, SupportedCipherSuiteFilter.INSTANCE);
-                builder.applicationProtocolConfig(HTTPS_ALPN_CFG);
-
+                SslContextUtil.configureDefaults(builder, false);
                 tlsCustomizer.accept(builder);
 
                 return builder.build();


### PR DESCRIPTION
While working on other SSL stuff, I noticed that the logic for SSL configuration is in two places and a bit confusing. And it's not too hard to enable TLSv1.3, so figured may as well turn it on since it seems to be getting more widely used now. FWIU, openssl intends users to automatically get it enabled when updating their dependency version, so figure similar for Armeria should be acceptable, but let me know if we should flag this. For reference, https://wiki.openssl.org/index.php/TLS1.3

No rush on this PR :)