### PR TITLE
RequestContextCurrentTraceContext.setCurrentThreadNotRequestThread code

### DIFF
--- a/brave/src/main/java/com/linecorp/armeria/common/brave/RequestContextCurrentTraceContext.java
+++ b/brave/src/main/java/com/linecorp/armeria/common/brave/RequestContextCurrentTraceContext.java
@@ -59,12 +59,14 @@ public final class RequestContextCurrentTraceContext extends CurrentTraceContext
      * a {@link java.util.concurrent.ThreadFactory} like the following:
      * <pre>{@code
      * > ThreadFactory factory = (runnable) -> new Thread(new Runnable() {
-     * >     @Override public void run() {
+     * >     @Override
+     * >     public void run() {
      * >         RequestContextCurrentTraceContext.setCurrentThreadNotRequestThread(true);
      * >         runnable.run();
      * >     }
      * >
-     * >     @Override public String toString() {
+     * >     @Override
+     * >     public String toString() {
      * >         return runnable.toString();
      * >     }
      * > });

--- a/brave/src/main/java/com/linecorp/armeria/common/brave/RequestContextCurrentTraceContext.java
+++ b/brave/src/main/java/com/linecorp/armeria/common/brave/RequestContextCurrentTraceContext.java
@@ -55,7 +55,8 @@ public final class RequestContextCurrentTraceContext extends CurrentTraceContext
      * background threads, such as the thread that reports traced spans to storage, to prevent logging a
      * warning when trying to start a trace without having a {@link RequestContext}.
      *
-     * <p>For example, to prevent warnings from an administrative thread controlled by a thread factory:
+     * <p>For example, you could prevent warnings from the administrative threads controlled by
+     * a {@link java.util.concurrent.ThreadFactory} like the following:
      * <pre>{@code
      * > ThreadFactory factory = (runnable) -> new Thread(new Runnable() {
      * >     @Override public void run() {

--- a/brave/src/main/java/com/linecorp/armeria/common/brave/RequestContextCurrentTraceContext.java
+++ b/brave/src/main/java/com/linecorp/armeria/common/brave/RequestContextCurrentTraceContext.java
@@ -55,18 +55,18 @@ public final class RequestContextCurrentTraceContext extends CurrentTraceContext
      * background threads, such as the thread that reports traced spans to storage, to prevent logging a
      * warning when trying to start a trace without having a {@link RequestContext}.
      *
-     * Ex. To prevent warnings from an administrative thread controlled by a thread factory:
+     * <p>For example, to prevent warnings from an administrative thread controlled by a thread factory:
      * <pre>{@code
-     * threadFactory = (runnable) -> new Thread(new Runnable() {
-     *   @Override public void run() {
-     *     RequestContextCurrentTraceContext.setCurrentThreadNotRequestThread(true);
-     *     runnable.run();
-     *   }
-     *
-     *   @Override public String toString() {
-     *     return runnable.toString();
-     *   }
-     * });
+     * > ThreadFactory factory = (runnable) -> new Thread(new Runnable() {
+     * >     @Override public void run() {
+     * >         RequestContextCurrentTraceContext.setCurrentThreadNotRequestThread(true);
+     * >         runnable.run();
+     * >     }
+     * >
+     * >     @Override public String toString() {
+     * >         return runnable.toString();
+     * >     }
+     * > });
      * }</pre>
      */
     public static void setCurrentThreadNotRequestThread(boolean value) {

--- a/brave/src/main/java/com/linecorp/armeria/common/brave/RequestContextCurrentTraceContext.java
+++ b/brave/src/main/java/com/linecorp/armeria/common/brave/RequestContextCurrentTraceContext.java
@@ -54,6 +54,20 @@ public final class RequestContextCurrentTraceContext extends CurrentTraceContext
      * server or client request and will never have a {@link RequestContext} available. This can be called from
      * background threads, such as the thread that reports traced spans to storage, to prevent logging a
      * warning when trying to start a trace without having a {@link RequestContext}.
+     *
+     * Ex. To prevent warnings from an administrative thread controlled by a thread factory:
+     * <pre>{@code
+     * threadFactory = (runnable) -> new Thread(new Runnable() {
+     *   @Override public void run() {
+     *     RequestContextCurrentTraceContext.setCurrentThreadNotRequestThread(true);
+     *     runnable.run();
+     *   }
+     *
+     *   @Override public String toString() {
+     *     return runnable.toString();
+     *   }
+     * });
+     * }</pre>
      */
     public static void setCurrentThreadNotRequestThread(boolean value) {
         if (value) {


### PR DESCRIPTION
This shows how to use `setCurrentThreadNotRequestThread` until we have
a function of Thread instead.