### PR TITLE
Add `(ServerBuilder|VirtualHostBuilder).decorator(DecoratingServiceFunction)`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -1135,14 +1135,14 @@ public final class ServerBuilder {
     }
 
     /**
-     * Decorates all {@link Service}s with the specified {@code decorator}.
+     * Decorates all {@link Service}s with the specified {@code decoratingServiceFunction}.
      *
      * @param decoratingServiceFunction the {@link DecoratingServiceFunction} that decorates a {@link Service}.
      */
     public ServerBuilder decorator(
             DecoratingServiceFunction<HttpRequest, HttpResponse> decoratingServiceFunction) {
-        requireNonNull(decoratingServiceFunction, "decorator");
-        return decorator(service -> (ctx, req) -> decoratingServiceFunction.serve(service, ctx, req));
+        requireNonNull(decoratingServiceFunction, "decoratingServiceFunction");
+        return decorator(delegate -> new FunctionalDecoratingService<>(delegate, decoratingServiceFunction));
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -1137,12 +1137,12 @@ public final class ServerBuilder {
     /**
      * Decorates all {@link Service}s with the specified {@code decorator}.
      *
-     * @param decorator the {@link DecoratingServiceFunction} that decorates a {@link Service}.
+     * @param decoratingServiceFunction the {@link DecoratingServiceFunction} that decorates a {@link Service}.
      */
-    public ServerBuilder decorator(DecoratingServiceFunction<HttpRequest, HttpResponse> decorator) {
-        return this.decorator(service -> {
-            return (ctx, req) -> decorator.serve(service, ctx, req);
-        });
+    public ServerBuilder decorator(
+            DecoratingServiceFunction<HttpRequest, HttpResponse> decoratingServiceFunction) {
+        requireNonNull(decoratingServiceFunction, "decorator");
+        return decorator(service -> (ctx, req) -> decoratingServiceFunction.serve(service, ctx, req));
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -1135,7 +1135,7 @@ public final class ServerBuilder {
     }
 
     /**
-     * Decorates all {@link Service}s with the specified {@code decoratingServiceFunction}.
+     * Decorates all {@link Service}s with the specified {@link DecoratingServiceFunction}.
      *
      * @param decoratingServiceFunction the {@link DecoratingServiceFunction} that decorates a {@link Service}.
      */

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -1135,6 +1135,17 @@ public final class ServerBuilder {
     }
 
     /**
+     * Decorates all {@link Service}s with the specified {@code decorator}.
+     *
+     * @param decorator the {@link DecoratingServiceFunction} that decorates a {@link Service}.
+     */
+    public ServerBuilder decorator(DecoratingServiceFunction<HttpRequest, HttpResponse> decorator) {
+        return this.decorator(service -> {
+            return (ctx, req) -> decorator.serve(service, ctx, req);
+        });
+    }
+
+    /**
      * Sets a list of {@link ClientAddressSource}s which are used to determine where to look for the
      * client address, in the order of preference. {@code Forwarded} header, {@code X-Forwarded-For} header
      * and the source address of a PROXY protocol header will be used by default.

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
@@ -589,7 +589,7 @@ public final class VirtualHostBuilder {
     }
 
     /**
-     * Decorates all {@link Service}s with the specified {@code decoratingServiceFunction}.
+     * Decorates all {@link Service}s with the specified {@link DecoratingServiceFunction}.
      *
      * @param decoratingServiceFunction the {@link DecoratingServiceFunction} that decorates a {@link Service}.
      */

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
@@ -48,6 +48,8 @@ import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.Request;
+import com.linecorp.armeria.common.Response;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.logging.ContentPreviewer;
 import com.linecorp.armeria.common.logging.ContentPreviewerFactory;
@@ -586,6 +588,17 @@ public final class VirtualHostBuilder {
         }
 
         return this;
+    }
+
+    /**
+     * Decorates all {@link Service}s with the specified {@code decorator}.
+     *
+     * @param decorator the {@link DecoratingServiceFunction} that decorates a {@link Service}.
+     */
+    public VirtualHostBuilder decorator(DecoratingServiceFunction<HttpRequest, HttpResponse> decorator) {
+        return decorator(service -> {
+            return (ctx,req) -> decorator.serve(service, ctx, req);
+        });
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
@@ -48,8 +48,6 @@ import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.common.Request;
-import com.linecorp.armeria.common.Response;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.logging.ContentPreviewer;
 import com.linecorp.armeria.common.logging.ContentPreviewerFactory;
@@ -593,12 +591,12 @@ public final class VirtualHostBuilder {
     /**
      * Decorates all {@link Service}s with the specified {@code decorator}.
      *
-     * @param decorator the {@link DecoratingServiceFunction} that decorates a {@link Service}.
+     * @param decoratingServiceFunction the {@link DecoratingServiceFunction} that decorates a {@link Service}.
      */
-    public VirtualHostBuilder decorator(DecoratingServiceFunction<HttpRequest, HttpResponse> decorator) {
-        return decorator(service -> {
-            return (ctx,req) -> decorator.serve(service, ctx, req);
-        });
+    public VirtualHostBuilder decorator(
+            DecoratingServiceFunction<HttpRequest, HttpResponse> decoratingServiceFunction) {
+        requireNonNull(decoratingServiceFunction, "decorator");
+        return decorator(service -> (ctx, req) -> decoratingServiceFunction.serve(service, ctx, req));
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
@@ -589,14 +589,14 @@ public final class VirtualHostBuilder {
     }
 
     /**
-     * Decorates all {@link Service}s with the specified {@code decorator}.
+     * Decorates all {@link Service}s with the specified {@code decoratingServiceFunction}.
      *
      * @param decoratingServiceFunction the {@link DecoratingServiceFunction} that decorates a {@link Service}.
      */
     public VirtualHostBuilder decorator(
             DecoratingServiceFunction<HttpRequest, HttpResponse> decoratingServiceFunction) {
-        requireNonNull(decoratingServiceFunction, "decorator");
-        return decorator(service -> (ctx, req) -> decoratingServiceFunction.serve(service, ctx, req));
+        requireNonNull(decoratingServiceFunction, "decoratingServiceFunction");
+        return decorator(delegate -> new FunctionalDecoratingService<>(delegate, decoratingServiceFunction));
     }
 
     /**

--- a/core/src/test/java/com/linecorp/armeria/server/ServerBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerBuilderTest.java
@@ -66,6 +66,7 @@ public class ServerBuilderTest {
                 .addressResolverGroupFactory(eventLoopGroup -> MockAddressResolverGroup.localhost())
                 .build();
     }
+
     @AfterClass
     public static void destroy() {
         clientFactory.close();
@@ -224,10 +225,10 @@ public class ServerBuilderTest {
         assertThat(res2.headers().get("global_decorator")).isEqualTo("true");
         assertThat(res2.headers().contains("virtualhost_decorator")).isEqualTo(false);
 
-        final HttpClient vhostClient = HttpClient.of(clientFactory, "http://test.example.com:" + server.httpPort());
+        final HttpClient vhostClient = HttpClient.of(clientFactory,
+                                                     "http://test.example.com:" + server.httpPort());
         final AggregatedHttpResponse res3 = vhostClient.get("/").aggregate().get();
         assertThat(res3.headers().get("global_decorator")).isEqualTo("true");
         assertThat(res3.headers().get("virtualhost_decorator")).isEqualTo("true");
-
     }
 }


### PR DESCRIPTION
Motivation:
Provide `(ServierBuilder|VirtualHostBuilder).decorator(DecoratingServiceFunction)`
see #1882 

Modification:
- Added `decorator(DecoratingServiceFunction)`  in `ServerBuilder` and `VirtualHostBuilder`

