### PR TITLE
Update dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.google.gradle:osdetector-gradle-plugin:1.6.2'
-        classpath 'io.spring.gradle:dependency-management-plugin:1.0.7.RELEASE'
+        classpath 'io.spring.gradle:dependency-management-plugin:1.0.8.RELEASE'
     }
 }
 

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -46,7 +46,7 @@ com.github.jengelman.gradle.plugins:
   shadow: { version: '5.0.0' }
 
 com.google.api:
-  gax-grpc: { version: '1.45.0' }
+  gax-grpc: { version: '1.47.0' }
 
 com.google.code.findbugs:
   jsr305: { version: '3.0.2' }
@@ -93,13 +93,13 @@ com.google.protobuf:
     version: *PROTOBUF_VERSION
     exclusions:
     - com.google.errorprone:error_prone_annotations
-  protobuf-gradle-plugin: { version: '0.8.8' }
+  protobuf-gradle-plugin: { version: '0.8.9' }
 
 com.moowork.gradle:
   gradle-node-plugin: { version: '1.3.1' }
 
 com.puppycrawl.tools:
-  checkstyle: { version: '8.19' }
+  checkstyle: { version: '8.22' }
 
 com.spotify:
   completable-futures:
@@ -159,24 +159,24 @@ io.grpc:
 
 io.micrometer:
   micrometer-core:
-    version: &MICROMETER_VERSION '1.1.4'
+    version: &MICROMETER_VERSION '1.2.0'
     javadocs:
-    - https://static.javadoc.io/io.micrometer/micrometer-core/1.1.4/
+    - https://static.javadoc.io/io.micrometer/micrometer-core/1.2.0/
   micrometer-registry-prometheus:
     version: *MICROMETER_VERSION
     javadocs:
-    - https://static.javadoc.io/io.micrometer/micrometer-registry-prometheus/1.1.4/
+    - https://static.javadoc.io/io.micrometer/micrometer-registry-prometheus/1.2.0/
   micrometer-spring-legacy:
     version: *MICROMETER_VERSION
     javadocs:
-    - https://static.javadoc.io/io.micrometer/micrometer-spring-legacy/1.1.4/
+    - https://static.javadoc.io/io.micrometer/micrometer-spring-legacy/1.2.0/
     exclusions:
     - org.springframework:spring-web
     - org.springframework:spring-webmvc
 
 io.netty:
   netty-common:
-    version: &NETTY_VERSION '4.1.34.Final'
+    version: &NETTY_VERSION '4.1.37.Final'
     javadocs:
     - https://netty.io/4.1/api/
   netty-buffer: { version: *NETTY_VERSION }
@@ -191,7 +191,7 @@ io.netty:
   netty-transport: { version: *NETTY_VERSION }
   netty-transport-native-epoll: { version: *NETTY_VERSION }
   netty-transport-native-unix-common: { version: *NETTY_VERSION }
-  netty-tcnative-boringssl-static: { version: '2.0.23.Final' }
+  netty-tcnative-boringssl-static: { version: '2.0.25.Final' }
 
 io.projectreactor:
   reactor-core:
@@ -208,19 +208,20 @@ io.prometheus:
 
 io.reactivex.rxjava2:
   rxjava:
-    version: '2.2.9'
+    version: '2.2.10'
     javadocs:
     - http://reactivex.io/RxJava/2.x/javadoc/
 
 io.zipkin.brave:
   brave:
-    version: '5.6.3'
+    version: '5.6.5'
+    # ':site:javadoc' fails when we use a newer version of Javadoc.
     javadocs:
     - https://static.javadoc.io/io.zipkin.brave/brave/5.6.3/
 
 it.unimi.dsi:
   fastutil:
-    version: '8.2.2'
+    version: '8.2.3'
     relocations:
     - from: it.unimi.dsi.fastutil
       to: com.linecorp.armeria.internal.shaded.fastutil
@@ -242,7 +243,7 @@ junit:
 
 org.junit.jupiter:
   junit-jupiter-api:
-    version: &JUNIT_JUPITER_VERSION '5.4.2'
+    version: &JUNIT_JUPITER_VERSION '5.5.0'
     javadocs:
     - https://junit.org/junit5/docs/5.4.2/api/
   junit-jupiter-engine:
@@ -251,15 +252,15 @@ org.junit.jupiter:
     version: *JUNIT_JUPITER_VERSION
 org.junit.platform:
   junit-platform-commons:
-    version: &JUNIT_PLATFORM_VERSION '1.4.2'
+    version: &JUNIT_PLATFORM_VERSION '1.5.0'
   junit-platform-launcher:
     version: *JUNIT_PLATFORM_VERSION
 org.junit.vintage:
   junit-vintage-engine:
-    version: '5.4.2'
+    version: '5.5.0'
 
 kr.motd.gradle:
-  sphinx-gradle-plugin: { version: '2.4.0' }
+  sphinx-gradle-plugin: { version: '2.5.0' }
 
 # We do not depend on log4j. We just need this to stop dependency-management-plugin from
 # complaining about its bad POM.
