### PR TITLE
Update protobuf-jackson to 1.0.0

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -351,7 +351,10 @@ org.checkerframework:
   checker-compat-qual: { version: '2.5.5' }
 
 org.curioswitch.curiostack:
-  protobuf-jackson: { version: '0.4.0' }
+  protobuf-jackson:
+    version: '1.0.0'
+    javadocs:
+    - https://developers.curioswitch.org/apidocs/java/
 
 org.dmonix.junit:
   zookeeper-junit: { version: '1.2' }


### PR DESCRIPTION
`protobuf-jackson` has released stable version (same as last version) and published javadoc

https://github.com/curioswitch/curiostack/releases/tag/protobuf-jackson-1.0.0