### PR TITLE
Ensure shadeTest also uses JUnit 5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,7 +113,7 @@ configure(projectsWithFlags('java')) {
         }
     }
 
-    test {
+    tasks.withType(Test) {
         useJUnitPlatform()
     }
 }


### PR DESCRIPTION
Motivation:

- JUnit 5 tests in `shadeTest` are not run

Modification:

- Ensure all `Test` tasks `useJUnitPlatform()`

Result:

with current master code:
```bash
~/code/armeria master
❯ head
core/build/test-results/shadedTest/TEST-com.linecorp.armeria.client.HttpClientIntegrationTest.xml
head: cannot open
'core/build/test-results/shadedTest/TEST-com.linecorp.armeria.client.HttpClientIntegrationTest.xml'
for reading: No such file or directory
```

with this fix:
```bash
~/code/armeria master
❯ head core/build/test-results/shadedTest/TEST-com.linecorp.armeria.client.HttpClientIntegrationTest.xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuite name="com.linecorp.armeria.client.HttpClientIntegrationTest" tests="20" skipped="0" failures="0" errors="0" timestamp="2019-05-28T13:32:05" hostname="Young-MBPII.local" time="1.739">
  <properties/>
  <testcase name="testUserAgentOverridableByClientOption()" classname="com.linecorp.armeria.client.HttpClientIntegrationTest" time="0.021"/>
  <testcase name="givenHttpClientUriPathAndRequestPath_whenGet_thenRequestToConcatenatedPath()" classname="com.linecorp.armeria.client.HttpClientIntegrationTest" time="0.008"/>
  <testcase name="testRequestNoBody()" classname="com.linecorp.armeria.client.HttpClientIntegrationTest" time="0.011"/>
  <testcase name="testEscapedPathParam()" classname="com.linecorp.armeria.client.HttpClientIntegrationTest" time="0.006"/>
  <testcase name="httpDecoding_noEncodingApplied()" classname="com.linecorp.armeria.client.HttpClientIntegrationTest" time="0.007"/>
  <testcase name="givenRequestPath_whenGet_thenRequestToPath()" classname="com.linecorp.armeria.client.HttpClientIntegrationTest" time="0.007"/>
  <testcase name="testAuthorityOverridableByClientOption()" classname="com.linecorp.armeria.client.HttpClientIntegrationTest" time="0.007"/>
```