@@ -362,7 +363,7 @@ org.dmonix.junit:
   zookeeper-junit: { version: '1.2' }
 
 org.eclipse.jetty:
-  apache-jsp: { version: &JETTY_VERSION '9.4.18.v20190429' }
+  apache-jsp: { version: &JETTY_VERSION '9.4.19.v20190610' }
   apache-jstl: { version: *JETTY_VERSION }
   jetty-annotations:
     version: *JETTY_VERSION
@@ -382,7 +383,7 @@ org.eclipse.jetty.http2:
   http2-server: { version: *JETTY_VERSION }
 
 org.hibernate.validator:
-  hibernate-validator: { version: '6.0.16.Final' }
+  hibernate-validator: { version: '6.0.17.Final' }
 
 org.jctools:
   jctools-core:
@@ -440,7 +441,7 @@ org.slf4j:
 
 org.springframework.boot:
   spring-boot-starter:
-    version: &SPRING_BOOT_VERSION '2.1.5.RELEASE'
+    version: &SPRING_BOOT_VERSION '2.1.6.RELEASE'
     javadocs:
     - https://docs.spring.io/spring/docs/current/javadoc-api/
   spring-boot-actuator-autoconfigure: { version: *SPRING_BOOT_VERSION }
@@ -455,7 +456,7 @@ org.springframework.boot:
   spring-boot-gradle-plugin: { version: *SPRING_BOOT_VERSION }
 
 pl.project13.scala:
-  sbt-jmh-extras: { version: 0.3.6 }
+  sbt-jmh-extras: { version: 0.3.7 }
 
 # Needed to work around the problem with Gradle not supporting POM relocation correctly.
 xml-apis:

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
-distributionSha256Sum=14cd15fc8cc8705bd69dcfa3c8fefb27eb7027f5de4b47a8b279218f76895a91
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.5-all.zip
+distributionSha256Sum=302b7df46730ce75c582542c056c9bf5cac2b94fbf2cc656d0e37e41e8a5d371
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -5,7 +5,7 @@
 @rem you may not use this file except in compliance with the License.
 @rem You may obtain a copy of the License at
 @rem
-@rem      http://www.apache.org/licenses/LICENSE-2.0
+@rem      https://www.apache.org/licenses/LICENSE-2.0
 @rem
 @rem Unless required by applicable law or agreed to in writing, software
 @rem distributed under the License is distributed on an "AS IS" BASIS,

--- a/settings/checkstyle/checkstyle-suppressions.xml
+++ b/settings/checkstyle/checkstyle-suppressions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE suppressions PUBLIC
-  "-//Puppy Crawl//DTD Suppressions 1.1//EN"
-  "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+  "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+  "https://checkstyle.org/dtds/suppressions_1_2.dtd">
 
 <suppressions>
   <!-- Suppress Javadoc-related checks in non-public code. -->

--- a/settings/checkstyle/checkstyle.xml
+++ b/settings/checkstyle/checkstyle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC
-  "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-  "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+  "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+  "https://checkstyle.org/dtds/configuration_1_3.dtd">
 
 <module name="Checker">
   <property name="charset" value="UTF-8"/>
@@ -118,9 +118,12 @@
     </module>
     <module name="LeftCurly"/>
     <module name="NeedBraces"/>
-    <module name="RightCurly"/>
     <module name="RightCurly">
-      <property name="option" value="alone"/>
+      <property name="id" value="RightCurly1"/>
+    </module>
+    <module name="RightCurly">
+      <property name="id" value="RightCurly2"/>
+      <property name="option" value="alone_or_singleline"/>
       <property name="tokens"
                 value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT, INSTANCE_INIT"/>
     </module>


### PR DESCRIPTION
- Micrometer 1.1.4 -> 1.2.0
- Netty 4.1.34 -> 4.1.37
  - TCNative BoringSSL 2.0.23 -> 2.0.25
- RxJava 2.2.9 -> 2.2.10
- Brave 5.6.3 -> 5.6.5
- FastUtil 8.2.2 -> 8.2.3
- Jetty 9.4.18 -> 9.4.19
- Hibernate Validator 6.0.16 -> 6.0.17
- Spring Boot 2.1.5 -> 2.1.6
- Build
  - Gradle 5.4.1 -> 5.5
  - dependency-management-plugin 1.0.7 -> 1.0.8
  - gax-grpc 1.45.0 -> 1.47.0
  - protobuf-gradle-plugin 0.8.8 -> 0.8.9
  - Checkstyle 8.19 -> 8.22
    - Relaxed `RightCurly` check a little so that it does not complain
      about an empty `{}` block
  - jUnit platform 1.4.2 -> 1.5.0
  - jUnit 5.4.2 -> 5.5.0
  - sphinx-gradle-plugin 2.4.0 -> 2.5.0
  - sbt-jmh-extras 0.3.6 -> 0.3.7