### PR TITLE
Move Endpoint selection to the beginning of client execution

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
@@ -27,6 +27,7 @@ import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
 
+import com.linecorp.armeria.client.endpoint.EndpointSelector;
 import com.linecorp.armeria.common.ContentTooLargeException;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpRequest;
@@ -34,6 +35,9 @@ import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.Response;
 import com.linecorp.armeria.common.RpcRequest;
+import com.linecorp.armeria.common.logging.RequestLog;
+
+import io.netty.util.Attribute;
 
 /**
  * Provides information about a {@link Request}, its {@link Response} and its related utilities.
@@ -139,8 +143,28 @@ public interface ClientRequestContext extends RequestContext {
     ClientRequestContext newDerivedContext(Request request);
 
     /**
-     * Returns the remote {@link Endpoint} of the current {@link Request}.
+     * Creates a new derived {@link RequestContext} with the specified {@link Request} and {@link Endpoint}
+     * which the {@link RequestLog} is different from the deriving context.
+     * Note that the references of {@link Attribute}s in the {@link #attrs()} are copied as well.
      */
+    ClientRequestContext newDerivedContext(Request request, Endpoint endpoint);
+
+    /**
+     * Returns the {@link EndpointSelector} used for the current {@link Request}.
+     *
+     * @return the {@link EndpointSelector} if a user specified a group {@link Endpoint}
+     *         {@code null} if a user specified a host {@link Endpoint}.
+     */
+    @Nullable
+    EndpointSelector endpointSelector();
+
+    /**
+     * Returns the remote {@link Endpoint} of the current {@link Request}.
+     *
+     * @return the remote {@link Endpoint}. {@code null} if the {@link Request} has failed
+     *         before its remote {@link Endpoint} is determined.
+     */
+    @Nullable
     Endpoint endpoint();
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
@@ -136,23 +136,31 @@ public interface ClientRequestContext extends RequestContext {
         return ClientRequestContextBuilder.of(request, uri).build();
     }
 
+    /**
+     * Creates a new {@link ClientRequestContext} whose properties and {@link Attribute}s are copied from this
+     * {@link ClientRequestContext}, except having its own {@link RequestLog}.
+     */
     @Override
     ClientRequestContext newDerivedContext();
 
+    /**
+     * Creates a new {@link ClientRequestContext} whose properties and {@link Attribute}s are copied from this
+     * {@link ClientRequestContext}, except having a different {@link Request} and its own {@link RequestLog}.
+     */
     @Override
     ClientRequestContext newDerivedContext(Request request);
 
     /**
-     * Creates a new derived {@link RequestContext} with the specified {@link Request} and {@link Endpoint}
-     * which the {@link RequestLog} is different from the deriving context.
-     * Note that the references of {@link Attribute}s in the {@link #attrs()} are copied as well.
+     * Creates a new {@link ClientRequestContext} whose properties and {@link Attribute}s are copied from this
+     * {@link ClientRequestContext}, except having different {@link Request}, {@link Endpoint} and its own
+     * {@link RequestLog}.
      */
     ClientRequestContext newDerivedContext(Request request, Endpoint endpoint);
 
     /**
      * Returns the {@link EndpointSelector} used for the current {@link Request}.
      *
-     * @return the {@link EndpointSelector} if a user specified a group {@link Endpoint}
+     * @return the {@link EndpointSelector} if a user specified a group {@link Endpoint}.
      *         {@code null} if a user specified a host {@link Endpoint}.
      */
     @Nullable
@@ -162,7 +170,7 @@ public interface ClientRequestContext extends RequestContext {
      * Returns the remote {@link Endpoint} of the current {@link Request}.
      *
      * @return the remote {@link Endpoint}. {@code null} if the {@link Request} has failed
-     *         before its remote {@link Endpoint} is determined.
+     *         because its remote {@link Endpoint} couldn't be determined.
      */
     @Nullable
     Endpoint endpoint();

--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextBuilder.java
@@ -106,8 +106,9 @@ public final class ClientRequestContextBuilder
         }
 
         final DefaultClientRequestContext ctx = new DefaultClientRequestContext(
-                eventLoop(), meterRegistry(), sessionProtocol(), endpoint,
+                eventLoop(), meterRegistry(), sessionProtocol(),
                 method(), path(), query(), fragment, options, request());
