### PR TITLE
RequestMetricSupport: use Micrometer dotted notation in metric names

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/metric/MoreNamingConventions.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/MoreNamingConventions.java
@@ -37,6 +37,7 @@ import io.micrometer.prometheus.PrometheusNamingConvention;
 /**
  * Provides commonly-used {@link NamingConvention}s.
  */
+@Deprecated
 public final class MoreNamingConventions {
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/metric/PrometheusMeterRegistries.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/PrometheusMeterRegistries.java
@@ -69,7 +69,6 @@ public final class PrometheusMeterRegistries {
      */
     public static <T extends PrometheusMeterRegistry> T configureRegistry(T meterRegistry) {
         requireNonNull(meterRegistry, "meterRegistry");
-        meterRegistry.config().namingConvention(MoreNamingConventions.prometheus());
         meterRegistry.config().pauseDetector(new NoPauseDetector());
         return meterRegistry;
     }

--- a/core/src/main/java/com/linecorp/armeria/internal/metric/RequestMetricSupport.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/metric/RequestMetricSupport.java
@@ -66,7 +66,7 @@ public final class RequestMetricSupport {
         final RequestContext ctx = log.context();
         final MeterRegistry registry = ctx.meterRegistry();
         final MeterIdPrefix activeRequestsId = meterIdPrefixFunction.activeRequestPrefix(registry, log)
-                                                                    .append("activeRequests");
+                                                                    .append("active.requests");
 
         final ActiveRequestMetrics activeRequestMetrics = MicrometerUtil.register(
                 registry, activeRequestsId, ActiveRequestMetrics.class,
@@ -231,15 +231,15 @@ public final class RequestMetricSupport {
             failure = parent.counter(requests, idPrefix.tags("result", "failure"));
 
             requestDuration = newTimer(
-                    parent, idPrefix.name("requestDuration"), idPrefix.tags());
+                    parent, idPrefix.name("request.duration"), idPrefix.tags());
             requestLength = newDistributionSummary(
-                    parent, idPrefix.name("requestLength"), idPrefix.tags());
+                    parent, idPrefix.name("request.length"), idPrefix.tags());
             responseDuration = newTimer(
-                    parent, idPrefix.name("responseDuration"), idPrefix.tags());
+                    parent, idPrefix.name("response.duration"), idPrefix.tags());
             responseLength = newDistributionSummary(
-                    parent, idPrefix.name("responseLength"), idPrefix.tags());
+                    parent, idPrefix.name("response.length"), idPrefix.tags());
             totalDuration = newTimer(
-                    parent, idPrefix.name("totalDuration"), idPrefix.tags());
+                    parent, idPrefix.name("total.duration"), idPrefix.tags());
         }
 
         @Override
@@ -305,11 +305,11 @@ public final class RequestMetricSupport {
             this.idPrefix = idPrefix;
 
             connectionAcquisitionDuration = newTimer(
-                    parent, idPrefix.name("connectionAcquisitionDuration"), idPrefix.tags());
-            dnsResolutionDuration = newTimer(parent, idPrefix.name("dnsResolutionDuration"), idPrefix.tags());
-            socketConnectDuration = newTimer(parent, idPrefix.name("socketConnectDuration"), idPrefix.tags());
+                    parent, idPrefix.name("connection.acquisition.duration"), idPrefix.tags());
+            dnsResolutionDuration = newTimer(parent, idPrefix.name("dns.resolution.duration"), idPrefix.tags());
+            socketConnectDuration = newTimer(parent, idPrefix.name("socket.connect.duration"), idPrefix.tags());
             pendingAcquisitionDuration = newTimer(
-                    parent, idPrefix.name("pendingAcquisitionDuration"), idPrefix.tags());
+                    parent, idPrefix.name("pending.acquisition.duration"), idPrefix.tags());
 
             final String timeouts = idPrefix.name("timeouts");
             writeTimeouts = parent.counter(timeouts, idPrefix.tags("cause", "WriteTimeoutException"));
@@ -323,7 +323,7 @@ public final class RequestMetricSupport {
                 return actualRequests;
             }
 
-            final Counter counter = parent.counter(idPrefix.name("actualRequests"), idPrefix.tags());
+            final Counter counter = parent.counter(idPrefix.name("actual.requests"), idPrefix.tags());
             if (actualRequestsUpdater.compareAndSet(this, null, counter)) {
                 return counter;
             }

