### PR TITLE
Add `HealthCheckedEndpointGroupBuilder.clientOptions()`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/AbstractHealthCheckedEndpointGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/AbstractHealthCheckedEndpointGroupBuilder.java
@@ -25,6 +25,7 @@ import java.util.function.Function;
 
 import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.client.ClientFactory;
+import com.linecorp.armeria.client.ClientOptions;
 import com.linecorp.armeria.client.ClientOptionsBuilder;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
@@ -121,6 +122,21 @@ public abstract class AbstractHealthCheckedEndpointGroupBuilder {
     public AbstractHealthCheckedEndpointGroupBuilder retryBackoff(Backoff retryBackoff) {
         this.retryBackoff = requireNonNull(retryBackoff, "retryBackoff");
         return this;
+    }
+
+    /**
+     * Sets the {@link ClientOptions} of the {@link Client} that sends health check requests.
+     * This method can be useful if you already have an Armeria client and want to reuse its configuration,
+     * such as using the same decorators.
+     * <pre>{@code
+     * HttpClient myClient = ...;
+     * // Use the same settings and decorators with `myClient` when sending health check requests.
+     * builder.clientOptions(myClient.options());
+     * }</pre>
+     */
+    public AbstractHealthCheckedEndpointGroupBuilder clientOptions(ClientOptions clientOptions) {
+        requireNonNull(clientOptions, "clientOptions");
+        return withClientOptions(b -> b.options(clientOptions));
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupBuilder.java
@@ -22,6 +22,7 @@ import java.time.Duration;
 import java.util.function.Function;
 
 import com.linecorp.armeria.client.ClientFactory;
+import com.linecorp.armeria.client.ClientOptions;
 import com.linecorp.armeria.client.ClientOptionsBuilder;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.client.retry.Backoff;
@@ -79,6 +80,11 @@ public class HealthCheckedEndpointGroupBuilder extends AbstractHealthCheckedEndp
     @Override
     public HealthCheckedEndpointGroupBuilder retryBackoff(Backoff retryBackoff) {
         return (HealthCheckedEndpointGroupBuilder) super.retryBackoff(retryBackoff);
+    }
+
+    @Override
+    public HealthCheckedEndpointGroupBuilder clientOptions(ClientOptions options) {
+        return (HealthCheckedEndpointGroupBuilder) super.clientOptions(options);
     }
 
     @Override

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthCheckedEndpointGroupTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.params.provider.EnumSource;
 
 import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.ClientFactoryBuilder;
+import com.linecorp.armeria.client.ClientOptionsBuilder;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.endpoint.StaticEndpointGroup;
 import com.linecorp.armeria.client.endpoint.dns.DnsAddressEndpointGroup;
@@ -303,7 +304,7 @@ class HttpHealthCheckedEndpointGroupTest {
                                              SessionProtocol protocol) {
         return builder.protocol(protocol)
                       .clientFactory(clientFactory)
-                      .withClientOptions(b -> b.decorator(LoggingClient.newDecorator()))
+                      .clientOptions(new ClientOptionsBuilder().decorator(LoggingClient.newDecorator()).build())
                       .build();
     }
 }


### PR DESCRIPTION
Related: #1913
Motivation:

By adding a builder method that accepts `ClientOptions` directly instead
of the function that mutates `ClientOptions`, a user can easily reuse
his or her `ClientOptions` instance:

    HttpClient myClient = ...;
    // Before:
    builder.withClientOptions(b -> b.options(myClient.options()));
    // After:
    builder.clientOptions(myClient.options());

Modifications:

- Add `clientOptions(ClientOptions)` method to `HealthCheckedEndpointGroupBuilder`.

Result:

- User friendliness.