### PR TITLE
Update dependencies

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/Http2ClientConnectionHandlerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http2ClientConnectionHandlerBuilder.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client;
+
+import com.linecorp.armeria.internal.AbstractHttp2ConnectionHandlerBuilder;
+
+import io.netty.channel.Channel;
+import io.netty.handler.codec.http2.Http2ConnectionDecoder;
+import io.netty.handler.codec.http2.Http2ConnectionEncoder;
+import io.netty.handler.codec.http2.Http2Settings;
+
+final class Http2ClientConnectionHandlerBuilder
+        extends AbstractHttp2ConnectionHandlerBuilder<Http2ClientConnectionHandler,
+                                                      Http2ClientConnectionHandlerBuilder> {
+
+    private final HttpClientFactory clientFactory;
+
+    Http2ClientConnectionHandlerBuilder(Channel ch, HttpClientFactory clientFactory) {
+        super(ch);
+        this.clientFactory = clientFactory;
+    }
+
+    @Override
+    protected Http2ClientConnectionHandler build(Http2ConnectionDecoder decoder,
+                                                 Http2ConnectionEncoder encoder,
+                                                 Http2Settings initialSettings) throws Exception {
+        return new Http2ClientConnectionHandler(decoder, encoder, initialSettings, channel(), clientFactory);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
@@ -74,19 +74,10 @@ import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
-import io.netty.handler.codec.http2.DefaultHttp2Connection;
-import io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder;
-import io.netty.handler.codec.http2.DefaultHttp2ConnectionEncoder;
-import io.netty.handler.codec.http2.DefaultHttp2FrameReader;
-import io.netty.handler.codec.http2.DefaultHttp2FrameWriter;
 import io.netty.handler.codec.http2.Http2ClientUpgradeCodec;
 import io.netty.handler.codec.http2.Http2CodecUtil;
 import io.netty.handler.codec.http2.Http2Connection;
-import io.netty.handler.codec.http2.Http2ConnectionDecoder;
-import io.netty.handler.codec.http2.Http2ConnectionEncoder;
 import io.netty.handler.codec.http2.Http2Exception;
-import io.netty.handler.codec.http2.Http2FrameReader;
-import io.netty.handler.codec.http2.Http2FrameWriter;
 import io.netty.handler.codec.http2.Http2Settings;
 import io.netty.handler.flush.FlushConsolidationHandler;
 import io.netty.handler.ssl.ApplicationProtocolNames;
@@ -605,15 +596,11 @@ final class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
     }
 
     private Http2ClientConnectionHandler newHttp2ConnectionHandler(Channel ch) {
-        final boolean validateHeaders = false;
-        final Http2Connection conn = new DefaultHttp2Connection(false);
-        final Http2FrameReader reader = new DefaultHttp2FrameReader(validateHeaders);
-        final Http2FrameWriter writer = new DefaultHttp2FrameWriter();
-
-        final Http2ConnectionEncoder encoder = new DefaultHttp2ConnectionEncoder(conn, writer);
-        final Http2ConnectionDecoder decoder = new DefaultHttp2ConnectionDecoder(conn, encoder, reader);
-
-        return new Http2ClientConnectionHandler(decoder, encoder, http2Settings(), ch, clientFactory);
+        return new Http2ClientConnectionHandlerBuilder(ch, clientFactory)
+                .server(false)
+                .validateHeaders(false)
+                .initialSettings(http2Settings())
+                .build();
     }
 
     private Http2Settings http2Settings() {

--- a/core/src/main/java/com/linecorp/armeria/internal/AbstractHttp2ConnectionHandlerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/AbstractHttp2ConnectionHandlerBuilder.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.internal;
+
+import io.netty.channel.Channel;
+import io.netty.handler.codec.http2.Http2Connection;
+import io.netty.handler.codec.http2.Http2ConnectionDecoder;
+import io.netty.handler.codec.http2.Http2ConnectionEncoder;
+import io.netty.handler.codec.http2.Http2FrameListener;
+import io.netty.handler.codec.http2.Http2FrameLogger;
+import io.netty.handler.codec.http2.Http2HeadersEncoder.SensitivityDetector;
+import io.netty.handler.codec.http2.Http2PromisedRequestVerifier;
+import io.netty.handler.codec.http2.Http2Settings;
+
+@SuppressWarnings("ClassNameSameAsAncestorName")
+public abstract class AbstractHttp2ConnectionHandlerBuilder<T extends AbstractHttp2ConnectionHandler,
+        B extends AbstractHttp2ConnectionHandlerBuilder<T, B>>
+        extends io.netty.handler.codec.http2.AbstractHttp2ConnectionHandlerBuilder<T, B> {
+
+    private final Channel ch;
+
+    protected AbstractHttp2ConnectionHandlerBuilder(Channel ch) {
+        this.ch = ch;
+    }
+
+    protected final Channel channel() {
+        return ch;
+    }
+
+    // Override the builder methods to increase the visibility.
+
+    @Override
+    public final T build() {
+        return super.build();
+    }
+
+    @Override
+    public B initialSettings(Http2Settings settings) {
+        return super.initialSettings(settings);
+    }
+
+    @Override
+    public B frameListener(Http2FrameListener frameListener) {
+        return super.frameListener(frameListener);
+    }
+
+    @Override
+    public B gracefulShutdownTimeoutMillis(long gracefulShutdownTimeoutMillis) {
+        return super.gracefulShutdownTimeoutMillis(gracefulShutdownTimeoutMillis);
+    }
+
+    @Override
+    public B server(boolean isServer) {
+        return super.server(isServer);
+    }
+
+    @Override
+    public B maxReservedStreams(int maxReservedStreams) {
+        return super.maxReservedStreams(maxReservedStreams);
+    }
+
+    @Override
+    public B connection(Http2Connection connection) {
+        return super.connection(connection);
+    }
+
+    @Override
+    public B codec(Http2ConnectionDecoder decoder, Http2ConnectionEncoder encoder) {
+        return super.codec(decoder, encoder);
+    }
+
+    @Override
+    public B validateHeaders(boolean validateHeaders) {
+        return super.validateHeaders(validateHeaders);
+    }
+
+    @Override
+    public B frameLogger(Http2FrameLogger frameLogger) {
+        return super.frameLogger(frameLogger);
+    }
+
+    @Override
+    public B encoderEnforceMaxConcurrentStreams(boolean encoderEnforceMaxConcurrentStreams) {
+        return super.encoderEnforceMaxConcurrentStreams(encoderEnforceMaxConcurrentStreams);
+    }
+
+    @Override
+    public B encoderEnforceMaxQueuedControlFrames(int maxQueuedControlFrames) {
+        return super.encoderEnforceMaxQueuedControlFrames(maxQueuedControlFrames);
+    }
+
+    @Override
+    public B headerSensitivityDetector(SensitivityDetector headerSensitivityDetector) {
+        return super.headerSensitivityDetector(headerSensitivityDetector);
+    }
+
+    @Override
+    public B encoderIgnoreMaxHeaderListSize(boolean ignoreMaxHeaderListSize) {
+        return super.encoderIgnoreMaxHeaderListSize(ignoreMaxHeaderListSize);
+    }
+
+    @Override
+    public B promisedRequestVerifier(Http2PromisedRequestVerifier promisedRequestVerifier) {
+        return super.promisedRequestVerifier(promisedRequestVerifier);
+    }
+
+    @Override
+    public B decoderEnforceMaxConsecutiveEmptyDataFrames(int maxConsecutiveEmptyFrames) {
+        return super.decoderEnforceMaxConsecutiveEmptyDataFrames(maxConsecutiveEmptyFrames);
+    }
+
+    @Override
+    public B autoAckSettingsFrame(boolean autoAckSettings) {
+        return super.autoAckSettingsFrame(autoAckSettings);
+    }
+
+    @Override
+    public B autoAckPingFrame(boolean autoAckPingFrame) {
+        return super.autoAckPingFrame(autoAckPingFrame);
+    }
+
+    @Override
+    public B decoupleCloseAndGoAway(boolean decoupleCloseAndGoAway) {
+        return super.decoupleCloseAndGoAway(decoupleCloseAndGoAway);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/Http2ServerConnectionHandlerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http2ServerConnectionHandlerBuilder.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server;
+
+import com.linecorp.armeria.internal.AbstractHttp2ConnectionHandlerBuilder;
+
+import io.netty.channel.Channel;
+import io.netty.handler.codec.http2.Http2ConnectionDecoder;
+import io.netty.handler.codec.http2.Http2ConnectionEncoder;
+import io.netty.handler.codec.http2.Http2Settings;
+
+final class Http2ServerConnectionHandlerBuilder
+        extends AbstractHttp2ConnectionHandlerBuilder<Http2ServerConnectionHandler,
+                                                      Http2ServerConnectionHandlerBuilder> {
+
+    private final ServerConfig config;
+    private final GracefulShutdownSupport gracefulShutdownSupport;
+    private final String scheme;
+
+    Http2ServerConnectionHandlerBuilder(Channel ch, ServerConfig config,
+                                        GracefulShutdownSupport gracefulShutdownSupport,
+                                        String scheme) {
+        super(ch);
+        this.config = config;
+        this.gracefulShutdownSupport = gracefulShutdownSupport;
+        this.scheme = scheme;
+    }
+
+    @Override
+    protected Http2ServerConnectionHandler build(Http2ConnectionDecoder decoder,
+                                                 Http2ConnectionEncoder encoder,
+                                                 Http2Settings initialSettings) throws Exception {
+        return new Http2ServerConnectionHandler(decoder, encoder, initialSettings, channel(),
+                                                config, gracefulShutdownSupport, scheme);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
@@ -55,18 +55,8 @@ import io.netty.handler.codec.haproxy.HAProxyMessage;
 import io.netty.handler.codec.haproxy.HAProxyMessageDecoder;
 import io.netty.handler.codec.http.HttpServerCodec;
 import io.netty.handler.codec.http.HttpServerUpgradeHandler;
-import io.netty.handler.codec.http2.DefaultHttp2Connection;
-import io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder;
-import io.netty.handler.codec.http2.DefaultHttp2ConnectionEncoder;
-import io.netty.handler.codec.http2.DefaultHttp2FrameReader;
-import io.netty.handler.codec.http2.DefaultHttp2FrameWriter;
 import io.netty.handler.codec.http2.Http2CodecUtil;
-import io.netty.handler.codec.http2.Http2Connection;
-import io.netty.handler.codec.http2.Http2ConnectionDecoder;
-import io.netty.handler.codec.http2.Http2ConnectionEncoder;
 import io.netty.handler.codec.http2.Http2ConnectionHandler;
-import io.netty.handler.codec.http2.Http2FrameReader;
-import io.netty.handler.codec.http2.Http2FrameWriter;
 import io.netty.handler.codec.http2.Http2ServerUpgradeCodec;
 import io.netty.handler.codec.http2.Http2Settings;
 import io.netty.handler.flush.FlushConsolidationHandler;
@@ -176,17 +166,12 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
     }
 
     private Http2ConnectionHandler newHttp2ConnectionHandler(ChannelPipeline pipeline, AsciiString scheme) {
-
-        final Http2Connection conn = new DefaultHttp2Connection(true);
-        final Http2FrameReader reader = new DefaultHttp2FrameReader(true);
-        final Http2FrameWriter writer = new DefaultHttp2FrameWriter();
-
-        final Http2ConnectionEncoder encoder = new DefaultHttp2ConnectionEncoder(conn, writer);
-        final Http2ConnectionDecoder decoder = new DefaultHttp2ConnectionDecoder(conn, encoder, reader);
-
-        return new Http2ServerConnectionHandler(
-                decoder, encoder, http2Settings(), pipeline.channel(),
-                config, gracefulShutdownSupport, scheme.toString());
+        return new Http2ServerConnectionHandlerBuilder(pipeline.channel(), config,
+                                                       gracefulShutdownSupport,
+                                                       scheme.toString())
+                .server(true)
+                .initialSettings(http2Settings())
+                .build();
     }
 
     private Http2Settings http2Settings() {

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -3,7 +3,7 @@
 #
 
 cglib:
-  cglib: { version: '3.2.12' }
+  cglib: { version: '3.3.0' }
 
 ch.qos.logback:
   logback-classic:
@@ -87,8 +87,8 @@ com.google.j2objc:
 # See: https://github.com/grpc/grpc-java/blob/master/build.gradle
 #      (Switch to the right tag and look for 'protobufVersion' and 'protocVersion'.)
 com.google.protobuf:
-  protoc: { version: '3.7.1' }
-  protobuf-java: { version: &PROTOBUF_VERSION '3.7.1' }
+  protoc: { version: '3.9.1' }
+  protobuf-java: { version: &PROTOBUF_VERSION '3.9.1' }
   protobuf-java-util:
     version: *PROTOBUF_VERSION
     exclusions:
@@ -128,7 +128,7 @@ io.dropwizard.metrics:
 # Ensure to update the Protobuf version in this file when updating gRPC.
 io.grpc:
   grpc-core:
-    version: &GRPC_VERSION '1.22.1'
+    version: &GRPC_VERSION '1.23.0'
     javadocs:
     - https://grpc.io/grpc-java/javadoc/
     - https://developers.google.com/protocol-buffers/docs/reference/java/
@@ -176,7 +176,7 @@ io.micrometer:
 
 io.netty:
   netty-common:
-    version: &NETTY_VERSION '4.1.38.Final'
+    version: &NETTY_VERSION '4.1.39.Final'
     javadocs:
     - https://netty.io/4.1/api/
   netty-buffer: { version: *NETTY_VERSION }
@@ -214,7 +214,7 @@ io.reactivex.rxjava2:
 
 io.zipkin.brave:
   brave:
-    version: &BRAVE_VERSION '5.6.9'
+    version: &BRAVE_VERSION '5.6.10'
     # ':site:javadoc' fails when we use a newer version of Javadoc.
     javadocs:
     - https://static.javadoc.io/io.zipkin.brave/brave/5.6.3/
@@ -432,7 +432,7 @@ org.reflections:
       to: com.linecorp.armeria.internal.shaded.reflections
 
 org.slf4j:
-  jcl-over-slf4j: { version: &SLF4J_VERSION '1.7.27' }
+  jcl-over-slf4j: { version: &SLF4J_VERSION '1.7.28' }
   jul-to-slf4j: { version: *SLF4J_VERSION }
   log4j-over-slf4j: { version: *SLF4J_VERSION }
   slf4j-api:


### PR DESCRIPTION
- Brave 5.6.9 -> 5.6.10
- CGLIB 3.2.12 -> 3.3.0
- gRPC 1.22.1 -> 1.23.0
- Netty 4.1.38 -> 4.1.39
- Protobuf 3.7.1 -> 3.9.1
- SLF4J 1.7.27 -> 1.7.28

Need to release 0.90.2 to pull the security fix in from Netty 4.1.39. See https://netty.io/news/2019/08/13/4-1-39-Final.html for more information.