### PR TITLE
Add SubscriptionOption

### DIFF
--- a/benchmarks/src/jmh/java/com/linecorp/armeria/thrift/PooledResponseBufferBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/thrift/PooledResponseBufferBenchmark.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.thrift;
 
+import static com.linecorp.armeria.common.stream.SubscriptionOption.WITH_POOLED_OBJECTS;
+
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
@@ -91,7 +93,7 @@ public class PooledResponseBufferBenchmark {
                 public void onComplete() {
                     decorated.close();
                 }
-            }, true);
+            }, WITH_POOLED_OBJECTS);
             return decorated;
         }
     }
@@ -127,7 +129,7 @@ public class PooledResponseBufferBenchmark {
                 public void onComplete() {
                     decorated.close();
                 }
-            }, false);
+            });
             return decorated;
         }
     }

--- a/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
@@ -19,6 +19,7 @@ import static com.linecorp.armeria.common.SessionProtocol.H1;
 import static com.linecorp.armeria.common.SessionProtocol.H1C;
 import static com.linecorp.armeria.common.SessionProtocol.H2;
 import static com.linecorp.armeria.common.SessionProtocol.H2C;
+import static com.linecorp.armeria.common.stream.SubscriptionOption.WITH_POOLED_OBJECTS;
 import static java.util.Objects.requireNonNull;
 
 import java.util.concurrent.ScheduledFuture;
@@ -156,8 +157,7 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
                 new HttpRequestSubscriber(channel, requestEncoder,
                                           numRequestsSent, req, wrappedRes, ctx,
                                           writeTimeoutMillis),
