### PR TITLE
Add literal value field for enum in internal documentation

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/docs/DocService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/DocService.java
@@ -245,6 +245,7 @@ public class DocService extends AbstractCompositeService<HttpRequest, HttpRespon
     private static EnumValueInfo addEnumValueDocString(EnumInfo e, EnumValueInfo v,
                                                        Map<String, String> docStrings) {
         return new EnumValueInfo(v.name(),
+                                 v.intValue(),
                                  docString(e.name() + '/' + v.name(), v.docString(), docStrings));
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/docs/EnumValueInfo.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/EnumValueInfo.java
@@ -17,11 +17,14 @@ package com.linecorp.armeria.server.docs;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Objects;
+
 import javax.annotation.Nullable;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Strings;
 
 /**
@@ -32,6 +35,8 @@ public final class EnumValueInfo {
     private final String name;
     @Nullable
     private final String docString;
+    @Nullable
+    private final Integer intValue;
 
     /**
      * Creates a new instance.
@@ -39,17 +44,29 @@ public final class EnumValueInfo {
      * @param name the name of the enum value
      */
     public EnumValueInfo(String name) {
-        this(name, null);
+        this(name, null, null);
     }
 
     /**
      * Creates a new instance.
      *
      * @param name the name of the enum value
+     * @param intValue the integer value of the enum value
+     */
+    public EnumValueInfo(String name, @Nullable Integer intValue) {
+        this(name, intValue, null);
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param name the name of the enum value
+     * @param intValue the integer value of the enum value
      * @param docString the documentation string that describes the enum value
      */
-    public EnumValueInfo(String name, @Nullable String docString) {
+    public EnumValueInfo(String name, @Nullable Integer intValue, @Nullable String docString) {
         this.name = requireNonNull(name, "name");
+        this.intValue = intValue;
         this.docString = Strings.emptyToNull(docString);
     }
 
@@ -59,6 +76,16 @@ public final class EnumValueInfo {
     @JsonProperty
     public String name() {
         return name;
+    }
+
+    /**
+     * Returns the integer value of the enum value.
+     */
+    @JsonProperty
+    @JsonInclude(Include.NON_NULL)
+    @Nullable
+    public Integer intValue() {
+        return intValue;
     }
 
     /**
@@ -73,7 +100,7 @@ public final class EnumValueInfo {
 
     @Override
     public int hashCode() {
-        return name.hashCode();
+        return Objects.hash(name, intValue);
     }
 
     @Override
@@ -85,11 +112,17 @@ public final class EnumValueInfo {
             return false;
         }
 
-        return name.equals(((EnumValueInfo) o).name);
+        final EnumValueInfo that = (EnumValueInfo) o;
+        return name.equals(that.name) && Objects.equals(intValue, that.intValue);
     }
 
     @Override
     public String toString() {
-        return name();
+        return MoreObjects.toStringHelper(this)
+                          .omitNullValues()
+                          .add("name", name)
+                          .add("intValue", intValue)
+                          .add("docString", docString)
+                          .toString();
     }
 }

--- a/docs-client/src/containers/EnumPage/index.tsx
+++ b/docs-client/src/containers/EnumPage/index.tsx
@@ -45,6 +45,9 @@ export default class EnumPage extends React.PureComponent<Props> {
       return <>Not found.</>;
     }
 
+    const hasIntValue = data.values.some((value) => !!value.intValue);
+    const hasDocString = data.values.some((value) => !!value.docString);
+
     return (
       <>
         <Typography variant="h5">
@@ -62,7 +65,8 @@ export default class EnumPage extends React.PureComponent<Props> {
             <TableHead>
               <TableRow>
                 <TableCell>Name</TableCell>
-                <TableCell>Description</TableCell>
+                {hasIntValue && <TableCell>Int Value</TableCell>}
+                {hasDocString && <TableCell>Description</TableCell>}
               </TableRow>
             </TableHead>
             <TableBody>
@@ -72,7 +76,8 @@ export default class EnumPage extends React.PureComponent<Props> {
                     <TableCell>
                       <code>{value.name}</code>
                     </TableCell>
-                    <TableCell>{value.docString}</TableCell>
+                    {hasIntValue && <TableCell>{value.intValue}</TableCell>}
+                    {hasDocString && <TableCell>{value.docString}</TableCell>}
                   </TableRow>
                 ))
               ) : (

--- a/docs-client/src/lib/specification.tsx
+++ b/docs-client/src/lib/specification.tsx
@@ -62,6 +62,7 @@ export interface Service {
 
 export interface Value {
   name: string;
+  intValue?: number;
   docString?: DocString;
 }
 

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcDocServicePlugin.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcDocServicePlugin.java
@@ -372,7 +372,7 @@ public class GrpcDocServicePlugin implements DocServicePlugin {
         return new EnumInfo(
                 enumDescriptor.getFullName(),
                 enumDescriptor.getValues().stream()
-                              .map(d -> new EnumValueInfo(d.getName()))
+                              .map(d -> new EnumValueInfo(d.getName(), d.getNumber()))
                               .collect(toImmutableList()));
     }
 

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcDocServicePluginTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcDocServicePluginTest.java
@@ -211,9 +211,9 @@ public class GrpcDocServicePluginTest {
         final EnumInfo enumInfo = generator.newEnumInfo(CompressionType.getDescriptor());
         assertThat(enumInfo).isEqualTo(new EnumInfo(
                 "armeria.grpc.testing.CompressionType",
-                ImmutableList.of(new EnumValueInfo("NONE"),
-                                 new EnumValueInfo("GZIP"),
-                                 new EnumValueInfo("DEFLATE"))));
+                ImmutableList.of(new EnumValueInfo("NONE", 0),
+                                 new EnumValueInfo("GZIP", 1),
+                                 new EnumValueInfo("DEFLATE", 3))));
     }
 
     @Test

--- a/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/messages.proto
+++ b/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/messages.proto
@@ -66,7 +66,7 @@ enum CompressionType {
   // No compression
   NONE = 0;
   GZIP = 1;
-  DEFLATE = 2;
+  DEFLATE = 3;
 }
 
 // A block of data, to simply increase gRPC message size.

--- a/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftDocServicePluginTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/server/thrift/ThriftDocServicePluginTest.java
@@ -19,6 +19,7 @@ package com.linecorp.armeria.server.thrift;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.linecorp.armeria.internal.docs.DocServiceUtil.unifyFilter;
+import static com.linecorp.armeria.server.thrift.ThriftDocServicePlugin.newEnumInfo;
 import static com.linecorp.armeria.server.thrift.ThriftDocServicePlugin.newExceptionInfo;
 import static com.linecorp.armeria.server.thrift.ThriftDocServicePlugin.newFieldInfo;
 import static com.linecorp.armeria.server.thrift.ThriftDocServicePlugin.newStructInfo;
@@ -187,12 +188,12 @@ public class ThriftDocServicePluginTest {
 
     @Test
     public void testNewEnumInfo() {
-        final EnumInfo enumInfo = new EnumInfo(FooEnum.class);
+        final EnumInfo enumInfo = newEnumInfo(FooEnum.class);
 
         assertThat(enumInfo).isEqualTo(new EnumInfo(FooEnum.class.getName(),
-                                                    Arrays.asList(new EnumValueInfo("VAL1"),
-                                                                  new EnumValueInfo("VAL2"),
-                                                                  new EnumValueInfo("VAL3"))));
+                                                    Arrays.asList(new EnumValueInfo("VAL1", 1),
+                                                                  new EnumValueInfo("VAL2", 2),
+                                                                  new EnumValueInfo("VAL3", 3))));
     }
 
     @Test


### PR DESCRIPTION
**Motivation**
#1966

**Modification**
Add literal value field for enum in documentation.
-> Add literal value as member variable to EnumValueInfo, modify following changes.

**Result**
User can see literal value of enum values in doc pages

There's a question I have working on this issue.
I wonder what is the standard to define 'enum' or 'struct',
Because I defined enums in thrift file but they're partially shown.