### PR TITLE
Ignore `CancelledSubscriptionException` and `AbortedStreamException`

### DIFF
--- a/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
+++ b/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
@@ -57,6 +57,7 @@ import org.springframework.http.server.reactive.HttpHandler;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 
+import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.server.Route;
@@ -208,7 +209,9 @@ public class ArmeriaReactiveWebServerFactory extends AbstractReactiveWebServerFa
             final Disposable disposable = handler.handle(ctx, req, future, serverHeader).subscribe();
             response.completionFuture().handle((unused, cause) -> {
                 if (cause != null) {
-                    logger.debug("{} Response stream has been cancelled.", ctx, cause);
+                    if (ctx.method() != HttpMethod.HEAD) {
+                        logger.debug("{} Response stream has been cancelled.", ctx, cause);
+                    }
                     disposable.dispose();
                 }
                 return null;

--- a/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ReactiveWebServerLoadBalancerInteropTest.java
+++ b/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ReactiveWebServerLoadBalancerInteropTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.spring.web.reactive;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.google.common.io.ByteStreams;
+
+import io.netty.util.NetUtil;
+import reactor.core.publisher.Mono;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test_loadbalancer")
+class ReactiveWebServerLoadBalancerInteropTest {
+
+    @SpringBootApplication
+    @Configuration
+    static class TestConfiguration {
+        @RestController
+        static class TestController {
+            @GetMapping("/api/ping")
+            Mono<String> ping() {
+                return Mono.just("PONG");
+            }
+        }
+    }
+
+    @LocalServerPort
+    int port;
+
+    @Test
+    void get() throws Exception {
+        try (Socket s = new Socket(NetUtil.LOCALHOST4, port)) {
+            s.setSoTimeout(10000);
+            final InputStream in = s.getInputStream();
+            final OutputStream out = s.getOutputStream();
+            out.write("GET /api/ping HTTP/1.0\r\n\r\n".getBytes(StandardCharsets.US_ASCII));
+
+            // Should not be chunked.
+            assertThat(new String(ByteStreams.toByteArray(in))).isEqualTo(
+                    "HTTP/1.1 200 OK\r\n" +
+                    "content-type: text/plain;charset=UTF-8\r\n" +
+                    "content-length: 4\r\n\r\n" +
+                    "PONG");
+        }
+    }
+
+    @Test
+    void head() throws Exception {
+        try (Socket s = new Socket(NetUtil.LOCALHOST4, port)) {
+            s.setSoTimeout(10000);
+            final InputStream in = s.getInputStream();
+            final OutputStream out = s.getOutputStream();
+            out.write("HEAD /api/ping HTTP/1.0\r\n\r\n".getBytes(StandardCharsets.US_ASCII));
+
+            // Should neither be chunked nor have content.
+            assertThat(new String(ByteStreams.toByteArray(in))).isEqualTo(
+                    "HTTP/1.1 200 OK\r\n" +
+                    "content-type: text/plain;charset=UTF-8\r\n" +
+                    "content-length: 4\r\n\r\n");
+        }
+    }
+}

--- a/spring/boot-webflux-autoconfigure/src/test/resources/config/application-test_loadbalancer.yml
+++ b/spring/boot-webflux-autoconfigure/src/test/resources/config/application-test_loadbalancer.yml
@@ -1,0 +1,2 @@
+server:
+  address: 127.0.0.1


### PR DESCRIPTION
.. while handling a WebFlux response.

Motivation:

When handling a `HEAD` request, Webflux can get the response from a `GET`
request handler and cancel the body subscription immediately. In that
case, `PublisherBasedHttpResponse` will fail its `completionFuture` with
a `CancelledSubscriptionException`, which will be propagated to WebFlux
as an unhandled exception.

Modifications:

- Filter out `CancelledSubscriptionException` and
  `AbortedStreamException` so that WebFlux does not write an ERROR log
  about an unhandled exception.
- Do not log at DEBUG level about a cancelled stream when the current
  request method is `HEAD` because it's expected.

Result:

- Less noisy error handling
- Fixes #1847