-                channel.eventLoop(),
-                true);
+                channel.eventLoop(), WITH_POOLED_OBJECTS);
 
         if (numRequestsSent >= MAX_NUM_REQUESTS_SENT) {
             responseDecoder.disconnectWhenFinished();

--- a/core/src/main/java/com/linecorp/armeria/common/FilteredHttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/FilteredHttpResponse.java
@@ -41,9 +41,10 @@ public abstract class FilteredHttpResponse
      * Creates a new {@link FilteredHttpResponse} that filters objects published by {@code delegate}
      * before passing to a subscriber.
      *
-     * @param withPooledObjects if {@code true}, {@link #filter(Object)} receives the pooled {@link ByteBuf}
-     *                          and {@link ByteBufHolder} as is, without making a copy. If you don't know what
-     *                          this means, use {@link #FilteredHttpResponse(HttpResponse)}.
+     * @param withPooledObjects if {@code true}, {@link FilteredStreamMessage#filter(Object)} receives the
+     *                          pooled {@link ByteBuf} and {@link ByteBufHolder} as is, without making a copy.
+     *                          If you don't know what this means,
+     *                          use {@link #FilteredHttpResponse(HttpResponse)}.
      */
     protected FilteredHttpResponse(HttpResponse delegate, boolean withPooledObjects) {
         super(delegate, withPooledObjects);

--- a/core/src/main/java/com/linecorp/armeria/common/HeaderOverridingHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HeaderOverridingHttpRequest.java
@@ -15,6 +15,8 @@
  */
 package com.linecorp.armeria.common;
 
+import static com.linecorp.armeria.common.stream.SubscriptionOption.WITH_POOLED_OBJECTS;
+
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
@@ -23,6 +25,8 @@ import javax.annotation.Nullable;
 import org.reactivestreams.Subscriber;
 
 import com.google.common.base.MoreObjects;
+
+import com.linecorp.armeria.common.stream.SubscriptionOption;
 
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.util.concurrent.EventExecutor;
@@ -76,18 +80,32 @@ final class HeaderOverridingHttpRequest implements HttpRequest {
 
     @Override
     public void subscribe(Subscriber<? super HttpObject> subscriber, boolean withPooledObjects) {
-        delegate.subscribe(subscriber, withPooledObjects);
+        if (withPooledObjects) {
+            delegate.subscribe(subscriber, WITH_POOLED_OBJECTS);
+        } else {
+            delegate.subscribe(subscriber);
+        }
     }
 
     @Override
-    public void subscribe(Subscriber<? super HttpObject> subscriber, EventExecutor executor) {
-        delegate.subscribe(subscriber, executor);
+    public void subscribe(Subscriber<? super HttpObject> subscriber, SubscriptionOption... options) {
+        delegate.subscribe(subscriber, options);
     }
 
     @Override
-    public void subscribe(Subscriber<? super HttpObject> subscriber,
-                          EventExecutor executor, boolean withPooledObjects) {
-        delegate.subscribe(subscriber, executor, withPooledObjects);
+    public void subscribe(Subscriber<? super HttpObject> subscriber, EventExecutor executor,
+                          boolean withPooledObjects) {
+        if (withPooledObjects) {
+            delegate.subscribe(subscriber, executor, WITH_POOLED_OBJECTS);
+        } else {
+            delegate.subscribe(subscriber, executor);
+        }
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super HttpObject> subscriber, EventExecutor executor,
+                          SubscriptionOption... options) {
+        delegate.subscribe(subscriber, executor, options);
     }
 
     @Override
@@ -96,19 +114,31 @@ final class HeaderOverridingHttpRequest implements HttpRequest {
     }
 
     @Override
-    public CompletableFuture<List<HttpObject>> drainAll(EventExecutor executor) {
-        return delegate.drainAll(executor);
-    }
-
-    @Override
     public CompletableFuture<List<HttpObject>> drainAll(boolean withPooledObjects) {
-        return delegate.drainAll(withPooledObjects);
+        if (withPooledObjects) {
+            return drainAll(WITH_POOLED_OBJECTS);
+        } else {
+            return drainAll();
+        }
     }
 
     @Override
-    public CompletableFuture<List<HttpObject>> drainAll(EventExecutor executor,
-                                                        boolean withPooledObjects) {
-        return delegate.drainAll(executor, withPooledObjects);
+    public CompletableFuture<List<HttpObject>> drainAll(SubscriptionOption... options) {
+        return delegate.drainAll(options);
+    }
+
+    @Override
+    public CompletableFuture<List<HttpObject>> drainAll(EventExecutor executor, boolean withPooledObjects) {
+        if (withPooledObjects) {
+            return drainAll(executor, WITH_POOLED_OBJECTS);
+        } else {
+            return drainAll(executor);
+        }
+    }
+
+    @Override
+    public CompletableFuture<List<HttpObject>> drainAll(EventExecutor executor, SubscriptionOption... options) {
+        return delegate.drainAll(executor, options);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/HeaderOverridingHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HeaderOverridingHttpRequest.java
@@ -93,6 +93,11 @@ final class HeaderOverridingHttpRequest implements HttpRequest {
     }
 
     @Override
+    public void subscribe(Subscriber<? super HttpObject> subscriber, EventExecutor executor) {
+        delegate.subscribe(subscriber, executor);
+    }
+
+    @Override
     public void subscribe(Subscriber<? super HttpObject> subscriber, EventExecutor executor,
                           boolean withPooledObjects) {
         if (withPooledObjects) {
@@ -125,6 +130,11 @@ final class HeaderOverridingHttpRequest implements HttpRequest {
     @Override
     public CompletableFuture<List<HttpObject>> drainAll(SubscriptionOption... options) {
         return delegate.drainAll(options);
+    }
+
+    @Override
+    public CompletableFuture<List<HttpObject>> drainAll(EventExecutor executor) {
+        return delegate.drainAll(executor);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
@@ -34,6 +34,7 @@ import com.linecorp.armeria.common.FixedHttpRequest.OneElementFixedHttpRequest;
 import com.linecorp.armeria.common.FixedHttpRequest.RegularFixedHttpRequest;
 import com.linecorp.armeria.common.FixedHttpRequest.TwoElementFixedHttpRequest;
 import com.linecorp.armeria.common.stream.StreamMessage;
+import com.linecorp.armeria.common.stream.SubscriptionOption;
 
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.util.concurrent.EventExecutor;
@@ -348,7 +349,6 @@ public interface HttpRequest extends Request, StreamMessage<HttpObject> {
     default CompletableFuture<AggregatedHttpRequest> aggregate() {
         final CompletableFuture<AggregatedHttpRequest> future = new CompletableFuture<>();
         final HttpRequestAggregator aggregator = new HttpRequestAggregator(this, future, null);
-        completionFuture().handle(aggregator);
         subscribe(aggregator);
         return future;
     }
@@ -361,7 +361,6 @@ public interface HttpRequest extends Request, StreamMessage<HttpObject> {
         requireNonNull(executor, "executor");
         final CompletableFuture<AggregatedHttpRequest> future = new CompletableFuture<>();
         final HttpRequestAggregator aggregator = new HttpRequestAggregator(this, future, null);
-        completionFuture().handleAsync(aggregator, executor);
         subscribe(aggregator, executor);
         return future;
     }
@@ -376,8 +375,7 @@ public interface HttpRequest extends Request, StreamMessage<HttpObject> {
         requireNonNull(alloc, "alloc");
         final CompletableFuture<AggregatedHttpRequest> future = new CompletableFuture<>();
         final HttpRequestAggregator aggregator = new HttpRequestAggregator(this, future, alloc);
-        completionFuture().handle(aggregator);
-        subscribe(aggregator, true);
+        subscribe(aggregator, SubscriptionOption.WITH_POOLED_OBJECTS);
         return future;
     }
 
@@ -393,8 +391,7 @@ public interface HttpRequest extends Request, StreamMessage<HttpObject> {
         requireNonNull(alloc, "alloc");
         final CompletableFuture<AggregatedHttpRequest> future = new CompletableFuture<>();
         final HttpRequestAggregator aggregator = new HttpRequestAggregator(this, future, alloc);
-        completionFuture().handleAsync(aggregator, executor);
-        subscribe(aggregator, executor, true);
+        subscribe(aggregator, executor, SubscriptionOption.WITH_POOLED_OBJECTS);
         return future;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -34,6 +34,7 @@ import com.linecorp.armeria.common.FixedHttpResponse.OneElementFixedHttpResponse
 import com.linecorp.armeria.common.FixedHttpResponse.RegularFixedHttpResponse;
 import com.linecorp.armeria.common.FixedHttpResponse.TwoElementFixedHttpResponse;
 import com.linecorp.armeria.common.stream.StreamMessage;
+import com.linecorp.armeria.common.stream.SubscriptionOption;
 import com.linecorp.armeria.common.util.Exceptions;
 
 import io.netty.buffer.ByteBufAllocator;
@@ -352,7 +353,6 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
     default CompletableFuture<AggregatedHttpResponse> aggregate() {
         final CompletableFuture<AggregatedHttpResponse> future = new CompletableFuture<>();
         final HttpResponseAggregator aggregator = new HttpResponseAggregator(future, null);
-        completionFuture().handle(aggregator);
         subscribe(aggregator);
         return future;
     }
@@ -364,7 +364,6 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
     default CompletableFuture<AggregatedHttpResponse> aggregate(EventExecutor executor) {
         final CompletableFuture<AggregatedHttpResponse> future = new CompletableFuture<>();
         final HttpResponseAggregator aggregator = new HttpResponseAggregator(future, null);
-        completionFuture().handleAsync(aggregator, executor);
         subscribe(aggregator, executor);
         return future;
     }
@@ -379,8 +378,7 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
         requireNonNull(alloc, "alloc");
         final CompletableFuture<AggregatedHttpResponse> future = new CompletableFuture<>();
         final HttpResponseAggregator aggregator = new HttpResponseAggregator(future, alloc);
-        completionFuture().handle(aggregator);
-        subscribe(aggregator, true);
+        subscribe(aggregator, SubscriptionOption.WITH_POOLED_OBJECTS);
         return future;
     }
 
@@ -396,8 +394,7 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
         requireNonNull(alloc, "alloc");
         final CompletableFuture<AggregatedHttpResponse> future = new CompletableFuture<>();
         final HttpResponseAggregator aggregator = new HttpResponseAggregator(future, alloc);
-        completionFuture().handleAsync(aggregator, executor);
-        subscribe(aggregator, executor, true);
+        subscribe(aggregator, executor, SubscriptionOption.WITH_POOLED_OBJECTS);
         return future;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessageDuplicator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessageDuplicator.java
@@ -20,6 +20,9 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.linecorp.armeria.common.stream.StreamMessageUtil.abortedOrLate;
+import static com.linecorp.armeria.common.stream.StreamMessageUtil.containsNotifyCancellation;
+import static com.linecorp.armeria.common.stream.StreamMessageUtil.containsWithPooledObjects;
+import static com.linecorp.armeria.common.stream.SubscriptionOption.WITH_POOLED_OBJECTS;
 import static java.util.Objects.requireNonNull;
 
 import java.util.ArrayList;
@@ -54,22 +57,20 @@ import io.netty.util.concurrent.ImmediateEventExecutor;
 
 /**
  * Allows subscribing to a {@link StreamMessage} multiple times by duplicating the stream.
- * <p>
- * Only one subscriber can subscribe other stream messages such as {@link DefaultStreamMessage},
+ *
+ * <p>Only one subscriber can subscribe other stream messages such as {@link DefaultStreamMessage},
  * {@link DeferredStreamMessage}, etc.
  * This factory is wrapping one of those {@link StreamMessage}s and spawns duplicated stream messages
  * which are created using {@link AbstractStreamMessageDuplicator#duplicateStream()} and subscribed
- * by subscribers one by one.
- * </p><p>
- * The published elements can be shared across {@link Subscriber}s, so do not manipulate the
- * data unless you copy them. Only one case does not share the elements which is when you
- * {@link StreamMessage#subscribe(Subscriber, boolean)} with the {@code withPooledObjects}
- * as {@code false} while the elements is one of two pooled object classes which are {@link ByteBufHolder}
- * and {@link ByteBuf}.
- * </p><p>
- * This factory has to be closed by {@link AbstractStreamMessageDuplicator#close()} when
- * you do not need the contents anymore, otherwise memory leak might happen.
- * </p>
+ * by subscribers one by one.</p>
+ *
+ * <p>The published elements can be shared across {@link Subscriber}s, if you subscribe with the
+ * {@link SubscriptionOption#WITH_POOLED_OBJECTS}, so do not manipulate the
+ * data unless you copy them.</p>
+ *
+ * <p>This factory has to be closed by {@link AbstractStreamMessageDuplicator#close()} when
+ * you do not need the contents anymore, otherwise memory leak might happen.</p>
+ *
  * @param <T> the type of elements
  * @param <U> the type of the publisher and duplicated stream messages
  */
@@ -130,8 +131,7 @@ public abstract class AbstractStreamMessageDuplicator<T, U extends StreamMessage
 
     /**
      * Returns the default {@link EventExecutor} which will be used when a user subscribes to a child
-     * stream using {@link StreamMessage#subscribe(Subscriber)} or
-     * {@link StreamMessage#subscribe(Subscriber, boolean)}.
+     * stream using {@link StreamMessage#subscribe(Subscriber, SubscriptionOption...)}.
      */
     protected EventExecutor duplicatorExecutor() {
         return duplicatorExecutor;
@@ -204,7 +204,8 @@ public abstract class AbstractStreamMessageDuplicator<T, U extends StreamMessage
                 this.maxSignalLength = (int) maxSignalLength;
             }
             signals = new SignalQueue(this.signalLengthGetter);
-            upstream.subscribe(this, processorExecutor, true);
+            upstream.subscribe(this, processorExecutor,
+                               WITH_POOLED_OBJECTS, SubscriptionOption.NOTIFY_CANCELLATION);
         }
 
         StreamMessage<T> upstream() {
@@ -340,7 +341,7 @@ public abstract class AbstractStreamMessageDuplicator<T, U extends StreamMessage
             }
 
             try {
-                if (!(cause instanceof CancelledSubscriptionException)) {
+                if (subscription.notifyCancellation || !(cause instanceof CancelledSubscriptionException)) {
                     subscriber.onError(cause);
                 }
             } finally {
@@ -461,27 +462,45 @@ public abstract class AbstractStreamMessageDuplicator<T, U extends StreamMessage
         @Override
         public void subscribe(Subscriber<? super T> subscriber) {
             requireNonNull(subscriber, "subscriber");
-            subscribe(subscriber, parent.duplicatorExecutor(), false);
+            subscribe(subscriber, parent.duplicatorExecutor());
         }
 
         @Override
         public void subscribe(Subscriber<? super T> subscriber, boolean withPooledObjects) {
-            requireNonNull(subscriber, "subscriber");
-            subscribe(subscriber, parent.duplicatorExecutor(), withPooledObjects);
+            if (withPooledObjects) {
+                subscribe(subscriber, WITH_POOLED_OBJECTS);
+            } else {
+                subscribe(subscriber);
+            }
         }
 
         @Override
-        public void subscribe(Subscriber<? super T> subscriber, EventExecutor executor) {
-            subscribe(subscriber, executor, false);
+        public void subscribe(Subscriber<? super T> subscriber, SubscriptionOption... options) {
+            requireNonNull(subscriber, "subscriber");
+            subscribe(subscriber, parent.duplicatorExecutor(), options);
         }
 
         @Override
         public void subscribe(Subscriber<? super T> subscriber, EventExecutor executor,
                               boolean withPooledObjects) {
+            if (withPooledObjects) {
+                subscribe(subscriber, executor, WITH_POOLED_OBJECTS);
+            } else {
+                subscribe(subscriber, executor);
+            }
+        }
+
+        @Override
+        public void subscribe(Subscriber<? super T> subscriber, EventExecutor executor,
+                              SubscriptionOption... options) {
             requireNonNull(subscriber, "subscriber");
             requireNonNull(executor, "executor");
+            requireNonNull(options, "options");
+
+            final boolean withPooledObjects = containsWithPooledObjects(options);
+            final boolean notifyCancellation = containsNotifyCancellation(options);
             final DownstreamSubscription<T> subscription = new DownstreamSubscription<>(
-                    this, subscriber, processor, executor, withPooledObjects, lastStream);
+                    this, subscriber, processor, executor, withPooledObjects, notifyCancellation, lastStream);
 
             if (!subscribe0(subscription)) {
                 final DownstreamSubscription<T> oldSubscription = this.subscription;
@@ -511,26 +530,43 @@ public abstract class AbstractStreamMessageDuplicator<T, U extends StreamMessage
 
         @Override
         public CompletableFuture<List<T>> drainAll() {
-            return drainAll(parent.duplicatorExecutor(), false);
-        }
-
-        @Override
-        public CompletableFuture<List<T>> drainAll(EventExecutor executor) {
-            return drainAll(executor, false);
+            return drainAll(parent.duplicatorExecutor());
         }
 
         @Override
         public CompletableFuture<List<T>> drainAll(boolean withPooledObjects) {
-            return drainAll(parent.duplicatorExecutor(), withPooledObjects);
+            if (withPooledObjects) {
+                return drainAll(parent.duplicatorExecutor(), WITH_POOLED_OBJECTS);
+            } else {
+                return drainAll(parent.duplicatorExecutor());
+            }
+        }
+
+        @Override
+        public CompletableFuture<List<T>> drainAll(SubscriptionOption... options) {
+            return drainAll(parent.duplicatorExecutor(), options);
         }
 
         @Override
         public CompletableFuture<List<T>> drainAll(EventExecutor executor, boolean withPooledObjects) {
-            requireNonNull(executor, "executor");
+            if (withPooledObjects) {
+                return drainAll(executor, WITH_POOLED_OBJECTS);
+            } else {
+                return drainAll(executor);
+            }
+        }
 
+        @Override
+        public CompletableFuture<List<T>> drainAll(EventExecutor executor, SubscriptionOption... options) {
+            requireNonNull(executor, "executor");
+            requireNonNull(options, "options");
+
+            final boolean withPooledObjects = containsWithPooledObjects(options);
             final StreamMessageDrainer<T> drainer = new StreamMessageDrainer<>(withPooledObjects);
             final DownstreamSubscription<T> subscription = new DownstreamSubscription<>(
-                    this, drainer, processor, executor, withPooledObjects, lastStream);
+                    this, drainer, processor, executor, withPooledObjects,
+                    false, /* We do not call Subscription.cancel() in StreamMessageDrainer. */
+                    lastStream);
             if (!subscribe0(subscription)) {
                 final DownstreamSubscription<T> oldSubscription = this.subscription;
                 assert oldSubscription != null;
@@ -550,7 +586,8 @@ public abstract class AbstractStreamMessageDuplicator<T, U extends StreamMessage
             }
 
             final DownstreamSubscription<T> newSubscription = new DownstreamSubscription<>(
-                    this, AbortingSubscriber.get(), processor, ImmediateEventExecutor.INSTANCE, false, false);
+                    this, AbortingSubscriber.get(), processor, ImmediateEventExecutor.INSTANCE,
+                    false, false, false);
             if (subscriptionUpdater.compareAndSet(this, null, newSubscription)) {
                 newSubscription.completionFuture().completeExceptionally(AbortedStreamException.get());
             } else {
@@ -578,6 +615,7 @@ public abstract class AbstractStreamMessageDuplicator<T, U extends StreamMessage
         private final StreamMessageProcessor<T> processor;
         private final EventExecutor executor;
         private final boolean withPooledObjects;
+        private final boolean notifyCancellation;
         final boolean lastSubscription;
 
         @SuppressWarnings("unused")
@@ -599,12 +637,14 @@ public abstract class AbstractStreamMessageDuplicator<T, U extends StreamMessage
 
         DownstreamSubscription(ChildStreamMessage<T> streamMessage,
                                Subscriber<? super T> subscriber, StreamMessageProcessor<T> processor,
-                               EventExecutor executor, boolean withPooledObjects, boolean lastSubscription) {
+                               EventExecutor executor, boolean withPooledObjects, boolean notifyCancellation,
+                               boolean lastSubscription) {
             this.streamMessage = streamMessage;
             this.subscriber = subscriber;
             this.processor = processor;
             this.executor = executor;
             this.withPooledObjects = withPooledObjects;
+            this.notifyCancellation = notifyCancellation;
             this.lastSubscription = lastSubscription;
         }
 

--- a/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
@@ -137,7 +137,7 @@ public class DefaultStreamMessage<T> extends AbstractStreamMessageAndWriter<T> {
         }
 
         final SubscriptionImpl newSubscription = new SubscriptionImpl(
-                this, AbortingSubscriber.get(), ImmediateEventExecutor.INSTANCE, false);
+                this, AbortingSubscriber.get(), ImmediateEventExecutor.INSTANCE, false, false);
         if (subscriptionUpdater.compareAndSet(this, null, newSubscription)) {
             // We don't need to invoke onSubscribe() for AbortingSubscriber because it's just a placeholder.
             invokedOnSubscribe = true;

--- a/core/src/main/java/com/linecorp/armeria/common/stream/FixedStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/FixedStreamMessage.java
@@ -144,7 +144,7 @@ abstract class FixedStreamMessage<T> extends AbstractStreamMessage<T> {
         }
 
         final SubscriptionImpl newSubscription = new SubscriptionImpl(
-                this, AbortingSubscriber.get(), ImmediateEventExecutor.INSTANCE, false);
+                this, AbortingSubscriber.get(), ImmediateEventExecutor.INSTANCE, false, false);
         subscriptionUpdater.compareAndSet(this, null, newSubscription);
         cancelOrAbort(false);
     }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -69,9 +69,13 @@ import io.netty.util.concurrent.EventExecutor;
  * leaks.
  *
  * <p>If a {@link Subscriber} does not want a {@link StreamMessage} to make a copy of a {@link ByteBufHolder},
- * use {@link #subscribe(Subscriber, boolean)} or {@link #subscribe(Subscriber, EventExecutor, boolean)} and
- * specify {@code true} for {@code withPooledObjects}. Note that the {@link Subscriber} is responsible for
- * releasing the objects given with {@link Subscriber#onNext(Object)}.
+ * specify {@link SubscriptionOption#WITH_POOLED_OBJECTS} when you subscribe. Note that the {@link Subscriber}
+ * is responsible for releasing the objects given with {@link Subscriber#onNext(Object)}.
+ *
+ * <p>{@link Subscriber#onError(Throwable)} is invoked when any exception is raised except the
+ * {@link CancelledSubscriptionException} which is caused by {@link Subscription#cancel()}. If you want your
+ * {@link Subscriber} get notified by {@link Subscriber#onError(Throwable)} when {@link Subscription#cancel()}
+ * is called, specify {@link SubscriptionOption#NOTIFY_CANCELLATION} when you subscribe.
  *
  * @param <T> the type of element signaled
  */
@@ -185,6 +189,9 @@ public interface StreamMessage<T> extends Publisher<T> {
      * <ul>
      *   <li>{@link IllegalStateException} if other {@link Subscriber} subscribed to this stream already.</li>
      *   <li>{@link AbortedStreamException} if this stream has been {@linkplain #abort() aborted}.</li>
+     *   <li>{@link CancelledSubscriptionException} if this stream has been
+     *       {@linkplain Subscription#cancel() cancelled} and {@link SubscriptionOption#NOTIFY_CANCELLATION} is
+     *       specified when subscribed.</li>
      *   <li>Other exceptions that occurred due to an error while retrieving the elements.</li>
      * </ul>
      */
@@ -197,13 +204,48 @@ public interface StreamMessage<T> extends Publisher<T> {
      * <ul>
      *   <li>{@link IllegalStateException} if other {@link Subscriber} subscribed to this stream already.</li>
      *   <li>{@link AbortedStreamException} if this stream has been {@linkplain #abort() aborted}.</li>
+     *   <li>{@link CancelledSubscriptionException} if this stream has been
+     *       {@linkplain Subscription#cancel() cancelled} and {@link SubscriptionOption#NOTIFY_CANCELLATION} is
+     *       specified when subscribed.</li>
      *   <li>Other exceptions that occurred due to an error while retrieving the elements.</li>
      * </ul>
      *
-     * @param withPooledObjects if {@code true}, receives the pooled {@link ByteBuf} and {@link ByteBufHolder}
-     *                          as is, without making a copy. If you don't know what this means, use
-     *                          {@link StreamMessage#subscribe(Subscriber)}.
+     * @param options {@link SubscriptionOption}s to subscribe with
      */
+    void subscribe(Subscriber<? super T> subscriber, SubscriptionOption... options);
+
+    /**
+     * Requests to start streaming data to the specified {@link Subscriber}. If there is a problem subscribing,
+     * {@link Subscriber#onError(Throwable)} will be invoked with one of the following exceptions:
+     * <ul>
+     *   <li>{@link IllegalStateException} if other {@link Subscriber} subscribed to this stream already.</li>
+     *   <li>{@link AbortedStreamException} if this stream has been {@linkplain #abort() aborted}.</li>
+     *   <li>{@link CancelledSubscriptionException} if this stream has been
+     *       {@linkplain Subscription#cancel() cancelled} and {@link SubscriptionOption#NOTIFY_CANCELLATION} is
+     *       specified when subscribed.</li>
+     *   <li>Other exceptions that occurred due to an error while retrieving the elements.</li>
+     * </ul>
+     *
+     * @param executor the executor to subscribe
+     * @param options {@link SubscriptionOption}s to subscribe with
+     */
+    void subscribe(Subscriber<? super T> subscriber, EventExecutor executor, SubscriptionOption... options);
+
+    /**
+     * Requests to start streaming data to the specified {@link Subscriber}. If there is a problem subscribing,
+     * {@link Subscriber#onError(Throwable)} will be invoked with one of the following exceptions:
+     * <ul>
+     *   <li>{@link IllegalStateException} if other {@link Subscriber} subscribed to this stream already.</li>
+     *   <li>{@link AbortedStreamException} if this stream has been {@linkplain #abort() aborted}.</li>
+     *   <li>{@link CancelledSubscriptionException} if this stream has been
+     *       {@linkplain Subscription#cancel() cancelled} and {@link SubscriptionOption#NOTIFY_CANCELLATION} is
+     *       specified when subscribed.</li>
+     *   <li>Other exceptions that occurred due to an error while retrieving the elements.</li>
+     * </ul>
+     *
+     * @deprecated Use {@link #subscribe(Subscriber, SubscriptionOption...)}.
+     */
+    @Deprecated
     void subscribe(Subscriber<? super T> subscriber, boolean withPooledObjects);
 
     /**
@@ -213,25 +255,17 @@ public interface StreamMessage<T> extends Publisher<T> {
      * <ul>
      *   <li>{@link IllegalStateException} if other {@link Subscriber} subscribed to this stream already.</li>
      *   <li>{@link AbortedStreamException} if this stream has been {@linkplain #abort() aborted}.</li>
-     *   <li>Other exceptions that occurred due to an error while retrieving the elements.</li>
-     * </ul>
-     */
-    void subscribe(Subscriber<? super T> subscriber, EventExecutor executor);
-
-    /**
-     * Requests to start streaming data, invoking the specified {@link Subscriber} from the specified
-     * {@link Executor}. If there is a problem subscribing, {@link Subscriber#onError(Throwable)} will be
-     * invoked with one of the following exceptions:
-     * <ul>
-     *   <li>{@link IllegalStateException} if other {@link Subscriber} subscribed to this stream already.</li>
-     *   <li>{@link AbortedStreamException} if this stream has been {@linkplain #abort() aborted}.</li>
+     *   <li>{@link CancelledSubscriptionException} if this stream has been
+     *       {@linkplain Subscription#cancel() cancelled} and {@link SubscriptionOption#NOTIFY_CANCELLATION} is
+     *       specified when subscribed.</li>
      *   <li>Other exceptions that occurred due to an error while retrieving the elements.</li>
      * </ul>
      *
-     * @param withPooledObjects if {@code true}, receives the pooled {@link ByteBuf} and {@link ByteBufHolder}
-     *                          as is, without making a copy. If you don't know what this means, use
-     *                          {@link StreamMessage#subscribe(Subscriber)}.
+     * @deprecated Use {@link #subscribe(Subscriber, EventExecutor, SubscriptionOption...)}.
+     *
+     * @param executor the executor to subscribe
      */
+    @Deprecated
     void subscribe(Subscriber<? super T> subscriber, EventExecutor executor, boolean withPooledObjects);
 
     /**
@@ -243,8 +277,11 @@ public interface StreamMessage<T> extends Publisher<T> {
      *   <li>Other exceptions that occurred due to an error while retrieving the elements.</li>
      * </ul>
      *
+     * @deprecated Use {@link #drainAll(SubscriptionOption...)}.
+     *
      * @return the {@link CompletableFuture} which will be completed with the list of the elements retrieved.
      */
+    @Deprecated
     CompletableFuture<List<T>> drainAll();
 
     /**
@@ -256,25 +293,11 @@ public interface StreamMessage<T> extends Publisher<T> {
      *   <li>Other exceptions that occurred due to an error while retrieving the elements.</li>
      * </ul>
      *
-     * @param executor the executor to retrieve all elements
-     * @return the {@link CompletableFuture} which will be completed with the list of the elements retrieved.
-     */
-    CompletableFuture<List<T>> drainAll(EventExecutor executor);
-
-    /**
-     * Subscribes to this {@link StreamMessage} and retrieves all elements from it.
-     * The returned {@link CompletableFuture} may be completed exceptionally with the following exceptions:
-     * <ul>
-     *   <li>{@link IllegalStateException} if other {@link Subscriber} subscribed to this stream already.</li>
-     *   <li>{@link AbortedStreamException} if this stream has been {@linkplain #abort() aborted}.</li>
-     *   <li>Other exceptions that occurred due to an error while retrieving the elements.</li>
-     * </ul>
+     * @deprecated Use {@link #drainAll(SubscriptionOption...)}.
      *
-     * @param withPooledObjects if {@code true}, receives the pooled {@link ByteBuf} and {@link ByteBufHolder}
-     *                          as is, without making a copy. If you don't know what this means, use
-     *                          {@link StreamMessage#drainAll()}.
      * @return the {@link CompletableFuture} which will be completed with the list of the elements retrieved.
      */
+    @Deprecated
     CompletableFuture<List<T>> drainAll(boolean withPooledObjects);
 
     /**
@@ -286,13 +309,47 @@ public interface StreamMessage<T> extends Publisher<T> {
      *   <li>Other exceptions that occurred due to an error while retrieving the elements.</li>
      * </ul>
      *
+     * @deprecated Use {@link #drainAll(EventExecutor, SubscriptionOption...)}.
+     *
      * @param executor the executor to retrieve all elements
-     * @param withPooledObjects if {@code true}, receives the pooled {@link ByteBuf} and {@link ByteBufHolder}
-     *                          as is, without making a copy. If you don't know what this means, use
-     *                          {@link StreamMessage#drainAll(EventExecutor)}.
+     *
      * @return the {@link CompletableFuture} which will be completed with the list of the elements retrieved.
      */
+    @Deprecated
     CompletableFuture<List<T>> drainAll(EventExecutor executor, boolean withPooledObjects);
+
+    /**
+     * Subscribes to this {@link StreamMessage} and retrieves all elements from it.
+     * The returned {@link CompletableFuture} may be completed exceptionally with the following exceptions:
+     * <ul>
+     *   <li>{@link IllegalStateException} if other {@link Subscriber} subscribed to this stream already.</li>
+     *   <li>{@link AbortedStreamException} if this stream has been {@linkplain #abort() aborted}.</li>
+     *   <li>Other exceptions that occurred due to an error while retrieving the elements.</li>
+     * </ul>
+     *
+     * @param options {@link SubscriptionOption}s to subscribe with. Note that
+     *                {@link SubscriptionOption#NOTIFY_CANCELLATION} is ineffective because there's no
+     *                cancelling while draining all elements.
+     * @return the {@link CompletableFuture} which will be completed with the list of the elements retrieved.
+     */
+    CompletableFuture<List<T>> drainAll(SubscriptionOption... options);
+
+    /**
+     * Subscribes to this {@link StreamMessage} and retrieves all elements from it.
+     * The returned {@link CompletableFuture} may be completed exceptionally with the following exceptions:
+     * <ul>
+     *   <li>{@link IllegalStateException} if other {@link Subscriber} subscribed to this stream already.</li>
+     *   <li>{@link AbortedStreamException} if this stream has been {@linkplain #abort() aborted}.</li>
+     *   <li>Other exceptions that occurred due to an error while retrieving the elements.</li>
+     * </ul>
+     *
+     * @param executor the executor to retrieve all elements
+     * @param options {@link SubscriptionOption}s to subscribe with. Note that
+     *                {@link SubscriptionOption#NOTIFY_CANCELLATION} is ineffective because there's no
+     *                cancelling while draining all elements.
+     * @return the {@link CompletableFuture} which will be completed with the list of the elements retrieved.
+     */
+    CompletableFuture<List<T>> drainAll(EventExecutor executor, SubscriptionOption... options);
 
     /**
      * Closes this stream with {@link AbortedStreamException} and prevents further subscription.

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -227,6 +227,22 @@ public interface StreamMessage<T> extends Publisher<T> {
      * </ul>
      *
      * @param executor the executor to subscribe
+     */
+    void subscribe(Subscriber<? super T> subscriber, EventExecutor executor);
+
+    /**
+     * Requests to start streaming data to the specified {@link Subscriber}. If there is a problem subscribing,
+     * {@link Subscriber#onError(Throwable)} will be invoked with one of the following exceptions:
+     * <ul>
+     *   <li>{@link IllegalStateException} if other {@link Subscriber} subscribed to this stream already.</li>
+     *   <li>{@link AbortedStreamException} if this stream has been {@linkplain #abort() aborted}.</li>
+     *   <li>{@link CancelledSubscriptionException} if this stream has been
+     *       {@linkplain Subscription#cancel() cancelled} and {@link SubscriptionOption#NOTIFY_CANCELLATION} is
+     *       specified when subscribed.</li>
+     *   <li>Other exceptions that occurred due to an error while retrieving the elements.</li>
+     * </ul>
+     *
+     * @param executor the executor to subscribe
      * @param options {@link SubscriptionOption}s to subscribe with
      */
     void subscribe(Subscriber<? super T> subscriber, EventExecutor executor, SubscriptionOption... options);
@@ -277,11 +293,8 @@ public interface StreamMessage<T> extends Publisher<T> {
      *   <li>Other exceptions that occurred due to an error while retrieving the elements.</li>
      * </ul>
      *
-     * @deprecated Use {@link #drainAll(SubscriptionOption...)}.
-     *
      * @return the {@link CompletableFuture} which will be completed with the list of the elements retrieved.
      */
-    @Deprecated
     CompletableFuture<List<T>> drainAll();
 
     /**
@@ -333,6 +346,20 @@ public interface StreamMessage<T> extends Publisher<T> {
      * @return the {@link CompletableFuture} which will be completed with the list of the elements retrieved.
      */
     CompletableFuture<List<T>> drainAll(SubscriptionOption... options);
+
+    /**
+     * Subscribes to this {@link StreamMessage} and retrieves all elements from it.
+     * The returned {@link CompletableFuture} may be completed exceptionally with the following exceptions:
+     * <ul>
+     *   <li>{@link IllegalStateException} if other {@link Subscriber} subscribed to this stream already.</li>
+     *   <li>{@link AbortedStreamException} if this stream has been {@linkplain #abort() aborted}.</li>
+     *   <li>Other exceptions that occurred due to an error while retrieving the elements.</li>
+     * </ul>
+     *
+     * @param executor the executor to retrieve all elements
+     * @return the {@link CompletableFuture} which will be completed with the list of the elements retrieved.
+     */
+    CompletableFuture<List<T>> drainAll(EventExecutor executor);
 
     /**
      * Subscribes to this {@link StreamMessage} and retrieves all elements from it.

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageUtil.java
@@ -16,6 +16,10 @@
 
 package com.linecorp.armeria.common.stream;
 
+import static com.linecorp.armeria.common.stream.SubscriptionOption.NOTIFY_CANCELLATION;
+import static com.linecorp.armeria.common.stream.SubscriptionOption.WITH_POOLED_OBJECTS;
+import static java.util.Objects.requireNonNull;
+
 import org.reactivestreams.Subscriber;
 
 final class StreamMessageUtil {
@@ -26,6 +30,28 @@ final class StreamMessageUtil {
         }
 
         return new IllegalStateException("subscribed by other subscriber already");
+    }
+
+    static boolean containsWithPooledObjects(SubscriptionOption... options) {
+        requireNonNull(options, "options");
+        for (SubscriptionOption option : options) {
+            if (option == WITH_POOLED_OBJECTS) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    static boolean containsNotifyCancellation(SubscriptionOption... options) {
+        requireNonNull(options, "options");
+        for (SubscriptionOption option : options) {
+            if (option == NOTIFY_CANCELLATION) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private StreamMessageUtil() {}

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageWrapper.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.common.stream;
 
+import static com.linecorp.armeria.common.stream.SubscriptionOption.WITH_POOLED_OBJECTS;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
@@ -72,45 +73,70 @@ public class StreamMessageWrapper<T> implements StreamMessage<T> {
 
     @Override
     public void subscribe(Subscriber<? super T> s, boolean withPooledObjects) {
-        delegate().subscribe(s, withPooledObjects);
+        if (withPooledObjects) {
+            delegate().subscribe(s, WITH_POOLED_OBJECTS);
+        } else {
+            delegate().subscribe(s);
+        }
     }
 
     @Override
-    public void subscribe(Subscriber<? super T> s, EventExecutor executor) {
-        delegate().subscribe(s, executor);
+    public void subscribe(Subscriber<? super T> subscriber, SubscriptionOption... options) {
+        delegate().subscribe(subscriber, options);
     }
 
     @Override
     public void subscribe(Subscriber<? super T> s, EventExecutor executor, boolean withPooledObjects) {
-        delegate().subscribe(s, executor, withPooledObjects);
+        if (withPooledObjects) {
+            delegate().subscribe(s, executor, WITH_POOLED_OBJECTS);
+        } else {
+            delegate().subscribe(s, executor);
+        }
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super T> subscriber, EventExecutor executor,
+                          SubscriptionOption... options) {
+        delegate().subscribe(subscriber, executor, options);
     }
 
     @Override
     @SuppressWarnings("unchecked")
     public CompletableFuture<List<T>> drainAll() {
-        final CompletableFuture<? extends List<? extends T>> future = delegate().drainAll();
-        return (CompletableFuture<List<T>>) future;
+        return cast(delegate().drainAll());
     }
 
     @Override
-    @SuppressWarnings("unchecked")
-    public CompletableFuture<List<T>> drainAll(EventExecutor executor) {
-        final CompletableFuture<? extends List<? extends T>> future = delegate().drainAll(executor);
-        return (CompletableFuture<List<T>>) future;
-    }
-
-    @Override
-    @SuppressWarnings("unchecked")
     public CompletableFuture<List<T>> drainAll(boolean withPooledObjects) {
-        final CompletableFuture<? extends List<? extends T>> future = delegate().drainAll(withPooledObjects);
-        return (CompletableFuture<List<T>>) future;
+        if (withPooledObjects) {
+            return drainAll(WITH_POOLED_OBJECTS);
+        } else {
+            return drainAll();
+        }
     }
 
     @Override
     @SuppressWarnings("unchecked")
+    public CompletableFuture<List<T>> drainAll(SubscriptionOption... options) {
+        return cast(delegate().drainAll(options));
+    }
+
+    @Override
     public CompletableFuture<List<T>> drainAll(EventExecutor executor, boolean withPooledObjects) {
-        final CompletableFuture<? extends List<? extends T>> future =
-                delegate().drainAll(executor, withPooledObjects);
+        if (withPooledObjects) {
+            return drainAll(executor, WITH_POOLED_OBJECTS);
+        } else {
+            return drainAll(executor);
+        }
+    }
+
+    @Override
+    public CompletableFuture<List<T>> drainAll(EventExecutor executor, SubscriptionOption... options) {
+        return cast(delegate().drainAll(executor, options));
+    }
+
+    @SuppressWarnings("unchecked")
+    private CompletableFuture<List<T>> cast(CompletableFuture<? extends List<? extends T>> future) {
         return (CompletableFuture<List<T>>) future;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageWrapper.java
@@ -86,6 +86,11 @@ public class StreamMessageWrapper<T> implements StreamMessage<T> {
     }
 
     @Override
+    public void subscribe(Subscriber<? super T> subscriber, EventExecutor executor) {
+        delegate().subscribe(subscriber, executor);
+    }
+
+    @Override
     public void subscribe(Subscriber<? super T> s, EventExecutor executor, boolean withPooledObjects) {
         if (withPooledObjects) {
             delegate().subscribe(s, executor, WITH_POOLED_OBJECTS);
@@ -101,7 +106,6 @@ public class StreamMessageWrapper<T> implements StreamMessage<T> {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public CompletableFuture<List<T>> drainAll() {
         return cast(delegate().drainAll());
     }
@@ -116,9 +120,13 @@ public class StreamMessageWrapper<T> implements StreamMessage<T> {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public CompletableFuture<List<T>> drainAll(SubscriptionOption... options) {
         return cast(delegate().drainAll(options));
+    }
+
+    @Override
+    public CompletableFuture<List<T>> drainAll(EventExecutor executor) {
+        return cast(delegate().drainAll(executor));
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/stream/SubscriptionOption.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/SubscriptionOption.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.stream;
+
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufHolder;
+import io.netty.util.concurrent.EventExecutor;
+
+/**
+ * Options used when subscribing to a {@link StreamMessage}.
+ *
+ * @see StreamMessage#subscribe(Subscriber, SubscriptionOption...)
+ * @see StreamMessage#subscribe(Subscriber, EventExecutor, SubscriptionOption...)
+ */
+public enum SubscriptionOption {
+
+    /**
+     * To receive the pooled {@link ByteBuf} and {@link ByteBufHolder} as is, without making a copy.
+     * If you don't know what this means, do not specify this when you subscribe the {@link StreamMessage}.
+     */
+    WITH_POOLED_OBJECTS,
+
+    /**
+     * To get notified by {@link Subscriber#onError(Throwable)} even when the {@link StreamMessage} is
+     * {@linkplain Subscription#cancel() cancelled}.
+     */
+    NOTIFY_CANCELLATION
+}

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -21,6 +21,7 @@ import static com.linecorp.armeria.common.SessionProtocol.H1;
 import static com.linecorp.armeria.common.SessionProtocol.H1C;
 import static com.linecorp.armeria.common.SessionProtocol.H2;
 import static com.linecorp.armeria.common.SessionProtocol.H2C;
+import static com.linecorp.armeria.common.stream.SubscriptionOption.WITH_POOLED_OBJECTS;
 import static com.linecorp.armeria.internal.ArmeriaHttpUtil.isCorsPreflightRequest;
 import static com.linecorp.armeria.server.HttpHeaderUtil.determineClientAddress;
 import static io.netty.handler.codec.http2.Http2CodecUtil.DEFAULT_WINDOW_SIZE;
@@ -440,7 +441,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
             final HttpResponseSubscriber resSubscriber =
                     new HttpResponseSubscriber(ctx, responseEncoder, reqCtx, req, accessLogWriter);
             reqCtx.setRequestTimeoutChangeListener(resSubscriber);
-            res.subscribe(resSubscriber, eventLoop, true);
+            res.subscribe(resSubscriber, eventLoop, WITH_POOLED_OBJECTS);
         }
     }
 

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientIntegrationTest.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.client;
 
+import static com.linecorp.armeria.common.stream.SubscriptionOption.WITH_POOLED_OBJECTS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
@@ -160,7 +161,7 @@ class HttpClientIntegrationTest {
                 public void onComplete() {
                     decorated.close();
                 }
-            }, true);
+            }, WITH_POOLED_OBJECTS);
             return decorated;
         }
     }

--- a/core/src/test/java/com/linecorp/armeria/common/stream/DefaultStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/DefaultStreamMessageTest.java
@@ -47,7 +47,8 @@ class DefaultStreamMessageTest {
     /**
      * Makes sure {@link Subscriber#onComplete()} is always invoked after
      * {@link Subscriber#onSubscribe(Subscription)} even if
-     * {@link StreamMessage#subscribe(Subscriber, EventExecutor)} is called from non-{@link EventLoop}.
+     * {@link StreamMessage#subscribe(Subscriber, EventExecutor, SubscriptionOption...)}
+     * is called from non-{@link EventLoop}.
      */
     @Test
     void onSubscribeBeforeOnComplete() throws Exception {

--- a/core/src/test/java/com/linecorp/armeria/common/stream/DeferredStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/DeferredStreamMessageTest.java
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.verify;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
@@ -35,10 +35,10 @@ import com.linecorp.armeria.common.util.Exceptions;
 
 import io.netty.util.concurrent.ImmediateEventExecutor;
 
-public class DeferredStreamMessageTest {
+class DeferredStreamMessageTest {
 
     @Test
-    public void testInitialState() {
+    void testInitialState() {
         final DeferredStreamMessage<Object> m = new DeferredStreamMessage<>();
         assertThat(m.isOpen()).isTrue();
         assertThat(m.isEmpty()).isFalse();
@@ -46,7 +46,7 @@ public class DeferredStreamMessageTest {
     }
 
     @Test
-    public void testSetDelegate() {
+    void testSetDelegate() {
         final DeferredStreamMessage<Object> m = new DeferredStreamMessage<>();
         m.delegate(new DefaultStreamMessage<>());
         assertThatThrownBy(() -> m.delegate(new DefaultStreamMessage<>()))
@@ -55,7 +55,7 @@ public class DeferredStreamMessageTest {
     }
 
     @Test
-    public void testEarlyAbort() {
+    void testEarlyAbort() {
         final DeferredStreamMessage<Object> m = new DeferredStreamMessage<>();
         m.abort();
         assertAborted(m);
@@ -63,7 +63,7 @@ public class DeferredStreamMessageTest {
     }
 
     @Test
-    public void testEarlyAbortWithSubscriber() {
+    void testEarlyAbortWithSubscriber() {
         final DeferredStreamMessage<Object> m = new DeferredStreamMessage<>();
         @SuppressWarnings("unchecked")
         final Subscriber<Object> subscriber = mock(Subscriber.class);
@@ -77,7 +77,7 @@ public class DeferredStreamMessageTest {
     }
 
     @Test
-    public void testLateAbort() {
+    void testLateAbort() {
         final DeferredStreamMessage<Object> m = new DeferredStreamMessage<>();
         final DefaultStreamMessage<Object> d = new DefaultStreamMessage<>();
 
@@ -89,7 +89,7 @@ public class DeferredStreamMessageTest {
     }
 
     @Test
-    public void testLateAbortWithSubscriber() {
+    void testLateAbortWithSubscriber() {
         final DeferredStreamMessage<Object> m = new DeferredStreamMessage<>();
         final DefaultStreamMessage<Object> d = new DefaultStreamMessage<>();
         @SuppressWarnings("unchecked")
@@ -107,7 +107,7 @@ public class DeferredStreamMessageTest {
     }
 
     @Test
-    public void testEarlySubscription() {
+    void testEarlySubscription() {
         final DeferredStreamMessage<Object> m = new DeferredStreamMessage<>();
         final DefaultStreamMessage<Object> d = new DefaultStreamMessage<>();
         @SuppressWarnings("unchecked")
@@ -121,7 +121,7 @@ public class DeferredStreamMessageTest {
     }
 
     @Test
-    public void testLateSubscription() {
+    void testLateSubscription() {
         final DeferredStreamMessage<Object> m = new DeferredStreamMessage<>();
         final DefaultStreamMessage<Object> d = new DefaultStreamMessage<>();
 
@@ -152,7 +152,7 @@ public class DeferredStreamMessageTest {
     }
 
     @Test
-    public void testStreaming() {
+    void testStreaming() {
         final DeferredStreamMessage<String> m = new DeferredStreamMessage<>();
         final DefaultStreamMessage<String> d = new DefaultStreamMessage<>();
         m.delegate(d);
@@ -178,7 +178,7 @@ public class DeferredStreamMessageTest {
     }
 
     @Test
-    public void testStreamingError() {
+    void testStreamingError() {
         final DeferredStreamMessage<String> m = new DeferredStreamMessage<>();
         final DefaultStreamMessage<String> d = new DefaultStreamMessage<>();
         m.delegate(d);

--- a/core/src/test/java/com/linecorp/armeria/common/stream/DeferredStreamMessageVerification.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/DeferredStreamMessageVerification.java
@@ -49,9 +49,11 @@ public class DeferredStreamMessageVerification extends StreamMessageVerification
         }
 
         stream.delegate(new StreamMessageWrapper<Long>(createStreamMessage(elements + 1, false)) {
+
             @Override
             public void subscribe(
-                    Subscriber<? super Long> subscriber, EventExecutor executor, boolean withPooledObjects) {
+                    Subscriber<? super Long> subscriber, EventExecutor executor,
+                    SubscriptionOption... options) {
                 super.subscribe(new Subscriber<Long>() {
                     @Override
                     public void onSubscribe(Subscription s) {
@@ -75,7 +77,7 @@ public class DeferredStreamMessageVerification extends StreamMessageVerification
                     public void onComplete() {
                         subscriber.onComplete();
                     }
-                }, executor, withPooledObjects);
+                }, executor, options);
             }
         });
 

--- a/core/src/test/java/com/linecorp/armeria/common/stream/FilteredStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/FilteredStreamMessageTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.stream;
+
+import static com.linecorp.armeria.common.stream.StreamMessageTest.newPooledBuffer;
+import static com.linecorp.armeria.common.stream.SubscriptionOptionTest.subscriptionOptions;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.junit.Assert.fail;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.annotation.Nullable;
+
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import com.linecorp.armeria.unsafe.ByteBufHttpData;
+
+import io.netty.buffer.ByteBufHolder;
+
+class FilteredStreamMessageTest {
+
+    @Test
+    void withPooledObjects() {
+        boolean filterSupportsPooledObjects = true;
+        boolean subscribedWithPooledObjects = false;
+        int expectedRefCntInFilter = 1;
+        int expectedRefCntInOnNext = 0;
+
+        withPooledObjects(filterSupportsPooledObjects, subscribedWithPooledObjects,
+                          expectedRefCntInFilter, expectedRefCntInOnNext);
+
+        filterSupportsPooledObjects = true;
+        subscribedWithPooledObjects = true;
+        expectedRefCntInFilter = 1;
+        expectedRefCntInOnNext = 1;
+
+        withPooledObjects(filterSupportsPooledObjects, subscribedWithPooledObjects,
+                          expectedRefCntInFilter, expectedRefCntInOnNext);
+
+        filterSupportsPooledObjects = false;
+        subscribedWithPooledObjects = false;
+        expectedRefCntInFilter = 0;
+        expectedRefCntInOnNext = 0;
+
+        withPooledObjects(filterSupportsPooledObjects, subscribedWithPooledObjects,
+                          expectedRefCntInFilter, expectedRefCntInOnNext);
+
+        filterSupportsPooledObjects = false;
+        subscribedWithPooledObjects = true;
+        expectedRefCntInFilter = 0;
+        // Because filterSupportsPooledObjects is false, the data is already released even though
+        // subscribedWithPooledObjects is true.
+        expectedRefCntInOnNext = 0;
+
+        withPooledObjects(filterSupportsPooledObjects, subscribedWithPooledObjects,
+                          expectedRefCntInFilter, expectedRefCntInOnNext);
+    }
+
+    private static void withPooledObjects(
+            boolean filterSupportsPooledObjects, boolean subscribedWithPooledObjects,
+            int refCntInFilter, int refCntInOnNext) {
+        final ByteBufHttpData data = new ByteBufHttpData(newPooledBuffer(), true);
+        final DefaultStreamMessage<ByteBufHttpData> stream = new DefaultStreamMessage<>();
+        stream.write(data);
+        stream.close();
+
+        final FilteredStreamMessage<ByteBufHttpData, ByteBufHttpData> filtered =
+                new FilteredStreamMessage<ByteBufHttpData, ByteBufHttpData>(stream,
+                                                                            filterSupportsPooledObjects) {
+                    @Override
+                    protected ByteBufHttpData filter(ByteBufHttpData obj) {
+                        assertThat(data.refCnt()).isEqualTo(refCntInFilter);
+                        return obj;
+                    }
+                };
+
+        final AtomicBoolean completed = new AtomicBoolean();
+        final SubscriptionOption[] options = subscriptionOptions(subscribedWithPooledObjects);
+        filtered.subscribe(new Subscriber<ByteBufHttpData>() {
+
+            @Nullable
+            private Subscription subscription;
+
+            @Override
+            public void onSubscribe(Subscription s) {
+                subscription = s;
+                s.request(1);
+            }
+
+            @Override
+            public void onNext(ByteBufHttpData b) {
+                assertThat(data.refCnt()).isEqualTo(refCntInOnNext);
+                subscription.cancel();
+                b.release();
+                completed.set(true);
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                // This is not called because we didn't specify NOTIFY_CANCELLATION when subscribe.
+                fail();
+            }
+
+            @Override
+            public void onComplete() {
+                fail();
+            }
+        }, options);
+
+        await().untilAsserted(() -> assertThat(completed).isTrue());
+    }
+
+    @Test
+    void notifyCancellation() {
+        final ByteBufHttpData data = new ByteBufHttpData(newPooledBuffer(), true);
+        final DefaultStreamMessage<ByteBufHolder> stream = new DefaultStreamMessage<>();
+        stream.write(data);
+        stream.close();
+
+        final FilteredStreamMessage<ByteBufHolder, ByteBufHolder> filtered =
+                new FilteredStreamMessage<ByteBufHolder, ByteBufHolder>(stream) {
+                    @Override
+                    protected ByteBufHolder filter(ByteBufHolder obj) {
+                        return obj;
+                    }
+                };
+        SubscriptionOptionTest.notifyCancellation(filtered);
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageTest.java
@@ -17,9 +17,10 @@
 package com.linecorp.armeria.common.stream;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.linecorp.armeria.common.stream.SubscriptionOption.WITH_POOLED_OBJECTS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import java.util.ArrayList;
@@ -256,6 +257,7 @@ class StreamMessageTest {
 
             @Override
             public void onError(Throwable throwable) {
+                // This is not called because we didn't specify NOTIFY_CANCELLATION when subscribe.
                 fail();
             }
 
@@ -263,7 +265,7 @@ class StreamMessageTest {
             public void onComplete() {
                 fail();
             }
-        }, true);
+        }, WITH_POOLED_OBJECTS);
 
         await().untilAsserted(() -> assertThat(stream.isOpen()).isFalse());
         await().untilAsserted(() -> assertThat(data.refCnt()).isZero());
@@ -291,6 +293,7 @@ class StreamMessageTest {
 
             @Override
             public void onError(Throwable throwable) {
+                // This is not called because we didn't specify NOTIFY_CANCELLATION when subscribe.
                 fail();
             }
 
@@ -298,7 +301,7 @@ class StreamMessageTest {
             public void onComplete() {
                 fail();
             }
-        }, true);
+        }, WITH_POOLED_OBJECTS);
 
         await().untilAsserted(() -> assertThat(stream.isOpen()).isFalse());
         await().untilAsserted(() -> assertThat(data.refCnt()).isZero());
@@ -366,7 +369,7 @@ class StreamMessageTest {
         }
     }
 
-    protected static ByteBuf newPooledBuffer() {
+    static ByteBuf newPooledBuffer() {
         return PooledByteBufAllocator.DEFAULT.buffer().writeByte(0);
     }
 

--- a/core/src/test/java/com/linecorp/armeria/common/stream/SubscriptionOptionTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/SubscriptionOptionTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.stream;
+
+import static com.linecorp.armeria.common.stream.StreamMessageTest.newPooledBuffer;
+import static com.linecorp.armeria.common.stream.SubscriptionOption.NOTIFY_CANCELLATION;
+import static com.linecorp.armeria.common.stream.SubscriptionOption.WITH_POOLED_OBJECTS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.params.provider.Arguments.of;
+
+import java.util.ArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Stream;
+
+import javax.annotation.Nullable;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import com.linecorp.armeria.unsafe.ByteBufHttpData;
+
+import io.netty.buffer.ByteBufHolder;
+
+class SubscriptionOptionTest {
+
+    @ParameterizedTest
+    @ArgumentsSource(ByteBufHolderStreamProvider.class)
+    void withPooledObjects_true(ByteBufHolder data, StreamMessage<ByteBufHolder> stream) {
+        final boolean withPooledObjects = true;
+        final int expectedRefCnt = 1;
+
+        withPooledObjects(data, stream, withPooledObjects, expectedRefCnt);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ByteBufHolderStreamProvider.class)
+    void withPooledObjects_false(ByteBufHolder data, StreamMessage<ByteBufHolder> stream) {
+        final boolean withPooledObjects = false;
+        final int expectedRefCnt = 0;
+
+        withPooledObjects(data, stream, withPooledObjects, expectedRefCnt);
+    }
+
+    private static void withPooledObjects(ByteBufHolder data, StreamMessage<ByteBufHolder> stream,
+                                          boolean withPooledObjects, int expectedRefCnt) {
+        final AtomicBoolean completed = new AtomicBoolean();
+        stream.subscribe(new Subscriber<ByteBufHolder>() {
+            @Nullable
+            Subscription subscription;
+
+            @Override
+            public void onSubscribe(Subscription subscription) {
+                this.subscription = subscription;
+                subscription.request(1);
+            }
+
+            @Override
+            public void onNext(ByteBufHolder b) {
+                assertThat(data.refCnt()).isEqualTo(expectedRefCnt);
+                subscription.cancel();
+                b.release();
+                completed.set(true);
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                // This is not called because we didn't specify NOTIFY_CANCELLATION when subscribe.
+                fail();
+            }
+
+            @Override
+            public void onComplete() {
+                fail();
+            }
+        }, subscriptionOptions(withPooledObjects));
+
+        await().untilAsserted(() -> assertThat(completed).isTrue());
+        assertThat(data.refCnt()).isZero();
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ByteBufHolderStreamProvider.class)
+    void notifyCancellation(ByteBufHolder unused, StreamMessage<ByteBufHolder> stream) {
+        notifyCancellation(stream);
+    }
+
+    static void notifyCancellation(StreamMessage<ByteBufHolder> stream) {
+        final AtomicBoolean completed = new AtomicBoolean();
+        stream.subscribe(new Subscriber<ByteBufHolder>() {
+            @Override
+            public void onSubscribe(Subscription s) {
+                s.cancel();
+            }
+
+            @Override
+            public void onNext(ByteBufHolder b) {
+                fail();
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                assertThat(t).isInstanceOf(CancelledSubscriptionException.class);
+                completed.set(true);
+            }
+
+            @Override
+            public void onComplete() {
+                fail();
+            }
+        }, NOTIFY_CANCELLATION);
+
+        await().untilAsserted(() -> assertThat(completed).isTrue());
+        await().untilAsserted(() -> assertThat(stream.completionFuture().isCompletedExceptionally()));
+    }
+
+    static SubscriptionOption[] subscriptionOptions(boolean subscribedWithPooledObjects) {
+        final ArrayList<SubscriptionOption> options = new ArrayList<>(1);
+        if (subscribedWithPooledObjects) {
+            options.add(WITH_POOLED_OBJECTS);
+        }
+        return options.toArray(new SubscriptionOption[0]);
+    }
+
+    private static class ByteBufHolderStreamProvider implements ArgumentsProvider {
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+            return Stream.of(defaultStream(), fixedStream(), deferredStream());
+        }
+
+        private static Arguments defaultStream() {
+            final DefaultStreamMessage<ByteBufHolder> defaultStream = new DefaultStreamMessage<>();
+            final ByteBufHttpData data = new ByteBufHttpData(newPooledBuffer(), true);
+            defaultStream.write(data);
+            defaultStream.close();
+            return of(data, defaultStream);
+        }
+
+        private static Arguments fixedStream() {
+            final ByteBufHttpData data = new ByteBufHttpData(newPooledBuffer(), true);
+            final StreamMessage<ByteBufHttpData> fixedStream = StreamMessage.of(data);
+            return of(data, fixedStream);
+        }
+
+        private static Arguments deferredStream() {
+            final DeferredStreamMessage<ByteBufHttpData> deferredStream = new DeferredStreamMessage<>();
+            final DefaultStreamMessage<ByteBufHttpData> d = new DefaultStreamMessage<>();
+            deferredStream.delegate(d);
+            final ByteBufHttpData data = new ByteBufHttpData(newPooledBuffer(), true);
+            d.write(data);
+            d.close();
+            return of(data, deferredStream);
+        }
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/common/stream/TwoElementFixedStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/TwoElementFixedStreamMessageTest.java
@@ -16,11 +16,12 @@
 
 package com.linecorp.armeria.common.stream;
 
+import static com.linecorp.armeria.common.stream.SubscriptionOption.WITH_POOLED_OBJECTS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import javax.annotation.Nullable;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
@@ -30,27 +31,29 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.util.ReferenceCountUtil;
 
-public class TwoElementFixedStreamMessageTest {
+class TwoElementFixedStreamMessageTest {
 
     @Test
-    public void cancelOnFirstElement() {
+    void cancelOnFirstElement() {
         final ByteBuf obj1 = newBuffer("obj1");
         final ByteBuf obj2 = newBuffer("obj2");
         final TwoElementFixedStreamMessage<ByteBuf> streamMessage =
                 new TwoElementFixedStreamMessage<>(obj1, obj2);
-        streamMessage.subscribe(new CancelSubscriber(1), EventLoopGroups.directEventLoop(), true);
+        streamMessage.subscribe(new CancelSubscriber(1), EventLoopGroups.directEventLoop(),
+                                WITH_POOLED_OBJECTS);
 
         assertThat(obj1.refCnt()).isZero();
         assertThat(obj2.refCnt()).isZero();
     }
 
     @Test
-    public void cancelOnSecondElement() {
+    void cancelOnSecondElement() {
         final ByteBuf obj1 = newBuffer("obj1");
         final ByteBuf obj2 = newBuffer("obj2");
         final TwoElementFixedStreamMessage<ByteBuf> streamMessage =
                 new TwoElementFixedStreamMessage<>(obj1, obj2);
-        streamMessage.subscribe(new CancelSubscriber(2), EventLoopGroups.directEventLoop(), true);
+        streamMessage.subscribe(new CancelSubscriber(2), EventLoopGroups.directEventLoop(),
+                                WITH_POOLED_OBJECTS);
 
         assertThat(obj1.refCnt()).isZero();
         assertThat(obj2.refCnt()).isZero();

--- a/examples/proxy-server/src/main/java/example/armeria/proxy/ProxyService.java
+++ b/examples/proxy-server/src/main/java/example/armeria/proxy/ProxyService.java
@@ -16,11 +16,11 @@ import com.linecorp.armeria.client.endpoint.healthcheck.HttpHealthCheckedEndpoin
 import com.linecorp.armeria.client.logging.LoggingClient;
 import com.linecorp.armeria.common.FilteredHttpResponse;
 import com.linecorp.armeria.common.HttpHeaderNames;
-import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpObject;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.server.AbstractHttpService;
 import com.linecorp.armeria.server.ServiceRequestContext;
@@ -138,10 +138,10 @@ public final class ProxyService extends AbstractHttpService {
             @Override
             protected HttpObject filter(HttpObject obj) {
                 // You can remove or add specific headers to a response.
-                if (obj instanceof HttpHeaders) {
-                    return ((HttpHeaders) obj).toBuilder()
-                                              .add(HttpHeaderNames.VIA, viaHeaderValue)
-                                              .build();
+                if (obj instanceof ResponseHeaders) {
+                    return ((ResponseHeaders) obj).toBuilder()
+                                                  .add(HttpHeaderNames.VIA, viaHeaderValue)
+                                                  .build();
                 }
                 return obj;
             }

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaClientCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaClientCall.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.client.grpc;
 
+import static com.linecorp.armeria.common.stream.SubscriptionOption.WITH_POOLED_OBJECTS;
 import static java.util.Objects.requireNonNull;
 
 import java.util.concurrent.CancellationException;
@@ -173,7 +174,7 @@ class ArmeriaClientCall<I, O> extends ClientCall<I, O>
             close(GrpcStatus.fromThrowable(e), new Metadata());
             return;
         }
-        res.subscribe(responseReader, ctx.eventLoop(), true);
+        res.subscribe(responseReader, ctx.eventLoop(), WITH_POOLED_OBJECTS);
         res.completionFuture().handleAsync(responseReader, ctx.eventLoop());
     }
 

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.server.grpc;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.linecorp.armeria.common.stream.SubscriptionOption.WITH_POOLED_OBJECTS;
 import static java.util.Objects.requireNonNull;
 
 import java.time.Duration;
@@ -179,7 +180,7 @@ public final class GrpcService extends AbstractHttpService
                 methodName, method, ctx, req.headers(), res, serializationFormat);
         if (call != null) {
             ctx.setRequestTimeoutHandler(() -> call.close(Status.DEADLINE_EXCEEDED, new Metadata()));
-            req.subscribe(call.messageReader(), ctx.eventLoop(), true);
+            req.subscribe(call.messageReader(), ctx.eventLoop(), WITH_POOLED_OBJECTS);
             req.completionFuture().handleAsync(call.messageReader(), ctx.eventLoop());
         }
         return res;

--- a/site/src/sphinx/client-thrift.rst
+++ b/site/src/sphinx/client-thrift.rst
@@ -74,7 +74,7 @@ You can also use the builder pattern for client construction:
 
     HelloService.Iface helloService = new ClientBuilder("tbinary+http://127.0.0.1:8080/hello")
             .responseTimeoutMillis(10000)
-            .decorator(LoggingClient.newDecorator())
+            .rpcDecorator(LoggingClient.newDecorator())
             .build(HelloService.Iface.class); // or AsyncIface.class
 
     String greeting = helloService.hello("Armerian World");

--- a/site/src/sphinx/server-annotated-service.rst
+++ b/site/src/sphinx/server-annotated-service.rst
@@ -348,7 +348,6 @@ Other classes automatically injected
 
 The following classes are automatically injected when you specify them on the parameter list of your method.
 
--
 - :api:`ServiceRequestContext` (or :api:`RequestContext`)
 - :api:`RequestHeaders` (or :api:`HttpHeaders`)
 - :api:`HttpRequest` (or :api:`Request`)


### PR DESCRIPTION
Motivation:
Currently, `Subscriber.onError(cause)` is not invoked when a `StreamMessage` is canceled.
This is because the subscriber is able to handle the situation after canceling the `StreamMessage`
so that it does not have to wait for `Subscriber.onError(cause)`.
However, if we provide an option which calls `Subscriber.onError(cause)` with the `CancelledSusbscriptionException`,
the user might set the ending logic in the `onError` method.

Modifications:
- Add `SubscriptionOption` to specify when calling `StreamMessage.subscribe()`.
  - `WITH_POOLED_OBJECTS`: to receive pooled `ByteBuf` and `ByteBufHolder`.
  - `NOTIFY_CANCELLATION`: to get notified by `Subscriber.onError(cause)` when canceling.
- Deprecated
  - `StreamMessage.subscribe(..., withPooledObject)` -> `StreamMessage.subscribe(..., SubscriptionOption.WITH_POOLED_OBJECTS)`

Result:
- You can now get notified in `Subscriber.onError(cause)` when you cancel the `StreamMessage`.
- Close #1700