### PR TITLE
Implement ByteBufHttpData.toInputStream

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/HttpData.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpData.java
@@ -32,6 +32,7 @@ import java.util.Locale;
 import com.linecorp.armeria.unsafe.ByteBufHttpData;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.ByteBufUtil;
 import it.unimi.dsi.fastutil.io.FastByteArrayInputStream;
 
@@ -386,6 +387,10 @@ public interface HttpData extends HttpObject {
 
     /**
      * Returns a new {@link InputStream} that is sourced from this data.
+     *
+     * <p>Note, if this {@link HttpData} is pooled (e.g., it is the result of a call to
+     * {@link HttpResponse#aggregateWithPooledObjects(ByteBufAllocator)}), then this {@link InputStream} will
+     * release the underlying buffer back to the pool when closed.
      */
     default InputStream toInputStream() {
         return new FastByteArrayInputStream(array());

--- a/core/src/main/java/com/linecorp/armeria/common/HttpData.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpData.java
@@ -34,6 +34,7 @@ import com.linecorp.armeria.unsafe.ByteBufHttpData;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.ByteBufUtil;
+import io.netty.util.ReferenceCountUtil;
 import it.unimi.dsi.fastutil.io.FastByteArrayInputStream;
 
 /**
@@ -391,7 +392,8 @@ public interface HttpData extends HttpObject {
      * <p>Note, if this {@link HttpData} is pooled (e.g., it is the result of a call to
      * {@link HttpResponse#aggregateWithPooledObjects(ByteBufAllocator)}), then this {@link InputStream} will
      * increase the reference count of the underlying buffer. Make sure to call {@link InputStream#close()},
-     * usually using a try-with-resources invocation, to release this extra reference.
+     * usually using a try-with-resources invocation, to release this extra reference. And as usual, don't
+     * forget to call {@link ReferenceCountUtil#release(Object)} on this {@link HttpData} itself too.
      */
     default InputStream toInputStream() {
         return new FastByteArrayInputStream(array());

--- a/core/src/main/java/com/linecorp/armeria/common/HttpData.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpData.java
@@ -390,7 +390,8 @@ public interface HttpData extends HttpObject {
      *
      * <p>Note, if this {@link HttpData} is pooled (e.g., it is the result of a call to
      * {@link HttpResponse#aggregateWithPooledObjects(ByteBufAllocator)}), then this {@link InputStream} will
-     * release the underlying buffer back to the pool when closed.
+     * increase the reference count of the underlying buffer. Make sure to call {@link InputStream#close()},
+     * usually using a try-with-resources invocation, to release this extra reference.
      */
     default InputStream toInputStream() {
         return new FastByteArrayInputStream(array());

--- a/core/src/main/java/com/linecorp/armeria/unsafe/ByteBufHttpData.java
+++ b/core/src/main/java/com/linecorp/armeria/unsafe/ByteBufHttpData.java
@@ -167,6 +167,6 @@ public class ByteBufHttpData extends AbstractHttpData implements ByteBufHolder {
 
     @Override
     public InputStream toInputStream() {
-        return new ByteBufInputStream(buf, true);
+        return new ByteBufInputStream(buf.retainedDuplicate(), true);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/unsafe/ByteBufHttpData.java
+++ b/core/src/main/java/com/linecorp/armeria/unsafe/ByteBufHttpData.java
@@ -160,13 +160,13 @@ public class ByteBufHttpData extends AbstractHttpData implements ByteBufHolder {
     }
 
     @Override
-    public InputStream toInputStream() {
-        return new ByteBufInputStream(buf, true);
-    }
-
-    @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
                           .add("buf", buf.toString()).toString();
+    }
+
+    @Override
+    public InputStream toInputStream() {
+        return new ByteBufInputStream(buf, true);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/unsafe/ByteBufHttpData.java
+++ b/core/src/main/java/com/linecorp/armeria/unsafe/ByteBufHttpData.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.unsafe;
 
 import static java.util.Objects.requireNonNull;
 
+import java.io.InputStream;
 import java.nio.charset.Charset;
 
 import com.google.common.base.MoreObjects;
@@ -27,6 +28,7 @@ import com.linecorp.armeria.common.HttpData;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
+import io.netty.buffer.ByteBufInputStream;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
 
@@ -155,6 +157,11 @@ public class ByteBufHttpData extends AbstractHttpData implements ByteBufHolder {
     @Override
     public String toString(Charset charset) {
         return buf.toString(charset);
+    }
+
+    @Override
+    public InputStream toInputStream() {
+        return new ByteBufInputStream(buf, true);
     }
 
     @Override

--- a/core/src/test/java/com/linecorp/armeria/common/HttpDataTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/HttpDataTest.java
@@ -133,6 +133,17 @@ class HttpDataTest {
         assertThat(in2.read()).isEqualTo(2);
         assertThat(in2.read()).isEqualTo(3);
         assertThat(in2.read()).isEqualTo(-1);
+
+        final ByteBuf buf = Unpooled.copiedBuffer(new byte[] { 1, 2, 3, 4 });
+        assertThat(buf.refCnt()).isOne();
+        try (InputStream in3 = HttpData.wrap(buf).toInputStream()) {
+            assertThat(in3.read()).isOne();
+            assertThat(in3.read()).isEqualTo(2);
+            assertThat(in3.read()).isEqualTo(3);
+            assertThat(in3.read()).isEqualTo(4);
+            assertThat(in3.read()).isEqualTo(-1);
+        }
+        assertThat(buf.refCnt()).isZero();
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/common/HttpDataTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/HttpDataTest.java
@@ -135,15 +135,30 @@ class HttpDataTest {
         assertThat(in2.read()).isEqualTo(-1);
 
         final ByteBuf buf = Unpooled.copiedBuffer(new byte[] { 1, 2, 3, 4 });
-        assertThat(buf.refCnt()).isOne();
-        try (InputStream in3 = HttpData.wrap(buf).toInputStream()) {
-            assertThat(in3.read()).isOne();
-            assertThat(in3.read()).isEqualTo(2);
-            assertThat(in3.read()).isEqualTo(3);
-            assertThat(in3.read()).isEqualTo(4);
-            assertThat(in3.read()).isEqualTo(-1);
+        try {
+            assertThat(buf.refCnt()).isOne();
+            final HttpData data = HttpData.wrap(buf);
+            try (InputStream in3 = data.toInputStream()) {
+                assertThat(buf.refCnt()).isEqualTo(2);
+                assertThat(in3.read()).isOne();
+                assertThat(in3.read()).isEqualTo(2);
+                assertThat(in3.read()).isEqualTo(3);
+                assertThat(in3.read()).isEqualTo(4);
+                assertThat(in3.read()).isEqualTo(-1);
+            }
+            assertThat(buf.refCnt()).isOne();
+            // Can call toInputstream again
+            try (InputStream in3 = data.toInputStream()) {
+                assertThat(buf.refCnt()).isEqualTo(2);
+                assertThat(in3.read()).isOne();
+                assertThat(in3.read()).isEqualTo(2);
+                assertThat(in3.read()).isEqualTo(3);
+                assertThat(in3.read()).isEqualTo(4);
+                assertThat(in3.read()).isEqualTo(-1);
+            }
+        } finally {
+            buf.release();
         }
-        assertThat(buf.refCnt()).isZero();
     }
 
     @Test


### PR DESCRIPTION
It's fairly common to convert a `HttpData` to an `InputStream`, e.g. when parsing into Jackson, so it's nice to make sure `ByteBufHttpData.toInputStream` is efficient too.

Fixes #1918 