### PR TITLE
Remove the self-type parameters from abstract builders

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextBuilder.java
@@ -17,22 +17,28 @@ package com.linecorp.armeria.client;
 
 import static java.util.Objects.requireNonNull;
 
+import java.net.InetSocketAddress;
 import java.net.URI;
 
 import javax.annotation.Nullable;
+import javax.net.ssl.SSLSession;
 
 import com.linecorp.armeria.common.AbstractRequestContextBuilder;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.RpcRequest;
+import com.linecorp.armeria.common.SessionProtocol;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.EventLoop;
 
 /**
  * Builds a new {@link ClientRequestContext}. Note that it is not usually required to create a new context by
  * yourself, because Armeria will always provide a context object for you. However, it may be useful in some
  * cases such as unit testing.
  */
-public final class ClientRequestContextBuilder
-        extends AbstractRequestContextBuilder<ClientRequestContextBuilder> {
+public final class ClientRequestContextBuilder extends AbstractRequestContextBuilder {
 
     /**
      * Returns a new {@link ClientRequestContextBuilder} created from the specified {@link HttpRequest}.
@@ -123,5 +129,49 @@ public final class ClientRequestContextBuilder
             ctx.logBuilder().requestContent(request(), null);
         }
         return ctx;
+    }
+
+    // Methods that were overridden to change the return type.
+
+    @Override
+    public ClientRequestContextBuilder meterRegistry(MeterRegistry meterRegistry) {
+        return (ClientRequestContextBuilder) super.meterRegistry(meterRegistry);
+    }
+
+    @Override
+    public ClientRequestContextBuilder eventLoop(EventLoop eventLoop) {
+        return (ClientRequestContextBuilder) super.eventLoop(eventLoop);
+    }
+
+    @Override
+    public ClientRequestContextBuilder alloc(ByteBufAllocator alloc) {
+        return (ClientRequestContextBuilder) super.alloc(alloc);
+    }
+
+    @Override
+    public ClientRequestContextBuilder sessionProtocol(SessionProtocol sessionProtocol) {
+        return (ClientRequestContextBuilder) super.sessionProtocol(sessionProtocol);
+    }
+
+    @Override
+    public ClientRequestContextBuilder remoteAddress(InetSocketAddress remoteAddress) {
+        return (ClientRequestContextBuilder) super.remoteAddress(remoteAddress);
+    }
+
+    @Override
+    public ClientRequestContextBuilder localAddress(InetSocketAddress localAddress) {
+        return (ClientRequestContextBuilder) super.localAddress(localAddress);
+    }
+
+    @Override
+    public ClientRequestContextBuilder sslSession(SSLSession sslSession) {
+        return (ClientRequestContextBuilder) super.sslSession(sslSession);
+    }
+
+    @Override
+    public ClientRequestContextBuilder requestStartTime(long requestStartTimeNanos,
+                                                        long requestStartTimeMicros) {
+        return (ClientRequestContextBuilder) super.requestStartTime(requestStartTimeNanos,
+                                                                    requestStartTimeMicros);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClientBuilder.java
@@ -30,15 +30,13 @@ import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
 
 /**
- * Builds a new {@link CircuitBreakerClient} or its decorator function.
+ * A skeletal builder implementation that builds a new {@link CircuitBreakerClient} or its decorator function.
  *
- * @param <T> the type of {@link CircuitBreakerClientBuilder}
- * @param <U> the type of the {@link Client} that this builder builds or decorates
+ * @param <T> the type of the {@link Client} that this builder builds or decorates
  * @param <I> the type of outgoing {@link Request} of the {@link Client}
  * @param <O> the type of incoming {@link Response} of the {@link Client}
  */
-public abstract class CircuitBreakerClientBuilder<
-        T extends CircuitBreakerClientBuilder<T, U, I, O>, U extends CircuitBreakerClient<I, O>,
+public abstract class CircuitBreakerClientBuilder<T extends CircuitBreakerClient<I, O>,
         I extends Request, O extends Response> {
 
     @Nullable
@@ -69,11 +67,6 @@ public abstract class CircuitBreakerClientBuilder<
         this.strategyWithContent = strategyWithContent;
     }
 
-    @SuppressWarnings("unchecked")
-    final T self() {
-        return (T) this;
-    }
-
     CircuitBreakerStrategy strategy() {
         checkState(strategy != null, "strategy is not set.");
         return strategy;
@@ -88,27 +81,40 @@ public abstract class CircuitBreakerClientBuilder<
      * Sets the {@link CircuitBreakerMapping}. If unspecified, {@link CircuitBreakerMapping#ofDefault()}
      * will be used.
      *
-     * @return {@link T} to support method chaining.
+     * @return {@code this} to support method chaining.
+     *
+     * @deprecated Use {@link #mapping(CircuitBreakerMapping)}.
      */
-    public T circuitBreakerMapping(CircuitBreakerMapping mapping) {
-        this.mapping = requireNonNull(mapping, "mapping");
-        return self();
+    @Deprecated
+    public CircuitBreakerClientBuilder<T, I, O> circuitBreakerMapping(CircuitBreakerMapping mapping) {
+        return mapping(mapping);
     }
 
-    CircuitBreakerMapping circuitBreakerMapping() {
+    /**
+     * Sets the {@link CircuitBreakerMapping}. If unspecified, {@link CircuitBreakerMapping#ofDefault()}
+     * will be used.
+     *
+     * @return {@code this} to support method chaining.
+     */
+    public CircuitBreakerClientBuilder<T, I, O> mapping(CircuitBreakerMapping mapping) {
+        this.mapping = requireNonNull(mapping, "mapping");
+        return this;
+    }
+
+    CircuitBreakerMapping mapping() {
         return mapping;
     }
 
     /**
      * Returns a newly-created {@link CircuitBreakerClient} based on the properties of this builder.
      */
-    abstract U build(Client<I, O> delegate);
+    public abstract T build(Client<I, O> delegate);
 
     /**
      * Returns a newly-created decorator that decorates a {@link Client} with a new {@link CircuitBreakerClient}
      * based on the properties of this builder.
      */
-    abstract Function<Client<I, O>, U> newDecorator();
+    public abstract Function<Client<I, O>, T> newDecorator();
 
     @Override
     public String toString() {

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerHttpClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerHttpClientBuilder.java
@@ -65,7 +65,7 @@ public final class CircuitBreakerHttpClientBuilder
 
     @Override
     public CircuitBreakerHttpClientBuilder circuitBreakerMapping(CircuitBreakerMapping mapping) {
-        return (CircuitBreakerHttpClientBuilder) super.circuitBreakerMapping(mapping);
+        return mapping(mapping);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerHttpClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerHttpClientBuilder.java
@@ -25,8 +25,8 @@ import com.linecorp.armeria.common.HttpResponse;
 /**
  * Builds a new {@link CircuitBreakerHttpClient} or its decorator function.
  */
-public final class CircuitBreakerHttpClientBuilder extends CircuitBreakerClientBuilder<
-        CircuitBreakerHttpClientBuilder, CircuitBreakerHttpClient, HttpRequest, HttpResponse> {
+public final class CircuitBreakerHttpClientBuilder
+        extends CircuitBreakerClientBuilder<CircuitBreakerHttpClient, HttpRequest, HttpResponse> {
 
     private final boolean needsContentInStrategy;
 
@@ -50,14 +50,26 @@ public final class CircuitBreakerHttpClientBuilder extends CircuitBreakerClientB
     @Override
     public CircuitBreakerHttpClient build(Client<HttpRequest, HttpResponse> delegate) {
         if (needsContentInStrategy) {
-            return new CircuitBreakerHttpClient(delegate, circuitBreakerMapping(), strategyWithContent());
+            return new CircuitBreakerHttpClient(delegate, mapping(), strategyWithContent());
         }
 
-        return new CircuitBreakerHttpClient(delegate, circuitBreakerMapping(), strategy());
+        return new CircuitBreakerHttpClient(delegate, mapping(), strategy());
     }
 
     @Override
     public Function<Client<HttpRequest, HttpResponse>, CircuitBreakerHttpClient> newDecorator() {
         return this::build;
+    }
+
+    // Methods that were overridden to change the return type.
+
+    @Override
+    public CircuitBreakerHttpClientBuilder circuitBreakerMapping(CircuitBreakerMapping mapping) {
+        return (CircuitBreakerHttpClientBuilder) super.circuitBreakerMapping(mapping);
+    }
+
+    @Override
+    public CircuitBreakerHttpClientBuilder mapping(CircuitBreakerMapping mapping) {
+        return (CircuitBreakerHttpClientBuilder) super.mapping(mapping);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerRpcClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerRpcClientBuilder.java
@@ -25,8 +25,8 @@ import com.linecorp.armeria.common.RpcResponse;
 /**
  * Builds a new {@link CircuitBreakerRpcClient} or its decorator function.
  */
-public final class CircuitBreakerRpcClientBuilder extends CircuitBreakerClientBuilder<
-        CircuitBreakerRpcClientBuilder, CircuitBreakerRpcClient, RpcRequest, RpcResponse> {
+public final class CircuitBreakerRpcClientBuilder
+        extends CircuitBreakerClientBuilder<CircuitBreakerRpcClient, RpcRequest, RpcResponse> {
 
     /**
      * Creates a new builder with the specified {@link CircuitBreakerStrategyWithContent}.
@@ -36,12 +36,24 @@ public final class CircuitBreakerRpcClientBuilder extends CircuitBreakerClientBu
     }
 
     @Override
-    CircuitBreakerRpcClient build(Client<RpcRequest, RpcResponse> delegate) {
-        return new CircuitBreakerRpcClient(delegate, circuitBreakerMapping(), strategyWithContent());
+    public CircuitBreakerRpcClient build(Client<RpcRequest, RpcResponse> delegate) {
+        return new CircuitBreakerRpcClient(delegate, mapping(), strategyWithContent());
     }
 
     @Override
-    Function<Client<RpcRequest, RpcResponse>, CircuitBreakerRpcClient> newDecorator() {
+    public Function<Client<RpcRequest, RpcResponse>, CircuitBreakerRpcClient> newDecorator() {
         return this::build;
+    }
+
+    // Methods that were overridden to change the return type.
+
+    @Override
+    public CircuitBreakerRpcClientBuilder circuitBreakerMapping(CircuitBreakerMapping mapping) {
+        return (CircuitBreakerRpcClientBuilder) super.circuitBreakerMapping(mapping);
+    }
+
+    @Override
+    public CircuitBreakerRpcClientBuilder mapping(CircuitBreakerMapping mapping) {
+        return (CircuitBreakerRpcClientBuilder) super.mapping(mapping);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerRpcClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerRpcClientBuilder.java
@@ -49,7 +49,7 @@ public final class CircuitBreakerRpcClientBuilder
 
     @Override
     public CircuitBreakerRpcClientBuilder circuitBreakerMapping(CircuitBreakerMapping mapping) {
-        return (CircuitBreakerRpcClientBuilder) super.circuitBreakerMapping(mapping);
+        return mapping(mapping);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClientBuilder.java
@@ -110,7 +110,8 @@ public abstract class RetryingClientBuilder<T extends RetryingClient<I, O>,
      * @see <a href="https://line.github.io/armeria/advanced-retry.html#per-attempt-timeout">Per-attempt
      *      timeout</a>
      */
-    public RetryingClientBuilder<T, I, O> responseTimeoutMillisForEachAttempt(long responseTimeoutMillisForEachAttempt) {
+    public RetryingClientBuilder<T, I, O> responseTimeoutMillisForEachAttempt(
+            long responseTimeoutMillisForEachAttempt) {
         checkArgument(responseTimeoutMillisForEachAttempt >= 0,
                       "responseTimeoutMillisForEachAttempt: %s (expected: >= 0)",
                       responseTimeoutMillisForEachAttempt);
@@ -131,7 +132,8 @@ public abstract class RetryingClientBuilder<T extends RetryingClient<I, O>,
      * @see <a href="https://line.github.io/armeria/advanced-retry.html#per-attempt-timeout">Per-attempt
      *      timeout</a>
      */
-    public RetryingClientBuilder<T, I, O> responseTimeoutForEachAttempt(Duration responseTimeoutForEachAttempt) {
+    public RetryingClientBuilder<T, I, O> responseTimeoutForEachAttempt(
+            Duration responseTimeoutForEachAttempt) {
         checkArgument(
                 !requireNonNull(responseTimeoutForEachAttempt, "responseTimeoutForEachAttempt").isNegative(),
                 "responseTimeoutForEachAttempt: %s (expected: >= 0)", responseTimeoutForEachAttempt);

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClientBuilder.java
@@ -36,13 +36,11 @@ import com.linecorp.armeria.common.Response;
 /**
  * Builds a new {@link RetryingClient} or its decorator function.
  *
- * @param <T> the type of {@link RetryingClientBuilder}
- * @param <U> the type of the {@link Client} that this builder builds or decorates
+ * @param <T> the type of the {@link Client} that this builder builds or decorates
  * @param <I> the type of outgoing {@link Request} of the {@link Client}
  * @param <O> the type of incoming {@link Response} of the {@link Client}
  */
-public abstract class RetryingClientBuilder<
-        T extends RetryingClientBuilder<T, U, I, O>, U extends RetryingClient<I, O>,
+public abstract class RetryingClientBuilder<T extends RetryingClient<I, O>,
         I extends Request, O extends Response> {
 
     @Nullable
@@ -74,11 +72,6 @@ public abstract class RetryingClientBuilder<
         this.retryStrategyWithContent = retryStrategyWithContent;
     }
 
-    @SuppressWarnings("unchecked")
-    final T self() {
-        return (T) this;
-    }
-
     RetryStrategy retryStrategy() {
         checkState(retryStrategy != null, "retryStrategy is not set.");
         return retryStrategy;
@@ -93,13 +86,13 @@ public abstract class RetryingClientBuilder<
      * Sets the maximum number of total attempts. If unspecified, the value from
      * {@link Flags#defaultMaxTotalAttempts()} will be used.
      *
-     * @return {@link T} to support method chaining.
+     * @return {@code this} to support method chaining.
      */
-    public T maxTotalAttempts(int maxTotalAttempts) {
+    public RetryingClientBuilder<T, I, O> maxTotalAttempts(int maxTotalAttempts) {
         checkArgument(maxTotalAttempts > 0,
                       "maxTotalAttempts: %s (expected: > 0)", maxTotalAttempts);
         this.maxTotalAttempts = maxTotalAttempts;
-        return self();
+        return this;
     }
 
     int maxTotalAttempts() {
@@ -112,17 +105,17 @@ public abstract class RetryingClientBuilder<
      * It will be set by the default value in {@link Flags#defaultResponseTimeoutMillis()}, if the client
      * dose not specify.
      *
-     * @return {@link T} to support method chaining.
+     * @return {@code this} to support method chaining.
      *
      * @see <a href="https://line.github.io/armeria/advanced-retry.html#per-attempt-timeout">Per-attempt
      *      timeout</a>
      */
-    public T responseTimeoutMillisForEachAttempt(long responseTimeoutMillisForEachAttempt) {
+    public RetryingClientBuilder<T, I, O> responseTimeoutMillisForEachAttempt(long responseTimeoutMillisForEachAttempt) {
         checkArgument(responseTimeoutMillisForEachAttempt >= 0,
                       "responseTimeoutMillisForEachAttempt: %s (expected: >= 0)",
                       responseTimeoutMillisForEachAttempt);
         this.responseTimeoutMillisForEachAttempt = responseTimeoutMillisForEachAttempt;
-        return self();
+        return this;
     }
 
     long responseTimeoutMillisForEachAttempt() {
@@ -133,12 +126,12 @@ public abstract class RetryingClientBuilder<
      * Sets the response timeout for each attempt. When requests in {@link RetryingClient} are made,
      * corresponding responses are timed out by this value. {@code 0} disables the timeout.
      *
-     * @return {@link T} to support method chaining.
+     * @return {@code this} to support method chaining.
      *
      * @see <a href="https://line.github.io/armeria/advanced-retry.html#per-attempt-timeout">Per-attempt
      *      timeout</a>
      */
-    public T responseTimeoutForEachAttempt(Duration responseTimeoutForEachAttempt) {
+    public RetryingClientBuilder<T, I, O> responseTimeoutForEachAttempt(Duration responseTimeoutForEachAttempt) {
         checkArgument(
                 !requireNonNull(responseTimeoutForEachAttempt, "responseTimeoutForEachAttempt").isNegative(),
                 "responseTimeoutForEachAttempt: %s (expected: >= 0)", responseTimeoutForEachAttempt);
@@ -148,13 +141,13 @@ public abstract class RetryingClientBuilder<
     /**
      * Returns a newly-created {@link RetryingClient} based on the properties of this builder.
      */
-    abstract U build(Client<I, O> delegate);
+    public abstract T build(Client<I, O> delegate);
 
     /**
      * Returns a newly-created decorator that decorates a {@link Client} with a new {@link RetryingClient}
      * based on the properties of this builder.
      */
-    abstract Function<Client<I, O>, U> newDecorator();
+    public abstract Function<Client<I, O>, T> newDecorator();
 
     @Override
     public String toString() {

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingHttpClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingHttpClientBuilder.java
@@ -19,6 +19,7 @@ package com.linecorp.armeria.client.retry;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 
+import java.time.Duration;
 import java.util.function.Function;
 
 import com.google.common.base.MoreObjects.ToStringHelper;
@@ -30,8 +31,8 @@ import com.linecorp.armeria.common.HttpResponse;
 /**
  * Builds a new {@link RetryingHttpClient} or its decorator function.
  */
-public class RetryingHttpClientBuilder extends RetryingClientBuilder<
-        RetryingHttpClientBuilder, RetryingHttpClient, HttpRequest, HttpResponse> {
+public class RetryingHttpClientBuilder
+        extends RetryingClientBuilder<RetryingHttpClient, HttpRequest, HttpResponse> {
 
     private static final int DEFAULT_CONTENT_PREVIEW_LENGTH = Integer.MAX_VALUE;
 
@@ -69,7 +70,7 @@ public class RetryingHttpClientBuilder extends RetryingClientBuilder<
      */
     public RetryingHttpClientBuilder useRetryAfter(boolean useRetryAfter) {
         this.useRetryAfter = useRetryAfter;
-        return self();
+        return this;
     }
 
     /**
@@ -94,7 +95,7 @@ public class RetryingHttpClientBuilder extends RetryingClientBuilder<
         checkArgument(contentPreviewLength > 0,
                       "contentPreviewLength: %s (expected: > 0)", contentPreviewLength);
         this.contentPreviewLength = contentPreviewLength;
-        return self();
+        return this;
     }
 
     /**
@@ -128,5 +129,24 @@ public class RetryingHttpClientBuilder extends RetryingClientBuilder<
             stringHelper.add("contentPreviewLength", contentPreviewLength);
         }
         return stringHelper.toString();
+    }
+
+    // Methods that were overridden to change the return type.
+
+    @Override
+    public RetryingHttpClientBuilder maxTotalAttempts(int maxTotalAttempts) {
+        return (RetryingHttpClientBuilder) super.maxTotalAttempts(maxTotalAttempts);
+    }
+
+    @Override
+    public RetryingHttpClientBuilder responseTimeoutMillisForEachAttempt(
+            long responseTimeoutMillisForEachAttempt) {
+        return (RetryingHttpClientBuilder)
+                super.responseTimeoutMillisForEachAttempt(responseTimeoutMillisForEachAttempt);
+    }
+
+    @Override
+    public RetryingHttpClientBuilder responseTimeoutForEachAttempt(Duration responseTimeoutForEachAttempt) {
+        return (RetryingHttpClientBuilder) super.responseTimeoutForEachAttempt(responseTimeoutForEachAttempt);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClientBuilder.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.client.retry;
 
+import java.time.Duration;
 import java.util.function.Function;
 
 import com.linecorp.armeria.client.Client;
@@ -26,7 +27,7 @@ import com.linecorp.armeria.common.RpcResponse;
  * Builds a new {@link RetryingRpcClient} or its decorator function.
  */
 public class RetryingRpcClientBuilder
-        extends RetryingClientBuilder<RetryingRpcClientBuilder, RetryingRpcClient, RpcRequest, RpcResponse> {
+        extends RetryingClientBuilder<RetryingRpcClient, RpcRequest, RpcResponse> {
 
     /**
      * Creates a new builder with the specified {@link RetryStrategyWithContent}.
@@ -52,5 +53,25 @@ public class RetryingRpcClientBuilder
     @Override
     public Function<Client<RpcRequest, RpcResponse>, RetryingRpcClient> newDecorator() {
         return this::build;
+    }
+
+    // Methods that were overridden to change the return type.
+
+    @Override
+    public RetryingRpcClientBuilder maxTotalAttempts(
+            int maxTotalAttempts) {
+        return (RetryingRpcClientBuilder) super.maxTotalAttempts(maxTotalAttempts);
+    }
+
+    @Override
+    public RetryingRpcClientBuilder responseTimeoutMillisForEachAttempt(
+            long responseTimeoutMillisForEachAttempt) {
+        return (RetryingRpcClientBuilder) super.responseTimeoutMillisForEachAttempt(responseTimeoutMillisForEachAttempt);
+    }
+
+    @Override
+    public RetryingRpcClientBuilder responseTimeoutForEachAttempt(
+            Duration responseTimeoutForEachAttempt) {
+        return (RetryingRpcClientBuilder) super.responseTimeoutForEachAttempt(responseTimeoutForEachAttempt);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClientBuilder.java
@@ -66,7 +66,8 @@ public class RetryingRpcClientBuilder
     @Override
     public RetryingRpcClientBuilder responseTimeoutMillisForEachAttempt(
             long responseTimeoutMillisForEachAttempt) {
-        return (RetryingRpcClientBuilder) super.responseTimeoutMillisForEachAttempt(responseTimeoutMillisForEachAttempt);
+        return (RetryingRpcClientBuilder)
+                super.responseTimeoutMillisForEachAttempt(responseTimeoutMillisForEachAttempt);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/AbstractRequestContextBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AbstractRequestContextBuilder.java
@@ -372,7 +372,8 @@ public abstract class AbstractRequestContextBuilder {
      * @param requestStartTimeNanos the {@link System#nanoTime()} value when the request started.
      * @param requestStartTimeMicros the number of microseconds since the epoch when the request started.
      */
-    public AbstractRequestContextBuilder requestStartTime(long requestStartTimeNanos, long requestStartTimeMicros) {
+    public AbstractRequestContextBuilder requestStartTime(long requestStartTimeNanos,
+                                                          long requestStartTimeMicros) {
         this.requestStartTimeNanos = requestStartTimeNanos;
         this.requestStartTimeMicros = requestStartTimeMicros;
         requestStartTimeSet = true;

--- a/core/src/main/java/com/linecorp/armeria/common/AbstractRequestContextBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AbstractRequestContextBuilder.java
@@ -52,11 +52,10 @@ import io.netty.util.NetUtil;
 /**
  * Provides the information required for building a {@link RequestContext}.
  *
- * @param <B> the self type.
  * @see ServiceRequestContextBuilder
  * @see ClientRequestContextBuilder
  */
-public abstract class AbstractRequestContextBuilder<B extends AbstractRequestContextBuilder<B>> {
+public abstract class AbstractRequestContextBuilder {
 
     private static final String FALLBACK_AUTHORITY = "127.0.0.1";
 
@@ -96,9 +95,7 @@ public abstract class AbstractRequestContextBuilder<B extends AbstractRequestCon
         this.request = requireNonNull(request, "request");
         sessionProtocol = SessionProtocol.H2C;
 
-        final HttpMethod method = request.headers().method();
-        checkArgument(method != null, "request.method is not valid: %s", request);
-        this.method = method;
+        method = request.headers().method();
         authority = firstNonNull(request.headers().authority(), FALLBACK_AUTHORITY);
 
         final String pathAndQueryStr = request.headers().path();
@@ -145,11 +142,6 @@ public abstract class AbstractRequestContextBuilder<B extends AbstractRequestCon
         query = pathAndQuery.query();
     }
 
-    @SuppressWarnings("unchecked")
-    private B self() {
-        return (B) this;
-    }
-
     /**
      * Returns the {@link MeterRegistry}.
      */
@@ -160,9 +152,9 @@ public abstract class AbstractRequestContextBuilder<B extends AbstractRequestCon
     /**
      * Sets the {@link MeterRegistry}. If not set, {@link NoopMeterRegistry} is used.
      */
-    public final B meterRegistry(MeterRegistry meterRegistry) {
+    public AbstractRequestContextBuilder meterRegistry(MeterRegistry meterRegistry) {
         this.meterRegistry = requireNonNull(meterRegistry, "meterRegistry");
-        return self();
+        return this;
     }
 
     /**
@@ -179,9 +171,9 @@ public abstract class AbstractRequestContextBuilder<B extends AbstractRequestCon
      * Sets the {@link EventLoop} that handles the request.
      * If not set, one of the {@link CommonPools#workerGroup()} is used.
      */
-    public final B eventLoop(EventLoop eventLoop) {
+    public AbstractRequestContextBuilder eventLoop(EventLoop eventLoop) {
         this.eventLoop = requireNonNull(eventLoop, "eventLoop");
-        return self();
+        return this;
     }
 
     /**
@@ -194,9 +186,9 @@ public abstract class AbstractRequestContextBuilder<B extends AbstractRequestCon
     /**
      * Sets the {@link ByteBufAllocator}. If not set, {@link ByteBufAllocator#DEFAULT} is used.
      */
-    public final B alloc(ByteBufAllocator alloc) {
+    public AbstractRequestContextBuilder alloc(ByteBufAllocator alloc) {
         this.alloc = requireNonNull(alloc, "alloc");
-        return self();
+        return this;
     }
 
     /**
@@ -222,7 +214,7 @@ public abstract class AbstractRequestContextBuilder<B extends AbstractRequestCon
      *                                  For example, you cannot specify {@link SessionProtocol#H2C} if you
      *                                  created this builder with {@code h1c://example.com/}.
      */
-    public final B sessionProtocol(SessionProtocol sessionProtocol) {
+    public AbstractRequestContextBuilder sessionProtocol(SessionProtocol sessionProtocol) {
         requireNonNull(sessionProtocol, "sessionProtocol");
         if (request instanceof RpcRequest) {
             checkArgument(sessionProtocol == this.sessionProtocol,
@@ -231,7 +223,7 @@ public abstract class AbstractRequestContextBuilder<B extends AbstractRequestCon
         } else {
             this.sessionProtocol = sessionProtocol;
         }
-        return self();
+        return this;
     }
 
     /**
@@ -253,9 +245,9 @@ public abstract class AbstractRequestContextBuilder<B extends AbstractRequestCon
      * Sets the remote socket address of the connection. If not set, it is auto-generated with the localhost
      * IP address (e.g. {@code "127.0.0.1"} or {@code "::1"}).
      */
-    public final B remoteAddress(InetSocketAddress remoteAddress) {
+    public AbstractRequestContextBuilder remoteAddress(InetSocketAddress remoteAddress) {
         this.remoteAddress = requireNonNull(remoteAddress, "remoteAddress");
-        return self();
+        return this;
     }
 
     /**
@@ -277,9 +269,9 @@ public abstract class AbstractRequestContextBuilder<B extends AbstractRequestCon
      * Sets the local socket address of the connection. If not set, it is auto-generated with the localhost
      * IP address (e.g. {@code "127.0.0.1"} or {@code "::1"}).
      */
-    public final B localAddress(InetSocketAddress localAddress) {
+    public AbstractRequestContextBuilder localAddress(InetSocketAddress localAddress) {
         this.localAddress = requireNonNull(localAddress, "localAddress");
-        return self();
+        return this;
     }
 
     private static int guessServerPort(SessionProtocol sessionProtocol, @Nullable String authority) {
@@ -329,7 +321,7 @@ public abstract class AbstractRequestContextBuilder<B extends AbstractRequestCon
      * Note that upgrading the current {@link SessionProtocol} may trigger an {@link IllegalArgumentException},
      * as described in {@link #sessionProtocol(SessionProtocol)}.
      */
-    public final B sslSession(SSLSession sslSession) {
+    public AbstractRequestContextBuilder sslSession(SSLSession sslSession) {
         this.sslSession = requireNonNull(sslSession, "sslSession");
         switch (sessionProtocol) {
             case HTTP:
@@ -342,7 +334,7 @@ public abstract class AbstractRequestContextBuilder<B extends AbstractRequestCon
                 sessionProtocol(SessionProtocol.H2);
                 break;
         }
-        return self();
+        return this;
     }
 
     /**
@@ -380,11 +372,11 @@ public abstract class AbstractRequestContextBuilder<B extends AbstractRequestCon
      * @param requestStartTimeNanos the {@link System#nanoTime()} value when the request started.
      * @param requestStartTimeMicros the number of microseconds since the epoch when the request started.
      */
-    public final B requestStartTime(long requestStartTimeNanos, long requestStartTimeMicros) {
+    public AbstractRequestContextBuilder requestStartTime(long requestStartTimeNanos, long requestStartTimeMicros) {
         this.requestStartTimeNanos = requestStartTimeNanos;
         this.requestStartTimeMicros = requestStartTimeMicros;
         requestStartTimeSet = true;
-        return self();
+        return this;
     }
 
     /**
@@ -402,7 +394,7 @@ public abstract class AbstractRequestContextBuilder<B extends AbstractRequestCon
      *                                  creating this builder. This exception is not thrown if you
      *                                  created a builder with an {@link RpcRequest}.
      */
-    protected B method(HttpMethod method) {
+    protected AbstractRequestContextBuilder method(HttpMethod method) {
         requireNonNull(method, "method");
         if (request instanceof HttpRequest) {
             checkArgument(method == ((HttpRequest) request).method(),
@@ -410,7 +402,7 @@ public abstract class AbstractRequestContextBuilder<B extends AbstractRequestCon
         } else {
             this.method = method;
         }
-        return self();
+        return this;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextBuilder.java
@@ -18,24 +18,30 @@ package com.linecorp.armeria.server;
 import static java.util.Objects.requireNonNull;
 
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 
 import javax.annotation.Nullable;
+import javax.net.ssl.SSLSession;
 
 import com.linecorp.armeria.common.AbstractRequestContextBuilder;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.SessionProtocol;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.EventLoop;
 
 /**
  * Builds a new {@link ServiceRequestContext}. Note that it is not usually required to create a new context by
  * yourself, because Armeria will always provide a context object for you. However, it may be useful in some
  * cases such as unit testing.
  */
-public final class ServiceRequestContextBuilder
-        extends AbstractRequestContextBuilder<ServiceRequestContextBuilder> {
+public final class ServiceRequestContextBuilder extends AbstractRequestContextBuilder {
 
     /**
      * A placeholder service to make {@link ServerBuilder} happy.
@@ -186,5 +192,49 @@ public final class ServiceRequestContextBuilder
         }
 
         throw new Error(); // Never reaches here.
+    }
+
+    // Methods that were overridden to change the return type.
+
+    @Override
+    public ServiceRequestContextBuilder meterRegistry(MeterRegistry meterRegistry) {
+        return (ServiceRequestContextBuilder) super.meterRegistry(meterRegistry);
+    }
+
+    @Override
+    public ServiceRequestContextBuilder eventLoop(EventLoop eventLoop) {
+        return (ServiceRequestContextBuilder) super.eventLoop(eventLoop);
+    }
+
+    @Override
+    public ServiceRequestContextBuilder alloc(ByteBufAllocator alloc) {
+        return (ServiceRequestContextBuilder) super.alloc(alloc);
+    }
+
+    @Override
+    public ServiceRequestContextBuilder sessionProtocol(SessionProtocol sessionProtocol) {
+        return (ServiceRequestContextBuilder) super.sessionProtocol(sessionProtocol);
+    }
+
+    @Override
+    public ServiceRequestContextBuilder remoteAddress(InetSocketAddress remoteAddress) {
+        return (ServiceRequestContextBuilder) super.remoteAddress(remoteAddress);
+    }
+
+    @Override
+    public ServiceRequestContextBuilder localAddress(InetSocketAddress localAddress) {
+        return (ServiceRequestContextBuilder) super.localAddress(localAddress);
+    }
+
+    @Override
+    public ServiceRequestContextBuilder sslSession(SSLSession sslSession) {
+        return (ServiceRequestContextBuilder) super.sslSession(sslSession);
+    }
+
+    @Override
+    public ServiceRequestContextBuilder requestStartTime(long requestStartTimeNanos,
+                                                         long requestStartTimeMicros) {
+        return (ServiceRequestContextBuilder) super.requestStartTime(requestStartTimeNanos,
+                                                                     requestStartTimeMicros);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/composition/AbstractCompositeServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/composition/AbstractCompositeServiceBuilder.java
@@ -64,14 +64,12 @@ import com.linecorp.armeria.server.Service;
  * }
  * }</pre>
  *
- * @param <T> the self type
  * @param <I> the {@link Request} type
  * @param <O> the {@link Response} type
  *
  * @see CompositeServiceEntry
  */
-public abstract class AbstractCompositeServiceBuilder<T extends AbstractCompositeServiceBuilder<T, I, O>,
-                                                      I extends Request, O extends Response> {
+public abstract class AbstractCompositeServiceBuilder<I extends Request, O extends Response> {
 
     private final List<CompositeServiceEntry<I, O>> services = new ArrayList<>();
     private final List<CompositeServiceEntry<I, O>> unmodifiableServices =
@@ -81,14 +79,6 @@ public abstract class AbstractCompositeServiceBuilder<T extends AbstractComposit
      * Creates a new instance.
      */
     protected AbstractCompositeServiceBuilder() {}
-
-    /**
-     * Returns {@code this} cast to the type {@code T}.
-     */
-    @SuppressWarnings("unchecked")
-    protected final T self() {
-        return (T) this;
-    }
 
     /**
      * Returns the list of the {@link CompositeServiceEntry}s added via {@link #service(String, Service)},
@@ -105,14 +95,14 @@ public abstract class AbstractCompositeServiceBuilder<T extends AbstractComposit
      * @deprecated Use {@link #service(String, Service)} instead.
      */
     @Deprecated
-    protected T serviceAt(String pathPattern, Service<I, O> service) {
+    protected AbstractCompositeServiceBuilder<I, O> serviceAt(String pathPattern, Service<I, O> service) {
         return service(pathPattern, service);
     }
 
     /**
      * Binds the specified {@link Service} under the specified directory..
      */
-    protected T serviceUnder(String pathPrefix, Service<I, O> service) {
+    protected AbstractCompositeServiceBuilder<I, O> serviceUnder(String pathPrefix, Service<I, O> service) {
         return service(CompositeServiceEntry.ofPrefix(pathPrefix, service));
     }
 
@@ -130,23 +120,23 @@ public abstract class AbstractCompositeServiceBuilder<T extends AbstractComposit
      *
      * @throws IllegalArgumentException if the specified path pattern is invalid
      */
-    protected T service(String pathPattern, Service<I, O> service) {
+    protected AbstractCompositeServiceBuilder<I, O> service(String pathPattern, Service<I, O> service) {
         return service(CompositeServiceEntry.of(pathPattern, service));
     }
 
     /**
      * Binds the specified {@link Service} at the specified {@link Route}.
      */
-    protected T service(Route route, Service<I, O> service) {
+    protected AbstractCompositeServiceBuilder<I, O> service(Route route, Service<I, O> service) {
         return service(CompositeServiceEntry.of(route, service));
     }
 
     /**
      * Binds the specified {@link CompositeServiceEntry}.
      */
-    protected T service(CompositeServiceEntry<I, O> entry) {
+    protected AbstractCompositeServiceBuilder<I, O> service(CompositeServiceEntry<I, O> entry) {
         services.add(requireNonNull(entry, "entry"));
-        return self();
+        return this;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/composition/SimpleCompositeServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/composition/SimpleCompositeServiceBuilder.java
@@ -29,30 +29,26 @@ import com.linecorp.armeria.server.Service;
  * @param <O> the {@link Response} type
  */
 public final class SimpleCompositeServiceBuilder<I extends Request, O extends Response>
-        extends AbstractCompositeServiceBuilder<SimpleCompositeServiceBuilder<I, O>, I, O> {
+        extends AbstractCompositeServiceBuilder<I, O> {
 
     @Override
-    public SimpleCompositeServiceBuilder<I, O> serviceAt(
-            String pathPattern, Service<I, O> service) {
-        return super.service(pathPattern, service);
+    public SimpleCompositeServiceBuilder<I, O> serviceAt(String pathPattern, Service<I, O> service) {
+        return (SimpleCompositeServiceBuilder<I, O>) super.service(pathPattern, service);
     }
 
     @Override
-    public SimpleCompositeServiceBuilder<I, O> serviceUnder(
-            String pathPrefix, Service<I, O>  service) {
-        return super.serviceUnder(pathPrefix, service);
+    public SimpleCompositeServiceBuilder<I, O> serviceUnder(String pathPrefix, Service<I, O>  service) {
+        return (SimpleCompositeServiceBuilder<I, O>) super.serviceUnder(pathPrefix, service);
     }
 
     @Override
-    public SimpleCompositeServiceBuilder<I, O> service(
-            String pathPattern, Service<I, O> service) {
-        return super.service(pathPattern, service);
+    public SimpleCompositeServiceBuilder<I, O> service(String pathPattern, Service<I, O> service) {
+        return (SimpleCompositeServiceBuilder<I, O>) super.service(pathPattern, service);
     }
 
     @Override
-    public SimpleCompositeServiceBuilder<I, O> service(
-            Route route, Service<I, O>  service) {
-        return super.service(route, service);
+    public SimpleCompositeServiceBuilder<I, O> service(Route route, Service<I, O>  service) {
+        return (SimpleCompositeServiceBuilder<I, O>) super.service(route, service);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/file/AbstractHttpFileBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/AbstractHttpFileBuilder.java
@@ -32,10 +32,8 @@ import com.linecorp.armeria.common.MediaType;
 
 /**
  * A skeletal builder class which helps easier implementation of an {@link HttpFile} builder.
- *
- * @param <B> the type of {@code this}
  */
-public abstract class AbstractHttpFileBuilder<B extends AbstractHttpFileBuilder<B>> {
+public abstract class AbstractHttpFileBuilder {
 
     private Clock clock = Clock.systemUTC();
     private boolean dateEnabled = true;
@@ -45,14 +43,6 @@ public abstract class AbstractHttpFileBuilder<B extends AbstractHttpFileBuilder<
     private BiFunction<String, HttpFileAttributes, String> entityTagFunction = DefaultEntityTagFunction.get();
     @Nullable
     private HttpHeadersBuilder headers;
-
-    /**
-     * Returns {@code this}.
-     */
-    @SuppressWarnings("unchecked")
-    protected final B self() {
-        return (B) this;
-    }
 
     /**
      * Returns the {@link Clock} that provides the current date and time.
@@ -65,9 +55,9 @@ public abstract class AbstractHttpFileBuilder<B extends AbstractHttpFileBuilder<
      * Sets the {@link Clock} that provides the current date and time. By default, {@link Clock#systemUTC()}
      * is used.
      */
-    public final B clock(Clock clock) {
+    public AbstractHttpFileBuilder clock(Clock clock) {
         this.clock = requireNonNull(clock, "clock");
-        return self();
+        return this;
     }
 
     /**
@@ -81,9 +71,9 @@ public abstract class AbstractHttpFileBuilder<B extends AbstractHttpFileBuilder<
      * Sets whether to set the {@code "date"} header automatically. By default, the {@code "date"} header is
      * set automatically.
      */
-    public final B date(boolean dateEnabled) {
+    public AbstractHttpFileBuilder date(boolean dateEnabled) {
         this.dateEnabled = dateEnabled;
-        return self();
+        return this;
     }
 
     /**
@@ -97,9 +87,9 @@ public abstract class AbstractHttpFileBuilder<B extends AbstractHttpFileBuilder<
      * Sets whether to set the {@code "last-modified"} header automatically. By default,
      * the {@code "last-modified"} is set automatically.
      */
-    public final B lastModified(boolean lastModifiedEnabled) {
+    public AbstractHttpFileBuilder lastModified(boolean lastModifiedEnabled) {
         this.lastModifiedEnabled = lastModifiedEnabled;
-        return self();
+        return this;
     }
 
     /**
@@ -116,9 +106,9 @@ public abstract class AbstractHttpFileBuilder<B extends AbstractHttpFileBuilder<
      * Sets whether to set the {@code "content-type"} header automatically based on the extension of the file.
      * By default, the {@code "content-type"} header is set automatically.
      */
-    public final B autoDetectedContentType(boolean contentTypeAutoDetectionEnabled) {
+    public AbstractHttpFileBuilder autoDetectedContentType(boolean contentTypeAutoDetectionEnabled) {
         this.contentTypeAutoDetectionEnabled = contentTypeAutoDetectionEnabled;
-        return self();
+        return this;
     }
 
     /**
@@ -137,9 +127,9 @@ public abstract class AbstractHttpFileBuilder<B extends AbstractHttpFileBuilder<
      * file. By default, the {@code "etag"} header is set automatically. Use {@link #entityTag(BiFunction)} to
      * customize how an entity tag is generated.
      */
-    public final B entityTag(boolean enabled) {
+    public AbstractHttpFileBuilder entityTag(boolean enabled) {
         entityTagFunction = enabled ? DefaultEntityTagFunction.get() : null;
-        return self();
+        return this;
     }
 
     /**
@@ -149,9 +139,9 @@ public abstract class AbstractHttpFileBuilder<B extends AbstractHttpFileBuilder<
      * @param entityTagFunction the entity tag function that generates the entity tag, or {@code null}
      *                          to disable setting the {@code "etag"} header.
      */
-    public final B entityTag(BiFunction<String, HttpFileAttributes, String> entityTagFunction) {
+    public AbstractHttpFileBuilder entityTag(BiFunction<String, HttpFileAttributes, String> entityTagFunction) {
         this.entityTagFunction = requireNonNull(entityTagFunction, "entityTagFunction");
-        return self();
+        return this;
     }
 
     /**
@@ -172,39 +162,39 @@ public abstract class AbstractHttpFileBuilder<B extends AbstractHttpFileBuilder<
     /**
      * Adds the specified HTTP header.
      */
-    public final B addHeader(CharSequence name, Object value) {
+    public AbstractHttpFileBuilder addHeader(CharSequence name, Object value) {
         requireNonNull(name, "name");
         requireNonNull(value, "value");
         headersBuilder().addObject(HttpHeaderNames.of(name), value);
-        return self();
+        return this;
     }
 
     /**
      * Adds the specified HTTP headers.
      */
-    public final B addHeaders(Iterable<? extends Entry<? extends CharSequence, ?>> headers) {
+    public AbstractHttpFileBuilder addHeaders(Iterable<? extends Entry<? extends CharSequence, ?>> headers) {
         requireNonNull(headers, "headers");
         headersBuilder().addObject(headers);
-        return self();
+        return this;
     }
 
     /**
      * Sets the specified HTTP header.
      */
-    public final B setHeader(CharSequence name, Object value) {
+    public AbstractHttpFileBuilder setHeader(CharSequence name, Object value) {
         requireNonNull(name, "name");
         requireNonNull(value, "value");
         headersBuilder().setObject(HttpHeaderNames.of(name), value);
-        return self();
+        return this;
     }
 
     /**
      * Sets the specified HTTP headers.
      */
-    public final B setHeaders(Iterable<? extends Entry<? extends CharSequence, ?>> headers) {
+    public AbstractHttpFileBuilder setHeaders(Iterable<? extends Entry<? extends CharSequence, ?>> headers) {
         requireNonNull(headers, "headers");
         headersBuilder().setObject(headers);
-        return self();
+        return this;
     }
 
     /**
@@ -214,11 +204,11 @@ public abstract class AbstractHttpFileBuilder<B extends AbstractHttpFileBuilder<
      * builder.setHeader(HttpHeaderNames.CONTENT_TYPE, contentType);
      * }</pre>
      */
-    public final B contentType(MediaType contentType) {
+    public AbstractHttpFileBuilder contentType(MediaType contentType) {
         requireNonNull(contentType, "contentType");
         autoDetectedContentType(false);
         headersBuilder().contentType(contentType);
-        return self();
+        return this;
     }
 
     /**
@@ -228,7 +218,7 @@ public abstract class AbstractHttpFileBuilder<B extends AbstractHttpFileBuilder<
      * builder.setHeader(HttpHeaderNames.CONTENT_TYPE, contentType);
      * }</pre>
      */
-    public final B contentType(CharSequence contentType) {
+    public AbstractHttpFileBuilder contentType(CharSequence contentType) {
         requireNonNull(contentType, "contentType");
         autoDetectedContentType(false);
         return setHeader(HttpHeaderNames.CONTENT_TYPE, contentType);
@@ -240,7 +230,7 @@ public abstract class AbstractHttpFileBuilder<B extends AbstractHttpFileBuilder<
      * builder.setHeader(HttpHeaderNames.CACHE_CONTROL, cacheControl);
      * }</pre>
      */
-    public final B cacheControl(CacheControl cacheControl) {
+    public AbstractHttpFileBuilder cacheControl(CacheControl cacheControl) {
         requireNonNull(cacheControl, "cacheControl");
         return setHeader(HttpHeaderNames.CACHE_CONTROL, cacheControl);
     }
@@ -251,7 +241,7 @@ public abstract class AbstractHttpFileBuilder<B extends AbstractHttpFileBuilder<
      * builder.setHeader(HttpHeaderNames.CACHE_CONTROL, cacheControl);
      * }</pre>
      */
-    public final B cacheControl(CharSequence cacheControl) {
+    public AbstractHttpFileBuilder cacheControl(CharSequence cacheControl) {
         requireNonNull(cacheControl, "cacheControl");
         return setHeader(HttpHeaderNames.CACHE_CONTROL, cacheControl);
     }

--- a/core/src/main/java/com/linecorp/armeria/server/file/HttpFileBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/HttpFileBuilder.java
@@ -21,8 +21,13 @@ import java.io.File;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Path;
+import java.time.Clock;
+import java.util.Map.Entry;
+import java.util.function.BiFunction;
 
+import com.linecorp.armeria.common.CacheControl;
 import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.MediaType;
 
 /**
  * Builds an {@link HttpFile} from a file, a classpath resource or an {@link HttpData}.
@@ -45,7 +50,7 @@ import com.linecorp.armeria.common.HttpData;
  *                        .build();
  * }</pre>
  */
-public abstract class HttpFileBuilder extends AbstractHttpFileBuilder<HttpFileBuilder> {
+public abstract class HttpFileBuilder extends AbstractHttpFileBuilder {
 
     /**
      * Returns a new {@link HttpFileBuilder} that builds an {@link HttpFile} from the specified {@link File}.
@@ -147,6 +152,80 @@ public abstract class HttpFileBuilder extends AbstractHttpFileBuilder<HttpFileBu
      * an {@link AggregatedHttpFile}.
      */
     public abstract HttpFile build();
+
+    // Methods from the supertype that are overridden to change the return type.
+
+    @Override
+    public HttpFileBuilder clock(Clock clock) {
+        return (HttpFileBuilder) super.clock(clock);
+    }
+
+    @Override
+    public HttpFileBuilder date(boolean dateEnabled) {
+        return (HttpFileBuilder) super.date(dateEnabled);
+    }
+
+    @Override
+    public HttpFileBuilder lastModified(boolean lastModifiedEnabled) {
+        return (HttpFileBuilder) super.lastModified(lastModifiedEnabled);
+    }
+
+    @Override
+    public HttpFileBuilder autoDetectedContentType(boolean contentTypeAutoDetectionEnabled) {
+        return (HttpFileBuilder) super.autoDetectedContentType(contentTypeAutoDetectionEnabled);
+    }
+
+    @Override
+    public HttpFileBuilder entityTag(boolean enabled) {
+        return (HttpFileBuilder) super.entityTag(enabled);
+    }
+
+    @Override
+    public HttpFileBuilder entityTag(BiFunction<String, HttpFileAttributes, String> entityTagFunction) {
+        return (HttpFileBuilder) super.entityTag(entityTagFunction);
+    }
+
+    @Override
+    public HttpFileBuilder addHeader(CharSequence name, Object value) {
+        return (HttpFileBuilder) super.addHeader(name, value);
+    }
+
+    @Override
+    public HttpFileBuilder addHeaders(Iterable<? extends Entry<? extends CharSequence, ?>> headers) {
+        return (HttpFileBuilder) super.addHeaders(headers);
+    }
+
+    @Override
+    public HttpFileBuilder setHeader(CharSequence name, Object value) {
+        return (HttpFileBuilder) super.setHeader(name, value);
+    }
+
+    @Override
+    public HttpFileBuilder setHeaders(Iterable<? extends Entry<? extends CharSequence, ?>> headers) {
+        return (HttpFileBuilder) super.setHeaders(headers);
+    }
+
+    @Override
+    public HttpFileBuilder contentType(MediaType contentType) {
+        return (HttpFileBuilder) super.contentType(contentType);
+    }
+
+    @Override
+    public HttpFileBuilder contentType(CharSequence contentType) {
+        return (HttpFileBuilder) super.contentType(contentType);
+    }
+
+    @Override
+    public HttpFileBuilder cacheControl(CacheControl cacheControl) {
+        return (HttpFileBuilder) super.cacheControl(cacheControl);
+    }
+
+    @Override
+    public HttpFileBuilder cacheControl(CharSequence cacheControl) {
+        return (HttpFileBuilder) super.cacheControl(cacheControl);
+    }
+
+    // Builder implementations
 
     private static final class FileSystemHttpFileBuilder extends HttpFileBuilder {
 

--- a/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerHttpClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerHttpClientTest.java
@@ -154,7 +154,7 @@ public class CircuitBreakerHttpClientTest {
 
         final CircuitBreakerMapping mapping = (ctx, req) -> circuitBreaker;
         final HttpClient client = new HttpClientBuilder(server.uri("/"))
-                .decorator(builder.circuitBreakerMapping(mapping).newDecorator())
+                .decorator(builder.mapping(mapping).newDecorator())
                 .build();
 
         ticker.advance(Duration.ofMillis(1).toNanos());


### PR DESCRIPTION
Motivation:

Self type parameters are useful when you write an abstract builder
with method chaining, but the Javadoc generated from it looks less
intuitive.

Modifications:

- Remove the usage of the self-type parameters from abstract builders.
- Miscellaneous:
  - Add `CircuitBreakerClientBuilder.mapping()`.
  - Deprecate `CircuitBreakerClientBuilder.circuitBreakerMapping()`.

Result:

- Looks prettier to users
- Increased maintanence burden for devs
- Deprecation of `CircuitBreakerClientBuilder.circuitBreakerMapping()` in favor of `mapping()`