### PR TITLE
Don't add a second translated header when it already exists.

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -40,7 +40,6 @@ dependencies {
     // Bouncy Castle
     compile 'org.bouncycastle:bcprov-jdk15on'
 
-
     // Jetty, for testing interoperability with other servers.
     testCompile 'org.eclipse.jetty:jetty-webapp'
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -39,6 +39,10 @@ dependencies {
 
     // Bouncy Castle
     compile 'org.bouncycastle:bcprov-jdk15on'
+
+
+    // Jetty, for testing interoperability with other servers.
+    testCompile 'org.eclipse.jetty:jetty-webapp'
 }
 
 sourceSets {

--- a/core/src/main/java/com/linecorp/armeria/internal/ArmeriaHttpUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/ArmeriaHttpUtil.java
@@ -868,7 +868,7 @@ public final class ArmeriaHttpUtil {
                 final AsciiString name = entry.getKey();
                 final String value = entry.getValue();
                 final AsciiString translatedName = translations.get(name);
-                if (translatedName != null) {
+                if (translatedName != null && !inputHeaders.contains(translatedName)) {
                     outputHeaders.add(translatedName, value);
                     continue;
                 }

--- a/core/src/main/java/com/linecorp/armeria/internal/ArmeriaHttpUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/ArmeriaHttpUtil.java
@@ -214,7 +214,9 @@ public final class ArmeriaHttpUtil {
     }
 
     /**
-     * Translations from HTTP/2 header name to the HTTP/1.x equivalent.
+     * Translations from HTTP/2 header name to the HTTP/1.x equivalent. Currently, we expect these headers to
+     * only allow a single value in the request. If adding headers that can potentially have multiple values,
+     * please check the usage in code accordingly.
      */
     private static final CharSequenceMap REQUEST_HEADER_TRANSLATIONS = new CharSequenceMap();
     private static final CharSequenceMap RESPONSE_HEADER_TRANSLATIONS = new CharSequenceMap();

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientIntegrationTest.java
@@ -30,11 +30,24 @@ import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.IntFunction;
 
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
@@ -727,6 +740,47 @@ class HttpClientIntegrationTest {
         assertEquals(HttpStatus.OK, response.status());
 
         clientFactory.close();
+    }
+
+    @Nested
+    @TestInstance(Lifecycle.PER_CLASS)
+    class JettyInterop {
+
+        org.eclipse.jetty.server.Server jetty;
+
+        @BeforeAll
+        void startJetty() throws Exception {
+            jetty = new org.eclipse.jetty.server.Server(0);
+            jetty.setHandler(new AbstractHandler() {
+                @Override
+                public void handle(String target, Request baseRequest, HttpServletRequest request,
+                                   HttpServletResponse response) throws IOException, ServletException {
+                    if (Collections.list(request.getHeaders("host")).size() > 1) {
+                        response.sendError(HttpStatus.INTERNAL_SERVER_ERROR.code());
+                    } else {
+                        response.setStatus(HttpStatus.OK.code());
+                    }
+                    baseRequest.setHandled(true);
+                }
+            });
+            jetty.start();
+        }
+
+        @AfterAll
+        void stopJetty() throws Exception {
+            jetty.stop();
+        }
+
+        @Test
+        void http1SendsOneHostHeaderWhenUserSetsIt() {
+            final HttpClient client = HttpClient.of(
+                    "h1c://localhost:" + ((ServerConnector)jetty.getConnectors()[0]).getLocalPort() + '/');
+
+            final AggregatedHttpResponse response = client.execute(
+                    RequestHeaders.of(HttpMethod.GET, "/onlyonehost", HttpHeaderNames.HOST, "foobar")
+            ).aggregate().join();
+            assertThat(response.status()).isEqualTo(HttpStatus.OK);
+        }
     }
 
     private static void checkGetRequest(String path, HttpClient client) throws Exception {

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientIntegrationTest.java
@@ -755,10 +755,10 @@ class HttpClientIntegrationTest {
                 @Override
                 public void handle(String target, Request baseRequest, HttpServletRequest request,
                                    HttpServletResponse response) throws IOException, ServletException {
-                    if (Collections.list(request.getHeaders("host")).size() > 1) {
-                        response.sendError(HttpStatus.INTERNAL_SERVER_ERROR.code());
-                    } else {
+                    if (Collections.list(request.getHeaders("host")).size() == 1) {
                         response.setStatus(HttpStatus.OK.code());
+                    } else {
+                        response.sendError(HttpStatus.INTERNAL_SERVER_ERROR.code());
                     }
                     baseRequest.setHandled(true);
                 }


### PR DESCRIPTION
During https://github.com/openzipkin/zipkin-aws/pull/135 we found that Armeria will add a second `host` header even if one is already set in the request headers before sending them. This can break behavior and I suppose must break some HTTP spec too.

I wasn't sure whether to respect or ignore the user's setting, but with this change, if a user themselves set an authority and host to different values, we'll leave the host as is. While this is a bad user, I guess we should trust they did it on purpose.

I had to write the unit test in Jetty since during the conversion from HTTP/1 headers to Armeria headers, the duplicate hosts got normalized. 

/cc @adriancole 