### PR TITLE
Moves brave, jackson and netty version management to bom (Bill of Materials)

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -181,18 +181,6 @@ io.netty:
   netty-common:
     javadocs:
     - https://netty.io/4.1/api/
-  netty-buffer: {}
-  netty-codec: {}
-  netty-codec-dns: {}
-  netty-codec-http: {}
-  netty-codec-http2: {}
-  netty-codec-haproxy: {}
-  netty-handler: {}
-  netty-resolver: {}
-  netty-resolver-dns: {}
-  netty-transport: {}
-  netty-transport-native-epoll: {}
-  netty-transport-native-unix-common: {}
   # TODO: get netty-bom to claim this version!
   netty-tcnative-boringssl-static: { version: '2.0.25.Final' }
 
@@ -220,8 +208,6 @@ io.zipkin.brave:
     # ':site:javadoc' fails when we use a newer version of Javadoc.
     javadocs:
     - https://static.javadoc.io/io.zipkin.brave/brave/5.6.3/
-  brave-instrumentation-http: {}
-  brave-instrumentation-http-tests: {}
 
 it.unimi.dsi:
   fastutil:

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -3,6 +3,7 @@
 #
 
 boms:
+  - com.fasterxml.jackson:jackson-bom:2.9.9.20190807
   - io.zipkin.brave:brave-bom:5.6.11
 
 cglib:
@@ -22,15 +23,12 @@ com.auth0:
 
 com.fasterxml.jackson.core:
   jackson-annotations:
-    version: &JACKSON_VERSION '2.9.9'
     javadocs:
     - https://fasterxml.github.io/jackson-annotations/javadoc/2.9/
   jackson-core:
-    version: *JACKSON_VERSION
     javadocs:
     - https://fasterxml.github.io/jackson-core/javadoc/2.9/
   jackson-databind:
-    version: *JACKSON_VERSION
     javadocs:
     - https://fasterxml.github.io/jackson-databind/javadoc/2.9/
 

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -5,6 +5,8 @@
 boms:
   - com.fasterxml.jackson:jackson-bom:2.9.9.20190807
   - io.zipkin.brave:brave-bom:5.6.11
+  # NOTE: When changing this, re-evaluate netty-tcnative-boringssl-static below
+  - io.netty:netty-bom:4.1.39.Final
 
 cglib:
   cglib: { version: '3.3.0' }
@@ -177,21 +179,21 @@ io.micrometer:
 
 io.netty:
   netty-common:
-    version: &NETTY_VERSION '4.1.39.Final'
     javadocs:
     - https://netty.io/4.1/api/
-  netty-buffer: { version: *NETTY_VERSION }
-  netty-codec: { version: *NETTY_VERSION }
-  netty-codec-dns: { version: *NETTY_VERSION }
-  netty-codec-http: { version: *NETTY_VERSION }
-  netty-codec-http2: { version: *NETTY_VERSION }
-  netty-codec-haproxy: { version: *NETTY_VERSION }
-  netty-handler: { version: *NETTY_VERSION }
-  netty-resolver: { version: *NETTY_VERSION }
-  netty-resolver-dns: { version: *NETTY_VERSION }
-  netty-transport: { version: *NETTY_VERSION }
-  netty-transport-native-epoll: { version: *NETTY_VERSION }
-  netty-transport-native-unix-common: { version: *NETTY_VERSION }
+  netty-buffer: {}
+  netty-codec: {}
+  netty-codec-dns: {}
+  netty-codec-http: {}
+  netty-codec-http2: {}
+  netty-codec-haproxy: {}
+  netty-handler: {}
+  netty-resolver: {}
+  netty-resolver-dns: {}
+  netty-transport: {}
+  netty-transport-native-epoll: {}
+  netty-transport-native-unix-common: {}
+  # TODO: get netty-bom to claim this version!
   netty-tcnative-boringssl-static: { version: '2.0.25.Final' }
 
 io.projectreactor:

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -2,6 +2,9 @@
 # NB: Update NOTICE.txt and add/remove LICENSE.*.txt when adding/removing a dependency.
 #
 
+boms:
+  - io.zipkin.brave:brave-bom:5.6.11
+
 cglib:
   cglib: { version: '3.3.0' }
 
@@ -214,12 +217,11 @@ io.reactivex.rxjava2:
 
 io.zipkin.brave:
   brave:
-    version: &BRAVE_VERSION '5.6.10'
     # ':site:javadoc' fails when we use a newer version of Javadoc.
     javadocs:
     - https://static.javadoc.io/io.zipkin.brave/brave/5.6.3/
-  brave-instrumentation-http: { version: *BRAVE_VERSION }
-  brave-instrumentation-http-tests: { version: *BRAVE_VERSION }
+  brave-instrumentation-http: {}
+  brave-instrumentation-http-tests: {}
 
 it.unimi.dsi:
   fastutil:

--- a/site/src/sphinx/advanced-spring-webflux-integration.rst
+++ b/site/src/sphinx/advanced-spring-webflux-integration.rst
@@ -40,7 +40,7 @@ For Maven:
         <dependency>
           <groupId>io.netty</groupId>
           <artifactId>netty-bom</artifactId>
-          <version>\ |io.netty:netty-common:version|\ </version>
+          <version>\ |io.netty:netty-bom:version|\ </version>
           <type>pom</type>
           <scope>import</scope>
         </dependency>
@@ -64,7 +64,7 @@ For Gradle:
     dependencyManagement {
         imports {
             mavenBom 'com.linecorp.armeria:armeria-bom:\ |release|\ '
-            mavenBom 'io.netty:netty-bom:\ |io.netty:netty-common:version|\ '
+            mavenBom 'io.netty:netty-bom:\ |io.netty:netty-bom:version|\ '
         }
     }
 

--- a/site/src/sphinx/conf.py
+++ b/site/src/sphinx/conf.py
@@ -52,9 +52,10 @@ for groupId in dependencies.keys():
             rst_epilog += '.. |' + k + '| replace:: ' + v + '\n'
     else:
         for artifactId in dependencies[groupId]:
-            k = groupId + ':' + artifactId + ':version'
-            v = dependencies[groupId][artifactId]['version']
-            rst_epilog += '.. |' + k + '| replace:: ' + v + '\n'
+            if 'version' in dependencies[groupId][artifactId]:
+                k = groupId + ':' + artifactId + ':version'
+                v = dependencies[groupId][artifactId]['version']
+                rst_epilog += '.. |' + k + '| replace:: ' + v + '\n'
 rst_epilog += '\n'
 
 needs_sphinx = '1.0'


### PR DESCRIPTION
This moves brave, jackson and netty versions to use bom. Notably, in jackson this helps because not everything has a uniform version number. Also notably, the netty-bom doesn't claim netty-tcnative-boringssl-static, which could lead to compatability problems iiuc

Note: Sphinx is very upset at me. It prefers versions declared explicitly.

```
Configuration on demand is an incubating feature.
Running Sphinx v2.1.2

Traceback (most recent call last):
  File "/Users/travis/build/trustin/sphinx-binary/build/venv/lib/python3.6/site-packages/sphinx/config.py", line 361, in eval_config_file
  File "/Users/travis/build/trustin/sphinx-binary/build/venv/lib/python3.6/site-packages/sphinx/util/pycompat.py", line 86, in execfile_
  File "/Users/acole/oss/armeria/site/src/sphinx/conf.py", line 50, in <module>
    v = dependencies[groupId][artifactId]['version']
TypeError: list indices must be integers or slices, not str
```

Fixes #2011