### PR TITLE
Fix additional trailers are not added for trailers-only responses and add some advanced gRPC unit tests.

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/ArmeriaHttpUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/ArmeriaHttpUtil.java
@@ -346,17 +346,7 @@ public final class ArmeriaHttpUtil {
      * be always empty (1xx, 204, 205 and 304 responses.)
      */
     public static boolean isContentAlwaysEmpty(HttpStatus status) {
-        if (status.codeClass() == HttpStatusClass.INFORMATIONAL) {
-            return true;
-        }
-
-        switch (status.code()) {
-            case 204:
-            case 205:
-            case 304:
-                return true;
-        }
-        return false;
+        return isContentAlwaysEmpty(status.code());
     }
 
     /**
@@ -369,9 +359,9 @@ public final class ArmeriaHttpUtil {
         }
 
         switch (statusCode) {
-            case 204:
-            case 205:
-            case 304:
+            case /* NO_CONTENT */ 204:
+            case /* RESET_CONTENT */ 205:
+            case /* NOT_MODIFIED */ 304:
                 return true;
         }
         return false;

--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
@@ -172,7 +172,7 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject>, RequestTim
                 final HttpHeaders additionalHeaders = reqCtx.additionalResponseHeaders();
                 final HttpHeaders additionalTrailers = reqCtx.additionalResponseTrailers();
 
-                ResponseHeadersBuilder newHeaders = fillAdditionalHeaders(headers, additionalHeaders);
+                final ResponseHeadersBuilder newHeaders = fillAdditionalHeaders(headers, additionalHeaders);
                 if (endOfStream && !additionalTrailers.isEmpty()) {
                     newHeaders.setIfAbsent(additionalTrailers);
                 }

--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
@@ -170,7 +170,13 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject>, RequestTim
                 }
 
                 final HttpHeaders additionalHeaders = reqCtx.additionalResponseHeaders();
-                final ResponseHeadersBuilder newHeaders = fillAdditionalHeaders(headers, additionalHeaders);
+                final HttpHeaders additionalTrailers = reqCtx.additionalResponseTrailers();
+
+                ResponseHeadersBuilder newHeaders = fillAdditionalHeaders(headers, additionalHeaders);
+                if (endOfStream && !additionalTrailers.isEmpty()) {
+                    newHeaders.setIfAbsent(additionalTrailers);
+                }
+
                 if (newHeaders.contains(HttpHeaderNames.CONTENT_LENGTH) &&
                     !reqCtx.additionalResponseTrailers().isEmpty()) {
                     newHeaders.remove(HttpHeaderNames.CONTENT_LENGTH);

--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
@@ -169,11 +169,6 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject>, RequestTim
                     break;
                 }
 
-                final HttpHeaders additionalHeaders = reqCtx.additionalResponseHeaders();
-                final HttpHeaders additionalTrailers = reqCtx.additionalResponseTrailers();
-
-                final ResponseHeadersBuilder newHeaders = fillAdditionalHeaders(headers, additionalHeaders);
-
                 if (req.method() == HttpMethod.HEAD) {
                     // HEAD responses always close the stream with the initial headers, even if not explicitly
                     // set.
@@ -184,14 +179,19 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject>, RequestTim
                         case 204:
                         case 205:
                         case 304:
-                            // These responses are not allowed to have content so we always close the stream even if
-                            // not explicitly set.
+                            // These responses are not allowed to have content so we always close the stream
+                            // even if not explicitly set.
                             endOfStream = true;
                             break;
                         default:
                             state = State.NEEDS_DATA_OR_TRAILING_HEADERS;
                     }
                 }
