### PR TITLE
Enable message compression on server by default.

### DIFF
--- a/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/ArmeriaMessageFramer.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/ArmeriaMessageFramer.java
@@ -82,7 +82,8 @@ public class ArmeriaMessageFramer implements AutoCloseable {
     private final ByteBufAllocator alloc;
     private final int maxOutboundMessageSize;
 
-    private boolean messageCompression;
+    private boolean messageCompression = true;
+
     @Nullable
     private Compressor compressor;
     private boolean closed;

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/ArmeriaServerCall.java
@@ -130,7 +130,10 @@ class ArmeriaServerCall<I, O> extends ServerCall<I, O>
 
     @Nullable
     private Compressor compressor;
-    private boolean messageCompression;
+
+    // Message compression defaults to being enabled unless a user disables it using a server interceptor.
+    private boolean messageCompression = true;
+
     private boolean messageReceived;
 
     // state


### PR DESCRIPTION
This matches the default as documented in `ServerCall.setMessageCompression`. I personally don't like the default very much though... I think we would generally want to encourage using stream encoding via `HttpEncodingService` / `HttpDecodingClient` instead of message compression, which will have much better performance.

Fixes #1885