### PR TITLE
Add literal value field for enum in internal documentation #1966

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/docs/DocService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/DocService.java
@@ -245,6 +245,7 @@ public class DocService extends AbstractCompositeService<HttpRequest, HttpRespon
     private static EnumValueInfo addEnumValueDocString(EnumInfo e, EnumValueInfo v,
                                                        Map<String, String> docStrings) {
         return new EnumValueInfo(v.name(),
+                                 v.literalValue(),
                                  docString(e.name() + '/' + v.name(), v.docString(), docStrings));
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/docs/EnumInfo.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/EnumInfo.java
@@ -129,6 +129,6 @@ public final class EnumInfo implements NamedTypeInfo {
         final Class<?> rawEnumType = requireNonNull(enumType, "enumType");
         @SuppressWarnings({ "unchecked", "rawtypes" })
         final Set<Enum> values = EnumSet.allOf((Class<Enum>) rawEnumType);
-        return values.stream().map(e -> new EnumValueInfo(e.name()))::iterator;
+        return values.stream().map(e -> new EnumValueInfo(e.name(), Integer.toString(e.ordinal())))::iterator;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/docs/EnumValueInfo.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/EnumValueInfo.java
@@ -78,7 +78,9 @@ public final class EnumValueInfo {
      * Returns the literal value (for example, int value) for the enum value.
      */
     @JsonProperty
-    public String literalValue() { return literalValue; }
+    public String literalValue() {
+        return literalValue;
+    }
 
     /**
      * Returns the documentation string that describes the enum value.

--- a/core/src/main/java/com/linecorp/armeria/server/docs/EnumValueInfo.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/EnumValueInfo.java
@@ -32,6 +32,7 @@ public final class EnumValueInfo {
     private final String name;
     @Nullable
     private final String docString;
+    private final String literalValue;
 
     /**
      * Creates a new instance.
@@ -39,17 +40,29 @@ public final class EnumValueInfo {
      * @param name the name of the enum value
      */
     public EnumValueInfo(String name) {
-        this(name, null);
+        this(name, null, null);
     }
 
     /**
      * Creates a new instance.
      *
      * @param name the name of the enum value
+     * @param literalValue literal value (for example, int value) for the enum value
+     */
+    public EnumValueInfo(String name, String literalValue) {
+        this(name, literalValue, null);
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param name the name of the enum value
+     * @param literalValue literal value (for example, int value) for the enum value
      * @param docString the documentation string that describes the enum value
      */
-    public EnumValueInfo(String name, @Nullable String docString) {
+    public EnumValueInfo(String name, String literalValue, @Nullable String docString) {
         this.name = requireNonNull(name, "name");
+        this.literalValue = Strings.emptyToNull(literalValue);
         this.docString = Strings.emptyToNull(docString);
     }
 
@@ -60,6 +73,12 @@ public final class EnumValueInfo {
     public String name() {
         return name;
     }
+
+    /**
+     * Returns the literal value (for example, int value) for the enum value.
+     */
+    @JsonProperty
+    public String literalValue() { return literalValue; }
 
     /**
      * Returns the documentation string that describes the enum value.

--- a/docs-client/src/containers/EnumPage/index.tsx
+++ b/docs-client/src/containers/EnumPage/index.tsx
@@ -62,6 +62,7 @@ export default class EnumPage extends React.PureComponent<Props> {
             <TableHead>
               <TableRow>
                 <TableCell>Name</TableCell>
+                <TableCell>Literal Value</TableCell>
                 <TableCell>Description</TableCell>
               </TableRow>
             </TableHead>
@@ -72,6 +73,7 @@ export default class EnumPage extends React.PureComponent<Props> {
                     <TableCell>
                       <code>{value.name}</code>
                     </TableCell>
+                    <TableCell>{value.literalValue}</TableCell>
                     <TableCell>{value.docString}</TableCell>
                   </TableRow>
                 ))

--- a/docs-client/src/lib/specification.tsx
+++ b/docs-client/src/lib/specification.tsx
@@ -62,6 +62,7 @@ export interface Service {
 
 export interface Value {
   name: string;
+  literalValue?: string;
   docString?: DocString;
 }
 

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcDocServicePlugin.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcDocServicePlugin.java
@@ -372,7 +372,7 @@ public class GrpcDocServicePlugin implements DocServicePlugin {
         return new EnumInfo(
                 enumDescriptor.getFullName(),
                 enumDescriptor.getValues().stream()
-                              .map(d -> new EnumValueInfo(d.getName()))
+                              .map(d -> new EnumValueInfo(d.getName(), Integer.toString(d.getNumber())))
                               .collect(toImmutableList()));
     }
 


### PR DESCRIPTION
**Motivation**
#1966

**Modification**
Add literal value field for enum in documentation.
 -> Add literal value as member variable to EnumValueInfo, modify following changes.

**Result**
User can see literal value of enum values in doc pages


There's a question I have working on this issue.
I wonder what is the standard to define 'enum' or 'struct',
Because I defined enums in thrift file but they're partially shown.
