### PR TITLE
Handle the case where `@Default` annotation is specified withou…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedValueResolver.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedValueResolver.java
@@ -1023,7 +1023,7 @@ final class AnnotatedValueResolver {
                     }
 
                     shouldExist = false;
-                    defaultValue = getSpecifiedValue(aDefault.value()).get();
+                    defaultValue = getSpecifiedValue(aDefault.value()).orElse(null);
                 } else {
                     // Warn if @Default exists in an unsupported place.
                     final StringBuilder msg = new StringBuilder();

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceTest.java
@@ -482,6 +482,13 @@ public class AnnotatedHttpServiceTest {
         }
 
         @Get
+        @Path("/param/default_null")
+        public String paramDefaultNull(RequestContext ctx, @Param @Default String value) {
+            validateContext(ctx);
+            return value;
+        }
+
+        @Get
         @Path("/param/precedence/{username}")
         public String paramPrecedence(RequestContext ctx,
                                       @Param("username") String username,
@@ -779,6 +786,8 @@ public class AnnotatedHttpServiceTest {
             testBody(hc, get("/7/param/precedence/line5?username=dot&password=armeria5"), "line5/armeria5");
 
             testStatusCode(hc, get("/7/param/default2"), 400);
+
+            testBody(hc, get("/7/param/default_null"), "(null)");
         }
     }
 


### PR DESCRIPTION
Motivation:

A `NoSuchElementException` is raised during server startup time if a
user specified a `@Default` annotation without a value:

    public class MyAnnotatedService {
        @Get("/foo")
        public String foo(@Param @Default String value) {
            return String.valueOf(value);
        }
    }

Modifications:

- Allow having no value in `@Default` annotation

Result:

- Fixes #1858