### PR TITLE
Marshal headers <-> gRPC Metadata.

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaClientCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaClientCall.java
@@ -149,6 +149,7 @@ class ArmeriaClientCall<I, O> extends ClientCall<I, O>
     @Override
     public void start(Listener<O> responseListener, Metadata metadata) {
         requireNonNull(responseListener, "responseListener");
+        requireNonNull(metadata, "metadata");
         final Compressor compressor;
         if (callOptions.getCompressor() != null) {
             compressor = compressorRegistry.lookupCompressor(callOptions.getCompressor());

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaClientCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaClientCall.java
@@ -48,6 +48,7 @@ import com.linecorp.armeria.internal.grpc.GrpcLogUtil;
 import com.linecorp.armeria.internal.grpc.GrpcMessageMarshaller;
 import com.linecorp.armeria.internal.grpc.GrpcStatus;
 import com.linecorp.armeria.internal.grpc.HttpStreamReader;
+import com.linecorp.armeria.internal.grpc.MetadataUtil;
 import com.linecorp.armeria.internal.grpc.TimeoutHeaderUtil;
 import com.linecorp.armeria.internal.grpc.TransportStatusListener;
 import com.linecorp.armeria.unsafe.grpc.GrpcUnsafeBufferUtil;
@@ -72,8 +73,6 @@ class ArmeriaClientCall<I, O> extends ClientCall<I, O>
 
     private static final Runnable NO_OP = () -> {
     };
-
-    private static final Metadata EMPTY_METADATA = new Metadata();
 
     private static final Logger logger = LoggerFactory.getLogger(ArmeriaClientCall.class);
 
@@ -148,7 +147,7 @@ class ArmeriaClientCall<I, O> extends ClientCall<I, O>
     }
 
     @Override
-    public void start(Listener<O> responseListener, Metadata unused) {
+    public void start(Listener<O> responseListener, Metadata metadata) {
         requireNonNull(responseListener, "responseListener");
         final Compressor compressor;
         if (callOptions.getCompressor() != null) {
@@ -157,20 +156,20 @@ class ArmeriaClientCall<I, O> extends ClientCall<I, O>
                 responseListener.onClose(
                         Status.INTERNAL.withDescription(
                                 "Unable to find compressor by name " + callOptions.getCompressor()),
-                        EMPTY_METADATA);
+                        new Metadata());
                 return;
             }
         } else {
             compressor = Identity.NONE;
         }
         messageFramer.setCompressor(ForwardingCompressor.forGrpc(compressor));
-        final HttpRequest req = prepareHeaders(compressor);
+        final HttpRequest req = prepareHeaders(compressor, metadata);
         listener = responseListener;
         final HttpResponse res;
         try (SafeCloseable ignored = ctx.push()) {
             res = httpClient.execute(ctx, req);
         } catch (Exception e) {
-            close(GrpcStatus.fromThrowable(e));
+            close(GrpcStatus.fromThrowable(e), new Metadata());
             return;
         }
         res.subscribe(responseReader, ctx.eventLoop(), true);
@@ -211,7 +210,7 @@ class ArmeriaClientCall<I, O> extends ClientCall<I, O>
         if (cause != null) {
             status = status.withCause(cause);
         }
-        close(status);
+        close(status, new Metadata());
         req.abort();
     }
 
@@ -251,7 +250,7 @@ class ArmeriaClientCall<I, O> extends ClientCall<I, O>
                     try (SafeCloseable ignored = ctx.push()) {
                         listener.onReady();
                     } catch (Throwable t) {
-                        close(GrpcStatus.fromThrowable(t));
+                        close(GrpcStatus.fromThrowable(t), new Metadata());
                     }
                 }
             });
@@ -292,11 +291,11 @@ class ArmeriaClientCall<I, O> extends ClientCall<I, O>
     }
 
     @Override
