### PR TITLE
Precompute exponential backoff.

### DIFF
--- a/benchmarks/src/jmh/java/com/linecorp/armeria/core/client/retry/BackoffBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/core/client/retry/BackoffBenchmark.java
@@ -28,7 +28,7 @@ public class BackoffBenchmark {
 
     private static final Backoff EXPONENTIAL_BACKOFF = Backoff.exponential(100, 5000, 2.0);
 
-    @Param({ "1", "2", "3", "4", "5" })
+    @Param({ "1", "2", "3", "4", "5", "10", "20" })
     private int numAttemptsSoFar;
 
     @Benchmark

--- a/benchmarks/src/jmh/java/com/linecorp/armeria/core/client/retry/BackoffBenchmark.java
+++ b/benchmarks/src/jmh/java/com/linecorp/armeria/core/client/retry/BackoffBenchmark.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.core.client.retry;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+import com.linecorp.armeria.client.retry.Backoff;
+
+@State(Scope.Benchmark)
+public class BackoffBenchmark {
+
+    private static final Backoff EXPONENTIAL_BACKOFF = Backoff.exponential(100, 5000, 2.0);
+
+    @Param({ "1", "2", "3", "4", "5" })
+    private int numAttemptsSoFar;
+
+    @Benchmark
+    public long exponential() {
+        return EXPONENTIAL_BACKOFF.nextDelayMillis(numAttemptsSoFar);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/client/retry/ExponentialBackoff.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/ExponentialBackoff.java
@@ -65,11 +65,7 @@ final class ExponentialBackoff extends AbstractBackoff {
     protected long doNextDelayMillis(int numAttemptsSoFar) {
         if (precomputedDelays != null) {
             int index = numAttemptsSoFar - 1;
-            if (index >= precomputedDelays.length) {
-                return precomputedDelays[precomputedDelays.length - 1];
-            } else {
-                return precomputedDelays[index];
-            }
+            return precomputedDelays[Math.min(index, precomputedDelays.length - 1)];
         }
 
         return computeNextDelayMillis(numAttemptsSoFar);

--- a/core/src/main/java/com/linecorp/armeria/client/retry/ExponentialBackoff.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/ExponentialBackoff.java
@@ -44,9 +44,9 @@ final class ExponentialBackoff extends AbstractBackoff {
 
         if (computeNextDelayMillis(30) >= maxDelayMillis) {
             // We'll only have a maximum of 30 different delays, so may as well precompute them.
-            List<Long> precomputed = new ArrayList<>();
+            final List<Long> precomputed = new ArrayList<>();
             for (int i = 1; i <= 30; i++) {
-                long delay = computeNextDelayMillis(i);
+                final long delay = computeNextDelayMillis(i);
                 if (delay < maxDelayMillis) {
                     precomputed.add(delay);
                 } else {

--- a/core/src/main/java/com/linecorp/armeria/client/retry/ExponentialBackoff.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/ExponentialBackoff.java
@@ -42,7 +42,7 @@ final class ExponentialBackoff extends AbstractBackoff {
         this.maxDelayMillis = maxDelayMillis;
         this.multiplier = multiplier;
 
-        if (saturatedMultiply(initialDelayMillis, Math.pow(multiplier, 30)) > maxDelayMillis) {
+        if (computeNextDelayMillis(30) > maxDelayMillis) {
             // We'll only have a maximum of 30 different delays, so may as well precompute them.
             List<Long> precomputed = new ArrayList<>();
             long delay = initialDelayMillis;
@@ -71,6 +71,10 @@ final class ExponentialBackoff extends AbstractBackoff {
             }
         }
 
+        return computeNextDelayMillis(numAttemptsSoFar);
+    }
+
+    private long computeNextDelayMillis(int numAttemptsSoFar) {
         if (numAttemptsSoFar == 1) {
             return initialDelayMillis;
         }

--- a/core/src/main/java/com/linecorp/armeria/client/retry/ExponentialBackoff.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/ExponentialBackoff.java
@@ -42,7 +42,7 @@ final class ExponentialBackoff extends AbstractBackoff {
         this.maxDelayMillis = maxDelayMillis;
         this.multiplier = multiplier;
 
-        if (computeNextDelayMillis(30) > maxDelayMillis) {
+        if (computeNextDelayMillis(30) >= maxDelayMillis) {
             // We'll only have a maximum of 30 different delays, so may as well precompute them.
             List<Long> precomputed = new ArrayList<>();
             for (int i = 1; i <= 30; i++) {
@@ -55,7 +55,6 @@ final class ExponentialBackoff extends AbstractBackoff {
                 }
             }
             precomputedDelays = precomputed.stream().mapToLong(l -> l).toArray();
-
         } else {
             precomputedDelays = null;
         }

--- a/core/src/main/java/com/linecorp/armeria/client/retry/ExponentialBackoff.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/ExponentialBackoff.java
@@ -63,6 +63,10 @@ final class ExponentialBackoff extends AbstractBackoff {
 
     @Override
     protected long doNextDelayMillis(int numAttemptsSoFar) {
+        if (numAttemptsSoFar == 1) {
+            return initialDelayMillis;
+        }
+
         if (precomputedDelays != null) {
             int index = numAttemptsSoFar - 1;
             return precomputedDelays[Math.min(index, precomputedDelays.length - 1)];

--- a/core/src/main/java/com/linecorp/armeria/client/retry/ExponentialBackoff.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/ExponentialBackoff.java
@@ -45,13 +45,14 @@ final class ExponentialBackoff extends AbstractBackoff {
         if (computeNextDelayMillis(30) > maxDelayMillis) {
             // We'll only have a maximum of 30 different delays, so may as well precompute them.
             List<Long> precomputed = new ArrayList<>();
-            long delay = initialDelayMillis;
-            while (delay < maxDelayMillis) {
-                precomputed.add(delay);
-                delay *= multiplier;
-            }
-            if (delay != maxDelayMillis) {
-                precomputed.add(maxDelayMillis);
+            for (int i = 1; i <= 30; i++) {
+                long delay = computeNextDelayMillis(i);
+                if (delay < maxDelayMillis) {
+                    precomputed.add(delay);
+                } else {
+                    precomputed.add(maxDelayMillis);
+                    break;
+                }
             }
             precomputedDelays = precomputed.stream().mapToLong(l -> l).toArray();
 

--- a/core/src/test/java/com/linecorp/armeria/client/retry/ExponentialBackoffTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/ExponentialBackoffTest.java
@@ -34,10 +34,22 @@ class ExponentialBackoffTest {
     }
 
     @Test
-    void testOverflow() {
+    void nonPrecomputed() {
+        final Backoff backoff = new ExponentialBackoff(10, Long.MAX_VALUE, 2.0);
+        assertThat(backoff.nextDelayMillis(1)).isEqualTo(10);
+        assertThat(backoff.nextDelayMillis(2)).isEqualTo(20);
+        assertThat(backoff.nextDelayMillis(3)).isEqualTo(40);
+        assertThat(backoff.nextDelayMillis(30)).isEqualTo(5368709120L);
+        // Not precomputed, should fallback to computation and return a correct value.
+        assertThat(backoff.nextDelayMillis(31)).isEqualTo(10737418240L);
+    }
+
+    @Test
+    void overflow() {
         final Backoff backoff = new ExponentialBackoff(Long.MAX_VALUE / 3, Long.MAX_VALUE, 2.0);
         assertThat(backoff.nextDelayMillis(1)).isEqualTo(Long.MAX_VALUE / 3);
         assertThat(backoff.nextDelayMillis(2)).isEqualTo((long) (Long.MAX_VALUE / 3 * 2.0));
         assertThat(backoff.nextDelayMillis(3)).isEqualTo(Long.MAX_VALUE);
+        assertThat(backoff.nextDelayMillis(4)).isEqualTo(Long.MAX_VALUE);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/retry/ExponentialBackoffTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/ExponentialBackoffTest.java
@@ -17,12 +17,12 @@ package com.linecorp.armeria.client.retry;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ExponentialBackoffTest {
+class ExponentialBackoffTest {
 
     @Test
-    public void normal() {
+    void normal() {
         final Backoff backoff = new ExponentialBackoff(10, 120, 3.0);
         assertThat(backoff.nextDelayMillis(1)).isEqualTo(10);
         assertThat(backoff.nextDelayMillis(2)).isEqualTo(30);
@@ -34,7 +34,7 @@ public class ExponentialBackoffTest {
     }
 
     @Test
-    public void testOverflow() {
+    void testOverflow() {
         final Backoff backoff = new ExponentialBackoff(Long.MAX_VALUE / 3, Long.MAX_VALUE, 2.0);
         assertThat(backoff.nextDelayMillis(1)).isEqualTo(Long.MAX_VALUE / 3);
         assertThat(backoff.nextDelayMillis(2)).isEqualTo((long) (Long.MAX_VALUE / 3 * 2.0));

--- a/core/src/test/java/com/linecorp/armeria/client/retry/ExponentialBackoffTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/ExponentialBackoffTest.java
@@ -22,12 +22,15 @@ import org.junit.Test;
 public class ExponentialBackoffTest {
 
     @Test
-    public void test() {
+    public void normal() {
         final Backoff backoff = new ExponentialBackoff(10, 120, 3.0);
         assertThat(backoff.nextDelayMillis(1)).isEqualTo(10);
         assertThat(backoff.nextDelayMillis(2)).isEqualTo(30);
         assertThat(backoff.nextDelayMillis(3)).isEqualTo(90);
         assertThat(backoff.nextDelayMillis(4)).isEqualTo(120);
+        assertThat(backoff.nextDelayMillis(5)).isEqualTo(120);
+        assertThat(backoff.nextDelayMillis(6)).isEqualTo(120);
+        assertThat(backoff.nextDelayMillis(7)).isEqualTo(120);
     }
 
     @Test


### PR DESCRIPTION
This is inspired by discussion in #1979. Since the memory overhead is small enough, it seems nice to not redo the same fixed computation over and over.

After (consistent and fast)
```
Benchmark                     (numAttemptsSoFar)   Mode  Cnt          Score           Error  Units
BackoffBenchmark.exponential                   1  thrpt    5  391031493.454 ▒   6193827.024  ops/s
BackoffBenchmark.exponential                   2  thrpt    5  319670068.844 ▒  10576871.127  ops/s
BackoffBenchmark.exponential                   3  thrpt    5  251773952.326 ▒   5541318.925  ops/s
BackoffBenchmark.exponential                   4  thrpt    5  264484115.245 ▒ 125757992.112  ops/s
BackoffBenchmark.exponential                   5  thrpt    5  322578825.056 ▒   5550847.620  ops/s
BackoffBenchmark.exponential                  10  thrpt    5  323118760.381 ▒   3278461.442  ops/s
BackoffBenchmark.exponential                  20  thrpt    5  259118914.289 ▒  26549834.642  ops/s
```

Before (it's sort of fun seeing strange humps in Math.pow performance)
```
Benchmark                     (numAttemptsSoFar)   Mode  Cnt          Score          Error  Units
BackoffBenchmark.exponential                   1  thrpt    5  393497265.014 ▒  6031142.619  ops/s
BackoffBenchmark.exponential                   2  thrpt    5   45874162.736 ▒  1048826.502  ops/s
BackoffBenchmark.exponential                   3  thrpt    5  133158773.299 ▒ 26495529.116  ops/s
BackoffBenchmark.exponential                   4  thrpt    5   37305773.350 ▒  4522808.500  ops/s
BackoffBenchmark.exponential                   5  thrpt    5   36848933.046 ▒  4290268.120  ops/s
BackoffBenchmark.exponential                  10  thrpt    5   45985501.961 ▒   824254.753  ops/s
BackoffBenchmark.exponential                  20  thrpt    5   46190670.884 ▒   615251.881  ops/s
```

/cc @thinkgruen