### PR TITLE
Add `PrometheusMeterRegistries.configureRegistry()`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/metric/DropwizardMeterRegistries.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/DropwizardMeterRegistries.java
@@ -136,15 +136,16 @@ public final class DropwizardMeterRegistries {
             }
         };
 
-        configureRegistry(meterRegistry);
-        return meterRegistry;
+        return configureRegistry(meterRegistry);
     }
 
     /**
      * Configures the {@link DropwizardMeterRegistry} with Armeria's defaults. Useful when using a different
      * implementation of {@link DropwizardMeterRegistry}, e.g., a {@code JmxMeterRegistry}.
+     *
+     * @return the specified {@link DropwizardMeterRegistry}
      */
-    public static void configureRegistry(DropwizardMeterRegistry meterRegistry) {
+    public static <T extends DropwizardMeterRegistry> T configureRegistry(T meterRegistry) {
         requireNonNull(meterRegistry, "meterRegistry");
         meterRegistry.config().meterFilter(new MeterFilter() {
             @Override
@@ -160,6 +161,7 @@ public final class DropwizardMeterRegistries {
         });
         meterRegistry.config().namingConvention(MoreNamingConventions.dropwizard());
         meterRegistry.config().pauseDetector(new NoPauseDetector());
+        return meterRegistry;
     }
 
     private DropwizardMeterRegistries() {}

--- a/core/src/main/java/com/linecorp/armeria/common/metric/PrometheusMeterRegistries.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/PrometheusMeterRegistries.java
@@ -59,6 +59,16 @@ public final class PrometheusMeterRegistries {
     public static PrometheusMeterRegistry newRegistry(CollectorRegistry registry, Clock clock) {
         final PrometheusMeterRegistry meterRegistry = new PrometheusMeterRegistry(
                 PrometheusConfig.DEFAULT, requireNonNull(registry, "registry"), requireNonNull(clock, "clock"));
+        return configureRegistry(meterRegistry);
+    }
+
+    /**
+     * Configures the {@link PrometheusMeterRegistry} with Armeria's defaults.
+     *
+     * @return the specified {@link PrometheusMeterRegistry}
+     */
+    public static <T extends PrometheusMeterRegistry> T configureRegistry(T meterRegistry) {
+        requireNonNull(meterRegistry, "meterRegistry");
         meterRegistry.config().namingConvention(MoreNamingConventions.prometheus());
         meterRegistry.config().pauseDetector(new NoPauseDetector());
         return meterRegistry;


### PR DESCRIPTION
Motivation:

`DropwizardMeterRegistries` has `configureRegistry()` while
`PrometheusMeterRegistries` does not.

Modifications:

- Add `PrometheusMeterRegistries.configureRegistry()`
- Allow method chaining for `configureRegistry()`

Result:

- Consistency
- Convenience