-    public void transportReportStatus(Status status) {
-        close(status);
+    public void transportReportStatus(Status status, Metadata metadata) {
+        close(status, metadata);
     }
 
-    private HttpRequest prepareHeaders(Compressor compressor) {
+    private HttpRequest prepareHeaders(Compressor compressor, Metadata metadata) {
         final RequestHeadersBuilder newHeaders = req.headers().toBuilder();
         if (compressor != Identity.NONE) {
             newHeaders.set(GrpcHeaderNames.GRPC_ENCODING, compressor.getMessageEncoding());
@@ -310,18 +309,20 @@ class ArmeriaClientCall<I, O> extends ClientCall<I, O>
                        TimeoutHeaderUtil.toHeaderValue(
                                TimeUnit.MILLISECONDS.toNanos(ctx.responseTimeoutMillis())));
 
+        MetadataUtil.fillHeaders(metadata, newHeaders);
+
         final HttpRequest newReq = HttpRequest.of(req, newHeaders.build());
         ctx.updateRequest(newReq);
         return newReq;
     }
 
-    private void close(Status status) {
+    private void close(Status status, Metadata metadata) {
         ctx.logBuilder().responseContent(GrpcLogUtil.rpcResponse(status, firstResponse), null);
         req.abort();
         responseReader.cancel();
 
         try (SafeCloseable ignored = ctx.push()) {
-            listener.onClose(status, EMPTY_METADATA);
+            listener.onClose(status, metadata);
         }
 
         notifyExecutor();

--- a/grpc/src/main/java/com/linecorp/armeria/internal/grpc/HttpStreamReader.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/grpc/HttpStreamReader.java
@@ -45,6 +45,7 @@ import com.linecorp.armeria.internal.ArmeriaHttpUtil;
 
 import io.grpc.Decompressor;
 import io.grpc.DecompressorRegistry;
+import io.grpc.Metadata;
 import io.grpc.Status;
 
 /**
@@ -149,7 +150,10 @@ public class HttpStreamReader implements Subscriber<HttpObject>, BiFunction<Void
                 if (grpcThrowable != null) {
                     status = addCause(status, grpcThrowable);
                 }
-                transportStatusListener.transportReportStatus(status);
+
+                Metadata metadata = MetadataUtil.copyFromHeaders(headers);
+
+                transportStatusListener.transportReportStatus(status, metadata);
                 return;
             }
             // Headers without grpc-status are the leading headers of a non-failing response, prepare to receive

--- a/grpc/src/main/java/com/linecorp/armeria/internal/grpc/MetadataUtil.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/grpc/MetadataUtil.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.internal.grpc;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Map.Entry;
 
 import org.slf4j.Logger;
@@ -106,20 +107,20 @@ public final class MetadataUtil {
                 int commaIndex = COMMA_MATCHER.indexIn(value);
                 if (commaIndex == -1) {
                     metadata[i++] = nameBytes;
-                    metadata[i++] = BASE64_ENCODING_OMIT_PADDING.decode(value);
+                    metadata[i++] = Base64.getDecoder().decode(value);
                 } else {
                     int substringStartIndex = 0;
                     while (commaIndex != -1) {
                         final String substring = value.substring(substringStartIndex, commaIndex);
                         metadata[i++] = nameBytes;
-                        metadata[i++] = BASE64_ENCODING_OMIT_PADDING.decode(substring);
+                        metadata[i++] = Base64.getDecoder().decode(substring);
 
                         substringStartIndex = commaIndex + 1;
                         commaIndex = COMMA_MATCHER.indexIn(value, commaIndex + 1);
                     }
                     final String substring = value.substring(substringStartIndex);
                     metadata[i++] = nameBytes;
-                    metadata[i++] = BASE64_ENCODING_OMIT_PADDING.decode(substring);
+                    metadata[i++] = Base64.getDecoder().decode(substring);
                 }
             } else {
                 metadata[i++] = nameBytes;

--- a/grpc/src/main/java/com/linecorp/armeria/internal/grpc/MetadataUtil.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/grpc/MetadataUtil.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.grpc;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Map.Entry;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpHeadersBuilder;
+
+import io.grpc.InternalMetadata;
+import io.grpc.Metadata;
+import io.netty.util.AsciiString;
+
+/**
+ * Utilities for working with {@link Metadata}.
+ */
+public final class MetadataUtil {
+
+    private static final Logger logger = LoggerFactory.getLogger(MetadataUtil.class);
+
+    /**
+     * Copies the headers in the gRPC {@link Metadata} to the Armeria {@link HttpHeadersBuilder}. Headers will
+     * be added, without replacing any currently present in the {@link HttpHeaders}.
+     */
+    public static void fillHeaders(Metadata metadata, HttpHeadersBuilder builder) {
+        if (InternalMetadata.headerCount(metadata) == 0) {
+            return;
+        }
+
+        final byte[][] serializedMetadata = InternalMetadata.serialize(metadata);
+        assert serializedMetadata.length % 2 == 0;
+
+        for (int i = 0; i < serializedMetadata.length; i += 2) {
+            final AsciiString name = new AsciiString(serializedMetadata[i], false);
+
+            final byte[] valueBytes = serializedMetadata[i + 1];
+
+            final String value;
+            if (isBinary(name)) {
+                value = InternalMetadata.BASE64_ENCODING_OMIT_PADDING.encode(valueBytes);
+            } else {
+                if (!isGrpcAscii(valueBytes)) {
+                    logger.warn("Metadata name=" + name + ", value=" + Arrays.toString(valueBytes) +
+                                " contains invalid ASCII characters, skipping.");
+                    continue;
+                }
+                value = new String(valueBytes, StandardCharsets.US_ASCII);
+            }
+            builder.add(name, value);
+        }
+    }
+
+    /**
+     * Copies the headers in the Armeria {@link HttpHeaders} into a gRPC {@link Metadata}.
+     */
+    public static Metadata copyFromHeaders(HttpHeaders headers) {
+        if (headers.isEmpty()) {
+            return new Metadata();
+        }
+
+        final byte[][] metadata = new byte[headers.size() * 2][];
+
+        int i = 0;
+        for (Entry<AsciiString, String> entry : headers) {
+            final AsciiString name = entry.getKey();
+            final String value = entry.getValue();
+            final byte[] valueBytes;
+            if (isBinary(name)) {
+                valueBytes = InternalMetadata.BASE64_ENCODING_OMIT_PADDING.decode(value);
+            } else {
+                valueBytes = value.getBytes(StandardCharsets.UTF_8);
+            }
+
+            metadata[i++] = name.isEntireArrayUsed() ? name.array() : name.toByteArray();
+            metadata[i++] = valueBytes;
+        }
+
+        return InternalMetadata.newMetadata(metadata);
+    }
+
+    private static boolean isBinary(AsciiString name) {
+        return name.endsWith(Metadata.BINARY_HEADER_SUFFIX);
+    }
+
+    /**
+     * Returns whether the metadata value is a valid gRPC header value, which is only allowed to be readable
+     * ASCII.
+     */
+    private static boolean isGrpcAscii(byte[] value) {
+        for (byte b : value) {
+            if (b < 32 || b > 126) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private MetadataUtil() {}
+}

--- a/grpc/src/main/java/com/linecorp/armeria/internal/grpc/MetadataUtil.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/grpc/MetadataUtil.java
@@ -65,13 +65,12 @@ public final class MetadataUtil {
             final String value;
             if (isBinary(name)) {
                 value = BASE64_ENCODING_OMIT_PADDING.encode(valueBytes);
-            } else {
-                if (!isGrpcAscii(valueBytes)) {
-                    logger.warn("Metadata name=" + name + ", value=" + Arrays.toString(valueBytes) +
-                                " contains invalid ASCII characters, skipping.");
-                    continue;
-                }
+            } else if (isGrpcAscii(valueBytes)) {
                 value = new String(valueBytes, StandardCharsets.US_ASCII);
+            } else {
+                logger.warn("Metadata name=" + name + ", value=" + Arrays.toString(valueBytes) +
+                            " contains invalid ASCII characters, skipping.");
+                continue;
             }
             builder.add(name, value);
         }

--- a/grpc/src/main/java/com/linecorp/armeria/internal/grpc/MetadataUtil.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/grpc/MetadataUtil.java
@@ -24,6 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.CharMatcher;
+import com.google.common.io.BaseEncoding;
 
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpHeadersBuilder;
@@ -40,6 +41,8 @@ public final class MetadataUtil {
     private static final Logger logger = LoggerFactory.getLogger(MetadataUtil.class);
 
     private static final CharMatcher COMMA_MATCHER = CharMatcher.is(',');
+
+    private static final BaseEncoding BASE64_ENCODING_OMIT_PADDING = BaseEncoding.base64().omitPadding();
 
     /**
      * Copies the headers in the gRPC {@link Metadata} to the Armeria {@link HttpHeadersBuilder}. Headers will
@@ -60,7 +63,7 @@ public final class MetadataUtil {
 
             final String value;
             if (isBinary(name)) {
-                value = InternalMetadata.BASE64_ENCODING_OMIT_PADDING.encode(valueBytes);
+                value = BASE64_ENCODING_OMIT_PADDING.encode(valueBytes);
             } else {
                 if (!isGrpcAscii(valueBytes)) {
                     logger.warn("Metadata name=" + name + ", value=" + Arrays.toString(valueBytes) +
@@ -103,20 +106,20 @@ public final class MetadataUtil {
                 int commaIndex = COMMA_MATCHER.indexIn(value);
                 if (commaIndex == -1) {
                     metadata[i++] = nameBytes;
-                    metadata[i++] = InternalMetadata.BASE64_ENCODING_OMIT_PADDING.decode(value);
+                    metadata[i++] = BASE64_ENCODING_OMIT_PADDING.decode(value);
                 } else {
                     int substringStartIndex = 0;
                     while (commaIndex != -1) {
                         final String substring = value.substring(substringStartIndex, commaIndex);
                         metadata[i++] = nameBytes;
-                        metadata[i++] = InternalMetadata.BASE64_ENCODING_OMIT_PADDING.decode(substring);
+                        metadata[i++] = BASE64_ENCODING_OMIT_PADDING.decode(substring);
 
                         substringStartIndex = commaIndex + 1;
                         commaIndex = COMMA_MATCHER.indexIn(value, commaIndex + 1);
                     }
                     final String substring = value.substring(substringStartIndex);
                     metadata[i++] = nameBytes;
-                    metadata[i++] = InternalMetadata.BASE64_ENCODING_OMIT_PADDING.decode(substring);
+                    metadata[i++] = BASE64_ENCODING_OMIT_PADDING.decode(substring);
                 }
             } else {
                 metadata[i++] = nameBytes;

--- a/grpc/src/main/java/com/linecorp/armeria/internal/grpc/TransportStatusListener.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/grpc/TransportStatusListener.java
@@ -16,13 +16,17 @@
 
 package com.linecorp.armeria.internal.grpc;
 
+import io.grpc.Metadata;
 import io.grpc.Status;
 
 /**
  * A listener of gRPC {@link Status}s. Any errors occuring within the armeria will be returned to gRPC business
  * logic through this listener, and for clients the final response {@link Status} is also returned.
  */
-@FunctionalInterface
 public interface TransportStatusListener {
-    void transportReportStatus(Status status);
+    default void transportReportStatus(Status status) {
+        transportReportStatus(status, new Metadata());
+    }
+
+    void transportReportStatus(Status status, Metadata metadata);
 }

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
@@ -103,8 +103,6 @@ class ArmeriaServerCall<I, O> extends ServerCall<I, O>
     @VisibleForTesting
     static final byte TRAILERS_FRAME_HEADER = (byte) (1 << 7);
 
-    private static final Metadata EMPTY_METADATA = new Metadata();
-
     private static final Splitter ACCEPT_ENCODING_SPLITTER = Splitter.on(',').trimResults();
 
     private final MethodDescriptor<I, O> method;
@@ -186,7 +184,7 @@ class ArmeriaServerCall<I, O> extends ServerCall<I, O>
                 // Closed by client, not by server.
                 cancelled = true;
                 try (SafeCloseable ignore = ctx.pushIfAbsent()) {
-                    close(Status.CANCELLED, EMPTY_METADATA);
+                    close(Status.CANCELLED, new Metadata());
                 }
             }
             return null;
@@ -274,10 +272,10 @@ class ArmeriaServerCall<I, O> extends ServerCall<I, O>
                 }
             });
         } catch (RuntimeException e) {
-            close(GrpcStatus.fromThrowable(e), EMPTY_METADATA);
+            close(GrpcStatus.fromThrowable(e), new Metadata());
             throw e;
         } catch (Throwable t) {
-            close(GrpcStatus.fromThrowable(t), EMPTY_METADATA);
+            close(GrpcStatus.fromThrowable(t), new Metadata());
             throw new RuntimeException(t);
         }
     }
@@ -286,7 +284,7 @@ class ArmeriaServerCall<I, O> extends ServerCall<I, O>
         try {
             listener.onReady();
         } catch (Throwable t) {
-            close(GrpcStatus.fromThrowable(t), EMPTY_METADATA);
+            close(GrpcStatus.fromThrowable(t), new Metadata());
         }
     }
 
