### PR TITLE
Add `current/mapCurrent/currentOrNull()` to `Service/ClientRequestContext`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/RequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestContext.java
@@ -70,11 +70,21 @@ public interface RequestContext extends AttributeMap {
      * @throws IllegalStateException if the context is unavailable in the current thread
      */
     static <T extends RequestContext> T current() {
-        final T ctx = RequestContextThreadLocal.get();
+        final T ctx = currentOrNull();
         if (ctx == null) {
             throw new IllegalStateException(RequestContext.class.getSimpleName() + " unavailable");
         }
         return ctx;
+    }
+
+    /**
+     * Returns the context of the {@link Request} that is being handled in the current thread.
+     *
+     * @return the {@link RequestContext} available in the current thread, or {@code null} if unavailable.
+     */
+    @Nullable
+    static <T extends RequestContext> T currentOrNull() {
+        return RequestContextThreadLocal.get();
     }
 
     /**
@@ -89,7 +99,7 @@ public interface RequestContext extends AttributeMap {
     static <T> T mapCurrent(
             Function<? super RequestContext, T> mapper, @Nullable Supplier<T> defaultValueSupplier) {
 
-        final RequestContext ctx = RequestContextThreadLocal.get();
+        final RequestContext ctx = currentOrNull();
         if (ctx != null) {
             return mapper.apply(ctx);
         }

--- a/core/src/test/java/com/linecorp/armeria/client/ClientRequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientRequestContextTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.function.Function;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.util.SafeCloseable;
+import com.linecorp.armeria.server.ServiceRequestContext;
+
+class ClientRequestContextTest {
+
+    private static final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/");
+
+    @Test
+    void current() {
+        assertThatThrownBy(ClientRequestContext::current).isInstanceOf(IllegalStateException.class)
+                                                         .hasMessageContaining("unavailable");
+
+        final ClientRequestContext ctx = ClientRequestContext.of(req);
+        try (SafeCloseable unused = ctx.push()) {
+            assertThat(ClientRequestContext.current()).isSameAs(ctx);
+        }
+
+        try (SafeCloseable unused = ServiceRequestContext.of(req).push()) {
+            assertThatThrownBy(ClientRequestContext::current)
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("not a client-side context");
+        }
+    }
+
+    @Test
+    void currentOrNull() {
+        assertThat(ClientRequestContext.currentOrNull()).isNull();
+
+        final ClientRequestContext ctx = ClientRequestContext.of(req);
+        try (SafeCloseable unused = ctx.push()) {
+            assertThat(ClientRequestContext.currentOrNull()).isSameAs(ctx);
+        }
+
+        try (SafeCloseable unused = ServiceRequestContext.of(req).push()) {
+            assertThatThrownBy(ClientRequestContext::currentOrNull)
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("not a client-side context");
+        }
+    }
+
+    @Test
+    void mapCurrent() {
+        assertThat(ClientRequestContext.mapCurrent(ctx -> "foo", () -> "bar")).isEqualTo("bar");
+        assertThat(ClientRequestContext.mapCurrent(Function.identity(), null)).isNull();
+
+        final ClientRequestContext ctx = ClientRequestContext.of(req);
+        try (SafeCloseable unused = ctx.push()) {
+            assertThat(ClientRequestContext.mapCurrent(c -> "foo", () -> "bar")).isEqualTo("foo");
+            assertThat(ClientRequestContext.mapCurrent(Function.identity(), null)).isSameAs(ctx);
+        }
+
+        try (SafeCloseable unused = ServiceRequestContext.of(req).push()) {
+            assertThatThrownBy(() -> ClientRequestContext.mapCurrent(c -> "foo", () -> "bar"))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("not a client-side context");
+        }
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceTest.java
@@ -1119,14 +1119,14 @@ public class AnnotatedHttpServiceTest {
     }
 
     static void validateContext(RequestContext ctx) {
-        if (RequestContext.current() != ctx) {
+        if (ServiceRequestContext.current() != ctx) {
             throw new RuntimeException("ServiceRequestContext instances are not same!");
         }
     }
 
-    static void validateContextAndRequest(RequestContext ctx, Object req) {
+    static void validateContextAndRequest(RequestContext ctx, Request req) {
         validateContext(ctx);
-        if (RequestContext.current().request() != req) {
+        if (ServiceRequestContext.current().request() != req) {
             throw new RuntimeException("HttpRequest instances are not same!");
         }
     }

--- a/core/src/test/java/com/linecorp/armeria/server/ServiceRequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServiceRequestContextTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.function.Function;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.util.SafeCloseable;
+
+class ServiceRequestContextTest {
+
+    private static final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/");
+
+    @Test
+    void current() {
+        assertThatThrownBy(ServiceRequestContext::current).isInstanceOf(IllegalStateException.class)
+                                                          .hasMessageContaining("unavailable");
+
+        final ServiceRequestContext ctx = ServiceRequestContext.of(req);
+        try (SafeCloseable unused = ctx.push()) {
+            assertThat(ServiceRequestContext.current()).isSameAs(ctx);
+        }
+
+        try (SafeCloseable unused = ClientRequestContext.of(req).push()) {
+            assertThatThrownBy(ServiceRequestContext::current)
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("not a server-side context");
+        }
+    }
+
+    @Test
+    void currentOrNull() {
+        assertThat(ServiceRequestContext.currentOrNull()).isNull();
+
+        final ServiceRequestContext ctx = ServiceRequestContext.of(req);
+        try (SafeCloseable unused = ctx.push()) {
+            assertThat(ServiceRequestContext.currentOrNull()).isSameAs(ctx);
+        }
+
+        try (SafeCloseable unused = ClientRequestContext.of(req).push()) {
+            assertThatThrownBy(ServiceRequestContext::currentOrNull)
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("not a server-side context");
+        }
+    }
+
+    @Test
+    void mapCurrent() {
+        assertThat(ServiceRequestContext.mapCurrent(ctx -> "foo", () -> "bar")).isEqualTo("bar");
+        assertThat(ServiceRequestContext.mapCurrent(Function.identity(), null)).isNull();
+
+        final ServiceRequestContext ctx = ServiceRequestContext.of(req);
+        try (SafeCloseable unused = ctx.push()) {
+            assertThat(ServiceRequestContext.mapCurrent(c -> "foo", () -> "bar")).isEqualTo("foo");
+            assertThat(ServiceRequestContext.mapCurrent(Function.identity(), null)).isSameAs(ctx);
+        }
+
+        try (SafeCloseable unused = ClientRequestContext.of(req).push()) {
+            assertThatThrownBy(() -> ServiceRequestContext.mapCurrent(c -> "foo", () -> "bar"))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("not a server-side context");
+        }
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/TestConverters.java
+++ b/core/src/test/java/com/linecorp/armeria/server/TestConverters.java
@@ -25,7 +25,6 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpResponseWriter;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
-import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.ResponseHeadersBuilder;
 import com.linecorp.armeria.server.annotation.ResponseConverterFunction;
@@ -129,8 +128,7 @@ public final class TestConverters {
         headers.setInt(HttpHeaderNames.CONTENT_LENGTH, data.length());
         headers.setTimeMillis(HttpHeaderNames.DATE, current);
 
-        final MediaType contentType =
-                ((ServiceRequestContext) RequestContext.current()).negotiatedResponseMediaType();
+        final MediaType contentType = ServiceRequestContext.current().negotiatedResponseMediaType();
         if (contentType != null) {
             headers.contentType(contentType);
         }

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientTest.java
@@ -56,6 +56,7 @@ import com.google.protobuf.StringValue;
 
 import com.linecorp.armeria.client.ClientBuilder;
 import com.linecorp.armeria.client.ClientOption;
+import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.DecoratingClientFunction;
 import com.linecorp.armeria.client.Endpoint;
@@ -67,7 +68,6 @@ import com.linecorp.armeria.common.HttpHeadersBuilder;
 import com.linecorp.armeria.common.HttpObject;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.RpcResponse;
 import com.linecorp.armeria.common.grpc.protocol.GrpcHeaderNames;
@@ -275,7 +275,7 @@ public class GrpcClientTest {
             @Override
             public void onNext(SimpleResponse value) {
                 try {
-                    final RequestContext ctx = RequestContext.current();
+                    final ClientRequestContext ctx = ClientRequestContext.current();
                     assertThat(value).isEqualTo(goldenResponse);
                     final ByteBuf buf = ctx.attr(GrpcUnsafeBufferUtil.BUFFERS).get().get(value);
                     assertThat(buf.refCnt()).isNotZero();

--- a/grpc/src/test/java/com/linecorp/armeria/internal/grpc/TestServiceImpl.java
+++ b/grpc/src/test/java/com/linecorp/armeria/internal/grpc/TestServiceImpl.java
@@ -38,7 +38,6 @@ import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpObject;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.grpc.testing.Messages;
 import com.linecorp.armeria.grpc.testing.Messages.PayloadType;
 import com.linecorp.armeria.grpc.testing.Messages.ResponseParameters;
@@ -94,9 +93,7 @@ public class TestServiceImpl extends TestServiceGrpc.TestServiceImplBase {
     @Override
     public void emptyCall(EmptyProtos.Empty empty,
                           StreamObserver<Empty> responseObserver) {
-        ServiceRequestContext ctx = RequestContext.current();
-
-        ctx.addAdditionalResponseTrailer(
+        ServiceRequestContext.current().addAdditionalResponseTrailer(
                 STRING_VALUE_KEY.name(),
                 Base64.getEncoder().encodeToString(
                         StringValue.newBuilder().setValue("hello").build().toByteArray()) +

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
@@ -71,7 +71,6 @@ import com.linecorp.armeria.common.HttpObject;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
-import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.RpcResponse;
@@ -200,11 +199,11 @@ class GrpcServiceServerTest {
 
         @Override
         public void errorWithMessage(SimpleRequest request, StreamObserver<SimpleResponse> responseObserver) {
-            Metadata metadata = new Metadata();
+            final Metadata metadata = new Metadata();
             metadata.put(STRING_VALUE_KEY, StringValue.newBuilder().setValue("custom metadata").build());
             metadata.put(CUSTOM_VALUE_KEY, "custom value");
 
-            ServiceRequestContext ctx = RequestContext.current();
+            final ServiceRequestContext ctx = ServiceRequestContext.current();
             // Metadata takes priority, this trailer will not be written since it has the same name.
             ctx.addAdditionalResponseTrailer(
                     STRING_VALUE_KEY.name(),
@@ -216,7 +215,7 @@ class GrpcServiceServerTest {
                     INT_32_VALUE_KEY.name(),
                     Base64.getEncoder().encodeToString(
                             Int32Value.newBuilder().setValue(10).build().toByteArray()) +
-                    "," +
+                    ',' +
                     Base64.getEncoder().encodeToString(
                             Int32Value.newBuilder().setValue(20).build().toByteArray()));
 
@@ -269,12 +268,12 @@ class GrpcServiceServerTest {
         @Override
         public StreamObserver<SimpleRequest> checkRequestContext(
                 StreamObserver<SimpleResponse> responseObserver) {
-            final RequestContext ctx = RequestContext.current();
+            final ServiceRequestContext ctx = ServiceRequestContext.current();
             ctx.attr(CHECK_REQUEST_CONTEXT_COUNT).set(0);
             return new StreamObserver<SimpleRequest>() {
                 @Override
                 public void onNext(SimpleRequest value) {
-                    final RequestContext ctx = RequestContext.current();
+                    final ServiceRequestContext ctx = ServiceRequestContext.current();
                     final Attribute<Integer> attr = ctx.attr(CHECK_REQUEST_CONTEXT_COUNT);
                     attr.set(attr.get() + 1);
                 }
@@ -284,7 +283,7 @@ class GrpcServiceServerTest {
 
                 @Override
                 public void onCompleted() {
-                    final RequestContext ctx = RequestContext.current();
+                    final ServiceRequestContext ctx = ServiceRequestContext.current();
                     final int count = ctx.attr(CHECK_REQUEST_CONTEXT_COUNT).get();
                     responseObserver.onNext(
                             SimpleResponse.newBuilder()
@@ -334,8 +333,7 @@ class GrpcServiceServerTest {
         @Override
         public void errorAdditionalMetadata(SimpleRequest request,
                                             StreamObserver<SimpleResponse> responseObserver) {
-            final ServiceRequestContext ctx = RequestContext.current();
-            ctx.addAdditionalResponseTrailer(
+            ServiceRequestContext.current().addAdditionalResponseTrailer(
                     ERROR_METADATA_HEADER,
                     Base64.getEncoder().encodeToString(StringValue.newBuilder()
                                                                   .setValue("an error occurred")

--- a/logback/src/main/java/com/linecorp/armeria/common/logback/RequestContextExportingAppender.java
+++ b/logback/src/main/java/com/linecorp/armeria/common/logback/RequestContextExportingAppender.java
@@ -207,7 +207,7 @@ public class RequestContextExportingAppender extends UnsynchronizedAppenderBase<
 
     @Override
     protected void append(ILoggingEvent eventObject) {
-        final RequestContext ctx = RequestContext.mapCurrent(Function.identity(), () -> null);
+        final RequestContext ctx = RequestContext.currentOrNull();
         if (ctx != null) {
             final State state = state(ctx);
             final RequestLog log = ctx.log();

--- a/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaWebClientTest.java
+++ b/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaWebClientTest.java
@@ -44,7 +44,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.linecorp.armeria.client.ClientFactoryBuilder;
-import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.testing.internal.MockAddressResolverGroup;
 
@@ -89,8 +88,8 @@ public class ArmeriaWebClientTest {
                 return new Person(person.name(), person.age() + 1);
             }
 
-            private void ensureInRequestContextAwareEventLoop() {
-                assertThat((ServiceRequestContext) RequestContext.current()).isNotNull();
+            private static void ensureInRequestContextAwareEventLoop() {
+                assertThat(ServiceRequestContext.current()).isNotNull();
             }
         }
     }

--- a/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ByteBufLeakTest.java
+++ b/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ByteBufLeakTest.java
@@ -46,8 +46,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.linecorp.armeria.client.HttpClient;
-import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.logging.RequestLogAvailability;
+import com.linecorp.armeria.server.ServiceRequestContext;
 
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.util.NetUtil;
@@ -100,8 +100,8 @@ public class ByteBufLeakTest {
                 return Mono.empty();
             }
 
-            private void addListenerForCountingCompletedRequests() {
-                RequestContext.current().log().addListener(
+            private static void addListenerForCountingCompletedRequests() {
+                ServiceRequestContext.current().log().addListener(
                         log -> completed.incrementAndGet(), RequestLogAvailability.COMPLETE);
                 requestReceived.set(true);
             }

--- a/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ReactiveWebServerAutoConfigurationTest.java
+++ b/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ReactiveWebServerAutoConfigurationTest.java
@@ -55,7 +55,6 @@ import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpStatus;
-import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.server.ServiceRequestContext;
@@ -77,7 +76,7 @@ class ReactiveWebServerAutoConfigurationTest {
             @GetMapping("/hello")
             Flux<String> hello() {
                 // This method would be called in one of Armeria worker threads.
-                assertThat((ServiceRequestContext) RequestContext.current()).isNotNull();
+                assertThat(ServiceRequestContext.current()).isNotNull();
                 return Flux.just("h", "e", "l", "l", "o");
             }
         }
@@ -97,13 +96,13 @@ class ReactiveWebServerAutoConfigurationTest {
         @Component
         static class TestHandler {
             public Mono<ServerResponse> route(ServerRequest request) {
-                assertThat((ServiceRequestContext) RequestContext.current()).isNotNull();
+                assertThat(ServiceRequestContext.current()).isNotNull();
                 return ServerResponse.ok().contentType(MediaType.TEXT_PLAIN)
                                      .body(BodyInserters.fromObject("route"));
             }
 
             public Mono<ServerResponse> route2(ServerRequest request) {
-                assertThat((ServiceRequestContext) RequestContext.current()).isNotNull();
+                assertThat(ServiceRequestContext.current()).isNotNull();
                 return Mono.from(request.bodyToMono(Map.class))
                            .map(map -> assertThat(map.get("a")).isEqualTo(1))
                            .then(ServerResponse.ok().contentType(MediaType.APPLICATION_JSON)

--- a/thrift/src/main/java/com/linecorp/armeria/server/thrift/ThriftCallService.java
+++ b/thrift/src/main/java/com/linecorp/armeria/server/thrift/ThriftCallService.java
@@ -21,7 +21,6 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
 
 import javax.annotation.Nullable;
 
@@ -59,7 +58,7 @@ public final class ThriftCallService implements Service<RpcRequest, RpcResponse>
 
         @Override
         public void onError(Exception e) {
-            logOneWayFunctionFailure(RequestContext.mapCurrent(Function.identity(), null), e);
+            logOneWayFunctionFailure(RequestContext.currentOrNull(), e);
         }
     };
 

--- a/thrift/src/test/java/com/linecorp/armeria/client/thrift/ThriftOverHttpClientTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/client/thrift/ThriftOverHttpClientTest.java
@@ -60,7 +60,6 @@ import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
-import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.RpcResponse;
 import com.linecorp.armeria.common.SerializationFormat;
@@ -73,6 +72,7 @@ import com.linecorp.armeria.common.thrift.ThriftSerializationFormats;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.Service;
+import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.logging.LoggingService;
 import com.linecorp.armeria.server.thrift.THttpService;
 import com.linecorp.armeria.service.test.thrift.main.BinaryService;
@@ -141,8 +141,8 @@ class ThriftOverHttpClientTest {
 
     private static final HeaderService.AsyncIface headerServiceHandler =
             (name, resultHandler) -> {
-                final HttpRequest req = RequestContext.current().request();
-                resultHandler.onComplete(req.headers().get(HttpHeaderNames.of(name), ""));
+                resultHandler.onComplete(ServiceRequestContext.current().request()
+                                                              .headers().get(HttpHeaderNames.of(name), ""));
             };
 
     private enum Handlers {

--- a/thrift/src/test/java/com/linecorp/armeria/it/server/GracefulShutdownIntegrationTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/server/GracefulShutdownIntegrationTest.java
@@ -35,10 +35,10 @@ import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.common.ClosedSessionException;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
-import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.logging.AccessLogWriter;
 import com.linecorp.armeria.server.thrift.THttpService;
 import com.linecorp.armeria.service.test.thrift.main.SleepService;
@@ -59,7 +59,7 @@ public class GracefulShutdownIntegrationTest {
 
             sb.service("/sleep", THttpService.of(
                     (AsyncIface) (milliseconds, resultHandler) ->
-                            RequestContext.current().eventLoop().schedule(
+                            ServiceRequestContext.current().eventLoop().schedule(
                                     () -> resultHandler.onComplete(milliseconds), milliseconds, MILLISECONDS)));
 
             final AccessLogWriter writer1 = new AccessLogWriter() {

--- a/thrift/src/test/java/com/linecorp/armeria/it/thrift/ThriftDynamicTimeoutTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/thrift/ThriftDynamicTimeoutTest.java
@@ -37,7 +37,6 @@ import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.client.ClientBuilder;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.SimpleDecoratingClient;
-import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.RpcResponse;
 import com.linecorp.armeria.server.ServerBuilder;
@@ -56,11 +55,11 @@ import com.linecorp.armeria.testing.junit.server.ServerExtension;
 class ThriftDynamicTimeoutTest {
 
     private static final SleepService.AsyncIface sleepService = (delay, resultHandler) ->
-            RequestContext.current().eventLoop().schedule(
+            ServiceRequestContext.current().eventLoop().schedule(
                     () -> resultHandler.onComplete(delay), delay, TimeUnit.MILLISECONDS);
 
     private static final SleepService.AsyncIface fakeSleepService = (delay, resultHandler) ->
-            RequestContext.current().eventLoop().execute(
+            ServiceRequestContext.current().eventLoop().execute(
                     () -> resultHandler.onComplete(delay));
 
     @RegisterExtension

--- a/thrift/src/test/java/com/linecorp/armeria/it/thrift/ThriftHttpHeaderTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/thrift/ThriftHttpHeaderTest.java
@@ -37,7 +37,6 @@ import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpObject;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.util.SafeCloseable;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.ServiceRequestContext;
@@ -54,7 +53,7 @@ public class ThriftHttpHeaderTest {
     private static final String SECRET = "QWxhZGRpbjpPcGVuU2VzYW1l";
 
     private static final HelloService.AsyncIface helloService = (name, resultHandler) -> {
-        final ServiceRequestContext ctx = RequestContext.current();
+        final ServiceRequestContext ctx = ServiceRequestContext.current();
         final HttpRequest httpReq = ctx.request();
         final HttpHeaders headers = httpReq.headers();
         if (headers.contains(AUTHORIZATION, SECRET)) {

--- a/thrift/src/test/java/com/linecorp/armeria/server/thrift/AbstractThriftOverHttpTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/server/thrift/AbstractThriftOverHttpTest.java
@@ -41,7 +41,6 @@ import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.RpcResponse;
 import com.linecorp.armeria.common.logging.RequestLog;
@@ -127,7 +126,7 @@ public abstract class AbstractThriftOverHttpTest {
 
             sb.service("/sleep", THttpService.of(
                     (SleepService.AsyncIface) (milliseconds, resultHandler) ->
-                            RequestContext.current().eventLoop().schedule(
+                            ServiceRequestContext.current().eventLoop().schedule(
                                     () -> resultHandler.onComplete(milliseconds),
                                     milliseconds, TimeUnit.MILLISECONDS)));
 


### PR DESCRIPTION
Motivation:

A user often has to downcast `RequestContext`:

    ServiceRequestContext ctx = (ServiceRequestContext) RequestContext.current();

Because of this, the code often gets pretty verbose:

    ((ServiceRequestContext) RequestContext.current()).routingContext().hostname();

If we have `ServiceRequestContext.current()`, it would have been much nicer:

  ServiceRequestContext.current().routingContext().hostname();

If the current context is not a `ServiceRequestContext` (or `ClientRequestContext`), we could simply raise an `IllegalStateException`.

Modifications:

- Add `currentOrNull()` to `RequestContext`
- Add `current()`, `mapCurrent()` and `currentOrNull()` to `Service/ClientRequestContext`
- Use `Service/ClientRequestContext.current/mapCurrent/currentOrNull()` wherever
  possible.

Result:

- Closes #1869