### PR TITLE
Fix not to raise ClosedPublisherException when the HttpResponse is ab…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/Http1ResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http1ResponseDecoder.java
@@ -161,13 +161,11 @@ final class Http1ResponseDecoder extends HttpResponseDecoder implements ChannelI
                             state = State.NEED_DATA_OR_TRAILERS;
                         }
 
+                        res.scheduleTimeout(ctx.channel().eventLoop());
                         // If this tryWrite() returns false, it means the response stream has been closed due to
                         // disconnection or by the response consumer. We do not need to handle such cases here
                         // because it will be notified to the response consumer anyway.
-                        if (!res.tryWrite(ArmeriaHttpUtil.toArmeria(nettyRes))) {
-                            // Schedule only when the response stream is still open.
-                            res.scheduleTimeout(ctx.channel().eventLoop());
-                        }
+                        res.tryWrite(ArmeriaHttpUtil.toArmeria(nettyRes));
                     } else {
                         failWithUnexpectedMessageType(ctx, msg);
                     }

--- a/core/src/main/java/com/linecorp/armeria/client/Http1ResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http1ResponseDecoder.java
@@ -161,10 +161,7 @@ final class Http1ResponseDecoder extends HttpResponseDecoder implements ChannelI
                             state = State.NEED_DATA_OR_TRAILERS;
                         }
 
-                        res.scheduleTimeout(ctx.channel().eventLoop());
-                        // If this tryWrite() returns false, it means the response stream has been closed due to
-                        // disconnection or by the response consumer. We do not need to handle such cases here
-                        // because it will be notified to the response consumer anyway.
+                        res.scheduleTimeout(channel().eventLoop());
                         res.tryWrite(ArmeriaHttpUtil.toArmeria(nettyRes));
                     } else {
                         failWithUnexpectedMessageType(ctx, msg);
@@ -195,10 +192,6 @@ final class Http1ResponseDecoder extends HttpResponseDecoder implements ChannelI
                                 fail(ctx, ContentTooLargeException.get());
                                 return;
                             } else {
-                                // If this tryWrite() returns false, it means the response stream has been
-                                // closed due to disconnection or by the response consumer.
-                                // We do not need to handle such cases here because it will be notified
-                                // to the response consumer anyway.
                                 res.tryWrite(HttpData.wrap(data.retain()));
                             }
                         }
@@ -213,10 +206,6 @@ final class Http1ResponseDecoder extends HttpResponseDecoder implements ChannelI
 
                             final HttpHeaders trailingHeaders = ((LastHttpContent) msg).trailingHeaders();
                             if (!trailingHeaders.isEmpty()) {
-                                // If this tryWrite() returns false, it means the response stream has been
-                                // closed due to disconnection or by the response consumer.
-                                // We do not need to handle such cases here because it will be notified
-                                // to the response consumer anyway.
                                 res.tryWrite(ArmeriaHttpUtil.toArmeria(trailingHeaders));
                             }
 

--- a/core/src/main/java/com/linecorp/armeria/client/Http2ResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http2ResponseDecoder.java
@@ -196,13 +196,11 @@ final class Http2ResponseDecoder extends HttpResponseDecoder implements Http2Con
 
         final HttpHeaders converted = ArmeriaHttpUtil.toArmeria(headers, false, endOfStream);
         try {
+            res.scheduleTimeout(ctx.channel().eventLoop());
             // If this tryWrite() returns false, it means the response stream has been closed due to
             // disconnection or by the response consumer. We do not need to handle such cases here because
             // it will be notified to the response consumer anyway.
-            if (!res.tryWrite(converted)) {
-                // Schedule only when the response stream is still open.
-                res.scheduleTimeout(ctx.channel().eventLoop());
-            }
+            res.tryWrite(converted);
         } catch (Throwable t) {
             res.close(t);
             throw connectionError(INTERNAL_ERROR, t, "failed to consume a HEADERS frame");

--- a/core/src/main/java/com/linecorp/armeria/client/Http2ResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http2ResponseDecoder.java
@@ -196,10 +196,7 @@ final class Http2ResponseDecoder extends HttpResponseDecoder implements Http2Con
 
         final HttpHeaders converted = ArmeriaHttpUtil.toArmeria(headers, false, endOfStream);
         try {
-            res.scheduleTimeout(ctx.channel().eventLoop());
-            // If this tryWrite() returns false, it means the response stream has been closed due to
-            // disconnection or by the response consumer. We do not need to handle such cases here because
-            // it will be notified to the response consumer anyway.
+            res.scheduleTimeout(channel().eventLoop());
             res.tryWrite(converted);
         } catch (Throwable t) {
             res.close(t);
@@ -248,9 +245,6 @@ final class Http2ResponseDecoder extends HttpResponseDecoder implements Http2Con
         }
 
         try {
-            // If this tryWrite() returns false, it means the response stream has been closed due to
-            // disconnection or by the response consumer. We do not need to handle such cases here because
-            // it will be notified to the response consumer anyway.
             res.tryWrite(new ByteBufHttpData(data.retain(), endOfStream));
         } catch (Throwable t) {
             res.close(t);

--- a/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
@@ -215,6 +215,13 @@ abstract class HttpResponseDecoder {
             return delegate.isOpen();
         }
 
+        /**
+         * Writes the specified {@link HttpObject} to {@link DecodedHttpResponse}. This method is only called
+         * from {@link Http1ResponseDecoder} and {@link Http2ResponseDecoder}. If this returns {@code false},
+         * it means the response stream has been closed due to disconnection or by the response consumer.
+         * So the caller do not need to handle such cases because it will be notified to the response
+         * consumer anyway.
+         */
         @Override
         public boolean tryWrite(HttpObject o) {
             switch (state) {


### PR DESCRIPTION
…orted by client

Motivation:
`HttpResponse` can be aborted by the client. e.g, `RetryingClient` can just look at the header to
determine to retry or not and discard the rest of the response.
In that situation, because the response decoder writes to the aborted `HttpResponse`, it raises `ClosedPublisherException`.

Modification:
- Use `HttpResponse.tryWrite()` instead of `HttpResponse.write()` in `Http1ResponseDecoder`.

Result:
- `ClosedPublihserException` is no longer raised when writing to aborted `HttpResponse`