@@ -412,7 +410,7 @@ class ArmeriaServerCall<I, O> extends ServerCall<I, O>
         try (SafeCloseable ignored = ctx.push()) {
             listener.onMessage(request);
         } catch (Throwable t) {
-            close(GrpcStatus.fromThrowable(t), EMPTY_METADATA);
+            close(GrpcStatus.fromThrowable(t), new Metadata());
         }
     }
 
@@ -436,7 +434,7 @@ class ArmeriaServerCall<I, O> extends ServerCall<I, O>
         try (SafeCloseable ignored = ctx.push()) {
             listener.onHalfClose();
         } catch (Throwable t) {
-            close(GrpcStatus.fromThrowable(t), EMPTY_METADATA);
+            close(GrpcStatus.fromThrowable(t), new Metadata());
         }
     }
 
@@ -505,7 +503,7 @@ class ArmeriaServerCall<I, O> extends ServerCall<I, O>
                 // A custom error when dealing with client cancel or transport issues should be
                 // returned. We have already closed the listener, so it will not receive any more
                 // callbacks as designed.
-                close(GrpcStatus.fromThrowable(t), EMPTY_METADATA);
+                close(GrpcStatus.fromThrowable(t), new Metadata());
             }
         }
     }

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
@@ -88,8 +88,6 @@ public final class GrpcService extends AbstractHttpService
 
     static final int NO_MAX_INBOUND_MESSAGE_SIZE = -1;
 