+
+                final HttpHeaders additionalHeaders = reqCtx.additionalResponseHeaders();
+                final HttpHeaders additionalTrailers = reqCtx.additionalResponseTrailers();
+
+                final ResponseHeadersBuilder newHeaders = fillAdditionalHeaders(headers, additionalHeaders);
 
                 if (endOfStream && !additionalTrailers.isEmpty()) {
                     newHeaders.setIfAbsent(additionalTrailers);

--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
@@ -178,7 +178,10 @@ final class HttpResponseSubscriber implements Subscriber<HttpObject>, RequestTim
                 }
 
                 if (newHeaders.contains(HttpHeaderNames.CONTENT_LENGTH) &&
-                    !reqCtx.additionalResponseTrailers().isEmpty()) {
+                    !additionalTrailers.isEmpty()) {
+                    // We don't apply chunked encoding when the content-length header is set, which would
+                    // prevent the trailers from being sent so we go ahead and remove content-length to force
+                    // chunked encoding.
                     newHeaders.remove(HttpHeaderNames.CONTENT_LENGTH);
                 }
 

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
@@ -19,6 +19,7 @@ package com.linecorp.armeria.server.grpc;
 import static com.linecorp.armeria.internal.grpc.GrpcTestUtil.REQUEST_MESSAGE;
 import static com.linecorp.armeria.internal.grpc.GrpcTestUtil.RESPONSE_MESSAGE;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.Assertions.entry;
 import static org.awaitility.Awaitility.await;
@@ -100,8 +101,15 @@ import com.linecorp.armeria.testing.junit4.server.ServerRule;
 
 import io.grpc.Codec;
 import io.grpc.DecompressorRegistry;
+import io.grpc.ForwardingServerCall.SimpleForwardingServerCall;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCall.Listener;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.ServerInterceptors;
 import io.grpc.Status;
 import io.grpc.Status.Code;
 import io.grpc.StatusException;
@@ -285,7 +293,33 @@ public class GrpcServiceServerTest {
             ((ServerCallStreamObserver<?>) responseObserver).setOnCancelHandler(() -> COMPLETED.set(true));
             responseObserver.onNext(SimpleResponse.getDefaultInstance());
         }
+
+        @Override
+        public void errorReplaceException(SimpleRequest request,
+                                          StreamObserver<SimpleResponse> responseObserver) {
+            responseObserver.onError(new IllegalStateException("This error should be replaced"));
+        }
     }
+
+    private static final ServerInterceptor REPLACE_EXCEPTION = new ServerInterceptor() {
+        @Override
+        public <REQ, RESP> Listener<REQ> interceptCall(ServerCall<REQ, RESP> call, Metadata headers,
+                                                          ServerCallHandler<REQ, RESP> next) {
+            if (!call.getMethodDescriptor().equals(UnitTestServiceGrpc.getErrorReplaceExceptionMethod())) {
+                return next.startCall(call, headers);
+            }
+            return next.startCall(new SimpleForwardingServerCall<REQ, RESP>(call) {
+                @Override
+                public void close(Status status, Metadata trailers) {
+                    if (status.getCause() instanceof IllegalStateException &&
+                        status.getCause().getMessage().equals("This error should be replaced")) {
+                        status = status.withDescription("Error was replaced");
+                    }
+                    delegate().close(status, trailers);
+                }
+            }, headers);
+        }
+    };
 
     private static final BlockingQueue<RequestLog> requestLogQueue = new LinkedTransferQueue<>();
 
