### PR TITLE
Simplify a glob path mapping with prefix into a glob

### DIFF
--- a/brave/src/main/java/com/linecorp/armeria/client/brave/ArmeriaHttpClientParser.java
+++ b/brave/src/main/java/com/linecorp/armeria/client/brave/ArmeriaHttpClientParser.java
@@ -28,7 +28,7 @@ import brave.http.HttpClientParser;
 
 /**
  * Default implementation of {@link HttpClientParser}.
- * This parser add some custom tags and overwrite the name of span if {@link RequestLog#requestContent()}
+ * This parser adds some custom tags and overwrites the name of span if {@link RequestLog#requestContent()}
  * is {@link RpcRequest}.
  * The following tags become available:
  * <ul>
@@ -39,7 +39,6 @@ import brave.http.HttpClientParser;
  *   <li>address.remote</li>
  *   <li>address.local</li>
  * </ul>
- * User can extend this class or implement own {@link HttpClientParser}.
  */
 final class ArmeriaHttpClientParser extends HttpClientParser {
 

--- a/brave/src/main/java/com/linecorp/armeria/server/brave/ArmeriaHttpServerAdapter.java
+++ b/brave/src/main/java/com/linecorp/armeria/server/brave/ArmeriaHttpServerAdapter.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.server.brave;
 
+import java.util.List;
+
 import javax.annotation.Nullable;
 
 import com.linecorp.armeria.common.Request;
@@ -100,15 +102,16 @@ final class ArmeriaHttpServerAdapter extends HttpServerAdapter<RequestLog, Reque
     public String route(RequestLog response) {
         assert response.context() instanceof ServiceRequestContext;
         final Route route = ((ServiceRequestContext) response.context()).route();
+        final List<String> paths = route.paths();
         switch (route.pathType()) {
             case EXACT:
             case PREFIX:
             case PARAMETERIZED:
-                return route.paths().get(1);
+                return paths.get(1);
             case REGEX:
-                return route.paths().get(0);
+                return paths.get(paths.size() - 1);
             case REGEX_WITH_PREFIX:
-                return route.paths().get(1) + ' ' + route.paths().get(0);
+                return paths.get(1) + paths.get(0);
         }
         return null;
     }
@@ -161,7 +164,7 @@ final class ArmeriaHttpServerAdapter extends HttpServerAdapter<RequestLog, Reque
 
     /**
      * This sets the client IP:port to the {@link RequestContext#remoteAddress()}
-     * if the {@link HttpServerAdapter#parseClientIpAndPort default parsing} fails.
+     * if the {@linkplain HttpServerAdapter#parseClientIpAndPort default parsing} fails.
      */
     @Override
     public boolean parseClientIpAndPort(RequestLog requestLog, Span span) {

--- a/brave/src/main/java/com/linecorp/armeria/server/brave/ArmeriaHttpServerParser.java
+++ b/brave/src/main/java/com/linecorp/armeria/server/brave/ArmeriaHttpServerParser.java
@@ -28,7 +28,7 @@ import brave.http.HttpServerParser;
 
 /**
  * Default implementation of {@link HttpServerParser}.
- * This parser add some custom tags and overwrite the name of span if {@link RequestLog#requestContent()}
+ * This parser adds some custom tags and overwrites the name of span if {@link RequestLog#requestContent()}
  * is {@link RpcRequest}.
  * The following tags become available:
  * <ul>
@@ -39,7 +39,6 @@ import brave.http.HttpServerParser;
  *   <li>address.remote</li>
  *   <li>address.local</li>
  * </ul>
- * User can extend this class or implement own {@link HttpServerParser}.
  */
 final class ArmeriaHttpServerParser extends HttpServerParser {
 

--- a/brave/src/test/java/com/linecorp/armeria/client/brave/ArmeriaHttpClientAdapterTest.java
+++ b/brave/src/test/java/com/linecorp/armeria/client/brave/ArmeriaHttpClientAdapterTest.java
@@ -40,19 +40,19 @@ class ArmeriaHttpClientAdapterTest {
     private RequestLog requestLog;
 
     @Test
-    public void path() {
+    void path() {
         when(requestLog.path()).thenReturn("/foo");
         assertThat(ArmeriaHttpClientAdapter.get().path(requestLog)).isEqualTo("/foo");
     }
 
     @Test
-    public void method() {
+    void method() {
         when(requestLog.method()).thenReturn(HttpMethod.GET);
         assertThat(ArmeriaHttpClientAdapter.get().method(requestLog)).isEqualTo("GET");
     }
 
     @Test
-    public void url() {
+    void url() {
         when(requestLog.isAvailable(RequestLogAvailability.SCHEME)).thenReturn(true);
         when(requestLog.isAvailable(RequestLogAvailability.REQUEST_HEADERS)).thenReturn(true);
         when(requestLog.scheme()).thenReturn(Scheme.of(SerializationFormat.NONE, SessionProtocol.HTTP));
@@ -63,7 +63,7 @@ class ArmeriaHttpClientAdapterTest {
     }
 
     @Test
-    public void statusCode() {
+    void statusCode() {
         when(requestLog.isAvailable(RequestLogAvailability.RESPONSE_HEADERS)).thenReturn(true);
         when(requestLog.status()).thenReturn(HttpStatus.OK);
         assertThat(ArmeriaHttpClientAdapter.get().statusCode(requestLog)).isEqualTo(200);
@@ -75,28 +75,28 @@ class ArmeriaHttpClientAdapterTest {
     }
 
     @Test
-    public void statusCode_notAvailable() {
+    void statusCode_notAvailable() {
         when(requestLog.isAvailable(RequestLogAvailability.RESPONSE_HEADERS)).thenReturn(false);
         assertThat(ArmeriaHttpClientAdapter.get().statusCode(requestLog)).isNull();
         assertThat(ArmeriaHttpClientAdapter.get().statusCodeAsInt(requestLog)).isEqualTo(0);
     }
 
     @Test
-    public void authority() {
+    void authority() {
         when(requestLog.isAvailable(RequestLogAvailability.REQUEST_HEADERS)).thenReturn(true);
         when(requestLog.authority()).thenReturn("example.com");
         assertThat(ArmeriaHttpClientAdapter.get().authority(requestLog)).isEqualTo("example.com");
     }
 
     @Test
-    public void protocol() {
+    void protocol() {
         when(requestLog.isAvailable(RequestLogAvailability.SCHEME)).thenReturn(true);
         when(requestLog.scheme()).thenReturn(Scheme.of(SerializationFormat.NONE, SessionProtocol.HTTP));
         assertThat(ArmeriaHttpClientAdapter.get().protocol(requestLog)).isEqualTo("http");
     }
 
     @Test
-    public void serializationFormat() {
+    void serializationFormat() {
         when(requestLog.isAvailable(RequestLogAvailability.SCHEME)).thenReturn(true);
         when(requestLog.scheme()).thenReturn(Scheme.of(SerializationFormat.of("tjson"), SessionProtocol.HTTP));
         assertThat(ArmeriaHttpClientAdapter.get().serializationFormat(requestLog)).isEqualTo("tjson");
@@ -105,7 +105,7 @@ class ArmeriaHttpClientAdapterTest {
     }
 
     @Test
-    public void rpcMethod() {
+    void rpcMethod() {
         when(requestLog.isAvailable(RequestLogAvailability.REQUEST_CONTENT)).thenReturn(true);
         assertThat(ArmeriaHttpClientAdapter.get().rpcMethod(requestLog)).isNull();
 
@@ -116,7 +116,7 @@ class ArmeriaHttpClientAdapterTest {
     }
 
     @Test
-    public void requestHeader() {
+    void requestHeader() {
         when(requestLog.isAvailable(RequestLogAvailability.REQUEST_HEADERS)).thenReturn(true);
         final RequestHeaders requestHeaders = mock(RequestHeaders.class);
         when(requestLog.requestHeaders()).thenReturn(requestHeaders);

--- a/brave/src/test/java/com/linecorp/armeria/server/brave/ArmeriaHttpServerAdapterTest.java
+++ b/brave/src/test/java/com/linecorp/armeria/server/brave/ArmeriaHttpServerAdapterTest.java
@@ -48,19 +48,19 @@ class ArmeriaHttpServerAdapterTest {
     private RequestLog requestLog;
 
     @Test
-    public void path() {
+    void path() {
         when(requestLog.path()).thenReturn("/foo");
         assertThat(ArmeriaHttpServerAdapter.get().path(requestLog)).isEqualTo("/foo");
     }
 
     @Test
-    public void method() {
+    void method() {
         when(requestLog.method()).thenReturn(HttpMethod.GET);
         assertThat(ArmeriaHttpServerAdapter.get().method(requestLog)).isEqualTo("GET");
     }
 
     @Test
-    public void url() {
+    void url() {
         when(requestLog.isAvailable(RequestLogAvailability.SCHEME)).thenReturn(true);
         when(requestLog.isAvailable(RequestLogAvailability.REQUEST_HEADERS)).thenReturn(true);
         when(requestLog.scheme()).thenReturn(Scheme.of(SerializationFormat.NONE, SessionProtocol.HTTP));
@@ -72,7 +72,7 @@ class ArmeriaHttpServerAdapterTest {
     }
 
     @Test
-    public void statusCode() {
+    void statusCode() {
         when(requestLog.isAvailable(RequestLogAvailability.RESPONSE_HEADERS)).thenReturn(true);
         when(requestLog.status()).thenReturn(HttpStatus.OK);
         assertThat(ArmeriaHttpServerAdapter.get().statusCode(requestLog)).isEqualTo(200);
@@ -84,28 +84,28 @@ class ArmeriaHttpServerAdapterTest {
     }
 
     @Test
-    public void statusCode_notAvailable() {
+    void statusCode_notAvailable() {
         when(requestLog.isAvailable(RequestLogAvailability.RESPONSE_HEADERS)).thenReturn(false);
         assertThat(ArmeriaHttpServerAdapter.get().statusCode(requestLog)).isNull();
         assertThat(ArmeriaHttpServerAdapter.get().statusCodeAsInt(requestLog)).isEqualTo(0);
     }
 
     @Test
-    public void authority() {
+    void authority() {
         when(requestLog.isAvailable(RequestLogAvailability.REQUEST_HEADERS)).thenReturn(true);
         when(requestLog.authority()).thenReturn("example.com");
         assertThat(ArmeriaHttpServerAdapter.get().authority(requestLog)).isEqualTo("example.com");
     }
 
     @Test
-    public void protocol() {
+    void protocol() {
         when(requestLog.isAvailable(RequestLogAvailability.SCHEME)).thenReturn(true);
         when(requestLog.scheme()).thenReturn(Scheme.of(SerializationFormat.NONE, SessionProtocol.HTTP));
         assertThat(ArmeriaHttpServerAdapter.get().protocol(requestLog)).isEqualTo("http");
     }
 
     @Test
-    public void serializationFormat() {
+    void serializationFormat() {
         when(requestLog.isAvailable(RequestLogAvailability.SCHEME)).thenReturn(true);
         when(requestLog.scheme()).thenReturn(Scheme.of(SerializationFormat.of("tjson"), SessionProtocol.HTTP));
         assertThat(ArmeriaHttpServerAdapter.get().serializationFormat(requestLog)).isEqualTo("tjson");
@@ -115,7 +115,7 @@ class ArmeriaHttpServerAdapterTest {
     }
 
     @Test
-    public void rpcMethod() {
+    void rpcMethod() {
         when(requestLog.isAvailable(RequestLogAvailability.REQUEST_CONTENT)).thenReturn(true);
         assertThat(ArmeriaHttpServerAdapter.get().rpcMethod(requestLog)).isNull();
 
@@ -126,7 +126,7 @@ class ArmeriaHttpServerAdapterTest {
     }
 
     @Test
-    public void requestHeader() {
+    void requestHeader() {
         when(requestLog.isAvailable(RequestLogAvailability.REQUEST_HEADERS)).thenReturn(true);
         final RequestHeaders requestHeaders = mock(RequestHeaders.class);
         when(requestLog.requestHeaders()).thenReturn(requestHeaders);
@@ -135,7 +135,7 @@ class ArmeriaHttpServerAdapterTest {
     }
 
     @Test
-    public void parseClientIpAndPort() throws Exception {
+    void parseClientIpAndPort() throws Exception {
         when(requestLog.isAvailable(RequestLogAvailability.REQUEST_HEADERS)).thenReturn(true);
         final RequestHeaders requestHeaders = mock(RequestHeaders.class);
         when(requestLog.requestHeaders()).thenReturn(requestHeaders);
@@ -151,7 +151,7 @@ class ArmeriaHttpServerAdapterTest {
     }
 
     @Test
-    public void route() {
+    void route() {
         final ServiceRequestContext context = mock(ServiceRequestContext.class);
         when(requestLog.context()).thenReturn(context);
         when(context.route()).thenReturn(Route.builder().path("/foo/:bar/hoge").build());
@@ -159,7 +159,7 @@ class ArmeriaHttpServerAdapterTest {
     }
 
     @Test
-    public void route_prefix() {
+    void route_prefix() {
         final ServiceRequestContext context = mock(ServiceRequestContext.class);
         when(requestLog.context()).thenReturn(context);
         when(context.route()).thenReturn(Route.builder().path("exact:/foo").build());
@@ -167,10 +167,18 @@ class ArmeriaHttpServerAdapterTest {
     }
 
     @Test
-    public void route_pathWithPrefix() {
+    void route_pathWithPrefix_glob() {
         final ServiceRequestContext context = mock(ServiceRequestContext.class);
         when(requestLog.context()).thenReturn(context);
         when(context.route()).thenReturn(Route.builder().pathWithPrefix("/foo/", "glob:bar").build());
-        assertThat(ArmeriaHttpServerAdapter.get().route(requestLog)).isEqualTo("/foo/ ^/(?:.+/)?bar$");
+        assertThat(ArmeriaHttpServerAdapter.get().route(requestLog)).isEqualTo("/foo/**/bar");
+    }
+
+    @Test
+    void route_pathWithPrefix_regex() {
+        final ServiceRequestContext context = mock(ServiceRequestContext.class);
+        when(requestLog.context()).thenReturn(context);
+        when(context.route()).thenReturn(Route.builder().pathWithPrefix("/foo/", "regex:(bar|baz)").build());
+        assertThat(ArmeriaHttpServerAdapter.get().route(requestLog)).isEqualTo("/foo/(bar|baz)");
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/Route.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Route.java
@@ -90,7 +90,11 @@ public interface Route {
      *   <li>PARAMETERIZED: {@code [ "/foo/:", "/foo/:" ]} (The trie path is the same.)</li>
      * </ul>
      *
-     * {@link RoutePathType#REGEX} has only one path that represents it. e.g, {@code [ "^/(?<foo>.*)$" ]}
+     * <p>{@link RoutePathType#REGEX} may have one or two paths. If the {@link Route} was created from a glob
+     * pattern, it will have two paths where the first one is the regular expression and the second one
+     * is the glob pattern, e.g. {@code [ "^/(?(.+)/)?foo$", "/*&#42;/foo" ]}.
+     * If not created from a glob pattern, it will have only one path, which is the regular expression,
+     * e.g, {@code [ "^/(?<foo>.*)$" ]}</p>
      *
      * <p>{@link RoutePathType#REGEX_WITH_PREFIX} has two paths. The first one is the regex and the second
      * one is the path. e.g, {@code [ "^/(?<foo>.*)$", "/bar/" ]}

--- a/core/src/main/java/com/linecorp/armeria/server/RouteBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RouteBuilder.java
@@ -73,13 +73,13 @@ public class RouteBuilder {
         return pathMapping(getPathMapping(pathPattern));
     }
 
-    private static PathMapping globPathMapping(String glob) {
+    private static PathMapping globPathMapping(String glob, int numGroupsToSkip) {
         if (glob.startsWith("/") && !glob.contains("*")) {
             // Does not have a pattern matcher.
             return new ExactPathMapping(glob);
         }
 
-        return new GlobPathMapping(glob);
+        return new GlobPathMapping(glob, numGroupsToSkip);
     }
 
     RouteBuilder pathMapping(PathMapping pathMapping) {
@@ -138,7 +138,11 @@ public class RouteBuilder {
      * path components recursively.
      */
     public RouteBuilder glob(String glob) {
-        return pathMapping(globPathMapping(requireNonNull(glob, "glob")));
+        return glob(glob, 0);
+    }
+
+    private RouteBuilder glob(String glob, int numGroupsToSkip) {
+        return pathMapping(globPathMapping(requireNonNull(glob, "glob"), numGroupsToSkip));
     }
 
     /**
@@ -195,6 +199,8 @@ public class RouteBuilder {
             final String glob = pathPattern.substring(GLOB.length());
             if (glob.startsWith("/")) {
                 return glob(concatPaths(prefix, glob));
+            } else {
+                return glob(concatPaths(prefix + "**/", glob), 1);
             }
         }
 
@@ -317,7 +323,7 @@ public class RouteBuilder {
         }
         if (pathPattern.startsWith(GLOB)) {
             final String glob = pathPattern.substring(GLOB.length());
-            return globPathMapping(glob);
+            return globPathMapping(glob, 0);
         }
         if (pathPattern.startsWith(REGEX)) {
             return new RegexPathMapping(Pattern.compile(pathPattern.substring(REGEX.length())));

--- a/core/src/test/java/com/linecorp/armeria/server/PathWithPrefixTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/PathWithPrefixTest.java
@@ -26,11 +26,11 @@ class PathWithPrefixTest {
     void prefix() {
         Route route = Route.builder().pathWithPrefix("/foo/", "glob:/bar/**").build();
         assertThat(route.pathType()).isSameAs(RoutePathType.REGEX);
-        assertThat(route.paths()).containsExactly("^/foo/bar/(.*)$");
+        assertThat(route.paths()).containsExactly("^/foo/bar/(.*)$", "/foo/bar/**");
 
         route = Route.builder().pathWithPrefix("/foo/", "glob:bar").build();
-        assertThat(route.pathType()).isSameAs(RoutePathType.REGEX_WITH_PREFIX);
-        assertThat(route.paths()).containsExactly("^/(?:.+/)?bar$", "/foo/");
+        assertThat(route.pathType()).isSameAs(RoutePathType.REGEX);
+        assertThat(route.paths()).containsExactly("^/foo/(?:.+/)?bar$", "/foo/**/bar");
     }
 
     @Test
@@ -51,7 +51,7 @@ class PathWithPrefixTest {
         assertThat(route.meterTag()).isEqualTo("glob:/foo/bar/**");
 
         route = Route.builder().pathWithPrefix("/foo/", "glob:bar").build();
-        assertThat(route.meterTag()).isEqualTo("prefix:/foo/,glob:/**/bar");
+        assertThat(route.meterTag()).isEqualTo("glob:/foo/**/bar");
 
         route = Route.builder().pathWithPrefix("/foo/", "regex:/(foo|bar)").build();
         assertThat(route.meterTag()).isEqualTo("prefix:/foo/,regex:/(foo|bar)");

--- a/core/src/test/java/com/linecorp/armeria/server/RouteTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/RouteTest.java
@@ -68,15 +68,60 @@ class RouteTest {
 
         route = Route.builder().path("glob:/home/*/files/**").build();
         assertThat(route.pathType()).isSameAs(RoutePathType.REGEX);
-        assertThat(route.paths()).containsExactly("^/home/([^/]+)/files/(.*)$");
+        assertThat(route.paths()).containsExactly("^/home/([^/]+)/files/(.*)$", "/home/*/files/**");
 
         route = Route.builder().path("glob:foo").build();
         assertThat(route.pathType()).isSameAs(RoutePathType.REGEX);
-        assertThat(route.paths()).containsExactly("^/(?:.+/)?foo$");
+        assertThat(route.paths()).containsExactly("^/(?:.+/)?foo$", "/**/foo");
 
         route = Route.builder().path("regex:^/files/(?<filePath>.*)$").build();
         assertThat(route.pathType()).isSameAs(RoutePathType.REGEX);
         assertThat(route.paths()).containsExactly("^/files/(?<filePath>.*)$");
+    }
+
+    @Test
+    void routePathWithPrefix() {
+        Route route;
+
+        route = Route.builder().pathWithPrefix("/foo", "/bar").build();
+        assertThat(route.pathType()).isSameAs(RoutePathType.EXACT);
+        assertThat(route.paths()).containsExactly("/foo/bar", "/foo/bar");
+
+        route = Route.builder().pathWithPrefix("/foo", "/bar/{baz}").build();
+        assertThat(route.pathType()).isSameAs(RoutePathType.PARAMETERIZED);
+        assertThat(route.paths()).containsExactly("/foo/bar/:", "/foo/bar/:");
+
+        route = Route.builder().pathWithPrefix("/bar", "/baz/:qux").build();
+        assertThat(route.pathType()).isSameAs(RoutePathType.PARAMETERIZED);
+        assertThat(route.paths()).containsExactly("/bar/baz/:", "/bar/baz/:");
+
+        route = Route.builder().pathWithPrefix("/foo", "exact:/:bar/baz").build();
+        assertThat(route.pathType()).isSameAs(RoutePathType.EXACT);
+        assertThat(route.paths()).containsExactly("/foo/:bar/baz", "/foo/:bar/baz");
+
+        route = Route.builder().pathWithPrefix("/foo", "prefix:/").build();
+        assertThat(route.pathType()).isSameAs(RoutePathType.PREFIX);
+        assertThat(route.paths()).containsExactly("/foo/", "/foo/*");
+
+        route = Route.builder().pathWithPrefix("/foo", "prefix:/bar/baz").build();
+        assertThat(route.pathType()).isSameAs(RoutePathType.PREFIX);
+        assertThat(route.paths()).containsExactly("/foo/bar/baz/", "/foo/bar/baz/*");
+
+        route = Route.builder().pathWithPrefix("/foo", "glob:/bar/baz").build();
+        assertThat(route.pathType()).isSameAs(RoutePathType.EXACT);
+        assertThat(route.paths()).containsExactly("/foo/bar/baz", "/foo/bar/baz");
+
+        route = Route.builder().pathWithPrefix("/foo", "glob:/home/*/files/**").build();
+        assertThat(route.pathType()).isSameAs(RoutePathType.REGEX);
+        assertThat(route.paths()).containsExactly("^/foo/home/([^/]+)/files/(.*)$", "/foo/home/*/files/**");
+
+        route = Route.builder().pathWithPrefix("/foo", "glob:bar").build();
+        assertThat(route.pathType()).isSameAs(RoutePathType.REGEX);
+        assertThat(route.paths()).containsExactly("^/foo/(?:.+/)?bar$", "/foo/**/bar");
+
+        route = Route.builder().pathWithPrefix("/foo", "regex:^/files/(?<filePath>.*)$").build();
+        assertThat(route.pathType()).isSameAs(RoutePathType.REGEX_WITH_PREFIX);
+        assertThat(route.paths()).containsExactly("^/files/(?<filePath>.*)$", "/foo/");
     }
 
     @Test


### PR DESCRIPTION
Related: #1906
Motivation:

When a user builds a `Route` with `pathWithPrefix()`, the following
route:

    pathWithPrefix("/prefix", "glob:foo")

can be simplified into:

    path("glob:/prefix/**/foo")

only except that the `**` must not be captured.

Modifications:

- Simplify a glob path mapping with prefix into a simple glob path
  mapping, not into `PrefixPathMapping`.
- Add `numGroupsToSkip` option to `GlobPathMapping` so that we can skip
  the `**` group we added implicitly.
- Miscellaneous:
  - Address the comments which were not addressed in #1906
    - Javadoc fixes
    - Removal of redundant `public` modifiers
    - Do not insert between `prefix` and `regex` when generating a span
      name for `PrefixPathMapping`.

Result:

- Much cleaner Brave span names and meter tags for the route with a
  prefix and a glob.
- Potentially better performance for the route with a prefix and a glob.