### PR TITLE
Various improvements in health checking code

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
@@ -321,8 +321,54 @@ public final class Endpoint implements Comparable<Endpoint> {
     }
 
     /**
+     * Returns whether this endpoint has a port number specified.
+     *
+     * @return {@code true} if and only if this endpoint has a port number.
+     * @throws IllegalStateException if this endpoint is not a host but a group
+     */
+    public boolean hasPort() {
+        return port(0) != 0;
+    }
+
+    /**
+     * Returns a new host endpoint with the specified port number.
+     *
+     * @param port the new port number
+     * @return the new endpoint with the specified port number if this endpoint does not have a port or
+     *         it has a different port number than what's specified.
+     *         {@code this} if this endpoint has the same port number with the specified one.
+     *
+     * @throws IllegalStateException if this endpoint is not a host but a group
+     */
+    public Endpoint withPort(int port) {
+        ensureSingle();
+        validatePort("port", port);
+        if (this.port == port) {
+            return this;
+        }
+        return new Endpoint(host, ipAddr, port, weight, hostType);
+    }
+
+    /**
+     * Returns a new host endpoint with its port number unspecified.
+     *
+     * @return the new endpoint whose port is unspecified if this endpoint has its port.
+     *         {@code this} if this endpoint does not have a port already.
+     *
+     * @throws IllegalStateException if this endpoint is not a host but a group
+     */
+    public Endpoint withoutPort() {
+        ensureSingle();
+        if (port == 0) {
+            return this;
+        }
+        return new Endpoint(host, ipAddr, 0, weight, hostType);
+    }
+
+    /**
      * Returns a new host endpoint with the specified default port number.
      *
+     * @param defaultPort the default port number
      * @return the new endpoint whose port is {@code defaultPort} if this endpoint does not have its port
      *         specified. {@code this} if this endpoint already has its port specified.
      *
@@ -336,7 +382,28 @@ public final class Endpoint implements Comparable<Endpoint> {
             return this;
         }
 
-        return new Endpoint(host(), ipAddr(), defaultPort, weight(), hostType);
+        return new Endpoint(host, ipAddr, defaultPort, weight, hostType);
+    }
+
+    /**
+     * Returns a new host endpoint with the default port number removed.
+     *
+     * @param defaultPort the default port number
+     * @return the new endpoint without a port number if this endpoint had the same port number
+     *         with the specified default port number. {@code this} if this endpoint had a different
+     *         port number than the specified default port number or this endpoint already does not have
+     *         a port number.
+     *
+     * @throws IllegalStateException if this endpoint is not a host but a group
+     */
+    public Endpoint withoutDefaultPort(int defaultPort) {
+        ensureSingle();
+        validatePort("defaultPort", defaultPort);
+        if (port == 0 || port != defaultPort) {
+            return this;
+        }
+
+        return new Endpoint(host, ipAddr, 0, weight, hostType);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
@@ -399,11 +399,10 @@ public final class Endpoint implements Comparable<Endpoint> {
     public Endpoint withoutDefaultPort(int defaultPort) {
         ensureSingle();
         validatePort("defaultPort", defaultPort);
-        if (port == 0 || port != defaultPort) {
-            return this;
+        if (port == defaultPort) {
+            return new Endpoint(host, ipAddr, 0, weight, hostType);
         }
-
-        return new Endpoint(host, ipAddr, 0, weight, hostType);
+        return this;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
@@ -327,7 +327,8 @@ public final class Endpoint implements Comparable<Endpoint> {
      * @throws IllegalStateException if this endpoint is not a host but a group
      */
     public boolean hasPort() {
-        return port(0) != 0;
+        ensureSingle();
+        return port != 0;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/AbstractHealthCheckedEndpointGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/AbstractHealthCheckedEndpointGroupBuilder.java
@@ -38,7 +38,6 @@ import com.linecorp.armeria.common.util.AsyncCloseable;
 public abstract class AbstractHealthCheckedEndpointGroupBuilder {
 
     private final EndpointGroup delegate;
-    private final Function<? super HealthCheckerContext, ? extends AsyncCloseable> checker;
 
     private SessionProtocol protocol = SessionProtocol.HTTP;
     private Backoff retryBackoff = DEFAULT_HEALTH_CHECK_RETRY_BACKOFF;
@@ -50,19 +49,9 @@ public abstract class AbstractHealthCheckedEndpointGroupBuilder {
      * Creates a new {@link AbstractHealthCheckedEndpointGroupBuilder}.
      *
      * @param delegate the {@link EndpointGroup} which provides the candidate {@link Endpoint}s
-     * @param checker the {@link Function} that starts to send health check requests to the {@link Endpoint}
-     *                specified in a given {@link HealthCheckerContext} when invoked.
-     *                The {@link Function} must update the health of the {@link Endpoint} with a value
-     *                between [0, 1] via {@link HealthCheckerContext#updateHealth(double)}.
-     *                {@link HealthCheckedEndpointGroup} will call {@link AsyncCloseable#closeAsync()} on
-     *                the {@link AsyncCloseable} returned by the {@link Function} when it needs to stop sending
-     *                health check requests.
      */
-    protected AbstractHealthCheckedEndpointGroupBuilder(
-            EndpointGroup delegate,
-            Function<? super HealthCheckerContext, ? extends AsyncCloseable> checker) {
+    protected AbstractHealthCheckedEndpointGroupBuilder(EndpointGroup delegate) {
         this.delegate = requireNonNull(delegate, "delegate");
-        this.checker = requireNonNull(checker, "checker");
     }
 
     /**
@@ -155,6 +144,16 @@ public abstract class AbstractHealthCheckedEndpointGroupBuilder {
      */
     public HealthCheckedEndpointGroup build() {
         return new HealthCheckedEndpointGroup(delegate, clientFactory, protocol, port,
-                                              retryBackoff, configurator, checker);
+                                              retryBackoff, configurator, newCheckerFactory());
     }
+
+    /**
+     * Returns the {@link Function} that starts to send health check requests to the {@link Endpoint}
+     * specified in a given {@link HealthCheckerContext} when invoked. The {@link Function} must update
+     * the health of the {@link Endpoint} with a value between [0, 1] via
+     * {@link HealthCheckerContext#updateHealth(double)}. {@link HealthCheckedEndpointGroup} will call
+     * {@link AsyncCloseable#closeAsync()}on the {@link AsyncCloseable} returned by the {@link Function}
+     * when it needs to stop sending health check requests.
+     */
+    protected abstract Function<? super HealthCheckerContext, ? extends AsyncCloseable> newCheckerFactory();
 }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/AbstractHealthCheckedEndpointGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/AbstractHealthCheckedEndpointGroupBuilder.java
@@ -152,7 +152,7 @@ public abstract class AbstractHealthCheckedEndpointGroupBuilder {
      * specified in a given {@link HealthCheckerContext} when invoked. The {@link Function} must update
      * the health of the {@link Endpoint} with a value between [0, 1] via
      * {@link HealthCheckerContext#updateHealth(double)}. {@link HealthCheckedEndpointGroup} will call
-     * {@link AsyncCloseable#closeAsync()}on the {@link AsyncCloseable} returned by the {@link Function}
+     * {@link AsyncCloseable#closeAsync()} on the {@link AsyncCloseable} returned by the {@link Function}
      * when it needs to stop sending health check requests.
      */
     protected abstract Function<? super HealthCheckerContext, ? extends AsyncCloseable> newCheckerFactory();

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckerContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckerContext.java
@@ -46,14 +46,6 @@ public interface HealthCheckerContext {
     SessionProtocol protocol();
 
     /**
-     * Returns the port where a health check request will be sent instead of the original port number
-     * specified by {@link #endpoint()}.
-     *
-     * @return {@code 0} to send to the original port, or the alternative port number.
-     */
-    int port();
-
-    /**
      * Returns the {@link Function} that customizes a {@link Client} that sends health check requests.
      */
     Function<? super ClientOptionsBuilder, ClientOptionsBuilder> clientConfigurator();

--- a/core/src/test/java/com/linecorp/armeria/client/EndpointTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/EndpointTest.java
@@ -20,16 +20,16 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.net.StandardProtocolFamily;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.linecorp.armeria.common.Scheme;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.SessionProtocol;
 
-public class EndpointTest {
+class EndpointTest {
 
     @Test
-    public void parse() {
+    void parse() {
         final Endpoint foo = Endpoint.parse("foo");
         assertThat(foo).isEqualTo(Endpoint.of("foo"));
         assertThatThrownBy(foo::port).isInstanceOf(IllegalStateException.class);
@@ -37,6 +37,7 @@ public class EndpointTest {
         assertThat(foo.ipAddr()).isNull();
         assertThat(foo.ipFamily()).isNull();
         assertThat(foo.hasIpAddr()).isFalse();
+        assertThat(foo.hasPort()).isFalse();
         assertThat(foo.toUri("none+http").toString()).isEqualTo("none+http://foo");
 
         final Endpoint bar = Endpoint.parse("bar:80");
@@ -46,13 +47,14 @@ public class EndpointTest {
         assertThat(bar.ipAddr()).isNull();
         assertThat(bar.ipFamily()).isNull();
         assertThat(bar.hasIpAddr()).isFalse();
+        assertThat(bar.hasPort()).isTrue();
         assertThat(bar.toUri("none+http").toString()).isEqualTo("none+http://bar:80");
 
         assertThat(Endpoint.parse("group:foo")).isEqualTo(Endpoint.ofGroup("foo"));
     }
 
     @Test
-    public void group() {
+    void group() {
         final Endpoint foo = Endpoint.ofGroup("foo");
         assertThat(foo.isGroup()).isTrue();
         assertThat(foo.groupName()).isEqualTo("foo");
@@ -64,10 +66,11 @@ public class EndpointTest {
         assertThatThrownBy(foo::ipFamily).isInstanceOf(IllegalStateException.class);
         assertThatThrownBy(foo::hasIpAddr).isInstanceOf(IllegalStateException.class);
         assertThatThrownBy(foo::port).isInstanceOf(IllegalStateException.class);
+        assertThatThrownBy(foo::hasPort).isInstanceOf(IllegalStateException.class);
     }
 
     @Test
-    public void hostWithoutPort() {
+    void hostWithoutPort() {
         final Endpoint foo = Endpoint.of("foo.com");
         assertThat(foo.isGroup()).isFalse();
         assertThat(foo.host()).isEqualTo("foo.com");
@@ -75,6 +78,7 @@ public class EndpointTest {
         assertThat(foo.ipFamily()).isNull();
         assertThat(foo.hasIpAddr()).isFalse();
         assertThat(foo.port(42)).isEqualTo(42);
+        assertThat(foo.hasPort()).isFalse();
         assertThat(foo.withDefaultPort(42).port()).isEqualTo(42);
         assertThat(foo.weight()).isEqualTo(1000);
         assertThat(foo.authority()).isEqualTo("foo.com");
@@ -87,7 +91,7 @@ public class EndpointTest {
     }
 
     @Test
-    public void hostWithPort() {
+    void hostWithPort() {
         final Endpoint foo = Endpoint.of("foo.com", 80);
         assertThat(foo.isGroup()).isFalse();
         assertThat(foo.host()).isEqualTo("foo.com");
@@ -96,6 +100,7 @@ public class EndpointTest {
         assertThat(foo.hasIpAddr()).isFalse();
         assertThat(foo.port()).isEqualTo(80);
         assertThat(foo.port(42)).isEqualTo(80);
+        assertThat(foo.hasPort()).isTrue();
         assertThat(foo.withDefaultPort(42)).isSameAs(foo);
         assertThat(foo.weight()).isEqualTo(1000);
         assertThat(foo.authority()).isEqualTo("foo.com:80");
@@ -105,7 +110,7 @@ public class EndpointTest {
     }
 
     @Test
-    public void hostWithWeight() {
+    void hostWithWeight() {
         final Endpoint foo = Endpoint.of("foo.com", 80).withWeight(500);
         assertThat(foo.weight()).isEqualTo(500);
         assertThat(foo.withWeight(750).weight()).isEqualTo(750);
@@ -116,7 +121,7 @@ public class EndpointTest {
     }
 
     @Test
-    public void hostWithIpAddr() {
+    void hostWithIpAddr() {
         final Endpoint foo = Endpoint.of("foo.com").withIpAddr("192.168.0.1");
         assertThat(foo.authority()).isEqualTo("foo.com");
         assertThat(foo.ipAddr()).isEqualTo("192.168.0.1");
@@ -142,7 +147,7 @@ public class EndpointTest {
     }
 
     @Test
-    public void badHost() {
+    void badHost() {
         // Should not accept the host name followed by a port.
         assertThatThrownBy(() -> Endpoint.of("foo:80")).isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(() -> Endpoint.of("127.0.0.1:80")).isInstanceOf(IllegalArgumentException.class);
@@ -150,7 +155,7 @@ public class EndpointTest {
     }
 
     @Test
-    public void ipV4() {
+    void ipV4() {
         final Endpoint a = Endpoint.of("192.168.0.1");
         assertThat(a.host()).isEqualTo("192.168.0.1");
         assertThat(a.ipAddr()).isEqualTo("192.168.0.1");
@@ -166,7 +171,7 @@ public class EndpointTest {
     }
 
     @Test
-    public void ipV4Parse() {
+    void ipV4Parse() {
         final Endpoint a = Endpoint.parse("192.168.0.1:80");
         assertThat(a.host()).isEqualTo("192.168.0.1");
         assertThat(a.ipAddr()).isEqualTo("192.168.0.1");
@@ -178,7 +183,7 @@ public class EndpointTest {
     }
 
     @Test
-    public void ipV6() {
+    void ipV6() {
         final Endpoint a = Endpoint.of("::1");
         assertThat(a.host()).isEqualTo("::1");
         assertThat(a.ipAddr()).isEqualTo("::1");
@@ -226,7 +231,7 @@ public class EndpointTest {
     }
 
     @Test
-    public void ipV6Parse() {
+    void ipV6Parse() {
         final Endpoint a = Endpoint.parse("[::1]:80");
         assertThat(a.host()).isEqualTo("::1");
         assertThat(a.ipAddr()).isEqualTo("::1");
@@ -238,7 +243,7 @@ public class EndpointTest {
     }
 
     @Test
-    public void authorityCache() {
+    void authorityCache() {
         final Endpoint foo = Endpoint.of("foo.com", 80);
         final String authority1 = foo.authority();
         final String authority2 = foo.authority();
@@ -246,7 +251,46 @@ public class EndpointTest {
     }
 
     @Test
-    public void toUri() {
+    void withPort() {
+        final Endpoint foo = Endpoint.of("foo");
+        final Endpoint foo80 = Endpoint.of("foo", 80);
+        assertThat(foo.withPort(80)).isEqualTo(foo80);
+        assertThat(foo80.withPort(80)).isSameAs(foo80);
+        assertThatThrownBy(() -> foo.withPort(0)).isInstanceOf(IllegalArgumentException.class)
+                                                 .hasMessageContaining("port");
+    }
+
+    @Test
+    void withoutPort() {
+        final Endpoint foo = Endpoint.of("foo");
+        final Endpoint foo80 = Endpoint.of("foo", 80);
+        assertThat(foo.withoutPort()).isSameAs(foo);
+        assertThat(foo80.withoutPort()).isEqualTo(foo);
+    }
+
+    @Test
+    void withDefaultPort() {
+        final Endpoint foo = Endpoint.of("foo");
+        final Endpoint foo80 = Endpoint.of("foo", 80);
+        assertThat(foo.withDefaultPort(80)).isEqualTo(foo80);
+        assertThat(foo80.withDefaultPort(80)).isSameAs(foo80);
+        assertThatThrownBy(() -> foo.withDefaultPort(0)).isInstanceOf(IllegalArgumentException.class)
+                                                        .hasMessageContaining("defaultPort");
+    }
+
+    @Test
+    void withoutDefaultPort() {
+        final Endpoint foo = Endpoint.of("foo");
+        final Endpoint foo80 = Endpoint.of("foo", 80);
+        assertThat(foo.withoutDefaultPort(80)).isSameAs(foo);
+        assertThat(foo80.withoutDefaultPort(80)).isEqualTo(foo);
+        assertThat(foo80.withoutDefaultPort(8080)).isSameAs(foo80);
+        assertThatThrownBy(() -> foo.withoutDefaultPort(0)).isInstanceOf(IllegalArgumentException.class)
+                                                           .hasMessageContaining("defaultPort");
+    }
+
+    @Test
+    void toUri() {
         final Endpoint group = Endpoint.ofGroup("a");
         assertThat(group.toUri("http").toString())
                 .isEqualTo("http://group:a");
@@ -293,7 +337,7 @@ public class EndpointTest {
     }
 
     @Test
-    public void equals() {
+    void equals() {
         final Endpoint a1 = Endpoint.of("a");
         final Endpoint a2 = Endpoint.of("a");
         final Endpoint groupA1 = Endpoint.ofGroup("a");
@@ -309,7 +353,7 @@ public class EndpointTest {
     }
 
     @Test
-    public void portEquals() {
+    void portEquals() {
         final Endpoint a = Endpoint.of("a");
         final Endpoint b = Endpoint.of("a", 80);
         final Endpoint c = Endpoint.of("a", 80);
@@ -326,7 +370,7 @@ public class EndpointTest {
     }
 
     @Test
-    public void ipAddrEquals() {
+    void ipAddrEquals() {
         final Endpoint a = Endpoint.of("a");
         final Endpoint b = Endpoint.of("a").withIpAddr("::1");
         final Endpoint c = Endpoint.of("a").withIpAddr("::1");
@@ -343,7 +387,7 @@ public class EndpointTest {
     }
 
     @Test
-    public void testHashCode() {
+    void testHashCode() {
         assertThat(Endpoint.of("a").hashCode()).isNotZero();
         assertThat(Endpoint.of("a", 80).hashCode()).isNotZero();
         assertThat(Endpoint.of("a").withIpAddr("::1").hashCode()).isNotZero();
@@ -356,7 +400,7 @@ public class EndpointTest {
     }
 
     @Test
-    public void testToString() {
+    void testToString() {
         assertThat(Endpoint.ofGroup("g").toString()).isEqualTo("Endpoint{group:g}");
         assertThat(Endpoint.of("a").toString()).isEqualTo("Endpoint{a, weight=1000}");
         assertThat(Endpoint.of("a", 80).toString()).isEqualTo("Endpoint{a:80, weight=1000}");
@@ -369,7 +413,7 @@ public class EndpointTest {
     }
 
     @Test
-    public void comparison() {
+    void comparison() {
         assertThat(Endpoint.ofGroup("a")).isEqualByComparingTo(Endpoint.ofGroup("a"));
         assertThat(Endpoint.ofGroup("a")).isLessThan(Endpoint.ofGroup("b"));
         assertThat(Endpoint.ofGroup("a")).isLessThan(Endpoint.of("a"));

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroupAuthorityTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroupAuthorityTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client.endpoint.healthcheck;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedTransferQueue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.endpoint.StaticEndpointGroup;
+import com.linecorp.armeria.client.logging.LoggingClient;
+import com.linecorp.armeria.common.RequestHeaders;
+
+class HttpHealthCheckedEndpointGroupAuthorityTest {
+
+    private static final String HEALTH_CHECK_PATH = "/healthcheck";
+
+    private final BlockingQueue<RequestHeaders> logs = new LinkedTransferQueue<>();
+
+    @BeforeEach
+    void clearLogs() {
+        logs.clear();
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            // Host name only
+            "localhost, localhost",
+            "localhost:1, localhost:1",
+            "localhost:80, localhost",
+            // IPv4 address only
+            "127.0.0.1, 127.0.0.1",
+            "127.0.0.1:1, 127.0.0.1:1",
+            "127.0.0.1:80, 127.0.0.1",
+            // IPv6 address only
+            "[::1], [::1]",
+            "[::1]:1, [::1]:1",
+            "[::1]:80, [::1]"
+    })
+    @Timeout(10)
+    void hostOnlyOrIpAddrOnly(String endpoint, String expectedAuthority) throws Exception {
+        try (HealthCheckedEndpointGroup ignored = build(Endpoint.parse(endpoint))) {
+            final RequestHeaders log = logs.take();
+            assertThat(log.authority()).isEqualTo(expectedAuthority);
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "foo, 127.0.0.1, foo",
+            "foo:1, 127.0.0.1, foo:1",
+            "foo:80, 127.0.0.1, foo",
+            "foo, ::1, foo",
+            "foo:1, ::1, foo:1",
+            "foo:80, ::1, foo"
+    })
+    @Timeout(10)
+    void hostAndIpAddr(String endpoint, String ipAddr, String expectedAuthority) throws Exception {
+        try (HealthCheckedEndpointGroup ignored = build(Endpoint.parse(endpoint).withIpAddr(ipAddr))) {
+            final RequestHeaders log = logs.take();
+            assertThat(log.authority()).isEqualTo(expectedAuthority);
+        }
+    }
+
+    private HealthCheckedEndpointGroup build(Endpoint endpoint) {
+        final HealthCheckedEndpointGroupBuilder builder = HealthCheckedEndpointGroup.builder(
+                new StaticEndpointGroup(endpoint), HEALTH_CHECK_PATH);
+        builder.withClientOptions(b -> {
+            b.decorator(LoggingClient.newDecorator());
+            b.decorator((delegate, ctx, req) -> {
+                // Record when health check requests were sent.
+                logs.add(req.headers());
+                return delegate.execute(ctx, req);
+            });
+            return b;
+        });
+        return builder.build();
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroupTest.java
@@ -163,17 +163,15 @@ class HttpHealthCheckedEndpointGroupTest {
     @EnumSource(value = SessionProtocol.class, names = { "HTTP", "HTTPS" })
     void endpoints_customPort(SessionProtocol protocol) throws Exception {
         serverOne.start();
-        serverTwo.start();
         final int portOne = serverOne.port(protocol);
-        final int portTwo = serverTwo.port(protocol);
 
         try (HealthCheckedEndpointGroup endpointGroup = build(
                 HealthCheckedEndpointGroup.builder(
-                        new StaticEndpointGroup(Endpoint.of("127.0.0.1", portOne)),
+                        new StaticEndpointGroup(Endpoint.of("127.0.0.1", 1)),
                         HEALTH_CHECK_PATH).port(portOne),
                 protocol)) {
             await().untilAsserted(() -> {
-                assertThat(endpointGroup.endpoints()).containsOnly(Endpoint.of("127.0.0.1", portOne));
+                assertThat(endpointGroup.endpoints()).containsOnly(Endpoint.of("127.0.0.1", 1));
             });
         }
     }

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroupTest.java
@@ -25,6 +25,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
 
 import com.linecorp.armeria.client.ClientFactory;
@@ -75,8 +76,8 @@ class HttpHealthCheckedEndpointGroupTest {
             .build();
 
     @ParameterizedTest
-    @EnumSource(value = SessionProtocol.class, names = { "HTTP", "HTTPS" })
-    void endpoints(SessionProtocol protocol) throws Exception {
+    @CsvSource({ "HTTP, false", "HTTP, true", "HTTPS, false", "HTTPS, true" })
+    void endpoints(SessionProtocol protocol, boolean useGet) throws Exception {
         serverOne.start();
         serverTwo.start();
 
@@ -86,7 +87,7 @@ class HttpHealthCheckedEndpointGroupTest {
                 HealthCheckedEndpointGroup.builder(
                         new StaticEndpointGroup(Endpoint.of("127.0.0.1", portOne),
                                                 Endpoint.of("127.0.0.1", portTwo)),
-                        HEALTH_CHECK_PATH),
+                        HEALTH_CHECK_PATH).useGet(useGet),
                 protocol)) {
 
             endpointGroup.newMeterBinder("foo").bindTo(registry);


### PR DESCRIPTION
Motivation:

- When a server stops, the clients who sent long-polling health check
  requests will currently get a GOAWAY frame or an immediate
  disconnection.
- The port number specified in `HealthCheckedEndpointGroupBuilder.port()`
  is not used when filling the `:authority` header.
- A user sometimes wants to send a `GET` request rather than `HEAD`.

Modifications:

- Modify `HealthCheckService` to send a response even when a server is
  stopping, so that the client is given a chance to receive them.
- Update `HttpHealthCheckedEndpointGroupLongPollingTest` to make sure
  the client gets the correct 'unhealthy' response with `armeria-lphc: 0`
  header when a server stops.
- Made sure the custom port numbers are respected when building URI and
  `:authority` header.
- Add `useGet(boolean)` option to the builder.

Result:

- No unexpected disconnection/GOAWAY when a server stops.
- No more incorrect `:authority` header.
- A user can choose to send `GET` health check requests instead of `HEAD`.