### PR TITLE
Automatically enable MockitoExtension in JUnit 5 tests.

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -383,7 +383,8 @@ org.jsoup:
   jsoup: { version: '1.12.1' }
 
 org.mockito:
-  mockito-core: { version: '2.27.0' }
+  mockito-core: { version: &MOCKITO_VERSION '2.27.0' }
+  mockito-junit-jupiter: { version: *MOCKITO_VERSION }
 
 org.mortbay.jetty.alpn:
   jetty-alpn-agent: { version: '2.0.9' }

--- a/testing-internal/build.gradle
+++ b/testing-internal/build.gradle
@@ -5,4 +5,5 @@ dependencies {
     compile 'org.apache.httpcomponents:httpclient'
     compile 'org.assertj:assertj-core'
     compile 'org.junit.jupiter:junit-jupiter-params'
+    compile 'org.mockito:mockito-junit-jupiter'
 }

--- a/testing-internal/src/main/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/testing-internal/src/main/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,1 @@
+org.mockito.junit.jupiter.MockitoExtension

--- a/testing-internal/src/main/resources/junit-platform.properties
+++ b/testing-internal/src/main/resources/junit-platform.properties
@@ -1,0 +1,1 @@
+junit.jupiter.extensions.autodetection.enabled = true


### PR DESCRIPTION
We commonly use mockito in tests so it should make sense to always have it enabled for junit5 tests. This change ensures it's always as easy (or easier) to write a junit5 test as junit4 in the codebase.

Migrated one test to demonstrate it works.

This extension defaults to mockito's strict stubs setting - `@MockitoSettings` can be applied to disable this. But Mockito seems to strongly recommend this and is going to default it in mockito 3 because it removes the needs to set stubs, then verify them - verification happens automatically with the strict stubs setting.