### PR TITLE
Add docs proxy prefix in WEBPACK_SERVE mode of docs-client

### DIFF
--- a/docs-client/README.md
+++ b/docs-client/README.md
@@ -18,21 +18,25 @@ $ ./gradlew :docs-client:yarn_run_start --no-daemon
 ```
 
 This will usually not be useful since without a server running, the client does not have any spec it can render.
-You can have server calls proxied to a running Armeria server by specifying the `PROXY_PORT` environment
-variable, e.g.,
+You can have server calls proxied to a running Armeria server by specifying environment variables.
+
+* `PROXY_PORT`: Armeria server port (default: 8080)
+* `PROXY_DOC_PREFIX`: Armeria server DocService path prefix (default: '/docs')
+
+e.g.
 
 ```bash
-$ PROXY_PORT=51234 yarn run start
+$ PROXY_PORT=51234 PROXY_DOC_PREFIX='/documentation' yarn run start
 ```
 
 or with Gradle
 
 ```bash
-$ PROXY_PORT=51234 ./gradlew :docs-client:yarn_run_start --no-daemon
+$ PROXY_PORT=51234  PROXY_DOC_PREFIX='/documentation' ./gradlew :docs-client:yarn_run_start --no-daemon
 ```
 
 Replacing the port of a docs page in the running server with `3000` will use the dev server to render while
-proxying all server calls to the actual Armeria server.
+proxying all server calls to the actual Armeria server port and docs path.
 
 ## Updating licenses
 

--- a/docs-client/scripts/serve.ts
+++ b/docs-client/scripts/serve.ts
@@ -42,10 +42,13 @@ async function historyFallback(ctx: any, next: any) {
 }
 
 const proxyPort = process.env.PROXY_PORT || '8080';
+const proxyDocPrefix = process.env.PROXY_DOC_PREFIX || '/docs';
 
 const proxier = proxy('/', {
   target: `http://127.0.0.1:${proxyPort}`,
   changeOrigin: true,
+  logs: process.env.WEBPACK_SERVE,
+  rewrite: (path: string) => `${proxyDocPrefix}${path}`,
 });
 
 async function proxyToApi(ctx: any, next: any) {

--- a/docs-client/scripts/serve.ts
+++ b/docs-client/scripts/serve.ts
@@ -47,7 +47,7 @@ const proxyDocPrefix = process.env.PROXY_DOC_PREFIX || '/docs';
 const proxier = proxy('/', {
   target: `http://127.0.0.1:${proxyPort}`,
   changeOrigin: true,
-  logs: process.env.WEBPACK_SERVE,
+  logs: !!process.env.WEBPACK_SERVE,
   rewrite: (path: string) => `${proxyDocPrefix}${path}`,
 });
 


### PR DESCRIPTION
Motivation
* Current Armeria server is able to set prefix of `DocService`,
  but docs-client with `WEBPACK_SERVE` mode can't set prefix to proxy to DocService.

Modification
* Add `PROXY_DOC_PREFIX` evironment variable with default value of '/docs'.
* Enable proxy logs when `WEBPACK_SERV` is true for better debug experience.
* Add rewrite rule in proxy to set prefix path.

Result
* We can control proxy doc prefix using the evironment variable `PROXY_DOC_PREFIX` in WEBPACK_SERVE mode.

