### PR TITLE
Disable TLS v1.3 when using JdkSslContext

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ After importing the project, import the IDE settings as well.
 #### IntelliJ IDEA
 
 - [`settings.jar`](https://raw.githubusercontent.com/line/armeria/master/settings/intellij_idea/settings.jar) -
-  See [Importing settings from a JAR archive](https://www.jetbrains.com/help/idea/sharing-your-ide-settings.html#23c8afba).
+  See [Import settings from a ZIP archive](https://www.jetbrains.com/help/idea/sharing-your-ide-settings.html#23c8afba).
 - Make sure to use 'LINE OSS' code style and inspection profile.
   - Go to `Preferences` > `Editors` > `Code Style` and set `Scheme` option to `LINE OSS`.
   - Go to `Preferences` > `Editors` > `Inspections` and set `Profile` option to `LINE OSS`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ After importing the project, import the IDE settings as well.
 #### IntelliJ IDEA
 
 - [`settings.jar`](https://raw.githubusercontent.com/line/armeria/master/settings/intellij_idea/settings.jar) -
-  See [Import settings from a ZIP archive](https://www.jetbrains.com/help/idea/sharing-your-ide-settings.html#23c8afba).
+  See [Import settings from a ZIP archive](https://www.jetbrains.com/help/idea/sharing-your-ide-settings.html#7a4f08b8).
 - Make sure to use 'LINE OSS' code style and inspection profile.
   - Go to `Preferences` > `Editors` > `Code Style` and set `Scheme` option to `LINE OSS`.
   - Go to `Preferences` > `Editors` > `Inspections` and set `Profile` option to `LINE OSS`.

--- a/core/src/main/java/com/linecorp/armeria/internal/SslContextUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/SslContextUtil.java
@@ -72,8 +72,8 @@ public final class SslContextUtil {
     private static final List<String> DEFAULT_JDKENGINE_PROTOCOLS = ImmutableList.of("TLSv1.2");
 
     /**
-     * Creates a {@link SslContext} with Armeria's defaults, enabling support for HTTP/2, TLSv1.3 (if supported), and
-     * TLSv1.2.
+     * Creates a {@link SslContext} with Armeria's defaults, enabling support for HTTP/2,
+     * TLSv1.3 (if supported), and TLSv1.2.
      */
     public static SslContext createSslContext(Supplier<SslContextBuilder> sslContextSupplier,
                                               boolean forceHttp1,

--- a/core/src/main/java/com/linecorp/armeria/internal/SslContextUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/SslContextUtil.java
@@ -156,8 +156,7 @@ public final class SslContextUtil {
         } catch (Exception e) {
             throw new IllegalStateException(
                     "Failed to get the list of supported protocols from an SSLContext.", e);
-        }
-        finally {
+        } finally {
             ReferenceCountUtil.release(engine);
             ReferenceCountUtil.release(ctx);
         }

--- a/core/src/test/java/com/linecorp/armeria/internal/SslContextUtilTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/SslContextUtilTest.java
@@ -23,6 +23,7 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 import com.linecorp.armeria.common.Flags;
+import com.linecorp.armeria.common.util.SystemInfo;
 
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslProvider;
@@ -41,6 +42,10 @@ class SslContextUtilTest {
     void jdkSsl() {
         final Set<String> supportedProtocols = SslContextUtil.supportedProtocols(
                 SslContextBuilder.forClient().sslProvider(SslProvider.JDK));
-        assertThat(supportedProtocols).contains("TLSv1.2");
+        if (SystemInfo.javaVersion() >= 11) {
+            assertThat(supportedProtocols).contains("TLSv1.2", "TLSv1.3");
+        } else {
+            assertThat(supportedProtocols).contains("TLSv1.2");
+        }
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/internal/SslContextUtilTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/SslContextUtilTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.common.Flags;
+
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.SslProvider;
+
+class SslContextUtilTest {
+
+    @Test
+    void openSsl() {
+        assumeThat(Flags.useOpenSsl()).isTrue();
+        final Set<String> supportedProtocols = SslContextUtil.supportedProtocols(
+                SslContextBuilder.forClient().sslProvider(SslProvider.OPENSSL));
+        assertThat(supportedProtocols).contains("TLSv1.2", "TLSv1.3");
+    }
+
+    @Test
+    void jdkSsl() {
+        final Set<String> supportedProtocols = SslContextUtil.supportedProtocols(
+                SslContextBuilder.forClient().sslProvider(SslProvider.JDK));
+        assertThat(supportedProtocols).contains("TLSv1.2");
+    }
+}


### PR DESCRIPTION
Motivation:
  Netty's JdkSslContext does not support TLSv1.3. Armeria should disable TLS v1.3 when using JdkSslContext. 

Result:
  Fixes #1984 