### PR TITLE
Provide a way to request from an absolute URL with HttpClient

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/DefaultHttpClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultHttpClient.java
@@ -16,7 +16,7 @@
 
 package com.linecorp.armeria.client;
 
-import static com.linecorp.armeria.client.HttpClientBuilder.UNDEFINED_URI;
+import static com.linecorp.armeria.client.HttpClientBuilder.isUndefinedUri;
 import static com.linecorp.armeria.internal.ArmeriaHttpUtil.concatPaths;
 
 import java.net.URI;
@@ -49,7 +49,7 @@ final class DefaultHttpClient extends UserClient<HttpRequest, HttpResponse> impl
         final URI uri = URI.create(req.path());
         final String authority = uri.getAuthority();
 
-        if (uri() == UNDEFINED_URI && authority == null) {
+        if (isUndefinedUri(uri()) && authority == null) {
             return HttpResponse.ofFailure(new IllegalArgumentException("no authority: " + req.path()));
         } else if (authority != null) {
             final Endpoint endpoint = Endpoint.parse(authority);

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClient.java
@@ -16,7 +16,7 @@
 
 package com.linecorp.armeria.client;
 
-import static com.linecorp.armeria.client.HttpClientBuilder.UNDEFINED_URI;
+import static com.linecorp.armeria.client.HttpClientBuilder.undefinedUri;
 
 import java.net.URI;
 import java.nio.charset.Charset;
@@ -38,7 +38,7 @@ public interface HttpClient extends ClientBuilderParams {
      * Creates a new HTTP client using the {@link ClientFactory#DEFAULT} and the {@link ClientOptions#DEFAULT}.
      */
     static HttpClient of() {
-        return of(ClientFactory.DEFAULT, UNDEFINED_URI, ClientOptions.DEFAULT);
+        return of(ClientFactory.DEFAULT, undefinedUri(), ClientOptions.DEFAULT);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClient.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.client;
 
+import static com.linecorp.armeria.client.HttpClientBuilder.UNDEFINED_URI;
+
 import java.net.URI;
 import java.nio.charset.Charset;
 
@@ -31,6 +33,13 @@ import com.linecorp.armeria.common.SessionProtocol;
  * An HTTP client.
  */
 public interface HttpClient extends ClientBuilderParams {
+
+    /**
+     * Creates a new HTTP client using the {@link ClientFactory#DEFAULT} and the {@link ClientOptions#DEFAULT}.
+     */
+    static HttpClient of() {
+        return of(ClientFactory.DEFAULT, UNDEFINED_URI, ClientOptions.DEFAULT);
+    }
 
     /**
      * Creates a new HTTP client that connects to the specified {@code uri} using the default

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClient.java
@@ -16,8 +16,6 @@
 
 package com.linecorp.armeria.client;
 
-import static com.linecorp.armeria.client.HttpClientBuilder.undefinedUri;
-
 import java.net.URI;
 import java.nio.charset.Charset;
 
@@ -38,7 +36,7 @@ public interface HttpClient extends ClientBuilderParams {
      * Creates a new HTTP client using the {@link ClientFactory#DEFAULT} and the {@link ClientOptions#DEFAULT}.
      */
     static HttpClient of() {
-        return of(ClientFactory.DEFAULT, undefinedUri(), ClientOptions.DEFAULT);
+        return new HttpClientBuilder().options(ClientOptions.DEFAULT).build();
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientBuilder.java
@@ -83,7 +83,7 @@ public final class HttpClientBuilder extends AbstractClientOptionsBuilder<HttpCl
      *                                  in {@link SessionProtocol}
      */
     public HttpClientBuilder(URI uri) {
-        if (uri == UNDEFINED_URI) {
+        if (isUndefinedUri(uri)) {
             this.uri = uri;
         } else {
             validateScheme(requireNonNull(uri, "uri").getScheme());

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientBuilder.java
@@ -38,14 +38,7 @@ public final class HttpClientBuilder extends AbstractClientOptionsBuilder<HttpCl
     /**
      * An undefined {@link URI} to create {@link HttpClient} without specifying {@link URI}.
      */
-    private static final URI UNDEFINED_URI = URI.create("none+http://127.0.0.1");
-
-    /**
-     * Returns an undefined {@link URI}.
-     */
-    static URI undefinedUri() {
-        return UNDEFINED_URI;
-    }
+    private static final URI UNDEFINED_URI = URI.create("none+http://undefined");
 
     /**
      * Returns {@code true} if the specified {@code uri} is an undefined {@link URI}.
@@ -63,6 +56,15 @@ public final class HttpClientBuilder extends AbstractClientOptionsBuilder<HttpCl
     @Nullable
     private String path;
     private ClientFactory factory = ClientFactory.DEFAULT;
+
+    /**
+     * Creates a new instance.
+     */
+    public HttpClientBuilder() {
+        uri = UNDEFINED_URI;
+        scheme = null;
+        endpoint = null;
+    }
 
     /**
      * Creates a new instance.

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientBuilder.java
@@ -36,9 +36,23 @@ import com.linecorp.armeria.common.SessionProtocol;
 public final class HttpClientBuilder extends AbstractClientOptionsBuilder<HttpClientBuilder> {
 
     /**
-     * An undefined URI to create {@link HttpClient#of()} without specifying URI.
+     * An undefined {@link URI} to create {@link HttpClient} without specifying {@link URI}.
      */
-    static final URI UNDEFINED_URI = URI.create("none+http://127.0.0.1");
+    private static final URI UNDEFINED_URI = URI.create("none+http://127.0.0.1");
+
+    /**
+     * Returns an undefined {@link URI}.
+     */
+    static URI undefinedUri() {
+        return UNDEFINED_URI;
+    }
+
+    /**
+     * Returns {@code true} if the specified {@code uri} is an undefined {@link URI}.
+     */
+    static boolean isUndefinedUri(URI uri) {
+        return UNDEFINED_URI == uri;
+    }
 
     @Nullable
     private final URI uri;

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientBuilder.java
@@ -35,6 +35,11 @@ import com.linecorp.armeria.common.SessionProtocol;
  */
 public final class HttpClientBuilder extends AbstractClientOptionsBuilder<HttpClientBuilder> {
 
+    /**
+     * An undefined URI to create {@link HttpClient#of()} without specifying URI.
+     */
+    static final URI UNDEFINED_URI = URI.create("none+http://127.0.0.1");
+
     @Nullable
     private final URI uri;
     @Nullable
@@ -62,9 +67,12 @@ public final class HttpClientBuilder extends AbstractClientOptionsBuilder<HttpCl
      *                                  in {@link SessionProtocol}
      */
     public HttpClientBuilder(URI uri) {
-        validateScheme(requireNonNull(uri, "uri").getScheme());
-
-        this.uri = URI.create(SerializationFormat.NONE + "+" + uri);
+        if (uri == UNDEFINED_URI) {
+            this.uri = uri;
+        } else {
+            validateScheme(requireNonNull(uri, "uri").getScheme());
+            this.uri = URI.create(SerializationFormat.NONE + "+" + uri);
+        }
         scheme = null;
         endpoint = null;
     }

--- a/core/src/main/java/com/linecorp/armeria/client/UserClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/UserClient.java
@@ -125,13 +125,14 @@ public abstract class UserClient<I extends Request, O extends Response> implemen
      */
     protected final O execute(HttpMethod method, String path, @Nullable String query, @Nullable String fragment,
                               I req, BiFunction<ClientRequestContext, Throwable, O> fallback) {
-        return execute(null, method, path, query, fragment, req, fallback);
+        return execute(null, endpoint, method, path, query, fragment, req, fallback);
     }
 
     /**
      * Executes the specified {@link Request} via {@link #delegate()}.
      *
      * @param eventLoop the {@link EventLoop} to execute the {@link Request}
+     * @param endpoint the {@link Endpoint} of the {@link Request}
      * @param method the method of the {@link Request}
      * @param path the path part of the {@link Request} URI
      * @param query the query part of the {@link Request} URI
@@ -140,7 +141,7 @@ public abstract class UserClient<I extends Request, O extends Response> implemen
      * @param fallback the fallback response {@link BiFunction} to use when
      *                 {@link Client#execute(ClientRequestContext, Request)} of {@link #delegate()} throws
      */
-    protected final O execute(@Nullable EventLoop eventLoop,
+    protected final O execute(@Nullable EventLoop eventLoop, Endpoint endpoint,
                               HttpMethod method, String path, @Nullable String query, @Nullable String fragment,
                               I req, BiFunction<ClientRequestContext, Throwable, O> fallback) {
         final DefaultClientRequestContext ctx;

--- a/core/src/main/java/com/linecorp/armeria/internal/ArmeriaHttpUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/ArmeriaHttpUtil.java
@@ -337,20 +337,20 @@ public final class ArmeriaHttpUtil {
     /**
      * Returns {@code true} if the specified {@code path} is an absolute {@code URI}.
      */
-    public static boolean isAbsolutePath(@Nullable String path) {
-        if (path == null) {
+    public static boolean isAbsoluteUri(@Nullable String maybeUri) {
+        if (maybeUri == null) {
             return false;
         }
-        final int firstColonIdx = path.indexOf(':');
-        if (firstColonIdx <= 0 || firstColonIdx + 3 >= path.length()) {
+        final int firstColonIdx = maybeUri.indexOf(':');
+        if (firstColonIdx <= 0 || firstColonIdx + 3 >= maybeUri.length()) {
             return false;
         }
-        final int firstSlashIdx = path.indexOf('/');
+        final int firstSlashIdx = maybeUri.indexOf('/');
         if (firstSlashIdx <= 0 || firstSlashIdx < firstColonIdx) {
             return false;
         }
 
-        return path.charAt(firstColonIdx + 1) == '/' && path.charAt(firstColonIdx + 2) == '/';
+        return maybeUri.charAt(firstColonIdx + 1) == '/' && maybeUri.charAt(firstColonIdx + 2) == '/';
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/internal/ArmeriaHttpUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/ArmeriaHttpUtil.java
@@ -335,6 +335,25 @@ public final class ArmeriaHttpUtil {
     }
 
     /**
+     * Returns {@code true} if the specified {@code path} is an absolute {@code URI}.
+     */
+    public static boolean isAbsolutePath(@Nullable String path) {
+        if (path == null) {
+            return false;
+        }
+        final int firstColonIdx = path.indexOf(':');
+        if (firstColonIdx <= 0 || firstColonIdx + 3 >= path.length()) {
+            return false;
+        }
+        final int firstSlashIdx = path.indexOf('/');
+        if (firstSlashIdx <= 0 || firstSlashIdx < firstColonIdx) {
+            return false;
+        }
+
+        return path.charAt(firstColonIdx + 1) == '/' && path.charAt(firstColonIdx + 2) == '/';
+    }
+
+    /**
      * Returns {@code true} if the specified HTTP status string represents an informational status.
      */
     public static boolean isInformational(@Nullable String statusText) {

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientRequestPathTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientRequestPathTest.java
@@ -38,15 +38,14 @@ import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.testing.junit.server.ServerExtension;
 
-class SimpleHttpClientTest {
+class HttpClientRequestPathTest {
 
     @RegisterExtension
     @Order(10)
     static final ServerExtension server1 = new ServerExtension() {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
-            sb.http(0)
-              .service("/new-location", (ctx, req) -> HttpResponse.of(OK));
+            sb.service("/new-location", (ctx, req) -> HttpResponse.of(OK));
         }
     };
 
@@ -55,8 +54,7 @@ class SimpleHttpClientTest {
     static final ServerExtension server2 = new ServerExtension() {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
-            sb.http(0)
-              .service("/simple-client", (ctx, req) -> HttpResponse.of(OK))
+            sb.service("/simple-client", (ctx, req) -> HttpResponse.of(OK))
               .service("/redirect", (ctx, req) -> {
                   final HttpHeaders headers = ResponseHeaders.of(HttpStatus.TEMPORARY_REDIRECT,
                                                                  LOCATION, server1.uri("/new-location"));

--- a/core/src/test/java/com/linecorp/armeria/client/SimpleHttpClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/SimpleHttpClientTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import static com.linecorp.armeria.common.HttpHeaderNames.LOCATION;
+import static com.linecorp.armeria.common.HttpStatus.OK;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.EnumSource.Mode;
+
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.testing.junit.server.ServerExtension;
+
+class SimpleHttpClientTest {
+
+    @RegisterExtension
+    @Order(10)
+    static final ServerExtension server1 = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.http(0)
+              .service("/new-location", (ctx, req) -> HttpResponse.of(OK));
+        }
+    };
+
+    @RegisterExtension
+    @Order(20)
+    static final ServerExtension server2 = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.http(0)
+              .service("/simple-client", (ctx, req) -> HttpResponse.of(OK))
+              .service("/redirect", (ctx, req) -> {
+                  final HttpHeaders headers = ResponseHeaders.of(HttpStatus.TEMPORARY_REDIRECT,
+                                                                 LOCATION, server1.uri("/new-location"));
+                  return HttpResponse.of(headers);
+              });
+        }
+    };
+
+    @ParameterizedTest
+    @EnumSource(value = HttpMethod.class, mode = Mode.EXCLUDE, names = "UNKNOWN")
+    void default_withAbsolutePath(HttpMethod method) {
+        final HttpRequest request = HttpRequest.of(method, server2.uri("/simple-client"));
+        final HttpResponse response = HttpClient.of().execute(request);
+        assertThat(response.aggregate().join().status()).isEqualTo(OK);
+    }
+
+    @Test
+    void default_withRelativePath() {
+        final HttpRequest request = HttpRequest.of(HttpMethod.GET, "/simple-client");
+        final HttpResponse response = HttpClient.of().execute(request);
+        assertThatThrownBy(() -> response.aggregate().join())
+                .hasCauseInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("no authority");
+    }
+
+    @Test
+    void custom_withAbsolutePath() {
+        final HttpClient client = HttpClient.of(server1.uri("/"));
+        final HttpRequest request = HttpRequest.of(HttpMethod.GET, server2.uri("/simple-client"));
+        final HttpResponse response = client.execute(request);
+        assertThat(response.aggregate().join().status()).isEqualTo(OK);
+    }
+
+    @Test
+    void custom_withRelativePath() {
+        final HttpClient client = HttpClient.of(server2.uri("/"));
+        final HttpRequest request = HttpRequest.of(HttpMethod.GET, "/simple-client");
+        final HttpResponse response = client.execute(request);
+        assertThat(response.aggregate().join().status()).isEqualTo(OK);
+    }
+
+    @Test
+    void redirect() {
+        final HttpClient client = HttpClient.of(server2.uri("/"));
+        final AggregatedHttpResponse redirected = client.get("/redirect").aggregate().join();
+        final String location = redirected.headers().get(LOCATION);
+        assertThat(location).isNotNull();
+        final AggregatedHttpResponse actual = client.get(location).aggregate().join();
+        assertThat(actual.status()).isEqualTo(OK);
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/internal/ArmeriaHttpUtilTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/ArmeriaHttpUtilTest.java
@@ -476,9 +476,9 @@ class ArmeriaHttpUtilTest {
     }
 
     @Test
-    void isAbsolutePath() {
+    void isAbsoluteUri() {
         final String good = "none+http://a.com";
-        assertThat(ArmeriaHttpUtil.isAbsolutePath(good)).isTrue();
+        assertThat(ArmeriaHttpUtil.isAbsoluteUri(good)).isTrue();
         final List<String> bad = Arrays.asList(
                 "none+http:/a",
                 "//a",
@@ -488,7 +488,7 @@ class ArmeriaHttpUtilTest {
                 "://",
                 "",
                 null);
-        bad.forEach(path -> assertThat(ArmeriaHttpUtil.isAbsolutePath(path)).isFalse());
+        bad.forEach(path -> assertThat(ArmeriaHttpUtil.isAbsoluteUri(path)).isFalse());
     }
 
     private static ServerConfig serverConfig() {

--- a/core/src/test/java/com/linecorp/armeria/internal/ArmeriaHttpUtilTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/ArmeriaHttpUtilTest.java
@@ -29,7 +29,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.net.InetSocketAddress;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.function.BiConsumer;
 
@@ -58,9 +60,9 @@ import io.netty.handler.codec.http2.Http2Exception;
 import io.netty.handler.codec.http2.Http2Headers;
 import io.netty.handler.codec.http2.HttpConversionUtil.ExtensionHeaderNames;
 
-public class ArmeriaHttpUtilTest {
+class ArmeriaHttpUtilTest {
     @Test
-    public void testConcatPaths() throws Exception {
+    void testConcatPaths() throws Exception {
         assertThat(concatPaths(null, "a")).isEqualTo("/a");
         assertThat(concatPaths(null, "/a")).isEqualTo("/a");
 
@@ -76,7 +78,7 @@ public class ArmeriaHttpUtilTest {
     }
 
     @Test
-    public void testDecodePath() throws Exception {
+    void testDecodePath() throws Exception {
         // Fast path
         final String pathThatDoesNotNeedDecode = "/foo_bar_baz";
         assertThat(decodePath(pathThatDoesNotNeedDecode)).isSameAs(pathThatDoesNotNeedDecode);
@@ -93,7 +95,7 @@ public class ArmeriaHttpUtilTest {
     }
 
     @Test
-    public void testParseDirectives() {
+    void testParseDirectives() {
         final Map<String, String> values = new LinkedHashMap<>();
         final BiConsumer<String, String> cb = (name, value) -> assertThat(values.put(name, value)).isNull();
 
@@ -147,7 +149,7 @@ public class ArmeriaHttpUtilTest {
     }
 
     @Test
-    public void outboundCookiesMustBeMergedForHttp1() throws Http2Exception {
+    void outboundCookiesMustBeMergedForHttp1() throws Http2Exception {
         final HttpHeaders in = HttpHeaders.builder()
                                           .add(HttpHeaderNames.COOKIE, "a=b; c=d")
                                           .add(HttpHeaderNames.COOKIE, "e=f;g=h")
@@ -165,7 +167,7 @@ public class ArmeriaHttpUtilTest {
     }
 
     @Test
-    public void outboundCookiesMustBeSplitForHttp2() {
+    void outboundCookiesMustBeSplitForHttp2() {
         final HttpHeaders in = HttpHeaders.builder()
                                           .add(HttpHeaderNames.COOKIE, "a=b; c=d")
                                           .add(HttpHeaderNames.COOKIE, "e=f;g=h")
@@ -180,7 +182,7 @@ public class ArmeriaHttpUtilTest {
     }
 
     @Test
-    public void inboundCookiesMustBeMergedForHttp1() {
+    void inboundCookiesMustBeMergedForHttp1() {
         final io.netty.handler.codec.http.HttpHeaders in = new DefaultHttpHeaders();
         in.add(HttpHeaderNames.COOKIE, "a=b; c=d");
         in.add(HttpHeaderNames.COOKIE, "e=f;g=h");
@@ -196,7 +198,7 @@ public class ArmeriaHttpUtilTest {
     }
 
     @Test
-    public void endOfStreamSet() {
+    void endOfStreamSet() {
         final Http2Headers in = new DefaultHttp2Headers();
         in.setInt(HttpHeaderNames.CONTENT_LENGTH, 0);
         final HttpHeaders out = toArmeria(in, true, true);
@@ -207,7 +209,7 @@ public class ArmeriaHttpUtilTest {
     }
 
     @Test
-    public void endOfStreamSetEmpty() {
+    void endOfStreamSetEmpty() {
         final Http2Headers in = new DefaultHttp2Headers();
         final HttpHeaders out = toArmeria(in, true, true);
         assertThat(out.isEndOfStream()).isTrue();
@@ -217,7 +219,7 @@ public class ArmeriaHttpUtilTest {
     }
 
     @Test
-    public void inboundCookiesMustBeMergedForHttp2() {
+    void inboundCookiesMustBeMergedForHttp2() {
         final Http2Headers in = new DefaultHttp2Headers();
 
         in.add(HttpHeaderNames.COOKIE, "a=b; c=d");
@@ -233,7 +235,7 @@ public class ArmeriaHttpUtilTest {
     }
 
     @Test
-    public void addHttp2AuthorityWithoutUserInfo() {
+    void addHttp2AuthorityWithoutUserInfo() {
         final RequestHeadersBuilder headers = RequestHeaders.builder();
 
         addHttp2Authority("foo", headers);
@@ -241,7 +243,7 @@ public class ArmeriaHttpUtilTest {
     }
 
     @Test
-    public void addHttp2AuthorityWithUserInfo() {
+    void addHttp2AuthorityWithUserInfo() {
         final RequestHeadersBuilder headers = RequestHeaders.builder();
 
         addHttp2Authority("info@foo", headers);
@@ -254,7 +256,7 @@ public class ArmeriaHttpUtilTest {
     }
 
     @Test
-    public void addHttp2AuthorityNullOrEmpty() {
+    void addHttp2AuthorityNullOrEmpty() {
         final RequestHeadersBuilder headers = RequestHeaders.builder();
 
         addHttp2Authority(null, headers);
@@ -265,13 +267,13 @@ public class ArmeriaHttpUtilTest {
     }
 
     @Test
-    public void addHttp2AuthorityWithEmptyAuthority() {
+    void addHttp2AuthorityWithEmptyAuthority() {
         assertThatThrownBy(() -> addHttp2Authority("info@", RequestHeaders.builder()))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    public void stripTEHeaders() {
+    void stripTEHeaders() {
         final io.netty.handler.codec.http.HttpHeaders in = new DefaultHttpHeaders();
         in.add(HttpHeaderNames.TE, HttpHeaderValues.GZIP);
         final HttpHeadersBuilder out = HttpHeaders.builder();
@@ -280,7 +282,7 @@ public class ArmeriaHttpUtilTest {
     }
 
     @Test
-    public void stripTEHeadersExcludingTrailers() {
+    void stripTEHeadersExcludingTrailers() {
         final io.netty.handler.codec.http.HttpHeaders in = new DefaultHttpHeaders();
         in.add(HttpHeaderNames.TE, HttpHeaderValues.GZIP);
         in.add(HttpHeaderNames.TE, HttpHeaderValues.TRAILERS);
@@ -290,7 +292,7 @@ public class ArmeriaHttpUtilTest {
     }
 
     @Test
-    public void stripTEHeadersCsvSeparatedExcludingTrailers() {
+    void stripTEHeadersCsvSeparatedExcludingTrailers() {
         final io.netty.handler.codec.http.HttpHeaders in = new DefaultHttpHeaders();
         in.add(HttpHeaderNames.TE, HttpHeaderValues.GZIP + "," + HttpHeaderValues.TRAILERS);
         final HttpHeadersBuilder out = HttpHeaders.builder();
@@ -299,7 +301,7 @@ public class ArmeriaHttpUtilTest {
     }
 
     @Test
-    public void stripTEHeadersCsvSeparatedAccountsForValueSimilarToTrailers() {
+    void stripTEHeadersCsvSeparatedAccountsForValueSimilarToTrailers() {
         final io.netty.handler.codec.http.HttpHeaders in = new DefaultHttpHeaders();
         in.add(HttpHeaderNames.TE, HttpHeaderValues.GZIP + "," + HttpHeaderValues.TRAILERS + "foo");
         final HttpHeadersBuilder out = HttpHeaders.builder();
@@ -308,7 +310,7 @@ public class ArmeriaHttpUtilTest {
     }
 
     @Test
-    public void stripTEHeadersAccountsForValueSimilarToTrailers() {
+    void stripTEHeadersAccountsForValueSimilarToTrailers() {
         final io.netty.handler.codec.http.HttpHeaders in = new DefaultHttpHeaders();
         in.add(HttpHeaderNames.TE, HttpHeaderValues.TRAILERS + "foo");
         final HttpHeadersBuilder out = HttpHeaders.builder();
@@ -317,7 +319,7 @@ public class ArmeriaHttpUtilTest {
     }
 
     @Test
-    public void stripTEHeadersAccountsForOWS() {
+    void stripTEHeadersAccountsForOWS() {
         final io.netty.handler.codec.http.HttpHeaders in = new DefaultHttpHeaders();
         in.add(HttpHeaderNames.TE, " " + HttpHeaderValues.TRAILERS + ' ');
         final HttpHeadersBuilder out = HttpHeaders.builder();
@@ -326,7 +328,7 @@ public class ArmeriaHttpUtilTest {
     }
 
     @Test
-    public void stripConnectionHeadersAndNominees() {
+    void stripConnectionHeadersAndNominees() {
         final io.netty.handler.codec.http.HttpHeaders in = new DefaultHttpHeaders();
         in.add(HttpHeaderNames.CONNECTION, "foo");
         in.add("foo", "bar");
@@ -336,7 +338,7 @@ public class ArmeriaHttpUtilTest {
     }
 
     @Test
-    public void stripConnectionNomineesWithCsv() {
+    void stripConnectionNomineesWithCsv() {
         final io.netty.handler.codec.http.HttpHeaders in = new DefaultHttpHeaders();
         in.add(HttpHeaderNames.CONNECTION, "foo,  bar");
         in.add("foo", "baz");
@@ -349,7 +351,7 @@ public class ArmeriaHttpUtilTest {
     }
 
     @Test
-    public void excludeBlacklistHeadersWhileHttp2ToHttp1() throws Http2Exception {
+    void excludeBlacklistHeadersWhileHttp2ToHttp1() throws Http2Exception {
         final HttpHeaders in = HttpHeaders.builder()
                                           .add(HttpHeaderNames.TRAILER, "foo")
                                           .add(HttpHeaderNames.AUTHORITY, "bar") // Translated to host
@@ -373,7 +375,7 @@ public class ArmeriaHttpUtilTest {
     }
 
     @Test
-    public void excludeBlacklistInTrailers() throws Http2Exception {
+    void excludeBlacklistInTrailers() throws Http2Exception {
         final HttpHeaders in = HttpHeaders.builder()
                                           .add(HttpHeaderNames.of("foo"), "bar")
                                           .add(HttpHeaderNames.TRANSFER_ENCODING, "dummy")
@@ -411,7 +413,7 @@ public class ArmeriaHttpUtilTest {
     }
 
     @Test
-    public void convertedHeaderTypes() {
+    void convertedHeaderTypes() {
         final Http2Headers in = new DefaultHttp2Headers().set("a", "b");
 
         // Request headers without pseudo headers.
@@ -454,7 +456,7 @@ public class ArmeriaHttpUtilTest {
     }
 
     @Test
-    public void toArmeriaRequestHeaders() {
+    void toArmeriaRequestHeaders() {
         final Http2Headers in = new DefaultHttp2Headers().set("a", "b");
 
         final InetSocketAddress socketAddress = new InetSocketAddress(36462);
@@ -471,6 +473,22 @@ public class ArmeriaHttpUtilTest {
                 ArmeriaHttpUtil.toArmeriaRequestHeaders(ctx, in, false, "https", serverConfig());
         assertThat(headers.scheme()).isEqualTo("https");
         assertThat(headers.authority()).isEqualTo("foo:36462");
+    }
+
+    @Test
+    void isAbsolutePath() {
+        final String good = "none+http://a.com";
+        assertThat(ArmeriaHttpUtil.isAbsolutePath(good)).isTrue();
+        final List<String> bad = Arrays.asList(
+                "none+http:/a",
+                "//a",
+                "://a",
+                "a/b://c",
+                "http://",
+                "://",
+                "",
+                null);
+        bad.forEach(path -> assertThat(ArmeriaHttpUtil.isAbsolutePath(path)).isFalse());
     }
 
     private static ServerConfig serverConfig() {


### PR DESCRIPTION
Motivation:
Currently, HttpClient executes can only be used by a URI path.
If HttpClient accepts absolute URI and executes with default options, it is easy for the first user to use it.

Modifications:
* Add static method `of()` in `HttpClient` to execute request with
  absolute URI
* Add package private `UNDEFINED_URI` in `HttpClientBuilder` to create
 `HttpClient#of()` without specifying URI

Result:
A user who wants to use HttpClient with default options can reduce boilerplate code.

Fixes: #1143