### PR TITLE
Add unit test that uses gRPC Context.

### DIFF
--- a/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/test.proto
+++ b/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/test.proto
@@ -139,7 +139,10 @@ service UnitTestService {
     rpc ErrorReplaceException(SimpleRequest) returns (SimpleResponse);
 
     // A call that has an error with extra metadata attached to it.
-    rpc ErrorAdditionalMetadata(SimpleRequest) returns(SimpleResponse);
+    rpc ErrorAdditionalMetadata(SimpleRequest) returns (SimpleResponse);
+
+    // A call where we check an interceptor correctly set a context value.
+    rpc GrpcContext(SimpleRequest) returns (SimpleResponse);
 }
 
 // A simple service NOT implemented at servers so clients can test for


### PR DESCRIPTION
While looking into gRPC context, I noticed the implementation is very similar to Armeria's, using a thread-local. So didn't find any reason not to work, and at least this example seems to be working ok. Let's add the test for now and follow up on what use cases don't work.

/cc @andrewoma 