### PR TITLE
Fix the uri of ArmeriaServerHttpRequest to contain the base url

### DIFF
--- a/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpRequest.java
+++ b/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpRequest.java
@@ -56,9 +56,7 @@ final class ArmeriaServerHttpRequest extends AbstractServerHttpRequest {
     ArmeriaServerHttpRequest(ServiceRequestContext ctx,
                              HttpRequest req,
                              DataBufferFactoryWrapper<?> factoryWrapper) {
-        super(URI.create(requireNonNull(req, "req").path()),
-              null,
-              fromArmeriaHttpHeaders(req.headers()));
+        super(uri(req), null, fromArmeriaHttpHeaders(req.headers()));
         this.ctx = requireNonNull(ctx, "ctx");
         this.req = req;
 
@@ -66,6 +64,15 @@ final class ArmeriaServerHttpRequest extends AbstractServerHttpRequest {
                    // Guarantee that the context is accessible from a controller method
                    // when a user specify @RequestBody in order to convert a request body into an object.
                    .publishOn(Schedulers.fromExecutor(ctx.contextAwareExecutor()));
+    }
+
+    private static URI uri(HttpRequest req) {
+        final String scheme = req.scheme();
+        final String authority = req.authority();
+        // Server side Armeria HTTP request always has the scheme and authority.
+        assert scheme != null;
+        assert authority != null;
+        return URI.create(scheme + "://" + authority + req.path());
     }
 
     private static HttpHeaders fromArmeriaHttpHeaders(com.linecorp.armeria.common.HttpHeaders httpHeaders) {

--- a/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpResponse.java
+++ b/spring/boot-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpResponse.java
@@ -283,14 +283,19 @@ final class ArmeriaServerHttpResponse implements ServerHttpResponse {
     /**
      * Converts the specified {@link ResponseCookie} to Netty's {@link Cookie} interface.
      */
-    static Cookie toNettyCookie(ResponseCookie resCookie) {
+    private static Cookie toNettyCookie(ResponseCookie resCookie) {
         final DefaultCookie cookie = new DefaultCookie(resCookie.getName(), resCookie.getValue());
-        cookie.setHttpOnly(resCookie.isHttpOnly());
-        cookie.setMaxAge(resCookie.getMaxAge().getSeconds());
+        if (!resCookie.getMaxAge().isNegative()) {
+            cookie.setMaxAge(resCookie.getMaxAge().getSeconds());
+        }
+        if (resCookie.getDomain() != null) {
+            cookie.setDomain(resCookie.getDomain());
+        }
+        if (resCookie.getPath() != null) {
+            cookie.setPath(resCookie.getPath());
+        }
         cookie.setSecure(resCookie.isSecure());
-        // Domain and path are nullable, but the setters allow null as their input.
-        cookie.setDomain(resCookie.getDomain());
-        cookie.setPath(resCookie.getPath());
+        cookie.setHttpOnly(resCookie.isHttpOnly());
         return cookie;
     }
 

--- a/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpRequestTest.java
+++ b/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpRequestTest.java
@@ -67,7 +67,6 @@ class ArmeriaServerHttpRequestTest {
 
         final ServiceRequestContext ctx = newRequestContext(httpRequest);
         final ArmeriaServerHttpRequest req = request(ctx);
-        System.err.println(req.getURI());
         assertThat(req.getMethodValue()).isEqualTo(HttpMethod.POST.name());
         assertThat(req.<Object>getNativeRequest()).isInstanceOf(HttpRequest.class).isEqualTo(httpRequest);
 

--- a/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpRequestTest.java
+++ b/spring/boot-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpRequestTest.java
@@ -22,7 +22,7 @@ import static org.awaitility.Awaitility.await;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpCookie;
 import org.springframework.util.MultiValueMap;
 
@@ -39,20 +39,35 @@ import com.linecorp.armeria.server.ServiceRequestContextBuilder;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 
-public class ArmeriaServerHttpRequestTest {
+class ArmeriaServerHttpRequestTest {
 
     private static ArmeriaServerHttpRequest request(ServiceRequestContext ctx) {
         return new ArmeriaServerHttpRequest(ctx, ctx.request(), DataBufferFactoryWrapper.DEFAULT);
     }
 
     @Test
-    public void readBodyStream() throws Exception {
+    void requestUriContainsBaseUrl() {
+        final HttpRequest httpRequest = HttpRequest.of(RequestHeaders.builder(HttpMethod.POST, "/")
+                                                                     .scheme("http")
+                                                                     .authority("127.0.0.1")
+                                                                     .build());
+        final ServiceRequestContext ctx = newRequestContext(httpRequest);
+        final ArmeriaServerHttpRequest req = request(ctx);
+        assertThat(req.getURI().toString()).isEqualTo("http://127.0.0.1/");
+    }
+
+    @Test
+    void readBodyStream() {
         final HttpRequest httpRequest =
-                HttpRequest.of(RequestHeaders.of(HttpMethod.POST, "/"),
+                HttpRequest.of(RequestHeaders.builder(HttpMethod.POST, "/")
+                                             .scheme("http")
+                                             .authority("127.0.0.1")
+                                             .build(),
                                Flux.just("a", "b", "c", "d", "e").map(HttpData::ofUtf8));
 
         final ServiceRequestContext ctx = newRequestContext(httpRequest);
         final ArmeriaServerHttpRequest req = request(ctx);
+        System.err.println(req.getURI());
         assertThat(req.getMethodValue()).isEqualTo(HttpMethod.POST.name());
         assertThat(req.<Object>getNativeRequest()).isInstanceOf(HttpRequest.class).isEqualTo(httpRequest);
 
@@ -72,9 +87,12 @@ public class ArmeriaServerHttpRequestTest {
     }
 
     @Test
-    public void getCookies() {
-        final HttpRequest httpRequest = HttpRequest.of(RequestHeaders.of(HttpMethod.POST, "/",
-                                                                         HttpHeaderNames.COOKIE, "a=1;b=2"));
+    void getCookies() {
+        final HttpRequest httpRequest = HttpRequest.of(RequestHeaders.builder(HttpMethod.POST, "/")
+                                                                     .scheme("http")
+                                                                     .authority("127.0.0.1")
+                                                                     .add(HttpHeaderNames.COOKIE, "a=1;b=2")
+                                                                     .build());
         final ServiceRequestContext ctx = newRequestContext(httpRequest);
         final ArmeriaServerHttpRequest req = request(ctx);
 
@@ -88,9 +106,12 @@ public class ArmeriaServerHttpRequestTest {
     }
 
     @Test
-    public void cancel() {
+    void cancel() {
         final HttpRequest httpRequest =
-                HttpRequest.of(RequestHeaders.of(HttpMethod.POST, "/"),
+                HttpRequest.of(RequestHeaders.builder(HttpMethod.POST, "/")
+                                             .scheme("http")
+                                             .authority("127.0.0.1")
+                                             .build(),
                                Flux.just("a", "b", "c", "d", "e").map(HttpData::ofUtf8));
 
         final ServiceRequestContext ctx = newRequestContext(httpRequest);


### PR DESCRIPTION
Motivation:
The uri of `ServerHttpRequest` in Spring Web flux contains the base URL.
Also, a negative value of "max-age" from "set-cookie" means no "max-age" attribute, we shouldn't set it.

Modification:
- Add the base URL when `ArmeriaServerHttpRequest` is created.
- Do not set max-age from set-cookie when the value is negative

Result:
- Spring integration