### PR TITLE
Make health check client retry interval more configurable to ba…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
@@ -42,7 +42,7 @@ import io.micrometer.core.instrument.binder.MeterBinder;
  * An {@link EndpointGroup} decorator that only provides healthy {@link Endpoint}s.
  */
 public abstract class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
-    static final Backoff DEFAULT_HEALTHCHECK_RETRY_BACKOFF = Backoff.fixed(3000).withJitter(0.1);
+    static final Backoff DEFAULT_HEALTHCHECK_RETRY_BACKOFF = Backoff.fixed(3000).withJitter(0.2);
 
     private final ClientFactory clientFactory;
     private final EndpointGroup delegate;
@@ -61,7 +61,8 @@ public abstract class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
                                          EndpointGroup delegate,
                                          Duration retryInterval) {
         this(clientFactory, delegate,
-             Backoff.fixed(requireNonNull(retryInterval, "retryInterval").toMillis()));
+             Backoff.fixed(requireNonNull(retryInterval, "retryInterval").toMillis())
+                    .withJitter(0.2));
     }
 
     /**
@@ -95,7 +96,7 @@ public abstract class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
     private void scheduleCheckAndUpdateHealthyServers() {
         clientFactory.eventLoopGroup().schedule(
                 () -> checkAndUpdateHealthyServers().thenRun(this::scheduleCheckAndUpdateHealthyServers),
-                retryBackoff.nextDelayMillis(0), TimeUnit.MILLISECONDS);
+                retryBackoff.nextDelayMillis(1), TimeUnit.MILLISECONDS);
     }
 
     private CompletableFuture<Void> checkAndUpdateHealthyServers() {

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroup.java
@@ -28,6 +28,7 @@ import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.client.HttpClientBuilder;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
+import com.linecorp.armeria.client.retry.Backoff;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.SessionProtocol;
@@ -86,9 +87,9 @@ public final class HttpHealthCheckedEndpointGroup extends HealthCheckedEndpointG
                                    SessionProtocol protocol,
                                    String healthCheckPath,
                                    int healthCheckPort,
-                                   Duration healthCheckRetryInterval,
+                                   Backoff healthCheckRetryBackoff,
                                    Function<? super ClientOptionsBuilder, ClientOptionsBuilder> configurator) {
-        super(clientFactory, delegate, healthCheckRetryInterval);
+        super(clientFactory, delegate, healthCheckRetryBackoff);
         this.protocol = requireNonNull(protocol, "protocol");
         this.healthCheckPath = requireNonNull(healthCheckPath, "healthCheckPath");
         this.healthCheckPort = healthCheckPort;

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroupBuilder.java
@@ -84,7 +84,8 @@ public class HttpHealthCheckedEndpointGroupBuilder {
         requireNonNull(retryInterval, "retryInterval");
         checkArgument(!retryInterval.isNegative() && !retryInterval.isZero(),
                       "retryInterval: %s (expected > 0)", retryInterval);
-        retryBackoff = Backoff.fixed(retryInterval.toMillis());
+        retryBackoff = Backoff.fixed(retryInterval.toMillis())
+                              .withJitter(0.2);
         return this;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroupBuilder.java
@@ -17,7 +17,7 @@
 package com.linecorp.armeria.client.endpoint.healthcheck;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.linecorp.armeria.client.endpoint.healthcheck.HealthCheckedEndpointGroup.DEFAULT_HEALTHCHECK_RETRY_INTERVAL;
+import static com.linecorp.armeria.client.endpoint.healthcheck.HealthCheckedEndpointGroup.DEFAULT_HEALTHCHECK_RETRY_BACKOFF;
 import static java.util.Objects.requireNonNull;
 
 import java.time.Duration;
@@ -29,6 +29,7 @@ import com.linecorp.armeria.client.ClientOptionsBuilder;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
+import com.linecorp.armeria.client.retry.Backoff;
 import com.linecorp.armeria.common.SessionProtocol;
 
 /**
@@ -40,7 +41,7 @@ public class HttpHealthCheckedEndpointGroupBuilder {
     private final String healthCheckPath;
 
     private SessionProtocol protocol = SessionProtocol.HTTP;
-    private Duration retryInterval = DEFAULT_HEALTHCHECK_RETRY_INTERVAL;
+    private Backoff retryBackoff = DEFAULT_HEALTHCHECK_RETRY_BACKOFF;
     private ClientFactory clientFactory = ClientFactory.DEFAULT;
     private Function<? super ClientOptionsBuilder, ClientOptionsBuilder> configurator = Function.identity();
     private int healthCheckPort;
@@ -76,12 +77,22 @@ public class HttpHealthCheckedEndpointGroupBuilder {
 
     /**
      * Sets the interval between health check requests. Must be positive.
+     * @deprecated Use {@link #retryBackoff(Backoff)}.
      */
+    @Deprecated
     public HttpHealthCheckedEndpointGroupBuilder retryInterval(Duration retryInterval) {
         requireNonNull(retryInterval, "retryInterval");
         checkArgument(!retryInterval.isNegative() && !retryInterval.isZero(),
                       "retryInterval: %s (expected > 0)", retryInterval);
-        this.retryInterval = retryInterval;
+        retryBackoff = Backoff.fixed(retryInterval.toMillis());
+        return this;
+    }
+
+    /**
+     * Sets the backoff between health check requests.
+     */
+    public HttpHealthCheckedEndpointGroupBuilder retryBackoff(Backoff retryBackoff) {
+        this.retryBackoff = requireNonNull(retryBackoff, "retryBackoff");
         return this;
     }
 
@@ -115,6 +126,6 @@ public class HttpHealthCheckedEndpointGroupBuilder {
      */
     public HttpHealthCheckedEndpointGroup build() {
         return new HttpHealthCheckedEndpointGroup(clientFactory, delegate, protocol, healthCheckPath,
-                                                  healthCheckPort, retryInterval, configurator);
+                                                  healthCheckPort, retryBackoff, configurator);
     }
 }


### PR DESCRIPTION
…healthcheck request among servers

Motivation:
- About HealthCheckedEndpointGroup, it causes a little bit heavy load when 1. about 1000 clients send a healthcheck request to a server at the same time and 2. when a backend server is not warmed up yet and not JIT-compiled well yet.

Changes
- Introduce `Backoff` to HealthCheckedEndpointGroup to give a chance to balance the request among HealthCheckedEndpointGroup users