### PR TITLE
Relax the output type constraint of sanitizer functions

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/logging/LoggingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/logging/LoggingClient.java
@@ -76,14 +76,14 @@ public final class LoggingClient<I extends Request, O extends Response> extends 
     private final LogLevel requestLogLevel;
     private final LogLevel successfulResponseLogLevel;
     private final LogLevel failedResponseLogLevel;
-    private final Function<? super HttpHeaders, ? extends HttpHeaders> requestHeadersSanitizer;
+    private final Function<? super HttpHeaders, ?> requestHeadersSanitizer;
     private final Function<Object, ?> requestContentSanitizer;
-    private final Function<? super HttpHeaders, ? extends HttpHeaders> requestTrailersSanitizer;
+    private final Function<? super HttpHeaders, ?> requestTrailersSanitizer;
 
-    private final Function<? super HttpHeaders, ? extends HttpHeaders> responseHeadersSanitizer;
+    private final Function<? super HttpHeaders, ?> responseHeadersSanitizer;
     private final Function<Object, ?> responseContentSanitizer;
-    private final Function<? super HttpHeaders, ? extends HttpHeaders> responseTrailersSanitizer;
-    private final Function<? super Throwable, ? extends Throwable> responseCauseSanitizer;
+    private final Function<? super HttpHeaders, ?> responseTrailersSanitizer;
+    private final Function<? super Throwable, ?> responseCauseSanitizer;
     private final Sampler sampler;
 
     /**
@@ -126,13 +126,13 @@ public final class LoggingClient<I extends Request, O extends Response> extends 
                   LogLevel requestLogLevel,
                   LogLevel successfulResponseLogLevel,
                   LogLevel failedResponseLogLevel,
-                  Function<? super HttpHeaders, ? extends HttpHeaders> requestHeadersSanitizer,
+                  Function<? super HttpHeaders, ?> requestHeadersSanitizer,
                   Function<Object, ?> requestContentSanitizer,
-                  Function<? super HttpHeaders, ? extends HttpHeaders> requestTrailersSanitizer,
-                  Function<? super HttpHeaders, ? extends HttpHeaders> responseHeadersSanitizer,
+                  Function<? super HttpHeaders, ?> requestTrailersSanitizer,
+                  Function<? super HttpHeaders, ?> responseHeadersSanitizer,
                   Function<Object, ?> responseContentSanitizer,
-                  Function<? super HttpHeaders, ? extends HttpHeaders> responseTrailersSanitizer,
-                  Function<? super Throwable, ? extends Throwable> responseCauseSanitizer,
+                  Function<? super HttpHeaders, ?> responseTrailersSanitizer,
+                  Function<? super Throwable, ?> responseCauseSanitizer,
                   Sampler sampler) {
         super(requireNonNull(delegate, "delegate"));
         this.requestLogLevel = requireNonNull(requestLogLevel, "requestLogLevel");

--- a/core/src/main/java/com/linecorp/armeria/common/logging/LoggingDecoratorBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/LoggingDecoratorBuilder.java
@@ -37,19 +37,15 @@ public abstract class LoggingDecoratorBuilder<T extends LoggingDecoratorBuilder<
     private LogLevel requestLogLevel = LogLevel.TRACE;
     private LogLevel successfulResponseLogLevel = LogLevel.TRACE;
     private LogLevel failedResponseLogLevel = LogLevel.WARN;
-    private Function<? super HttpHeaders, ? extends HttpHeaders> requestHeadersSanitizer =
-            DEFAULT_HEADERS_SANITIZER;
+    private Function<? super HttpHeaders, ?> requestHeadersSanitizer = DEFAULT_HEADERS_SANITIZER;
     private Function<Object, ?> requestContentSanitizer = DEFAULT_CONTENT_SANITIZER;
-    private Function<? super HttpHeaders, ? extends HttpHeaders> requestTrailersSanitizer =
-            DEFAULT_HEADERS_SANITIZER;
+    private Function<? super HttpHeaders, ?> requestTrailersSanitizer = DEFAULT_HEADERS_SANITIZER;
 
-    private Function<? super HttpHeaders, ? extends HttpHeaders> responseHeadersSanitizer =
-            DEFAULT_HEADERS_SANITIZER;
+    private Function<? super HttpHeaders, ?> responseHeadersSanitizer = DEFAULT_HEADERS_SANITIZER;
     private Function<Object, ?> responseContentSanitizer = DEFAULT_CONTENT_SANITIZER;
-    private Function<? super Throwable, ? extends Throwable> responseCauseSanitizer = DEFAULT_CAUSE_SANITIZER;
+    private Function<? super Throwable, ?> responseCauseSanitizer = DEFAULT_CAUSE_SANITIZER;
     private float samplingRate = 1.0f;
-    private Function<? super HttpHeaders, ? extends HttpHeaders> responseTrailersSanitizer =
-            DEFAULT_HEADERS_SANITIZER;
+    private Function<? super HttpHeaders, ?> responseTrailersSanitizer = DEFAULT_HEADERS_SANITIZER;
 
     /**
      * Sets the {@link LogLevel} to use when logging requests. If unset, will use {@link LogLevel#TRACE}.
@@ -104,8 +100,7 @@ public abstract class LoggingDecoratorBuilder<T extends LoggingDecoratorBuilder<
      * {@link Function} that removes sensitive headers, like {@code Cookie}, before logging. If unset, will use
      * {@link Function#identity()}.
      */
