### PR TITLE
Support multiple Path annotations

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceFactory.java
@@ -525,7 +525,7 @@ public final class AnnotatedHttpServiceFactory {
 
         final Map<HttpMethod, List<String>> httpMethodAnnotatedPatternMap =
                 getHttpMethodAnnotatedPatternMap(methodAnnotations);
-        if (httpMethodAnnotatedPatternMap.keySet().isEmpty()) {
+        if (httpMethodAnnotatedPatternMap.isEmpty()) {
             throw new IllegalArgumentException(method.getDeclaringClass().getName() + '#' + method.getName() +
                                                " must have an HTTP method annotation.");
         }

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/Paths.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/Paths.java
@@ -17,21 +17,18 @@
 package com.linecorp.armeria.server.annotation;
 
 import java.lang.annotation.ElementType;
-import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotation for mapping dynamic web requests onto specific method.
+ * The containing annotation type for {@link Path}.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
-@Repeatable(value = Paths.class)
-public @interface Path {
-
+public @interface Paths {
     /**
-     * A path pattern for the annotated method.
+     * An array of {@link Path}s.
      */
-    String value();
+    Path[] value();
 }

--- a/core/src/main/java/com/linecorp/armeria/server/docs/ServiceInfo.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/ServiceInfo.java
@@ -80,7 +80,7 @@ public final class ServiceInfo {
                        @Nullable String docString) {
 
         this.name = requireNonNull(name, "name");
-        this.methods = ImmutableList.copyOf(mergeEndpoints(requireNonNull(methods)));
+        this.methods = mergeEndpoints(requireNonNull(methods));
         this.exampleHttpHeaders = ImmutableList.copyOf(requireNonNull(exampleHttpHeaders,
                                                                       "exampleHttpHeaders"));
         this.docString = Strings.emptyToNull(docString);

--- a/core/src/main/java/com/linecorp/armeria/server/docs/ServiceInfo.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/ServiceInfo.java
@@ -16,7 +16,6 @@
 
 package com.linecorp.armeria.server.docs;
 
-import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Comparator.comparing;
 import static java.util.Objects.requireNonNull;
 
@@ -49,7 +48,7 @@ import com.linecorp.armeria.server.Service;
 public final class ServiceInfo {
 
     private final String name;
-    private final List<MethodInfo> methods;
+    private final Set<MethodInfo> methods;
     private final List<HttpHeaders> exampleHttpHeaders;
     @Nullable
     private final String docString;
@@ -98,7 +97,7 @@ public final class ServiceInfo {
      * Returns the metadata about the methods available in the service.
      */
     @JsonProperty
-    public List<MethodInfo> methods() {
+    public Set<MethodInfo> methods() {
         return methods;
     }
 
@@ -109,7 +108,7 @@ public final class ServiceInfo {
      * {@code exampleHttpHeaders} and {@code exampleRequests}.
      */
     @VisibleForTesting
-    static List<MethodInfo> mergeEndpoints(Iterable<MethodInfo> methodInfos) {
+    static Set<MethodInfo> mergeEndpoints(Iterable<MethodInfo> methodInfos) {
         final Map<List<Object>, MethodInfo> methodInfoMap = new HashMap<>();
         for (MethodInfo methodInfo : methodInfos) {
             final List<Object> mergeKey = ImmutableList.of(methodInfo.name(), methodInfo.httpMethod());
@@ -127,9 +126,10 @@ public final class ServiceInfo {
                 }
             });
         }
-        return methodInfoMap.values().stream()
-                            .sorted(comparing(MethodInfo::name).thenComparing(MethodInfo::httpMethod))
-                            .collect(toImmutableList());
+        return ImmutableSortedSet
+                .orderedBy(comparing(MethodInfo::name).thenComparing(MethodInfo::httpMethod))
+                .addAll(methodInfoMap.values())
+                .build();
     }
 
     /**

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpDocServicePluginTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpDocServicePluginTest.java
@@ -297,7 +297,7 @@ public class AnnotatedHttpDocServicePluginTest {
         final Set<String> paths = methods.get("multiGet").endpoints()
                                          .stream().map(EndpointInfo::pathMapping)
                                          .collect(toImmutableSet());
-        assertThat(paths).isEqualTo(ImmutableSet.of("exact:/path1", "exact:/path2"));
+        assertThat(paths).containsOnly("exact:/path1", "exact:/path2");
     }
 
     private static void checkFooService(ServiceInfo fooServiceInfo) {
@@ -358,7 +358,7 @@ public class AnnotatedHttpDocServicePluginTest {
                                                      DocServiceFilter exclude,
                                                      Object... services) {
         final ServerBuilder builder = Server.builder();
-        Arrays.stream(services).forEach(service -> builder.annotatedService(service));
+        Arrays.stream(services).forEach(builder::annotatedService);
         final Server server = builder.build();
         final ServiceSpecification specification =
                 plugin.generateSpecification(ImmutableSet.copyOf(server.serviceConfigs()),

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpDocServicePluginTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpDocServicePluginTest.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.internal.annotation;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.linecorp.armeria.internal.annotation.AnnotatedHttpDocServicePlugin.BEAN;
 import static com.linecorp.armeria.internal.annotation.AnnotatedHttpDocServicePlugin.INT;
 import static com.linecorp.armeria.internal.annotation.AnnotatedHttpDocServicePlugin.LONG;
@@ -39,7 +40,6 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiFunction;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
@@ -296,7 +296,7 @@ public class AnnotatedHttpDocServicePluginTest {
                         .collect(toImmutableMap(MethodInfo::name, Function.identity()));
         final Set<String> paths = methods.get("multiGet").endpoints()
                                          .stream().map(EndpointInfo::pathMapping)
-                                         .collect(Collectors.toSet());
+                                         .collect(toImmutableSet());
         assertThat(paths).isEqualTo(ImmutableSet.of("exact:/path1", "exact:/path2"));
     }
 

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpDocServicePluginTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpDocServicePluginTest.java
@@ -31,6 +31,7 @@ import static com.linecorp.armeria.server.docs.FieldLocation.QUERY;
 import static com.linecorp.armeria.server.docs.FieldRequirement.REQUIRED;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -38,6 +39,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
@@ -54,9 +56,11 @@ import com.linecorp.armeria.internal.annotation.AnnotatedHttpDocServicePluginTes
 import com.linecorp.armeria.server.Route;
 import com.linecorp.armeria.server.RouteBuilder;
 import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.annotation.Get;
 import com.linecorp.armeria.server.annotation.Header;
 import com.linecorp.armeria.server.annotation.Param;
+import com.linecorp.armeria.server.annotation.Path;
 import com.linecorp.armeria.server.annotation.RequestObject;
 import com.linecorp.armeria.server.docs.DocServiceFilter;
 import com.linecorp.armeria.server.docs.EndpointInfo;
@@ -218,7 +222,9 @@ public class AnnotatedHttpDocServicePluginTest {
     @Test
     public void testGenerateSpecification() {
         final Map<String, ServiceInfo> services = services((plugin, service, method) -> true,
-                                                           (plugin, service, method) -> false);
+                                                           (plugin, service, method) -> false,
+                                                           new FooClass(),
+                                                           new BarClass());
 
         assertThat(services).containsOnlyKeys(FOO_NAME, BAR_NAME);
         checkFooService(services.get(FOO_NAME));
@@ -237,12 +243,12 @@ public class AnnotatedHttpDocServicePluginTest {
         // 1. Nothing specified.
         DocServiceFilter include = (plugin, service, method) -> true;
         DocServiceFilter exclude = (plugin, service, method) -> false;
-        Map<String, ServiceInfo> services = services(include, exclude);
+        Map<String, ServiceInfo> services = services(include, exclude, new FooClass(), new BarClass());
         assertThat(services).containsOnlyKeys(FOO_NAME, BAR_NAME);
 
         // 2. Exclude specified.
         exclude = DocServiceFilter.ofMethodName(FOO_NAME, "fooMethod");
-        services = services(include, exclude);
+        services = services(include, exclude, new FooClass(), new BarClass());
         assertThat(services).containsOnlyKeys(FOO_NAME, BAR_NAME);
 
         List<String> methods = methods(services);
@@ -252,7 +258,7 @@ public class AnnotatedHttpDocServicePluginTest {
         include = DocServiceFilter.ofServiceName(FOO_NAME);
         // Set the exclude to the default.
         exclude = (plugin, service, method) -> false;
-        services = services(include, exclude);
+        services = services(include, exclude, new FooClass(), new BarClass());
         assertThat(services).containsOnlyKeys(FOO_NAME);
 
         methods = methods(services);
@@ -260,7 +266,7 @@ public class AnnotatedHttpDocServicePluginTest {
 
         // 3-2. Include methodName specified.
         include = DocServiceFilter.ofMethodName(FOO_NAME, "fooMethod");
-        services = services(include, exclude);
+        services = services(include, exclude, new FooClass(), new BarClass());
         assertThat(services).containsOnlyKeys(FOO_NAME);
 
         methods = methods(services);
@@ -269,7 +275,7 @@ public class AnnotatedHttpDocServicePluginTest {
         // 4-1. Include and exclude specified.
         include = DocServiceFilter.ofServiceName(FOO_NAME);
         exclude = DocServiceFilter.ofMethodName(FOO_NAME, "fooMethod");
-        services = services(include, exclude);
+        services = services(include, exclude, new FooClass());
         assertThat(services).containsOnlyKeys(FOO_NAME);
 
         methods = methods(services);
@@ -278,8 +284,20 @@ public class AnnotatedHttpDocServicePluginTest {
         // 4-2. Include and exclude specified.
         include = DocServiceFilter.ofMethodName(FOO_NAME, "fooMethod");
         exclude = DocServiceFilter.ofServiceName(FOO_NAME);
-        services = services(include, exclude);
+        services = services(include, exclude, new FooClass(), new BarClass());
         assertThat(services.size()).isZero();
+    }
+
+    @Test
+    public void testMultiPath() {
+        final Map<String, ServiceInfo> services = services(new MultiPathClass());
+        final Map<String, MethodInfo> methods =
+                services.get(MultiPathClass.class.getName()).methods().stream()
+                        .collect(toImmutableMap(MethodInfo::name, Function.identity()));
+        final Set<String> paths = methods.get("multiGet").endpoints()
+                                         .stream().map(EndpointInfo::pathMapping)
+                                         .collect(Collectors.toSet());
+        assertThat(paths).isEqualTo(ImmutableSet.of("exact:/path1", "exact:/path2"));
     }
 
     private static void checkFooService(ServiceInfo fooServiceInfo) {
@@ -330,11 +348,18 @@ public class AnnotatedHttpDocServicePluginTest {
         assertFieldInfos(fieldInfos, ImmutableList.of(bar, compositeBean()));
     }
 
-    private static Map<String, ServiceInfo> services(DocServiceFilter include, DocServiceFilter exclude) {
-        final Server server = Server.builder()
-                                    .annotatedService(new FooClass())
-                                    .annotatedService(new BarClass())
-                                    .build();
+    private static Map<String, ServiceInfo> services(Object... services) {
+        final DocServiceFilter include = (plugin, service, method) -> true;
+        final DocServiceFilter exclude = (plugin, service, method) -> false;
+        return services(include, exclude, services);
+    }
+
+    private static Map<String, ServiceInfo> services(DocServiceFilter include,
+                                                     DocServiceFilter exclude,
+                                                     Object... services) {
+        final ServerBuilder builder = Server.builder();
+        Arrays.stream(services).forEach(service -> builder.annotatedService(service));
+        final Server server = builder.build();
         final ServiceSpecification specification =
                 plugin.generateSpecification(ImmutableSet.copyOf(server.serviceConfigs()),
                                              unifyFilter(include, exclude));
@@ -410,6 +435,13 @@ public class AnnotatedHttpDocServicePluginTest {
     private static class BarClass {
         @Get("/bar")
         public void barMethod(@Param String bar, CompositeBean compositeBean) {}
+    }
+
+    private static class MultiPathClass {
+        @Get
+        @Path("/path1")
+        @Path("/path2")
+        public void multiGet() {}
     }
 
     static class CompositeBean {

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpDocServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpDocServiceTest.java
@@ -134,6 +134,7 @@ public class AnnotatedHttpDocServiceTest {
         addPrefixMethodInfo(methodInfos);
         addConsumesMethodInfo(methodInfos);
         addBeanMethodInfo(methodInfos);
+        addMultiMethodInfo(methodInfos);
         final Map<Class<?>, String> serviceDescription = ImmutableMap.of(MyService.class, "My service class");
 
         final JsonNode expectedJson = mapper.valueToTree(AnnotatedHttpDocServicePlugin.generate(
@@ -242,6 +243,17 @@ public class AnnotatedHttpDocServiceTest {
         final MethodInfo methodInfo = new MethodInfo(
                 "bean", TypeSignature.ofBase("HttpResponse"), fieldInfos, ImmutableList.of(),
                 ImmutableList.of(endpoint), HttpMethod.GET, null);
+        methodInfos.computeIfAbsent(MyService.class, unused -> new HashSet<>()).add(methodInfo);
+    }
+
+    private static void addMultiMethodInfo(Map<Class<?>, Set<MethodInfo>> methodInfos) {
+        final EndpointInfo endpoint1 = new EndpointInfoBuilder("*", "exact:/service/multi")
+                .availableMimeTypes(MediaType.JSON_UTF_8).build();
+        final EndpointInfo endpoint2 = new EndpointInfoBuilder("*", "prefix:/service/multi2/")
+                .availableMimeTypes(MediaType.JSON_UTF_8).build();
+        final MethodInfo methodInfo = new MethodInfo(
+                "multi", TypeSignature.ofBase("HttpResponse"), ImmutableList.of(), ImmutableList.of(),
+                ImmutableList.of(endpoint1, endpoint2), HttpMethod.GET, null);
         methodInfos.computeIfAbsent(MyService.class, unused -> new HashSet<>()).add(methodInfo);
     }
 
@@ -370,6 +382,13 @@ public class AnnotatedHttpDocServiceTest {
 
         @Get("/exclude2")
         public HttpResponse exclude2() {
+            return HttpResponse.of(200);
+        }
+
+        @Get
+        @Path("/multi")
+        @Path("prefix:/multi2")
+        public HttpResponse multi() {
             return HttpResponse.of(200);
         }
     }

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceBuilderTest.java
@@ -39,7 +39,6 @@ import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
 import com.linecorp.armeria.server.annotation.Get;
 import com.linecorp.armeria.server.annotation.Header;
 import com.linecorp.armeria.server.annotation.JacksonRequestConverterFunction;
-import com.linecorp.armeria.server.annotation.Options;
 import com.linecorp.armeria.server.annotation.Param;
 import com.linecorp.armeria.server.annotation.Path;
 import com.linecorp.armeria.server.annotation.Post;
@@ -189,13 +188,6 @@ public class AnnotatedHttpServiceBuilderTest {
             @Get
             @Post
             @Path("/a")
-            @Path("/b")
-            public void root(BeanB b) {}
-        });
-
-        Server.builder().annotatedService(new Object() {
-            @Path("/")
-            @Get("/")
             public void root() {}
         });
 
@@ -342,9 +334,25 @@ public class AnnotatedHttpServiceBuilderTest {
         })).isInstanceOf(IllegalArgumentException.class);
 
         assertThatThrownBy(() -> Server.builder().annotatedService(new Object() {
-            @Options
             @Get
             @Post("/")
+            public void root() {}
+        })).isInstanceOf(IllegalArgumentException.class);
+
+        assertThatThrownBy(() -> Server.builder().annotatedService(new Object() {
+            @Get("/")
+            @Path("/")
+            public void root() {}
+        })).isInstanceOf(IllegalArgumentException.class);
+
+        assertThatThrownBy(() -> Server.builder().annotatedService(new Object() {
+            @Path("")
+            public void root() {}
+        })).isInstanceOf(IllegalArgumentException.class);
+
+        // TODO: Check if we must support this
+        assertThatThrownBy(() -> Server.builder().annotatedService(new Object() {
+            @Path("/")
             public void root() {}
         })).isInstanceOf(IllegalArgumentException.class);
     }

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceBuilderTest.java
@@ -39,6 +39,7 @@ import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
 import com.linecorp.armeria.server.annotation.Get;
 import com.linecorp.armeria.server.annotation.Header;
 import com.linecorp.armeria.server.annotation.JacksonRequestConverterFunction;
+import com.linecorp.armeria.server.annotation.Options;
 import com.linecorp.armeria.server.annotation.Param;
 import com.linecorp.armeria.server.annotation.Path;
 import com.linecorp.armeria.server.annotation.Post;
@@ -66,14 +67,6 @@ public class AnnotatedHttpServiceBuilderTest {
             @Post
             public void root() {}
         });
-
-        // TODO: Check if we need to keep supporting this
-        //        Server.builder().annotatedService(new Object() {
-        //            @Options
-        //            @Get
-        //            @Post("/")
-        //            public void root() {}
-        //        });
 
         Server.builder().annotatedService(new Object() {
             @Get("/")
@@ -346,6 +339,13 @@ public class AnnotatedHttpServiceBuilderTest {
         assertThatThrownBy(() -> Server.builder().annotatedService(new Object() {
             @Get("/test")
             public void root(BeanA a) {}
+        })).isInstanceOf(IllegalArgumentException.class);
+
+        assertThatThrownBy(() -> Server.builder().annotatedService(new Object() {
+            @Options
+            @Get
+            @Post("/")
+            public void root() {}
         })).isInstanceOf(IllegalArgumentException.class);
     }
 

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceBuilderTest.java
@@ -350,7 +350,6 @@ public class AnnotatedHttpServiceBuilderTest {
             public void root() {}
         })).isInstanceOf(IllegalArgumentException.class);
 
-        // TODO: Check if we must support this
         assertThatThrownBy(() -> Server.builder().annotatedService(new Object() {
             @Path("/")
             public void root() {}

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceBuilderTest.java
@@ -39,7 +39,6 @@ import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
 import com.linecorp.armeria.server.annotation.Get;
 import com.linecorp.armeria.server.annotation.Header;
 import com.linecorp.armeria.server.annotation.JacksonRequestConverterFunction;
-import com.linecorp.armeria.server.annotation.Options;
 import com.linecorp.armeria.server.annotation.Param;
 import com.linecorp.armeria.server.annotation.Path;
 import com.linecorp.armeria.server.annotation.Post;
@@ -68,12 +67,13 @@ public class AnnotatedHttpServiceBuilderTest {
             public void root() {}
         });
 
-        Server.builder().annotatedService(new Object() {
-            @Options
-            @Get
-            @Post("/")
-            public void root() {}
-        });
+        // TODO: Check if we need to keep supporting this
+        //        Server.builder().annotatedService(new Object() {
+        //            @Options
+        //            @Get
+        //            @Post("/")
+        //            public void root() {}
+        //        });
 
         Server.builder().annotatedService(new Object() {
             @Get("/")
@@ -191,6 +191,59 @@ public class AnnotatedHttpServiceBuilderTest {
                              @Header("a") LinkedList<String> b) {}
         });
 
+        // Multiple paths are allowed
+        Server.builder().annotatedService(new Object() {
+            @Get
+            @Post
+            @Path("/a")
+            @Path("/b")
+            public void root(BeanB b) {}
+        });
+
+        Server.builder().annotatedService(new Object() {
+            @Path("/")
+            @Get("/")
+            public void root() {}
+        });
+
+        Server.builder().annotatedService(new Object() {
+            @Post("/")
+            @Get("/")
+            public void root() {}
+        });
+
+        // Multiple paths with matching params
+        Server.builder().annotatedService(new Object() {
+            @Get
+            @Path("/a/{param}")
+            @Path("/b/{param}")
+            public void root(@Param("param") String param) {}
+        });
+
+        // Multiple paths with non matching but optional path variables
+        Server.builder().annotatedService(new Object() {
+            @Get
+            @Path("/a")
+            @Path("/b/{param}")
+            public void root(@Param("param") Optional<String> param) {}
+        });
+
+        // Multiple paths with non matching non-optional path variables
+        Server.builder().annotatedService(new Object() {
+            @Get
+            @Path("/a/{param1}")
+            @Path("/b/{param2}")
+            public void root(String param1, String param2) {}
+        });
+
+        // Multiple paths with same value
+        Server.builder().annotatedService(new Object() {
+            @Get
+            @Path("/a")
+            @Path("/a")
+            public void root(BeanB b) {}
+        });
+
         // Optional is redundant, but we just warn.
         Server.builder().annotatedService(new Object() {
             @Get("/{name}")
@@ -244,18 +297,6 @@ public class AnnotatedHttpServiceBuilderTest {
 
     @Test
     public void failedOf() {
-        assertThatThrownBy(() -> Server.builder().annotatedService(new Object() {
-            @Path("/")
-            @Get("/")
-            public void root() {}
-        })).isInstanceOf(IllegalArgumentException.class);
-
-        assertThatThrownBy(() -> Server.builder().annotatedService(new Object() {
-            @Post("/")
-            @Get("/")
-            public void root() {}
-        })).isInstanceOf(IllegalArgumentException.class);
-
         assertThatThrownBy(() -> Server.builder().annotatedService(new Object() {
             @Get
             public void root() {}

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceFactoryTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceFactoryTest.java
@@ -226,6 +226,42 @@ public class AnnotatedHttpServiceFactoryTest {
     }
 
     @Test
+    public void testMultiPathAnnotations() {
+        final List<AnnotatedHttpServiceElement> getServiceElements = getServiceElements(
+                new MultiPathSuccessService(), "multiPathAnnotations", HttpMethod.GET);
+        final Set<Route> getRoutes = getServiceElements.stream().map(AnnotatedHttpServiceElement::route)
+                                                       .collect(Collectors.toSet());
+        assertThat(getRoutes).containsOnly(Route.builder().path("/path1").methods(HttpMethod.GET).build(),
+                                           Route.builder().path("/path2").methods(HttpMethod.GET).build());
+
+        final List<AnnotatedHttpServiceElement> postServiceElements = getServiceElements(
+                new MultiPathSuccessService(), "multiPathAnnotations", HttpMethod.POST);
+        final Set<Route> postRoutes = postServiceElements.stream().map(AnnotatedHttpServiceElement::route)
+                                                         .collect(Collectors.toSet());
+        assertThat(postRoutes).containsOnly(Route.builder().path("/path1").methods(HttpMethod.POST).build(),
+                                            Route.builder().path("/path2").methods(HttpMethod.POST).build());
+    }
+
+    @Test
+    public void testDuplicatePathAnnotations() {
+        final List<AnnotatedHttpServiceElement> getServiceElements = getServiceElements(
+                new MultiPathSuccessService(), "duplicatePathAnnotations", HttpMethod.GET);
+        assertThat(getServiceElements).hasSize(2);
+        final Set<Route> getRoutes = getServiceElements.stream().map(AnnotatedHttpServiceElement::route)
+                                                       .collect(Collectors.toSet());
+        assertThat(getRoutes).containsOnly(Route.builder().path("/path").methods(HttpMethod.GET).build(),
+                                           Route.builder().path("/path").methods(HttpMethod.GET).build());
+
+        final List<AnnotatedHttpServiceElement> postServiceElements = getServiceElements(
+                new MultiPathSuccessService(), "duplicatePathAnnotations", HttpMethod.POST);
+        assertThat(getServiceElements).hasSize(2);
+        final Set<Route> postRoutes = postServiceElements.stream().map(AnnotatedHttpServiceElement::route)
+                                                         .collect(Collectors.toSet());
+        assertThat(postRoutes).containsOnly(Route.builder().path("/path").methods(HttpMethod.POST).build(),
+                                            Route.builder().path("/path").methods(HttpMethod.POST).build());
+    }
+
+    @Test
     public void testMultiPathFailingService() {
         final MultiPathFailingService serviceObject = new MultiPathFailingService();
         getMethods(MultiPathFailingService.class, HttpResponse.class).forEach(method -> {
@@ -446,6 +482,22 @@ public class AnnotatedHttpServiceFactoryTest {
         @Post
         @Path("/path")
         public HttpResponse getPostMappingByPath() {
+            return HttpResponse.of(HttpStatus.OK);
+        }
+
+        @Get
+        @Post
+        @Path("/path1")
+        @Path("/path2")
+        public HttpResponse multiPathAnnotations() {
+            return HttpResponse.of(HttpStatus.OK);
+        }
+
+        @Get
+        @Post
+        @Path("/path")
+        @Path("/path")
+        public HttpResponse duplicatePathAnnotations() {
             return HttpResponse.of(HttpStatus.OK);
         }
     }

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceFactoryTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceFactoryTest.java
@@ -534,7 +534,6 @@ public class AnnotatedHttpServiceFactoryTest {
             return HttpResponse.of(HttpStatus.OK);
         }
 
-        // TODO: will leave this as failing until we decide how to process this
         @Path("/path")
         public HttpResponse pathMapping() {
             return HttpResponse.of(HttpStatus.OK);

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceTest.java
@@ -679,38 +679,44 @@ public class AnnotatedHttpServiceTest {
     public static class MyAnnotatedService12 {
 
         @Get
-        @Path("/multiGet1")
-        @Path("/multiGet2")
-        public String multipleGet(RequestContext ctx) {
+        @Path("/pathMapping1")
+        @Path("/pathMapping2")
+        public String pathMapping(RequestContext ctx) {
             return "multiGet";
         }
 
         @Get
-        @Path("/duplicateGet")
-        @Path("/duplicateGet")
-        public String duplicateGet(RequestContext ctx) {
-            return "duplicateGet";
+        @Path("/duplicatePath")
+        @Path("/duplicatePath")
+        public String duplicatePath(RequestContext ctx) {
+            return "duplicatePath";
         }
 
         @Get
-        @Path("/multiGetWithParam1/{param}")
-        @Path("/multiGetWithParam2/{param}")
-        public String multiGetWithParam(RequestContext ctx, @Param String param) {
+        @Path("/pathSameParam1/{param}")
+        @Path("/pathSameParam2/{param}")
+        public String pathSameParam(RequestContext ctx, @Param String param) {
             return param;
         }
 
         @Get
-        @Path("/multiGetDiffParam1/{param1}")
-        @Path("/multiGetDiffParam2/{param2}")
-        public String multiGetDiffParam(RequestContext ctx, @Param String param1, @Param String param2) {
-            return param1 + "_" + param2;
+        @Path("/pathDiffParam1/{param1}")
+        @Path("/pathDiffParam2/{param2}")
+        public String pathDiffParam(RequestContext ctx, @Param String param1, @Param String param2) {
+            return param1 + '_' + param2;
         }
 
         @Get
         @Post
-        @Path("/multiGetPost1")
-        @Path("/multiGetPost2")
-        public String multiGetPost(RequestContext ctx) {
+        @Path("/getPostWithPathMapping1")
+        @Path("/getPostWithPathMapping2")
+        public String getPostWithPathMapping(RequestContext ctx) {
+            return ctx.path();
+        }
+
+        @Get("/getMapping")
+        @Post("/postMapping")
+        public String getPostMapping(RequestContext ctx) {
             return ctx.path();
         }
     }
@@ -1031,23 +1037,28 @@ public class AnnotatedHttpServiceTest {
     @Test
     public void testMultiplePaths() throws Exception {
         try (CloseableHttpClient hc = HttpClients.createMinimal()) {
-            testStatusCode(hc, get("/12/multiGet1"), 200);
-            testStatusCode(hc, get("/12/multiGet2"), 200);
+            testStatusCode(hc, get("/12/pathMapping1"), 200);
+            testStatusCode(hc, get("/12/pathMapping2"), 200);
 
-            testStatusCode(hc, get("/12/duplicateGet"), 200);
+            testStatusCode(hc, get("/12/duplicatePath"), 200);
 
-            testBody(hc, get("/12/multiGetWithParam1/param"), "param");
-            testBody(hc, get("/12/multiGetWithParam2/param"), "param");
+            testBody(hc, get("/12/pathSameParam1/param"), "param");
+            testBody(hc, get("/12/pathSameParam2/param"), "param");
 
-            testStatusCode(hc, get("/12/multiGetDiffParam1/param1"), 400);
-            testBody(hc, get("/12/multiGetDiffParam1/param1?param2=param2"), "param1_param2");
-            testStatusCode(hc, get("/12/multiGetDiffParam2/param2"), 400);
-            testBody(hc, get("/12/multiGetDiffParam2/param2?param1=param1"), "param1_param2");
+            testStatusCode(hc, get("/12/pathDiffParam1/param1"), 400);
+            testBody(hc, get("/12/pathDiffParam1/param1?param2=param2"), "param1_param2");
+            testStatusCode(hc, get("/12/pathDiffParam2/param2"), 400);
+            testBody(hc, get("/12/pathDiffParam2/param2?param1=param1"), "param1_param2");
 
-            testBody(hc, get("/12/multiGetPost1"), "/12/multiGetPost1");
-            testBody(hc, post("/12/multiGetPost1"), "/12/multiGetPost1");
-            testBody(hc, get("/12/multiGetPost2"), "/12/multiGetPost2");
-            testBody(hc, post("/12/multiGetPost2"), "/12/multiGetPost2");
+            testBody(hc, get("/12/getPostWithPathMapping1"), "/12/getPostWithPathMapping1");
+            testBody(hc, post("/12/getPostWithPathMapping1"), "/12/getPostWithPathMapping1");
+            testBody(hc, get("/12/getPostWithPathMapping2"), "/12/getPostWithPathMapping2");
+            testBody(hc, post("/12/getPostWithPathMapping2"), "/12/getPostWithPathMapping2");
+
+            testBody(hc, get("/12/getMapping"), "/12/getMapping");
+            testStatusCode(hc, post("/12/getMapping"), 405);
+            testStatusCode(hc, get("/12/postMapping"), 405);
+            testBody(hc, post("/12/postMapping"), "/12/postMapping");
         }
     }
 

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceTest.java
@@ -703,7 +703,7 @@ public class AnnotatedHttpServiceTest {
         @Path("/multiGetDiffParam1/{param1}")
         @Path("/multiGetDiffParam2/{param2}")
         public String multiGetDiffParam(RequestContext ctx, @Param String param1, @Param String param2) {
-            return "multiGetDiffParam";
+            return param1 + "_" + param2;
         }
 
         @Get
@@ -711,7 +711,7 @@ public class AnnotatedHttpServiceTest {
         @Path("/multiGetPost1")
         @Path("/multiGetPost2")
         public String multiGetPost(RequestContext ctx) {
-            return "multiGetPost";
+            return ctx.path();
         }
     }
 
@@ -1040,14 +1040,14 @@ public class AnnotatedHttpServiceTest {
             testBody(hc, get("/12/multiGetWithParam2/param"), "param");
 
             testStatusCode(hc, get("/12/multiGetDiffParam1/param1"), 400);
-            testStatusCode(hc, get("/12/multiGetDiffParam1/param1?param2=param2"), 200);
+            testBody(hc, get("/12/multiGetDiffParam1/param1?param2=param2"), "param1_param2");
             testStatusCode(hc, get("/12/multiGetDiffParam2/param2"), 400);
-            testStatusCode(hc, get("/12/multiGetDiffParam2/param2?param1=param1"), 200);
+            testBody(hc, get("/12/multiGetDiffParam2/param2?param1=param1"), "param1_param2");
 
-            testStatusCode(hc, get("/12/multiGetPost1"), 200);
-            testStatusCode(hc, post("/12/multiGetPost1"), 200);
-            testStatusCode(hc, get("/12/multiGetPost2"), 200);
-            testStatusCode(hc, post("/12/multiGetPost2"), 200);
+            testBody(hc, get("/12/multiGetPost1"), "/12/multiGetPost1");
+            testBody(hc, post("/12/multiGetPost1"), "/12/multiGetPost1");
+            testBody(hc, get("/12/multiGetPost2"), "/12/multiGetPost2");
+            testBody(hc, post("/12/multiGetPost2"), "/12/multiGetPost2");
         }
     }
 

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceTest.java
@@ -707,6 +707,13 @@ public class AnnotatedHttpServiceTest {
         }
 
         @Get
+        @Path("/pathDiffPattern/path")
+        @Path("/pathDiffPattern/{param}")
+        public String pathDiffPattern(@Param @Default("default") String param) {
+            return param;
+        }
+
+        @Get
         @Post
         @Path("/getPostWithPathMapping1")
         @Path("/getPostWithPathMapping2")
@@ -1049,6 +1056,9 @@ public class AnnotatedHttpServiceTest {
             testBody(hc, get("/12/pathDiffParam1/param1?param2=param2"), "param1_param2");
             testStatusCode(hc, get("/12/pathDiffParam2/param2"), 400);
             testBody(hc, get("/12/pathDiffParam2/param2?param1=param1"), "param1_param2");
+
+            testBody(hc, get("/12/pathDiffPattern/path"), "default");
+            testBody(hc, get("/12/pathDiffPattern/customArg"), "customArg");
 
             testBody(hc, get("/12/getPostWithPathMapping1"), "/12/getPostWithPathMapping1");
             testBody(hc, post("/12/getPostWithPathMapping1"), "/12/getPostWithPathMapping1");

--- a/core/src/test/java/com/linecorp/armeria/server/docs/ServiceInfoTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/docs/ServiceInfoTest.java
@@ -1,0 +1,83 @@
+/*
+ *  Copyright 2018 LINE Corporation
+ *
+ *  LINE Corporation licenses this file to you under the Apache License,
+ *  version 2.0 (the "License"); you may not use this file except in compliance
+ *  with the License. You may obtain a copy of the License at:
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package com.linecorp.armeria.server.docs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.MediaType;
+
+class ServiceInfoTest {
+
+    private static MethodInfo createMethodInfo(String methodName, HttpMethod method,
+                                               String endpointPathMapping) {
+        final EndpointInfo endpoint = new EndpointInfoBuilder("*", endpointPathMapping)
+                .availableMimeTypes(MediaType.JSON_UTF_8).build();
+        return new MethodInfo(methodName, TypeSignature.ofBase("T"), ImmutableList.of(), ImmutableList.of(),
+                              ImmutableList.of(endpoint), method, null);
+    }
+
+    @Test
+    public void testCollectMethodsWithDifferentMethods() {
+
+        final MethodInfo barMethodInfo = createMethodInfo("bar", HttpMethod.GET, "exact:/bar");
+        final MethodInfo fooMethodInfo = createMethodInfo("foo", HttpMethod.GET, "exact:/foo");
+
+        final List<MethodInfo> inputMethodInfos = ImmutableList.of(barMethodInfo, fooMethodInfo);
+        final List<MethodInfo> collectMethods =
+                ImmutableList.copyOf(ServiceInfo.mergeEndpoints(inputMethodInfos));
+
+        assertEquals(inputMethodInfos, collectMethods);
+    }
+
+    @Test
+    public void testCollectMethodGrouping() {
+
+        final MethodInfo barGet1 = createMethodInfo("bar", HttpMethod.GET, "exact:/bar1");
+        final MethodInfo barGet2 = createMethodInfo("bar", HttpMethod.GET, "exact:/bar2");
+        final MethodInfo barPost3 = createMethodInfo("bar", HttpMethod.POST, "exact:/bar3");
+        final MethodInfo barPost4 = createMethodInfo("bar", HttpMethod.POST, "exact:/bar4");
+        final MethodInfo fooGet1 = createMethodInfo("foo", HttpMethod.GET, "exact:/foo1");
+        final MethodInfo fooGet2 = createMethodInfo("foo", HttpMethod.GET, "exact:/foo2");
+        final MethodInfo fooPost3 = createMethodInfo("foo", HttpMethod.POST, "exact:/foo3");
+        final MethodInfo fooPost4 = createMethodInfo("foo", HttpMethod.POST, "exact:/foo4");
+
+        final List<MethodInfo> inputMethodInfos = ImmutableList.of(barGet1, barGet2, barPost3, barPost4,
+                                                                   fooGet1, fooGet2, fooPost3, fooPost4);
+        final List<MethodInfo> collectMethods =
+                ImmutableList.copyOf(ServiceInfo.mergeEndpoints(inputMethodInfos));
+
+        assertEquals(4, collectMethods.size());
+
+        final Function<MethodInfo, Set<String>> getPaths = methodInfo ->
+                methodInfo.endpoints().stream().map(EndpointInfo::pathMapping).collect(Collectors.toSet());
+        assertEquals(ImmutableSet.of("exact:/bar1", "exact:/bar2"), getPaths.apply(collectMethods.get(0)));
+        assertEquals(ImmutableSet.of("exact:/bar3", "exact:/bar4"), getPaths.apply(collectMethods.get(1)));
+        assertEquals(ImmutableSet.of("exact:/foo1", "exact:/foo2"), getPaths.apply(collectMethods.get(2)));
+        assertEquals(ImmutableSet.of("exact:/foo3", "exact:/foo4"), getPaths.apply(collectMethods.get(3)));
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/docs/ServiceInfoTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/docs/ServiceInfoTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2018 LINE Corporation
+ *  Copyright 2019 LINE Corporation
  *
  *  LINE Corporation licenses this file to you under the Apache License,
  *  version 2.0 (the "License"); you may not use this file except in compliance
@@ -42,7 +42,7 @@ class ServiceInfoTest {
     }
 
     @Test
-    public void testCollectMethodsWithDifferentMethods() {
+    void testCollectMethodsWithDifferentMethods() {
         final MethodInfo barMethodInfo = createMethodInfo("bar", HttpMethod.GET, "exact:/bar");
         final MethodInfo fooMethodInfo = createMethodInfo("foo", HttpMethod.GET, "exact:/foo");
         final List<MethodInfo> inputMethodInfos = ImmutableList.of(barMethodInfo, fooMethodInfo);
@@ -50,7 +50,7 @@ class ServiceInfoTest {
     }
 
     @Test
-    public void testCollectMethodGrouping() {
+    void testCollectMethodGrouping() {
 
         final MethodInfo barGet1 = createMethodInfo("bar", HttpMethod.GET, "exact:/bar1");
         final MethodInfo barGet2 = createMethodInfo("bar", HttpMethod.GET, "exact:/bar2");

--- a/core/src/test/java/com/linecorp/armeria/server/docs/ServiceInfoTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/docs/ServiceInfoTest.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.server.docs;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
@@ -26,7 +27,6 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.MediaType;
@@ -43,15 +43,10 @@ class ServiceInfoTest {
 
     @Test
     public void testCollectMethodsWithDifferentMethods() {
-
         final MethodInfo barMethodInfo = createMethodInfo("bar", HttpMethod.GET, "exact:/bar");
         final MethodInfo fooMethodInfo = createMethodInfo("foo", HttpMethod.GET, "exact:/foo");
-
         final List<MethodInfo> inputMethodInfos = ImmutableList.of(barMethodInfo, fooMethodInfo);
-        final List<MethodInfo> collectMethods =
-                ImmutableList.copyOf(ServiceInfo.mergeEndpoints(inputMethodInfos));
-
-        assertEquals(inputMethodInfos, collectMethods);
+        assertThat(ServiceInfo.mergeEndpoints(inputMethodInfos)).isEqualTo(inputMethodInfos);
     }
 
     @Test
@@ -75,9 +70,9 @@ class ServiceInfoTest {
 
         final Function<MethodInfo, Set<String>> getPaths = methodInfo ->
                 methodInfo.endpoints().stream().map(EndpointInfo::pathMapping).collect(Collectors.toSet());
-        assertEquals(ImmutableSet.of("exact:/bar1", "exact:/bar2"), getPaths.apply(collectMethods.get(0)));
-        assertEquals(ImmutableSet.of("exact:/bar3", "exact:/bar4"), getPaths.apply(collectMethods.get(1)));
-        assertEquals(ImmutableSet.of("exact:/foo1", "exact:/foo2"), getPaths.apply(collectMethods.get(2)));
-        assertEquals(ImmutableSet.of("exact:/foo3", "exact:/foo4"), getPaths.apply(collectMethods.get(3)));
+        assertThat(getPaths.apply(collectMethods.get(0))).containsExactly("exact:/bar1", "exact:/bar2");
+        assertThat(getPaths.apply(collectMethods.get(1))).containsExactly("exact:/bar3", "exact:/bar4");
+        assertThat(getPaths.apply(collectMethods.get(2))).containsExactly("exact:/foo1", "exact:/foo2");
+        assertThat(getPaths.apply(collectMethods.get(3))).containsExactly("exact:/foo3", "exact:/foo4");
     }
 }

--- a/docs-client/src/containers/MethodPage/index.tsx
+++ b/docs-client/src/containers/MethodPage/index.tsx
@@ -79,14 +79,12 @@ function removeBrackets(headers: string): string {
   return headers.substring(1, length - 1).trim();
 }
 
-function isExactPathMapping(method: Method): boolean {
+function isSingleExactPathMapping(method: Method): boolean {
   const endpoints = method.endpoints;
-  if (endpoints.length !== 1) {
-    throw new Error(`
-    Endpoints size should be 1 to determine prefix or regex. size: ${endpoints.length}`);
-  }
-  const endpoint = endpoints[0];
-  return endpoint.pathMapping.startsWith('exact:');
+  return (
+    method.endpoints.length === 1 &&
+    endpoints[0].pathMapping.startsWith('exact:')
+  );
 }
 
 function useRequestBody(httpMethod: string) {
@@ -167,7 +165,7 @@ const MethodPage: React.FunctionComponent<Props> = (props) => {
             method,
           )}
           exactPathMapping={
-            isAnnotatedHttpService ? isExactPathMapping(method) : false
+            isAnnotatedHttpService ? isSingleExactPathMapping(method) : false
           }
           useRequestBody={useRequestBody(props.match.params.httpMethod)}
         />

--- a/site/src/sphinx/server-annotated-service.rst
+++ b/site/src/sphinx/server-annotated-service.rst
@@ -95,8 +95,8 @@ Please refer to :ref:`parameter-injection` for more information about :api:`@Par
     }
 
 Every service method in the examples so far had a single HTTP method annotation with it. What if you want
-to map more than one HTTP method to your service method? You can use :api:`@Path` annotation to specify
-a path and use the HTTP method annotations without a path to map multiple HTTP methods, e.g.
+to map more than one HTTP method or path to your service method? You can use :api:`@Path` annotations to
+specify multiple paths, and use the HTTP method annotations without a path to map multiple HTTP methods, e.g.
 
 .. code-block:: java
 
@@ -106,7 +106,8 @@ a path and use the HTTP method annotations without a path to map multiple HTTP m
         @Put
         @Delete
         @Path("/hello")
-        public HttpResponse hello() { ... }
+        @Path("/hi")
+        public HttpResponse greeting() { ... }
     }
 
 Every service method assumes that it returns an HTTP response with ``200 OK`` or ``204 No Content`` status

--- a/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/internal/spring/ArmeriaConfigurationUtilTest.java
+++ b/spring/boot-autoconfigure/src/test/java/com/linecorp/armeria/internal/spring/ArmeriaConfigurationUtilTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.util.function.Function;
@@ -28,6 +29,7 @@ import org.junit.Test;
 
 import com.google.common.collect.ImmutableList;
 
+import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
@@ -60,7 +62,7 @@ public class ArmeriaConfigurationUtilTest {
         final DocServiceBuilder dsb1 = new DocServiceBuilder();
         configureAnnotatedHttpServices(sb1, dsb1, ImmutableList.of(bean),
                                        MeterIdPrefixFunctionFactory.DEFAULT, null);
-        verify(decorator).apply(any());
+        verify(decorator, times(2)).apply(any());
         assertThat(service(sb1).as(MetricCollectingService.class)).isPresent();
 
         reset(decorator);
@@ -69,8 +71,9 @@ public class ArmeriaConfigurationUtilTest {
         final DocServiceBuilder dsb2 = new DocServiceBuilder();
         configureAnnotatedHttpServices(sb2, dsb2, ImmutableList.of(bean),
                                        null, null);
-        verify(decorator).apply(any());
-        assertThat(service(sb2)).isInstanceOf(AnnotatedHttpService.class);
+        verify(decorator, times(2)).apply(any());
+        assertThat(getServiceForHttpMethod(sb2.build(), HttpMethod.OPTIONS))
+                .isInstanceOf(AnnotatedHttpService.class);
     }
 
     @Test
@@ -86,13 +89,19 @@ public class ArmeriaConfigurationUtilTest {
         final DocServiceBuilder dsb = new DocServiceBuilder();
         configureAnnotatedHttpServices(sb, dsb, ImmutableList.of(bean),
                                        null, null);
-        verify(decorator).apply(any());
+        verify(decorator, times(2)).apply(any());
         assertThat(service(sb).as(SimpleDecorator.class)).isPresent();
     }
 
     private static Service<?, ?> service(ServerBuilder sb) {
         final Server server = sb.build();
         return server.config().defaultVirtualHost().serviceConfigs().get(0).service();
+    }
+
+    private static Service<?, ?> getServiceForHttpMethod(Server server, HttpMethod httpMethod) {
+        return server.serviceConfigs().stream()
+                     .filter(config -> config.route().methods().contains(httpMethod))
+                     .findFirst().get().service();
     }
 
     /**


### PR DESCRIPTION
Motivation:
A user might want to specify multiple paths for annotated http services. 

Modification:
- Allow repeatable annotations for `@Path` annotation.
- Different behavior in path declaration (described below)
- One `AnnotatedHttpService` is created for each `(httpMethod, pathMapping)`
    - It is difficult to accommodate multiple pathMappings using a single `AnnotatedHttpService` because `AnnotatedValueResolver` may be different
    - It may be possible to optimize this by serving multiple  `httpMethod`s that have the same `pathMapping` using a single `AnnotatedHttpService` at the cost of code complexiy
- Merge `MethodInfo` endpoints with same (`httpMethod`, `methodName`)
- Known issue: overloaded methods for `AnnotatedHttpService` are not displayed in docs. I'm thinking this can be tackled in a separate PR.

#### Breaking change in path declaration behavior
**AS-IS**
```
@Get("/")
@Post
public void method1() {} // accepts both Get("/") and Post("/")
```
**TO-BE**
```
@Get("/")
@Post
public void method1() {} // exception thrown. Path declared for Get not applied to Post
```
