### PR TITLE
Add SimpleDecoratingHttpService

### DIFF
--- a/brave/src/main/java/com/linecorp/armeria/client/brave/BraveClient.java
+++ b/brave/src/main/java/com/linecorp/armeria/client/brave/BraveClient.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
 
 import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.client.ClientRequestContext;
-import com.linecorp.armeria.client.SimpleDecoratingClient;
+import com.linecorp.armeria.client.SimpleDecoratingHttpClient;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.RequestHeadersBuilder;
@@ -53,7 +53,7 @@ import brave.propagation.TraceContext;
  * Decorates a {@link Client} to trace outbound {@link HttpRequest}s using
  * <a href="https://github.com/openzipkin/brave">Brave</a>.
  */
-public final class BraveClient extends SimpleDecoratingClient<HttpRequest, HttpResponse> {
+public final class BraveClient extends SimpleDecoratingHttpClient {
 
     private static final Logger logger = LoggerFactory.getLogger(BraveClient.class);
 

--- a/brave/src/main/java/com/linecorp/armeria/server/brave/BraveService.java
+++ b/brave/src/main/java/com/linecorp/armeria/server/brave/BraveService.java
@@ -30,7 +30,7 @@ import com.linecorp.armeria.internal.brave.SpanTags;
 import com.linecorp.armeria.internal.brave.TraceContextUtil;
 import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceRequestContext;
-import com.linecorp.armeria.server.SimpleDecoratingService;
+import com.linecorp.armeria.server.SimpleDecoratingHttpService;
 
 import brave.Span;
 import brave.Span.Kind;
@@ -44,7 +44,7 @@ import brave.propagation.TraceContextOrSamplingFlags;
  * Decorates a {@link Service} to trace inbound {@link HttpRequest}s using
  * <a href="https://github.com/openzipkin/brave">Brave</a>.
  */
-public final class BraveService extends SimpleDecoratingService<HttpRequest, HttpResponse> {
+public final class BraveService extends SimpleDecoratingHttpService {
 
     // TODO(minwoox) Add the variant which takes HttpTracing.
 

--- a/core/src/main/java/com/linecorp/armeria/client/SimpleDecoratingHttpClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/SimpleDecoratingHttpClient.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017 LINE Corporation
+ *  Copyright 2019 LINE Corporation
  *
  *  LINE Corporation licenses this file to you under the Apache License,
  *  version 2.0 (the "License"); you may not use this file except in compliance
@@ -16,23 +16,21 @@
 
 package com.linecorp.armeria.client;
 
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
 
 /**
- * Decorates a {@link Client}. Use {@link DecoratingClient} if your {@link Client} has different
+ * Decorates an HTTP {@link Client}. Use {@link DecoratingClient} if your {@link Client} has different
  * {@link Request} or {@link Response} type from the {@link Client} being decorated.
- *
- * @param <I> the {@link Request} type of the {@link Client} being decorated
- * @param <O> the {@link Response} type of the {@link Client} being decorated
  */
-public abstract class SimpleDecoratingClient<I extends Request, O extends Response>
-        extends DecoratingClient<I, O, I, O> {
+public abstract class SimpleDecoratingHttpClient extends SimpleDecoratingClient<HttpRequest, HttpResponse> {
 
     /**
      * Creates a new instance that decorates the specified {@link Client}.
      */
-    protected SimpleDecoratingClient(Client<I, O> delegate) {
+    protected SimpleDecoratingHttpClient(Client<HttpRequest, HttpResponse> delegate) {
         super(delegate);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/SimpleDecoratingRpcClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/SimpleDecoratingRpcClient.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017 LINE Corporation
+ *  Copyright 2019 LINE Corporation
  *
  *  LINE Corporation licenses this file to you under the Apache License,
  *  version 2.0 (the "License"); you may not use this file except in compliance
@@ -18,21 +18,19 @@ package com.linecorp.armeria.client;
 
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
+import com.linecorp.armeria.common.RpcRequest;
+import com.linecorp.armeria.common.RpcResponse;
 
 /**
- * Decorates a {@link Client}. Use {@link DecoratingClient} if your {@link Client} has different
+ * Decorates an RPC {@link Client}. Use {@link DecoratingClient} if your {@link Client} has different
  * {@link Request} or {@link Response} type from the {@link Client} being decorated.
- *
- * @param <I> the {@link Request} type of the {@link Client} being decorated
- * @param <O> the {@link Response} type of the {@link Client} being decorated
  */
-public abstract class SimpleDecoratingClient<I extends Request, O extends Response>
-        extends DecoratingClient<I, O, I, O> {
+public abstract class SimpleDecoratingRpcClient extends SimpleDecoratingClient<RpcRequest, RpcResponse> {
 
     /**
      * Creates a new instance that decorates the specified {@link Client}.
      */
-    protected SimpleDecoratingClient(Client<I, O> delegate) {
+    protected SimpleDecoratingRpcClient(Client<RpcRequest, RpcResponse> delegate) {
         super(delegate);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/encoding/HttpDecodingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/encoding/HttpDecodingClient.java
@@ -27,7 +27,7 @@ import com.google.common.collect.Streams;
 import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.DecoratingClient;
-import com.linecorp.armeria.client.SimpleDecoratingClient;
+import com.linecorp.armeria.client.SimpleDecoratingHttpClient;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
@@ -36,7 +36,7 @@ import com.linecorp.armeria.common.HttpResponse;
  * A {@link DecoratingClient} that requests and decodes HTTP encoding (e.g., gzip) that has been applied to the
  * content of a {@link HttpResponse}.
  */
-public final class HttpDecodingClient extends SimpleDecoratingClient<HttpRequest, HttpResponse> {
+public final class HttpDecodingClient extends SimpleDecoratingHttpClient {
 
     /**
      * Creates a new {@link HttpDecodingClient} decorator with the default encodings of 'gzip' and 'deflate'.

--- a/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpService.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpService.java
@@ -67,7 +67,7 @@ import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.Route;
 import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceRequestContext;
-import com.linecorp.armeria.server.SimpleDecoratingService;
+import com.linecorp.armeria.server.SimpleDecoratingHttpService;
 import com.linecorp.armeria.server.annotation.ByteArrayResponseConverterFunction;
 import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
 import com.linecorp.armeria.server.annotation.ExceptionVerbosity;
@@ -362,8 +362,7 @@ public class AnnotatedHttpService implements HttpService {
      * {@link Exception} to be handled by {@link ExceptionHandlerFunction}s even if the exception is raised
      * from a decorator.
      */
-    private class ExceptionFilteredHttpResponseDecorator
-            extends SimpleDecoratingService<HttpRequest, HttpResponse> {
+    private class ExceptionFilteredHttpResponseDecorator extends SimpleDecoratingHttpService {
 
         ExceptionFilteredHttpResponseDecorator(Service<HttpRequest, HttpResponse> delegate) {
             super(delegate);

--- a/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceFactory.java
@@ -86,7 +86,7 @@ import com.linecorp.armeria.server.HttpStatusException;
 import com.linecorp.armeria.server.Route;
 import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceRequestContext;
-import com.linecorp.armeria.server.SimpleDecoratingService;
+import com.linecorp.armeria.server.SimpleDecoratingHttpService;
 import com.linecorp.armeria.server.annotation.AdditionalHeader;
 import com.linecorp.armeria.server.annotation.AdditionalTrailer;
 import com.linecorp.armeria.server.annotation.ConsumeType;
@@ -362,7 +362,7 @@ public final class AnnotatedHttpServiceFactory {
         if (methods.contains(HttpMethod.OPTIONS)) {
             initialDecorator = Function.identity();
         } else {
-            initialDecorator = delegate -> new SimpleDecoratingService<HttpRequest, HttpResponse>(delegate) {
+            initialDecorator = delegate -> new SimpleDecoratingHttpService(delegate) {
                 @Override
                 public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
                     if (req.method() == HttpMethod.OPTIONS) {

--- a/core/src/main/java/com/linecorp/armeria/server/RpcService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RpcService.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import com.linecorp.armeria.common.RpcRequest;
+import com.linecorp.armeria.common.RpcResponse;
+
+/**
+ * An RPC {@link Service}.
+ *
+ * <p>This interface is a shortcut to {@code Service<RpcRequest, RpcResponse>}.
+ */
+@FunctionalInterface
+public interface RpcService extends Service<RpcRequest, RpcResponse> {
+
+    @Override
+    RpcResponse serve(ServiceRequestContext ctx, RpcRequest req) throws Exception;
+}

--- a/core/src/main/java/com/linecorp/armeria/server/SimpleDecoratingHttpService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/SimpleDecoratingHttpService.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+
+/**
+ * An {@link HttpService} that decorates another {@link HttpService}.
+ *
+ * @see Service#decorate(DecoratingServiceFunction)
+ */
+public abstract class SimpleDecoratingHttpService extends SimpleDecoratingService<HttpRequest, HttpResponse>
+        implements HttpService {
+    /**
+     * Creates a new instance that decorates the specified {@link Service}.
+     */
+    protected SimpleDecoratingHttpService(Service<HttpRequest, HttpResponse> delegate) {
+        super(delegate);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/SimpleDecoratingRpcService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/SimpleDecoratingRpcService.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import com.linecorp.armeria.common.RpcRequest;
+import com.linecorp.armeria.common.RpcResponse;
+
+/**
+ * An {@link RpcService} that decorates another {@link RpcService}.
+ *
+ * @see Service#decorate(DecoratingServiceFunction)
+ */
+public abstract class SimpleDecoratingRpcService extends SimpleDecoratingService<RpcRequest, RpcResponse>
+        implements RpcService {
+    /**
+     * Creates a new instance that decorates the specified {@link Service}.
+     */
+    protected SimpleDecoratingRpcService(Service<RpcRequest, RpcResponse> delegate) {
+        super(delegate);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/auth/HttpAuthService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/auth/HttpAuthService.java
@@ -30,14 +30,14 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceRequestContext;
-import com.linecorp.armeria.server.SimpleDecoratingService;
+import com.linecorp.armeria.server.SimpleDecoratingHttpService;
 
 /**
  * Decorates a {@link Service} to provide HTTP authorization functionality.
  *
  * @see HttpAuthServiceBuilder
  */
-public final class HttpAuthService extends SimpleDecoratingService<HttpRequest, HttpResponse> {
+public final class HttpAuthService extends SimpleDecoratingHttpService {
 
     static final Logger logger = LoggerFactory.getLogger(HttpAuthService.class);
 

--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsService.java
@@ -35,7 +35,7 @@ import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.ResponseHeadersBuilder;
 import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceRequestContext;
-import com.linecorp.armeria.server.SimpleDecoratingService;
+import com.linecorp.armeria.server.SimpleDecoratingHttpService;
 
 /**
  * Decorates an HTTP {@link Service} to add the
@@ -44,7 +44,7 @@ import com.linecorp.armeria.server.SimpleDecoratingService;
  *
  * @see CorsServiceBuilder
  */
-public final class CorsService extends SimpleDecoratingService<HttpRequest, HttpResponse> {
+public final class CorsService extends SimpleDecoratingHttpService {
 
     private static final Logger logger = LoggerFactory.getLogger(CorsService.class);
 

--- a/core/src/main/java/com/linecorp/armeria/server/encoding/HttpEncodingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/encoding/HttpEncodingService.java
@@ -29,7 +29,7 @@ import com.linecorp.armeria.server.DecoratingService;
 import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceRequestContext;
-import com.linecorp.armeria.server.SimpleDecoratingService;
+import com.linecorp.armeria.server.SimpleDecoratingHttpService;
 
 /**
  * Decorates a {@link Service} to apply HTTP encoding (e.g., gzip) to an {@link HttpService}.
@@ -41,8 +41,7 @@ import com.linecorp.armeria.server.SimpleDecoratingService;
  *     <li>the response either has no fixed content length or the length is larger than 1KB</li>
  * </ul>
  */
-public class HttpEncodingService
-        extends SimpleDecoratingService<HttpRequest, HttpResponse> {
+public class HttpEncodingService extends SimpleDecoratingHttpService {
 
     private static final Predicate<MediaType> DEFAULT_ENCODABLE_CONTENT_TYPE_PREDICATE =
             contentType -> Stream.of(MediaType.ANY_TEXT_TYPE,

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientIntegrationTest.java
@@ -72,6 +72,7 @@ import com.linecorp.armeria.server.AbstractHttpService;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.SimpleDecoratingHttpService;
 import com.linecorp.armeria.server.SimpleDecoratingService;
 import com.linecorp.armeria.server.encoding.HttpEncodingService;
 import com.linecorp.armeria.testing.junit.server.ServerExtension;
@@ -124,7 +125,7 @@ class HttpClientIntegrationTest {
         }
     }
 
-    private static final class PoolAwareDecorator extends SimpleDecoratingService<HttpRequest, HttpResponse> {
+    private static final class PoolAwareDecorator extends SimpleDecoratingHttpService {
 
         private PoolAwareDecorator(Service<HttpRequest, HttpResponse> delegate) {
             super(delegate);

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientWithLoggingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientWithLoggingTest.java
@@ -33,7 +33,7 @@ import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.client.HttpClientBuilder;
-import com.linecorp.armeria.client.SimpleDecoratingClient;
+import com.linecorp.armeria.client.SimpleDecoratingHttpClient;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
@@ -136,7 +136,7 @@ public class RetryingClientWithLoggingTest {
 
     private Function<Client<HttpRequest, HttpResponse>, Client<HttpRequest, HttpResponse>>
     loggingDecorator() {
-        return delegate -> new SimpleDecoratingClient<HttpRequest, HttpResponse>(delegate) {
+        return delegate -> new SimpleDecoratingHttpClient(delegate) {
             @Override
             public HttpResponse execute(ClientRequestContext ctx, HttpRequest req) throws Exception {
                 ctx.log().addListener(listener, RequestLogAvailability.REQUEST_END);

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceAnnotationAliasTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceAnnotationAliasTest.java
@@ -45,7 +45,7 @@ import com.linecorp.armeria.server.DecoratingServiceFunction;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceRequestContext;
-import com.linecorp.armeria.server.SimpleDecoratingService;
+import com.linecorp.armeria.server.SimpleDecoratingHttpService;
 import com.linecorp.armeria.server.annotation.AdditionalHeader;
 import com.linecorp.armeria.server.annotation.AdditionalTrailer;
 import com.linecorp.armeria.server.annotation.Consumes;
@@ -188,7 +188,7 @@ public class AnnotatedHttpServiceAnnotationAliasTest {
         @Override
         public Function<Service<HttpRequest, HttpResponse>,
                 ? extends Service<HttpRequest, HttpResponse>> newDecorator(MyDecorator3 parameter) {
-            return delegate -> new SimpleDecoratingService<HttpRequest, HttpResponse>(delegate) {
+            return delegate -> new SimpleDecoratingHttpService(delegate) {
                 @Override
                 public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
                     appendAttribute(ctx, " (decorated-3)");

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceFactoryTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceFactoryTest.java
@@ -36,7 +36,7 @@ import com.linecorp.armeria.internal.annotation.AnnotatedHttpServiceFactory.Deco
 import com.linecorp.armeria.server.DecoratingServiceFunction;
 import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceRequestContext;
-import com.linecorp.armeria.server.SimpleDecoratingService;
+import com.linecorp.armeria.server.SimpleDecoratingHttpService;
 import com.linecorp.armeria.server.annotation.Decorator;
 import com.linecorp.armeria.server.annotation.DecoratorFactory;
 import com.linecorp.armeria.server.annotation.DecoratorFactoryFunction;
@@ -184,7 +184,7 @@ public class AnnotatedHttpServiceFactoryTest {
         public Function<Service<HttpRequest, HttpResponse>,
                 ? extends Service<HttpRequest, HttpResponse>> newDecorator(
                 UserDefinedRepeatableDecorator parameter) {
-            return service -> new SimpleDecoratingService<HttpRequest, HttpResponse>(service) {
+            return service -> new SimpleDecoratingHttpService(service) {
                 @Override
                 public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
                     return service.serve(ctx, req);

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerStreamingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerStreamingTest.java
@@ -116,7 +116,7 @@ class HttpServerStreamingTest {
 
             final Function<Service<HttpRequest, HttpResponse>, Service<HttpRequest, HttpResponse>>
                     decorator =
-                    s -> new SimpleDecoratingService<HttpRequest, HttpResponse>(s) {
+                    s -> new SimpleDecoratingHttpService(s) {
                         @Override
                         public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
                             ctx.setMaxRequestLength(serverMaxRequestLength);

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerTest.java
@@ -417,7 +417,7 @@ class HttpServerTest {
             sb.service("/cached-exact-path", (ctx, req) -> HttpResponse.of(HttpStatus.OK));
 
             final Function<Service<HttpRequest, HttpResponse>, Service<HttpRequest, HttpResponse>> decorator =
-                    s -> new SimpleDecoratingService<HttpRequest, HttpResponse>(s) {
+                    s -> new SimpleDecoratingHttpService(s) {
                         @Override
                         public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
                             pendingRequestLogs.incrementAndGet();

--- a/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
@@ -132,7 +132,7 @@ public class ServerTest {
 
             // Disable request timeout for '/timeout-not' only.
             final Function<Service<HttpRequest, HttpResponse>, Service<HttpRequest, HttpResponse>> decorator =
-                    s -> new SimpleDecoratingService<HttpRequest, HttpResponse>(s) {
+                    s -> new SimpleDecoratingHttpService(s) {
                         @Override
                         public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
                             ctx.setRequestTimeoutMillis(

--- a/core/src/test/java/com/linecorp/armeria/server/ServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServiceTest.java
@@ -79,7 +79,7 @@ public class ServiceTest {
         return (Class<Service<?, ?>>) service.getClass();
     }
 
-    private static final class FooService implements Service<RpcRequest, RpcResponse> {
+    private static final class FooService implements RpcService {
 
         ServiceConfig cfg;
 
@@ -95,8 +95,8 @@ public class ServiceTest {
         }
     }
 
-    public static class FooServiceDecorator extends SimpleDecoratingService<RpcRequest, RpcResponse> {
-        public FooServiceDecorator(Service<RpcRequest, RpcResponse> delegate) {
+    public static class FooServiceDecorator extends SimpleDecoratingRpcService {
+        public FooServiceDecorator(RpcService delegate) {
             super(delegate);
         }
 
@@ -107,8 +107,7 @@ public class ServiceTest {
     }
 
     public static class BadFooServiceDecorator extends FooServiceDecorator {
-        public BadFooServiceDecorator(Service<RpcRequest, RpcResponse> delegate,
-                                      @SuppressWarnings("unused") Object unused) {
+        public BadFooServiceDecorator(RpcService delegate, @SuppressWarnings("unused") Object unused) {
             super(delegate);
         }
     }

--- a/core/src/test/java/com/linecorp/armeria/server/ServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServiceTest.java
@@ -96,7 +96,7 @@ public class ServiceTest {
     }
 
     public static class FooServiceDecorator extends SimpleDecoratingRpcService {
-        public FooServiceDecorator(RpcService delegate) {
+        public FooServiceDecorator(Service<RpcRequest, RpcResponse> delegate) {
             super(delegate);
         }
 
@@ -107,7 +107,8 @@ public class ServiceTest {
     }
 
     public static class BadFooServiceDecorator extends FooServiceDecorator {
-        public BadFooServiceDecorator(RpcService delegate, @SuppressWarnings("unused") Object unused) {
+        public BadFooServiceDecorator(Service<RpcRequest, RpcResponse> delegate,
+                                      @SuppressWarnings("unused") Object unused) {
             super(delegate);
         }
     }

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/UnaryGrpcClient.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/UnaryGrpcClient.java
@@ -24,7 +24,7 @@ import com.linecorp.armeria.client.ClientOption;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.HttpClient;
-import com.linecorp.armeria.client.SimpleDecoratingClient;
+import com.linecorp.armeria.client.SimpleDecoratingHttpClient;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpMethod;
@@ -104,7 +104,7 @@ public class UnaryGrpcClient {
                          });
     }
 
-    private static final class GrpcFramingDecorator extends SimpleDecoratingClient<HttpRequest, HttpResponse> {
+    private static final class GrpcFramingDecorator extends SimpleDecoratingHttpClient {
 
         private GrpcFramingDecorator(Client<HttpRequest, HttpResponse> delegate) {
             super(delegate);

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcService.java
@@ -47,7 +47,7 @@ import com.linecorp.armeria.server.Route;
 import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.ServiceWithRoutes;
-import com.linecorp.armeria.server.SimpleDecoratingService;
+import com.linecorp.armeria.server.SimpleDecoratingHttpService;
 import com.linecorp.armeria.server.encoding.HttpEncodingService;
 import com.linecorp.armeria.unsafe.ByteBufHttpData;
 
@@ -59,7 +59,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
 
 /**
- * A {@link SimpleDecoratingService} which allows {@link GrpcService} to serve requests without the framing
+ * A {@link SimpleDecoratingHttpService} which allows {@link GrpcService} to serve requests without the framing
  * specified by the gRPC wire protocol. This can be useful for serving both legacy systems and gRPC clients with
  * the same business logic.
  *
@@ -73,7 +73,7 @@ import io.netty.buffer.ByteBufHolder;
  *     </li>
  * </ul>
  */
-class UnframedGrpcService extends SimpleDecoratingService<HttpRequest, HttpResponse>
+class UnframedGrpcService extends SimpleDecoratingHttpService
         implements ServiceWithRoutes<HttpRequest, HttpResponse> {
 
     private static final char LINE_SEPARATOR = '\n';

--- a/grpc/src/test/java/com/linecorp/armeria/internal/grpc/TestServiceImpl.java
+++ b/grpc/src/test/java/com/linecorp/armeria/internal/grpc/TestServiceImpl.java
@@ -52,7 +52,7 @@ import com.linecorp.armeria.protobuf.EmptyProtos;
 import com.linecorp.armeria.protobuf.EmptyProtos.Empty;
 import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceRequestContext;
-import com.linecorp.armeria.server.SimpleDecoratingService;
+import com.linecorp.armeria.server.SimpleDecoratingHttpService;
 
 import io.grpc.Metadata;
 import io.grpc.Metadata.Key;
@@ -521,8 +521,7 @@ public class TestServiceImpl extends TestServiceGrpc.TestServiceImplBase {
         return payload;
     }
 
-    public static class EchoRequestHeadersInTrailers
-            extends SimpleDecoratingService<HttpRequest, HttpResponse> {
+    public static class EchoRequestHeadersInTrailers extends SimpleDecoratingHttpService {
 
         /**
          * Creates a new instance that decorates the specified {@link Service}.

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceServerTest.java
@@ -59,7 +59,7 @@ import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.ClientFactoryBuilder;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.HttpClient;
-import com.linecorp.armeria.client.SimpleDecoratingClient;
+import com.linecorp.armeria.client.SimpleDecoratingHttpClient;
 import com.linecorp.armeria.client.grpc.GrpcClientOptions;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.FilteredHttpResponse;
@@ -1026,7 +1026,7 @@ class GrpcServiceServerTest {
             final AtomicReference<byte[]> payload = new AtomicReference<>();
             final UnitTestServiceBlockingStub jsonStub =
                     new ClientBuilder(server.httpUri(GrpcSerializationFormats.JSON, "/"))
-                            .decorator(client -> new SimpleDecoratingClient<HttpRequest, HttpResponse>(client) {
+                            .decorator(client -> new SimpleDecoratingHttpClient(client) {
                                 @Override
                                 public HttpResponse execute(ClientRequestContext ctx, HttpRequest req)
                                         throws Exception {
@@ -1068,7 +1068,7 @@ class GrpcServiceServerTest {
                     new ClientBuilder(server.httpUri(GrpcSerializationFormats.JSON, "/json-preserving/"))
                             .option(GrpcClientOptions.JSON_MARSHALLER_CUSTOMIZER.newValue(
                                     marshaller -> marshaller.preservingProtoFieldNames(true)))
-                            .decorator(client -> new SimpleDecoratingClient<HttpRequest, HttpResponse>(client) {
+                            .decorator(client -> new SimpleDecoratingHttpClient(client) {
                                 @Override
                                 public HttpResponse execute(ClientRequestContext ctx, HttpRequest req)
                                         throws Exception {

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/SamlDecorator.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/SamlDecorator.java
@@ -52,14 +52,14 @@ import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceConfig;
 import com.linecorp.armeria.server.ServiceRequestContext;
-import com.linecorp.armeria.server.SimpleDecoratingService;
+import com.linecorp.armeria.server.SimpleDecoratingHttpService;
 import com.linecorp.armeria.server.auth.Authorizer;
 
 /**
  * A decorator which initiates an authentication request to the remote identity provider if the request is
  * not authenticated.
  */
-final class SamlDecorator extends SimpleDecoratingService<HttpRequest, HttpResponse> {
+final class SamlDecorator extends SimpleDecoratingHttpService {
     private static final Logger logger = LoggerFactory.getLogger(SamlDecorator.class);
 
     private final SamlServiceProvider sp;

--- a/thrift/src/main/java/com/linecorp/armeria/server/thrift/ThriftCallService.java
+++ b/thrift/src/main/java/com/linecorp/armeria/server/thrift/ThriftCallService.java
@@ -40,6 +40,7 @@ import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.RpcResponse;
 import com.linecorp.armeria.internal.thrift.ThriftFunction;
+import com.linecorp.armeria.server.RpcService;
 import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
@@ -48,7 +49,7 @@ import com.linecorp.armeria.server.ServiceRequestContext;
  *
  * @see THttpService
  */
-public final class ThriftCallService implements Service<RpcRequest, RpcResponse> {
+public final class ThriftCallService implements RpcService {
 
     private static final Logger logger = LoggerFactory.getLogger(ThriftCallService.class);
 

--- a/thrift/src/test/java/com/linecorp/armeria/it/thrift/ThriftDynamicTimeoutTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/thrift/ThriftDynamicTimeoutTest.java
@@ -39,8 +39,8 @@ import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.SimpleDecoratingRpcClient;
 import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.RpcResponse;
-import com.linecorp.armeria.server.RpcService;
 import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.SimpleDecoratingRpcService;
 import com.linecorp.armeria.server.thrift.THttpService;
@@ -129,7 +129,7 @@ class ThriftDynamicTimeoutTest {
 
     private static final class DynamicTimeoutService extends SimpleDecoratingRpcService {
 
-        DynamicTimeoutService(RpcService delegate) {
+        DynamicTimeoutService(Service<RpcRequest, RpcResponse> delegate) {
             super(delegate);
         }
 
@@ -143,7 +143,7 @@ class ThriftDynamicTimeoutTest {
 
     private static final class TimeoutDisablingService extends SimpleDecoratingRpcService {
 
-        TimeoutDisablingService(RpcService delegate) {
+        TimeoutDisablingService(Service<RpcRequest, RpcResponse> delegate) {
             super(delegate);
         }
 

--- a/thrift/src/test/java/com/linecorp/armeria/it/thrift/ThriftDynamicTimeoutTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/it/thrift/ThriftDynamicTimeoutTest.java
@@ -36,13 +36,13 @@ import com.google.common.base.Stopwatch;
 import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.client.ClientBuilder;
 import com.linecorp.armeria.client.ClientRequestContext;
-import com.linecorp.armeria.client.SimpleDecoratingClient;
+import com.linecorp.armeria.client.SimpleDecoratingRpcClient;
 import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.RpcResponse;
+import com.linecorp.armeria.server.RpcService;
 import com.linecorp.armeria.server.ServerBuilder;
-import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceRequestContext;
-import com.linecorp.armeria.server.SimpleDecoratingService;
+import com.linecorp.armeria.server.SimpleDecoratingRpcService;
 import com.linecorp.armeria.server.thrift.THttpService;
 import com.linecorp.armeria.server.thrift.ThriftCallService;
 import com.linecorp.armeria.service.test.thrift.main.SleepService;
@@ -127,9 +127,9 @@ class ThriftDynamicTimeoutTest {
         }
     }
 
-    private static final class DynamicTimeoutService extends SimpleDecoratingService<RpcRequest, RpcResponse> {
+    private static final class DynamicTimeoutService extends SimpleDecoratingRpcService {
 
-        DynamicTimeoutService(Service<RpcRequest, RpcResponse> delegate) {
+        DynamicTimeoutService(RpcService delegate) {
             super(delegate);
         }
 
@@ -141,10 +141,9 @@ class ThriftDynamicTimeoutTest {
         }
     }
 
-    private static final class TimeoutDisablingService
-            extends SimpleDecoratingService<RpcRequest, RpcResponse> {
+    private static final class TimeoutDisablingService extends SimpleDecoratingRpcService {
 
-        TimeoutDisablingService(Service<RpcRequest, RpcResponse> delegate) {
+        TimeoutDisablingService(RpcService delegate) {
             super(delegate);
         }
 
@@ -155,8 +154,7 @@ class ThriftDynamicTimeoutTest {
         }
     }
 
-    private static final class DynamicTimeoutClient
-            extends SimpleDecoratingClient<RpcRequest, RpcResponse> {
+    private static final class DynamicTimeoutClient extends SimpleDecoratingRpcClient {
 
         DynamicTimeoutClient(Client<RpcRequest, RpcResponse> delegate) {
             super(delegate);
@@ -170,8 +168,7 @@ class ThriftDynamicTimeoutTest {
         }
     }
 
-    private static final class TimeoutDisablingClient
-            extends SimpleDecoratingClient<RpcRequest, RpcResponse> {
+    private static final class TimeoutDisablingClient extends SimpleDecoratingRpcClient {
 
         TimeoutDisablingClient(Client<RpcRequest, RpcResponse> delegate) {
             super(delegate);

--- a/thrift/src/test/java/com/linecorp/armeria/server/thrift/AbstractThriftOverHttpTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/server/thrift/AbstractThriftOverHttpTest.java
@@ -53,7 +53,7 @@ import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.ServerPort;
 import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceRequestContext;
-import com.linecorp.armeria.server.SimpleDecoratingService;
+import com.linecorp.armeria.server.SimpleDecoratingHttpService;
 import com.linecorp.armeria.server.logging.LoggingService;
 import com.linecorp.armeria.service.test.thrift.main.HelloService;
 import com.linecorp.armeria.service.test.thrift.main.HelloService.AsyncIface;
@@ -138,7 +138,7 @@ public abstract class AbstractThriftOverHttpTest {
 
             final Function<Service<HttpRequest, HttpResponse>,
                     Service<HttpRequest, HttpResponse>> logCollectingDecorator =
-                    s -> new SimpleDecoratingService<HttpRequest, HttpResponse>(s) {
+                    s -> new SimpleDecoratingHttpService(s) {
                         @Override
                         public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
                             if (recordMessageLogs) {

--- a/zipkin/src/main/java/com/linecorp/armeria/client/tracing/HttpTracingClient.java
+++ b/zipkin/src/main/java/com/linecorp/armeria/client/tracing/HttpTracingClient.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
 
 import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.client.ClientRequestContext;
-import com.linecorp.armeria.client.SimpleDecoratingClient;
+import com.linecorp.armeria.client.SimpleDecoratingHttpClient;
 import com.linecorp.armeria.client.brave.BraveClient;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
@@ -61,7 +61,7 @@ import brave.propagation.TraceContext;
  * @deprecated Use {@link BraveClient}.
  */
 @Deprecated
-public class HttpTracingClient extends SimpleDecoratingClient<HttpRequest, HttpResponse> {
+public class HttpTracingClient extends SimpleDecoratingHttpClient {
 
     private static final Logger logger = LoggerFactory.getLogger(HttpTracingClient.class);
 

--- a/zipkin/src/main/java/com/linecorp/armeria/server/tracing/HttpTracingService.java
+++ b/zipkin/src/main/java/com/linecorp/armeria/server/tracing/HttpTracingService.java
@@ -31,7 +31,7 @@ import com.linecorp.armeria.internal.brave.SpanContextUtil;
 import com.linecorp.armeria.internal.brave.SpanTags;
 import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceRequestContext;
-import com.linecorp.armeria.server.SimpleDecoratingService;
+import com.linecorp.armeria.server.SimpleDecoratingHttpService;
 import com.linecorp.armeria.server.brave.BraveService;
 
 import brave.Span;
@@ -52,7 +52,7 @@ import brave.propagation.TraceContextOrSamplingFlags;
  * @deprecated Use {@link BraveService}.
  */
 @Deprecated
-public class HttpTracingService extends SimpleDecoratingService<HttpRequest, HttpResponse> {
+public class HttpTracingService extends SimpleDecoratingHttpService {
 
     /**
      * Creates a new tracing {@link Service} decorator using the specified {@link Tracing} instance.


### PR DESCRIPTION
Motivation:
A user has to specify type parameter when creating `SimpleDecoratingService`:
```
new SimpleDecoratingService<HttpRequest, HttpResponse>(delegate) {...}
new SimpleDecoratingService<RpcRequest, RpcResponse>(delegate) {...}
```
If we provide `SimpleDecoratingHttpService` and `SimpleDecoratingRpcService`,
it will make it simple.

Modifications:
- Add `SimpleDecoratingHttpService` and `SimpleDecoratingRpcService`
- Add `SimpleDecoratingHttpClient` and `SimpleDecoratingRpcClient`
- Add `RpcService` (we have `HttpService`)
- Use the classes where applicable

Result:
- Close #1881