### PR TITLE
Introduce `InvalidSamlRequestException` to distinguish invalid request errors…

### DIFF
--- a/saml/src/main/java/com/linecorp/armeria/server/saml/HttpPostBindingUtil.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/HttpPostBindingUtil.java
@@ -109,7 +109,8 @@ final class HttpPostBindingUtil {
         try {
             decoded = Base64.getMimeDecoder().decode(parameters.getFirstValue(name));
         } catch (IllegalArgumentException e) {
-            throw new SamlException("failed to decode a base64 string of the parameter: " + name, e);
+            throw new InvalidSamlRequestException(
+                    "failed to decode a base64 string of the parameter: " + name, e);
         }
 
         @SuppressWarnings("unchecked")

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/InvalidSamlRequestException.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/InvalidSamlRequestException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2019 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -17,55 +17,36 @@ package com.linecorp.armeria.server.saml;
 
 import javax.annotation.Nullable;
 
-import com.linecorp.armeria.common.Flags;
-
 /**
- * Indicates that an error occurs while processing a SAML request.
+ * Indicates that a SAML request is not valid so that its problem should be propagated to the sender.
  */
-public class SamlException extends RuntimeException {
+public class InvalidSamlRequestException extends SamlException {
 
-    private static final long serialVersionUID = -6694912876733624005L;
+    private static final long serialVersionUID = -8253266781662471590L;
 
     /**
      * Creates a new exception.
      */
-    public SamlException() {}
+    public InvalidSamlRequestException() {}
 
     /**
      * Creates a new instance with the specified {@code message}.
      */
-    public SamlException(@Nullable String message) {
+    public InvalidSamlRequestException(@Nullable String message) {
         super(message);
     }
 
     /**
      * Creates a new instance with the specified {@code message} and {@code cause}.
      */
-    public SamlException(@Nullable String message, @Nullable Throwable cause) {
+    public InvalidSamlRequestException(@Nullable String message, @Nullable Throwable cause) {
         super(message, cause);
     }
 
     /**
      * Creates a new instance with the specified {@code cause}.
      */
-    public SamlException(@Nullable Throwable cause) {
+    public InvalidSamlRequestException(@Nullable Throwable cause) {
         super(cause);
-    }
-
-    /**
-     * Creates a new instance with the specified {@code message}, {@code cause}, suppression enabled or
-     * disabled, and writable stack trace enabled or disabled.
-     */
-    protected SamlException(@Nullable String message, @Nullable Throwable cause,
-                            boolean enableSuppression, boolean writableStackTrace) {
-        super(message, cause, enableSuppression, writableStackTrace);
-    }
-
-    @Override
-    public Throwable fillInStackTrace() {
-        if (Flags.verboseExceptions()) {
-            return super.fillInStackTrace();
-        }
-        return this;
     }
 }

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/InvalidSamlRequestException.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/InvalidSamlRequestException.java
@@ -49,4 +49,13 @@ public class InvalidSamlRequestException extends SamlException {
     public InvalidSamlRequestException(@Nullable Throwable cause) {
         super(cause);
     }
+
+    /**
+     * Creates a new instance with the specified {@code message}, {@code cause}, suppression enabled or
+     * disabled, and writable stack trace enabled or disabled.
+     */
+    protected InvalidSamlRequestException(@Nullable String message, @Nullable Throwable cause,
+                                          boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
 }

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/InvalidSamlRequestException.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/InvalidSamlRequestException.java
@@ -18,7 +18,7 @@ package com.linecorp.armeria.server.saml;
 import javax.annotation.Nullable;
 
 /**
- * Indicates that a SAML request is not valid so that its problem should be propagated to the sender.
+ * Indicates that a SAML request is not valid.
  */
 public class InvalidSamlRequestException extends SamlException {
 

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/SamlAssertionConsumerFunction.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/SamlAssertionConsumerFunction.java
@@ -120,27 +120,27 @@ final class SamlAssertionConsumerFunction implements SamlServiceFunction {
                 return config;
             }
         }
-        throw new SamlException("failed to find identity provider from configuration " +
-                                issuer.getValue());
+        throw new InvalidSamlRequestException("failed to find identity provider from configuration " +
+                                              issuer.getValue());
     }
 
     private Assertion getValidatedAssertion(Response response, String endpointUri) {
         final Status status = response.getStatus();
         final String statusCode = status.getStatusCode().getValue();
         if (!StatusCode.SUCCESS.equals(statusCode)) {
-            throw new SamlException("response status code: " + statusCode +
-                                    " (expected: " + StatusCode.SUCCESS + ')');
+            throw new InvalidSamlRequestException("response status code: " + statusCode +
+                                                  " (expected: " + StatusCode.SUCCESS + ')');
         }
 
         final DateTime now = new DateTime();
         final DateTime issueInstant = response.getIssueInstant();
         if (issueInstant == null) {
-            throw new SamlException("failed to get IssueInstant attribute");
+            throw new InvalidSamlRequestException("failed to get IssueInstant attribute");
         }
         if (Math.abs(now.getMillis() - issueInstant.getMillis()) > MILLIS_IN_MINUTE) {
             // Allow if 'issueInstant' is in [now - 60s, now + 60s] because there might be the
             // time difference between SP's timer and IdP's timer.
-            throw new SamlException("invalid IssueInstant: " + issueInstant);
+            throw new InvalidSamlRequestException("invalid IssueInstant: " + issueInstant);
         }
 
         final List<Assertion> assertions;
@@ -175,7 +175,7 @@ final class SamlAssertionConsumerFunction implements SamlServiceFunction {
         //   unique identifier of the issuing identity provider; the Format attribute MUST be omitted or
         //   have a value of urn:oasis:names:tc:SAML:2.0:nameid-format:entity.
         if (assertions.isEmpty()) {
-            throw new SamlException("failed to get Assertion elements from the response");
+            throw new InvalidSamlRequestException("failed to get Assertion elements from the response");
         }
 
         // - The set of one or more assertions MUST contain at least one <AuthnStatement> that reflects the
@@ -183,7 +183,7 @@ final class SamlAssertionConsumerFunction implements SamlServiceFunction {
         for (final Assertion assertion : assertions) {
             final Issuer issuer = assertion.getIssuer();
             if (issuer == null || issuer.getValue() == null) {
-                throw new SamlException("failed to get an Issuer element from the assertion");
+                throw new InvalidSamlRequestException("failed to get an Issuer element from the assertion");
             }
 
             final SamlIdentityProviderConfig idp = resolveIdpConfig(issuer);
@@ -225,18 +225,21 @@ final class SamlAssertionConsumerFunction implements SamlServiceFunction {
                 }
 
                 if (!endpointUri.equals(data.getRecipient())) {
-                    throw new SamlException("recipient is not matched: " + data.getRecipient());
+                    throw new InvalidSamlRequestException(
+                            "recipient is not matched: " + data.getRecipient());
                 }
                 if (now.isAfter(data.getNotOnOrAfter())) {
-                    throw new SamlException("response has been expired: " + data.getNotOnOrAfter());
+                    throw new InvalidSamlRequestException(
+                            "response has been expired: " + data.getNotOnOrAfter());
                 }
                 if (!requestIdManager.validateId(data.getInResponseTo())) {
-                    throw new SamlException("request ID is not valid: " + data.getInResponseTo());
+                    throw new InvalidSamlRequestException(
+                            "request ID is not valid: " + data.getInResponseTo());
                 }
 
                 final Conditions conditions = assertion.getConditions();
                 if (conditions == null) {
-                    throw new SamlException("no condition found from the assertion");
+                    throw new InvalidSamlRequestException("no condition found from the assertion");
                 }
 
                 // - The assertion(s) containing a bearer subject confirmation MUST contain an
@@ -251,12 +254,13 @@ final class SamlAssertionConsumerFunction implements SamlServiceFunction {
                           .flatMap(r -> r.getAudiences().stream())
                           .filter(audience -> entityId.equals(audience.getAudienceURI()))
                           .findAny()
-                          .orElseThrow(() -> new SamlException("no audience found from the assertion"));
+                          .orElseThrow(() -> new InvalidSamlRequestException(
+                                  "no audience found from the assertion"));
 
                 return assertion;
             }
         }
-        throw new SamlException("no subject found from the assertions");
+        throw new InvalidSamlRequestException("no subject found from the assertions");
     }
 
     private static Assertion decryptAssertion(EncryptedAssertion encryptedAssertion,
@@ -269,7 +273,7 @@ final class SamlAssertionConsumerFunction implements SamlServiceFunction {
         try {
             return decrypter.decrypt(encryptedAssertion);
         } catch (DecryptionException e) {
-            throw new SamlException("failed to decrypt an assertion", e);
+            throw new InvalidSamlRequestException("failed to decrypt an assertion", e);
         }
     }
 }

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/SamlAssertionConsumerFunction.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/SamlAssertionConsumerFunction.java
@@ -120,7 +120,7 @@ final class SamlAssertionConsumerFunction implements SamlServiceFunction {
                 return config;
             }
         }
-        throw new InvalidSamlRequestException("failed to find identity provider from configuration " +
+        throw new InvalidSamlRequestException("failed to find identity provider from configuration: " +
                                               issuer.getValue());
     }
 

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/SamlException.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/SamlException.java
@@ -20,7 +20,7 @@ import javax.annotation.Nullable;
 import com.linecorp.armeria.common.Flags;
 
 /**
- * Indicates that an error occurs while processing a SAML request.
+ * Indicates that an error occurred while processing a SAML request.
  */
 public class SamlException extends RuntimeException {
 

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/SamlMessageUtil.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/SamlMessageUtil.java
@@ -118,7 +118,8 @@ final class SamlMessageUtil {
         try {
             return XMLObjectSupport.unmarshallFromInputStream(parserPool, is);
         } catch (XMLParserException | UnmarshallingException e) {
-            throw new SamlException("failed to deserialize an XML document bytes into a SAML object", e);
+            throw new InvalidSamlRequestException(
+                    "failed to deserialize an XML document bytes into a SAML object", e);
         }
     }
 
@@ -162,14 +163,14 @@ final class SamlMessageUtil {
 
         final Signature signature = signableObj.getSignature();
         if (signature == null) {
-            throw new SamlException("failed to validate a signature because no signature exists");
+            throw new InvalidSamlRequestException("failed to validate a signature because no signature exists");
         }
 
         try {
             signatureProfileValidator.validate(signature);
             SignatureValidator.validate(signature, validationCredential);
         } catch (SignatureException e) {
-            throw new SamlException("failed to validate a signature", e);
+            throw new InvalidSamlRequestException("failed to validate a signature", e);
         }
     }
 

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/SamlService.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/SamlService.java
@@ -207,12 +207,12 @@ final class SamlService implements ServiceWithPathMappings<HttpRequest, HttpResp
         /**
          * Returns the first value of the parameter with the specified {@code name}.
          *
-         * @throws SamlException if a parameter with the specified {@code name} does not exist
+         * @throws InvalidSamlRequestException if a parameter with the specified {@code name} does not exist
          */
         String getFirstValue(String name) {
             final String value = getFirstValueOrNull(name);
             if (value == null) {
-                throw new SamlException("failed to get the value of a parameter: " + name);
+                throw new InvalidSamlRequestException("failed to get the value of a parameter: " + name);
             }
             return value;
         }

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/SamlSingleLogoutFunction.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/SamlSingleLogoutFunction.java
@@ -167,14 +167,15 @@ final class SamlSingleLogoutFunction implements SamlServiceFunction {
                                                                String endpointUri) {
         final String issuer = logoutRequest.getIssuer().getValue();
         if (issuer == null) {
-            throw new SamlException("no issuer found from the logout request: " + logoutRequest.getID());
+            throw new InvalidSamlRequestException("no issuer found from the logout request: " +
+                                                  logoutRequest.getID());
         }
         if (!endpointUri.equals(logoutRequest.getDestination())) {
-            throw new SamlException("unexpected destination: " + logoutRequest.getDestination());
+            throw new InvalidSamlRequestException("unexpected destination: " + logoutRequest.getDestination());
         }
         final SamlIdentityProviderConfig config = idpConfigs.get(issuer);
         if (config == null) {
-            throw new SamlException("unexpected identity provider: " + issuer);
+            throw new InvalidSamlRequestException("unexpected identity provider: " + issuer);
         }
         return config;
     }


### PR DESCRIPTION
… from server errors

Motivation:
Currently, there is no way to distinguish between invalid request errors and server errors in the `SamlSingleSignOnHandler`.

Modifications:
- Added `InvalidSamlRequestException` for invalid request errors.
- It will be thrown when the request has an error.

Result:
- Closes #1780 
- A user can distinguish between invalid request errors and server errors in the `SamlSingleSignOnHandler`.