### PR TITLE
Wait for delegate endpoints before beginning health check.

### DIFF
--- a/benchmarks/src/jmh/java/com/linecorp/armeria/core/client/endpoint/DnsEndpointGroupBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/core/client/endpoint/DnsEndpointGroupBenchmark.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.core.client.endpoint;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+
+import com.linecorp.armeria.client.endpoint.dns.DnsAddressEndpointGroup;
+import com.linecorp.armeria.client.endpoint.healthcheck.HttpHealthCheckedEndpointGroup;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.ServerBuilder;
+
+@State(Scope.Thread)
+public class DnsEndpointGroupBenchmark {
+
+    private static final AggregatedHttpResponse OK = AggregatedHttpResponse.of(HttpStatus.OK);
+
+    private Server server;
+    private HttpHealthCheckedEndpointGroup endpointGroup;
+
+    @Setup(Level.Trial)
+    public void startServer() {
+        server = new ServerBuilder()
+                .service("/health", (ctx, req) -> HttpResponse.of(OK))
+                .build();
+        server.start().join();
+    }
+
+    @TearDown(Level.Trial)
+    public void stopServer() {
+        server.stop();
+    }
+
+    @Setup(Level.Invocation)
+    public void setUp() {
+        endpointGroup = HttpHealthCheckedEndpointGroup.of(
+                DnsAddressEndpointGroup.of("localhost",
+                                           server.activePort().get().localAddress().getPort()), "/health");
+    }
+
+    @TearDown(Level.Invocation)
+    public void tearDown() {
+        endpointGroup.close();
+    }
+
+    @Benchmark
+    public Object resolveLocalhost() throws Exception {
+        return endpointGroup.awaitInitialEndpoints();
+    }
+
+//    public static void main(String[] args) throws Exception {
+//        DnsEndpointGroupBenchmark benchmark = new DnsEndpointGroupBenchmark();
+//        benchmark.startServer();
+//        for (int i = 0; i < 100; i++) {
+//            benchmark.setUp();
+//            long currentTime = System.nanoTime();
+//            benchmark.resolveLocalhost();
+//            System.out.println(
+//                    "Took " + TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - currentTime) + " ms");
+//            benchmark.tearDown();
+//        }
+//        benchmark.stopServer();
+//    }
+}

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/core/client/endpoint/DnsEndpointGroupBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/core/client/endpoint/DnsEndpointGroupBenchmark.java
@@ -68,18 +68,4 @@ public class DnsEndpointGroupBenchmark {
     public Object resolveLocalhost() throws Exception {
         return endpointGroup.awaitInitialEndpoints();
     }
-
-//    public static void main(String[] args) throws Exception {
-//        DnsEndpointGroupBenchmark benchmark = new DnsEndpointGroupBenchmark();
-//        benchmark.startServer();
-//        for (int i = 0; i < 100; i++) {
-//            benchmark.setUp();
-//            long currentTime = System.nanoTime();
-//            benchmark.resolveLocalhost();
-//            System.out.println(
-//                    "Took " + TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - currentTime) + " ms");
-//            benchmark.tearDown();
-//        }
-//        benchmark.stopServer();
-//    }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroup.java
@@ -18,12 +18,7 @@ package com.linecorp.armeria.client.endpoint;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
 import java.util.List;
-import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -49,36 +44,9 @@ public class DynamicEndpointGroup extends AbstractListenable<List<Endpoint>> imp
     /**
      * Returns the {@link CompletableFuture} which is completed when the initial {@link Endpoint}s are ready.
      */
+    @Override
     public CompletableFuture<List<Endpoint>> initialEndpointsFuture() {
         return initialEndpointsFuture;
-    }
-
-    /**
-     * Waits until the initial {@link Endpoint}s are ready.
-     *
-     * @throws CancellationException if {@link #close()} was called before the initial {@link Endpoint}s are set
-     */
-    public List<Endpoint> awaitInitialEndpoints() throws InterruptedException {
-        try {
-            return initialEndpointsFuture.get();
-        } catch (ExecutionException e) {
-            throw new CompletionException(e.getCause());
-        }
-    }
-
-    /**
-     * Waits until the initial {@link Endpoint}s are ready, with timeout.
-     *
-     * @throws CancellationException if {@link #close()} was called before the initial {@link Endpoint}s are set
-     * @throws TimeoutException if the initial {@link Endpoint}s are not set until timeout
-     */
-    public List<Endpoint> awaitInitialEndpoints(long timeout, TimeUnit unit)
-            throws InterruptedException, TimeoutException {
-        try {
-            return initialEndpointsFuture.get(timeout, unit);
-        } catch (ExecutionException e) {
-            throw new CompletionException(e.getCause());
-        }
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/StaticEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/StaticEndpointGroup.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.client.endpoint;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 import com.google.common.collect.ImmutableList;
 
@@ -32,13 +33,13 @@ public final class StaticEndpointGroup implements EndpointGroup {
 
     private final List<Endpoint> endpoints;
 
+    private final CompletableFuture<List<Endpoint>> initialEndpointsFuture;
+
     /**
      * Creates a new instance.
      */
     public StaticEndpointGroup(Endpoint... endpoints) {
-        requireNonNull(endpoints, "endpoints");
-
-        this.endpoints = ImmutableList.copyOf(endpoints);
+        this(ImmutableList.copyOf(requireNonNull(endpoints, "endpoints")));
     }
 
     /**
@@ -48,11 +49,18 @@ public final class StaticEndpointGroup implements EndpointGroup {
         requireNonNull(endpoints, "endpoints");
 
         this.endpoints = ImmutableList.copyOf(endpoints);
+
+        initialEndpointsFuture = CompletableFuture.completedFuture(this.endpoints);
     }
 
     @Override
     public List<Endpoint> endpoints() {
         return endpoints;
+    }
+
+    @Override
+    public CompletableFuture<List<Endpoint>> initialEndpointsFuture() {
+        return initialEndpointsFuture;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
@@ -91,6 +91,10 @@ public abstract class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
     protected void init() {
         checkState(scheduledCheck == null, "init() must only be called once.");
 
+        if (delegate instanceof DynamicEndpointGroup) {
+            ((DynamicEndpointGroup) delegate).initialEndpointsFuture().join();
+        }
+
         checkAndUpdateHealthyServers().join();
         scheduleCheckAndUpdateHealthyServers();
     }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
@@ -91,9 +91,7 @@ public abstract class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
     protected void init() {
         checkState(scheduledCheck == null, "init() must only be called once.");
 
-        if (delegate instanceof DynamicEndpointGroup) {
-            ((DynamicEndpointGroup) delegate).initialEndpointsFuture().join();
-        }
+        delegate.initialEndpointsFuture().join();
 
         checkAndUpdateHealthyServers().join();
         scheduleCheckAndUpdateHealthyServers();


### PR DESCRIPTION
Also moves logic for waiting for endpoints to `EndpointGroup`. Many of our groups just delegate, so aren't `DynamicEndpointGroup`, but users shouldn't have to know whether a group is dynamic or not to do the initial endpoint wait.

I noticed when writing tests that use a health checked client, they were extremely slow. Investigating, I realized it's almost impossible for a health checked endpoint of a dns endpoint to resolve endpoints without waiting one interval of retry, which defaults to relatively slow 3 seconds, since health checking starts within microseconds - even a fast DNS resolution will take milliseconds. It seems too tedious to require users to await on DNS endpoint groups, before then constructing a health checked one, and waiting on it. 

I'm not so confident that sticking a `join` into a constructor is a good idea though. Haven't come up with any better ideas though.

While writing this, I also realized that `OrElseEndpointGroup` (and the newly introduced `CompositeEndpointGroup` do not support waiting for initial endpoints. Going to need to fix that too in another PR.