-    private static final Metadata EMPTY_METADATA = new Metadata();
-
     private final HandlerRegistry registry;
     private final Set<PathMapping> pathMappings;
     private final DecompressorRegistry decompressorRegistry;
@@ -157,7 +155,7 @@ public final class GrpcService extends AbstractHttpService
                     ArmeriaServerCall.statusToTrailers(
                             ctx,
                             Status.UNIMPLEMENTED.withDescription("Method not found: " + methodName),
-                            EMPTY_METADATA,
+                            new Metadata(),
                             false));
         }
 
@@ -169,7 +167,7 @@ public final class GrpcService extends AbstractHttpService
             } catch (IllegalArgumentException e) {
                 return HttpResponse.of(
                         ArmeriaServerCall.statusToTrailers(
-                                ctx, GrpcStatus.fromThrowable(e), EMPTY_METADATA, false));
+                                ctx, GrpcStatus.fromThrowable(e), new Metadata(), false));
             }
         }
 
@@ -180,7 +178,7 @@ public final class GrpcService extends AbstractHttpService
         final ArmeriaServerCall<?, ?> call = startCall(
                 methodName, method, ctx, req.headers(), res, serializationFormat);
         if (call != null) {
-            ctx.setRequestTimeoutHandler(() -> call.close(Status.DEADLINE_EXCEEDED, EMPTY_METADATA));
+            ctx.setRequestTimeoutHandler(() -> call.close(Status.DEADLINE_EXCEEDED, new Metadata()));
             req.subscribe(call.messageReader(), ctx.eventLoop(), true);
             req.completionFuture().handleAsync(call.messageReader(), ctx.eventLoop());
         }
