### PR TITLE
Fall back to the service with less constraint when content nego…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/Routers.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Routers.java
@@ -251,11 +251,11 @@ public final class Routers {
                     //
                     // The services are sorted as follows:
                     //
-                    // 1) annotated service with method and media type negotiation
+                    // 1) the service with method and media type negotiation
                     //    (consumable and producible)
-                    // 2) annotated service with method and producible media type negotiation
-                    // 3) annotated service with method and consumable media type negotiation
-                    // 4) annotated service with method negotiation
+                    // 2) the service with method and producible media type negotiation
+                    // 3) the service with method and consumable media type negotiation
+                    // 4) the service with method negotiation
                     // 5) the other services (in a registered order)
                     //
                     // 1) and 2) may produce a score between the lowest and the highest because they should
@@ -266,15 +266,6 @@ public final class Routers {
                     // Found the best matching.
                     if (routingResult.hasHighestScore()) {
                         result = Routed.of(route, routingResult, value);
-                        break;
-                    }
-
-                    // This means that the 'routingResult' is produced by one of 3), 4) and 5).
-                    // So we have no more chance to find a better matching from now.
-                    if (routingResult.hasLowestScore()) {
-                        if (!result.isPresent()) {
-                            result = Routed.of(route, routingResult, value);
-                        }
                         break;
                     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/RoutingContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RoutingContext.java
@@ -97,8 +97,12 @@ public interface RoutingContext {
      */
     default RoutingContext overridePath(String path) {
         requireNonNull(path, "path");
-        return new DefaultRoutingContext(virtualHost(), hostname(), method(), path, query(),
-                                         contentType(), acceptTypes(), isCorsPreflight());
+        return new RoutingContextWrapper(this) {
+            @Override
+            public String path() {
+                return path;
+            }
+        };
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/RoutingContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RoutingContextWrapper.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import java.util.List;
+import java.util.Optional;
+
+import javax.annotation.Nullable;
+
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.MediaType;
+
+class RoutingContextWrapper implements RoutingContext {
+
+    private final RoutingContext delegate;
+
+    RoutingContextWrapper(RoutingContext delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public VirtualHost virtualHost() {
+        return delegate.virtualHost();
+    }
+
+    @Override
+    public String hostname() {
+        return delegate.hostname();
+    }
+
+    @Override
+    public HttpMethod method() {
+        return delegate.method();
+    }
+
+    @Override
+    public String path() {
+        return delegate.path();
+    }
+
+    @Nullable
+    @Override
+    public String query() {
+        return delegate.query();
+    }
+
+    @Nullable
+    @Override
+    public MediaType contentType() {
+        return delegate.contentType();
+    }
+
+    @Override
+    public List<MediaType> acceptTypes() {
+        return delegate.acceptTypes();
+    }
+
+    @Override
+    public List<Object> summary() {
+        return delegate.summary();
+    }
+
+    @Override
+    public void delayThrowable(Throwable cause) {
+        delegate.delayThrowable(cause);
+    }
+
+    @Override
+    public Optional<Throwable> delayedThrowable() {
+        return delegate.delayedThrowable();
+    }
+
+    @Override
+    public boolean isCorsPreflight() {
+        return delegate.isCorsPreflight();
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceTest.java
@@ -787,12 +787,11 @@ public class AnnotatedHttpServiceTest {
         final HttpClient client = HttpClient.of(rule.uri("/"));
         final String path = "/8/same/path";
 
-        // No 'Accept' header means accepting everything. The order of -1 would be matched first.
         RequestHeaders headers = RequestHeaders.of(HttpMethod.GET, path);
         AggregatedHttpResponse res = client.execute(headers).aggregate().join();
         assertThat(res.status()).isSameAs(HttpStatus.OK);
-        assertThat(res.headers().contentType()).hasToString("text/plain");
-        assertThat(res.contentUtf8()).isEqualTo("GET/TEXT");
+        assertThat(res.headers().contentType()).isNull();
+        assertThat(res.contentUtf8()).isEqualTo("GET");
 
         // The same as the above.
         headers = RequestHeaders.of(HttpMethod.GET, path, HttpHeaderNames.ACCEPT, "*/*");
@@ -854,15 +853,15 @@ public class AnnotatedHttpServiceTest {
                                     HttpHeaderNames.CONTENT_TYPE, "application/json");
         res = client.execute(headers).aggregate().join();
         assertThat(res.status()).isSameAs(HttpStatus.OK);
-        assertThat(res.headers().contentType()).isSameAs(MediaType.JSON);
-        assertThat(res.contentUtf8()).isEqualTo("POST/JSON/BOTH");
+        assertThat(res.headers().contentType()).isNull();
+        assertThat(res.contentUtf8()).isEqualTo("POST/JSON");
 
         headers = RequestHeaders.of(HttpMethod.POST, path,
                                     HttpHeaderNames.ACCEPT, "application/json");
         res = client.execute(headers).aggregate().join();
         assertThat(res.status()).isSameAs(HttpStatus.OK);
-        assertThat(res.headers().contentType()).isNull();
-        assertThat(res.contentUtf8()).isEqualTo("POST");
+        assertThat(res.headers().contentType()).isSameAs(MediaType.JSON);
+        assertThat(res.contentUtf8()).isEqualTo("POST/JSON/BOTH");
 
         headers = RequestHeaders.of(HttpMethod.POST, path);
         res = client.execute(headers).aggregate().join();

--- a/core/src/test/java/com/linecorp/armeria/server/RouteTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/RouteTest.java
@@ -232,8 +232,6 @@ class RouteTest {
                      .build();
         getResult = route.apply(method(HttpMethod.GET));
         assertThat(getResult.isPresent()).isTrue();
-        // When there's no "Accept" header, it has the highest score.
-        assertThat(getResult.hasHighestScore()).isTrue();
 
         getResult = route.apply(withAcceptHeader(HttpMethod.GET, "application/json;charset=UTF-8"));
         assertThat(getResult.isPresent()).isFalse();
@@ -254,8 +252,6 @@ class RouteTest {
 
         getResult = route.apply(method(HttpMethod.GET));
         assertThat(getResult.isPresent()).isTrue();
-        // When there's no "Accept" header, it has the highest score.
-        assertThat(getResult.hasHighestScore()).isTrue();
 
         getResult = route.apply(withAcceptHeader(HttpMethod.GET, "*/*"));
         assertThat(getResult.isPresent()).isTrue();

--- a/core/src/test/java/com/linecorp/armeria/server/RoutingContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/RoutingContextTest.java
@@ -27,8 +27,6 @@ import javax.annotation.Nullable;
 
 import org.junit.jupiter.api.Test;
 
-import com.google.common.collect.ImmutableList;
-
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpMethod;
@@ -77,31 +75,36 @@ class RoutingContextTest {
         final RoutingContext ctx3;
 
         ctx1 = new DefaultRoutingContext(virtualHost, "example.com",
-                                         HttpMethod.GET, "/hello", null,
-                                         MediaType.JSON_UTF_8,
-                                         ImmutableList.of(MediaType.JSON_UTF_8, MediaType.XML_UTF_8),
-                                         false);
+                                         RequestHeaders.of(HttpMethod.GET, "/hello",
+                                                           HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_UTF_8,
+                                                           HttpHeaderNames.ACCEPT,
+                                                           MediaType.JSON_UTF_8 + ", " +
+                                                           MediaType.XML_UTF_8 + "; q=0.8"),
+                                         "/hello", null, false);
         ctx2 = new DefaultRoutingContext(virtualHost, "example.com",
-                                         HttpMethod.GET, "/hello", null,
-                                         MediaType.JSON_UTF_8,
-                                         ImmutableList.of(MediaType.JSON_UTF_8, MediaType.XML_UTF_8),
-                                         false);
+                                         RequestHeaders.of(HttpMethod.GET, "/hello",
+                                                           HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_UTF_8,
+                                                           HttpHeaderNames.ACCEPT,
+                                                           MediaType.JSON_UTF_8 + ", " +
+                                                           MediaType.XML_UTF_8 + "; q=0.8"),
+                                         "/hello", null, false);
         ctx3 = new DefaultRoutingContext(virtualHost, "example.com",
-                                         HttpMethod.GET, "/hello", null,
-                                         MediaType.JSON_UTF_8,
-                                         ImmutableList.of(MediaType.XML_UTF_8, MediaType.JSON_UTF_8),
-                                         false);
+                                         RequestHeaders.of(HttpMethod.GET, "/hello",
+                                                           HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_UTF_8,
+                                                           HttpHeaderNames.ACCEPT,
+                                                           MediaType.XML_UTF_8 + ", " +
+                                                           MediaType.JSON_UTF_8 + "; q=0.8"),
+                                         "/hello", null, false);
 
         assertThat(ctx1.hashCode()).isEqualTo(ctx2.hashCode());
         assertThat(ctx1).isEqualTo(ctx2);
         assertThat(ctx1).isNotEqualTo(ctx3);
 
         ctx1 = new DefaultRoutingContext(virtualHost, "example.com",
-                                         HttpMethod.GET, "/hello", "a=1&b=1",
-                                         null, ImmutableList.of(), false);
+                                         RequestHeaders.of(HttpMethod.GET, "/hello"),
+                                         "/hello", "a=1&b=1", false);
         ctx2 = new DefaultRoutingContext(virtualHost, "example.com",
-                                         HttpMethod.GET, "/hello", "a=1",
-                                         null, ImmutableList.of(), false);
+                                         RequestHeaders.of(HttpMethod.GET, "/hello"), "/hello", "a=1", false);
 
         assertThat(ctx1.hashCode()).isEqualTo(ctx2.hashCode());
         assertThat(ctx1).isEqualTo(ctx2);

--- a/core/src/test/java/com/linecorp/armeria/server/ServiceBindingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServiceBindingTest.java
@@ -105,11 +105,8 @@ class ServiceBindingTest {
                           final MediaType contentType = req.contentType();
                           if (contentType == MediaType.JSON) {
                               resContent = "{\"name\":\"" + request.contentUtf8() + "\"}";
-                          } else if (contentType == MediaType.PLAIN_TEXT_UTF_8) {
+                          } else  {
                               resContent = request.contentUtf8();
-                          } else {
-                              fail("Should never reach here");
-                              resContent = "Never reach here.";
                           }
                           return HttpResponse.of(resContent);
                       })));
@@ -140,7 +137,8 @@ class ServiceBindingTest {
         final HttpClient client = HttpClient.of(server.uri("/"));
         AggregatedHttpResponse res = client.execute(RequestHeaders.of(HttpMethod.POST, "/hello"), "armeria")
                                           .aggregate().join();
-        assertThat(res.status()).isSameAs(HttpStatus.UNSUPPORTED_MEDIA_TYPE);
+        assertThat(res.status()).isSameAs(HttpStatus.OK);
+        assertThat(res.contentUtf8()).isEqualTo("armeria");
 
         res = client.execute(RequestHeaders.of(HttpMethod.POST, "/hello",
                                                HttpHeaderNames.CONTENT_TYPE, MediaType.PLAIN_TEXT_UTF_8),

--- a/core/src/test/java/com/linecorp/armeria/server/cors/HttpServerCorsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/cors/HttpServerCorsTest.java
@@ -57,8 +57,9 @@ public class HttpServerCorsTest {
 
     private static final ClientFactory clientFactory = ClientFactory.DEFAULT;
 
-    @CorsDecorators(value = @CorsDecorator(origins = "http://example.com", exposedHeaders = "expose_header_1"),
-            shortCircuit = true)
+    @CorsDecorators(value = {
+            @CorsDecorator(origins = "http://example.com", exposedHeaders = "expose_header_1")
+    }, shortCircuit = true)
     private static class MyAnnotatedService {
 
         @Get("/index")
@@ -172,30 +173,37 @@ public class HttpServerCorsTest {
             sb.annotatedService("/cors6", new Object() {
 
                 @Get("/any/get")
-                @CorsDecorator(origins = "*", exposedHeaders = { "expose_header_1", "expose_header_2" },
+                @CorsDecorator(
+                        origins = "*", exposedHeaders = { "expose_header_1", "expose_header_2" },
                         allowedRequestHeaders = { "allow_request_1", "allow_request_2" },
                         allowedRequestMethods = HttpMethod.GET, maxAge = 3600,
-                        preflightRequestHeaders = @AdditionalHeader(name = "x-preflight-cors",
-                                value = { "Hello CORS", "Hello CORS2" }))
+                        preflightRequestHeaders = {
+                                @AdditionalHeader(name = "x-preflight-cors",
+                                        value = { "Hello CORS", "Hello CORS2" })
+                        })
                 public HttpResponse anyoneGet() {
                     return HttpResponse.of(HttpStatus.OK);
                 }
 
                 @Post("/one/post")
-                @CorsDecorator(origins = "http://example.com",
+                @CorsDecorator(
+                        origins = "http://example.com",
                         exposedHeaders = { "expose_header_1", "expose_header_2" },
                         allowedRequestMethods = HttpMethod.POST, credentialsAllowed = true,
                         allowedRequestHeaders = { "allow_request_1", "allow_request_2" }, maxAge = 1800,
-                        preflightRequestHeaders = @AdditionalHeader(name = "x-preflight-cors",
-                                value = "Hello CORS"))
+                        preflightRequestHeaders = {
+                                @AdditionalHeader(name = "x-preflight-cors", value = "Hello CORS")
+                        })
                 public HttpResponse onePolicyPost() {
                     return HttpResponse.of(HttpStatus.OK);
                 }
 
                 @Get("/multi/get")
-                @CorsDecorator(origins = "http://example.com", exposedHeaders = "expose_header_1",
+                @CorsDecorator(
+                        origins = "http://example.com", exposedHeaders = { "expose_header_1" },
                         allowedRequestMethods = HttpMethod.GET, credentialsAllowed = true)
-                @CorsDecorator(origins = "http://example2.com", exposedHeaders = "expose_header_2",
+                @CorsDecorator(
+                        origins = "http://example2.com", exposedHeaders = { "expose_header_2" },
                         allowedRequestMethods = HttpMethod.GET, credentialsAllowed = true)
                 public HttpResponse multiGet() {
                     return HttpResponse.of(HttpStatus.OK);

--- a/spring/boot-actuator-autoconfigure/src/test/java/com/linecorp/armeria/spring/actuate/ArmeriaSpringActuatorAutoConfigurationTest.java
+++ b/spring/boot-actuator-autoconfigure/src/test/java/com/linecorp/armeria/spring/actuate/ArmeriaSpringActuatorAutoConfigurationTest.java
@@ -192,9 +192,9 @@ public class ArmeriaSpringActuatorAutoConfigurationTest {
         final String loggerPath = "/internal/actuator/loggers/" + TEST_LOGGER_NAME;
         final AggregatedHttpResponse res =
                 client.execute(RequestHeaders.of(HttpMethod.POST, loggerPath),
-                               OBJECT_MAPPER.writeValueAsBytes(ImmutableMap.of("configuredLevel", "info")))
+                               OBJECT_MAPPER.writeValueAsBytes(ImmutableMap.of("configuredLevel", "debug")))
                       .aggregate().get();
-        assertThat(res.status()).isEqualTo(HttpStatus.UNSUPPORTED_MEDIA_TYPE);
+        assertThat(res.status()).isEqualTo(HttpStatus.NO_CONTENT);
     }
 
     @Test


### PR DESCRIPTION
Motivation:
Currently, a request which does not have a `content-type` header is not matched with the service which has `consumes` types.
We should mitigate the restriction so that the request can still find a service when there are no services which have exact matching conditions.

Modifications:
- Change the content negotiation logic
  - Exact matching first: `method`, `content-type` and `accept` of a request are contained in `methods`, `consumes` and `produces`, respectively, or both are `null`.
  - Do not enforce a request to have `content-type` and `accept` header.
    - The request can still find the service which has `consumes` and `produces` types.    
- Parse `accept` header when it's needed
- Make the log message which is logged while parsing invalid `accept` headers, more comprehensive and remove stack trace

Result:
- Close #1849