### PR TITLE
Hide `CacheControlBuilder` from the public API

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/CacheControl.java
+++ b/core/src/main/java/com/linecorp/armeria/common/CacheControl.java
@@ -37,7 +37,7 @@ public abstract class CacheControl {
      * @param noTransform whether the {@code "no-transform"} directive is enabled.
      * @param maxAgeSeconds the value of the {@code "max-age"} directive, or {@code -1} if disabled.
      */
-    protected CacheControl(boolean noCache, boolean noStore, boolean noTransform, long maxAgeSeconds) {
+    CacheControl(boolean noCache, boolean noStore, boolean noTransform, long maxAgeSeconds) {
         assert maxAgeSeconds >= -1 : maxAgeSeconds;
         this.noCache = noCache;
         this.noStore = noStore;
@@ -84,7 +84,7 @@ public abstract class CacheControl {
      * Returns a newly created {@link CacheControlBuilder} which has the same initial directives with
      * this {@link CacheControl}.
      */
-    public abstract CacheControlBuilder<?> toBuilder();
+    public abstract CacheControlBuilder toBuilder();
 
     /**
      * Encodes the directives in this {@link CacheControl} into an HTTP {@code "cache-control"} header value.
@@ -97,7 +97,7 @@ public abstract class CacheControl {
      * Returns a new {@link StringBuilder} with the common directives appended.
      * Note that the first two characters ({@code ", "} must be stripped.
      */
-    protected final StringBuilder newHeaderValueBuffer() {
+    final StringBuilder newHeaderValueBuffer() {
         final StringBuilder buf = new StringBuilder(40);
         if (noCache) {
             buf.append(", no-cache");

--- a/core/src/main/java/com/linecorp/armeria/common/CacheControlBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/CacheControlBuilder.java
@@ -26,11 +26,9 @@ import javax.annotation.Nullable;
  * building {@link ServerCacheControl} and {@link ClientCacheControlBuilder} for building
  * {@link ClientCacheControl}.
  *
- * @param <B> the self type
- *
  * @see <a href="https://developer.mozilla.org/docs/Web/HTTP/Headers/Cache-Control">Cache-Control (MDN)</a>
  */
-public abstract class CacheControlBuilder<B extends CacheControlBuilder<B>> {
+abstract class CacheControlBuilder {
 
     private boolean noCache;
     private boolean noStore;
@@ -40,27 +38,22 @@ public abstract class CacheControlBuilder<B extends CacheControlBuilder<B>> {
     /**
      * Creates a new builder with all directives disabled initially.
      */
-    protected CacheControlBuilder() {}
+    CacheControlBuilder() {}
 
     /**
      * Creates a new builder using the specified {@link CacheControl} as the initial directives.
      */
-    protected CacheControlBuilder(CacheControl c) {
+    CacheControlBuilder(CacheControl c) {
         noCache = c.noCache();
         noStore = c.noStore();
         noTransform = c.noTransform();
         maxAgeSeconds = c.maxAgeSeconds();
     }
 
-    @SuppressWarnings("unchecked")
-    private B self() {
-        return (B) this;
-    }
-
     /**
      * Enables the {@code "no-cache"} directive.
      */
-    public final B noCache() {
+    public CacheControlBuilder noCache() {
         return noCache(true);
     }
 
@@ -69,15 +62,15 @@ public abstract class CacheControlBuilder<B extends CacheControlBuilder<B>> {
      *
      * @param noCache {@code true} to enable or {@code false} to disable.
      */
-    public final B noCache(boolean noCache) {
+    public CacheControlBuilder noCache(boolean noCache) {
         this.noCache = noCache;
-        return self();
+        return this;
     }
 
     /**
      * Enables the {@code "no-store"} directive.
      */
-    public final B noStore() {
+    public CacheControlBuilder noStore() {
         return noStore(true);
     }
 
@@ -86,15 +79,15 @@ public abstract class CacheControlBuilder<B extends CacheControlBuilder<B>> {
      *
      * @param noStore {@code true} to enable or {@code false} to disable.
      */
-    public final B noStore(boolean noStore) {
+    public CacheControlBuilder noStore(boolean noStore) {
         this.noStore = noStore;
-        return self();
+        return this;
     }
 
     /**
      * Enables the {@code "no-transform"} directive.
      */
-    public final B noTransform() {
+    public CacheControlBuilder noTransform() {
         return noTransform(true);
     }
 
@@ -103,9 +96,9 @@ public abstract class CacheControlBuilder<B extends CacheControlBuilder<B>> {
      *
      * @param noTransform {@code true} to enable or {@code false} to disable.
      */
-    public final B noTransform(boolean noTransform) {
+    public CacheControlBuilder noTransform(boolean noTransform) {
         this.noTransform = noTransform;
-        return self();
+        return this;
     }
 
     /**
@@ -113,9 +106,9 @@ public abstract class CacheControlBuilder<B extends CacheControlBuilder<B>> {
      *
      * @param maxAge the value of the directive to enable, or {@code null} to disable.
      */
-    public final B maxAge(@Nullable Duration maxAge) {
+    public CacheControlBuilder maxAge(@Nullable Duration maxAge) {
         maxAgeSeconds = validateDuration(maxAge, "maxAge");
-        return self();
+        return this;
     }
 
     /**
@@ -125,7 +118,7 @@ public abstract class CacheControlBuilder<B extends CacheControlBuilder<B>> {
      * @param name the name of the parameter
      * @return the duration converted into seconds
      */
-    protected static long validateDuration(@Nullable Duration value, String name) {
+    static long validateDuration(@Nullable Duration value, String name) {
         if (value == null) {
             return -1;
         }
@@ -139,9 +132,9 @@ public abstract class CacheControlBuilder<B extends CacheControlBuilder<B>> {
      *
      * @param maxAgeSeconds the value in seconds.
      */
-    public final B maxAgeSeconds(long maxAgeSeconds) {
+    public CacheControlBuilder maxAgeSeconds(long maxAgeSeconds) {
         this.maxAgeSeconds = validateSeconds(maxAgeSeconds, "maxAgeSeconds");
-        return self();
+        return this;
     }
 
     /**
@@ -151,7 +144,7 @@ public abstract class CacheControlBuilder<B extends CacheControlBuilder<B>> {
      * @param name the name of the parameter
      * @return {@code value}
      */
-    protected static long validateSeconds(long value, String name) {
+    static long validateSeconds(long value, String name) {
         checkArgument(value >= 0, "%s: %s (expected: >= 0)", name, value);
         return value;
     }
@@ -168,6 +161,6 @@ public abstract class CacheControlBuilder<B extends CacheControlBuilder<B>> {
     /**
      * Returns a newly created instance with the specified properties.
      */
-    protected abstract CacheControl build(boolean noCache, boolean noStore,
-                                          boolean noTransform, long maxAgeSeconds);
+    abstract CacheControl build(boolean noCache, boolean noStore,
+                                boolean noTransform, long maxAgeSeconds);
 }

--- a/core/src/main/java/com/linecorp/armeria/common/ClientCacheControl.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ClientCacheControl.java
@@ -15,8 +15,8 @@
  */
 package com.linecorp.armeria.common;
 
-import static com.linecorp.armeria.internal.ArmeriaHttpUtil.parseCacheControl;
-import static com.linecorp.armeria.internal.ArmeriaHttpUtil.parseCacheControlSeconds;
+import static com.linecorp.armeria.internal.ArmeriaHttpUtil.parseDirectiveValueAsSeconds;
+import static com.linecorp.armeria.internal.ArmeriaHttpUtil.parseDirectives;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Map;
@@ -61,7 +61,7 @@ public final class ClientCacheControl extends CacheControl {
                     .put("no-store", (b, v) -> b.noStore())
                     .put("no-transform", (b, v) -> b.noTransform())
                     .put("max-age", (b, v) -> {
-                        final long maxAgeSeconds = parseCacheControlSeconds(v);
+                        final long maxAgeSeconds = parseDirectiveValueAsSeconds(v);
                         if (maxAgeSeconds >= 0) {
                             b.maxAgeSeconds(maxAgeSeconds);
                         }
@@ -71,26 +71,26 @@ public final class ClientCacheControl extends CacheControl {
                         if (v == null) {
                             b.maxStale();
                         } else {
-                            final long maxStaleSeconds = parseCacheControlSeconds(v);
+                            final long maxStaleSeconds = parseDirectiveValueAsSeconds(v);
                             if (maxStaleSeconds >= 0) {
                                 b.maxStaleSeconds(maxStaleSeconds);
                             }
                         }
                     })
                     .put("min-fresh", (b, v) -> {
-                        final long minFreshSeconds = parseCacheControlSeconds(v);
+                        final long minFreshSeconds = parseDirectiveValueAsSeconds(v);
                         if (minFreshSeconds >= 0) {
                             b.minFreshSeconds(minFreshSeconds);
                         }
                     })
                     .put("stale-while-revalidate", (b, v) -> {
-                        final long staleWhileRevalidateSeconds = parseCacheControlSeconds(v);
+                        final long staleWhileRevalidateSeconds = parseDirectiveValueAsSeconds(v);
                         if (staleWhileRevalidateSeconds >= 0) {
                             b.staleWhileRevalidateSeconds(staleWhileRevalidateSeconds);
                         }
                     })
                     .put("stale-if-error", (b, v) -> {
-                        final long staleIfErrorSeconds = parseCacheControlSeconds(v);
+                        final long staleIfErrorSeconds = parseDirectiveValueAsSeconds(v);
                         if (staleIfErrorSeconds >= 0) {
                             b.staleIfErrorSeconds(staleIfErrorSeconds);
                         }
@@ -117,7 +117,7 @@ public final class ClientCacheControl extends CacheControl {
         requireNonNull(directives, "directives");
         final ClientCacheControlBuilder builder = new ClientCacheControlBuilder();
         for (String d : directives) {
-            parseCacheControl(d, (name, value) -> {
+            parseDirectives(d, (name, value) -> {
                 final BiConsumer<ClientCacheControlBuilder, String> action = DIRECTIVES.get(name);
                 if (action != null) {
                     action.accept(builder, value);

--- a/core/src/main/java/com/linecorp/armeria/common/ClientCacheControlBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ClientCacheControlBuilder.java
@@ -31,7 +31,7 @@ import javax.annotation.Nullable;
  * @see <a href="https://developer.mozilla.org/docs/Web/HTTP/Headers/Cache-Control">Cache-Control (MDN)</a>
  * @see <a href="https://stackoverflow.com/q/14541077">Why is Cache-Control header sent in a request?</a>
  */
-public final class ClientCacheControlBuilder extends CacheControlBuilder<ClientCacheControlBuilder> {
+public final class ClientCacheControlBuilder extends CacheControlBuilder {
 
     private boolean onlyIfCached;
     private long maxStaleSeconds = -1;
@@ -177,10 +177,51 @@ public final class ClientCacheControlBuilder extends CacheControlBuilder<ClientC
     }
 
     @Override
-    protected ClientCacheControl build(boolean noCache, boolean noStore,
-                                       boolean noTransform, long maxAgeSeconds) {
+    ClientCacheControl build(boolean noCache, boolean noStore, boolean noTransform, long maxAgeSeconds) {
         return new ClientCacheControl(noCache, noStore, noTransform, maxAgeSeconds,
                                       onlyIfCached, maxStaleSeconds, minFreshSeconds,
                                       staleWhileRevalidateSeconds, staleIfErrorSeconds);
+    }
+
+    // Overridden to change the return type.
+
+    @Override
+    public ClientCacheControlBuilder noCache() {
+        return (ClientCacheControlBuilder) super.noCache();
+    }
+
+    @Override
+    public ClientCacheControlBuilder noCache(boolean noCache) {
+        return (ClientCacheControlBuilder) super.noCache(noCache);
+    }
+
+    @Override
+    public ClientCacheControlBuilder noStore() {
+        return (ClientCacheControlBuilder) super.noStore();
+    }
+
+    @Override
+    public ClientCacheControlBuilder noStore(boolean noStore) {
+        return (ClientCacheControlBuilder) super.noStore(noStore);
+    }
+
+    @Override
+    public ClientCacheControlBuilder noTransform() {
+        return (ClientCacheControlBuilder) super.noTransform();
+    }
+
+    @Override
+    public ClientCacheControlBuilder noTransform(boolean noTransform) {
+        return (ClientCacheControlBuilder) super.noTransform(noTransform);
+    }
+
+    @Override
+    public ClientCacheControlBuilder maxAge(@Nullable Duration maxAge) {
+        return (ClientCacheControlBuilder) super.maxAge(maxAge);
+    }
+
+    @Override
+    public ClientCacheControlBuilder maxAgeSeconds(long maxAgeSeconds) {
+        return (ClientCacheControlBuilder) super.maxAgeSeconds(maxAgeSeconds);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/ServerCacheControl.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ServerCacheControl.java
@@ -15,8 +15,8 @@
  */
 package com.linecorp.armeria.common;
 
-import static com.linecorp.armeria.internal.ArmeriaHttpUtil.parseCacheControl;
-import static com.linecorp.armeria.internal.ArmeriaHttpUtil.parseCacheControlSeconds;
+import static com.linecorp.armeria.internal.ArmeriaHttpUtil.parseDirectiveValueAsSeconds;
+import static com.linecorp.armeria.internal.ArmeriaHttpUtil.parseDirectives;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Map;
@@ -65,7 +65,7 @@ public final class ServerCacheControl extends CacheControl {
                     .put("no-store", (b, v) -> b.noStore())
                     .put("no-transform", (b, v) -> b.noTransform())
                     .put("max-age", (b, v) -> {
-                        final long maxAgeSeconds = parseCacheControlSeconds(v);
+                        final long maxAgeSeconds = parseDirectiveValueAsSeconds(v);
                         if (maxAgeSeconds >= 0) {
                             b.maxAgeSeconds(maxAgeSeconds);
                         }
@@ -76,7 +76,7 @@ public final class ServerCacheControl extends CacheControl {
                     .put("must-revalidate", (b, v) -> b.mustRevalidate())
                     .put("proxy-revalidate", (b, v) -> b.proxyRevalidate())
                     .put("s-maxage", (b, v) -> {
-                        final long sMaxAgeSeconds = parseCacheControlSeconds(v);
+                        final long sMaxAgeSeconds = parseDirectiveValueAsSeconds(v);
                         if (sMaxAgeSeconds >= 0) {
                             b.sMaxAgeSeconds(sMaxAgeSeconds);
                         }
@@ -103,7 +103,7 @@ public final class ServerCacheControl extends CacheControl {
         requireNonNull(directives, "directives");
         final ServerCacheControlBuilder builder = new ServerCacheControlBuilder();
         for (String d : directives) {
-            parseCacheControl(d, (name, value) -> {
+            parseDirectives(d, (name, value) -> {
                 final BiConsumer<ServerCacheControlBuilder, String> action = DIRECTIVES.get(name);
                 if (action != null) {
                     action.accept(builder, value);

--- a/core/src/main/java/com/linecorp/armeria/common/ServerCacheControlBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ServerCacheControlBuilder.java
@@ -35,7 +35,7 @@ import javax.annotation.Nullable;
  * @see <a href="https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/http-caching">HTTP Caching (Google)</a>
  * @see <a href="https://developer.mozilla.org/docs/Web/HTTP/Headers/Cache-Control">Cache-Control (MDN)</a>
  */
-public final class ServerCacheControlBuilder extends CacheControlBuilder<ServerCacheControlBuilder> {
+public final class ServerCacheControlBuilder extends CacheControlBuilder {
 
     private boolean cachePublic;
     private boolean cachePrivate;
@@ -173,12 +173,53 @@ public final class ServerCacheControlBuilder extends CacheControlBuilder<ServerC
     }
 
     @Override
-    protected ServerCacheControl build(boolean noCache, boolean noStore,
-                                       boolean noTransform, long maxAgeSeconds) {
+    ServerCacheControl build(boolean noCache, boolean noStore, boolean noTransform, long maxAgeSeconds) {
         // 'public' and 'private' are mutually exclusive.
         final boolean cachePublic = cachePrivate ? false : this.cachePublic;
         return new ServerCacheControl(noCache, noStore, noTransform, maxAgeSeconds,
                                       cachePublic, cachePrivate, immutable,
                                       mustRevalidate, proxyRevalidate, sMaxAgeSeconds);
+    }
+
+    // Overridden to change the return type.
+
+    @Override
+    public ServerCacheControlBuilder noCache() {
+        return (ServerCacheControlBuilder) super.noCache();
+    }
+
+    @Override
+    public ServerCacheControlBuilder noCache(boolean noCache) {
+        return (ServerCacheControlBuilder) super.noCache(noCache);
+    }
+
+    @Override
+    public ServerCacheControlBuilder noStore() {
+        return (ServerCacheControlBuilder) super.noStore();
+    }
+
+    @Override
+    public ServerCacheControlBuilder noStore(boolean noStore) {
+        return (ServerCacheControlBuilder) super.noStore(noStore);
+    }
+
+    @Override
+    public ServerCacheControlBuilder noTransform() {
+        return (ServerCacheControlBuilder) super.noTransform();
+    }
+
+    @Override
+    public ServerCacheControlBuilder noTransform(boolean noTransform) {
+        return (ServerCacheControlBuilder) super.noTransform(noTransform);
+    }
+
+    @Override
+    public ServerCacheControlBuilder maxAge(@Nullable Duration maxAge) {
+        return (ServerCacheControlBuilder) super.maxAge(maxAge);
+    }
+
+    @Override
+    public ServerCacheControlBuilder maxAgeSeconds(long maxAgeSeconds) {
+        return (ServerCacheControlBuilder) super.maxAgeSeconds(maxAgeSeconds);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/internal/ArmeriaHttpUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/ArmeriaHttpUtil.java
@@ -403,10 +403,10 @@ public final class ArmeriaHttpUtil {
     }
 
     /**
-     * Parses the specified {@code "cache-control"} directives and invokes the specified {@code callback}
+     * Parses the specified HTTP header directives and invokes the specified {@code callback}
      * with the directive names and values.
      */
-    public static void parseCacheControl(String directives, BiConsumer<String, String> callback) {
+    public static void parseDirectives(String directives, BiConsumer<String, String> callback) {
         final int len = directives.length();
         for (int i = 0; i < len;) {
             final int nameStart = i;
@@ -487,12 +487,12 @@ public final class ArmeriaHttpUtil {
     }
 
     /**
-     * Converts the specified {@code "cache-control"} directive value into a long integer.
+     * Converts the specified HTTP header directive value into a long integer.
      *
      * @return the converted value if {@code value} is equal to or greater than {@code 0}.
      *         {@code -1} otherwise, i.e. if a negative integer or not a number.
      */
-    public static long parseCacheControlSeconds(@Nullable String value) {
+    public static long parseDirectiveValueAsSeconds(@Nullable String value) {
         if (value == null) {
             return -1;
         }

--- a/core/src/test/java/com/linecorp/armeria/common/CacheControlTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/CacheControlTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Duration;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CacheControlTest {
 
@@ -102,7 +102,7 @@ public class CacheControlTest {
                      .build().isEmpty()).isTrue();
     }
 
-    private static final class CacheControlImplBuilder extends CacheControlBuilder<CacheControlImplBuilder> {
+    private static final class CacheControlImplBuilder extends CacheControlBuilder {
 
         CacheControlImplBuilder() {}
 
@@ -124,7 +124,7 @@ public class CacheControlTest {
         }
 
         @Override
-        public CacheControlBuilder<?> toBuilder() {
+        public CacheControlBuilder toBuilder() {
             return new CacheControlImplBuilder(this);
         }
 


### PR DESCRIPTION
Motivation:

We moved `Client/ServerCacheControl*` into the `common` package in #1816.
This means we can make `protected` methods package-local.

Modifications:

- Make `CacheControlBuilder` package-local
- Make all `protected` methods package-local
- Rename `ArmeriaHttpUtil.parseCacheControl()` to `parseDirectives()`
  for future reuse
- Rename `ArmeriaHttpUtil.parseCacheControlSeconds()` to
  `parseDirectiveValueAsSeconds()` for future reuse.
- Remove type parameter from `CacheControlBuilder` for cleaner Javadoc
  generation

Result:

- Leaner public API which hides the stuff which was unnecessarily
  visible from users.
