### PR TITLE
New `HealthCheckService` with long-polling support

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/DefaultHealthCheckUpdateHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/DefaultHealthCheckUpdateHandler.java
@@ -35,9 +35,9 @@ import com.linecorp.armeria.server.ServiceRequestContext;
 
 final class DefaultHealthCheckUpdateHandler implements HealthCheckUpdateHandler {
 
-    static final DefaultHealthCheckUpdateHandler INSTANCE = new DefaultHealthCheckUpdateHandler();
+    private static final ObjectMapper mapper = new ObjectMapper();
 
-    private final ObjectMapper mapper = new ObjectMapper();
+    static final DefaultHealthCheckUpdateHandler INSTANCE = new DefaultHealthCheckUpdateHandler();
 
     private DefaultHealthCheckUpdateHandler() {}
 

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/DefaultHealthCheckUpdateHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/DefaultHealthCheckUpdateHandler.java
@@ -15,6 +15,8 @@
  */
 package com.linecorp.armeria.server.healthcheck;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -42,6 +44,7 @@ final class DefaultHealthCheckUpdateHandler implements HealthCheckUpdateHandler 
 
     @Override
     public CompletionStage<Boolean> handle(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+        requireNonNull(req, "req");
         switch (req.method()) {
             case PUT:
             case POST:

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/DefaultHealthCheckUpdateHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/DefaultHealthCheckUpdateHandler.java
@@ -93,10 +93,9 @@ final class DefaultHealthCheckUpdateHandler implements HealthCheckUpdateHandler 
         if (contentType != null && !contentType.is(MediaType.JSON)) {
             throw HttpStatusException.of(HttpStatus.UNSUPPORTED_MEDIA_TYPE);
         }
+
         final Charset charset = contentType == null ? StandardCharsets.UTF_8
                                                     : contentType.charset().orElse(StandardCharsets.UTF_8);
-
-        final JsonNode node;
         try {
             return mapper.readTree(req.content(charset));
         } catch (IOException e) {

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/DefaultHealthCheckUpdateHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/DefaultHealthCheckUpdateHandler.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.healthcheck;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletionStage;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeType;
+
+import com.linecorp.armeria.common.AggregatedHttpRequest;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.server.HttpStatusException;
+import com.linecorp.armeria.server.ServiceRequestContext;
+
+final class DefaultHealthCheckUpdateHandler implements HealthCheckUpdateHandler {
+
+    static final DefaultHealthCheckUpdateHandler INSTANCE = new DefaultHealthCheckUpdateHandler();
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    private DefaultHealthCheckUpdateHandler() {}
+
+    @Override
+    public CompletionStage<Boolean> handle(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+        switch (req.method()) {
+            case PUT:
+            case POST:
+                return req.aggregate().thenApply(this::handlePut);
+            case PATCH:
+                return req.aggregate().thenApply(this::handlePatch);
+            default:
+                throw HttpStatusException.of(HttpStatus.METHOD_NOT_ALLOWED);
+        }
+    }
+
+    private Boolean handlePut(AggregatedHttpRequest req) {
+        final JsonNode json = toJsonNode(req);
+        if (json.getNodeType() != JsonNodeType.OBJECT) {
+            throw HttpStatusException.of(HttpStatus.BAD_REQUEST);
+        }
+
+        final JsonNode healthy = json.get("healthy");
+        if (healthy == null) {
+            throw HttpStatusException.of(HttpStatus.BAD_REQUEST);
+        }
+        if (healthy.getNodeType() != JsonNodeType.BOOLEAN) {
+            throw HttpStatusException.of(HttpStatus.BAD_REQUEST);
+        }
+
+        return healthy.booleanValue();
+    }
+
+    private Boolean handlePatch(AggregatedHttpRequest req) {
+        final String json;
+        try {
+            json = mapper.writeValueAsString(toJsonNode(req));
+        } catch (JsonProcessingException e) {
+            throw new Error(e); // Never happens.
+        }
+
+        switch (json) {
+            case "[{\"op\":\"replace\",\"path\":\"/healthy\",\"value\":true}]":
+                return true;
+            case "[{\"op\":\"replace\",\"path\":\"/healthy\",\"value\":false}]":
+                return false;
+            default:
+                throw HttpStatusException.of(HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    private JsonNode toJsonNode(AggregatedHttpRequest req) {
+        final MediaType contentType = req.contentType();
+        if (contentType != null && !contentType.is(MediaType.JSON)) {
+            throw HttpStatusException.of(HttpStatus.UNSUPPORTED_MEDIA_TYPE);
+        }
+        final Charset charset = contentType == null ? StandardCharsets.UTF_8
+                                                    : contentType.charset().orElse(StandardCharsets.UTF_8);
+
+        final JsonNode node;
+        try {
+            return mapper.readTree(req.content(charset));
+        } catch (IOException e) {
+            throw HttpStatusException.of(HttpStatus.BAD_REQUEST);
+        }
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckService.java
@@ -126,7 +126,7 @@ public final class HealthCheckService implements HttpService, TransientService<H
     private final AggregatedHttpResponse unhealthyResponse;
     private final ResponseHeaders notModifiedHeaders;
     private final long maxLongPollingTimeoutMillis;
-    private final float longPollingTimeoutJitterRate;
+    private final double longPollingTimeoutJitterRate;
     @Nullable
     private final Consumer<HealthChecker> healthCheckerListener;
     @Nullable
@@ -141,7 +141,7 @@ public final class HealthCheckService implements HttpService, TransientService<H
 
     HealthCheckService(Iterable<HealthChecker> healthCheckers,
                        AggregatedHttpResponse healthyResponse, AggregatedHttpResponse unhealthyResponse,
-                       long maxLongPollingTimeoutMillis, float longPollingTimeoutJitterRate,
+                       long maxLongPollingTimeoutMillis, double longPollingTimeoutJitterRate,
                        @Nullable HealthCheckUpdateHandler updateHandler) {
         serverHealth = new SettableHealthChecker(false);
         this.healthCheckers = ImmutableSet.copyOf(healthCheckers);

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckService.java
@@ -1,0 +1,420 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.healthcheck;
+
+import java.util.ArrayDeque;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import javax.annotation.Nullable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Ascii;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.math.LongMath;
+
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.internal.ArmeriaHttpUtil;
+import com.linecorp.armeria.server.HttpService;
+import com.linecorp.armeria.server.HttpStatusException;
+import com.linecorp.armeria.server.RequestTimeoutException;
+import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.ServerListenerAdapter;
+import com.linecorp.armeria.server.ServiceConfig;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.TransientService;
+
+import io.netty.util.AsciiString;
+import io.netty.util.concurrent.ScheduledFuture;
+
+/**
+ * An {@link HttpService} that responds with HTTP status {@code "200 OK"} if the server is healthy and can
+ * accept requests and HTTP status {@code "503 Service Not Available"} if the server is unhealthy and cannot
+ * accept requests. The default behavior is to respond healthy after the server is started and unhealthy
+ * after it started to stop.
+ *
+ * <h3>Long-polling support</h3>
+ *
+ * <p>A client that sends health check requests to this service can send a long-polling request to get notified
+ * immediately when a {@link Server} becomes healthy or unhealthy, rather than sending health check requests
+ * periodically.</p>
+ *
+ * <p>To wait until a {@link Server} becomes unhealthy, i.e. wait for the failure, send an HTTP request with
+ * two additional headers:
+ * <ul>
+ *   <li>{@code If-None-Match: "healthy"}</li>
+ *   <li>{@code Prefer: wait=<seconds>}
+ *     <ul>
+ *       <li>e.g. {@code Prefer: wait=60}</li>
+ *     </ul>
+ *   </li>
+ * </ul></p>
+ *
+ * <p>To wait until a {@link Server} becomes healthy, i.e. wait for the recovery, send an HTTP request with
+ * two additional headers:
+ * <ul>
+ *   <li>{@code If-None-Match: "unhealthy"}</li>
+ *   <li>{@code Prefer: wait=<seconds>}</li>
+ * </ul></p>
+ *
+ * <p>The {@link Server} will wait up to the amount of seconds specified in the {@code "Prefer"} header
+ * and respond with {@code "200 OK"}, {@code "503 Service Unavailable"} or {@code "304 Not Modified"}.
+ * {@code "304 Not Modifies"} signifies that the healthiness of the {@link Server} did not change.
+ * Once the response is received, the client is supposed to send a new long-polling request to continue
+ * watching the healthiness of the {@link Server}.</p>
+ *
+ * <p>All health check responses will contain a {@code "long-polling-supported"} header whose value is
+ * {@code "true"} or {@code "false"}.</p>
+ *
+ * @see HealthCheckServiceBuilder
+ */
+public final class HealthCheckService implements HttpService, TransientService<HttpRequest, HttpResponse> {
+
+    private static final Logger logger = LoggerFactory.getLogger(HealthCheckService.class);
+    private static final AsciiString LONG_POLLING_SUPPORTED = HttpHeaderNames.of("long-polling-supported");
+    private static final PendingResponse[] EMPTY_PENDING_RESPONSES = new PendingResponse[0];
+
+    /**
+     * Returns a newly created {@link HealthCheckService} with the specified {@link HealthChecker}s.
+     */
+    public static HealthCheckService of(HealthChecker... healthCheckers) {
+        return builder().checkers(healthCheckers).build();
+    }
+
+    /**
+     * Returns a newly created {@link HealthCheckService} with the specified {@link HealthChecker}s.
+     */
+    public static HealthCheckService of(Iterable<? extends HealthChecker> healthCheckers) {
+        return builder().checkers(healthCheckers).build();
+    }
+
+    /**
+     * Returns a new builder which builds a new {@link HealthCheckService}.
+     */
+    public static HealthCheckServiceBuilder builder() {
+        return new HealthCheckServiceBuilder();
+    }
+
+    private final SettableHealthChecker serverHealth;
+    private final Set<HealthChecker> healthCheckers;
+    private final AggregatedHttpResponse healthyResponse;
+    private final AggregatedHttpResponse unhealthyResponse;
+    private final ResponseHeaders notModifiedHeaders;
+    private final long maxLongPollingTimeoutMillis;
+    private final float longPollingTimeoutJitterRate;
+    @Nullable
+    private final Consumer<HealthChecker> healthCheckerListener;
+    @Nullable
+    private final Queue<PendingResponse> pendingHealthyResponses;
+    @Nullable
+    private final Queue<PendingResponse> pendingUnhealthyResponses;
+    @Nullable
+    private final HealthCheckUpdateHandler updateHandler;
+
+    @Nullable
+    private Server server;
+
+    HealthCheckService(Iterable<HealthChecker> healthCheckers,
+                       AggregatedHttpResponse healthyResponse, AggregatedHttpResponse unhealthyResponse,
+                       long maxLongPollingTimeoutMillis, float longPollingTimeoutJitterRate,
+                       @Nullable HealthCheckUpdateHandler updateHandler) {
+        serverHealth = new SettableHealthChecker(false);
+        this.healthCheckers = ImmutableSet.copyOf(healthCheckers);
+        this.updateHandler = updateHandler;
+
+        if (maxLongPollingTimeoutMillis > 0 &&
+            this.healthCheckers.stream().allMatch(ListenableHealthChecker.class::isInstance)) {
+            this.maxLongPollingTimeoutMillis = maxLongPollingTimeoutMillis;
+            this.longPollingTimeoutJitterRate = longPollingTimeoutJitterRate;
+            healthCheckerListener = this::onHealthCheckerUpdate;
+            pendingHealthyResponses = new ArrayDeque<>();
+            pendingUnhealthyResponses = new ArrayDeque<>();
+        } else {
+            this.maxLongPollingTimeoutMillis = 0;
+            this.longPollingTimeoutJitterRate = 0;
+            healthCheckerListener = null;
+            pendingHealthyResponses = null;
+            pendingUnhealthyResponses = null;
+
+            if (maxLongPollingTimeoutMillis > 0) {
+                logger.warn("Long-polling support has been disabled for {} " +
+                            "because some of the specified {}s are not listenable.",
+                            getClass().getSimpleName(), HealthChecker.class.getSimpleName());
+            }
+        }
+
+        this.healthyResponse = addCommonHeaders(healthyResponse);
+        this.unhealthyResponse = addCommonHeaders(unhealthyResponse);
+        notModifiedHeaders = ResponseHeaders.builder()
+                                            .add(this.unhealthyResponse.headers())
+                                            .status(HttpStatus.NOT_MODIFIED)
+                                            .removeAndThen(HttpHeaderNames.CONTENT_LENGTH)
+                                            .build();
+    }
+
+    private AggregatedHttpResponse addCommonHeaders(AggregatedHttpResponse res) {
+        return AggregatedHttpResponse.of(res.informationals(),
+                                         res.headers().toBuilder()
+                                            .set(LONG_POLLING_SUPPORTED, String.valueOf(isLongPollingEnabled()))
+                                            .build(),
+                                         res.content(),
+                                         res.trailers().toBuilder()
+                                            .removeAndThen(LONG_POLLING_SUPPORTED)
+                                            .build());
+    }
+
+    @Override
+    public void serviceAdded(ServiceConfig cfg) throws Exception {
+        if (server != null) {
+            if (server != cfg.server()) {
+                throw new IllegalStateException("cannot be added to more than one server");
+            } else {
+                return;
+            }
+        }
+
+        server = cfg.server();
+        server.addListener(new ServerListenerAdapter() {
+            @Override
+            public void serverStarting(Server server) throws Exception {
+                if (healthCheckerListener != null) {
+                    healthCheckers.stream().map(ListenableHealthChecker.class::cast).forEach(c -> {
+                        c.addListener(healthCheckerListener);
+                    });
+                }
+            }
+
+            @Override
+            public void serverStarted(Server server) {
+                serverHealth.setHealthy(true);
+            }
+
+            @Override
+            public void serverStopping(Server server) {
+                serverHealth.setHealthy(false);
+            }
+
+            @Override
+            public void serverStopped(Server server) throws Exception {
+                if (healthCheckerListener != null) {
+                    healthCheckers.stream().map(ListenableHealthChecker.class::cast).forEach(c -> {
+                        c.removeListener(healthCheckerListener);
+                    });
+                }
+            }
+        });
+    }
+
+    @Override
+    public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+        final long longPollingTimeoutMillis = getLongPollingTimeoutMillis(req);
+        final boolean isHealthy = isHealthy();
+        final boolean useLongPolling;
+        if (longPollingTimeoutMillis > 0) {
+            final String expectedState =
+                    Ascii.toLowerCase(req.headers().get(HttpHeaderNames.IF_NONE_MATCH, ""));
+            if ("\"healthy\"".equals(expectedState) || "w/\"healthy\"".equals(expectedState)) {
+                useLongPolling = isHealthy;
+            } else if ("\"unhealthy\"".equals(expectedState) || "w/\"unhealthy\"".equals(expectedState)) {
+                useLongPolling = !isHealthy;
+            } else {
+                useLongPolling = false;
+            }
+        } else {
+            useLongPolling = false;
+        }
+
+        final HttpMethod method = ctx.method();
+        if (useLongPolling) {
+            // Disallow other methods than HEAD/GET for long polling.
+            switch (method) {
+                case HEAD:
+                case GET:
+                    break;
+                default:
+                    throw HttpStatusException.of(HttpStatus.METHOD_NOT_ALLOWED);
+            }
+
+            assert healthCheckerListener != null : "healthCheckerListener is null.";
+            assert pendingHealthyResponses != null : "pendingHealthyResponses is null.";
+            assert pendingUnhealthyResponses != null : "pendingUnhealthyResponses is null.";
+
+            // If healthy, wait until it becomes unhealthy, and vice versa.
+            synchronized (healthCheckerListener) {
+                final boolean currentHealthiness = isHealthy();
+                if (isHealthy == currentHealthiness) {
+                    final CompletableFuture<HttpResponse> future = new CompletableFuture<>();
+                    final ScheduledFuture<Boolean> timeoutFuture = ctx.eventLoop().schedule(
+                            () -> future.complete(HttpResponse.of(notModifiedHeaders)),
+                            longPollingTimeoutMillis, TimeUnit.MILLISECONDS);
+                    final PendingResponse pendingResponse = new PendingResponse(method, future, timeoutFuture);
+                    if (isHealthy) {
+                        pendingUnhealthyResponses.add(pendingResponse);
+                    } else {
+                        pendingHealthyResponses.add(pendingResponse);
+                    }
+
+                    updateRequestTimeout(ctx, longPollingTimeoutMillis);
+                    return HttpResponse.from(future);
+                } else {
+                    // State has been changed before we acquire the lock.
+                    // Fall through because there's no need for long polling.
+                }
+            }
+        }
+
+        switch (method) {
+            case HEAD:
+            case GET:
+                return newResponse(method, isHealthy);
+            case CONNECT:
+            case DELETE:
+            case OPTIONS:
+            case TRACE:
+                return HttpResponse.of(HttpStatus.METHOD_NOT_ALLOWED);
+        }
+
+        if (updateHandler == null) {
+            return HttpResponse.of(HttpStatus.METHOD_NOT_ALLOWED);
+        }
+
+        return HttpResponse.from(updateHandler.handle(ctx, req).thenApply(updateResult -> {
+            if (updateResult != null) {
+                serverHealth.setHealthy(updateResult);
+            }
+            return HttpResponse.of(newResponse(method, isHealthy()));
+        }));
+    }
+
+    private boolean isHealthy() {
+        for (HealthChecker healthChecker : healthCheckers) {
+            if (!healthChecker.isHealthy()) {
+                return false;
+            }
+        }
+        return serverHealth.isHealthy();
+    }
+
+    private long getLongPollingTimeoutMillis(HttpRequest req) {
+        if (!isLongPollingEnabled()) {
+            return 0;
+        }
+
+        final String prefer = req.headers().get(HttpHeaderNames.PREFER);
+        if (prefer == null) {
+            return 0;
+        }
+
+        // TODO(trustin): Optimize this once https://github.com/line/armeria/issues/1835 is resolved.
+        final LongHolder timeoutMillisHolder = new LongHolder();
+        try {
+            ArmeriaHttpUtil.parseDirectives(prefer, (name, value) -> {
+                if ("wait".equals(name)) {
+                    timeoutMillisHolder.value = TimeUnit.SECONDS.toMillis(Long.parseLong(value));
+                }
+            });
+        } catch (NumberFormatException ignored) {
+            // Malformed "wait" value.
+        }
+
+        if (timeoutMillisHolder.value <= 0) {
+            throw HttpStatusException.of(HttpStatus.BAD_REQUEST);
+        }
+
+        return (long) (Math.min(timeoutMillisHolder.value, maxLongPollingTimeoutMillis) *
+                       (1.0 - ThreadLocalRandom.current().nextDouble(longPollingTimeoutJitterRate)));
+    }
+
+    private boolean isLongPollingEnabled() {
+        return healthCheckerListener != null;
+    }
+
+    /**
+     * Extends the request timeout by the specified {@code longPollingTimeoutMillis}, because otherwise
+     * the client will get {@code "503 Service Unavailable} due to a {@link RequestTimeoutException} before
+     * long-polling finishes.
+     */
+    private static void updateRequestTimeout(ServiceRequestContext ctx, long longPollingTimeoutMillis) {
+        final long requestTimeoutMillis = ctx.requestTimeoutMillis();
+        if (requestTimeoutMillis > 0) {
+            ctx.setRequestTimeoutMillis(LongMath.saturatedAdd(longPollingTimeoutMillis, requestTimeoutMillis));
+        }
+    }
+
+    private HttpResponse newResponse(HttpMethod method, boolean isHealthy) {
+        final AggregatedHttpResponse aRes = isHealthy ? healthyResponse : unhealthyResponse;
+        if (method == HttpMethod.HEAD) {
+            return HttpResponse.of(aRes.headers());
+        } else {
+            return HttpResponse.of(aRes);
+        }
+    }
+
+    private void onHealthCheckerUpdate(HealthChecker unused) {
+        assert healthCheckerListener != null : "healthCheckerListener is null.";
+        assert pendingHealthyResponses != null : "pendingHealthyResponses is null.";
+        assert pendingUnhealthyResponses != null : "pendingUnhealthyResponses is null.";
+
+        final boolean isHealthy = isHealthy();
+        final PendingResponse[] pendingResponses;
+        synchronized (healthCheckerListener) {
+            final Queue<PendingResponse> queue = isHealthy ? pendingHealthyResponses
+                                                           : pendingUnhealthyResponses;
+            if (!queue.isEmpty()) {
+                pendingResponses = queue.toArray(EMPTY_PENDING_RESPONSES);
+                queue.clear();
+            } else {
+                pendingResponses = EMPTY_PENDING_RESPONSES;
+            }
+        }
+
+        for (PendingResponse e : pendingResponses) {
+            if (e.timeoutFuture.cancel(false)) {
+                e.future.complete(newResponse(e.method, isHealthy));
+            }
+        }
+    }
+
+    private static final class PendingResponse {
+        final HttpMethod method;
+        final CompletableFuture<HttpResponse> future;
+        final ScheduledFuture<Boolean> timeoutFuture;
+
+        PendingResponse(HttpMethod method,
+                        CompletableFuture<HttpResponse> future,
+                        ScheduledFuture<Boolean> timeoutFuture) {
+            this.method = method;
+            this.future = future;
+            this.timeoutFuture = timeoutFuture;
+        }
+    }
+
+    private static final class LongHolder {
+        long value;
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceBuilder.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.healthcheck;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+import java.time.Duration;
+
+import javax.annotation.Nullable;
+
+import com.google.common.collect.ImmutableSet;
+
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.Service;
+import com.linecorp.armeria.server.auth.HttpAuthService;
+
+/**
+ * Builds a {@link HealthCheckService}.
+ */
+public final class HealthCheckServiceBuilder {
+
+    private static final long DEFAULT_LONG_POLLING_TIMEOUT_MILLIS = 60_000;
+    private static final float DEFAULT_LONG_POLLING_TIMEOUT_JITTER_RATE = 0.2f;
+
+    private final ImmutableSet.Builder<HealthChecker> healthCheckers = ImmutableSet.builder();
+    private AggregatedHttpResponse healthyResponse = AggregatedHttpResponse.of(HttpStatus.OK,
+                                                                               MediaType.JSON_UTF_8,
+                                                                               "{\"healthy\":true}");
+    private AggregatedHttpResponse unhealthyResponse = AggregatedHttpResponse.of(HttpStatus.SERVICE_UNAVAILABLE,
+                                                                                 MediaType.JSON_UTF_8,
+                                                                                 "{\"healthy\":false}");
+    private long maxLongPollingTimeoutMillis = DEFAULT_LONG_POLLING_TIMEOUT_MILLIS;
+    private float longPollingTimeoutJitterRate = DEFAULT_LONG_POLLING_TIMEOUT_JITTER_RATE;
+    @Nullable
+    private HealthCheckUpdateHandler updateHandler;
+
+    HealthCheckServiceBuilder() {}
+
+    /**
+     * Adds the specified {@link HealthChecker}s that determines the healthiness of the {@link Server}.
+     *
+     * @return {@code this}
+     */
+    public HealthCheckServiceBuilder checkers(HealthChecker... healthCheckers) {
+        return checkers(ImmutableSet.copyOf(requireNonNull(healthCheckers, "healthCheckers")));
+    }
+
+    /**
+     * Adds the specified {@link HealthChecker}s that determines the healthiness of the {@link Server}.
+     *
+     * @return {@code this}
+     */
+    public HealthCheckServiceBuilder checkers(Iterable<? extends HealthChecker> healthCheckers) {
+        this.healthCheckers.addAll(requireNonNull(healthCheckers, "healthCheckers"));
+        return this;
+    }
+
+    /**
+     * Sets the {@link AggregatedHttpResponse} to send when the {@link Service} is healthy. The following
+     * response is sent by default:
+     *
+     * <pre>{@code
+     * HTTP/1.1 200 OK
+     * Content-Type: application/json; charset=utf-8
+     *
+     * { "healthy": true }
+     * }</pre>
+     *
+     * @return {@code this}
+     */
+    public HealthCheckServiceBuilder healthyResponse(AggregatedHttpResponse healthyResponse) {
+        this.healthyResponse = requireNonNull(healthyResponse, "healthyResponse");
+        return this;
+    }
+
+    /**
+     * Sets the {@link AggregatedHttpResponse} to send when the {@link Service} is unhealthy. The following
+     * response is sent by default:
+     *
+     * <pre>{@code
+     * HTTP/1.1 200 OK
+     * Content-Type: application/json; charset=utf-8
+     *
+     * { "healthy": false }
+     * }</pre>
+     *
+     * @return {@code this}
+     */
+    public HealthCheckServiceBuilder unhealthyResponse(AggregatedHttpResponse unhealthyResponse) {
+        this.unhealthyResponse = requireNonNull(unhealthyResponse, "unhealthyResponse");
+        return this;
+    }
+
+    /**
+     * Enables or disables long-polling support. By default, long-polling support is enabled with
+     * the max timeout of {@value #DEFAULT_LONG_POLLING_TIMEOUT_MILLIS} milliseconds and
+     * the jitter rate of {@value #DEFAULT_LONG_POLLING_TIMEOUT_JITTER_RATE}.
+     *
+     * @param maxLongPollingTimeout A positive maximum allowed timeout value which is specified by a client
+     *                              in the {@code "prefer: wait=<n>"} request header.
+     *                              Specify {@code 0} to disable long-polling support.
+     * @return {@code this}
+     * @see #longPolling(Duration, float)
+     */
+    public HealthCheckServiceBuilder longPolling(Duration maxLongPollingTimeout) {
+        return longPolling(maxLongPollingTimeout, longPollingTimeoutJitterRate);
+    }
+
+    /**
+     * Enables or disables long-polling support. By default, long-polling support is enabled with
+     * the max timeout of {@value #DEFAULT_LONG_POLLING_TIMEOUT_MILLIS} milliseconds and
+     * the jitter rate of {@value #DEFAULT_LONG_POLLING_TIMEOUT_JITTER_RATE}.
+     *
+     * @param maxLongPollingTimeoutMillis A positive maximum allowed timeout value which is specified by
+     *                                    a client in the {@code "prefer: wait=<n>"} request header.
+     *                                    Specify {@code 0} to disable long-polling support.
+     * @return {@code this}
+     * @see #longPolling(long, float)
+     */
+    public HealthCheckServiceBuilder longPolling(long maxLongPollingTimeoutMillis) {
+        return longPolling(maxLongPollingTimeoutMillis, longPollingTimeoutJitterRate);
+    }
+
+    /**
+     * Enables or disables long-polling support. By default, long-polling support is enabled with
+     * the max timeout of {@value #DEFAULT_LONG_POLLING_TIMEOUT_MILLIS} milliseconds and
+     * the jitter rate of {@value #DEFAULT_LONG_POLLING_TIMEOUT_JITTER_RATE}.
+     *
+     * @param maxLongPollingTimeout A positive maximum allowed timeout value which is specified by a client
+     *                              in the {@code "prefer: wait=<n>"} request header.
+     *                              Specify {@code 0} to disable long-polling support.
+     * @param longPollingTimeoutJitterRate The jitter rate which adds a random variation to the long-polling
+     *                                     timeout specified in the {@code "prefer: wait=<n>"} header.
+     * @return {@code this}
+     * @see #longPolling(Duration)
+     */
+    public HealthCheckServiceBuilder longPolling(Duration maxLongPollingTimeout,
+                                                 float longPollingTimeoutJitterRate) {
+        requireNonNull(maxLongPollingTimeout, "maxLongPollingTimeout");
+        checkArgument(!maxLongPollingTimeout.isNegative(),
+                      "maxLongPollingTimeout: %s (expected: >= 0)", maxLongPollingTimeout);
+        return longPolling(maxLongPollingTimeout.toMillis(), longPollingTimeoutJitterRate);
+    }
+
+    /**
+     * Enables or disables long-polling support. By default, long-polling support is enabled with
+     * the max timeout of {@value #DEFAULT_LONG_POLLING_TIMEOUT_MILLIS} milliseconds and
+     * the jitter rate of {@value #DEFAULT_LONG_POLLING_TIMEOUT_JITTER_RATE}.
+     *
+     * @param maxLongPollingTimeoutMillis A positive maximum allowed timeout value which is specified by
+     *                                    a client in the {@code "prefer: wait=<n>"} request header.
+     *                                    Specify {@code 0} to disable long-polling support.
+     * @param longPollingTimeoutJitterRate The jitter rate which adds a random variation to the long-polling
+     *                                     timeout specified in the {@code "prefer: wait=<n>"} header.
+     * @return {@code this}
+     * @see #longPolling(long)
+     */
+    public HealthCheckServiceBuilder longPolling(long maxLongPollingTimeoutMillis,
+                                                 float longPollingTimeoutJitterRate) {
+        checkArgument(maxLongPollingTimeoutMillis >= 0,
+                      "maxLongPollingTimeoutMillis: %s (expected: >= 0)", maxLongPollingTimeoutMillis);
+        checkArgument(longPollingTimeoutJitterRate >= 0 && longPollingTimeoutJitterRate <= 1,
+                      "longPollingTimeoutJitterRate: %s (longPollingTimeoutJitterRate: >= 0 && <= 1)",
+                      longPollingTimeoutJitterRate);
+        this.maxLongPollingTimeoutMillis = maxLongPollingTimeoutMillis;
+        this.longPollingTimeoutJitterRate = longPollingTimeoutJitterRate;
+        return this;
+    }
+
+    /**
+     * Specifies whether the healthiness of the {@link Server} can be updated by sending a {@code PUT},
+     * {@code POST} or {@code PATCH} request to the {@link HealthCheckService}. This feature is disabled
+     * by default. If enabled, a JSON object which has a boolean property named {@code "healthy"} can be
+     * sent using a {@code PUT} or {@code POST} request. A JSON patch in a {@code PATCH} request is also
+     * accepted. It is recommended to employ some authorization mechanism such as {@link HttpAuthService}
+     * when enabling this feature.
+     *
+     * @return {@code this}
+     * @see #updatable(HealthCheckUpdateHandler)
+     */
+    public HealthCheckServiceBuilder updatable(boolean updatable) {
+        if (updatable) {
+            return updatable(DefaultHealthCheckUpdateHandler.INSTANCE);
+        }
+
+        updateHandler = null;
+        return this;
+    }
+
+    /**
+     * Specifies a {@link HealthCheckUpdateHandler} which handles other HTTP methods than {@code HEAD} and
+     * {@code GET} which updates the healthiness of the {@link Server}. This feature is disabled by default.
+     * It is recommended to employ some authorization mechanism such as {@link HttpAuthService}
+     * when enabling this feature.
+     *
+     * @param updateHandler The {@link HealthCheckUpdateHandler} which handles {@code PUT}, {@code POST} or
+     *                      {@code PATCH} requests and tells if the {@link Server} needs to be marked as
+     *                      healthy or unhealthy.
+     * @see #updatable(boolean)
+     */
+    public HealthCheckServiceBuilder updatable(HealthCheckUpdateHandler updateHandler) {
+        this.updateHandler = requireNonNull(updateHandler, "updateHandler");
+        return this;
+    }
+
+    /**
+     * Returns a newly created {@link HealthCheckService} built from the properties specified so far.
+     */
+    public HealthCheckService build() {
+        return new HealthCheckService(healthCheckers.build(),
+                                      healthyResponse, unhealthyResponse,
+                                      maxLongPollingTimeoutMillis, longPollingTimeoutJitterRate,
+                                      updateHandler);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceBuilder.java
@@ -26,6 +26,7 @@ import javax.annotation.Nullable;
 import com.google.common.collect.ImmutableSet;
 
 import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.server.Server;
@@ -87,7 +88,8 @@ public final class HealthCheckServiceBuilder {
      * @return {@code this}
      */
     public HealthCheckServiceBuilder healthyResponse(AggregatedHttpResponse healthyResponse) {
-        this.healthyResponse = requireNonNull(healthyResponse, "healthyResponse");
+        requireNonNull(healthyResponse, "healthyResponse");
+        this.healthyResponse = copyResponse(healthyResponse);
         return this;
     }
 
@@ -105,8 +107,19 @@ public final class HealthCheckServiceBuilder {
      * @return {@code this}
      */
     public HealthCheckServiceBuilder unhealthyResponse(AggregatedHttpResponse unhealthyResponse) {
-        this.unhealthyResponse = requireNonNull(unhealthyResponse, "unhealthyResponse");
+        requireNonNull(unhealthyResponse, "unhealthyResponse");
+        this.unhealthyResponse = copyResponse(unhealthyResponse);
         return this;
+    }
+
+    /**
+     * Make a copy just in case the content is modified by the caller or is backed by ByteBuf.
+     */
+    private static AggregatedHttpResponse copyResponse(AggregatedHttpResponse res) {
+        return AggregatedHttpResponse.of(res.informationals(),
+                                         res.headers(),
+                                         HttpData.copyOf(res.content().array()),
+                                         res.trailers());
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceBuilder.java
@@ -55,7 +55,7 @@ public final class HealthCheckServiceBuilder {
     HealthCheckServiceBuilder() {}
 
     /**
-     * Adds the specified {@link HealthChecker}s that determines the healthiness of the {@link Server}.
+     * Adds the specified {@link HealthChecker}s that determine the healthiness of the {@link Server}.
      *
      * @return {@code this}
      */
@@ -64,7 +64,7 @@ public final class HealthCheckServiceBuilder {
     }
 
     /**
-     * Adds the specified {@link HealthChecker}s that determines the healthiness of the {@link Server}.
+     * Adds the specified {@link HealthChecker}s that determine the healthiness of the {@link Server}.
      *
      * @return {@code this}
      */

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceBuilder.java
@@ -19,6 +19,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nullable;
 
@@ -36,8 +37,8 @@ import com.linecorp.armeria.server.auth.HttpAuthService;
  */
 public final class HealthCheckServiceBuilder {
 
-    private static final long DEFAULT_LONG_POLLING_TIMEOUT_MILLIS = 60_000;
-    private static final float DEFAULT_LONG_POLLING_TIMEOUT_JITTER_RATE = 0.2f;
+    private static final int DEFAULT_LONG_POLLING_TIMEOUT_SECONDS = 60;
+    private static final double DEFAULT_LONG_POLLING_TIMEOUT_JITTER_RATE = 0.2;
 
     private final ImmutableSet.Builder<HealthChecker> healthCheckers = ImmutableSet.builder();
     private AggregatedHttpResponse healthyResponse = AggregatedHttpResponse.of(HttpStatus.OK,
@@ -46,8 +47,8 @@ public final class HealthCheckServiceBuilder {
     private AggregatedHttpResponse unhealthyResponse = AggregatedHttpResponse.of(HttpStatus.SERVICE_UNAVAILABLE,
                                                                                  MediaType.JSON_UTF_8,
                                                                                  "{\"healthy\":false}");
-    private long maxLongPollingTimeoutMillis = DEFAULT_LONG_POLLING_TIMEOUT_MILLIS;
-    private float longPollingTimeoutJitterRate = DEFAULT_LONG_POLLING_TIMEOUT_JITTER_RATE;
+    private long maxLongPollingTimeoutMillis = TimeUnit.SECONDS.toMillis(DEFAULT_LONG_POLLING_TIMEOUT_SECONDS);
+    private double longPollingTimeoutJitterRate = DEFAULT_LONG_POLLING_TIMEOUT_JITTER_RATE;
     @Nullable
     private HealthCheckUpdateHandler updateHandler;
 
@@ -110,14 +111,14 @@ public final class HealthCheckServiceBuilder {
 
     /**
      * Enables or disables long-polling support. By default, long-polling support is enabled with
-     * the max timeout of {@value #DEFAULT_LONG_POLLING_TIMEOUT_MILLIS} milliseconds and
+     * the max timeout of {@value #DEFAULT_LONG_POLLING_TIMEOUT_SECONDS} seconds and
      * the jitter rate of {@value #DEFAULT_LONG_POLLING_TIMEOUT_JITTER_RATE}.
      *
      * @param maxLongPollingTimeout A positive maximum allowed timeout value which is specified by a client
      *                              in the {@code "prefer: wait=<n>"} request header.
      *                              Specify {@code 0} to disable long-polling support.
      * @return {@code this}
-     * @see #longPolling(Duration, float)
+     * @see #longPolling(Duration, double)
      */
     public HealthCheckServiceBuilder longPolling(Duration maxLongPollingTimeout) {
         return longPolling(maxLongPollingTimeout, longPollingTimeoutJitterRate);
@@ -125,14 +126,14 @@ public final class HealthCheckServiceBuilder {
 
     /**
      * Enables or disables long-polling support. By default, long-polling support is enabled with
-     * the max timeout of {@value #DEFAULT_LONG_POLLING_TIMEOUT_MILLIS} milliseconds and
+     * the max timeout of {@value #DEFAULT_LONG_POLLING_TIMEOUT_SECONDS} seconds and
      * the jitter rate of {@value #DEFAULT_LONG_POLLING_TIMEOUT_JITTER_RATE}.
      *
      * @param maxLongPollingTimeoutMillis A positive maximum allowed timeout value which is specified by
      *                                    a client in the {@code "prefer: wait=<n>"} request header.
      *                                    Specify {@code 0} to disable long-polling support.
      * @return {@code this}
-     * @see #longPolling(long, float)
+     * @see #longPolling(long, double)
      */
     public HealthCheckServiceBuilder longPolling(long maxLongPollingTimeoutMillis) {
         return longPolling(maxLongPollingTimeoutMillis, longPollingTimeoutJitterRate);
@@ -140,7 +141,7 @@ public final class HealthCheckServiceBuilder {
 
     /**
      * Enables or disables long-polling support. By default, long-polling support is enabled with
-     * the max timeout of {@value #DEFAULT_LONG_POLLING_TIMEOUT_MILLIS} milliseconds and
+     * the max timeout of {@value #DEFAULT_LONG_POLLING_TIMEOUT_SECONDS} seconds and
      * the jitter rate of {@value #DEFAULT_LONG_POLLING_TIMEOUT_JITTER_RATE}.
      *
      * @param maxLongPollingTimeout A positive maximum allowed timeout value which is specified by a client
@@ -152,7 +153,7 @@ public final class HealthCheckServiceBuilder {
      * @see #longPolling(Duration)
      */
     public HealthCheckServiceBuilder longPolling(Duration maxLongPollingTimeout,
-                                                 float longPollingTimeoutJitterRate) {
+                                                 double longPollingTimeoutJitterRate) {
         requireNonNull(maxLongPollingTimeout, "maxLongPollingTimeout");
         checkArgument(!maxLongPollingTimeout.isNegative(),
                       "maxLongPollingTimeout: %s (expected: >= 0)", maxLongPollingTimeout);
@@ -161,7 +162,7 @@ public final class HealthCheckServiceBuilder {
 
     /**
      * Enables or disables long-polling support. By default, long-polling support is enabled with
-     * the max timeout of {@value #DEFAULT_LONG_POLLING_TIMEOUT_MILLIS} milliseconds and
+     * the max timeout of {@value #DEFAULT_LONG_POLLING_TIMEOUT_SECONDS} seconds and
      * the jitter rate of {@value #DEFAULT_LONG_POLLING_TIMEOUT_JITTER_RATE}.
      *
      * @param maxLongPollingTimeoutMillis A positive maximum allowed timeout value which is specified by
@@ -173,7 +174,7 @@ public final class HealthCheckServiceBuilder {
      * @see #longPolling(long)
      */
     public HealthCheckServiceBuilder longPolling(long maxLongPollingTimeoutMillis,
-                                                 float longPollingTimeoutJitterRate) {
+                                                 double longPollingTimeoutJitterRate) {
         checkArgument(maxLongPollingTimeoutMillis >= 0,
                       "maxLongPollingTimeoutMillis: %s (expected: >= 0)",
                       maxLongPollingTimeoutMillis);

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceBuilder.java
@@ -95,7 +95,7 @@ public final class HealthCheckServiceBuilder {
      * response is sent by default:
      *
      * <pre>{@code
-     * HTTP/1.1 200 OK
+     * HTTP/1.1 503 Service Unavailable
      * Content-Type: application/json; charset=utf-8
      *
      * { "healthy": false }
@@ -175,9 +175,10 @@ public final class HealthCheckServiceBuilder {
     public HealthCheckServiceBuilder longPolling(long maxLongPollingTimeoutMillis,
                                                  float longPollingTimeoutJitterRate) {
         checkArgument(maxLongPollingTimeoutMillis >= 0,
-                      "maxLongPollingTimeoutMillis: %s (expected: >= 0)", maxLongPollingTimeoutMillis);
+                      "maxLongPollingTimeoutMillis: %s (expected: >= 0)",
+                      maxLongPollingTimeoutMillis);
         checkArgument(longPollingTimeoutJitterRate >= 0 && longPollingTimeoutJitterRate <= 1,
-                      "longPollingTimeoutJitterRate: %s (longPollingTimeoutJitterRate: >= 0 && <= 1)",
+                      "longPollingTimeoutJitterRate: %s (expected: >= 0 && <= 1)",
                       longPollingTimeoutJitterRate);
         this.maxLongPollingTimeoutMillis = maxLongPollingTimeoutMillis;
         this.longPollingTimeoutJitterRate = longPollingTimeoutJitterRate;

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckUpdateHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckUpdateHandler.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.healthcheck;
+
+import java.util.concurrent.CompletionStage;
+
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.server.HttpResponseException;
+import com.linecorp.armeria.server.HttpStatusException;
+import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.ServiceRequestContext;
+
+/**
+ * Handles {@code PUT}, {@code POST} or {@code PATCH} requests sent to {@link HealthCheckService}.
+ */
+@FunctionalInterface
+public interface HealthCheckUpdateHandler {
+    /**
+     * Determines if the healthiness of the {@link Server} needs to be change or not from the given
+     * {@link HttpRequest}.
+     *
+     * @return A {@link CompletionStage} which is completed with one of the following values:
+     *         <ul>
+     *           <li>{@code true} - the {@link Server} has to be marked as 'healthy'.</li>
+     *           <li>{@code false} - the {@link Server} has to be marked as 'unhealthy'.</li>
+     *           <li>{@code null} - the healthiness of the {@link Server} has to remain as-is.</li>
+     *         </ul>
+     *         The {@link CompletionStage} can also be completed with an exception, such as
+     *         {@link HttpStatusException} and {@link HttpResponseException} to send a specific
+     *         HTTP response to the client.
+     */
+    CompletionStage<Boolean> handle(ServiceRequestContext ctx, HttpRequest req) throws Exception;
+}

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckUpdateHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckUpdateHandler.java
@@ -32,15 +32,11 @@ public interface HealthCheckUpdateHandler {
      * Determines if the healthiness of the {@link Server} needs to be changed or not from the given
      * {@link HttpRequest}.
      *
-     * @return A {@link CompletionStage} which is completed with one of the following values:
-     *         <ul>
-     *           <li>{@code true} - the {@link Server} has to be marked as 'healthy'.</li>
-     *           <li>{@code false} - the {@link Server} has to be marked as 'unhealthy'.</li>
-     *           <li>{@code null} - the healthiness of the {@link Server} has to remain as-is.</li>
-     *         </ul>
+     * @return A {@link CompletionStage} which is completed with {@link HealthCheckUpdateResult}.
      *         The {@link CompletionStage} can also be completed with an exception, such as
      *         {@link HttpStatusException} and {@link HttpResponseException} to send a specific
      *         HTTP response to the client.
      */
-    CompletionStage<Boolean> handle(ServiceRequestContext ctx, HttpRequest req) throws Exception;
+    CompletionStage<HealthCheckUpdateResult> handle(ServiceRequestContext ctx,
+                                                    HttpRequest req) throws Exception;
 }

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckUpdateHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckUpdateHandler.java
@@ -29,7 +29,7 @@ import com.linecorp.armeria.server.ServiceRequestContext;
 @FunctionalInterface
 public interface HealthCheckUpdateHandler {
     /**
-     * Determines if the healthiness of the {@link Server} needs to be change or not from the given
+     * Determines if the healthiness of the {@link Server} needs to be changed or not from the given
      * {@link HttpRequest}.
      *
      * @return A {@link CompletionStage} which is completed with one of the following values:

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckUpdateResult.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckUpdateResult.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.healthcheck;
+
+import com.linecorp.armeria.server.Server;
+
+/**
+ * The result of a request handled by {@link HealthCheckUpdateHandler}.
+ */
+public enum HealthCheckUpdateResult {
+    /**
+     * Tells {@link HealthCheckService} to mark the {@link Server} as 'healthy'.
+     */
+    HEALTHY,
+    /**
+     * Tells {@link HealthCheckService} to mark the {@link Server} as 'unhealthy'.
+     */
+    UNHEALTHY,
+    /**
+     * Tells {@link HealthCheckService} to leave the {@link Server} healthiness unchanged.
+     */
+    AS_IS
+}

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/HttpHealthCheckService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/HttpHealthCheckService.java
@@ -68,7 +68,10 @@ import com.linecorp.armeria.server.TransientService;
  *         .service("/health", new HttpHealthCheckService(healthChecker))
  *         .build();
  * }</pre>
+ *
+ * @deprecated Use {@link HealthCheckService}.
  */
+@Deprecated
 public class HttpHealthCheckService extends AbstractHttpService
         implements TransientService<HttpRequest, HttpResponse> {
 
@@ -138,15 +141,15 @@ public class HttpHealthCheckService extends AbstractHttpService
 
     @Override
     protected HttpResponse doHead(ServiceRequestContext ctx, HttpRequest req) {
-        return HttpResponse.of(newResponse(ctx).headers()); // Send without the content.
+        return HttpResponse.of(newResponse(ctx, req).headers()); // Send without the content.
     }
 
     @Override
     protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) {
-        return HttpResponse.of(newResponse(ctx));
+        return HttpResponse.of(newResponse(ctx, req));
     }
 
-    private AggregatedHttpResponse newResponse(ServiceRequestContext ctx) {
+    private AggregatedHttpResponse newResponse(ServiceRequestContext ctx, HttpRequest req) {
         return isHealthy() ? newHealthyResponse(ctx)
                            : newUnhealthyResponse(ctx);
     }

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/ListenableHealthChecker.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/ListenableHealthChecker.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.healthcheck;
+
+import com.linecorp.armeria.common.util.Listenable;
+
+/**
+ * A {@link HealthChecker} which notifies its state change to its listeners.
+ */
+public interface ListenableHealthChecker extends HealthChecker, Listenable<HealthChecker> {}

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/ManagedHttpHealthCheckService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/ManagedHttpHealthCheckService.java
@@ -48,7 +48,10 @@ import com.linecorp.armeria.server.ServiceRequestContext;
  * >         }
  * >     }).build();
  * }</pre>
+ *
+ * @deprecated Use {@link HealthCheckService}.
  */
+@Deprecated
 public class ManagedHttpHealthCheckService extends HttpHealthCheckService {
     private static final AggregatedHttpResponse TURN_ON_RES = AggregatedHttpResponse
             .of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, HttpData.ofUtf8("Set healthy."));

--- a/core/src/test/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceTest.java
@@ -82,11 +82,11 @@ class HealthCheckServiceTest {
                                                  final String content = aReq.contentAscii();
                                                  switch (content) {
                                                      case "OK":
-                                                         return true;
+                                                         return HealthCheckUpdateResult.HEALTHY;
                                                      case "KO":
-                                                         return false;
+                                                         return HealthCheckUpdateResult.UNHEALTHY;
                                                      case "NOOP":
-                                                         return null;
+                                                         return HealthCheckUpdateResult.AS_IS;
                                                      default:
                                                          throw HttpStatusException.of(HttpStatus.BAD_REQUEST);
                                                  }

--- a/core/src/test/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceTest.java
@@ -107,7 +107,7 @@ class HealthCheckServiceTest {
         assertResponseEquals("GET /hc HTTP/1.0",
                              "HTTP/1.1 200 OK\r\n" +
                              "content-type: application/json; charset=utf-8\r\n" +
-                             "long-polling-supported: true\r\n" +
+                             "armeria-lphc: 60\r\n" +
                              "content-length: 16\r\n\r\n" +
                              "{\"healthy\":true}");
     }
@@ -118,7 +118,7 @@ class HealthCheckServiceTest {
         assertResponseEquals("GET /hc HTTP/1.0",
                              "HTTP/1.1 503 Service Unavailable\r\n" +
                              "content-type: application/json; charset=utf-8\r\n" +
-                             "long-polling-supported: true\r\n" +
+                             "armeria-lphc: 60\r\n" +
                              "content-length: 17\r\n\r\n" +
                              "{\"healthy\":false}");
     }
@@ -128,7 +128,7 @@ class HealthCheckServiceTest {
         assertResponseEquals("HEAD /hc HTTP/1.0",
                              "HTTP/1.1 200 OK\r\n" +
                              "content-type: application/json; charset=utf-8\r\n" +
-                             "long-polling-supported: true\r\n" +
+                             "armeria-lphc: 60\r\n" +
                              "content-length: 16\r\n\r\n");
     }
 
@@ -138,7 +138,7 @@ class HealthCheckServiceTest {
         assertResponseEquals("HEAD /hc HTTP/1.0",
                              "HTTP/1.1 503 Service Unavailable\r\n" +
                              "content-type: application/json; charset=utf-8\r\n" +
-                             "long-polling-supported: true\r\n" +
+                             "armeria-lphc: 60\r\n" +
                              "content-length: 17\r\n\r\n");
     }
 
@@ -169,7 +169,7 @@ class HealthCheckServiceTest {
         withTimeout(() -> assertThat(f.join()).isEqualTo(AggregatedHttpResponse.of(
                 ResponseHeaders.of(HttpStatus.SERVICE_UNAVAILABLE,
                                    HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_UTF_8,
-                                   "long-polling-supported", true),
+                                   "armeria-lphc", 60),
                 HttpData.ofUtf8("{\"healthy\":false}"))));
     }
 
@@ -184,7 +184,7 @@ class HealthCheckServiceTest {
         withTimeout(() -> assertThat(f.get()).isEqualTo(AggregatedHttpResponse.of(
                 ResponseHeaders.of(HttpStatus.SERVICE_UNAVAILABLE,
                                    HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_UTF_8,
-                                   "long-polling-supported", true),
+                                   "armeria-lphc", 60),
                 HttpData.ofUtf8("{\"healthy\":false}"))));
     }
 
@@ -204,7 +204,7 @@ class HealthCheckServiceTest {
         withTimeout(() -> assertThat(f.get()).isEqualTo(AggregatedHttpResponse.of(
                 ResponseHeaders.of(HttpStatus.OK,
                                    HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_UTF_8,
-                                   "long-polling-supported", true),
+                                   "armeria-lphc", 60),
                 HttpData.ofUtf8("{\"healthy\":true}"))));
     }
 
@@ -216,7 +216,7 @@ class HealthCheckServiceTest {
         withTimeout(() -> assertThat(f.get()).isEqualTo(AggregatedHttpResponse.of(
                 ResponseHeaders.of(HttpStatus.OK,
                                    HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_UTF_8,
-                                   "long-polling-supported", true),
+                                   "armeria-lphc", 60),
                 HttpData.ofUtf8("{\"healthy\":true}"))));
     }
 
@@ -229,7 +229,7 @@ class HealthCheckServiceTest {
                                    .endOfStream(true)
                                    .status(HttpStatus.NOT_MODIFIED)
                                    .contentType(MediaType.JSON_UTF_8)
-                                   .setObject("long-polling-supported", true)
+                                   .setInt("armeria-lphc", 60)
                                    .build()));
         });
     }
@@ -273,7 +273,7 @@ class HealthCheckServiceTest {
         assertThat(f.get(10, TimeUnit.SECONDS)).isEqualTo(AggregatedHttpResponse.of(
                 ResponseHeaders.of(HttpStatus.OK,
                                    HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_UTF_8,
-                                   "long-polling-supported", false),
+                                   "armeria-lphc", 0),
                 HttpData.ofUtf8("{\"healthy\":true}")));
     }
 
@@ -295,7 +295,7 @@ class HealthCheckServiceTest {
         assertThat(res1).isEqualTo(AggregatedHttpResponse.of(
                 ResponseHeaders.of(HttpStatus.SERVICE_UNAVAILABLE,
                                    HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_UTF_8,
-                                   "long-polling-supported", true),
+                                   "armeria-lphc", 60),
                 HttpData.ofUtf8("{\"healthy\":false}")));
 
         // Make healthy.
@@ -304,7 +304,7 @@ class HealthCheckServiceTest {
         assertThat(res2).isEqualTo(AggregatedHttpResponse.of(
                 ResponseHeaders.of(HttpStatus.OK,
                                    HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_UTF_8,
-                                   "long-polling-supported", true),
+                                   "armeria-lphc", 60),
                 HttpData.ofUtf8("{\"healthy\":true}")));
     }
 
@@ -319,7 +319,7 @@ class HealthCheckServiceTest {
         assertThat(res1).isEqualTo(AggregatedHttpResponse.of(
                 ResponseHeaders.of(HttpStatus.SERVICE_UNAVAILABLE,
                                    HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_UTF_8,
-                                   "long-polling-supported", true),
+                                   "armeria-lphc", 60),
                 HttpData.ofUtf8("{\"healthy\":false}")));
 
         // Make healthy.
@@ -329,7 +329,7 @@ class HealthCheckServiceTest {
         assertThat(res2).isEqualTo(AggregatedHttpResponse.of(
                 ResponseHeaders.of(HttpStatus.OK,
                                    HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_UTF_8,
-                                   "long-polling-supported", true),
+                                   "armeria-lphc", 60),
                 HttpData.ofUtf8("{\"healthy\":true}")));
     }
 
@@ -343,7 +343,7 @@ class HealthCheckServiceTest {
         assertThat(res1).isEqualTo(AggregatedHttpResponse.of(
                 ResponseHeaders.of(HttpStatus.SERVICE_UNAVAILABLE,
                                    HttpHeaderNames.CONTENT_TYPE, MediaType.PLAIN_TEXT_UTF_8,
-                                   "long-polling-supported", true),
+                                   "armeria-lphc", 60),
                 HttpData.ofUtf8("not ok")));
 
         // Make healthy.
@@ -352,7 +352,7 @@ class HealthCheckServiceTest {
         assertThat(res2).isEqualTo(AggregatedHttpResponse.of(
                 ResponseHeaders.of(HttpStatus.OK,
                                    HttpHeaderNames.CONTENT_TYPE, MediaType.PLAIN_TEXT_UTF_8,
-                                   "long-polling-supported", true),
+                                   "armeria-lphc", 60),
                 HttpData.ofUtf8("ok")));
 
         // Send a no-op request.
@@ -361,7 +361,7 @@ class HealthCheckServiceTest {
         assertThat(res3).isEqualTo(AggregatedHttpResponse.of(
                 ResponseHeaders.of(HttpStatus.OK,
                                    HttpHeaderNames.CONTENT_TYPE, MediaType.PLAIN_TEXT_UTF_8,
-                                   "long-polling-supported", true),
+                                   "armeria-lphc", 60),
                 HttpData.ofUtf8("ok")));
     }
 

--- a/core/src/test/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceTest.java
@@ -1,0 +1,395 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.healthcheck;
+
+import static com.linecorp.armeria.testing.internal.TestUtil.withTimeout;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.google.common.io.ByteStreams;
+
+import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.server.HttpStatusException;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.testing.junit.server.ServerExtension;
+
+import io.netty.util.NetUtil;
+
+class HealthCheckServiceTest {
+
+    private static final SettableHealthChecker checker = new SettableHealthChecker();
+
+    @RegisterExtension
+    static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.service("/hc", HealthCheckService.of(checker));
+            sb.service("/hc_long_polling_disabled", HealthCheckService.builder()
+                                                                      .longPolling(0)
+                                                                      .build());
+            sb.service("/hc_updatable", HealthCheckService.builder()
+                                                          .updatable(true)
+                                                          .build());
+            sb.service("/hc_custom",
+                       HealthCheckService.builder()
+                                         .healthyResponse(AggregatedHttpResponse.of(
+                                                 HttpStatus.OK,
+                                                 MediaType.PLAIN_TEXT_UTF_8,
+                                                 "ok"))
+                                         .unhealthyResponse(AggregatedHttpResponse.of(
+                                                 HttpStatus.SERVICE_UNAVAILABLE,
+                                                 MediaType.PLAIN_TEXT_UTF_8,
+                                                 "not ok"))
+                                         .updatable((ctx, req) -> {
+                                             if (req.method() != HttpMethod.PUT) {
+                                                 throw HttpStatusException.of(HttpStatus.METHOD_NOT_ALLOWED);
+                                             }
+                                             return req.aggregate().thenApply(aReq -> {
+                                                 final String content = aReq.contentAscii();
+                                                 switch (content) {
+                                                     case "OK":
+                                                         return true;
+                                                     case "KO":
+                                                         return false;
+                                                     case "NOOP":
+                                                         return null;
+                                                     default:
+                                                         throw HttpStatusException.of(HttpStatus.BAD_REQUEST);
+                                                 }
+                                             });
+                                         })
+                                         .build());
+            sb.gracefulShutdownTimeout(Duration.ofSeconds(10), Duration.ofSeconds(10));
+        }
+    };
+
+    @BeforeEach
+    void clearChecker() {
+        checker.setHealthy(true);
+    }
+
+    @Test
+    void getWhenHealthy() throws Exception {
+        assertResponseEquals("GET /hc HTTP/1.0",
+                             "HTTP/1.1 200 OK\r\n" +
+                             "content-type: application/json; charset=utf-8\r\n" +
+                             "long-polling-supported: true\r\n" +
+                             "content-length: 16\r\n\r\n" +
+                             "{\"healthy\":true}");
+    }
+
+    @Test
+    void getWhenUnhealthy() throws Exception {
+        checker.setHealthy(false);
+        assertResponseEquals("GET /hc HTTP/1.0",
+                             "HTTP/1.1 503 Service Unavailable\r\n" +
+                             "content-type: application/json; charset=utf-8\r\n" +
+                             "long-polling-supported: true\r\n" +
+                             "content-length: 17\r\n\r\n" +
+                             "{\"healthy\":false}");
+    }
+
+    @Test
+    void headWhenHealthy() throws Exception {
+        assertResponseEquals("HEAD /hc HTTP/1.0",
+                             "HTTP/1.1 200 OK\r\n" +
+                             "content-type: application/json; charset=utf-8\r\n" +
+                             "long-polling-supported: true\r\n" +
+                             "content-length: 16\r\n\r\n");
+    }
+
+    @Test
+    void headWhenUnhealthy() throws Exception {
+        checker.setHealthy(false);
+        assertResponseEquals("HEAD /hc HTTP/1.0",
+                             "HTTP/1.1 503 Service Unavailable\r\n" +
+                             "content-type: application/json; charset=utf-8\r\n" +
+                             "long-polling-supported: true\r\n" +
+                             "content-length: 17\r\n\r\n");
+    }
+
+    private static void assertResponseEquals(String request, String expectedResponse) throws Exception {
+        final int port = server.httpPort();
+        try (Socket s = new Socket(NetUtil.LOCALHOST, port)) {
+            s.setSoTimeout(10000);
+            final InputStream in = s.getInputStream();
+            final OutputStream out = s.getOutputStream();
+            out.write((request + "\r\n\r\n").getBytes(StandardCharsets.US_ASCII));
+
+            // Should neither be chunked nor have content.
+            assertThat(new String(ByteStreams.toByteArray(in), StandardCharsets.UTF_8))
+                    .isEqualTo(expectedResponse);
+        }
+    }
+
+    @Test
+    void waitUntilUnhealthy() {
+        final CompletableFuture<AggregatedHttpResponse> f = sendLongPollingGet("healthy");
+
+        // Should not wake up until the server becomes unhealthy.
+        assertThatThrownBy(() -> f.get(1, TimeUnit.SECONDS))
+                .isInstanceOf(TimeoutException.class);
+
+        // Make the server unhealthy so the response comes in.
+        checker.setHealthy(false);
+        withTimeout(() -> assertThat(f.join()).isEqualTo(AggregatedHttpResponse.of(
+                ResponseHeaders.of(HttpStatus.SERVICE_UNAVAILABLE,
+                                   HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_UTF_8,
+                                   "long-polling-supported", true),
+                HttpData.ofUtf8("{\"healthy\":false}"))));
+    }
+
+    @Test
+    void waitUntilUnhealthyWithImmediateWakeup() throws Exception {
+        // Make the server unhealthy.
+        checker.setHealthy(false);
+
+        final CompletableFuture<AggregatedHttpResponse> f = sendLongPollingGet("healthy");
+
+        // The server is unhealthy already, so the response has to come in immediately.
+        withTimeout(() -> assertThat(f.get()).isEqualTo(AggregatedHttpResponse.of(
+                ResponseHeaders.of(HttpStatus.SERVICE_UNAVAILABLE,
+                                   HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_UTF_8,
+                                   "long-polling-supported", true),
+                HttpData.ofUtf8("{\"healthy\":false}"))));
+    }
+
+    @Test
+    void waitUntilHealthy() {
+        // Make the server unhealthy.
+        checker.setHealthy(false);
+
+        final CompletableFuture<AggregatedHttpResponse> f = sendLongPollingGet("unhealthy");
+
+        // Should not wake up until the server becomes unhealthy.
+        assertThatThrownBy(() -> f.get(1, TimeUnit.SECONDS))
+                .isInstanceOf(TimeoutException.class);
+
+        // Make the server healthy so the response comes in.
+        checker.setHealthy(true);
+        withTimeout(() -> assertThat(f.get()).isEqualTo(AggregatedHttpResponse.of(
+                ResponseHeaders.of(HttpStatus.OK,
+                                   HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_UTF_8,
+                                   "long-polling-supported", true),
+                HttpData.ofUtf8("{\"healthy\":true}"))));
+    }
+
+    @Test
+    void waitUntilHealthyWithImmediateWakeUp() throws Exception {
+        final CompletableFuture<AggregatedHttpResponse> f = sendLongPollingGet("unhealthy");
+
+        // The server is healthy already, so the response has to come in immediately.
+        withTimeout(() -> assertThat(f.get()).isEqualTo(AggregatedHttpResponse.of(
+                ResponseHeaders.of(HttpStatus.OK,
+                                   HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_UTF_8,
+                                   "long-polling-supported", true),
+                HttpData.ofUtf8("{\"healthy\":true}"))));
+    }
+
+    @Test
+    void waitTimeout() throws Exception {
+        withTimeout(() -> {
+            final AggregatedHttpResponse res = sendLongPollingGet("healthy", 1).get();
+            assertThat(res).isEqualTo(AggregatedHttpResponse.of(
+                    ResponseHeaders.builder()
+                                   .endOfStream(true)
+                                   .status(HttpStatus.NOT_MODIFIED)
+                                   .contentType(MediaType.JSON_UTF_8)
+                                   .setObject("long-polling-supported", true)
+                                   .build()));
+        });
+    }
+
+    @Test
+    void waitWithWrongMethod() throws Exception {
+        withTimeout(() -> {
+            final HttpClient client = HttpClient.of(server.httpUri("/"));
+            final CompletableFuture<AggregatedHttpResponse> f = client.execute(
+                    RequestHeaders.of(HttpMethod.POST, "/hc_custom",
+                                      HttpHeaderNames.PREFER, "wait=60",
+                                      HttpHeaderNames.IF_NONE_MATCH, "\"healthy\"")).aggregate();
+            assertThat(f.get().status()).isEqualTo(HttpStatus.METHOD_NOT_ALLOWED);
+        });
+    }
+
+    @Test
+    void waitWithWrongTimeout() throws Exception {
+        withTimeout(() -> {
+            final AggregatedHttpResponse res = sendLongPollingGet("healthy", -1).get();
+            assertThat(res.status()).isEqualTo(HttpStatus.BAD_REQUEST);
+        });
+    }
+
+    @Test
+    void waitWithOtherETag() throws Exception {
+        withTimeout(() -> {
+            // A never-matching etag must disable polling.
+            final AggregatedHttpResponse res = sendLongPollingGet("whatever", 1).get();
+            assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        });
+    }
+
+    @Test
+    void longPollingDisabled() throws Exception {
+        final HttpClient client = HttpClient.of(server.httpUri("/"));
+        final CompletableFuture<AggregatedHttpResponse> f = client.execute(
+                RequestHeaders.of(HttpMethod.GET, "/hc_long_polling_disabled",
+                                  HttpHeaderNames.PREFER, "wait=60",
+                                  HttpHeaderNames.IF_NONE_MATCH, "\"healthy\"")).aggregate();
+        assertThat(f.get(10, TimeUnit.SECONDS)).isEqualTo(AggregatedHttpResponse.of(
+                ResponseHeaders.of(HttpStatus.OK,
+                                   HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_UTF_8,
+                                   "long-polling-supported", false),
+                HttpData.ofUtf8("{\"healthy\":true}")));
+    }
+
+    @Test
+    void notUpdatableByDefault() throws Exception {
+        final HttpClient client = HttpClient.of(server.httpUri("/"));
+        final AggregatedHttpResponse res = client.execute(RequestHeaders.of(HttpMethod.POST, "/hc"),
+                                                          "{\"healthy\":false}").aggregate().join();
+        assertThat(res.status()).isEqualTo(HttpStatus.METHOD_NOT_ALLOWED);
+    }
+
+    @Test
+    void updateUsingPutOrPost() {
+        final HttpClient client = HttpClient.of(server.httpUri("/"));
+
+        // Make unhealthy.
+        final AggregatedHttpResponse res1 = client.execute(RequestHeaders.of(HttpMethod.PUT, "/hc_updatable"),
+                                                           "{\"healthy\":false}").aggregate().join();
+        assertThat(res1).isEqualTo(AggregatedHttpResponse.of(
+                ResponseHeaders.of(HttpStatus.SERVICE_UNAVAILABLE,
+                                   HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_UTF_8,
+                                   "long-polling-supported", true),
+                HttpData.ofUtf8("{\"healthy\":false}")));
+
+        // Make healthy.
+        final AggregatedHttpResponse res2 = client.execute(RequestHeaders.of(HttpMethod.POST, "/hc_updatable"),
+                                                           "{\"healthy\":true}").aggregate().join();
+        assertThat(res2).isEqualTo(AggregatedHttpResponse.of(
+                ResponseHeaders.of(HttpStatus.OK,
+                                   HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_UTF_8,
+                                   "long-polling-supported", true),
+                HttpData.ofUtf8("{\"healthy\":true}")));
+    }
+
+    @Test
+    void updateUsingPatch() {
+        final HttpClient client = HttpClient.of(server.httpUri("/"));
+
+        // Make unhealthy.
+        final AggregatedHttpResponse res1 = client.execute(
+                RequestHeaders.of(HttpMethod.PATCH, "/hc_updatable"),
+                "[{\"op\":\"replace\",\"path\":\"/healthy\",\"value\":false}]").aggregate().join();
+        assertThat(res1).isEqualTo(AggregatedHttpResponse.of(
+                ResponseHeaders.of(HttpStatus.SERVICE_UNAVAILABLE,
+                                   HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_UTF_8,
+                                   "long-polling-supported", true),
+                HttpData.ofUtf8("{\"healthy\":false}")));
+
+        // Make healthy.
+        final AggregatedHttpResponse res2 = client.execute(
+                RequestHeaders.of(HttpMethod.PATCH, "/hc_updatable"),
+                "[{\"op\":\"replace\",\"path\":\"/healthy\",\"value\":true}]").aggregate().join();
+        assertThat(res2).isEqualTo(AggregatedHttpResponse.of(
+                ResponseHeaders.of(HttpStatus.OK,
+                                   HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_UTF_8,
+                                   "long-polling-supported", true),
+                HttpData.ofUtf8("{\"healthy\":true}")));
+    }
+
+    @Test
+    void custom() {
+        final HttpClient client = HttpClient.of(server.httpUri("/"));
+
+        // Make unhealthy.
+        final AggregatedHttpResponse res1 = client.execute(RequestHeaders.of(HttpMethod.PUT, "/hc_custom"),
+                                                           "KO").aggregate().join();
+        assertThat(res1).isEqualTo(AggregatedHttpResponse.of(
+                ResponseHeaders.of(HttpStatus.SERVICE_UNAVAILABLE,
+                                   HttpHeaderNames.CONTENT_TYPE, MediaType.PLAIN_TEXT_UTF_8,
+                                   "long-polling-supported", true),
+                HttpData.ofUtf8("not ok")));
+
+        // Make healthy.
+        final AggregatedHttpResponse res2 = client.execute(RequestHeaders.of(HttpMethod.PUT, "/hc_custom"),
+                                                           "OK").aggregate().join();
+        assertThat(res2).isEqualTo(AggregatedHttpResponse.of(
+                ResponseHeaders.of(HttpStatus.OK,
+                                   HttpHeaderNames.CONTENT_TYPE, MediaType.PLAIN_TEXT_UTF_8,
+                                   "long-polling-supported", true),
+                HttpData.ofUtf8("ok")));
+
+        // Send a no-op request.
+        final AggregatedHttpResponse res3 = client.execute(RequestHeaders.of(HttpMethod.PUT, "/hc_custom"),
+                                                           "NOOP").aggregate().join();
+        assertThat(res3).isEqualTo(AggregatedHttpResponse.of(
+                ResponseHeaders.of(HttpStatus.OK,
+                                   HttpHeaderNames.CONTENT_TYPE, MediaType.PLAIN_TEXT_UTF_8,
+                                   "long-polling-supported", true),
+                HttpData.ofUtf8("ok")));
+    }
+
+    @Test
+    void customError() {
+        final HttpClient client = HttpClient.of(server.httpUri("/"));
+
+        // Use an unsupported method.
+        final AggregatedHttpResponse res1 = client.execute(RequestHeaders.of(HttpMethod.PATCH, "/hc_custom"))
+                                                  .aggregate().join();
+        assertThat(res1.status()).isEqualTo(HttpStatus.METHOD_NOT_ALLOWED);
+
+        // Send a wrong command.
+        final AggregatedHttpResponse res2 = client.execute(RequestHeaders.of(HttpMethod.PUT, "/hc_custom"),
+                                                           "BAD").aggregate().join();
+        assertThat(res2.status()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+    private static CompletableFuture<AggregatedHttpResponse> sendLongPollingGet(String healthiness) {
+        return sendLongPollingGet(healthiness, 120);
+    }
+
+    private static CompletableFuture<AggregatedHttpResponse> sendLongPollingGet(String healthiness,
+                                                                                int timeoutSeconds) {
+        final HttpClient client = HttpClient.of(server.httpUri("/"));
+        return client.execute(RequestHeaders.of(HttpMethod.GET, "/hc",
+                                                HttpHeaderNames.PREFER, "wait=" + timeoutSeconds,
+                                                HttpHeaderNames.IF_NONE_MATCH,
+                                                '"' + healthiness + '"')).aggregate();
+    }
+}


### PR DESCRIPTION
Motivation:

- By adding long-polling support to a health check service, an advanced
  health check client can get notified immediately when a server becomes
  healthy (or unhealthy), rather than polling periodically.
- `ManagedHttpHealthCheckService` provides only a very simple update
  mechanism that's hard to customize.

Modifications:

- Deprecate `*HttpHealthCheckService`
- Add `HealthCheckService` and its builder
- Add `ListenableHealthChecker` to implement notification

Result:

- Long-polling support for health checks, which will greatly reduce the
  delay between the actual moment when the server got unhealthy and when
  the client learns the unhealthiness.