-    public T requestHeadersSanitizer(
-            Function<? super HttpHeaders, ? extends HttpHeaders> requestHeadersSanitizer) {
+    public T requestHeadersSanitizer(Function<? super HttpHeaders, ?> requestHeadersSanitizer) {
         this.requestHeadersSanitizer = requireNonNull(requestHeadersSanitizer, "requestHeadersSanitizer");
         return self();
     }
@@ -113,7 +108,7 @@ public abstract class LoggingDecoratorBuilder<T extends LoggingDecoratorBuilder<
     /**
      * Returns the {@link Function} to use to sanitize request headers before logging.
      */
-    protected Function<? super HttpHeaders, ? extends HttpHeaders> requestHeadersSanitizer() {
+    protected Function<? super HttpHeaders, ?> requestHeadersSanitizer() {
         return requestHeadersSanitizer;
     }
 
@@ -122,8 +117,7 @@ public abstract class LoggingDecoratorBuilder<T extends LoggingDecoratorBuilder<
      * {@link Function} that removes sensitive headers, like {@code Set-Cookie}, before logging. If unset,
      * will use {@link Function#identity()}.
      */
-    public T responseHeadersSanitizer(
-            Function<? super HttpHeaders, ? extends HttpHeaders> responseHeadersSanitizer) {
+    public T responseHeadersSanitizer(Function<? super HttpHeaders, ?> responseHeadersSanitizer) {
         this.responseHeadersSanitizer = requireNonNull(responseHeadersSanitizer, "responseHeadersSanitizer");
         return self();
     }
@@ -131,7 +125,7 @@ public abstract class LoggingDecoratorBuilder<T extends LoggingDecoratorBuilder<
     /**
      * Returns the {@link Function} to use to sanitize response headers before logging.
      */
-    protected Function<? super HttpHeaders, ? extends HttpHeaders> responseHeadersSanitizer() {
+    protected Function<? super HttpHeaders, ?> responseHeadersSanitizer() {
         return responseHeadersSanitizer;
     }
 
@@ -139,8 +133,7 @@ public abstract class LoggingDecoratorBuilder<T extends LoggingDecoratorBuilder<
      * Sets the {@link Function} to use to sanitize request trailers before logging. If unset,
      * will use {@link Function#identity()}.
      */
-    public T requestTrailersSanitizer(
-            Function<? super HttpHeaders, ? extends HttpHeaders> requestTrailersSanitizer) {
+    public T requestTrailersSanitizer(Function<? super HttpHeaders, ?> requestTrailersSanitizer) {
         this.requestTrailersSanitizer = requireNonNull(requestTrailersSanitizer, "requestTrailersSanitizer");
         return self();
     }
@@ -148,7 +141,7 @@ public abstract class LoggingDecoratorBuilder<T extends LoggingDecoratorBuilder<
     /**
      * Returns the {@link Function} to use to sanitize request trailers before logging.
      */
-    protected Function<? super HttpHeaders, ? extends HttpHeaders> requestTrailersSanitizer() {
+    protected Function<? super HttpHeaders, ?> requestTrailersSanitizer() {
         return requestTrailersSanitizer;
     }
 
@@ -156,8 +149,7 @@ public abstract class LoggingDecoratorBuilder<T extends LoggingDecoratorBuilder<
      * Sets the {@link Function} to use to sanitize response trailers before logging. If unset,
      * will use {@link Function#identity()}.
      */
-    public T responseTrailersSanitizer(
-            Function<? super HttpHeaders, ? extends HttpHeaders> responseTrailersSanitizer) {
+    public T responseTrailersSanitizer(Function<? super HttpHeaders, ?> responseTrailersSanitizer) {
         this.responseTrailersSanitizer = requireNonNull(responseTrailersSanitizer, "responseTrailersSanitizer");
         return self();
     }
@@ -165,7 +157,7 @@ public abstract class LoggingDecoratorBuilder<T extends LoggingDecoratorBuilder<
     /**
      * Returns the {@link Function} to use to sanitize response trailers before logging.
      */
-    protected Function<? super HttpHeaders, ? extends HttpHeaders> responseTrailersSanitizer() {
+    protected Function<? super HttpHeaders, ?> responseTrailersSanitizer() {
         return responseTrailersSanitizer;
     }
 
@@ -185,7 +177,7 @@ public abstract class LoggingDecoratorBuilder<T extends LoggingDecoratorBuilder<
      * @see #responseHeadersSanitizer(Function)
      * @see #responseTrailersSanitizer(Function)
      */
-    public T headersSanitizer(Function<? super HttpHeaders, ? extends HttpHeaders> headersSanitizer) {
+    public T headersSanitizer(Function<? super HttpHeaders, ?> headersSanitizer) {
         requireNonNull(headersSanitizer, "headersSanitizer");
         requestHeadersSanitizer(headersSanitizer);
         requestTrailersSanitizer(headersSanitizer);
@@ -253,7 +245,7 @@ public abstract class LoggingDecoratorBuilder<T extends LoggingDecoratorBuilder<
      * the stack trace completely by returning {@code null} in the {@link Function}. If unset, will use
      * {@link Function#identity()}.
      */
-    public T responseCauseSanitizer(Function<? super Throwable, ? extends Throwable> responseCauseSanitizer) {
+    public T responseCauseSanitizer(Function<? super Throwable, ?> responseCauseSanitizer) {
         this.responseCauseSanitizer = requireNonNull(responseCauseSanitizer, "responseCauseSanitizer");
         return self();
     }
@@ -261,7 +253,7 @@ public abstract class LoggingDecoratorBuilder<T extends LoggingDecoratorBuilder<
     /**
      * Returns the {@link Function} to use to sanitize response cause before logging.
      */
-    protected Function<? super Throwable, ? extends Throwable> responseCauseSanitizer() {
+    protected Function<? super Throwable, ?> responseCauseSanitizer() {
         return responseCauseSanitizer;
     }
 
@@ -301,12 +293,12 @@ public abstract class LoggingDecoratorBuilder<T extends LoggingDecoratorBuilder<
             LogLevel requestLogLevel,
             LogLevel successfulResponseLogLevel,
             LogLevel failureResponseLogLevel,
-            Function<? super HttpHeaders, ? extends HttpHeaders> requestHeadersSanitizer,
+            Function<? super HttpHeaders, ?> requestHeadersSanitizer,
             Function<?, ?> requestContentSanitizer,
-            Function<? super HttpHeaders, ? extends HttpHeaders> requestTrailersSanitizer,
-            Function<? super HttpHeaders, ? extends HttpHeaders> responseHeadersSanitizer,
-            Function<?, ?> responseContentSanitizer,
-            Function<? super HttpHeaders, ? extends HttpHeaders> responseTrailersSanitizer,
+            Function<? super HttpHeaders, ?> requestTrailersSanitizer,
+            Function<? super HttpHeaders, ?> responseHeadersSanitizer,
+            Function<Object, ?> responseContentSanitizer,
+            Function<? super HttpHeaders, ?> responseTrailersSanitizer,
             float samplingRate) {
         final ToStringHelper helper = MoreObjects.toStringHelper(self)
                                                  .add("requestLogLevel", requestLogLevel)

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestLog.java
@@ -560,7 +560,7 @@ public interface RequestLog extends AttributeMap {
      * @param contentSanitizer a {@link Function} for sanitizing request content for logging. The result of the
      *                         {@link Function} is what is actually logged as content.
      */
-    String toStringRequestOnly(Function<? super HttpHeaders, ? extends HttpHeaders> headersSanitizer,
+    String toStringRequestOnly(Function<? super HttpHeaders, ?> headersSanitizer,
                                Function<Object, ?> contentSanitizer);
 
     /**
@@ -573,9 +573,9 @@ public interface RequestLog extends AttributeMap {
      * @param trailersSanitizer a {@link Function} for sanitizing HTTP trailers for logging. The result of the
      *                          {@link Function} is what is actually logged as trailers.
      */
-    String toStringRequestOnly(Function<? super RequestHeaders, ? extends HttpHeaders> headersSanitizer,
+    String toStringRequestOnly(Function<? super RequestHeaders, ?> headersSanitizer,
                                Function<Object, ?> contentSanitizer,
-                               Function<? super HttpHeaders, ? extends HttpHeaders> trailersSanitizer);
+                               Function<? super HttpHeaders, ?> trailersSanitizer);
 
     /**
      * Returns the string representation of the {@link Response}, with no sanitization of headers or content.
@@ -593,7 +593,7 @@ public interface RequestLog extends AttributeMap {
      * @param contentSanitizer a {@link Function} for sanitizing response content for logging. The result of the
      *                         {@link Function} is what is actually logged as content.
      */
-    String toStringResponseOnly(Function<? super HttpHeaders, ? extends HttpHeaders> headersSanitizer,
+    String toStringResponseOnly(Function<? super HttpHeaders, ?> headersSanitizer,
                                 Function<Object, ?> contentSanitizer);
 
     /**
@@ -606,7 +606,7 @@ public interface RequestLog extends AttributeMap {
      * @param trailersSanitizer a {@link Function} for sanitizing HTTP trailers for logging. The result of the
      *                         {@link Function} is what is actually logged as trailers.
      */
-    String toStringResponseOnly(Function<? super ResponseHeaders, ? extends HttpHeaders> headersSanitizer,
+    String toStringResponseOnly(Function<? super ResponseHeaders, ?> headersSanitizer,
                                 Function<Object, ?> contentSanitizer,
-                                Function<? super HttpHeaders, ? extends HttpHeaders> trailersSanitizer);
+                                Function<? super HttpHeaders, ?> trailersSanitizer);
 }

--- a/core/src/main/java/com/linecorp/armeria/server/logging/LoggingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/LoggingService.java
@@ -71,14 +71,14 @@ public final class LoggingService<I extends Request, O extends Response> extends
     private final LogLevel requestLogLevel;
     private final LogLevel successfulResponseLogLevel;
     private final LogLevel failedResponseLogLevel;
-    private final Function<? super RequestHeaders, ? extends HttpHeaders> requestHeadersSanitizer;
+    private final Function<? super RequestHeaders, ?> requestHeadersSanitizer;
     private final Function<Object, ?> requestContentSanitizer;
-    private final Function<? super HttpHeaders, ? extends HttpHeaders> requestTrailersSanitizer;
+    private final Function<? super HttpHeaders, ?> requestTrailersSanitizer;
 
-    private final Function<? super ResponseHeaders, ? extends HttpHeaders> responseHeadersSanitizer;
+    private final Function<? super ResponseHeaders, ?> responseHeadersSanitizer;
     private final Function<Object, ?> responseContentSanitizer;
-    private final Function<? super HttpHeaders, ? extends HttpHeaders> responseTrailersSanitizer;
-    private final Function<? super Throwable, ? extends Throwable> responseCauseSanitizer;
+    private final Function<? super HttpHeaders, ?> responseTrailersSanitizer;
+    private final Function<? super Throwable, ?> responseCauseSanitizer;
     private final Sampler sampler;
 
     /**
@@ -121,13 +121,13 @@ public final class LoggingService<I extends Request, O extends Response> extends
             LogLevel requestLogLevel,
             LogLevel successfulResponseLogLevel,
             LogLevel failedResponseLogLevel,
-            Function<? super RequestHeaders, ? extends HttpHeaders> requestHeadersSanitizer,
+            Function<? super RequestHeaders, ?> requestHeadersSanitizer,
             Function<Object, ?> requestContentSanitizer,
-            Function<? super HttpHeaders, ? extends HttpHeaders> requestTrailersSanitizer,
-            Function<? super ResponseHeaders, ? extends HttpHeaders> responseHeadersSanitizer,
+            Function<? super HttpHeaders, ?> requestTrailersSanitizer,
+            Function<? super ResponseHeaders, ?> responseHeadersSanitizer,
             Function<Object, ?> responseContentSanitizer,
-            Function<? super HttpHeaders, ? extends HttpHeaders> responseTrailersSanitizer,
-            Function<? super Throwable, ? extends Throwable> responseCauseSanitizer,
+            Function<? super HttpHeaders, ?> responseTrailersSanitizer,
+            Function<? super Throwable, ?> responseCauseSanitizer,
             Sampler sampler) {
         super(requireNonNull(delegate, "delegate"));
         this.requestLogLevel = requireNonNull(requestLogLevel, "requestLogLevel");


### PR DESCRIPTION
Related: #1810
Motivation:

When writing a header sanitization function, the function must be
written to return an `HttpHeaders`. For some users, it would be simpler
and/or more efficient if we relax the output type constraint of header
sanitizer functions, e.g.

    Function<HttpHeaders, Object> f = headers -> "sanitized!";

Modifications:

- Change the output type to `?` for all sanitizer functions.
- Miscellaneous:
  - Deduplicated sanitization logic in `DefaultRequestLog`.

Result:

- Convenience and efficiency