### PR TITLE
Implement long polling for `HealthCheckedEndpointGroup`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/Http1ResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http1ResponseDecoder.java
@@ -89,7 +89,7 @@ final class Http1ResponseDecoder extends HttpResponseDecoder implements ChannelI
 
     private void onWrapperCompleted(HttpResponseWrapper resWrapper, @Nullable Throwable cause) {
         // Cancel timeout future and abort the request if it exists.
-        resWrapper.onSubscriptionCancelled();
+        resWrapper.onSubscriptionCancelled(cause);
 
         if (cause != null) {
             // Disconnect when the response has been closed with an exception because there's no way

--- a/core/src/main/java/com/linecorp/armeria/client/Http2ResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http2ResponseDecoder.java
@@ -88,7 +88,7 @@ final class Http2ResponseDecoder extends HttpResponseDecoder implements Http2Con
 
     private void onWrapperCompleted(HttpResponseWrapper resWrapper, int id, @Nullable Throwable cause) {
         // Cancel timeout future and abort the request if it exists.
-        resWrapper.onSubscriptionCancelled();
+        resWrapper.onSubscriptionCancelled(cause);
 
         if (cause != null) {
             // We are not closing the connection but just send a RST_STREAM,

--- a/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
@@ -265,8 +265,8 @@ abstract class HttpResponseDecoder {
             return delegate.onDemand(task);
         }
 
-        void onSubscriptionCancelled() {
-            close(null, this::cancelAction);
+        void onSubscriptionCancelled(@Nullable Throwable cause) {
+            close(cause, this::cancelAction);
         }
 
         @Override
@@ -306,7 +306,11 @@ abstract class HttpResponseDecoder {
         }
 
         private void cancelAction(@Nullable Throwable cause) {
-            logBuilder.endResponse();
+            if (cause != null) {
+                logBuilder.endResponse(cause);
+            } else {
+                logBuilder.endResponse();
+            }
         }
 
         @Override

--- a/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
@@ -35,6 +35,7 @@ import com.linecorp.armeria.common.HttpStatusClass;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.logging.RequestLogBuilder;
+import com.linecorp.armeria.common.stream.CancelledSubscriptionException;
 import com.linecorp.armeria.common.stream.StreamWriter;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.internal.InboundTrafficController;
@@ -306,7 +307,7 @@ abstract class HttpResponseDecoder {
         }
 
         private void cancelAction(@Nullable Throwable cause) {
-            if (cause != null) {
+            if (cause != null && !(cause instanceof CancelledSubscriptionException)) {
                 logBuilder.endResponse(cause);
             } else {
                 logBuilder.endResponse();

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthChecker.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthChecker.java
@@ -40,7 +40,6 @@ import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.RequestHeadersBuilder;
 import com.linecorp.armeria.common.SessionProtocol;
-import com.linecorp.armeria.common.logging.RequestLogAvailability;
 import com.linecorp.armeria.common.util.AsyncCloseable;
 
 import io.netty.util.AsciiString;
@@ -155,11 +154,6 @@ final class HttpHealthChecker implements AsyncCloseable {
                             TimeUnit.SECONDS.toMillis(maxLongPollingSeconds));
                     ctx.setResponseTimeoutMillis(newResponseTimeoutMillis);
                 }
-                ctx.log().addListener(log -> {
-                    if (log.responseHeaders().status().code() == 0) {
-                        System.err.println("?");
-                    }
-                }, RequestLogAvailability.COMPLETE);
             }
             return delegate().execute(ctx, req);
         }

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroupLongPollingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroupLongPollingTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client.endpoint.healthcheck;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.time.Duration;
+import java.util.Queue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedTransferQueue;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.Nullable;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.google.common.base.Stopwatch;
+
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.endpoint.EndpointGroup;
+import com.linecorp.armeria.client.endpoint.StaticEndpointGroup;
+import com.linecorp.armeria.client.logging.LoggingClient;
+import com.linecorp.armeria.client.retry.Backoff;
+import com.linecorp.armeria.common.logging.RequestLog;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.healthcheck.HealthCheckService;
+import com.linecorp.armeria.server.healthcheck.SettableHealthChecker;
+import com.linecorp.armeria.testing.junit.server.ServerExtension;
+
+class HttpHealthCheckedEndpointGroupLongPollingTest {
+
+    private static final Duration RETRY_INTERVAL = Duration.ofSeconds(3);
+    private static final String HEALTH_CHECK_PATH = "/healthcheck";
+
+    private static final SettableHealthChecker health = new SettableHealthChecker();
+
+    @RegisterExtension
+    static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.service(HEALTH_CHECK_PATH, HealthCheckService.of(health));
+        }
+    };
+
+    @Nullable
+    private volatile BlockingQueue<RequestLog> healthCheckRequestLogs;
+
+    @Test
+    void immediateNotification() throws Exception {
+        final Endpoint endpoint = Endpoint.of("127.0.0.1", server.httpPort());
+        try (HealthCheckedEndpointGroup endpointGroup = build(
+                HealthCheckedEndpointGroup.builder(
+                        new StaticEndpointGroup(endpoint),
+                        HEALTH_CHECK_PATH))) {
+
+            // Check the initial state (healthy).
+            assertThat(endpointGroup.endpoints()).containsExactly(endpoint);
+
+            // Make the server unhealthy.
+            health.setHealthy(false);
+            waitForGroup(endpointGroup, null);
+
+            // Make the server healthy again.
+            health.setHealthy(true);
+            waitForGroup(endpointGroup, endpoint);
+
+            // Stop the server.
+            server.stop();
+            waitForGroup(endpointGroup, null);
+        }
+    }
+
+    @Test
+    @Timeout(15)
+    void periodicCheckWhenConnectionRefused() throws Exception {
+        final BlockingQueue<RequestLog> healthCheckRequestLogs = new LinkedTransferQueue<>();
+        this.healthCheckRequestLogs = healthCheckRequestLogs;
+        final Endpoint endpoint = Endpoint.of("127.0.0.1", 1);
+        try (HealthCheckedEndpointGroup endpointGroup = build(
+                HealthCheckedEndpointGroup.builder(
+                        new StaticEndpointGroup(endpoint),
+                        HEALTH_CHECK_PATH))) {
+
+            // Check the initial state (unhealthy).
+            assertThat(endpointGroup.endpoints()).isEmpty();
+
+            // Drop the first request.
+            healthCheckRequestLogs.take();
+
+            final Stopwatch stopwatch = Stopwatch.createUnstarted();
+            for (int i = 0; i < 2; i++) {
+                stopwatch.reset().start();
+                healthCheckRequestLogs.take();
+                assertThat(stopwatch.elapsed(TimeUnit.MILLISECONDS))
+                        .isGreaterThan(RETRY_INTERVAL.toMillis() * 4 / 5);
+            }
+        } finally {
+            this.healthCheckRequestLogs = null;
+        }
+    }
+
+    /**
+     * Makes sure the notification occurs as soon as possible thanks to long polling.
+     */
+    private static void waitForGroup(EndpointGroup group, @Nullable Endpoint expectedEndpoint) {
+        final Stopwatch stopwatch = Stopwatch.createStarted();
+        if (expectedEndpoint != null) {
+            await().untilAsserted(() -> assertThat(group.endpoints()).containsExactly(expectedEndpoint));
+        } else {
+            await().untilAsserted(() -> assertThat(group.endpoints()).isEmpty());
+        }
+        assertThat(stopwatch.elapsed(TimeUnit.MILLISECONDS)).isLessThan(RETRY_INTERVAL.toMillis() / 3);
+    }
+
+    private HealthCheckedEndpointGroup build(HealthCheckedEndpointGroupBuilder builder) {
+        // Specify backoff explicitly to disable jitter.
+        builder.retryBackoff(Backoff.fixed(RETRY_INTERVAL.toMillis()));
+        builder.withClientOptions(b -> {
+            b.decorator(LoggingClient.newDecorator());
+            b.decorator((delegate, ctx, req) -> {
+                // Record when health check requests were sent.
+                final Queue<RequestLog> healthCheckRequestLogs = this.healthCheckRequestLogs;
+                if (healthCheckRequestLogs != null) {
+                    healthCheckRequestLogs.add(ctx.log());
+                }
+                return delegate.execute(ctx, req);
+            });
+            return b;
+        });
+        return builder.build();
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroupTest.java
@@ -58,7 +58,7 @@ class HttpHealthCheckedEndpointGroupTest {
             sb.http(0);
             sb.https(0);
             sb.tlsSelfSigned();
-            sb.service(HEALTH_CHECK_PATH, HealthCheckService.of());
+            sb.service(HEALTH_CHECK_PATH, HealthCheckService.builder().longPolling(0).build());
         }
     }
 


### PR DESCRIPTION
Motivation:

`HealthCheckService` provides a way to get notified immediately when a
server becomes healthy or healthy. We should make use of it in
`HealthCheckedEndpointGroup`.

Modifications:

- Make `HttpHealthChecker` respect the `armeria-lphc` header.
- Miscellaneous:
  - Fix a bug where `RequestLog.responseCause()` is sometimes not
    recorded at all.

Result:

- `HealthCheckedEndpointGroup` knows really soon when a server becomes
  healthy or unhealthy, except when the server is completely
  unreachable, e.g. connection refused.
- `RequestLog.responseCause()` is recorded correctly.