@@ -299,7 +333,8 @@ public class GrpcServiceServerTest {
             sb.service(
                     new GrpcServiceBuilder()
                             .setMaxInboundMessageSizeBytes(MAX_MESSAGE_SIZE)
-                            .addService(new UnitTestServiceImpl())
+                            .addService(ServerInterceptors.intercept(
+                                    new UnitTestServiceImpl(), REPLACE_EXCEPTION))
                             .enableUnframedRequests(true)
                             .supportedSerializationFormats(GrpcSerializationFormats.values())
                             .build(),
@@ -336,7 +371,8 @@ public class GrpcServiceServerTest {
 
             sb.serviceUnder("/", new GrpcServiceBuilder()
                     .setMaxInboundMessageSizeBytes(MAX_MESSAGE_SIZE)
-                    .addService(new UnitTestServiceImpl())
+                    .addService(ServerInterceptors.intercept(
+                            new UnitTestServiceImpl(), REPLACE_EXCEPTION))
                     .enableUnframedRequests(true)
                     .supportedSerializationFormats(GrpcSerializationFormats.values())
                     .useBlockingTaskExecutor(true)
@@ -1007,6 +1043,15 @@ public class GrpcServiceServerTest {
                     assertThat(response.get().getListServicesResponse().getServiceList())
                             .hasSizeGreaterThanOrEqualTo(2);
                 });
+    }
+
+    @Test
+    public void replaceException() throws Exception {
+        assertThatThrownBy(() -> blockingClient.errorReplaceException(SimpleRequest.getDefaultInstance()))
+                .isInstanceOf(StatusRuntimeException.class)
+                .hasMessage("UNKNOWN: Error was replaced");
+
+        requestLogQueue.take();
     }
 
     private static void checkRequestLog(RequestLogChecker checker) throws Exception {

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
@@ -326,7 +326,7 @@ public class GrpcServiceServerTest {
     private static final ServerInterceptor REPLACE_EXCEPTION = new ServerInterceptor() {
         @Override
         public <REQ, RESP> Listener<REQ> interceptCall(ServerCall<REQ, RESP> call, Metadata headers,
-                                                          ServerCallHandler<REQ, RESP> next) {
+                                                       ServerCallHandler<REQ, RESP> next) {
             if (!call.getMethodDescriptor().equals(UnitTestServiceGrpc.getErrorReplaceExceptionMethod())) {
                 return next.startCall(call, headers);
             }

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
@@ -312,7 +312,7 @@ public class GrpcServiceServerTest {
         @Override
         public void errorAdditionalMetadata(SimpleRequest request,
                                             StreamObserver<SimpleResponse> responseObserver) {
-            ServiceRequestContext ctx = RequestContext.current();
+            final ServiceRequestContext ctx = RequestContext.current();
             ctx.addAdditionalResponseTrailer(
                     ERROR_METADATA_HEADER,
                     Base64.getEncoder().encodeToString(StringValue.newBuilder()
@@ -1078,7 +1078,7 @@ public class GrpcServiceServerTest {
 
     @Test
     public void errorAdditionalMetadata() throws Exception {
-        Throwable t = catchThrowable(
+        final Throwable t = catchThrowable(
                 () -> blockingClient.errorAdditionalMetadata(SimpleRequest.getDefaultInstance()));
         assertThat(t).isInstanceOfSatisfying(StatusRuntimeException.class, error -> {
             assertThat(error).hasMessage("UNKNOWN");

--- a/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/test.proto
+++ b/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/test.proto
@@ -134,6 +134,9 @@ service UnitTestService {
     // A streaming RPC where the client half-closes but cancels without explicitly closing the stream
     // before receiving the full response (e.g. socket disconnect).
     rpc StreamClientCancelsBeforeResponseClosedCancels(SimpleRequest) returns (stream SimpleResponse);
+
+    // A call that has an error in business logic replaced by an interceptor.
+    rpc ErrorReplaceException(SimpleRequest) returns (SimpleResponse);
 }
 
 // A simple service NOT implemented at servers so clients can test for

--- a/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/test.proto
+++ b/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/test.proto
@@ -137,6 +137,9 @@ service UnitTestService {
 
     // A call that has an error in business logic replaced by an interceptor.
     rpc ErrorReplaceException(SimpleRequest) returns (SimpleResponse);
+
+    // A call that has an error with extra metadata attached to it.
+    rpc ErrorAdditionalMetadata(SimpleRequest) returns(SimpleResponse);
 }
 
 // A simple service NOT implemented at servers so clients can test for


### PR DESCRIPTION
Currently, trailers are not added when the response is trailers-only. This means a user's call to `addAdditionalResponseTrailer` may be ignored based on whether the response has a stream of objects or only the trailers, which can be hard for gRPC users where both situations occur.

Also added a unit test demonstrating adding a protobuf to response trailers and using a server interceptor to replace exceptions.