### PR TITLE
Make sure all safely retriable exceptions are wrapped by UnprocessedR…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextWrapper.java
@@ -22,10 +22,9 @@ import java.util.Map.Entry;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.RequestContextWrapper;
-import com.linecorp.armeria.server.ServiceRequestContext;
 
 /**
- * Wraps an existing {@link ServiceRequestContext}.
+ * Wraps an existing {@link ClientRequestContext}.
  */
 public class ClientRequestContextWrapper
         extends RequestContextWrapper<ClientRequestContext> implements ClientRequestContext {

--- a/core/src/main/java/com/linecorp/armeria/client/GoAwayReceivedException.java
+++ b/core/src/main/java/com/linecorp/armeria/client/GoAwayReceivedException.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+/**
+ * A {@link RuntimeException} raised when a server sent an
+ * <a href="https://httpwg.org/specs/rfc7540.html#GOAWAY">HTTP/2 GOAWAY frame</a> with
+ * the {@code lastStreamId} less then the stream ID of the request.
+ */
+public final class GoAwayReceivedException extends RuntimeException {
+
+    private static final long serialVersionUID = -7167601309699030853L;
+
+    private static final GoAwayReceivedException INSTANCE = new GoAwayReceivedException();
+
+    /**
+     * Returns a singleton {@link GoAwayReceivedException}.
+     */
+    public static GoAwayReceivedException get() {
+        return INSTANCE;
+    }
+
+    private GoAwayReceivedException() {
+        super(null, null, false, false);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/client/Http2ResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http2ResponseDecoder.java
@@ -140,7 +140,7 @@ final class Http2ResponseDecoder extends HttpResponseDecoder implements Http2Con
 
         final int lastStreamId = conn.local().lastStreamKnownByPeer();
         if (stream.id() > lastStreamId) {
-            res.close(UnprocessedRequestException.get());
+            res.close(new UnprocessedRequestException(GoAwayReceivedException.get()));
         } else {
             res.close(ClosedSessionException.get());
         }

--- a/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
@@ -41,6 +41,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.MoreObjects;
 
+import com.linecorp.armeria.common.ClosedSessionException;
 import com.linecorp.armeria.common.SessionProtocol;
 
 import io.netty.bootstrap.Bootstrap;
@@ -391,7 +392,8 @@ final class HttpChannelPool implements AutoCloseable {
                 final SessionProtocol protocol = getProtocolIfHealthy(channel);
                 if (closed || protocol == null) {
                     channel.close();
-                    promise.completeExceptionally(UnprocessedRequestException.get());
+                    promise.completeExceptionally(
+                            new UnprocessedRequestException(ClosedSessionException.get()));
                     return;
                 }
 
@@ -421,7 +423,8 @@ final class HttpChannelPool implements AutoCloseable {
                 } else {
                     // Server set MAX_CONCURRENT_STREAMS to 0, which means we can't send anything.
                     channel.close();
-                    promise.completeExceptionally(UnprocessedRequestException.get());
+                    promise.completeExceptionally(
+                            new UnprocessedRequestException(RefusedStreamException.get()));
                 }
 
                 channel.closeFuture().addListener(f -> {
@@ -452,10 +455,10 @@ final class HttpChannelPool implements AutoCloseable {
                     }
                 });
             } else {
-                promise.completeExceptionally(future.cause());
+                promise.completeExceptionally(new UnprocessedRequestException(future.cause()));
             }
         } catch (Exception e) {
-            promise.completeExceptionally(e);
+            promise.completeExceptionally(new UnprocessedRequestException(e));
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientDelegate.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientDelegate.java
@@ -202,11 +202,13 @@ final class HttpClientDelegate implements Client<HttpRequest, HttpResponse> {
             final HttpSession session = HttpSession.get(channel);
             res.init(session.inboundTrafficController());
             final SessionProtocol sessionProtocol = session.protocol();
+
+            // Should never reach here.
             if (sessionProtocol == null) {
                 needsRelease = false;
                 try {
                     // TODO(minwoox): Make a test that handles this case
-                    final UnprocessedRequestException cause = UnprocessedRequestException.get();
+                    final NullPointerException cause = new NullPointerException("sessionProtocol");
                     handleEarlyRequestException(ctx, req, cause);
                     res.close(cause);
                 } finally {

--- a/core/src/main/java/com/linecorp/armeria/client/HttpRequestSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpRequestSubscriber.java
@@ -154,7 +154,7 @@ final class HttpRequestSubscriber implements Subscriber<HttpObject>, ChannelFutu
     private void writeFirstHeader() {
         final HttpSession session = HttpSession.get(ch);
         if (!session.canSendRequest()) {
-            failAndRespond(UnprocessedRequestException.get());
+            failAndRespond(new UnprocessedRequestException(ClosedSessionException.get()));
             return;
         }
 

--- a/core/src/main/java/com/linecorp/armeria/client/RefusedStreamException.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RefusedStreamException.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+/**
+ * A {@link RuntimeException} raised when a server set
+ * HTTP/2 <a href="https://httpwg.org/specs/rfc7540.html#SETTINGS_MAX_CONCURRENT_STREAMS">{@code MAX_CONCURRENT_STREAMS}</a> to 0,
+ * which means a client can't send anything.
+ */
+public final class RefusedStreamException extends RuntimeException {
+
+    private static final long serialVersionUID = 4865362114731585884L;
+
+    private static final RefusedStreamException INSTANCE = new RefusedStreamException();
+
+    /**
+     * Returns a singleton {@link RefusedStreamException}.
+     */
+    public static RefusedStreamException get() {
+        return INSTANCE;
+    }
+
+    private RefusedStreamException() {
+        super(null, null, false, false);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/client/UnprocessedRequestException.java
+++ b/core/src/main/java/com/linecorp/armeria/client/UnprocessedRequestException.java
@@ -16,6 +16,11 @@
 
 package com.linecorp.armeria.client;
 
+import static java.util.Objects.requireNonNull;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 import com.linecorp.armeria.common.Flags;
 
 /**
@@ -29,19 +34,31 @@ public final class UnprocessedRequestException extends RuntimeException {
 
     private static final long serialVersionUID = 4679512839715213302L;
 
-    private static final UnprocessedRequestException INSTANCE = new UnprocessedRequestException(false);
-
     /**
-     * Returns an {@link UnprocessedRequestException} which may be a singleton or a new instance, depending on
-     * whether {@linkplain Flags#verboseExceptions() the verbose exception mode} is enabled.
+     * Creates a new instance with the specified {@code message} and {@code cause}.
      */
-    public static UnprocessedRequestException get() {
-        return Flags.verboseExceptions() ? new UnprocessedRequestException() : INSTANCE;
+    public UnprocessedRequestException(@Nullable String message, Throwable cause) {
+        super(message, requireNonNull(cause, "cause"));
     }
 
-    private UnprocessedRequestException() {}
+    /**
+     * Creates a new instance with the specified {@code cause}.
+     */
+    public UnprocessedRequestException(Throwable cause) {
+        super(requireNonNull(cause, "cause").toString(), cause);
+    }
 
-    private UnprocessedRequestException(@SuppressWarnings("unused") boolean dummy) {
-        super(null, null, false, false);
+    @Nonnull
+    @Override
+    public Throwable getCause() {
+        return super.getCause();
+    }
+
+    @Override
+    public Throwable fillInStackTrace() {
+        if (Flags.verboseExceptions()) {
+            super.fillInStackTrace();
+        }
+        return this;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingClient.java
@@ -26,11 +26,12 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.client.ClientRequestContext;
-import com.linecorp.armeria.client.ResponseTimeoutException;
 import com.linecorp.armeria.client.SimpleDecoratingClient;
+import com.linecorp.armeria.client.UnprocessedRequestException;
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
 import com.linecorp.armeria.common.util.SafeCloseable;
+import com.linecorp.armeria.server.RequestTimeoutException;
 
 import io.netty.util.concurrent.ScheduledFuture;
 
@@ -124,7 +125,8 @@ public abstract class ConcurrencyLimitingClient<I extends Request, O extends Res
         if (!currentTask.isRun() && timeoutMillis != 0) {
             // Current request was not delegated. Schedule a timeout.
             final ScheduledFuture<?> timeoutFuture = ctx.eventLoop().schedule(
-                    () -> deferred.close(ResponseTimeoutException.get()),
+                    () -> deferred
+                            .close(new UnprocessedRequestException(RequestTimeoutException.get())),
                     timeoutMillis, TimeUnit.MILLISECONDS);
             currentTask.set(timeoutFuture);
         }

--- a/core/src/main/java/com/linecorp/armeria/internal/InboundTrafficController.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/InboundTrafficController.java
@@ -82,7 +82,7 @@ public final class InboundTrafficController extends AtomicInteger {
     public void dec(int numConsumedBytes) {
         final int oldValue = getAndAdd(-numConsumedBytes);
         if (oldValue > lowWatermark && oldValue - numConsumedBytes <= lowWatermark) {
-            // Just went below high watermark
+            // Just went below low watermark
             if (cfg != null) {
                 cfg.setAutoRead(true);
                 suspended = false;

--- a/core/src/test/java/com/linecorp/armeria/client/Http2GoAwayTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/Http2GoAwayTest.java
@@ -184,8 +184,8 @@ public class Http2GoAwayTest {
                 // The second request should fail with UnprocessedRequestException
                 // which has a cause of GoAwayReceivedException.
                 assertThatThrownBy(future2::join).isInstanceOf(CompletionException.class)
-                                                 .hasCauseExactlyInstanceOf(UnprocessedRequestException.class)
-                                                 .hasRootCauseExactlyInstanceOf(GoAwayReceivedException.class);
+                                                 .hasCauseInstanceOf(UnprocessedRequestException.class)
+                                                 .hasRootCauseInstanceOf(GoAwayReceivedException.class);
 
                 // The first request should not fail.
                 assertThat(future1).isNotDone();

--- a/core/src/test/java/com/linecorp/armeria/client/Http2GoAwayTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/Http2GoAwayTest.java
@@ -181,9 +181,12 @@ public class Http2GoAwayTest {
                 });
                 bos.flush();
 
-                // The second request should fail with UnprocessedRequestException.
+                // The second request should fail with UnprocessedRequestException
+                // which has a cause of GoAwayReceivedException.
                 assertThatThrownBy(future2::join).isInstanceOf(CompletionException.class)
-                                                 .hasCauseInstanceOf(UnprocessedRequestException.class);
+                                                 .hasCauseExactlyInstanceOf(UnprocessedRequestException.class)
+                                                 .hasRootCauseExactlyInstanceOf(GoAwayReceivedException.class);
+
                 // The first request should not fail.
                 assertThat(future1).isNotDone();
 

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientWithRequestLogTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientWithRequestLogTest.java
@@ -137,8 +137,8 @@ public class HttpClientWithRequestLogTest {
                 .build();
         final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/");
         assertThatThrownBy(() -> client.execute(req).aggregate().get())
-                .hasCauseExactlyInstanceOf(UnprocessedRequestException.class)
-                .hasRootCauseExactlyInstanceOf(ConnectException.class);
+                .hasCauseInstanceOf(UnprocessedRequestException.class)
+                .hasRootCauseInstanceOf(ConnectException.class);
 
         await().untilAsserted(() -> assertThat(ref.get()).isNotNull());
         final ClientConnectionTimings timings = ref.get();

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientWithRequestLogTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientWithRequestLogTest.java
@@ -137,7 +137,8 @@ public class HttpClientWithRequestLogTest {
                 .build();
         final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/");
         assertThatThrownBy(() -> client.execute(req).aggregate().get())
-                .hasCauseInstanceOf(ConnectException.class);
+                .hasCauseExactlyInstanceOf(UnprocessedRequestException.class)
+                .hasRootCauseExactlyInstanceOf(ConnectException.class);
 
         await().untilAsserted(() -> assertThat(ref.get()).isNotNull());
         final ClientConnectionTimings timings = ref.get();

--- a/core/src/test/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingHttpClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingHttpClientTest.java
@@ -141,8 +141,8 @@ class ConcurrencyLimitingHttpClientTest {
         Thread.sleep(1000);
         res2.subscribe(NoopSubscriber.get());
         assertThatThrownBy(() -> res2.completionFuture().join())
-                .hasCauseExactlyInstanceOf(UnprocessedRequestException.class)
-                .hasRootCauseExactlyInstanceOf(RequestTimeoutException.class);
+                .hasCauseInstanceOf(UnprocessedRequestException.class)
+                .hasRootCauseInstanceOf(RequestTimeoutException.class);
         assertThat(res2.isOpen()).isFalse();
 
         // req1 should not time out because it's been delegated already.

--- a/core/src/test/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingHttpClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingHttpClientTest.java
@@ -33,12 +33,13 @@ import org.mockito.Mock;
 import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.ClientRequestContextBuilder;
-import com.linecorp.armeria.client.ResponseTimeoutException;
+import com.linecorp.armeria.client.UnprocessedRequestException;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpResponseWriter;
 import com.linecorp.armeria.common.stream.NoopSubscriber;
+import com.linecorp.armeria.server.RequestTimeoutException;
 import com.linecorp.armeria.testing.junit.common.EventLoopExtension;
 
 class ConcurrencyLimitingHttpClientTest {
@@ -140,7 +141,8 @@ class ConcurrencyLimitingHttpClientTest {
         Thread.sleep(1000);
         res2.subscribe(NoopSubscriber.get());
         assertThatThrownBy(() -> res2.completionFuture().join())
-                .hasCauseInstanceOf(ResponseTimeoutException.class);
+                .hasCauseExactlyInstanceOf(UnprocessedRequestException.class)
+                .hasRootCauseExactlyInstanceOf(RequestTimeoutException.class);
         assertThat(res2.isOpen()).isFalse();
 
         // req1 should not time out because it's been delegated already.

--- a/thrift/src/test/java/com/linecorp/armeria/client/thrift/ThriftOverHttpClientTServletIntegrationTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/client/thrift/ThriftOverHttpClientTServletIntegrationTest.java
@@ -276,7 +276,7 @@ public class ThriftOverHttpClientTServletIntegrationTest {
             client.hello("unused");
             fail();
         } catch (UnprocessedRequestException e) {
-            assertThat(e).hasCauseExactlyInstanceOf(SessionProtocolNegotiationException.class);
+            assertThat(e).hasCauseInstanceOf(SessionProtocolNegotiationException.class);
             SessionProtocolNegotiationException cause = (SessionProtocolNegotiationException) e.getCause();
 
             // Test if a failed upgrade attempt triggers an exception with
@@ -291,7 +291,7 @@ public class ThriftOverHttpClientTServletIntegrationTest {
             client.hello("unused");
             fail();
         } catch (UnprocessedRequestException e) {
-            assertThat(e).hasCauseExactlyInstanceOf(SessionProtocolNegotiationException.class);
+            assertThat(e).hasCauseInstanceOf(SessionProtocolNegotiationException.class);
             SessionProtocolNegotiationException cause = (SessionProtocolNegotiationException) e.getCause();
             // Test if no upgrade attempt is made thanks to the cache.
             assertThat(cause.expected()).isEqualTo(H2C);


### PR DESCRIPTION
…equestException

Motivation:
`UnprocessedRequestException` means that the request has not been processed by the server.
If we wrap socket connect failures and more with UnprocessedRequestException,
user can safely retry the request without worrying about the idempotency of the request.

Modification:
* Add `GoAwayReceivedException` which raised when a server sent an HTTP/2 GOAWAY.
* Add `RefusedStreamException` which raised when a server set MAX_Current_STREAM to 0.
  see httpwg.org/specs/rfc7540.html#SETTINGS_MAX_CONCURRENT_STREAMS
* Remove singleton `INSTANCE` of `UnprocessedRequestException` and add a new constructor
  which accepts `Throwable` to make sure `UnprocessedRequestExecepion` always has a cause.
* Change `ResponseTimeoutException.get()` to
  `new UnprocessedRequestException(RequestTimeoutException.get())` in ConcurrencyLimitingClient.
* Change `UnprocessedRequestException.get()` to `NullPointerException`
  when sessionProtocol is null in `HttpClientDelegate#doExecute`.

Result:
* We can get more retriable exceptions.

Fixes #1653