### PR TITLE
Do not record wire timestamp when no request was transferred

### DIFF
--- a/brave/src/main/java/com/linecorp/armeria/client/brave/BraveClient.java
+++ b/brave/src/main/java/com/linecorp/armeria/client/brave/BraveClient.java
@@ -123,7 +123,10 @@ public final class BraveClient extends SimpleDecoratingClient<HttpRequest, HttpR
         ctx.onChild(TraceContextUtil::copy);
 
         ctx.log().addListener(log -> {
-            SpanTags.logWireSend(span, log.requestFirstBytesTransferredTimeNanos(), log);
+            // The request might have failed even before it's sent, e.g. validation failure, connection error.
+            if (log.isAvailable(RequestLogAvailability.REQUEST_FIRST_BYTES_TRANSFERRED)) {
+                SpanTags.logWireSend(span, log.requestFirstBytesTransferredTimeNanos(), log);
+            }
 
             // If the client timed-out the request, we will have never received any response data at all.
             if (log.isAvailable(RequestLogAvailability.RESPONSE_FIRST_BYTES_TRANSFERRED)) {

--- a/zipkin/src/main/java/com/linecorp/armeria/client/tracing/HttpTracingClient.java
+++ b/zipkin/src/main/java/com/linecorp/armeria/client/tracing/HttpTracingClient.java
@@ -137,7 +137,10 @@ public class HttpTracingClient extends SimpleDecoratingClient<HttpRequest, HttpR
         ctx.onChild(RequestContextCurrentTraceContext::copy);
 
         ctx.log().addListener(log -> {
-            SpanTags.logWireSend(span, log.requestFirstBytesTransferredTimeNanos(), log);
+            // The request might have failed even before it's sent, e.g. validation failure, connection error.
+            if (log.isAvailable(RequestLogAvailability.REQUEST_FIRST_BYTES_TRANSFERRED)) {
+                SpanTags.logWireSend(span, log.requestFirstBytesTransferredTimeNanos(), log);
+            }
 
             // If the client timed-out the request, we will have never received any response data at all.
             if (log.isAvailable(RequestLogAvailability.RESPONSE_FIRST_BYTES_TRANSFERRED)) {


### PR DESCRIPTION
Motivation:

On the client side, it is possible that a request is not sent to the
wire, e.g. when connection error or validation failure occurs.

Modifications:

- Make sure `REQUEST_FIRST_BYTES_TRANSFERRED` is available before
  logging wire receive.

Result:

- No more `RequestLogAvailabilityException` in `BraveClient` and
  `HttpTracingClient`.
- Fixes #1911