### PR TITLE
Handles gRPC status when deferred to trailers

### DIFF
--- a/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/UnaryGrpcClient.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/UnaryGrpcClient.java
@@ -94,7 +94,7 @@ public class UnaryGrpcClient {
                                          "Non-successful HTTP response code: " + msg.status());
                              }
 
-                             // Status can either be in the headers or trailers depending on error
+                             // Status can either be in the headers or trailers depending on errorUnaryGrpcClientTest
                              String grpcStatus = msg.headers().get(GrpcHeaderNames.GRPC_STATUS);
                              if (grpcStatus != null) {
                                  checkGrpcStatus(grpcStatus, msg.headers());

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/UnaryGrpcClient.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/UnaryGrpcClient.java
@@ -94,7 +94,7 @@ public class UnaryGrpcClient {
                                          "Non-successful HTTP response code: " + msg.status());
                              }
 
-                             // Status can either be in the headers or trailers depending on errorUnaryGrpcClientTest
+                             // Status can either be in the headers or trailers depending on error
                              String grpcStatus = msg.headers().get(GrpcHeaderNames.GRPC_STATUS);
                              if (grpcStatus != null) {
                                  checkGrpcStatus(grpcStatus, msg.headers());

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/UnaryGrpcClient.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/UnaryGrpcClient.java
@@ -17,6 +17,7 @@
 package com.linecorp.armeria.common.grpc.protocol;
 
 import java.util.concurrent.CompletableFuture;
+
 import javax.annotation.Nullable;
 
 import com.linecorp.armeria.client.Client;
@@ -27,8 +28,8 @@ import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.client.SimpleDecoratingHttpClient;
 import com.linecorp.armeria.common.HttpData;
-import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/UnaryGrpcClient.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/UnaryGrpcClient.java
@@ -16,9 +16,8 @@
 
 package com.linecorp.armeria.common.grpc.protocol;
 
-import com.linecorp.armeria.common.HttpHeaders;
-import com.linecorp.armeria.common.ResponseHeaders;
 import java.util.concurrent.CompletableFuture;
+import javax.annotation.Nullable;
 
 import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.client.ClientDecoration;
@@ -28,6 +27,7 @@ import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.client.SimpleDecoratingHttpClient;
 import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
@@ -42,7 +42,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http.HttpHeaderValues;
-import javax.annotation.Nullable;
 
 /**
  * A {@link UnaryGrpcClient} can be used to make requests to a gRPC server without depending on gRPC stubs.

--- a/grpc/src/test/java/com/linecorp/armeria/common/grpc/protocol/UnaryGrpcClientTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/common/grpc/protocol/UnaryGrpcClientTest.java
@@ -19,9 +19,6 @@ package com.linecorp.armeria.common.grpc.protocol;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import io.grpc.Status;
-import io.grpc.StatusException;
-import io.grpc.StatusRuntimeException;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletionException;
 
@@ -39,6 +36,8 @@ import com.linecorp.armeria.grpc.testing.Messages.SimpleResponse;
 import com.linecorp.armeria.grpc.testing.TestServiceGrpc.TestServiceImplBase;
 
 import io.grpc.Server;
+import io.grpc.Status;
+import io.grpc.StatusException;
 import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder;
 import io.grpc.stub.StreamObserver;
 
@@ -51,7 +50,7 @@ public class UnaryGrpcClientTest {
             final SimpleResponse response = SimpleResponse.newBuilder()
                                                           .setPayload(request.getPayload())
                                                           .build();
-            if (request.getPayload().getBody().toStringUtf8().equals("ice cream")){
+            if (request.getPayload().getBody().toStringUtf8().equals("ice cream")) {
                 responseObserver.onNext(response);
                 responseObserver.onError(new StatusException(Status.UNAVAILABLE));
             } else {


### PR DESCRIPTION
It seems stackdriver trace api will wait until trailers to set the
status for certain errors. This seems legit looking at the gRPC spec.

https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#errors

Example error:
```
2019-08-16 10:45:30.502  INFO 47885 --- [-worker-nio-2-2] c.l.a.c.l.LoggingClient                  : Response: {startTime=2019-08-16T02:45:30.498Z(1565923530498646), length=0B, duration=3786µs(3786891ns), headers=[:status=200, content-type=application/grpc, date=Fri, 16 Aug 2019 02:45:12 GMT, alt-svc=quic=":443"; ma=2592000; v="46,43,39"], trailers=[EOS, grpc-status=5, grpc-message=Requested entity was not found., google.rpc.resourceinfo-bin=EhNwcm9qZWN0cy96aXBraW4tZGV2, grpc-status-details-bin=CAUSH1JlcXVlc3RlZCBlbnRpdHkgd2FzIG5vdCBmb3VuZC4aRAordHlwZS5nb29nbGVhcGlzLmNvbS9nb29nbGUucnBjLlJlc291cmNlSW5mbxIVEhNwcm9qZWN0cy96aXBraW4tZGV2]}
```