### PR TITLE
Allow updating `ClientRequestContext.endpoint()` in a decorator

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
@@ -139,9 +139,15 @@ public interface ClientRequestContext extends RequestContext {
     ClientRequestContext newDerivedContext(Request request);
 
     /**
-     * Returns the remote {@link Endpoint} of the current {@link Request}.
+     * Returns the remote {@link Endpoint} where the current {@link Request} will be sent to.
      */
     Endpoint endpoint();
+
+    /**
+     * Sets the {@link Endpoint} where the current {@link Request} will be sent to.
+     * This method is useful to a decorator that manipulates the target host of the {@link Request}.
+     */
+    void setEndpoint(Endpoint endpoint);
 
     /**
      * Returns the {@link ClientOptions} of the current {@link Request}.

--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextWrapper.java
@@ -52,6 +52,11 @@ public class ClientRequestContextWrapper
     }
 
     @Override
+    public void setEndpoint(Endpoint endpoint) {
+        delegate().setEndpoint(endpoint);
+    }
+
+    @Override
     public String fragment() {
         return delegate().fragment();
     }

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -53,7 +53,7 @@ public class DefaultClientRequestContext extends NonWrappingRequestContext imple
 
     private final EventLoop eventLoop;
     private final ClientOptions options;
-    private Endpoint endpoint;
+    private volatile Endpoint endpoint;
     @Nullable
     private final String fragment;
 

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -53,7 +53,7 @@ public class DefaultClientRequestContext extends NonWrappingRequestContext imple
 
     private final EventLoop eventLoop;
     private final ClientOptions options;
-    private final Endpoint endpoint;
+    private Endpoint endpoint;
     @Nullable
     private final String fragment;
 
@@ -198,6 +198,11 @@ public class DefaultClientRequestContext extends NonWrappingRequestContext imple
     @Override
     public Endpoint endpoint() {
         return endpoint;
+    }
+
+    @Override
+    public void setEndpoint(Endpoint endpoint) {
+        this.endpoint = requireNonNull(endpoint, "endpoint");
     }
 
     @Override


### PR DESCRIPTION
Motivation:

- A user sometimes wants to write a decorator which overrides the target
  host specified from the client request URI, which is translated into
  `ClientRequestContext.endpoint()`.
- When a user specifies an endpoint group in a request URI, such as
  `http://group:foo/`, a decorator has no way to know which endpoint
  will actually handle the request, because it is determined after all
  decorators are evaluated. This can be a problem when a decorator has
  to do something based on the target endpoint's property such as host
  name and IP address.

Modifications:

- Add `ClientRequestContext.setEndpoint()` which allows updating the
  target remote endpoint where the request will be sent.
- Add a simple test case which shows how a decorator can select an
  `Endpoint` from an `EndpointGroup` before Armeria does it at the end
  of decorator chain.

Result:

- A user can reroute a request by using a decorator.
- A user can determine which endpoint a request will be sent to when an
  endpoint group is used.