### PR TITLE
Use BeanFactory's getBean in findBean

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,6 +93,7 @@ configure(projectsWithFlags('java')) {
         testCompile 'com.google.guava:guava-testlib'
         testCompile 'junit:junit'
         testCompile 'org.junit.jupiter:junit-jupiter-api'
+        testRuntime 'org.junit.platform:junit-platform-commons'
         testRuntime 'org.junit.platform:junit-platform-launcher'
         testRuntime 'org.junit.jupiter:junit-jupiter-engine'
         testRuntime 'org.junit.vintage:junit-vintage-engine'

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -241,8 +241,10 @@ org.junit.jupiter:
   junit-jupiter-engine:
     version: *JUNIT_JUPITER_VERSION
 org.junit.platform:
+  junit-platform-commons:
+    version: &JUNIT_PLATFORM_VERSION '1.4.2'
   junit-platform-launcher:
-    version: '1.4.2'
+    version: *JUNIT_PLATFORM_VERSION
 org.junit.vintage:
   junit-vintage-engine:
     version: '5.4.2'

--- a/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
+++ b/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
@@ -54,7 +54,6 @@ import org.springframework.boot.web.server.SslStoreProvider;
 import org.springframework.boot.web.server.WebServer;
 import org.springframework.http.server.reactive.HttpHandler;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 
@@ -260,8 +259,7 @@ public class ArmeriaReactiveWebServerFactory extends AbstractReactiveWebServerFa
         }
     }
 
-    @VisibleForTesting
-    <T> Optional<T> findBean(Class<T> clazz) {
+    private <T> Optional<T> findBean(Class<T> clazz) {
         try {
             return Optional.of(beanFactory.getBean(clazz));
         } catch (NoUniqueBeanDefinitionException e) {

--- a/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
+++ b/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
@@ -42,6 +42,8 @@ import javax.annotation.Nullable;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.NoUniqueBeanDefinitionException;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.boot.web.reactive.server.AbstractReactiveWebServerFactory;
 import org.springframework.boot.web.reactive.server.ReactiveWebServerFactory;
@@ -52,6 +54,7 @@ import org.springframework.boot.web.server.SslStoreProvider;
 import org.springframework.boot.web.server.WebServer;
 import org.springframework.http.server.reactive.HttpHandler;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 
@@ -257,16 +260,14 @@ public class ArmeriaReactiveWebServerFactory extends AbstractReactiveWebServerFa
         }
     }
 
-    private <T> Optional<T> findBean(Class<T> clazz) {
-        final List<T> beans = findBeans(clazz);
-        switch (beans.size()) {
-            case 0:
-                return Optional.empty();
-            case 1:
-                return Optional.of(beans.get(0));
-            default:
-                throw new IllegalStateException("Too many " + clazz.getSimpleName() + " beans: " +
-                                                beans + " (expected: 1)");
+    @VisibleForTesting
+    <T> Optional<T> findBean(Class<T> clazz) {
+        try {
+            return Optional.of(beanFactory.getBean(clazz));
+        } catch (NoUniqueBeanDefinitionException e) {
+            throw new IllegalStateException("Too many " + clazz.getSimpleName() + " beans: (expected: 1)", e);
+        } catch (NoSuchBeanDefinitionException e) {
+            return Optional.empty();
         }
     }
 


### PR DESCRIPTION
Motivation:

- `spring-boot-webflux-starter` app does not start when multiple
`MeterRegistry`s are registerted

```
org.springframework.context.ApplicationContextException: Unable to start reactive web server; nested exception is java.lang.IllegalStateException: Too many MeterRegistry beans: [io.micrometer.cloudwatch.CloudWatchMeterRegistry@6dd79214, io.micrometer.prometheus.PrometheusMeterRegistry@2c47a053, io.micrometer.core.instrument.composite.CompositeMeterRegistry@7767bd4e] (expected: 1)
	at org.springframework.boot.web.reactive.context.ReactiveWebServerApplicationContext.onRefresh(ReactiveWebServerApplicationContext.java:82)
	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:543)
	at org.springframework.boot.web.reactive.context.ReactiveWebServerApplicationContext.refresh(ReactiveWebServerApplicationContext.java:67)
	at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:775)
	at org.springframework.boot.SpringApplication.refreshContext(SpringApplication.java:397)
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:316)
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1260)
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1248)
	at ...
Caused by: java.lang.IllegalStateException: Too many MeterRegistry beans: [io.micrometer.cloudwatch.CloudWatchMeterRegistry@6dd79214, io.micrometer.prometheus.PrometheusMeterRegistry@2c47a053, io.micrometer.core.instrument.composite.CompositeMeterRegistry@7767bd4e] (expected: 1)
	at com.linecorp.armeria.spring.web.reactive.ArmeriaReactiveWebServerFactory.findBean(ArmeriaReactiveWebServerFactory.java:268)
	at com.linecorp.armeria.spring.web.reactive.ArmeriaReactiveWebServerFactory.configureArmeriaService(ArmeriaReactiveWebServerFactory.java:242)
	at com.linecorp.armeria.spring.web.reactive.ArmeriaReactiveWebServerFactory.lambda$getWebServer$2(ArmeriaReactiveWebServerFactory.java:189)
	at java.base/java.util.Optional.ifPresent(Optional.java:183)
	at com.linecorp.armeria.spring.web.reactive.ArmeriaReactiveWebServerFactory.getWebServer(ArmeriaReactiveWebServerFactory.java:189)
	at org.springframework.boot.web.reactive.context.ReactiveWebServerApplicationContext$ServerManager.<init>(ReactiveWebServerApplicationContext.java:202)
	at org.springframework.boot.web.reactive.context.ReactiveWebServerApplicationContext$ServerManager.get(ReactiveWebServerApplicationContext.java:221)
	at org.springframework.boot.web.reactive.context.ReactiveWebServerApplicationContext.createWebServer(ReactiveWebServerApplicationContext.java:90)
	at org.springframework.boot.web.reactive.context.ReactiveWebServerApplicationContext.onRefresh(ReactiveWebServerApplicationContext.java:79)
	... 8 common frames omitted
```

Modification:

- Use BeanFactory's getBean when finding a single bean
  - BeanFactory's getBean resolves a primary bean among many of the same type