### PR TITLE
Update clinet-retry.rst

### DIFF
--- a/site/src/sphinx/client-retry.rst
+++ b/site/src/sphinx/client-retry.rst
@@ -18,7 +18,7 @@ So, let's find out what we can do with :api:`RetryingClient`.
 ``RetryingClient``
 ------------------
 
-You can just use the ``decorator()`` method in :api:`HttpClientBuilder` to build a :api:`RetryingHttpClient`:
+You can just use the ``decorator()`` method in :api:`ClientBuilder` or :api:`HttpClientBuilder` to build a :api:`RetryingHttpClient`. For example:
 
 .. code-block:: java
 

--- a/site/src/sphinx/client-retry.rst
+++ b/site/src/sphinx/client-retry.rst
@@ -31,20 +31,20 @@ You can just use the ``decorator()`` method in :api:`ClientBuilder` to build a :
     import com.linecorp.armeria.common.HttpResponse;
 
     RetryStrategy strategy = RetryStrategy.onServerErrorStatus();
-    HttpClient client = new ClientBuilder(...)
+    HttpClient client = new ClientBuilder("none+http://example.com/hello")
             .decorator(RetryingHttpClient.newDecorator(strategy))
             .build(HttpClient.class);
 
     final AggregatedHttpResponse res = client.execute(...).aggregate().join();
 
-or even simply,
+or even simply using :api:`HttpClientBuilder`,
 
 .. code-block:: java
 
     import com.linecorp.armeria.client.HttpClientBuilder;
 
     RetryStrategy strategy = RetryStrategy.onServerErrorStatus();
-    HttpClient client = new HttpClientBuilder(...)
+    HttpClient client = new HttpClientBuilder("http://example.com/hello")
             .decorator(RetryingHttpClient.newDecorator(strategy))
             .build();
 

--- a/site/src/sphinx/client-retry.rst
+++ b/site/src/sphinx/client-retry.rst
@@ -18,30 +18,15 @@ So, let's find out what we can do with :api:`RetryingClient`.
 ``RetryingClient``
 ------------------
 
-You can just use the ``decorator()`` method in :api:`ClientBuilder` to build a :api:`RetryingHttpClient`:
+You can just use the ``decorator()`` method in :api:`HttpClientBuilder` to build a :api:`RetryingHttpClient`:
 
 .. code-block:: java
 
-    import com.linecorp.armeria.client.ClientBuilder;
     import com.linecorp.armeria.client.HttpClient;
+    import com.linecorp.armeria.client.HttpClientBuilder;
     import com.linecorp.armeria.client.retry.RetryingHttpClient;
     import com.linecorp.armeria.client.retry.RetryStrategy;
     import com.linecorp.armeria.common.AggregatedHttpResponse;
-    import com.linecorp.armeria.common.HttpRequest;
-    import com.linecorp.armeria.common.HttpResponse;
-
-    RetryStrategy strategy = RetryStrategy.onServerErrorStatus();
-    HttpClient client = new ClientBuilder("none+http://example.com/hello")
-            .decorator(RetryingHttpClient.newDecorator(strategy))
-            .build(HttpClient.class);
-
-    final AggregatedHttpResponse res = client.execute(...).aggregate().join();
-
-or even simply using :api:`HttpClientBuilder`,
-
-.. code-block:: java
-
-    import com.linecorp.armeria.client.HttpClientBuilder;
 
     RetryStrategy strategy = RetryStrategy.onServerErrorStatus();
     HttpClient client = new HttpClientBuilder("http://example.com/hello")


### PR DESCRIPTION
Motivation:
- (To me,) It is hard to understand difference between first and second example in retry-client.rst
- Related to #1781 

Modification:
 - Add uri for ClientBuilder and HttpClientBuilder to understand difference easily (thanks to suggestion @minwoox 

Results:
- Update document in retry-client.rst

I don't know it can give little help for someone like me.