### PR TITLE
Fix to contain te header in gRPC request

### DIFF
--- a/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/UnaryGrpcClient.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/UnaryGrpcClient.java
@@ -39,6 +39,7 @@ import com.linecorp.armeria.unsafe.ByteBufHttpData;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
 import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http.HttpHeaderValues;
 
 /**
  * A {@link UnaryGrpcClient} can be used to make requests to a gRPC server without depending on gRPC stubs.
@@ -79,7 +80,8 @@ public class UnaryGrpcClient {
     public CompletableFuture<byte[]> execute(String uri, byte[] payload) {
         final HttpRequest request = HttpRequest.of(
                 RequestHeaders.of(HttpMethod.POST, uri,
-                                  HttpHeaderNames.CONTENT_TYPE, "application/grpc+proto"),
+                                  HttpHeaderNames.CONTENT_TYPE, "application/grpc+proto",
+                                  HttpHeaderNames.TE, HttpHeaderValues.TRAILERS),
                 HttpData.wrap(payload));
         return httpClient.execute(request).aggregate()
                          .thenApply(msg -> {

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaChannel.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaChannel.java
@@ -50,6 +50,7 @@ import io.grpc.ManagedChannelBuilder;
 import io.grpc.MethodDescriptor;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.netty.channel.EventLoop;
+import io.netty.handler.codec.http.HttpHeaderValues;
 
 /**
  * A {@link Channel} backed by an armeria {@link Client}. Stores the {@link ClientBuilderParams} and other
@@ -97,7 +98,8 @@ class ArmeriaChannel extends Channel implements ClientBuilderParams {
             MethodDescriptor<I, O> method, CallOptions callOptions) {
         final HttpRequestWriter req = HttpRequest.streaming(
                 RequestHeaders.of(HttpMethod.POST, uri().getPath() + method.getFullMethodName(),
-                                  HttpHeaderNames.CONTENT_TYPE, serializationFormat.mediaType()));
+                                  HttpHeaderNames.CONTENT_TYPE, serializationFormat.mediaType(),
+                                  HttpHeaderNames.TE, HttpHeaderValues.TRAILERS));
         final DefaultClientRequestContext ctx = newContext(HttpMethod.POST, req);
         ctx.logBuilder().serializationFormat(serializationFormat);
         ctx.logBuilder().deferRequestContent();

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientTest.java
@@ -63,6 +63,7 @@ import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.ResponseTimeoutException;
 import com.linecorp.armeria.client.logging.LoggingClientBuilder;
 import com.linecorp.armeria.common.FilteredHttpResponse;
+import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpHeadersBuilder;
 import com.linecorp.armeria.common.HttpObject;
@@ -116,6 +117,7 @@ import io.grpc.StatusRuntimeException;
 import io.grpc.stub.MetadataUtils;
 import io.grpc.stub.StreamObserver;
 import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.http.HttpHeaderValues;
 
 public class GrpcClientTest {
 
@@ -789,8 +791,12 @@ public class GrpcClientTest {
 
         assertThat(stub.emptyCall(EMPTY)).isNotNull();
 
+        final HttpHeaders clientHeaders = CLIENT_HEADERS_CAPTURE.get();
+        assertThat(clientHeaders.get(HttpHeaderNames.TE))
+                .isEqualTo(HttpHeaderValues.TRAILERS.toString());
+
         // Assert that our side channel object is echoed back in both headers and trailers
-        assertThat(CLIENT_HEADERS_CAPTURE.get().get(TestServiceImpl.EXTRA_HEADER_NAME)).isEqualTo("dog");
+        assertThat(clientHeaders.get(TestServiceImpl.EXTRA_HEADER_NAME)).isEqualTo("dog");
         assertThat(SERVER_TRAILERS_CAPTURE.get().get(TestServiceImpl.EXTRA_HEADER_NAME)).isEqualTo("dog");
 
         assertThat(headers.get()).isNull();
@@ -838,8 +844,12 @@ public class GrpcClientTest {
         assertSuccess(recorder);
         assertThat(recorder.getValues()).hasSize(responseSizes.size() * numRequests);
 
+        final HttpHeaders clientHeaders = CLIENT_HEADERS_CAPTURE.get();
+        assertThat(clientHeaders.get(HttpHeaderNames.TE))
+                .isEqualTo(HttpHeaderValues.TRAILERS.toString());
+
         // Assert that our side channel object is echoed back in both headers and trailers
-        assertThat(CLIENT_HEADERS_CAPTURE.get().get(TestServiceImpl.EXTRA_HEADER_NAME)).isEqualTo("dog");
+        assertThat(clientHeaders.get(TestServiceImpl.EXTRA_HEADER_NAME)).isEqualTo("dog");
         assertThat(SERVER_TRAILERS_CAPTURE.get().get(TestServiceImpl.EXTRA_HEADER_NAME)).isEqualTo("dog");
 
         checkRequestLog((rpcReq, rpcRes, grpcStatus) -> {


### PR DESCRIPTION
Motivation:
According to the [spec](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#requests),
gRPC `Request-Headers` has to contain `te` header in order to detect incompatible proxies.

Modification:
- Add `te` header to gRPC request headers

Result:
- Fix #1963