### PR TITLE
Preserve percent-encoded character after parsing URI by PathAndQuery

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/PathAndQuery.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/PathAndQuery.java
@@ -178,7 +178,7 @@ public final class PathAndQuery {
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
+        return MoreObjects.toStringHelper(this).omitNullValues()
                           .add("path", path)
                           .add("query", query)
                           .toString();
@@ -351,7 +351,7 @@ public final class PathAndQuery {
             if (isPath) {
                 return false;
             } else if (cp != 0x0A && cp != 0x0D && cp != 0x09) {
-                // .. except 0x0A (LF), (byte) 0x0D (CR) and 0x09 (TAB) because they are used in a form.
+                // .. except 0x0A (LF), 0x0D (CR) and 0x09 (TAB) because they are used in a form.
                 return false;
             }
         }
@@ -538,7 +538,7 @@ public final class PathAndQuery {
 
     /**
      * Reserved characters which require percent-encoding. These values are only used for constructing
-     * {@link #RAW_CHAR_TO_MARKER} map and {@link #MARKER_TO_PERCENT_ENCODED_CHAR} map.
+     * {@link #RAW_CHAR_TO_MARKER} and {@link #MARKER_TO_PERCENT_ENCODED_CHAR} mapping tables.
      *
      * @see <a href="https://tools.ietf.org/html/rfc3986#section-2.2">RFC 3986, section 2.2</a>
      */

--- a/core/src/main/java/com/linecorp/armeria/internal/PathAndQuery.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/PathAndQuery.java
@@ -51,7 +51,7 @@ public final class PathAndQuery {
 
     private static final int PERCENT_ENCODING_MARKER = 0xFF;
 
-    private static final int[] RAW_CHAR_TO_MARKER = new int[256];
+    private static final byte[] RAW_CHAR_TO_MARKER = new byte[256];
     private static final String[] MARKER_TO_PERCENT_ENCODED_CHAR = new String[256];
 
     static {
@@ -263,15 +263,14 @@ public final class PathAndQuery {
                     }
                 } else {
                     // If query:
-                    assert decoded < 256;
-                    final int marker = RAW_CHAR_TO_MARKER[decoded];
-                    if (marker > 0) {
+                    final byte marker = RAW_CHAR_TO_MARKER[decoded];
+                    if (marker != 0) {
                         // Insert a special mark so we can distinguish a raw character and percent-encoded
                         // character in a query string, such as '&' and '%26'.
                         // We will encode this mark back into a percent-encoded character later.
                         buf.ensure(2);
                         buf.add((byte) PERCENT_ENCODING_MARKER);
-                        buf.add((byte) marker);
+                        buf.add(marker);
                         wasSlash = false;
                     } else if (appendOneByte(buf, decoded, wasSlash, isPath)) {
                         wasSlash = decoded == '/';
@@ -352,7 +351,7 @@ public final class PathAndQuery {
             if (isPath) {
                 return false;
             } else if (cp != 0x0A && cp != 0x0D && cp != 0x09) {
-                // .. except 0x0A (LF), 0x0D (CR) and 0x09 (TAB) because they are used in a form.
+                // .. except 0x0A (LF), (byte) 0x0D (CR) and 0x09 (TAB) because they are used in a form.
                 return false;
             }
         }
@@ -544,31 +543,31 @@ public final class PathAndQuery {
      * @see <a href="https://tools.ietf.org/html/rfc3986#section-2.2">RFC 3986, section 2.2</a>
      */
     private enum ReservedChar {
-        GEN_DELIM_01(':', "%3A", 0x01),
-        GEN_DELIM_02('/', "%2F", 0x02),
-        GEN_DELIM_03('?', "%3F", 0x03),
-        GEN_DELIM_04('#', "%23", 0x04),
-        GEN_DELIM_05('[', "%5B", 0x05),
-        GEN_DELIM_06(']', "%5D", 0x06),
-        GEN_DELIM_07('@', "%40", 0x07),
+        GEN_DELIM_01(':', "%3A", (byte) 0x01),
+        GEN_DELIM_02('/', "%2F", (byte) 0x02),
+        GEN_DELIM_03('?', "%3F", (byte) 0x03),
+        GEN_DELIM_04('#', "%23", (byte) 0x04),
+        GEN_DELIM_05('[', "%5B", (byte) 0x05),
+        GEN_DELIM_06(']', "%5D", (byte) 0x06),
+        GEN_DELIM_07('@', "%40", (byte) 0x07),
 
-        SUB_DELIM_01('!', "%21", 0x11),
-        SUB_DELIM_02('$', "%24", 0x12),
-        SUB_DELIM_03('&', "%26", 0x13),
-        SUB_DELIM_04('\'', "%27", 0x14),
-        SUB_DELIM_05('(', "%28", 0x15),
-        SUB_DELIM_06(')', "%29", 0x16),
-        SUB_DELIM_07('*', "%2A", 0x17),
-        SUB_DELIM_08('+', "%2B", 0x18),
-        SUB_DELIM_09(',', "%2C", 0x19),
-        SUB_DELIM_10(';', "%3B", 0x1A),
-        SUB_DELIM_11('=', "%3D", 0x1B);
+        SUB_DELIM_01('!', "%21", (byte) 0x11),
+        SUB_DELIM_02('$', "%24", (byte) 0x12),
+        SUB_DELIM_03('&', "%26", (byte) 0x13),
+        SUB_DELIM_04('\'', "%27", (byte) 0x14),
+        SUB_DELIM_05('(', "%28", (byte) 0x15),
+        SUB_DELIM_06(')', "%29", (byte) 0x16),
+        SUB_DELIM_07('*', "%2A", (byte) 0x17),
+        SUB_DELIM_08('+', "%2B", (byte) 0x18),
+        SUB_DELIM_09(',', "%2C", (byte) 0x19),
+        SUB_DELIM_10(';', "%3B", (byte) 0x1A),
+        SUB_DELIM_11('=', "%3D", (byte) 0x1B);
 
         private final int rawChar;
         private final String percentEncodedChar;
-        private final int marker;
+        private final byte marker;
 
-        ReservedChar(int rawChar, String percentEncodedChar, int marker) {
+        ReservedChar(int rawChar, String percentEncodedChar, byte marker) {
             this.rawChar = rawChar;
             this.percentEncodedChar = percentEncodedChar;
             this.marker = marker;

--- a/core/src/test/java/com/linecorp/armeria/internal/PathAndQueryTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/PathAndQueryTest.java
@@ -124,7 +124,7 @@ public class PathAndQueryTest {
         final PathAndQuery res = PathAndQuery.parse("%2F?%2F");
         assertThat(res).isNotNull();
         assertThat(res.path()).isEqualTo("/");
-        assertThat(res.query()).isEqualTo("/");
+        assertThat(res.query()).isEqualTo("%2F");
     }
 
     @Test
@@ -140,7 +140,7 @@ public class PathAndQueryTest {
                 "/path%2F/with/%2F/consecutive//%2F%2Fslashes?/query%2F/with/%2F/consecutive//%2F%2Fslashes");
         assertThat(res2).isNotNull();
         assertThat(res2.path()).isEqualTo("/path/with/consecutive/slashes");
-        assertThat(res2.query()).isEqualTo("/query//with///consecutive////slashes");
+        assertThat(res2.query()).isEqualTo("/query%2F/with/%2F/consecutive//%2F%2Fslashes");
     }
 
     @Test
@@ -247,10 +247,39 @@ public class PathAndQueryTest {
         assertThat(res.path()).isEqualTo("/=");
         assertThat(res.query()).isEqualTo("a=b=1");
 
-        // '%26' in a query string should never be decoded into '&'.
+        // '%3D' in a query string should never be decoded into '='.
         final PathAndQuery res2 = PathAndQuery.parse("/%3D?a%3db=1");
         assertThat(res2).isNotNull();
         assertThat(res2.path()).isEqualTo("/=");
         assertThat(res2.query()).isEqualTo("a%3Db=1");
+    }
+
+    @Test
+    public void sharp() {
+        final PathAndQuery res = PathAndQuery.parse("/#?a=b#1");
+        assertThat(res).isNotNull();
+        assertThat(res.path()).isEqualTo("/#");
+        assertThat(res.query()).isEqualTo("a=b#1");
+
+        // '%23' in a query string should never be decoded into '#'.
+        final PathAndQuery res2 = PathAndQuery.parse("/%23?a=b%231");
+        assertThat(res2).isNotNull();
+        assertThat(res2.path()).isEqualTo("/#");
+        assertThat(res2.query()).isEqualTo("a=b%231");
+    }
+
+    @Test
+    public void allReservedCharacters() {
+        final PathAndQuery res = PathAndQuery.parse("/#/:[]@!$&'()*+,;=?a=/#/:[]@!$&'()*+,;=");
+        assertThat(res).isNotNull();
+        assertThat(res.path()).isEqualTo("/#/:[]@!$&'()*+,;=");
+        assertThat(res.query()).isEqualTo("a=/#/:[]@!$&'()*+,;=");
+
+        final PathAndQuery res2 =
+                PathAndQuery.parse("/%23%2F%3A%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D%3F" +
+                                   "?a=%23%2F%3A%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D%3F");
+        assertThat(res2).isNotNull();
+        assertThat(res2.path()).isEqualTo("/#/:[]@!$&'()*+,;=?");
+        assertThat(res2.query()).isEqualTo("a=%23%2F%3A%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D%3F");
     }
 }


### PR DESCRIPTION
Motivation:
Currently, percent-encoded characters only for ampersand(`&`), semi-colon(`;`) and equal(`=`) are preserved after parsing URI by `PathAndQuery`. So, if a request has a percent-encoded `#`(`%23`), it is decoded as a raw `#` character. Due to this behavior, `QueryStringDecoder` cannot parse parameters correctly if a query string has a `#`, because `#` is a fragment identifier and the decoder ignores everything after the identifier.

Modifications:
- Every percent-encoded characters for reserved characters are preserved after parsing URI by `PathAndQuery`.
- Reserved characters. (from `https://tools.ietf.org/html/rfc3986#section-2.2`)
  - `:` / `/` / `?` / `#` / `[` / `]` / `@`
  - `!` / `$` / `&` / `'` / `(` / `)` / `*` / `+` / `,` / `;` / `=`