### PR TITLE
Enable DeferredHttpResponse to have a defaultSubscriberExecutor

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingHttpClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingHttpClient.java
@@ -25,6 +25,8 @@ import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 
+import io.netty.channel.EventLoop;
+
 /**
  * A {@link Client} decorator that limits the concurrent number of active HTTP requests.
  *
@@ -67,9 +69,10 @@ public final class ConcurrencyLimitingHttpClient extends ConcurrencyLimitingClie
 
     @Override
     protected Deferred<HttpResponse> defer(ClientRequestContext ctx, HttpRequest req) throws Exception {
+        final EventLoop eventLoop = ctx.eventLoop();
         return new Deferred<HttpResponse>() {
             private final CompletableFuture<HttpResponse> responseFuture = new CompletableFuture<>();
-            private final HttpResponse res = HttpResponse.from(responseFuture, ctx.eventLoop());
+            private final HttpResponse res = HttpResponse.from(responseFuture, eventLoop);
 
             @Override
             public HttpResponse response() {

--- a/core/src/main/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingHttpClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingHttpClient.java
@@ -69,7 +69,7 @@ public final class ConcurrencyLimitingHttpClient extends ConcurrencyLimitingClie
     protected Deferred<HttpResponse> defer(ClientRequestContext ctx, HttpRequest req) throws Exception {
         return new Deferred<HttpResponse>() {
             private final CompletableFuture<HttpResponse> responseFuture = new CompletableFuture<>();
-            private final HttpResponse res = HttpResponse.from(responseFuture);
+            private final HttpResponse res = HttpResponse.from(responseFuture, ctx.eventLoop());
 
             @Override
             public HttpResponse response() {

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingHttpClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingHttpClient.java
@@ -136,7 +136,7 @@ public final class RetryingHttpClient extends RetryingClient<HttpRequest, HttpRe
     protected HttpResponse doExecute(ClientRequestContext ctx, HttpRequest req) throws Exception {
         final boolean hasInitialAuthority = !isNullOrEmpty(req.headers().authority());
         final CompletableFuture<HttpResponse> responseFuture = new CompletableFuture<>();
-        final HttpResponse res = HttpResponse.from(responseFuture);
+        final HttpResponse res = HttpResponse.from(responseFuture, ctx.eventLoop());
         final HttpRequestDuplicator reqDuplicator = new HttpRequestDuplicator(req, 0, ctx.eventLoop());
         doExecute0(ctx, reqDuplicator, req, res, responseFuture, hasInitialAuthority);
         return res;

--- a/core/src/main/java/com/linecorp/armeria/common/DeferredHttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DeferredHttpResponse.java
@@ -18,7 +18,11 @@ package com.linecorp.armeria.common;
 
 import java.util.concurrent.CompletionStage;
 
+import javax.annotation.Nullable;
+
 import com.linecorp.armeria.common.stream.DeferredStreamMessage;
+
+import io.netty.util.concurrent.EventExecutor;
 
 /**
  * An {@link HttpResponse} whose stream is published later by another {@link HttpResponse}. It is used when
@@ -29,6 +33,17 @@ import com.linecorp.armeria.common.stream.DeferredStreamMessage;
 @Deprecated
 public class DeferredHttpResponse extends DeferredStreamMessage<HttpObject> implements HttpResponse {
 
+    @Nullable
+    private final EventExecutor executor;
+
+    public DeferredHttpResponse() {
+        this.executor = null;
+    }
+
+    DeferredHttpResponse(EventExecutor executor) {
+        this.executor = executor;
+    }
+
     /**
      * Sets the delegate {@link HttpResponse} which will publish the stream actually.
      *
@@ -37,5 +52,13 @@ public class DeferredHttpResponse extends DeferredStreamMessage<HttpObject> impl
      */
     public void delegate(HttpResponse delegate) {
         super.delegate(delegate);
+    }
+
+    @Override
+    protected EventExecutor defaultSubscriberExecutor() {
+        if (executor != null) {
+            return executor;
+        }
+        return super.defaultSubscriberExecutor();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -77,14 +77,14 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
      * closed with the same cause as well.
      *
      * @param stage the {@link CompletionStage} which will produce the actual {@link HttpResponse}
-     * @param defaultSubscriberExecutor the {@link EventExecutor} which will be used when a user subscribes
-     *                                  the returned {@link HttpResponse} using {@link #subscribe(Subscriber)}
-     *                                  or {@link #subscribe(Subscriber, SubscriptionOption...)}.
+     * @param subscriberExecutor the {@link EventExecutor} which will be used when a user subscribes
+     *                           the returned {@link HttpResponse} using {@link #subscribe(Subscriber)}
+     *                           or {@link #subscribe(Subscriber, SubscriptionOption...)}.
      */
     static HttpResponse from(CompletionStage<? extends HttpResponse> stage,
-                             EventExecutor defaultSubscriberExecutor) {
-        requireNonNull(defaultSubscriberExecutor, "defaultSubscriberExecutor");
-        final DeferredHttpResponse res = new DeferredHttpResponse(defaultSubscriberExecutor);
+                             EventExecutor subscriberExecutor) {
+        requireNonNull(subscriberExecutor, "subscriberExecutor");
+        final DeferredHttpResponse res = new DeferredHttpResponse(subscriberExecutor);
         delegateWhenStageComplete(stage, res);
         return res;
     }

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponseUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponseUtil.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.concurrent.CompletionStage;
+
+import com.linecorp.armeria.common.util.Exceptions;
+
+final class HttpResponseUtil {
+
+    static void delegateWhenStageComplete(CompletionStage<? extends HttpResponse> stage,
+                                          DeferredHttpResponse res) {
+        requireNonNull(stage, "stage");
+        stage.handle((delegate, thrown) -> {
+            if (thrown != null) {
+                res.close(Exceptions.peel(thrown));
+            } else if (delegate == null) {
+                res.close(new NullPointerException("delegate stage produced a null response: " + stage));
+            } else {
+                res.delegate(delegate);
+            }
+            return null;
+        });
+    }
+
+    private HttpResponseUtil() {}
+}

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/UnaryGrpcClient.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/UnaryGrpcClient.java
@@ -174,7 +174,7 @@ public class UnaryGrpcClient {
                                deframer.deframe(msg.content(), true);
                            }
                            return responseFuture;
-                       }));
+                       }), ctx.eventLoop());
         }
     }
 }


### PR DESCRIPTION
Motivation:
If a user calls `client.get(...).aggregate()`, it uses the `EventLoop` which is used for writing the elements
to the `HttpResponse` to subscribe. So the logic executed by one `EventLoop` seamlessly. However, if there's
a decorator which uses `DeferredHttpResponse` such as `ConcurrencyLimitingHttpClient` or `RetryingClient`,
it's executed not by one `EventLoop` but two `EventLoop`s which switching situation happens.

Modifications:
- Add `HttpResponse.from(stage, defaultSubscriberExecutor)`.
- Add a constructor which takes an `EventExecutor` to `DeferredHttpResponse`.
  - `DeferredHttpResponse` is public but it's deprecated a long time ago, so perhaps don't need to have a class which extends it.

Result:
- Aggregating `HttpResponse` becomes more efficient when `ConcurrencyLimitingHttpClient` or `RetryingClient` is used.
- Ready to move making connections to the beginning of client execution