### PR TITLE
Allows tracing of threads without a request context available using a…

### DIFF
--- a/brave/src/main/java/com/linecorp/armeria/common/brave/RequestContextCurrentTraceContext.java
+++ b/brave/src/main/java/com/linecorp/armeria/common/brave/RequestContextCurrentTraceContext.java
@@ -66,7 +66,7 @@ public final class RequestContextCurrentTraceContext extends CurrentTraceContext
     // Thread-local for storing TraceContext when invoking callbacks off the request thread.
     private static final ThreadLocal<TraceContext> THREAD_LOCAL_CONTEXT = new ThreadLocal<>();
 
-    private static final ThreadLocal<Boolean> THREAD_NOT_REQUEST_THREAD = ThreadLocal.withInitial(() -> false);
+    private static final ThreadLocal<Boolean> THREAD_NOT_REQUEST_THREAD = new ThreadLocal<>();
 
     private static final Scope INITIAL_REQUEST_SCOPE = new Scope() {
         @Override
@@ -250,7 +250,7 @@ public final class RequestContextCurrentTraceContext extends CurrentTraceContext
         @Override
         @Nullable
         public RequestContext get() {
-            if (THREAD_NOT_REQUEST_THREAD.get()) {
+            if (Boolean.TRUE.equals(THREAD_NOT_REQUEST_THREAD.get())) {
                 return null;
             }
             ClassLoaderHack.loadMe();

--- a/brave/src/main/java/com/linecorp/armeria/common/brave/RequestContextCurrentTraceContext.java
+++ b/brave/src/main/java/com/linecorp/armeria/common/brave/RequestContextCurrentTraceContext.java
@@ -56,7 +56,11 @@ public final class RequestContextCurrentTraceContext extends CurrentTraceContext
      * warning when trying to start a trace without having a {@link RequestContext}.
      */
     public static void setCurrentThreadNotRequestThread(boolean value) {
-        THREAD_NOT_REQUEST_THREAD.set(value);
+        if (value) {
+            THREAD_NOT_REQUEST_THREAD.set(true);
+        } else {
+            THREAD_NOT_REQUEST_THREAD.remove();
+        }
     }
 
     private static final CurrentTraceContext DEFAULT = new RequestContextCurrentTraceContext(new Builder());

--- a/brave/src/main/java/com/linecorp/armeria/common/brave/RequestContextCurrentTraceContext.java
+++ b/brave/src/main/java/com/linecorp/armeria/common/brave/RequestContextCurrentTraceContext.java
@@ -49,6 +49,16 @@ import io.netty.util.Attribute;
  */
 public final class RequestContextCurrentTraceContext extends CurrentTraceContext {
 
+    /**
+     * Sets whether the current thread is not a request thread, meaning it is never executed in the scope of a
+     * server or client request and will never have a {@link RequestContext} available. This can be called from
+     * background threads, such as the thread that reports traced spans to storage, to prevent logging a
+     * warning when trying to start a trace without having a {@link RequestContext}.
+     */
+    public static void setCurrentThreadNotRequestThread(boolean value) {
+        THREAD_NOT_REQUEST_THREAD.set(value);
+    }
+
     private static final CurrentTraceContext DEFAULT = new RequestContextCurrentTraceContext(new Builder());
 
     private static final Logger logger = LoggerFactory.getLogger(RequestContextCurrentTraceContext.class);
@@ -56,16 +66,7 @@ public final class RequestContextCurrentTraceContext extends CurrentTraceContext
     // Thread-local for storing TraceContext when invoking callbacks off the request thread.
     private static final ThreadLocal<TraceContext> THREAD_LOCAL_CONTEXT = new ThreadLocal<>();
 
-    private static final Scope INCOMPLETE_CONFIGURATION_SCOPE = new Scope() {
-        @Override
-        public void close() {
-        }
-
-        @Override
-        public String toString() {
-            return "IncompleteConfigurationScope";
-        }
-    };
+    private static final ThreadLocal<Boolean> THREAD_NOT_REQUEST_THREAD = ThreadLocal.withInitial(() -> false);
 
     private static final Scope INITIAL_REQUEST_SCOPE = new Scope() {
         @Override
@@ -142,8 +143,9 @@ public final class RequestContextCurrentTraceContext extends CurrentTraceContext
     public TraceContext get() {
         final RequestContext ctx = getRequestContextOrWarnOnce();
         if (ctx == null) {
-            return null;
+            return THREAD_LOCAL_CONTEXT.get();
         }
+
         if (ctx.eventLoop().inEventLoop()) {
             return getTraceContextAttribute(ctx).get();
         } else {
@@ -164,11 +166,8 @@ public final class RequestContextCurrentTraceContext extends CurrentTraceContext
         }
 
         final RequestContext ctx = getRequestContextOrWarnOnce();
-        if (ctx == null) {
-            return INCOMPLETE_CONFIGURATION_SCOPE;
-        }
 
-        if (ctx.eventLoop().inEventLoop()) {
+        if (ctx != null && ctx.eventLoop().inEventLoop()) {
             return createScopeForRequestThread(ctx, currentSpan);
         } else {
             // The RequestContext is the canonical thread-local storage for the thread processing the request.
@@ -251,6 +250,9 @@ public final class RequestContextCurrentTraceContext extends CurrentTraceContext
         @Override
         @Nullable
         public RequestContext get() {
+            if (THREAD_NOT_REQUEST_THREAD.get()) {
+                return null;
+            }
             ClassLoaderHack.loadMe();
             return null;
         }

--- a/brave/src/test/java/com/linecorp/armeria/common/brave/RequestContextCurrentTraceContextTest.java
+++ b/brave/src/test/java/com/linecorp/armeria/common/brave/RequestContextCurrentTraceContextTest.java
@@ -97,10 +97,10 @@ public class RequestContextCurrentTraceContextTest {
     }
 
     @Test
-    public void newScope_doesNothingWhenNoCurrentRequestContext() {
+    public void newScope_appliesWhenNoCurrentRequestContext() {
         try (Scope traceContextScope = currentTraceContext.newScope(traceContext)) {
-            assertThat(traceContextScope).hasToString("IncompleteConfigurationScope");
-            assertThat(currentTraceContext.get()).isNull();
+            assertThat(traceContextScope).hasToString("ThreadLocalScope");
+            assertThat(currentTraceContext.get()).isEqualTo(traceContext);
         }
     }
 


### PR DESCRIPTION
… normal thread-local, and allows opting a thread out of the request context warning.

Currently threads that are run without a `RequestContext` cannot have traces since we return no-op scopes. It doesn't hurt to go ahead and use thread local scopes for these since they may be background threads. In general, we will still log a warning in this case, but also provide a knob to let threads opt-out of this warning if they are purely background threads.

Fixes #1964 

/cc @adriancole 