### PR TITLE
Add a utility for executing junit5 tests with timeout and convert a parameterized test to it

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,6 +93,7 @@ configure(projectsWithFlags('java')) {
         testCompile 'com.google.guava:guava-testlib'
         testCompile 'junit:junit'
         testCompile 'org.junit.jupiter:junit-jupiter-api'
+        testCompile 'org.junit.jupiter:junit-jupiter-params'
         testRuntime 'org.junit.platform:junit-platform-commons'
         testRuntime 'org.junit.platform:junit-platform-launcher'
         testRuntime 'org.junit.jupiter:junit-jupiter-engine'

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -240,6 +240,8 @@ org.junit.jupiter:
     - https://junit.org/junit5/docs/5.4.2/api/
   junit-jupiter-engine:
     version: *JUNIT_JUPITER_VERSION
+  junit-jupiter-params:
+    version: *JUNIT_JUPITER_VERSION
 org.junit.platform:
   junit-platform-commons:
     version: &JUNIT_PLATFORM_VERSION '1.4.2'

--- a/testing-internal/src/main/java/com/linecorp/armeria/testing/internal/TestUtil.java
+++ b/testing-internal/src/main/java/com/linecorp/armeria/testing/internal/TestUtil.java
@@ -34,7 +34,7 @@ public final class TestUtil {
     }
 
     /**
-     * Executes {@code r}, timing it out if not done by the passing of {@code timeout} has passed. The timeout
+     * Executes {@code r}, timing it out if not done by the passing of {@code timeout}. The timeout
      * is not enabled if in an IDE debug mode.
      */
     public static void withTimeout(Executable r, Duration timeout) {

--- a/testing-internal/src/main/java/com/linecorp/armeria/testing/internal/TestUtil.java
+++ b/testing-internal/src/main/java/com/linecorp/armeria/testing/internal/TestUtil.java
@@ -23,6 +23,8 @@ import java.time.Duration;
 
 import org.junit.jupiter.api.function.Executable;
 
+import com.linecorp.armeria.common.util.Exceptions;
+
 public final class TestUtil {
 
     /**
@@ -42,7 +44,7 @@ public final class TestUtil {
             try {
                 r.execute();
             } catch (Throwable t) {
-                throw new Error(t);
+                Exceptions.throwUnsafely(t);
             }
         } else {
             assertTimeoutPreemptively(timeout, r);

--- a/testing-internal/src/main/java/com/linecorp/armeria/testing/internal/TestUtil.java
+++ b/testing-internal/src/main/java/com/linecorp/armeria/testing/internal/TestUtil.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.testing.internal;
+
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
+import java.lang.management.ManagementFactory;
+import java.time.Duration;
+
+import org.junit.jupiter.api.function.Executable;
+
+public final class TestUtil {
+
+    /**
+     * Executes {@code r}, timing it out if not done within 10 seconds. The timeout is not enabled if in an IDE
+     * debug mode.
+     */
+    public static void withTimeout(Executable r) {
+        withTimeout(r, Duration.ofSeconds(10));
+    }
+
+    /**
+     * Executes {@code r}, timing it out if not done by the passing of {@code timeout} has passed. The timeout
+     * is not enabled if in an IDE debug mode.
+     */
+    public static void withTimeout(Executable r, Duration timeout) {
+        if (isDebugging()) {
+            try {
+                r.execute();
+            } catch (Throwable t) {
+                throw new Error(t);
+            }
+        } else {
+            assertTimeoutPreemptively(timeout, r);
+        }
+    }
+
+    private static boolean isDebugging() {
+        return ManagementFactory.getRuntimeMXBean().getInputArguments().contains("-Xdebug");
+    }
+
+    private TestUtil() {}
+}


### PR DESCRIPTION
…arameterized test to it.

Was curious if junit5 has the same problem as #1601 and it doesn't! So I want to migrate all the parameterized tests to junit5 (or at least the gRPC ones since I use them a lot and it's annoying that I can't use Gradle runner because of them).

I found that the biggest missing piece from junit5 is global timeouts. 5.5 will have it, but that will probably take a while to be released. Also, I don't think they'll support disable-on-debug in their first release either. So wondering if it makes sense to add this utility for running a lambda with a timeout using the current junit5 style.