### PR TITLE
Add `as()` to `Client`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/Client.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Client.java
@@ -61,6 +61,6 @@ public interface Client<I extends Request, O extends Response> {
     default <T> Optional<T> as(Class<T> clientType) {
         requireNonNull(clientType, "clientType");
         return clientType.isInstance(this) ? Optional.of(clientType.cast(this))
-                                            : Optional.empty();
+                                              : Optional.empty();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/Client.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Client.java
@@ -61,6 +61,6 @@ public interface Client<I extends Request, O extends Response> {
     default <T> Optional<T> as(Class<T> clientType) {
         requireNonNull(clientType, "clientType");
         return clientType.isInstance(this) ? Optional.of(clientType.cast(this))
-                                              : Optional.empty();
+                                           : Optional.empty();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/Client.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Client.java
@@ -16,6 +16,10 @@
 
 package com.linecorp.armeria.client;
 
+import static java.util.Objects.requireNonNull;
+
+import java.util.Optional;
+
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.Request;
@@ -45,4 +49,18 @@ public interface Client<I extends Request, O extends Response> {
      * @return the {@link Response} to the specified {@link Request}
      */
     O execute(ClientRequestContext ctx, I req) throws Exception;
+
+    /**
+     * Undecorates this {@link Client} to find the {@link Client} which is an instance of the specified
+     * {@code clientType}.
+     *
+     * @param clientType the type of the desired {@link Client}
+     * @return the {@link Client} which is an instance of {@code clientType} if this {@link Client}
+     *         decorated such a {@link Client}. {@link Optional#empty()} otherwise.
+     */
+    default <T> Optional<T> as(Class<T> clientType) {
+        requireNonNull(clientType, "clientType");
+        return clientType.isInstance(this) ? Optional.of(clientType.cast(this))
+                                            : Optional.empty();
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/DecoratingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DecoratingClient.java
@@ -18,6 +18,8 @@ package com.linecorp.armeria.client;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Optional;
+
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
 
@@ -50,6 +52,12 @@ public abstract class DecoratingClient<T_I extends Request, T_O extends Response
     @SuppressWarnings("unchecked")
     protected final <T extends Client<T_I, T_O>> T delegate() {
         return (T) delegate;
+    }
+
+    @Override
+    public final <T> Optional<T> as(Class<T> clientType) {
+        final Optional<T> result = Client.super.as(clientType);
+        return result.isPresent() ? result : delegate.as(clientType);
     }
 
     @Override

--- a/core/src/test/java/com/linecorp/armeria/client/ClientOptionsBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientOptionsBuilderTest.java
@@ -147,4 +147,45 @@ public class ClientOptionsBuilderTest {
         assertThat(opts.responseTimeoutMillis()).isEqualTo(2000);
         assertThat(opts.maxResponseLength()).isEqualTo(3000);
     }
+
+    @Test
+    public void testDecoratorDowncast() {
+        final FooClient inner = new FooClient();
+        final FooDecorator outer = new FooDecorator(inner);
+
+        assertThat(outer.as(inner.getClass())).isPresent();
+        assertThat(outer.as(outer.getClass())).isPresent();
+
+        if (outer.as(inner.getClass()).isPresent()) {
+            assertThat(outer.as(inner.getClass()).get() == inner);
+        }
+
+        if (outer.as(outer.getClass()).isPresent()) {
+            assertThat(outer.as(outer.getClass()).get() == outer);
+        }
+
+        assertThat(outer.as(LoggingClient.class).isPresent()).isFalse();
+    }
+
+    private static final class FooClient implements Client<HttpRequest, HttpResponse> {
+        FooClient() { }
+
+        @Override
+        public HttpResponse execute(ClientRequestContext ctx, HttpRequest req) throws Exception {
+            // Will never reach here.
+            throw new Error();
+        }
+    }
+
+    private static final class FooDecorator extends SimpleDecoratingClient<HttpRequest, HttpResponse> {
+        FooDecorator(Client<HttpRequest, HttpResponse> delegate) {
+            super(delegate);
+        }
+
+        @Override
+        public HttpResponse execute(ClientRequestContext ctx, HttpRequest req) throws Exception {
+            // Will never reach here.
+            throw new Error();
+        }
+    }
 }


### PR DESCRIPTION
Motivation:

A user often need to downcast decorated `Client` to certain type of `Client`.
If we have `Client.as()`, it would be possible.

Modifications:

* Add `as()` to `Client`
* Add `as()` to `DecoratingClient`

Result:
* Closes #1883