### PR TITLE
Fix project evaluation dependencies

### DIFF
--- a/site/build.gradle
+++ b/site/build.gradle
@@ -18,13 +18,14 @@ buildscript {
 apply plugin: 'base'
 apply plugin: 'kr.motd.sphinx'
 
+def aggregatedProjects = projectsWithFlags('java', 'publish') - projectsWithFlags('no_aggregation')
+aggregatedProjects.each { evaluationDependsOn it.path }
+
 sphinx {
     group = 'Documentation'
     description = 'Generates the Sphinx web site.'
     sourceDirectory "${project.projectDir}/src/sphinx"
 }
-
-def aggregatedProjects = projectsWithFlags('java', 'publish') - projectsWithFlags('no_aggregation')
 
 task javadoc(type: Javadoc,
              group: 'Documentation',
@@ -32,7 +33,10 @@ task javadoc(type: Javadoc,
 
     destinationDir = project.file("${project.buildDir}/site/apidocs")
 
-    aggregatedProjects.each { source it.sourceSets.main.java.srcDirs }
+    aggregatedProjects.each {
+        source it.sourceSets.main.java.srcDirs
+        dependsOn it.tasks.compileJava
+    }
     classpath = aggregatedProjects.inject(project.files()) { ConfigurableFileCollection result, project ->
         result.from(project.sourceSets.main.compileClasspath)
         result.from(project.sourceSets.main.runtimeClasspath)

--- a/spring/boot1-autoconfigure/build.gradle
+++ b/spring/boot1-autoconfigure/build.gradle
@@ -1,3 +1,5 @@
+evaluationDependsOn ':spring:boot-autoconfigure'
+
 dependencies {
     compile(project(':thrift')) {
         ext.optional = true // To let a user choose between thrift and thrift0.9.
@@ -31,7 +33,7 @@ tasks.sourceJar.from "${autoconfigureProjectDir}/src/main/java"
 tasks.sourceJar.from "${autoconfigureProjectDir}/src/main/resources"
 tasks.javadoc.source "${autoconfigureProjectDir}/src/main/java"
 
-tasks.compileTestJava.dependsOn(project(':spring:boot-autoconfigure').tasks.findByName('compileTestThrift'))
+tasks.compileTestJava.dependsOn(project(':spring:boot-autoconfigure').tasks.compileTestThrift)
 
 // Disable checkstyle because it's checked by ':spring:boot-autoconfigure'.
 tasks.checkstyleMain.onlyIf { false }


### PR DESCRIPTION
Related: https://github.com/line/gradle-scripts/pull/61
Motivation:

When configure-on-demand is enabled, inter-project dependencies are
calculated correctly only when task dependency is specified as a task
path string or `Project.evaluationDependsOn()` must be used. See:

- https://docs.gradle.org/current/userguide/multi_project_builds.html#sec:configuration_on_demand

> The task dependencies declared via task path are supported and cause
> relevant projects to be configured.
> Example: someTask.dependsOn(":someOtherProject:someOtherTask")

Modifications:

- Add `Project.evaluationDependsOn()` calls where necessary

Result:

- Fixes a bug where a certain project is not configured when it has to
  be, causing a weird compilation error due to unconfigured dependencies.