### PR TITLE
Add 'requirements' to README.md and web site

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,10 @@ source projects you are aware of. It will be amazing if you could help us by doi
   - Browse [the list of previously answered questions](https://github.com/line/armeria/issues?q=label%3Aquestion).
 - Contribute your work by sending [a pull request](https://github.com/line/armeria/pulls).
 
+### Build requirements
+
+- [OpenJDK 11 (or later)](https://adoptopenjdk.net/)
+
 ### Contributor license agreement
 
 When you are sending a pull request and it's a non-trivial change beyond fixing typos, please sign 

--- a/README.md
+++ b/README.md
@@ -10,10 +10,15 @@ high-performance asynchronous microservices that use HTTP/2 as a session layer p
 It is open-sourced and licensed under [Apache License 2.0](https://tldrlegal.com/license/apache-license-2.0-(apache-2.0))
 by [LINE Corporation](https://linecorp.com/en/), who uses it in production.
 
+## Requirements
+
+[Java 8 or later](https://adoptopenjdk.net/).
+See [Requirements](https://line.github.io/armeria/setup.html#requirements) for more information.
+
 ## How to build
 
-We use [Gradle](https://gradle.org/) and [Java 11 or later](https://adoptopenjdk.net/) to build Armeria. The following command will compile Armeria and generate
-JARs and web site:
+We use [Gradle](https://gradle.org/) and Java 11 or later to build Armeria.
+The following command will compile Armeria and generate JARs and web site:
 
 ```bash
 $ ./gradlew build
@@ -22,7 +27,7 @@ $ ./gradlew build
 ## How to ask a question
 
 Just [create a new issue](https://github.com/line/armeria/issues/new) to ask a question, and browse
-[the list of previously answered questions](https://github.com/line/armeria/issues?q=label%3Aquestion).
+[the list of previous questions](https://github.com/line/armeria/issues?q=label%3Aquestion).
 
 We also have [a Slack workspace](https://join.slack.com/t/line-armeria/shared_invite/enQtNjIxNDU1ODU1MTI2LTgwMzk0MzVhOGRhZjJiY2ExODc0MzNhYzIxZDFlYjM5OGRjNTE1MzYzYzQ4MzNhNGY2ZDM0NThhMTRmZmQ3ZjQ).
 

--- a/site/src/sphinx/setup.rst
+++ b/site/src/sphinx/setup.rst
@@ -3,6 +3,19 @@
 Setting up a project
 ====================
 
+Requirements
+------------
+
+`Java 8 (or later) <https://adoptopenjdk.net/>`_ is required to build and run an application based on Armeria.
+
+.. note::
+
+    Use Java 11 (or later) if you are a contributor who tries to build Armeria itself.
+    See `CONTRIBUTING.md <https://github.com/line/armeria/blob/master/CONTRIBUTING.md>`_ for more information.
+
+Choosing the artifacts
+----------------------
+
 All Armeria JARs are available in `Maven Central Repository <https://search.maven.org/search?q=g:com.linecorp.armeria%20-shaded>`_
 under group ID ``com.linecorp.armeria`` so that you can fetch them easily using your favorite build tool.
 Add the Armeria artifacts that provide the desired functionality to your project dependencies. The following is


### PR DESCRIPTION
Related: #1851

Motivation:

Some users misinterpreted our `README.md` and thought our minimum
requirement is Java 11, which is not correct.

Modifications:

- Make it clear that our minimum requirement is Java 8.

Result:

- Hopefully less confusion