### PR TITLE
Add missing dependency for `javax.annotation.Generated`

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -353,6 +353,8 @@ org.checkerframework:
 org.curioswitch.curiostack:
   protobuf-jackson:
     version: '1.0.0'
+    exclusions:
+    - javax.annotation:javax.annotation-api
     javadocs:
     - https://developers.curioswitch.org/apidocs/java/
 

--- a/grpc/build.gradle
+++ b/grpc/build.gradle
@@ -3,6 +3,7 @@ dependencies {
 
     compile 'com.google.protobuf:protobuf-java'
     compile 'com.google.protobuf:protobuf-java-util'
+    compile 'jakarta.annotation:jakarta.annotation-api'
 
     // gRPC
     [ 'grpc-core', 'grpc-protobuf', 'grpc-services', 'grpc-stub' ].each {

--- a/thrift/build.gradle
+++ b/thrift/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
     // Thrift
     compile 'org.apache.thrift:libthrift'
+    compile 'jakarta.annotation:jakarta.annotation-api'
 
     // Jetty, for testing TServlet interoperability.
     testCompile 'org.eclipse.jetty:jetty-webapp'

--- a/thrift0.11/build.gradle
+++ b/thrift0.11/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     testCompile(project(':thrift')) {
         exclude group: 'org.apache.thrift', module: 'libthrift'
     }
-    testCompile('org.apache.thrift:libthrift')
+    testCompile 'org.apache.thrift:libthrift'
 
     // Jetty, for testing TServlet interoperability.
     testCompile 'org.eclipse.jetty:jetty-webapp'

--- a/thrift0.9/build.gradle
+++ b/thrift0.9/build.gradle
@@ -18,7 +18,8 @@ dependencyManagement {
 
 dependencies {
     // Thrift 0.9
-    compile('org.apache.thrift:libthrift')
+    compile 'org.apache.thrift:libthrift'
+    compile 'jakarta.annotation:jakarta.annotation-api'
 
     // Jetty, for testing TServlet interoperability.
     testCompile 'org.eclipse.jetty:jetty-webapp'


### PR DESCRIPTION
Motivation:

In some configuration, the `java.xml.ws.annotation` module, which
contains `javax.annotation.Generated`, is not added by default. As a
result, a user will get the 'cannot find symbol' compilation error.

Modifications:

- Add an explicit dependency to `jakarta.annotation:jakarta.annotation-api`
- Exclude the `javax.annotation:javax.annotation-api` which has been
  superceded by `jakarta.annotation-api`

Result:

- No more compilation errors