### PR TITLE
Update jmh-gradle-plugin version to 0.5.0-rc-1

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -269,7 +269,7 @@ log4j:
   log4j: { version: '1.2.17' }
 
 me.champeau.gradle:
-  jmh-gradle-plugin: { version: '0.4.8' }
+  jmh-gradle-plugin: { version: '0.5.0-rc-1' }
 
 net.javacrumbs.json-unit:
   json-unit: { version: &JSON_UNIT_VERSION '2.7.0' }


### PR DESCRIPTION
Motivation:
https://github.com/melix/jmh-gradle-plugin says that the minimal plugin version is `0.5.0` when using Gradle `5.5`.