### PR TITLE
Use pooled buffers in thrift client.

### DIFF
--- a/thrift/src/main/java/com/linecorp/armeria/client/thrift/THttpClientDelegate.java
+++ b/thrift/src/main/java/com/linecorp/armeria/client/thrift/THttpClientDelegate.java
@@ -114,10 +114,10 @@ final class THttpClientDelegate implements Client<RpcRequest, RpcResponse> {
             final TMessage header = new TMessage(fullMethod(ctx, method), func.messageType(), seqId);
 
             final ByteBuf buf = ctx.alloc().buffer(128);
-            final TByteBufTransport outTransport = new TByteBufTransport(buf);
-            final TProtocol tProtocol = protocolFactory.getProtocol(outTransport);
 
             try {
+                final TByteBufTransport outTransport = new TByteBufTransport(buf);
+                final TProtocol tProtocol = protocolFactory.getProtocol(outTransport);
                 tProtocol.writeMessageBegin(header);
                 @SuppressWarnings("rawtypes")
                 final TBase tArgs = func.newArgs(args);

--- a/thrift/src/main/java/com/linecorp/armeria/client/thrift/THttpClientDelegate.java
+++ b/thrift/src/main/java/com/linecorp/armeria/client/thrift/THttpClientDelegate.java
@@ -33,8 +33,8 @@ import org.apache.thrift.protocol.TMessage;
 import org.apache.thrift.protocol.TMessageType;
 import org.apache.thrift.protocol.TProtocol;
 import org.apache.thrift.protocol.TProtocolFactory;
-import org.apache.thrift.transport.TMemoryBuffer;
 import org.apache.thrift.transport.TMemoryInputTransport;
+import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
 
 import com.google.common.base.Strings;
@@ -62,9 +62,15 @@ import com.linecorp.armeria.common.thrift.ThriftReply;
 import com.linecorp.armeria.common.util.CompletionActions;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.internal.thrift.TApplicationExceptions;
+import com.linecorp.armeria.internal.thrift.TByteBufTransport;
 import com.linecorp.armeria.internal.thrift.ThriftFieldAccess;
 import com.linecorp.armeria.internal.thrift.ThriftFunction;
 import com.linecorp.armeria.internal.thrift.ThriftServiceMetadata;
+import com.linecorp.armeria.unsafe.ByteBufHttpData;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufHolder;
+import io.netty.util.ReferenceCountUtil;
 
 final class THttpClientDelegate implements Client<RpcRequest, RpcResponse> {
 
@@ -105,27 +111,34 @@ final class THttpClientDelegate implements Client<RpcRequest, RpcResponse> {
         }
 
         try {
-            final TMemoryBuffer outTransport = new TMemoryBuffer(128);
-            final TProtocol tProtocol = protocolFactory.getProtocol(outTransport);
             final TMessage header = new TMessage(fullMethod(ctx, method), func.messageType(), seqId);
 
-            tProtocol.writeMessageBegin(header);
-            @SuppressWarnings("rawtypes")
-            final TBase tArgs = func.newArgs(args);
-            tArgs.write(tProtocol);
-            tProtocol.writeMessageEnd();
+            final ByteBuf buf = ctx.alloc().buffer(128);
+            final TByteBufTransport outTransport = new TByteBufTransport(buf);
+            final TProtocol tProtocol = protocolFactory.getProtocol(outTransport);
 
-            ctx.logBuilder().requestContent(call, new ThriftCall(header, tArgs));
+            try {
+                tProtocol.writeMessageBegin(header);
+                @SuppressWarnings("rawtypes")
+                final TBase tArgs = func.newArgs(args);
+                tArgs.write(tProtocol);
+                tProtocol.writeMessageEnd();
+
+                ctx.logBuilder().requestContent(call, new ThriftCall(header, tArgs));
+            } catch (Throwable t) {
+                buf.release();
+                Exceptions.throwUnsafely(t);
+            }
 
             final HttpRequest httpReq = HttpRequest.of(
                     RequestHeaders.of(HttpMethod.POST, ctx.path(),
                                       HttpHeaderNames.CONTENT_TYPE, mediaType),
-                    HttpData.of(outTransport.getArray(), 0, outTransport.length()));
+                    new ByteBufHttpData(buf, true));
 
             ctx.logBuilder().deferResponseContent();
 
             final CompletableFuture<AggregatedHttpMessage> future =
-                    httpClient.execute(ctx, httpReq).aggregate();
+                    httpClient.execute(ctx, httpReq).aggregateWithPooledObjects(ctx.eventLoop(), ctx.alloc());
 
             future.handle((res, cause) -> {
                 if (cause != null) {
@@ -133,18 +146,22 @@ final class THttpClientDelegate implements Client<RpcRequest, RpcResponse> {
                     return null;
                 }
 
-                final HttpStatus status = res.status();
-                if (status.code() != HttpStatus.OK.code()) {
-                    handlePreDecodeException(
-                            ctx, reply, func,
-                            new InvalidResponseHeadersException(ResponseHeaders.of(res.headers())));
-                    return null;
-                }
-
                 try {
-                    handle(ctx, seqId, reply, func, res.content());
-                } catch (Throwable t) {
-                    handlePreDecodeException(ctx, reply, func, t);
+                    final HttpStatus status = res.status();
+                    if (status.code() != HttpStatus.OK.code()) {
+                        handlePreDecodeException(
+                                ctx, reply, func,
+                                new InvalidResponseHeadersException(ResponseHeaders.of(res.headers())));
+                        return null;
+                    }
+
+                    try {
+                        handle(ctx, seqId, reply, func, res.content());
+                    } catch (Throwable t) {
+                        handlePreDecodeException(ctx, reply, func, t);
+                    }
+                } finally {
+                    ReferenceCountUtil.safeRelease(res.content());
                 }
 
                 return null;
@@ -186,8 +203,13 @@ final class THttpClientDelegate implements Client<RpcRequest, RpcResponse> {
             throw new TApplicationException(TApplicationException.MISSING_RESULT);
         }
 
-        final TMemoryInputTransport inputTransport =
-                new TMemoryInputTransport(content.array(), content.offset(), content.length());
+        final TTransport inputTransport;
+        if (content instanceof ByteBufHolder) {
+            inputTransport = new TByteBufTransport(((ByteBufHolder) content).content());
+        } else {
+            inputTransport = new TMemoryInputTransport(content.array(), content.offset(), content.length());
+        }
+
         final TProtocol inputProtocol = protocolFactory.getProtocol(inputTransport);
 
         final TMessage header = inputProtocol.readMessageBegin();

--- a/thrift/src/main/java/com/linecorp/armeria/internal/thrift/TByteBufTransport.java
+++ b/thrift/src/main/java/com/linecorp/armeria/internal/thrift/TByteBufTransport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 LINE Corporation
+ * Copyright 2019 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-package com.linecorp.armeria.server.thrift;
+package com.linecorp.armeria.internal.thrift;
 
 import static java.util.Objects.requireNonNull;
 
@@ -25,11 +25,11 @@ import org.apache.thrift.transport.TTransportException;
 
 import io.netty.buffer.ByteBuf;
 
-final class TByteBufTransport extends TTransport {
+public final class TByteBufTransport extends TTransport {
 
     private final ByteBuf buf;
 
-    TByteBufTransport(ByteBuf buf) {
+    public TByteBufTransport(ByteBuf buf) {
         this.buf = requireNonNull(buf, "buf");
     }
 

--- a/thrift/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
+++ b/thrift/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
@@ -63,6 +63,7 @@ import com.linecorp.armeria.common.thrift.ThriftSerializationFormats;
 import com.linecorp.armeria.common.util.CompletionActions;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.common.util.SafeCloseable;
+import com.linecorp.armeria.internal.thrift.TByteBufTransport;
 import com.linecorp.armeria.internal.thrift.ThriftFieldAccess;
 import com.linecorp.armeria.internal.thrift.ThriftFunction;
 import com.linecorp.armeria.server.AbstractHttpService;


### PR DESCRIPTION
When looking for any places we slice a buffer when creating `HttpData`, I found this one. Switching to using pooled buffers removes this usage while also probably making the client more memory efficient (we switched the server a long time ago but never the client).