### PR TITLE
Update @ConsumesJson can consume 'appplication/json' by default.

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/annotation/ConsumesJson.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/ConsumesJson.java
@@ -21,10 +21,10 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * An alias for {@code @Consumes("application/json; charset=utf-8")}.
+ * An alias for {@code @Consumes("application/json")}.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.TYPE, ElementType.METHOD })
-@Consumes("application/json; charset=utf-8")
+@Consumes("application/json")
 public @interface ConsumesJson {
 }


### PR DESCRIPTION
By RFC7158, Json text is encoded in UTF-8 by default.
However @ConsumesJson can consume only "application/json; charset=utf-8"
not "application/json". Update @ConsumesJson can consume both way.

See https://tools.ietf.org/html/rfc7158#section-8.1