@@ -214,7 +212,7 @@ public final class GrpcService extends AbstractHttpService
             listener = methodDef.getServerCallHandler().startCall(call, MetadataUtil.copyFromHeaders(headers));
         } catch (Throwable t) {
             call.setListener(new EmptyListener<>());
-            call.close(GrpcStatus.fromThrowable(t), EMPTY_METADATA);
+            call.close(GrpcStatus.fromThrowable(t), new Metadata());
             logger.warn(
                     "Exception thrown from streaming request stub method before processing any request data" +
                     " - this is likely a bug in the stub implementation.");

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientTest.java
@@ -60,6 +60,7 @@ import com.linecorp.armeria.client.ResponseTimeoutException;
 import com.linecorp.armeria.client.logging.LoggingClientBuilder;
 import com.linecorp.armeria.common.FilteredHttpResponse;
 import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpHeadersBuilder;
 import com.linecorp.armeria.common.HttpObject;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
@@ -86,6 +87,7 @@ import com.linecorp.armeria.grpc.testing.TestServiceGrpc.TestServiceStub;
 import com.linecorp.armeria.grpc.testing.UnimplementedServiceGrpc;
 import com.linecorp.armeria.internal.grpc.GrpcLogUtil;
 import com.linecorp.armeria.internal.grpc.GrpcStatus;
+import com.linecorp.armeria.internal.grpc.MetadataUtil;
 import com.linecorp.armeria.internal.grpc.StreamRecorder;
 import com.linecorp.armeria.internal.grpc.TestServiceImpl;
 import com.linecorp.armeria.internal.grpc.TimeoutHeaderUtil;
@@ -97,11 +99,18 @@ import com.linecorp.armeria.unsafe.grpc.GrpcUnsafeBufferUtil;
 
 import io.grpc.CallOptions;
 import io.grpc.ClientCall;
+import io.grpc.ForwardingServerCall.SimpleForwardingServerCall;
 import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCall.Listener;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.ServerInterceptors;
 import io.grpc.Status;
 import io.grpc.Status.Code;
 import io.grpc.StatusException;
 import io.grpc.StatusRuntimeException;
+import io.grpc.stub.MetadataUtils;
 import io.grpc.stub.StreamObserver;
 import io.netty.buffer.ByteBuf;
 
@@ -126,16 +135,34 @@ public class GrpcClientTest {
             sb.idleTimeoutMillis(0);
 
             sb.serviceUnder("/", new GrpcServiceBuilder()
-                    .addService(new TestServiceImpl(Executors.newSingleThreadScheduledExecutor()))
+                    .addService(
+                            ServerInterceptors.intercept(
+                                    new TestServiceImpl(Executors.newSingleThreadScheduledExecutor()),
+                                    new ServerInterceptor() {
+                                        @Override
+                                        public <REQ, RESP> Listener<REQ> interceptCall(
+                                                ServerCall<REQ, RESP> call,
+                                                Metadata requestHeaders,
+                                                ServerCallHandler<REQ, RESP> next) {
+                                            HttpHeadersBuilder fromClient = HttpHeaders.builder();
+                                            MetadataUtil.fillHeaders(requestHeaders, fromClient);
+                                            CLIENT_HEADERS_CAPTURE.set(fromClient.build());
+                                            return next.startCall(
+                                                    new SimpleForwardingServerCall<REQ, RESP>(call) {
+                                                        @Override
+                                                        public void close(Status status, Metadata trailers) {
+                                                            trailers.merge(requestHeaders);
+                                                            super.close(status, trailers);
+                                                        }
+                                                    }, requestHeaders);
+                                        }
+                                    }))
                     .setMaxInboundMessageSizeBytes(MAX_MESSAGE_SIZE)
                     .setMaxOutboundMessageSizeBytes(MAX_MESSAGE_SIZE)
                     .build()
-                    .decorate(TestServiceImpl.EchoRequestHeadersInTrailers::new)
                     .decorate((client, ctx, req) -> {
-                        CLIENT_HEADERS_CAPTURE.set(req.headers());
                         final HttpResponse res = client.serve(ctx, req);
                         return new FilteredHttpResponse(res) {
-
                             private boolean headersReceived;
 
                             @Override
@@ -716,12 +743,30 @@ public class GrpcClientTest {
     }
 
     @Test
-    public void exchangeHeadersUnaryCall() throws Exception {
+    public void exchangeHeadersUnaryCall_armeriaHeaders() throws Exception {
         final TestServiceBlockingStub stub =
                 Clients.newDerivedClient(
                         blockingStub,
                         ClientOption.HTTP_HEADERS.newValue(
                                 HttpHeaders.of(TestServiceImpl.EXTRA_HEADER_NAME, "dog")));
+
+        assertThat(stub.emptyCall(EMPTY)).isNotNull();
+
+        // Assert that our side channel object is echoed back in both headers and trailers
+        assertThat(CLIENT_HEADERS_CAPTURE.get().get(TestServiceImpl.EXTRA_HEADER_NAME)).isEqualTo("dog");
+        assertThat(SERVER_TRAILERS_CAPTURE.get().get(TestServiceImpl.EXTRA_HEADER_NAME)).isEqualTo("dog");
+
+        checkRequestLog((rpcReq, rpcRes, grpcStatus) -> {
+            assertThat(rpcReq.params()).containsExactly(EMPTY);
+            assertThat(rpcRes.get()).isEqualTo(EMPTY);
+        });
+    }
+
+    @Test
+    public void exchangeHeadersUnaryCall_grpcMetadata() throws Exception {
+        Metadata metadata = new Metadata();
+        metadata.put(TestServiceImpl.EXTRA_HEADER_KEY, "dog");
+        final TestServiceBlockingStub stub = MetadataUtils.attachHeaders(blockingStub, metadata);
 
         assertThat(stub.emptyCall(EMPTY)).isNotNull();
 

--- a/grpc/src/test/java/com/linecorp/armeria/internal/grpc/TestServiceImpl.java
+++ b/grpc/src/test/java/com/linecorp/armeria/internal/grpc/TestServiceImpl.java
@@ -52,6 +52,8 @@ import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.SimpleDecoratingService;
 
+import io.grpc.Metadata;
+import io.grpc.Metadata.Key;
 import io.grpc.Status;
 import io.grpc.internal.LogExceptionRunnable;
 import io.grpc.stub.ServerCallStreamObserver;
@@ -61,6 +63,9 @@ import io.netty.util.AsciiString;
 public class TestServiceImpl extends TestServiceGrpc.TestServiceImplBase {
 
     public static final AsciiString EXTRA_HEADER_NAME = HttpHeaderNames.of("extra-header");
+
+    public static final Key<String> EXTRA_HEADER_KEY = Key.of(EXTRA_HEADER_NAME.toString(),
+                                                              Metadata.ASCII_STRING_MARSHALLER);
 
     private static final String UNCOMPRESSABLE_FILE =
             "/io/grpc/testing/integration/testdata/uncompressable.bin";

--- a/grpc/src/test/java/com/linecorp/armeria/internal/grpc/TestServiceImpl.java
+++ b/grpc/src/test/java/com/linecorp/armeria/internal/grpc/TestServiceImpl.java
@@ -17,6 +17,7 @@ package com.linecorp.armeria.internal.grpc;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Base64;
 import java.util.LinkedList;
 import java.util.Queue;
 import java.util.Random;
@@ -29,6 +30,7 @@ import javax.annotation.concurrent.GuardedBy;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Queues;
 import com.google.protobuf.ByteString;
+import com.google.protobuf.StringValue;
 
 import com.linecorp.armeria.common.FilteredHttpResponse;
 import com.linecorp.armeria.common.HttpHeaderNames;
@@ -36,6 +38,7 @@ import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpObject;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.grpc.testing.Messages;
 import com.linecorp.armeria.grpc.testing.Messages.PayloadType;
 import com.linecorp.armeria.grpc.testing.Messages.ResponseParameters;
@@ -56,6 +59,7 @@ import io.grpc.Metadata;
 import io.grpc.Metadata.Key;
 import io.grpc.Status;
 import io.grpc.internal.LogExceptionRunnable;
+import io.grpc.protobuf.ProtoUtils;
 import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
 import io.netty.util.AsciiString;
@@ -66,6 +70,9 @@ public class TestServiceImpl extends TestServiceGrpc.TestServiceImplBase {
 
     public static final Key<String> EXTRA_HEADER_KEY = Key.of(EXTRA_HEADER_NAME.toString(),
                                                               Metadata.ASCII_STRING_MARSHALLER);
+
+    public static final Key<StringValue> STRING_VALUE_KEY =
+            ProtoUtils.keyForProto(StringValue.getDefaultInstance());
 
     private static final String UNCOMPRESSABLE_FILE =
             "/io/grpc/testing/integration/testdata/uncompressable.bin";
@@ -87,6 +94,16 @@ public class TestServiceImpl extends TestServiceGrpc.TestServiceImplBase {
     @Override
     public void emptyCall(EmptyProtos.Empty empty,
                           StreamObserver<Empty> responseObserver) {
+        ServiceRequestContext ctx = RequestContext.current();
+
+        ctx.addAdditionalResponseTrailer(
+                STRING_VALUE_KEY.name(),
+                Base64.getEncoder().encodeToString(
+                        StringValue.newBuilder().setValue("hello").build().toByteArray()) +
+                ',' +
+                Base64.getEncoder().encodeToString(
+                        StringValue.newBuilder().setValue("world").build().toByteArray()));
+
         responseObserver.onNext(Empty.getDefaultInstance());
         responseObserver.onCompleted();
     }


### PR DESCRIPTION
Now incoming headers are copied into `Metadata` and outgoing `Metadata` is copied into headers. Since `Metadata` is supported now, I have stopped using `EMPTY_METADATA` which was questionable to begin with, since it's mutable so a singleton shouldn't be used. Tests have replaced some code that used to use armeria for manipulating headers with ones that use `Metadata` (armeria versions are very well tested in `core` already so don't really need them here I guess).

Will leave this WIP until hearing back on https://github.com/grpc/grpc-java/issues/5788