### PR TITLE
Ensure a user set the endpoint path in DocService when the path is not…

### DIFF
--- a/docs-client/README.md
+++ b/docs-client/README.md
@@ -18,17 +18,17 @@ $ ./gradlew :docs-client:yarn_run_start --no-daemon
 ```
 
 This will usually not be useful since without a server running, the client does not have any spec it can render.
-You can have server calls proxied to a running Armeria server by specifying the `PROXY_PORT` environment
+You can have server calls proxied to a running Armeria server by specifying the `ARMERIA_PORT` environment
 variable, e.g.,
 
 ```bash
-$ PROXY_PORT=51234 yarn run start
+$ ARMERIA_PORT=51234 yarn run start
 ```
 
 or with Gradle
 
 ```bash
-$ PROXY_PORT=51234 ./gradlew :docs-client:yarn_run_start --no-daemon
+$ ARMERIA_PORT=51234 ./gradlew :docs-client:yarn_run_start --no-daemon
 ```
 
 Replacing the port of a docs page in the running server with `3000` will use the dev server to render while

--- a/docs-client/scripts/serve.ts
+++ b/docs-client/scripts/serve.ts
@@ -41,10 +41,10 @@ async function historyFallback(ctx: any, next: any) {
   return next();
 }
 
-const proxyPort = process.env.PROXY_PORT || '8080';
+const armeriaPort = process.env.ARMERIA_PORT || '8080';
 
 const proxier = proxy('/', {
-  target: `http://127.0.0.1:${proxyPort}`,
+  target: `http://127.0.0.1:${armeriaPort}`,
   changeOrigin: true,
 });
 

--- a/docs-client/src/containers/MethodPage/DebugPage.tsx
+++ b/docs-client/src/containers/MethodPage/DebugPage.tsx
@@ -396,10 +396,8 @@ class DebugPage extends React.PureComponent<Props, State> {
             params.set('queries', queries);
           }
         } else {
-          if (endpointPath) {
-            this.validateEndpointPath(endpointPath);
-            params.set('endpoint_path', endpointPath);
-          }
+          this.validateEndpointPath(endpointPath);
+          params.set('endpoint_path', endpointPath);
         }
       }
 
@@ -449,6 +447,9 @@ class DebugPage extends React.PureComponent<Props, State> {
   };
 
   private validateEndpointPath(endpointPath: string) {
+    if (!endpointPath) {
+      throw new Error(`You should set the ENDPOINT PATH.`);
+    }
     const method = this.props.method;
     const endpoint = method.endpoints[0];
     const regexPathPrefix = endpoint.regexPathPrefix;

--- a/docs-client/src/containers/MethodPage/DebugPage.tsx
+++ b/docs-client/src/containers/MethodPage/DebugPage.tsx
@@ -448,7 +448,7 @@ class DebugPage extends React.PureComponent<Props, State> {
 
   private validateEndpointPath(endpointPath: string) {
     if (!endpointPath) {
-      throw new Error(`You should set the ENDPOINT PATH.`);
+      throw new Error('You must set the ENDPOINT PATH.');
     }
     const method = this.props.method;
     const endpoint = method.endpoints[0];

--- a/docs-client/src/containers/MethodPage/DebugPage.tsx
+++ b/docs-client/src/containers/MethodPage/DebugPage.tsx
@@ -448,7 +448,7 @@ class DebugPage extends React.PureComponent<Props, State> {
 
   private validateEndpointPath(endpointPath: string) {
     if (!endpointPath) {
-      throw new Error('You must set the ENDPOINT PATH.');
+      throw new Error('You must specify the endpoint path.');
     }
     const method = this.props.method;
     const endpoint = method.endpoints[0];


### PR DESCRIPTION
… an exact path type

Motivation:
When the path of s service in `DocService` is not an exact path type, a user should set the endpoint path
and we must validate it.

Modifications:
- Ensure a user set the endpoint path when the path is not an exact type.
- Rename `PROXY_PORT` to `ARMERIA_PORT` for clarity.

Result:
- Close #1856