### PR TITLE
Make `RetryingClient` respect the `Endpoint` selection order

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
@@ -256,9 +256,10 @@ public abstract class RetryingClient<I extends Request, O extends Response>
      * Creates a new derived {@link ClientRequestContext}, replacing the {@link Request} with {@code req}.
      * If {@link ClientRequestContext#endpointSelector()} exists, a new {@link Endpoint} will be selected.
      */
-    protected static ClientRequestContext newDerivedContext(ClientRequestContext ctx, Request req) {
+    protected static ClientRequestContext newDerivedContext(ClientRequestContext ctx,
+                                                            Request req, int totalAttempts) {
         final EndpointSelector endpointSelector = ctx.endpointSelector();
-        if (endpointSelector != null) {
+        if (endpointSelector != null && totalAttempts > 1) {
             return ctx.newDerivedContext(req, endpointSelector.select(ctx));
         } else {
             return ctx.newDerivedContext(req);

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingHttpClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingHttpClient.java
@@ -172,7 +172,7 @@ public final class RetryingHttpClient extends RetryingClient<HttpRequest, HttpRe
             duplicateReq = rootReqDuplicator.duplicateStream(newHeaders.build());
         }
 
-        final ClientRequestContext derivedCtx = newDerivedContext(ctx, duplicateReq);
+        final ClientRequestContext derivedCtx = newDerivedContext(ctx, duplicateReq, totalAttempts);
         ctx.logBuilder().addChild(derivedCtx.log());
 
         final HttpResponse response = executeWithFallback(delegate(), derivedCtx,

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClient.java
@@ -101,10 +101,10 @@ public final class RetryingRpcClient extends RetryingClient<RpcRequest, RpcRespo
             return;
         }
 
-        final ClientRequestContext derivedCtx = newDerivedContext(ctx, req);
+        final int totalAttempts = getTotalAttempts(ctx);
+        final ClientRequestContext derivedCtx = newDerivedContext(ctx, req, totalAttempts);
         ctx.logBuilder().addChild(derivedCtx.log());
 
-        final int totalAttempts = getTotalAttempts(ctx);
         if (totalAttempts > 1) {
             derivedCtx.setAdditionalRequestHeader(ARMERIA_RETRY_COUNT, Integer.toString(totalAttempts - 1));
         }

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientLoadBalancingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientLoadBalancingTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.retry;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.InetSocketAddress;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.client.HttpClientBuilder;
+import com.linecorp.armeria.client.endpoint.EndpointGroup;
+import com.linecorp.armeria.client.endpoint.EndpointGroupRegistry;
+import com.linecorp.armeria.client.endpoint.EndpointSelectionStrategy;
+import com.linecorp.armeria.client.endpoint.StaticEndpointGroup;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.logging.RequestLogAvailability;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.testing.junit.server.ServerExtension;
+
+public class RetryingClientLoadBalancingTest {
+
+    private static final int NUM_PORTS = 5;
+
+    private final List<Integer> accessedPorts = new CopyOnWriteArrayList<>();
+
+    @RegisterExtension
+    final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            accessedPorts.clear();
+
+            for (int i = 0; i < NUM_PORTS; i++) {
+                sb.http(0);
+            }
+
+            sb.service("/success", (ctx, req) -> {
+                accessedPorts.add(((InetSocketAddress) ctx.localAddress()).getPort());
+                return HttpResponse.of(HttpStatus.OK);
+            });
+
+            sb.service("/failure", (ctx, req) -> {
+                accessedPorts.add(((InetSocketAddress) ctx.localAddress()).getPort());
+                return HttpResponse.of(HttpStatus.SERVICE_UNAVAILABLE);
+            });
+        }
+    };
+
+    private enum TestMode {
+        SUCCESS("/success"),
+        FAILURE("/failure");
+
+        final String path;
+
+        TestMode(String path) {
+            this.path = path;
+        }
+    }
+
+    /**
+     * Makes sure that {@link RetryingClient} respects the {@link Endpoint} selection order.
+     */
+    @ParameterizedTest
+    @EnumSource(TestMode.class)
+    void test(TestMode mode) {
+        server.start();
+        final List<Integer> expectedPorts = server.server().activePorts().keySet().stream()
+                                                  .map(InetSocketAddress::getPort)
+                                                  .collect(toImmutableList());
+
+        final EndpointGroup group =
+                new StaticEndpointGroup(expectedPorts.stream()
+                                                     .map(port -> Endpoint.of("127.0.0.1", port))
+                                                     .collect(toImmutableList()));
+
+        final String groupName = "loadBalancedRetry";
+        EndpointGroupRegistry.register(groupName, group, EndpointSelectionStrategy.ROUND_ROBIN);
+        try {
+            final HttpClient c = new HttpClientBuilder("h2c://group:" + groupName)
+                    .decorator(new RetryingHttpClientBuilder((RetryStrategy) (ctx, cause) -> {
+                        // Get the response status.
+                        final HttpStatus status;
+                        if (ctx.log().isAvailable(RequestLogAvailability.RESPONSE_HEADERS)) {
+                            status = ctx.log().responseHeaders().status();
+                        } else {
+                            status = null;
+                        }
+
+                        // Retry only once on failure.
+                        if (!HttpStatus.OK.equals(status) && RetryingClient.getTotalAttempts(ctx) <= 1) {
+                            return CompletableFuture.completedFuture(Backoff.withoutDelay());
+                        } else {
+                            return CompletableFuture.completedFuture(null);
+                        }
+                    }).newDecorator())
+                    .build();
+
+            for (int i = 0; i < NUM_PORTS; i++) {
+                c.get(mode.path).aggregate().join();
+            }
+
+            switch (mode) {
+                case SUCCESS:
+                    assertThat(accessedPorts).isEqualTo(expectedPorts);
+                    break;
+                case FAILURE:
+                    final List<Integer> expectedPortsWhenRetried =
+                            ImmutableList.<Integer>builder()
+                                         .addAll(expectedPorts)
+                                         .addAll(expectedPorts)
+                                         .build();
+                    assertThat(accessedPorts).isEqualTo(expectedPortsWhenRetried);
+                    break;
+            }
+        } finally {
+            EndpointGroupRegistry.unregister(groupName);
+        }
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientLoadBalancingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientLoadBalancingTest.java
@@ -46,6 +46,17 @@ class RetryingClientLoadBalancingTest {
 
     private static final int NUM_PORTS = 5;
 
+    private enum TestMode {
+        SUCCESS("/success"),
+        FAILURE("/failure");
+
+        final String path;
+
+        TestMode(String path) {
+            this.path = path;
+        }
+    }
+
     private final List<Integer> accessedPorts = new CopyOnWriteArrayList<>();
 
     @RegisterExtension
@@ -58,28 +69,17 @@ class RetryingClientLoadBalancingTest {
                 sb.http(0);
             }
 
-            sb.service("/success", (ctx, req) -> {
+            sb.service(TestMode.SUCCESS.path, (ctx, req) -> {
                 accessedPorts.add(((InetSocketAddress) ctx.localAddress()).getPort());
                 return HttpResponse.of(HttpStatus.OK);
             });
 
-            sb.service("/failure", (ctx, req) -> {
+            sb.service(TestMode.FAILURE.path, (ctx, req) -> {
                 accessedPorts.add(((InetSocketAddress) ctx.localAddress()).getPort());
                 return HttpResponse.of(HttpStatus.SERVICE_UNAVAILABLE);
             });
         }
     };
-
-    private enum TestMode {
-        SUCCESS("/success"),
-        FAILURE("/failure");
-
-        final String path;
-
-        TestMode(String path) {
-            this.path = path;
-        }
-    }
 
     /**
      * Makes sure that {@link RetryingClient} respects the {@link Endpoint} selection order.

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientLoadBalancingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientLoadBalancingTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package com.linecorp.armeria.client.retry;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -43,7 +42,7 @@ import com.linecorp.armeria.common.logging.RequestLogAvailability;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.testing.junit.server.ServerExtension;
 
-public class RetryingClientLoadBalancingTest {
+class RetryingClientLoadBalancingTest {
 
     private static final int NUM_PORTS = 5;
 


### PR DESCRIPTION
Motivation:

`RetryingClient.newDerivedContext()` always selects a new `Endpoint`,
but it should never for the first attempt, because the `Endpoint` for
the first attempt has been already selected by the parent context.

Modifications:

- Add `totalAttempt` parameter to `RetryingClient.newDerivedContext()`
  and do not select a new `Endpoint` when it's greater than 1.
- Add a test case

Result:

- Fixes #1973