### PR TITLE
Enable TCP fallback for the default DNS name resolver

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/DefaultAddressResolverGroupFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultAddressResolverGroupFactory.java
@@ -49,6 +49,7 @@ final class DefaultAddressResolverGroupFactory
         nameResolverBuilder.traceEnabled(true);
         customizers.forEach(customizer -> customizer.accept(nameResolverBuilder));
         nameResolverBuilder.channelType(TransportType.datagramChannelType(eventLoopGroup));
+        nameResolverBuilder.socketChannelType(TransportType.socketChannelType(eventLoopGroup));
         return new DnsAddressResolverGroup(nameResolverBuilder);
     }
 }


### PR DESCRIPTION
Motivation:

@normanmaurer kindly suggested me to enable TCP fallback for our default
DNS name resolver, and we definitely should to handle a large DNS
response.

Modifications:

- Enable TCP fallback by calling `DnsNameResolverBuilder.socketChannelType()`

Result:

- Can handle a large DNS response