### PR TITLE
[WIP] Add HttpData#close, HttpData#toByteBuffer, and docs.

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/ByteRangeHttpData.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ByteRangeHttpData.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.common;
 
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 
 /**
@@ -49,6 +50,11 @@ class ByteRangeHttpData extends AbstractHttpData {
     @Override
     public int length() {
         return length;
+    }
+
+    @Override
+    public ByteBuffer toByteBuffer() {
+        return ByteBuffer.wrap(array, offset, length);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/HttpData.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpData.java
@@ -34,7 +34,6 @@ import com.linecorp.armeria.unsafe.ByteBufHttpData;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.ByteBufUtil;
-import io.netty.util.ReferenceCountUtil;
 import it.unimi.dsi.fastutil.io.FastByteArrayInputStream;
 
 /**
@@ -430,7 +429,8 @@ public interface HttpData extends HttpObject, AutoCloseable {
      * A no-op in most cases. This method will only have an effect when using pooled objects, e.g., when using
      * methods like {@link HttpResponse#aggregateWithPooledObjects(ByteBufAllocator)}. If not using pooled
      * objects, you can ignore this method. If you are, please see the documentation at
-     * {@link com.linecorp.armeria.unsafe.ByteBufHttpData}.
+     * {@link com.linecorp.armeria.unsafe.ByteBufHttpData}. {@link #close()} can be called multiple times, only
+     * the first will have an effect.
      */
     @Override
     default void close() {

--- a/core/src/main/java/com/linecorp/armeria/common/HttpData.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpData.java
@@ -388,12 +388,6 @@ public interface HttpData extends HttpObject, AutoCloseable {
 
     /**
      * Returns a new {@link InputStream} that is sourced from this data.
-     *
-     * <p>Note, if this {@link HttpData} is pooled (e.g., it is the result of a call to
-     * {@link HttpResponse#aggregateWithPooledObjects(ByteBufAllocator)}), then this {@link InputStream} will
-     * increase the reference count of the underlying buffer. Make sure to call {@link InputStream#close()},
-     * usually using a try-with-resources invocation, to release this extra reference. And as usual, don't
-     * forget to call {@link ReferenceCountUtil#release(Object)} on this {@link HttpData} itself too.
      */
     default InputStream toInputStream() {
         return new FastByteArrayInputStream(array());

--- a/core/src/main/java/com/linecorp/armeria/common/HttpData.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpData.java
@@ -44,7 +44,7 @@ import it.unimi.dsi.fastutil.io.FastByteArrayInputStream;
  * <p>Implementations should generally extend {@link AbstractHttpData} to interact with other {@link HttpData}
  * implementations.
  */
-public interface HttpData extends HttpObject {
+public interface HttpData extends HttpObject, AutoCloseable {
 
     /**
      * Empty HTTP/2 data.
@@ -422,5 +422,24 @@ public interface HttpData extends HttpObject {
      */
     default Reader toReaderAscii() {
         return toReader(StandardCharsets.US_ASCII);
+    }
+
+    /**
+     * Returns a new {@link ByteBuffer} that wraps this data. Mutations to the {@link ByteBuffer} will be
+     * reflected in this {@link HttpData} and vice versa.
+     */
+    default ByteBuffer toByteBuffer() {
+        return ByteBuffer.wrap(array());
+    }
+
+    /**
+     * A no-op in most cases. This method will only have an effect when using pooled objects, e.g., when using
+     * methods like {@link HttpResponse#aggregateWithPooledObjects(ByteBufAllocator)}. If not using pooled
+     * objects, you can ignore this method. If you are, please see the documentation at
+     * {@link com.linecorp.armeria.unsafe.ByteBufHttpData}.
+     */
+    @Override
+    default void close() {
+        // No-op
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
@@ -369,7 +369,8 @@ public interface HttpRequest extends Request, StreamMessage<HttpObject> {
      * Aggregates this request. The returned {@link CompletableFuture} will be notified when the content and
      * the trailers of the request is received fully. {@link AggregatedHttpRequest#content()} will
      * return a pooled object, and the caller must ensure to release it. If you don't know what this means,
-     * use {@link #aggregate()}.
+     * use {@link #aggregate()}. If you are considering using this method, please read through the documentation
+     * at {@link com.linecorp.armeria.unsafe.ByteBufHttpData} first.
      */
     default CompletableFuture<AggregatedHttpRequest> aggregateWithPooledObjects(ByteBufAllocator alloc) {
         requireNonNull(alloc, "alloc");
@@ -383,7 +384,8 @@ public interface HttpRequest extends Request, StreamMessage<HttpObject> {
      * Aggregates this request. The returned {@link CompletableFuture} will be notified when the content and
      * the trailers of the request is received fully. {@link AggregatedHttpRequest#content()} will
      * return a pooled object, and the caller must ensure to release it. If you don't know what this means,
-     * use {@link #aggregate()}.
+     * use {@link #aggregate()}. If you are considering using this method, please read through the documentation
+     * at {@link com.linecorp.armeria.unsafe.ByteBufHttpData} first.
      */
     default CompletableFuture<AggregatedHttpRequest> aggregateWithPooledObjects(
             EventExecutor executor, ByteBufAllocator alloc) {

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -372,7 +372,8 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
      * Aggregates this response. The returned {@link CompletableFuture} will be notified when the content and
      * the trailers of the response are received fully. {@link AggregatedHttpResponse#content()} will
      * return a pooled object, and the caller must ensure to release it. If you don't know what this means,
-     * use {@link #aggregate()}.
+     * use {@link #aggregate()}. If you are considering using this method, please read through the documentation
+     * at {@link com.linecorp.armeria.unsafe.ByteBufHttpData} first.
      */
     default CompletableFuture<AggregatedHttpResponse> aggregateWithPooledObjects(ByteBufAllocator alloc) {
         requireNonNull(alloc, "alloc");
@@ -386,7 +387,8 @@ public interface HttpResponse extends Response, StreamMessage<HttpObject> {
      * Aggregates this response. The returned {@link CompletableFuture} will be notified when the content and
      * the trailers of the request is received fully. {@link AggregatedHttpResponse#content()} will
      * return a pooled object, and the caller must ensure to release it. If you don't know what this means,
-     * use {@link #aggregate()}.
+     * use {@link #aggregate()}. If you are considering using this method, please read through the documentation
+     * at {@link com.linecorp.armeria.unsafe.ByteBufHttpData} first.
      */
     default CompletableFuture<AggregatedHttpResponse> aggregateWithPooledObjects(
             EventExecutor executor, ByteBufAllocator alloc) {

--- a/core/src/main/java/com/linecorp/armeria/common/stream/SubscriptionOption.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/SubscriptionOption.java
@@ -34,6 +34,8 @@ public enum SubscriptionOption {
     /**
      * To receive the pooled {@link ByteBuf} and {@link ByteBufHolder} as is, without making a copy.
      * If you don't know what this means, do not specify this when you subscribe the {@link StreamMessage}.
+     * If you are considering using this option, please read through the documentation at
+     * {@link com.linecorp.armeria.unsafe.ByteBufHttpData} first.
      */
     WITH_POOLED_OBJECTS,
 

--- a/core/src/main/java/com/linecorp/armeria/unsafe/ByteBufHttpData.java
+++ b/core/src/main/java/com/linecorp/armeria/unsafe/ByteBufHttpData.java
@@ -57,7 +57,7 @@ import io.netty.buffer.Unpooled;
  * failure to release the reference will result in a memory leak and poor performance. You must make sure to do
  * this by calling {@link HttpData#close()}, usually in a try-with-resources structure to avoid side effects.
  *
- * <p>For example, <pre>{code
+ * <p>For example, <pre>{@code
  *
  * HttpResponse response = client.get("/");
  * response.aggregateWithPooledObjects(ctx.alloc(), ctx.executor())

--- a/core/src/main/java/com/linecorp/armeria/unsafe/ByteBufHttpData.java
+++ b/core/src/main/java/com/linecorp/armeria/unsafe/ByteBufHttpData.java
@@ -86,7 +86,7 @@ import io.netty.buffer.Unpooled;
  * <h3>Writing code compatible with both pooled and unpooled objects</h3>
  *
  * <p>When requesting pooled objects, it is not guaranteed that all {@link HttpData} are actually pooled, e.g.,
- * a decorator may not understand pooled objects at which points objects will be copied to the Java heap. Code
+ * a decorator may not understand pooled objects, so it will copy objects onto the Java heap. Code
  * will still be able to operate on any type of {@link HttpData} as long as it calls
  * {@link HttpData#close()} and uses methods like {@link HttpData#toInputStream()},
  * {@link HttpData#toByteBuffer()}, or {@link HttpData#toStringUtf8()} to access the content. The above example

--- a/core/src/test/java/com/linecorp/armeria/common/HttpDataTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/HttpDataTest.java
@@ -27,6 +27,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import com.linecorp.armeria.unsafe.ByteBufHttpData;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
@@ -116,6 +118,17 @@ class HttpDataTest {
             payload.setByte(1, 5);
             assertThat(ByteBufUtil.getBytes(payload)).containsExactly(1, 5, 3, 4);
             assertThat(data.array()).containsExactly(1, 2, 3, 4);
+        }
+
+        @Test
+        void close() {
+            final ByteBufHttpData data = new ByteBufHttpData(payload, false);
+            assertThat(data.refCnt()).isOne();
+            data.close();
+            assertThat(data.refCnt()).isZero();
+            // Can call close multiple times.
+            data.close();
+            assertThat(data.refCnt()).isZero();
         }
     }
 


### PR DESCRIPTION
Also changes `ByteBufHttpData#toInputStream` to not create a new reference / release one. I think for usages of `HttpData`, it's clear enough that all the operations should happen in the scope of the try-with-resources so no need to worry about transfer of `InputStream` out of the block.

Fixes #1936
