### PR TITLE
Provide a way to specify per-service AccessLogWriter

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/AbstractServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AbstractServiceBindingBuilder.java
@@ -400,6 +400,8 @@ abstract class AbstractServiceBindingBuilder {
     /**
      * Sets the access log writer of this {@link Service}. If not set, {@link ServerConfig#accessLogWriter()}
      * is used.
+     *
+     * @param shutdownOnStop whether to shut down the {@link AccessLogWriter} when the {@link Server} stops
      */
     public AbstractServiceBindingBuilder accessLogWriter(AccessLogWriter accessLogWriter,
                                                          boolean shutdownOnStop) {

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
@@ -47,6 +47,7 @@ import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.logging.DefaultRequestLog;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.logging.RequestLogBuilder;
+import com.linecorp.armeria.server.logging.AccessLogWriter;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.netty.buffer.ByteBufAllocator;
@@ -437,6 +438,11 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
     @Override
     public boolean verboseResponses() {
         return cfg.verboseResponses();
+    }
+
+    @Override
+    public AccessLogWriter accessLogWriter() {
+        return cfg.accessLogWriter();
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -659,6 +659,10 @@ public final class ServerBuilder {
         return accessLogWriter;
     }
 
+    boolean shutdownAccessLogWriterOnStop() {
+        return shutdownAccessLogWriterOnStop;
+    }
+
     /**
      * Sets the maximum size of additional data for PROXY protocol. The default value of this property is
      * {@value #PROXY_PROTOCOL_DEFAULT_MAX_TLV_SIZE}.

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -655,6 +655,10 @@ public final class ServerBuilder {
         return this;
     }
 
+    AccessLogWriter accessLogWriter() {
+        return accessLogWriter;
+    }
+
     /**
      * Sets the maximum size of additional data for PROXY protocol. The default value of this property is
      * {@value #PROXY_PROTOCOL_DEFAULT_MAX_TLV_SIZE}.

--- a/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
@@ -771,7 +771,6 @@ public final class ServerConfig {
         buf.append(accessLogWriter);
         buf.append(", shutdownAccessLogWriterOnStop: ");
         buf.append(shutdownAccessLogWriterOnStop);
-        buf.append(')');
         buf.append(", channelOptions: ");
         buf.append(channelOptions);
         buf.append(", childChannelOptions: ");
@@ -782,6 +781,7 @@ public final class ServerConfig {
         buf.append(clientAddressTrustedProxyFilter);
         buf.append(", clientAddressFilter: ");
         buf.append(clientAddressFilter);
+        buf.append(')');
 
         return buf.toString();
     }

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceBindingBuilder.java
@@ -28,6 +28,7 @@ import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.logging.ContentPreviewerFactory;
+import com.linecorp.armeria.server.logging.AccessLogWriter;
 
 /**
  * A builder class for binding a {@link Service} fluently. This class can be instantiated through
@@ -193,6 +194,11 @@ public final class ServiceBindingBuilder extends AbstractServiceBindingBuilder {
     @Override
     public ServiceBindingBuilder contentPreviewerFactory(ContentPreviewerFactory factory) {
         return (ServiceBindingBuilder) super.contentPreviewerFactory(factory);
+    }
+
+    @Override
+    public ServiceBindingBuilder accessLogWriter(AccessLogWriter accessLogWriter, boolean shutdownOnStop) {
+        return (ServiceBindingBuilder) super.accessLogWriter(accessLogWriter, shutdownOnStop);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceConfigBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceConfigBuilder.java
@@ -25,6 +25,7 @@ import com.google.common.base.MoreObjects;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.logging.ContentPreviewerFactory;
+import com.linecorp.armeria.server.logging.AccessLogWriter;
 
 final class ServiceConfigBuilder {
 
@@ -43,6 +44,9 @@ final class ServiceConfigBuilder {
     private ContentPreviewerFactory requestContentPreviewerFactory;
     @Nullable
     private ContentPreviewerFactory responseContentPreviewerFactory;
+    @Nullable
+    private AccessLogWriter accessLogWriter;
+    private boolean shutdownAccessLogWriterOnStop;
 
     ServiceConfigBuilder(Route route, Service<HttpRequest, HttpResponse> service) {
         this.route = requireNonNull(route, "route");
@@ -106,15 +110,28 @@ final class ServiceConfigBuilder {
         return this;
     }
 
+    @Nullable
+    AccessLogWriter accessLogWriter() {
+        return accessLogWriter;
+    }
+
+    ServiceConfigBuilder accessLogWriter(AccessLogWriter accessLogWriter, boolean shutdownOnStop) {
+        this.accessLogWriter = accessLogWriter;
+        shutdownAccessLogWriterOnStop = shutdownOnStop;
+        return this;
+    }
+
     ServiceConfig build() {
         assert requestTimeoutMillis != null;
         assert maxRequestLength != null;
         assert verboseResponses != null;
         assert requestContentPreviewerFactory != null;
         assert responseContentPreviewerFactory != null;
+        assert accessLogWriter != null;
         return new ServiceConfig(route, service, loggerName, requestTimeoutMillis,
-                                 maxRequestLength, verboseResponses,
-                                 requestContentPreviewerFactory, responseContentPreviewerFactory);
+                                 maxRequestLength, verboseResponses, requestContentPreviewerFactory,
+                                 responseContentPreviewerFactory, accessLogWriter,
+                                 shutdownAccessLogWriterOnStop);
     }
 
     @Override
@@ -128,6 +145,8 @@ final class ServiceConfigBuilder {
                           .add("verboseResponses", verboseResponses)
                           .add("requestContentPreviewerFactory", requestContentPreviewerFactory)
                           .add("responseContentPreviewerFactory", responseContentPreviewerFactory)
+                          .add("accessLogWriter", accessLogWriter)
+                          .add("shutdownAccessLogWriterOnStop", shutdownAccessLogWriterOnStop)
                           .toString();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
@@ -39,6 +39,7 @@ import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.Response;
+import com.linecorp.armeria.server.logging.AccessLogWriter;
 
 /**
  * Provides information about an invocation and related utilities. Every request being handled has its own
@@ -254,6 +255,8 @@ public interface ServiceRequestContext extends RequestContext {
      * insecure. When disabled, the service responses will not expose such server-side details to the client.
      */
     boolean verboseResponses();
+
+    AccessLogWriter accessLogWriter();
 
     /**
      * Returns an immutable {@link HttpHeaders} which is included when a {@link Service} sends an

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
@@ -34,6 +34,7 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.RequestContextWrapper;
+import com.linecorp.armeria.server.logging.AccessLogWriter;
 
 /**
  * Wraps an existing {@link ServiceRequestContext}.
@@ -170,6 +171,11 @@ public class ServiceRequestContextWrapper
     @Override
     public boolean verboseResponses() {
         return delegate().verboseResponses();
+    }
+
+    @Override
+    public AccessLogWriter accessLogWriter() {
+        return delegate().accessLogWriter();
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
@@ -733,6 +733,8 @@ public final class VirtualHostBuilder {
     /**
      * Sets the access log writer of this {@link VirtualHost}. If not set,
      * {@link ServerBuilder#accessLogWriter()} is used.
+     *
+     * @param shutdownOnStop whether to shut down the {@link AccessLogWriter} when the {@link Server} stops
      */
     public VirtualHostBuilder accessLogWriter(AccessLogWriter accessLogWriter, boolean shutdownOnStop) {
         this.accessLogWriter = requireNonNull(accessLogWriter, "accessLogWriter");
@@ -772,8 +774,16 @@ public final class VirtualHostBuilder {
         final RejectedRouteHandler rejectedRouteHandler =
                 this.rejectedRouteHandler != null ?
                 this.rejectedRouteHandler : serverBuilder.rejectedRouteHandler();
-        final AccessLogWriter accessLogWriter =
-                this.accessLogWriter != null ? this.accessLogWriter : serverBuilder.accessLogWriter();
+
+        final AccessLogWriter accessLogWriter;
+        final boolean shutdownAccessLogWriterOnStop;
+        if (this.accessLogWriter != null) {
+            accessLogWriter = this.accessLogWriter;
+            shutdownAccessLogWriterOnStop = this.shutdownAccessLogWriterOnStop;
+        } else {
+            accessLogWriter = serverBuilder.accessLogWriter();
+            shutdownAccessLogWriterOnStop = serverBuilder.shutdownAccessLogWriterOnStop();
+        }
 
         final List<ServiceConfig> serviceConfigs = serviceConfigBuilders.stream().map(cfgBuilder -> {
             if (cfgBuilder.requestTimeoutMillis() == null) {

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostServiceBindingBuilder.java
@@ -28,6 +28,7 @@ import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.logging.ContentPreviewerFactory;
+import com.linecorp.armeria.server.logging.AccessLogWriter;
 
 /**
  * A builder class for binding a {@link Service} fluently. This class can be instantiated through
@@ -193,6 +194,12 @@ public final class VirtualHostServiceBindingBuilder extends AbstractServiceBindi
     @Override
     public VirtualHostServiceBindingBuilder contentPreviewerFactory(ContentPreviewerFactory factory) {
         return (VirtualHostServiceBindingBuilder) super.contentPreviewerFactory(factory);
+    }
+
+    @Override
+    public VirtualHostServiceBindingBuilder accessLogWriter(AccessLogWriter accessLogWriter,
+                                                            boolean shutdownOnStop) {
+        return (VirtualHostServiceBindingBuilder) super.accessLogWriter(accessLogWriter, shutdownOnStop);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/logging/AccessLogWriter.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/AccessLogWriter.java
@@ -23,10 +23,10 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import com.linecorp.armeria.common.logging.RequestLog;
-import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.Service;
 
 /**
- * Consumes the {@link RequestLog}s produced by a {@link Server}, usually for logging purpose.
+ * Consumes the {@link RequestLog}s produced by a {@link Service}, usually for logging purpose.
  */
 @FunctionalInterface
 public interface AccessLogWriter {

--- a/core/src/test/java/com/linecorp/armeria/server/HttpResponseSubscriberTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpResponseSubscriberTest.java
@@ -82,7 +82,7 @@ public class HttpResponseSubscriberTest {
         req.init(sctx);
         return new HttpResponseSubscriber(mock(ChannelHandlerContext.class),
                                           new ImmediateWriteEmulator(sctx.channel()),
-                                          sctx, req, unused -> {});
+                                          sctx, req);
     }
 
     private static ByteBuf newBuffer(String content) {

--- a/core/src/test/java/com/linecorp/armeria/server/ServiceBindingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServiceBindingTest.java
@@ -18,11 +18,9 @@ package com.linecorp.armeria.server;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
-import static org.awaitility.Awaitility.await;
 
 import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -110,7 +108,7 @@ class ServiceBindingTest {
                           final MediaType contentType = req.contentType();
                           if (contentType == MediaType.JSON) {
                               resContent = "{\"name\":\"" + request.contentUtf8() + "\"}";
-                          } else  {
+                          } else {
                               resContent = request.contentUtf8();
                           }
                           return HttpResponse.of(resContent);
@@ -147,7 +145,7 @@ class ServiceBindingTest {
     void consumesAndProduces() throws IOException {
         final HttpClient client = HttpClient.of(server.uri("/"));
         AggregatedHttpResponse res = client.execute(RequestHeaders.of(HttpMethod.POST, "/hello"), "armeria")
-                                          .aggregate().join();
+                                           .aggregate().join();
         assertThat(res.status()).isSameAs(HttpStatus.OK);
         assertThat(res.contentUtf8()).isEqualTo("armeria");
 
@@ -185,7 +183,6 @@ class ServiceBindingTest {
         client.execute(RequestHeaders.of(HttpMethod.POST, "/hello"), "armeria")
               .aggregate().join();
 
-        await().atMost(1, TimeUnit.SECONDS);
         assertThat(accessLogWriterCheckLatch.getCount()).isOne();
 
         client.get("/greet/armeria");

--- a/core/src/test/java/com/linecorp/armeria/server/ServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServiceTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.RpcResponse;
 import com.linecorp.armeria.common.logging.ContentPreviewerFactory;
+import com.linecorp.armeria.server.logging.AccessLogWriter;
 
 public class ServiceTest {
 
@@ -67,7 +68,8 @@ public class ServiceTest {
         final ServiceConfig cfg = new ServiceConfig(Route.builder().catchAll().build(),
                                                     (Service) outer, "foo", 1, 1,
                                                     true, ContentPreviewerFactory.disabled(),
-                                                    ContentPreviewerFactory.disabled());
+                                                    ContentPreviewerFactory.disabled(),
+                                                    AccessLogWriter.disabled(), false);
         outer.serviceAdded(cfg);
         assertThat(inner.cfg).isSameAs(cfg);
     }

--- a/kafka/src/main/java/com/linecorp/armeria/server/logging/kafka/KafkaAccessLogWriter.java
+++ b/kafka/src/main/java/com/linecorp/armeria/server/logging/kafka/KafkaAccessLogWriter.java
@@ -60,7 +60,7 @@ public final class KafkaAccessLogWriter<K, V> implements AccessLogWriter {
     public KafkaAccessLogWriter(Producer<K, V> producer, String topic,
                                 Function<? super RequestLog, ? extends V> valueExtractor) {
 
-        this(producer, topic, null, valueExtractor,0);
+        this(producer, topic, null, valueExtractor, 0);
     }
 
     /**


### PR DESCRIPTION
Motivation:
A user might want to specify `AccessLogWriter` per service when he/she uses `KafkaAccessLogWriter` or similar.

Modification:
- Add a setter for `AccessLogWriter` to `ServerBuilder.route()`.

Result:
- You can now specify `AccessLogWriter` per service.