--- a/core/src/test/java/com/linecorp/armeria/internal/metric/RequestMetricSupportTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/metric/RequestMetricSupportTest.java
@@ -59,7 +59,7 @@ public class RequestMetricSupportTest {
         ctx.logBuilder().requestLength(123);
 
         Map<String, Double> measurements = measureAll(registry);
-        assertThat(measurements).containsEntry("foo.activeRequests#value{method=POST}", 1.0);
+        assertThat(measurements).containsEntry("foo.active.requests#value{method=POST}", 1.0);
 
         ctx.logBuilder().responseHeaders(ResponseHeaders.of(200));
         ctx.logBuilder().responseLength(456);
@@ -68,27 +68,27 @@ public class RequestMetricSupportTest {
         ctx.logBuilder().endResponse();
 
         measurements = measureAll(registry);
-        assertThat(measurements).containsEntry("foo.activeRequests#value{method=POST}", 0.0)
+        assertThat(measurements).containsEntry("foo.active.requests#value{method=POST}", 0.0)
                                 .containsEntry("foo.requests#count{httpStatus=200,method=POST,result=success}",
                                                1.0)
                                 .containsEntry("foo.requests#count{httpStatus=200,method=POST,result=failure}",
                                                0.0)
-                                .containsEntry("foo.connectionAcquisitionDuration#count{httpStatus=200," +
+                                .containsEntry("foo.connection.acquisition.duration#count{httpStatus=200," +
                                                "method=POST}", 1.0)
-                                .containsEntry("foo.dnsResolutionDuration#count{httpStatus=200," +
+                                .containsEntry("foo.dns.resolution.duration#count{httpStatus=200," +
                                                "method=POST}", 1.0)
-                                .containsEntry("foo.socketConnectDuration#count{httpStatus=200," +
+                                .containsEntry("foo.socket.connect.duration#count{httpStatus=200," +
                                                "method=POST}", 1.0)
-                                .containsEntry("foo.pendingAcquisitionDuration#count{httpStatus=200," +
+                                .containsEntry("foo.pending.acquisition.duration#count{httpStatus=200," +
                                                "method=POST}", 1.0)
-                                .containsEntry("foo.requestLength#count{httpStatus=200,method=POST}", 1.0)
-                                .containsEntry("foo.requestLength#total{httpStatus=200,method=POST}", 123.0)
-                                .containsEntry("foo.responseDuration#count{httpStatus=200,method=POST}", 1.0)
-                                .containsEntry("foo.responseLength#count{httpStatus=200,method=POST}", 1.0)
-                                .containsEntry("foo.responseLength#total{httpStatus=200,method=POST}", 456.0)
-                                .containsEntry("foo.totalDuration#count{httpStatus=200,method=POST}", 1.0)
+                                .containsEntry("foo.request.length#count{httpStatus=200,method=POST}", 1.0)
+                                .containsEntry("foo.request.length#total{httpStatus=200,method=POST}", 123.0)
+                                .containsEntry("foo.response.duration#count{httpStatus=200,method=POST}", 1.0)
+                                .containsEntry("foo.response.length#count{httpStatus=200,method=POST}", 1.0)
+                                .containsEntry("foo.response.length#total{httpStatus=200,method=POST}", 456.0)
+                                .containsEntry("foo.total.duration#count{httpStatus=200,method=POST}", 1.0)
                                 // This metric is inserted only when RetryingClient is Used.
-                                .doesNotContainKey("foo.actualRequests#count{httpStatus=200,method=POST}");
+                                .doesNotContainKey("foo.actual.requests#count{httpStatus=200,method=POST}");
     }
 
     private static void setConnectionTimings(ClientRequestContext ctx) {
@@ -115,14 +115,14 @@ public class RequestMetricSupportTest {
         ctx.logBuilder().endResponse();
 
         final Map<String, Double> measurements = measureAll(registry);
-        assertThat(measurements).containsEntry("foo.activeRequests#value{method=POST}", 0.0)
+        assertThat(measurements).containsEntry("foo.active.requests#value{method=POST}", 0.0)
                                 .containsEntry("foo.requests#count{httpStatus=500,method=POST,result=success}",
                                                0.0)
                                 .containsEntry("foo.requests#count{httpStatus=500,method=POST,result=failure}",
                                                1.0)
-                                .containsEntry("foo.responseDuration#count{httpStatus=500,method=POST}", 1.0)
-                                .containsEntry("foo.responseLength#count{httpStatus=500,method=POST}", 1.0)
-                                .containsEntry("foo.totalDuration#count{httpStatus=500,method=POST}", 1.0);
+                                .containsEntry("foo.response.duration#count{httpStatus=500,method=POST}", 1.0)
+                                .containsEntry("foo.response.length#count{httpStatus=500,method=POST}", 1.0)
+                                .containsEntry("foo.total.duration#count{httpStatus=500,method=POST}", 1.0);
     }
 
     @Test
@@ -133,36 +133,36 @@ public class RequestMetricSupportTest {
         addLogInfoInDerivedCtx(ctx);
 
         Map<String, Double> measurements = measureAll(registry);
-        assertThat(measurements).containsEntry("foo.activeRequests#value{method=POST}", 1.0);
+        assertThat(measurements).containsEntry("foo.active.requests#value{method=POST}", 1.0);
 
         addLogInfoInDerivedCtx(ctx);
         // Does not increase the active requests.
-        assertThat(measurements).containsEntry("foo.activeRequests#value{method=POST}", 1.0);
+        assertThat(measurements).containsEntry("foo.active.requests#value{method=POST}", 1.0);
 
         ctx.logBuilder().endResponseWithLastChild();
 
         measurements = measureAll(registry);
-        assertThat(measurements).containsEntry("foo.activeRequests#value{method=POST}", 0.0)
+        assertThat(measurements).containsEntry("foo.active.requests#value{method=POST}", 0.0)
                                 .containsEntry("foo.requests#count{httpStatus=500,method=POST,result=success}",
                                                0.0)
                                 .containsEntry("foo.requests#count{httpStatus=500,method=POST,result=failure}",
                                                1.0)
-                                .containsEntry("foo.actualRequests#count{httpStatus=500,method=POST}",
+                                .containsEntry("foo.actual.requests#count{httpStatus=500,method=POST}",
                                                2.0)
-                                .containsEntry("foo.connectionAcquisitionDuration#count{httpStatus=500," +
+                                .containsEntry("foo.connection.acquisition.duration#count{httpStatus=500," +
                                                "method=POST}", 1.0)
-                                .containsEntry("foo.dnsResolutionDuration#count{httpStatus=500," +
+                                .containsEntry("foo.dns.resolution.duration#count{httpStatus=500," +
                                                "method=POST}", 1.0)
-                                .containsEntry("foo.socketConnectDuration#count{httpStatus=500," +
+                                .containsEntry("foo.socket.connect.duration#count{httpStatus=500," +
                                                "method=POST}", 1.0)
-                                .containsEntry("foo.pendingAcquisitionDuration#count{httpStatus=500," +
+                                .containsEntry("foo.pending.acquisition.duration#count{httpStatus=500," +
                                                "method=POST}", 1.0)
-                                .containsEntry("foo.requestLength#count{httpStatus=500,method=POST}", 1.0)
-                                .containsEntry("foo.requestLength#total{httpStatus=500,method=POST}", 123.0)
-                                .containsEntry("foo.responseDuration#count{httpStatus=500,method=POST}", 1.0)
-                                .containsEntry("foo.responseLength#count{httpStatus=500,method=POST}", 1.0)
-                                .containsEntry("foo.responseLength#total{httpStatus=500,method=POST}", 456.0)
-                                .containsEntry("foo.totalDuration#count{httpStatus=500,method=POST}", 1.0);
+                                .containsEntry("foo.request.length#count{httpStatus=500,method=POST}", 1.0)
+                                .containsEntry("foo.request.length#total{httpStatus=500,method=POST}", 123.0)
+                                .containsEntry("foo.response.duration#count{httpStatus=500,method=POST}", 1.0)
+                                .containsEntry("foo.response.length#count{httpStatus=500,method=POST}", 1.0)
+                                .containsEntry("foo.response.length#total{httpStatus=500,method=POST}", 456.0)
+                                .containsEntry("foo.total.duration#count{httpStatus=500,method=POST}", 1.0);
     }
 
     @Test
@@ -176,7 +176,7 @@ public class RequestMetricSupportTest {
         ctx.logBuilder().endResponse(ResponseTimeoutException.get());
 
         final Map<String, Double> measurements = measureAll(registry);
-        assertThat(measurements).containsEntry("foo.activeRequests#value{method=POST}", 0.0)
+        assertThat(measurements).containsEntry("foo.active.requests#value{method=POST}", 0.0)
                                 .containsEntry("foo.requests#count{httpStatus=0,method=POST,result=success}",
                                                0.0)
                                 .containsEntry("foo.requests#count{httpStatus=0,method=POST,result=failure}",
@@ -185,9 +185,9 @@ public class RequestMetricSupportTest {
                                                "httpStatus=0,method=POST}", 0.0)
                                 .containsEntry("foo.timeouts#count{cause=ResponseTimeoutException," +
                                                "httpStatus=0,method=POST}", 1.0)
-                                .containsEntry("foo.responseDuration#count{httpStatus=0,method=POST}", 1.0)
-                                .containsEntry("foo.responseLength#count{httpStatus=0,method=POST}", 1.0)
-                                .containsEntry("foo.totalDuration#count{httpStatus=0,method=POST}", 1.0);
+                                .containsEntry("foo.response.duration#count{httpStatus=0,method=POST}", 1.0)
+                                .containsEntry("foo.response.length#count{httpStatus=0,method=POST}", 1.0)
+                                .containsEntry("foo.total.duration#count{httpStatus=0,method=POST}", 1.0);
     }
 
     @Test
@@ -199,7 +199,7 @@ public class RequestMetricSupportTest {
         ctx.logBuilder().endResponse(WriteTimeoutException.get());
 
         final Map<String, Double> measurements = measureAll(registry);
-        assertThat(measurements).containsEntry("foo.activeRequests#value{method=POST}", 0.0)
+        assertThat(measurements).containsEntry("foo.active.requests#value{method=POST}", 0.0)
                                 .containsEntry("foo.requests#count{httpStatus=0,method=POST,result=success}",
                                                0.0)
                                 .containsEntry("foo.requests#count{httpStatus=0,method=POST,result=failure}",
@@ -208,9 +208,9 @@ public class RequestMetricSupportTest {
                                                "httpStatus=0,method=POST}", 1.0)
                                 .containsEntry("foo.timeouts#count{cause=ResponseTimeoutException," +
                                                "httpStatus=0,method=POST}", 0.0)
-                                .containsEntry("foo.responseDuration#count{httpStatus=0,method=POST}", 0.0)
-                                .containsEntry("foo.responseLength#count{httpStatus=0,method=POST}", 0.0)
-                                .containsEntry("foo.totalDuration#count{httpStatus=0,method=POST}", 0.0);
+                                .containsEntry("foo.response.duration#count{httpStatus=0,method=POST}", 0.0)
+                                .containsEntry("foo.response.length#count{httpStatus=0,method=POST}", 0.0)
+                                .containsEntry("foo.total.duration#count{httpStatus=0,method=POST}", 0.0);
     }
 
     private static ClientRequestContext setupClientRequestCtx(MeterRegistry registry) {
@@ -267,7 +267,7 @@ public class RequestMetricSupportTest {
 
         final Map<String, Double> measurements = measureAll(registry);
         assertThat(measurements)
-                .containsEntry("foo.activeRequests#value{hostnamePattern=*,method=POST," +
+                .containsEntry("foo.active.requests#value{hostnamePattern=*,method=POST," +
                                "route=exact:/foo}", 0.0)
                 .containsEntry("foo.requests#count{hostnamePattern=*,httpStatus=503,method=POST," +
                                "result=success,route=exact:/foo}", 0.0)
@@ -275,11 +275,11 @@ public class RequestMetricSupportTest {
                                "result=failure,route=exact:/foo}", 1.0)
                 .containsEntry("foo.timeouts#count{cause=RequestTimeoutException,hostnamePattern=*," +
                                "httpStatus=503,method=POST,route=exact:/foo}", 1.0)
-                .containsEntry("foo.responseDuration#count{hostnamePattern=*,httpStatus=503,method=POST," +
+                .containsEntry("foo.response.duration#count{hostnamePattern=*,httpStatus=503,method=POST," +
                                "route=exact:/foo}", 1.0)
-                .containsEntry("foo.responseLength#count{hostnamePattern=*,httpStatus=503,method=POST," +
+                .containsEntry("foo.response.length#count{hostnamePattern=*,httpStatus=503,method=POST," +
                                "route=exact:/foo}", 1.0)
-                .containsEntry("foo.totalDuration#count{hostnamePattern=*,httpStatus=503,method=POST," +
+                .containsEntry("foo.total.duration#count{hostnamePattern=*,httpStatus=503,method=POST," +
                                "route=exact:/foo}", 1.0);
     }
 
@@ -301,6 +301,6 @@ public class RequestMetricSupportTest {
         ctx.logBuilder().requestFirstBytesTransferred();
         ctx.logBuilder().requestContent(new DefaultRpcRequest(Object.class, "baz"), null);
 
-        assertThat(measureAll(registry)).containsEntry("bar.activeRequests#value{method=baz}", 1.0);
+        assertThat(measureAll(registry)).containsEntry("bar.active.requests#value{method=baz}", 1.0);
     }
 }

--- a/thrift/src/test/java/com/linecorp/armeria/it/metric/DropwizardMetricsIntegrationTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/metric/DropwizardMetricsIntegrationTest.java
@@ -94,8 +94,6 @@ public class DropwizardMetricsIntegrationTest {
             assertThat(dropwizardRegistry.getMeters()
                                          .get(clientMetricNameWithStatusAndResult("requests", 200, "failure"))
                                          .getCount()).isEqualTo(3L);
-            System.err.println(dropwizardRegistry.getMeters());
-            System.err.println(serverMetricNameWithStatusAndResult("requests", 200, "failure"));
             assertThat(dropwizardRegistry.getMeters()
                                          .get(serverMetricNameWithStatusAndResult("requests", 200, "failure"))
                                          .getCount()).isEqualTo(3L);
@@ -106,11 +104,11 @@ public class DropwizardMetricsIntegrationTest {
                                          .get(serverMetricNameWithStatusAndResult("requests", 200, "success"))
                                          .getCount()).isEqualTo(4L);
 
-            assertTimer("requestDuration", 7);
-            assertHistogram("requestLength", 7);
-            assertTimer("responseDuration", 7);
-            assertHistogram("responseLength", 7);
-            assertTimer("totalDuration", 7);
+            assertTimer("request.duration", 7);
+            assertHistogram("request.length", 7);
+            assertTimer("response.duration", 7);
+            assertHistogram("response.length", 7);
+            assertTimer("total.duration", 7);
         });
     }
 
@@ -123,6 +121,14 @@ public class DropwizardMetricsIntegrationTest {
     }
 
     private static void assertSummary(Map<String, ?> map, String property, int expectedCount) {
+        String clientMetricNameWithStatus = clientMetricNameWithStatus(property, 200);
+        String serverMetricNameWithStatus = serverMetricNameWithStatus(property, 200);
+
+        assertThat(map.get(clientMetricNameWithStatus)).as("Metric %s not found", clientMetricNameWithStatus)
+                .isNotNull();
+        assertThat(map.get(serverMetricNameWithStatus)).as("Metric %s nof found", serverMetricNameWithStatus)
+                .isNotNull();
+
         assertThat(((Counting) map.get(clientMetricNameWithStatus(property, 200))).getCount())
                 .isEqualTo(expectedCount);
         assertThat(((Sampling) map.get(clientMetricNameWithStatus(property, 200))).getSnapshot().getMean())


### PR DESCRIPTION
The [Micrometer naming conventions](http://micrometer.io/docs/concepts#_naming_meters) suggest that dotted notation (`foo.bar.baz`) should be used when naming meters. This has the advantage of letting different Micrometer monitoring implementations be able to convert it to the naming convention which is native for it (e.g. JMX, Prometheus etc).

Hence, the suggested change.

The PR changes the Dropwizard metric names slightly:

- `requestDuration` -> `request.duration`
- ` requestLength` -> `request.length`
- `responseDuration` -> `response.duration`
- `responseLength` -> `response.length`
- `totalDuration` -> `total.duration`

Prometheus metric names are unaffected by the change.