### PR TITLE
Cancel health check when closing health checked endpoint

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/OrElseEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/OrElseEndpointGroup.java
@@ -45,7 +45,8 @@ final class OrElseEndpointGroup extends AbstractListenable<List<Endpoint>> imple
 
     @Override
     public void close() {
-        try (EndpointGroup first = this.first; EndpointGroup second = this.second) {
+        try (EndpointGroup first = this.first;
+             EndpointGroup second = this.second) {
             // Just want to ensure closure.
         }
     }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/OrElseEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/OrElseEndpointGroup.java
@@ -42,4 +42,10 @@ final class OrElseEndpointGroup extends AbstractListenable<List<Endpoint>> imple
         }
         return second.endpoints();
     }
+
+    @Override
+    public void close() {
+        first.close();
+        second.close();
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/OrElseEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/OrElseEndpointGroup.java
@@ -45,7 +45,8 @@ final class OrElseEndpointGroup extends AbstractListenable<List<Endpoint>> imple
 
     @Override
     public void close() {
-        first.close();
-        second.close();
+        try (EndpointGroup first = this.first; EndpointGroup second = this.second) {
+            // Just want to ensure closure.
+        }
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
@@ -98,6 +98,8 @@ public abstract class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
     @Override
     public void close() {
         super.close();
+        delegate.close();
+
         ScheduledFuture<?> scheduledCheck = this.scheduledCheck;
         if (scheduledCheck != null) {
             scheduledCheck.cancel(true);


### PR DESCRIPTION
I ran into this while debugging why `awaitInitialEndpoints` in https://github.com/openzipkin/zipkin/pull/2653 often takes seconds to resolve `localhost`. I don't think I found the real culprit yet, but it does look like when closing and re-registering a health checked endpoint group, health checks from the closed one will still continue to be sent forever.

Also wondering if we need to redesign it so `EndpointGroupRegistry` is a field of `ClientFactory` instead of `static`.