### PR TITLE
Keep an endpoint's healthiness if long-poll health check returns NOT_…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthChecker.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthChecker.java
@@ -36,6 +36,7 @@ import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.RequestHeadersBuilder;
 import com.linecorp.armeria.common.util.AsyncCloseable;
@@ -108,6 +109,9 @@ final class HttpHealthChecker implements AsyncCloseable {
                         maxLongPollingSeconds = getMaxLongPollingSeconds(res);
                         break;
                     default:
+                        if (res.status() == HttpStatus.NOT_MODIFIED) {
+                            isHealthy = wasHealthy;
+                        }
                         // Do not use long polling on an unexpected status for safety.
                         maxLongPollingSeconds = 0;
                 }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthChecker.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthChecker.java
@@ -110,10 +110,12 @@ final class HttpHealthChecker implements AsyncCloseable {
                         break;
                     default:
                         if (res.status() == HttpStatus.NOT_MODIFIED) {
+                            maxLongPollingSeconds = getMaxLongPollingSeconds(res);
                             isHealthy = wasHealthy;
+                        } else {
+                            // Do not use long polling on an unexpected status for safety.
+                            maxLongPollingSeconds = 0;
                         }
-                        // Do not use long polling on an unexpected status for safety.
-                        maxLongPollingSeconds = 0;
                 }
             } else {
                 maxLongPollingSeconds = 0;


### PR DESCRIPTION
…MODIFIED status code