+        ctx.init(endpoint);
 
         if (isRequestStartTimeSet()) {
             ctx.logBuilder().startRequest(fakeChannel(), sessionProtocol(), sslSession(),

--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextWrapper.java
@@ -19,6 +19,7 @@ package com.linecorp.armeria.client;
 import java.time.Duration;
 import java.util.Map.Entry;
 
+import com.linecorp.armeria.client.endpoint.EndpointSelector;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.RequestContextWrapper;
@@ -44,6 +45,16 @@ public class ClientRequestContextWrapper
     @Override
     public ClientRequestContext newDerivedContext(Request request) {
         return delegate().newDerivedContext(request);
+    }
+
+    @Override
+    public ClientRequestContext newDerivedContext(Request request, Endpoint endpoint) {
+        return delegate().newDerivedContext(request, endpoint);
+    }
+
+    @Override
+    public EndpointSelector endpointSelector() {
+        return delegate().endpointSelector();
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/Clients.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Clients.java
@@ -26,6 +26,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Scheme;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.SessionProtocol;
@@ -552,6 +553,14 @@ public final class Clients {
      *     }
      * }
      * }</pre>
+     * Note that certain properties of {@link ClientRequestContext}, such as:
+     * <ul>
+     *   <li>{@link ClientRequestContext#endpoint()}</li>
+     *   <li>{@link ClientRequestContext#localAddress()}</li>
+     *   <li>{@link ClientRequestContext#remoteAddress()}</li>
+     * </ul>
+     * may be {@code null} while the customizer function runs, because the target host of the {@link Request}
+     * is not determined yet.
      *
      * @see #withHttpHeaders(Function)
      */

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -72,14 +72,14 @@ public class DefaultClientRequestContext extends NonWrappingRequestContext imple
     private long responseTimeoutMillis;
     private long maxResponseLength;
 
+    private volatile HttpHeaders additionalRequestHeaders = HttpHeaders.of();
+
     @Nullable
     private String strVal;
 
-    @Nullable
-    private volatile HttpHeaders additionalRequestHeaders;
-
     /**
-     * Creates a new instance.
+     * Creates a new instance. Note that {@link #init(Endpoint)} method must be invoked to finish
+     * the construction of this context.
      *
      * @param sessionProtocol the {@link SessionProtocol} of the invocation
      * @param request the request associated with this context
@@ -312,10 +312,6 @@ public class DefaultClientRequestContext extends NonWrappingRequestContext imple
 
     @Override
     public HttpHeaders additionalRequestHeaders() {
-        final HttpHeaders additionalRequestHeaders = this.additionalRequestHeaders;
-        if (additionalRequestHeaders == null) {
-            return HttpHeaders.of();
-        }
         return additionalRequestHeaders;
     }
 
@@ -323,42 +319,33 @@ public class DefaultClientRequestContext extends NonWrappingRequestContext imple
     public void setAdditionalRequestHeader(CharSequence name, Object value) {
         requireNonNull(name, "name");
         requireNonNull(value, "value");
-        additionalRequestHeaders = createAdditionalHeadersIfAbsent().toBuilder().setObject(name, value).build();
+        additionalRequestHeaders = additionalRequestHeaders.toBuilder().setObject(name, value).build();
     }
 
     @Override
     public void setAdditionalRequestHeaders(Iterable<? extends Entry<? extends CharSequence, ?>> headers) {
         requireNonNull(headers, "headers");
-        additionalRequestHeaders = createAdditionalHeadersIfAbsent().toBuilder().setObject(headers).build();
+        additionalRequestHeaders = additionalRequestHeaders.toBuilder().setObject(headers).build();
     }
 
     @Override
     public void addAdditionalRequestHeader(CharSequence name, Object value) {
         requireNonNull(name, "name");
         requireNonNull(value, "value");
-        additionalRequestHeaders = createAdditionalHeadersIfAbsent().toBuilder().addObject(name, value).build();
+        additionalRequestHeaders = additionalRequestHeaders.toBuilder().addObject(name, value).build();
     }
 
     @Override
     public void addAdditionalRequestHeaders(Iterable<? extends Entry<? extends CharSequence, ?>> headers) {
         requireNonNull(headers, "headers");
-        additionalRequestHeaders = createAdditionalHeadersIfAbsent().toBuilder().addObject(headers).build();
-    }
-
-    private HttpHeaders createAdditionalHeadersIfAbsent() {
-        final HttpHeaders additionalRequestHeaders = this.additionalRequestHeaders;
-        if (additionalRequestHeaders == null) {
-            return this.additionalRequestHeaders = HttpHeaders.of();
-        } else {
-            return additionalRequestHeaders;
-        }
+        additionalRequestHeaders = additionalRequestHeaders.toBuilder().addObject(headers).build();
     }
 
     @Override
     public boolean removeAdditionalRequestHeader(CharSequence name) {
         requireNonNull(name, "name");
         final HttpHeaders additionalRequestHeaders = this.additionalRequestHeaders;
-        if (additionalRequestHeaders == null || additionalRequestHeaders.isEmpty()) {
+        if (additionalRequestHeaders.isEmpty()) {
             return false;
         }
 

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientRequestContext.java
@@ -367,7 +367,7 @@ public class DefaultClientRequestContext extends NonWrappingRequestContext imple
         requireNonNull(name, "name");
         for (;;) {
             final HttpHeaders oldValue = additionalRequestHeaders;
-            if (oldValue.isEmpty() || oldValue.contains(name)) {
+            if (oldValue.isEmpty() || !oldValue.contains(name)) {
                 return false;
             }
 

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultHttpClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultHttpClient.java
@@ -24,7 +24,6 @@ import com.linecorp.armeria.common.AggregatedHttpRequest;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.SessionProtocol;
-import com.linecorp.armeria.common.logging.RequestLogAvailability;
 import com.linecorp.armeria.internal.PathAndQuery;
 
 import io.micrometer.core.instrument.MeterRegistry;
@@ -59,14 +58,7 @@ final class DefaultHttpClient extends UserClient<HttpRequest, HttpResponse> impl
         }
 
         return execute(eventLoop, newReq.method(), pathAndQuery.path(), pathAndQuery.query(), null, newReq,
-                       (ctx, cause) -> {
-                           if (ctx != null && !ctx.log().isAvailable(RequestLogAvailability.REQUEST_START)) {
-                               // An exception is raised even before sending a request, so abort the request to
-                               // release the elements.
-                               newReq.abort();
-                           }
-                           return HttpResponse.ofFailure(cause);
-                       });
+                       (ctx, cause) -> HttpResponse.ofFailure(cause));
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/KeyedCircuitBreakerMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/KeyedCircuitBreakerMapping.java
@@ -85,7 +85,9 @@ public class KeyedCircuitBreakerMapping<K> implements CircuitBreakerMapping {
         KeySelector<String> HOST =
                 (ctx, req) -> {
                     final Endpoint endpoint = ctx.endpoint();
-                    if (endpoint.isGroup()) {
+                    if (endpoint == null) {
+                        return "UNKNOWN";
+                    } else if (endpoint.isGroup()) {
                         return endpoint.authority();
                     } else {
                         final String ipAddr = endpoint.ipAddr();

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/EndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/EndpointGroup.java
@@ -28,6 +28,14 @@ import com.linecorp.armeria.common.util.SafeCloseable;
  */
 @FunctionalInterface
 public interface EndpointGroup extends Listenable<List<Endpoint>>, SafeCloseable {
+
+    /**
+     * Returns a singleton {@link EndpointGroup} which does not contain any {@link Endpoint}s.
+     */
+    static EndpointGroup empty() {
+        return StaticEndpointGroup.EMPTY;
+    }
+
     /**
      * Return the endpoints held by this {@link EndpointGroup}.
      */

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/EndpointGroupRegistry.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/EndpointGroupRegistry.java
@@ -114,10 +114,17 @@ public final class EndpointGroupRegistry {
         groupName = normalizeGroupName(groupName);
         final EndpointSelector endpointSelector = getNodeSelector(groupName);
         if (endpointSelector == null) {
-            throw new EndpointGroupException("non-existent EndpointGroup: " + groupName);
+            throw new EndpointGroupException("non-existent " + EndpointGroup.class.getSimpleName() + ": " +
+                                             groupName);
         }
 
-        return endpointSelector.select(ctx);
+        final Endpoint endpoint = endpointSelector.select(ctx);
+        if (endpoint.isGroup()) {
+            throw new EndpointGroupException(EndpointSelector.class.getSimpleName() +
+                                             "returned a group " + Endpoint.class.getSimpleName() + ": " +
+                                             endpointSelector + ", " + endpoint);
+        }
+        return endpoint;
     }
 
     private static String normalizeGroupName(String groupName) {

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/StaticEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/StaticEndpointGroup.java
@@ -29,6 +29,8 @@ import com.linecorp.armeria.client.Endpoint;
  */
 public final class StaticEndpointGroup implements EndpointGroup {
 
+    static final StaticEndpointGroup EMPTY = new StaticEndpointGroup();
+
     private final List<Endpoint> endpoints;
 
     /**
@@ -56,13 +58,6 @@ public final class StaticEndpointGroup implements EndpointGroup {
 
     @Override
     public String toString() {
-        final StringBuilder buf = new StringBuilder();
-        buf.append("StaticEndpointGroup(");
-        for (Endpoint endpoint : endpoints) {
-            buf.append(endpoint).append(',');
-        }
-        buf.setCharAt(buf.length() - 1, ')');
-
-        return buf.toString();
+        return getClass().getSimpleName() + endpoints;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/StaticEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/StaticEndpointGroup.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package com.linecorp.armeria.client.endpoint;
 
 import static java.util.Objects.requireNonNull;
@@ -58,6 +57,6 @@ public final class StaticEndpointGroup implements EndpointGroup {
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + endpoints;
+        return StaticEndpointGroup.class.getSimpleName() + endpoints;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
@@ -30,7 +30,9 @@ import org.slf4j.LoggerFactory;
 import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.SimpleDecoratingClient;
+import com.linecorp.armeria.client.endpoint.EndpointSelector;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
@@ -248,6 +250,19 @@ public abstract class RetryingClient<I extends Request, O extends Response>
             return 0;
         }
         return state.totalAttemptNo;
+    }
+
+    /**
+     * Creates a new derived {@link ClientRequestContext}, replacing the {@link Request} with {@code req}.
+     * If {@link ClientRequestContext#endpointSelector()} exists, a new {@link Endpoint} will be selected.
+     */
+    protected static ClientRequestContext newDerivedContext(ClientRequestContext ctx, Request req) {
+        final EndpointSelector endpointSelector = ctx.endpointSelector();
+        if (endpointSelector != null) {
+            return ctx.newDerivedContext(req, endpointSelector.select(ctx));
+        } else {
+            return ctx.newDerivedContext(req);
+        }
     }
 
     private static class State {

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingHttpClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingHttpClient.java
@@ -22,6 +22,7 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.linecorp.armeria.internal.ClientUtil.executeWithFallback;
 
 import java.time.Duration;
+import java.util.Date;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -48,6 +49,8 @@ import com.linecorp.armeria.common.HttpResponseDuplicator;
 import com.linecorp.armeria.common.RequestHeadersBuilder;
 import com.linecorp.armeria.common.logging.RequestLogAvailability;
 import com.linecorp.armeria.common.stream.AbortedStreamException;
+
+import io.netty.handler.codec.DateFormatter;
 
 /**
  * A {@link Client} decorator that handles failures of an invocation and retries HTTP requests.
@@ -169,19 +172,11 @@ public final class RetryingHttpClient extends RetryingClient<HttpRequest, HttpRe
             duplicateReq = rootReqDuplicator.duplicateStream(newHeaders.build());
         }
 
-        final ClientRequestContext derivedCtx = ctx.newDerivedContext(duplicateReq);
+        final ClientRequestContext derivedCtx = newDerivedContext(ctx, duplicateReq);
         ctx.logBuilder().addChild(derivedCtx.log());
 
-        final BiFunction<ClientRequestContext, Throwable, HttpResponse> fallback = (context, cause) -> {
-            if (context != null && !context.log().isAvailable(RequestLogAvailability.REQUEST_START)) {
-                // An exception is raised even before sending a request, so abort the request to
-                // release the elements.
-                duplicateReq.abort();
-            }
-            return HttpResponse.ofFailure(cause);
-        };
-
-        final HttpResponse response = executeWithFallback(delegate(), derivedCtx, duplicateReq, fallback);
+        final HttpResponse response = executeWithFallback(delegate(), derivedCtx,
+                                                          (context, cause) -> HttpResponse.ofFailure(cause));
 
         derivedCtx.log().addListener(log -> {
             if (needsContentInStrategy) {
@@ -254,24 +249,25 @@ public final class RetryingHttpClient extends RetryingClient<HttpRequest, HttpRe
 
     private static long getRetryAfterMillis(ClientRequestContext ctx) {
         final HttpHeaders headers = firstNonNull(ctx.log().responseHeaders(), HttpHeaders.of());
-        long millisAfter = -1;
         final String value = headers.get(HttpHeaderNames.RETRY_AFTER);
         if (value != null) {
             try {
-                millisAfter = Duration.ofSeconds(Integer.parseInt(value)).toMillis();
-                return millisAfter;
+                return Duration.ofSeconds(Integer.parseInt(value)).toMillis();
             } catch (Exception ignored) {
                 // Not a second value.
             }
-            try {
-                final Long later = headers.getTimeMillis(HttpHeaderNames.RETRY_AFTER);
-                millisAfter = later - System.currentTimeMillis();
-            } catch (Exception ignored) {
-                logger.debug("The retryAfter: {}, from the server is neither an HTTP date nor a second.",
-                             value);
+
+            @SuppressWarnings("UseOfObsoleteDateTimeApi")
+            final Date date = DateFormatter.parseHttpDate(value);
+            if (date != null) {
+                return date.getTime() - System.currentTimeMillis();
             }
+
+            logger.debug("The retryAfter: {}, from the server is neither an HTTP date nor a second.",
+                         value);
         }
-        return millisAfter;
+
+        return -1;
     }
 
     private static class ContentPreviewResponse extends FilteredHttpResponse {

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingHttpClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingHttpClient.java
@@ -257,10 +257,15 @@ public final class RetryingHttpClient extends RetryingClient<HttpRequest, HttpRe
                 // Not a second value.
             }
 
-            @SuppressWarnings("UseOfObsoleteDateTimeApi")
-            final Date date = DateFormatter.parseHttpDate(value);
-            if (date != null) {
-                return date.getTime() - System.currentTimeMillis();
+            try {
+                @SuppressWarnings("UseOfObsoleteDateTimeApi")
+                final Date date = DateFormatter.parseHttpDate(value);
+                if (date != null) {
+                    return date.getTime() - System.currentTimeMillis();
+                }
+            } catch (Exception ignored) {
+                // `parseHttpDate()` can raise an exception rather than returning `null`
+                // when the given value has more than 64 characters.
             }
 
             logger.debug("The retryAfter: {}, from the server is neither an HTTP date nor a second.",

--- a/core/src/main/java/com/linecorp/armeria/common/HttpHeadersBase.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpHeadersBase.java
@@ -931,7 +931,9 @@ class HttpHeadersBase implements HttpHeaderGetters {
             @SuppressWarnings("UseOfObsoleteDateTimeApi")
             final Date date = DateFormatter.parseHttpDate(v);
             return date != null ? date.getTime() : null;
-        } catch (RuntimeException ignore) {
+        } catch (Exception ignore) {
+            // `parseHttpDate()` can raise an exception rather than returning `null`
+            // when the given value has more than 64 characters.
             return null;
         }
     }

--- a/core/src/main/java/com/linecorp/armeria/common/RequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestContext.java
@@ -629,16 +629,14 @@ public interface RequestContext extends AttributeMap {
     }
 
     /**
-     * Creates a new derived {@link RequestContext} which only the {@link RequestLog}
-     * is different from the deriving context. Note that the references of {@link Attribute}s
-     * in the {@link #attrs()} are copied as well.
+     * Creates a new {@link RequestContext} whose properties and {@link Attribute}s are copied from this
+     * {@link RequestContext}, except having its own {@link RequestLog}.
      */
     RequestContext newDerivedContext();
 
     /**
-     * Creates a new derived {@link RequestContext} with the specified {@link Request} which the
-     * {@link RequestLog} is different from the deriving context.
-     * Note that the references of {@link Attribute}s in the {@link #attrs()} are copied as well.
+     * Creates a new {@link RequestContext} whose properties and {@link Attribute}s are copied from this
+     * {@link RequestContext}, except having a different {@link Request} and its own {@link RequestLog}.
      */
     RequestContext newDerivedContext(Request request);
 }

--- a/core/src/main/java/com/linecorp/armeria/common/StringValueConverter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/StringValueConverter.java
@@ -172,7 +172,14 @@ final class StringValueConverter implements ValueConverter<String> {
     @Override
     public long convertToTimeMillis(String value) {
         @SuppressWarnings("UseOfObsoleteDateTimeApi")
-        final Date date = DateFormatter.parseHttpDate(value);
+        Date date = null;
+        try {
+            date = DateFormatter.parseHttpDate(value);
+        } catch (Exception ignored) {
+            // `parseHttpDate()` can raise an exception rather than returning `null`
+            // when the given value has more than 64 characters.
+        }
+
         if (date == null) {
             throw new IllegalArgumentException("not a date: " + value);
         }

--- a/core/src/main/java/com/linecorp/armeria/internal/ClientUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/ClientUtil.java
@@ -22,34 +22,86 @@ import java.util.function.BiFunction;
 
 import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.DefaultClientRequestContext;
+import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
 import com.linecorp.armeria.common.logging.RequestLogAvailability;
 import com.linecorp.armeria.common.logging.RequestLogBuilder;
+import com.linecorp.armeria.common.stream.StreamMessage;
 import com.linecorp.armeria.common.util.SafeCloseable;
 
 public final class ClientUtil {
 
-    public static <I extends Request, O extends Response, U extends Client<I, O>> O executeWithFallback(
-            U delegate, ClientRequestContext ctx, I req,
-            BiFunction<ClientRequestContext, Throwable, O> fallback) {
+    public static <I extends Request, O extends Response, U extends Client<I, O>>
+    O initContextAndExecuteWithFallback(U delegate, DefaultClientRequestContext ctx, Endpoint endpoint,
+                                        BiFunction<ClientRequestContext, Throwable, O> fallback) {
+
         requireNonNull(delegate, "delegate");
         requireNonNull(ctx, "ctx");
-        requireNonNull(req, "req");
+        requireNonNull(endpoint, "endpoint");
         requireNonNull(fallback, "fallback");
 
-        try (SafeCloseable ignored = ctx.push()) {
-            return delegate.execute(ctx, req);
-        } catch (Throwable cause) {
-            final O fallbackRes = fallback.apply(ctx, cause);
-            final RequestLogBuilder logBuilder = ctx.logBuilder();
-            if (!ctx.log().isAvailable(RequestLogAvailability.REQUEST_START)) {
-                // An exception is raised even before sending a request, so end the request with the exception.
-                logBuilder.endRequest(cause);
+        try {
+            if (ctx.init(endpoint)) {
+                return pushAndExecute(delegate, ctx);
+            } else {
+                // Context initialization has failed, but we call the decorator chain anyway
+                // so that the request is seen by the decorators.
+                final O res = pushAndExecute(delegate, ctx);
+                // We will use the fallback response which is created from the exception
+                // raised in ctx.init(), so the response returned can be aborted.
+                if (res instanceof StreamMessage) {
+                    ((StreamMessage<?>) res).abort();
+                }
+                return fallback.apply(ctx, ctx.log().requestCause());
             }
-            logBuilder.endResponse(cause);
-            return fallbackRes;
+        } catch (Throwable cause) {
+            return failAndGetFallbackResponse(ctx, fallback, cause);
         }
+    }
+
+    public static <I extends Request, O extends Response, U extends Client<I, O>>
+    O executeWithFallback(U delegate, ClientRequestContext ctx,
+                          BiFunction<ClientRequestContext, Throwable, O> fallback) {
+
+        requireNonNull(delegate, "delegate");
+        requireNonNull(ctx, "ctx");
+        requireNonNull(fallback, "fallback");
+
+        try {
+            return pushAndExecute(delegate, ctx);
+        } catch (Throwable cause) {
+            return failAndGetFallbackResponse(ctx, fallback, cause);
+        }
+    }
+
+    private static <I extends Request, O extends Response, U extends Client<I, O>>
+    O pushAndExecute(U delegate, ClientRequestContext ctx) throws Exception {
+        try (SafeCloseable ignored = ctx.push()) {
+            return delegate.execute(ctx, ctx.request());
+        }
+    }
+
+    private static <O extends Response> O failAndGetFallbackResponse(
+            ClientRequestContext ctx,
+            BiFunction<ClientRequestContext, Throwable, O> fallback,
+            Throwable cause) {
+
+        final RequestLogBuilder logBuilder = ctx.logBuilder();
+        if (!ctx.log().isAvailable(RequestLogAvailability.REQUEST_START)) {
+            // An exception is raised even before sending a request,
+            // so end the request with the exception.
+            logBuilder.endRequest(cause);
+
+            final Request req = ctx.request();
+            if (req instanceof StreamMessage) {
+                ((StreamMessage<?>) req).abort();
+            }
+        }
+        logBuilder.endResponse(cause);
+
+        return fallback.apply(ctx, cause);
     }
 
     private ClientUtil() {}

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
@@ -67,7 +67,6 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
             additionalResponseTrailersUpdater = AtomicReferenceFieldUpdater.newUpdater(
             DefaultServiceRequestContext.class, HttpHeaders.class, "additionalResponseTrailers");
 
-
     private final Channel ch;
     private final ServiceConfig cfg;
     private final RoutingContext routingContext;

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
@@ -473,7 +473,7 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
         requireNonNull(name, "name");
         for (;;) {
             final HttpHeaders oldValue = additionalResponseHeaders;
-            if (oldValue.isEmpty() || oldValue.contains(name)) {
+            if (oldValue.isEmpty() || !oldValue.contains(name)) {
                 return false;
             }
 
@@ -544,7 +544,7 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
         requireNonNull(name, "name");
         for (;;) {
             final HttpHeaders oldValue = additionalResponseTrailers;
-            if (oldValue.isEmpty() || oldValue.contains(name)) {
+            if (oldValue.isEmpty() || !oldValue.contains(name)) {
                 return false;
             }
 

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
@@ -425,14 +425,14 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
         requireNonNull(name, "name");
         requireNonNull(value, "value");
         updateAdditionalResponseHeaders(additionalResponseHeadersUpdater,
-                                       builder -> builder.setObject(name, value));
+                                        builder -> builder.setObject(name, value));
     }
 
     @Override
     public void setAdditionalResponseHeaders(Iterable<? extends Entry<? extends CharSequence, ?>> headers) {
         requireNonNull(headers, "headers");
         updateAdditionalResponseHeaders(additionalResponseHeadersUpdater,
-                                       builder -> builder.setObject(headers));
+                                        builder -> builder.setObject(headers));
     }
 
     @Override
@@ -440,14 +440,14 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
         requireNonNull(name, "name");
         requireNonNull(value, "value");
         updateAdditionalResponseHeaders(additionalResponseHeadersUpdater,
-                                       builder -> builder.addObject(name, value));
+                                        builder -> builder.addObject(name, value));
     }
 
     @Override
     public void addAdditionalResponseHeaders(Iterable<? extends Entry<? extends CharSequence, ?>> headers) {
         requireNonNull(headers, "headers");
         updateAdditionalResponseHeaders(additionalResponseHeadersUpdater,
-                                       builder -> builder.addObject(headers));
+                                        builder -> builder.addObject(headers));
     }
 
     private void updateAdditionalResponseHeaders(
@@ -494,14 +494,14 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
         requireNonNull(name, "name");
         requireNonNull(value, "value");
         updateAdditionalResponseHeaders(additionalResponseTrailersUpdater,
-                                       builder -> builder.setObject(name, value));
+                                        builder -> builder.setObject(name, value));
     }
 
     @Override
     public void setAdditionalResponseTrailers(Iterable<? extends Entry<? extends CharSequence, ?>> headers) {
         requireNonNull(headers, "headers");
         updateAdditionalResponseHeaders(additionalResponseTrailersUpdater,
-                                       builder -> builder.setObject(headers));
+                                        builder -> builder.setObject(headers));
     }
 
     @Override
@@ -509,14 +509,14 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
         requireNonNull(name, "name");
         requireNonNull(value, "value");
         updateAdditionalResponseHeaders(additionalResponseTrailersUpdater,
-                                       builder -> builder.addObject(name, value));
+                                        builder -> builder.addObject(name, value));
     }
 
     @Override
     public void addAdditionalResponseTrailers(Iterable<? extends Entry<? extends CharSequence, ?>> headers) {
         requireNonNull(headers, "headers");
         updateAdditionalResponseHeaders(additionalResponseTrailersUpdater,
-                                       builder -> builder.addObject(headers));
+                                        builder -> builder.addObject(headers));
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServiceRequestContext.java
@@ -453,7 +453,7 @@ public class DefaultServiceRequestContext extends NonWrappingRequestContext impl
     private void updateAdditionalResponseHeaders(
             AtomicReferenceFieldUpdater<DefaultServiceRequestContext, HttpHeaders> atomicUpdater,
             Function<HttpHeadersBuilder, HttpHeadersBuilder> valueUpdater) {
-        for (; ; ) {
+        for (;;) {
             final HttpHeaders oldValue = atomicUpdater.get(this);
             final HttpHeaders newValue = valueUpdater.apply(oldValue.toBuilder()).build();
             if (atomicUpdater.compareAndSet(this, oldValue, newValue)) {

--- a/core/src/test/java/com/linecorp/armeria/client/ClientRequestContextInitFailureTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientRequestContextInitFailureTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.client.endpoint.EndpointGroup;
+import com.linecorp.armeria.client.endpoint.EndpointGroupException;
+import com.linecorp.armeria.client.endpoint.EndpointGroupRegistry;
+import com.linecorp.armeria.client.endpoint.EndpointSelectionStrategy;
+import com.linecorp.armeria.common.logging.RequestLogAvailability;
+import com.linecorp.armeria.common.util.SafeCloseable;
+
+class ClientRequestContextInitFailureTest {
+    @Test
+    void missingEndpointGroup() {
+        assertFailure("group:none", actualCause -> {
+            assertThat(actualCause).isInstanceOf(EndpointGroupException.class)
+                                   .hasMessageContaining("non-existent");
+        });
+    }
+
+    @Test
+    void endpointSelectionFailure() {
+        EndpointGroupRegistry.register("foo", EndpointGroup.empty(), EndpointSelectionStrategy.ROUND_ROBIN);
+        try {
+            assertFailure("group:foo", actualCause -> {
+                assertThat(actualCause).isInstanceOf(EndpointGroupException.class)
+                                       .hasMessageContaining("empty");
+            });
+        } finally {
+            EndpointGroupRegistry.unregister("foo");
+        }
+    }
+
+    @Test
+    void threadLocalCustomizerFailure() {
+        final RuntimeException cause = new RuntimeException();
+        try (SafeCloseable ignored = Clients.withContextCustomizer(ctx -> {
+            throw cause;
+        })) {
+            assertFailure("127.0.0.1:1", actualCause -> {
+                assertThat(actualCause).isSameAs(cause);
+            });
+        }
+    }
+
+    private static void assertFailure(String authority, Consumer<Throwable> requirements) {
+        final AtomicReference<ClientRequestContext> capturedCtx = new AtomicReference<>();
+        final HttpClient client = new HttpClientBuilder("http://" + authority)
+                .decorator((delegate, ctx, req) -> {
+                    capturedCtx.set(ctx);
+                    return delegate.execute(ctx, req);
+                }).build();
+
+        final Throwable actualCause = catchThrowable(() -> client.get("/").aggregate().join()).getCause();
+        assertThat(actualCause).isInstanceOf(UnprocessedRequestException.class);
+        assertThat(actualCause.getCause()).satisfies((Consumer) requirements);
+
+        assertThat(capturedCtx.get()).satisfies(ctx -> {
+            ctx.log().ensureAvailability(RequestLogAvailability.COMPLETE);
+            assertThat(ctx.log().requestCause()).isSameAs(actualCause);
+            assertThat(ctx.log().responseCause()).isSameAs(actualCause);
+        });
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/client/DefaultClientRequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/DefaultClientRequestContextTest.java
@@ -19,7 +19,7 @@ package com.linecorp.armeria.client;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
@@ -37,8 +37,9 @@ public class DefaultClientRequestContextTest {
     public void deriveContext() {
         final DefaultClientRequestContext originalCtx = new DefaultClientRequestContext(
                 mock(EventLoop.class), NoopMeterRegistry.get(), SessionProtocol.H2C,
-                Endpoint.of("example.com", 8080), HttpMethod.POST, "/foo", null, null,
+                HttpMethod.POST, "/foo", null, null,
                 ClientOptions.DEFAULT, mock(Request.class));
+        originalCtx.init(Endpoint.of("example.com", 8080));
 
         setAdditionalHeaders(originalCtx);
 

--- a/core/src/test/java/com/linecorp/armeria/client/DefaultClientRequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/DefaultClientRequestContextTest.java
@@ -31,10 +31,10 @@ import com.linecorp.armeria.common.metric.NoopMeterRegistry;
 import io.netty.channel.EventLoop;
 import io.netty.util.AttributeKey;
 
-public class DefaultClientRequestContextTest {
+class DefaultClientRequestContextTest {
 
     @Test
-    public void deriveContext() {
+    void deriveContext() {
         final DefaultClientRequestContext originalCtx = new DefaultClientRequestContext(
                 mock(EventLoop.class), NoopMeterRegistry.get(), SessionProtocol.H2C,
                 HttpMethod.POST, "/foo", null, null,

--- a/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/KeyedCircuitBreakerMappingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/KeyedCircuitBreakerMappingTest.java
@@ -18,7 +18,7 @@ package com.linecorp.armeria.client.circuitbreaker;
 import static com.linecorp.armeria.client.circuitbreaker.KeyedCircuitBreakerMapping.KeySelector.HOST;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.ClientRequestContextBuilder;
@@ -29,7 +29,6 @@ import com.linecorp.armeria.common.HttpRequest;
 public class KeyedCircuitBreakerMappingTest {
     @Test
     public void hostSelector() throws Exception {
-        assertThat(HOST.get(context(Endpoint.ofGroup("foo")), null)).isEqualTo("group:foo");
         assertThat(HOST.get(context(Endpoint.of("foo")), null)).isEqualTo("foo");
         assertThat(HOST.get(context(Endpoint.of("foo", 8080)), null)).isEqualTo("foo:8080");
         assertThat(HOST.get(context(Endpoint.of("foo").withIpAddr("1.2.3.4")), null)).isEqualTo("foo/1.2.3.4");

--- a/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/KeyedCircuitBreakerMappingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/KeyedCircuitBreakerMappingTest.java
@@ -26,9 +26,9 @@ import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 
-public class KeyedCircuitBreakerMappingTest {
+class KeyedCircuitBreakerMappingTest {
     @Test
-    public void hostSelector() throws Exception {
+    void hostSelector() throws Exception {
         assertThat(HOST.get(context(Endpoint.of("foo")), null)).isEqualTo("foo");
         assertThat(HOST.get(context(Endpoint.of("foo", 8080)), null)).isEqualTo("foo:8080");
         assertThat(HOST.get(context(Endpoint.of("foo").withIpAddr("1.2.3.4")), null)).isEqualTo("foo/1.2.3.4");

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientAuthorityHeaderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientAuthorityHeaderTest.java
@@ -38,6 +38,7 @@ import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.server.AbstractHttpService;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.logging.LoggingService;
 import com.linecorp.armeria.testing.junit4.server.ServerRule;
 
 public class RetryingClientAuthorityHeaderTest {
@@ -53,6 +54,7 @@ public class RetryingClientAuthorityHeaderTest {
                     return HttpResponse.of(SERVICE_UNAVAILABLE);
                 }
             });
+            sb.decorator(LoggingService.newDecorator());
         }
     };
 
@@ -67,6 +69,7 @@ public class RetryingClientAuthorityHeaderTest {
                     return HttpResponse.of(req.headers().authority());
                 }
             });
+            sb.decorator(LoggingService.newDecorator());
         }
     };
 

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaClientCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaClientCall.java
@@ -174,7 +174,6 @@ class ArmeriaClientCall<I, O> extends ClientCall<I, O>
         final HttpResponse res = initContextAndExecuteWithFallback(
                 httpClient, ctx, endpoint,
                 (unused, cause) -> HttpResponse.ofFailure(GrpcStatus.fromThrowable(cause)
-                                                                    .withCause(cause)
                                                                     .withDescription(cause.getMessage())
                                                                     .asRuntimeException()));
 

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaClientCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaClientCall.java
@@ -13,10 +13,10 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package com.linecorp.armeria.client.grpc;
 
 import static com.linecorp.armeria.common.stream.SubscriptionOption.WITH_POOLED_OBJECTS;
+import static com.linecorp.armeria.internal.ClientUtil.initContextAndExecuteWithFallback;
 import static java.util.Objects.requireNonNull;
 
 import java.util.concurrent.CancellationException;
@@ -32,7 +32,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.linecorp.armeria.client.Client;
-import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.DefaultClientRequestContext;
+import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpRequestWriter;
 import com.linecorp.armeria.common.HttpResponse;
@@ -42,6 +43,7 @@ import com.linecorp.armeria.common.grpc.protocol.ArmeriaMessageDeframer;
 import com.linecorp.armeria.common.grpc.protocol.ArmeriaMessageDeframer.ByteBufOrStream;
 import com.linecorp.armeria.common.grpc.protocol.ArmeriaMessageFramer;
 import com.linecorp.armeria.common.grpc.protocol.GrpcHeaderNames;
+import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.logging.RequestLogAvailability;
 import com.linecorp.armeria.common.util.SafeCloseable;
 import com.linecorp.armeria.internal.grpc.ForwardingCompressor;
@@ -81,7 +83,8 @@ class ArmeriaClientCall<I, O> extends ClientCall<I, O>
     private static final AtomicIntegerFieldUpdater<ArmeriaClientCall> pendingMessagesUpdater =
             AtomicIntegerFieldUpdater.newUpdater(ArmeriaClientCall.class, "pendingMessages");
 
-    private final ClientRequestContext ctx;
+    private final DefaultClientRequestContext ctx;
+    private final Endpoint endpoint;
     private final Client<HttpRequest, HttpResponse> httpClient;
     private final HttpRequestWriter req;
     private final MethodDescriptor<I, O> method;
@@ -89,7 +92,6 @@ class ArmeriaClientCall<I, O> extends ClientCall<I, O>
     private final ArmeriaMessageFramer messageFramer;
     private final GrpcMessageMarshaller<I, O> marshaller;
     private final CompressorRegistry compressorRegistry;
-    private final DecompressorRegistry decompressorRegistry;
     private final HttpStreamReader responseReader;
     private final boolean unsafeWrapResponseBuffers;
     @Nullable
@@ -107,7 +109,8 @@ class ArmeriaClientCall<I, O> extends ClientCall<I, O>
     private volatile int pendingMessages;
 
     ArmeriaClientCall(
-            ClientRequestContext ctx,
+            DefaultClientRequestContext ctx,
+            Endpoint endpoint,
             Client<HttpRequest, HttpResponse> httpClient,
             HttpRequestWriter req,
             MethodDescriptor<I, O> method,
@@ -121,12 +124,12 @@ class ArmeriaClientCall<I, O> extends ClientCall<I, O>
             boolean unsafeWrapResponseBuffers,
             String advertisedEncodingsHeader) {
         this.ctx = ctx;
+        this.endpoint = endpoint;
         this.httpClient = httpClient;
         this.req = req;
         this.method = method;
         this.callOptions = callOptions;
         this.compressorRegistry = compressorRegistry;
-        this.decompressorRegistry = decompressorRegistry;
         this.unsafeWrapResponseBuffers = unsafeWrapResponseBuffers;
         this.advertisedEncodingsHeader = advertisedEncodingsHeader;
         messageFramer = new ArmeriaMessageFramer(ctx.alloc(), maxOutboundMessageSizeBytes);
@@ -165,15 +168,16 @@ class ArmeriaClientCall<I, O> extends ClientCall<I, O>
             compressor = Identity.NONE;
         }
         messageFramer.setCompressor(ForwardingCompressor.forGrpc(compressor));
-        final HttpRequest req = prepareHeaders(compressor, metadata);
+        prepareHeaders(compressor, metadata);
         listener = responseListener;
-        final HttpResponse res;
-        try (SafeCloseable ignored = ctx.push()) {
-            res = httpClient.execute(ctx, req);
-        } catch (Exception e) {
-            close(GrpcStatus.fromThrowable(e), new Metadata());
-            return;
-        }
+
+        final HttpResponse res = initContextAndExecuteWithFallback(
+                httpClient, ctx, endpoint,
+                (unused, cause) -> HttpResponse.ofFailure(GrpcStatus.fromThrowable(cause)
+                                                                    .withCause(cause)
+                                                                    .withDescription(cause.getMessage())
+                                                                    .asRuntimeException()));
+
         res.subscribe(responseReader, ctx.eventLoop(), WITH_POOLED_OBJECTS);
         res.completionFuture().handleAsync(responseReader, ctx.eventLoop());
     }
@@ -241,8 +245,14 @@ class ArmeriaClientCall<I, O> extends ClientCall<I, O>
     }
 
     private void doSendMessage(I message) {
+        final RequestLog log = ctx.log();
+        if (log.isAvailable(RequestLogAvailability.COMPLETE)) {
+            // Completed already; no need to send anymore.
+            return;
+        }
+
         try {
-            if (!ctx.log().isAvailable(RequestLogAvailability.REQUEST_CONTENT)) {
+            if (!log.isAvailable(RequestLogAvailability.REQUEST_CONTENT)) {
                 ctx.logBuilder().requestContent(GrpcLogUtil.rpcRequest(method, message), null);
             }
             final ByteBuf serialized = marshaller.serializeRequest(message);
@@ -250,6 +260,7 @@ class ArmeriaClientCall<I, O> extends ClientCall<I, O>
             req.onDemand(() -> {
                 if (pendingMessagesUpdater.decrementAndGet(this) == 0) {
                     try (SafeCloseable ignored = ctx.push()) {
+                        assert listener != null;
                         listener.onReady();
                     } catch (Throwable t) {
                         close(GrpcStatus.fromThrowable(t), new Metadata());
@@ -274,11 +285,13 @@ class ArmeriaClientCall<I, O> extends ClientCall<I, O>
                 firstResponse = msg;
             }
 
-            if (unsafeWrapResponseBuffers && message.buf() != null) {
-                GrpcUnsafeBufferUtil.storeBuffer(message.buf(), msg, ctx);
+            final ByteBuf buf = message.buf();
+            if (unsafeWrapResponseBuffers && buf != null) {
+                GrpcUnsafeBufferUtil.storeBuffer(buf, msg, ctx);
             }
 
             try (SafeCloseable ignored = ctx.push()) {
+                assert listener != null;
                 listener.onMessage(msg);
             }
         } catch (Throwable t) {
@@ -297,7 +310,7 @@ class ArmeriaClientCall<I, O> extends ClientCall<I, O>
         close(status, metadata);
     }
 
-    private HttpRequest prepareHeaders(Compressor compressor, Metadata metadata) {
+    private void prepareHeaders(Compressor compressor, Metadata metadata) {
         final RequestHeadersBuilder newHeaders = req.headers().toBuilder();
         if (compressor != Identity.NONE) {
             newHeaders.set(GrpcHeaderNames.GRPC_ENCODING, compressor.getMessageEncoding());
@@ -315,7 +328,6 @@ class ArmeriaClientCall<I, O> extends ClientCall<I, O>
 
         final HttpRequest newReq = HttpRequest.of(req, newHeaders.build());
         ctx.updateRequest(newReq);
-        return newReq;
     }
 
     private void close(Status status, Metadata metadata) {
@@ -324,6 +336,7 @@ class ArmeriaClientCall<I, O> extends ClientCall<I, O>
         responseReader.cancel();
 
         try (SafeCloseable ignored = ctx.push()) {
+            assert listener != null;
             listener.onClose(status, metadata);
         }
 

--- a/grpc/src/main/java/com/linecorp/armeria/internal/grpc/GrpcStatus.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/grpc/GrpcStatus.java
@@ -39,6 +39,7 @@ import java.nio.channels.ClosedChannelException;
 
 import com.google.common.base.Strings;
 
+import com.linecorp.armeria.client.UnprocessedRequestException;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.TimeoutException;
 import com.linecorp.armeria.common.grpc.StackTraceElementProto;
@@ -88,7 +89,7 @@ public final class GrpcStatus {
             // instead.
             return Status.UNKNOWN.withCause(t);
         }
-        if (t instanceof IOException) {
+        if (t instanceof UnprocessedRequestException || t instanceof IOException) {
             return Status.UNAVAILABLE.withCause(t);
         }
         if (t instanceof Http2Exception) {

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientRequestContextInitFailureTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientRequestContextInitFailureTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client.grpc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.client.ClientBuilder;
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.Clients;
+import com.linecorp.armeria.client.UnprocessedRequestException;
+import com.linecorp.armeria.client.endpoint.EndpointGroup;
+import com.linecorp.armeria.client.endpoint.EndpointGroupException;
+import com.linecorp.armeria.client.endpoint.EndpointGroupRegistry;
+import com.linecorp.armeria.client.endpoint.EndpointSelectionStrategy;
+import com.linecorp.armeria.common.logging.RequestLogAvailability;
+import com.linecorp.armeria.common.util.SafeCloseable;
+import com.linecorp.armeria.grpc.testing.TestServiceGrpc.TestServiceBlockingStub;
+import com.linecorp.armeria.protobuf.EmptyProtos.Empty;
+
+import io.grpc.Status.Code;
+import io.grpc.StatusRuntimeException;
+
+class GrpcClientRequestContextInitFailureTest {
+    @Test
+    void missingEndpointGroup() {
+        assertFailure("group:none", actualCause -> {
+            assertThat(actualCause).isInstanceOf(EndpointGroupException.class)
+                                   .hasMessageContaining("non-existent");
+        });
+    }
+
+    @Test
+    void endpointSelectionFailure() {
+        EndpointGroupRegistry.register("foo", EndpointGroup.empty(), EndpointSelectionStrategy.ROUND_ROBIN);
+        try {
+            assertFailure("group:foo", actualCause -> {
+                assertThat(actualCause).isInstanceOf(EndpointGroupException.class)
+                                       .hasMessageContaining("empty");
+            });
+        } finally {
+            EndpointGroupRegistry.unregister("foo");
+        }
+    }
+
+    @Test
+    void threadLocalCustomizerFailure() {
+        final RuntimeException cause = new RuntimeException();
+        try (SafeCloseable ignored = Clients.withContextCustomizer(ctx -> {
+            throw cause;
+        })) {
+            assertFailure("127.0.0.1:1", actualCause -> {
+                assertThat(actualCause).isSameAs(cause);
+            });
+        }
+    }
+
+    private static void assertFailure(String authority, Consumer<Throwable> requirements) {
+        final AtomicReference<ClientRequestContext> capturedCtx = new AtomicReference<>();
+        final TestServiceBlockingStub client = new ClientBuilder("gproto+http://" + authority)
+                .decorator((delegate, ctx, req) -> {
+                    capturedCtx.set(ctx);
+                    return delegate.execute(ctx, req);
+                })
+                .build(TestServiceBlockingStub.class);
+
+        final Throwable grpcCause = catchThrowable(() -> client.emptyCall(Empty.getDefaultInstance()));
+        assertThat(grpcCause).isInstanceOfSatisfying(StatusRuntimeException.class, cause -> {
+            assertThat(cause.getStatus().getCode()).isSameAs(Code.UNAVAILABLE);
+        });
+
+        final Throwable actualCause = grpcCause.getCause();
+        assertThat(actualCause).isInstanceOf(UnprocessedRequestException.class);
+        assertThat(actualCause.getCause()).satisfies((Consumer) requirements);
+
+        assertThat(capturedCtx.get()).satisfies(ctx -> {
+            ctx.log().ensureAvailability(RequestLogAvailability.COMPLETE);
+            assertThat(ctx.log().requestCause()).isSameAs(actualCause);
+            assertThat(ctx.log().responseCause()).isSameAs(actualCause);
+        });
+    }
+}

--- a/logback/src/main/java/com/linecorp/armeria/common/logback/RequestContextExporter.java
+++ b/logback/src/main/java/com/linecorp/armeria/common/logback/RequestContextExporter.java
@@ -267,7 +267,9 @@ final class RequestContextExporter {
         } else {
             final ClientRequestContext cCtx = (ClientRequestContext) ctx;
             final Endpoint endpoint = cCtx.endpoint();
-            if (endpoint.isGroup()) {
+            if (endpoint == null) {
+                authority = "UNKNOWN";
+            } else if (endpoint.isGroup()) {
                 authority = endpoint.authority();
             } else {
                 final int defaultPort = cCtx.sessionProtocol().defaultPort();

--- a/thrift/src/test/java/com/linecorp/armeria/client/thrift/ThriftClientRequestContextInitFailureTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/client/thrift/ThriftClientRequestContextInitFailureTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client.thrift;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.client.ClientBuilder;
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.Clients;
+import com.linecorp.armeria.client.UnprocessedRequestException;
+import com.linecorp.armeria.client.endpoint.EndpointGroup;
+import com.linecorp.armeria.client.endpoint.EndpointGroupException;
+import com.linecorp.armeria.client.endpoint.EndpointGroupRegistry;
+import com.linecorp.armeria.client.endpoint.EndpointSelectionStrategy;
+import com.linecorp.armeria.common.logging.RequestLogAvailability;
+import com.linecorp.armeria.common.util.SafeCloseable;
+import com.linecorp.armeria.service.test.thrift.main.HelloService;
+
+class ThriftClientRequestContextInitFailureTest {
+    @Test
+    void missingEndpointGroup() {
+        assertFailure("group:none", actualCause -> {
+            assertThat(actualCause).isInstanceOf(EndpointGroupException.class)
+                                   .hasMessageContaining("non-existent");
+        });
+    }
+
+    @Test
+    void endpointSelectionFailure() {
+        EndpointGroupRegistry.register("foo", EndpointGroup.empty(), EndpointSelectionStrategy.ROUND_ROBIN);
+        try {
+            assertFailure("group:foo", actualCause -> {
+                assertThat(actualCause).isInstanceOf(EndpointGroupException.class)
+                                       .hasMessageContaining("empty");
+            });
+        } finally {
+            EndpointGroupRegistry.unregister("foo");
+        }
+    }
+
+    @Test
+    void threadLocalCustomizerFailure() {
+        final RuntimeException cause = new RuntimeException();
+        try (SafeCloseable ignored = Clients.withContextCustomizer(ctx -> {
+            throw cause;
+        })) {
+            assertFailure("127.0.0.1:1", actualCause -> {
+                assertThat(actualCause).isSameAs(cause);
+            });
+        }
+    }
+
+    private static void assertFailure(String uri, Consumer<Throwable> requirements) {
+        final AtomicBoolean rpcDecoratorRan = new AtomicBoolean();
+        final AtomicReference<ClientRequestContext> capturedCtx = new AtomicReference<>();
+        final HelloService.Iface client = new ClientBuilder("tbinary+http://" + uri)
+                .decorator((delegate, ctx, req) -> {
+                    capturedCtx.set(ctx);
+                    return delegate.execute(ctx, req);
+                })
+                .rpcDecorator((delegate, ctx, req) -> {
+                    rpcDecoratorRan.set(true);
+                    return delegate.execute(ctx, req);
+                }).build(HelloService.Iface.class);
+
+        final Throwable actualCause = catchThrowable(() -> client.hello(""));
+        assertThat(actualCause).isInstanceOf(UnprocessedRequestException.class);
+        assertThat(actualCause.getCause()).satisfies((Consumer) requirements);
+
+        assertThat(rpcDecoratorRan).isTrue();
+        assertThat(capturedCtx.get()).satisfies(ctx -> {
+            ctx.log().ensureAvailability(RequestLogAvailability.COMPLETE);
+            assertThat(ctx.log().requestCause()).isSameAs(actualCause);
+            assertThat(ctx.log().responseCause()).isSameAs(actualCause);
+        });
+    }
+}


### PR DESCRIPTION
Motivation:

`ClientRequestContext.endpoint()` currently return an `Endpoint` which
may be 1) a host:port endpoint or 2) a group endpoint. Therefore, a
client decorator does not know which host the request will be sent to
exactly; it is determined after all decorators are evaluated. This makes
it hard for client decorators to do the following:

- Injecting a header value derived from the target host name.
- Accounting for the number of requests sent to each host.

Modifications:

- Split the initialization of `DefaultClientRequestContext` into two:
  1) constructor and 2) `init()` method.
- Determine the target host at the context initialization phase.
- Make `ClientRequestContext.endpoint()` nullable, so that the
  decorators can handle the case where endpoint selection has failed.
- Add `ClientRequestContext.endpointSelector()`.
- Add test cases for HTTP, gRPC and Thrift.
- Miscellaneous:
  - Add `EndpointGroup.empty()`

Result:

- Client decorators now knows the exact target host of the request.
- We can make `Endpoint` always refer to a host:port, which will greatly
  simplify both users' code and ours in the future.
- We now have a proper place (`DefaultClientRequestContext.init()`) that
  can be used for `EventLoop` allocation and connection pooling in the
  future.

~It currently has the following issues:~

- ~When `EndpointSelector.select()` raises an exception, the construction of `ClientRequestContext` fails, which means you have no access to its `RequestLog`. We could make `ClientRequestContext` available by deferring `select()` until `ClientRequestContext` is constructed, but the decorators will still not be able to access to the request.~
  - ~The same problem will arise when we move the connection acquisition logic (connection pooling) to the beginning of request execution. The decorators will never see the connection failure.~