### PR TITLE
Add `ArmeriaRetrofitBuilder.clientOptions()`

### DIFF
--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/ArmeriaCallFactory.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/ArmeriaCallFactory.java
@@ -40,7 +40,6 @@ import com.linecorp.armeria.common.RequestHeadersBuilder;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.common.util.SafeCloseable;
 
-import io.netty.util.AttributeKey;
 import okhttp3.Call;
 import okhttp3.Call.Factory;
 import okhttp3.Callback;
@@ -58,9 +57,6 @@ import retrofit2.Invocation;
  * A {@link Factory} that creates a {@link Call} instance for {@link HttpClient}.
  */
 final class ArmeriaCallFactory implements Factory {
-
-    private static final AttributeKey<Invocation> RETROFIT_INVOCATION =
-            AttributeKey.valueOf(ArmeriaCallFactory.class, "RETROFIT_INVOCATION");
 
     static final String GROUP_PREFIX = "group_";
     private static final Pattern GROUP_PREFIX_MATCHER = Pattern.compile(GROUP_PREFIX);

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/ArmeriaRetrofitBuilder.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/ArmeriaRetrofitBuilder.java
@@ -27,6 +27,7 @@ import java.util.function.BiFunction;
 import javax.annotation.Nullable;
 
 import com.linecorp.armeria.client.ClientFactory;
+import com.linecorp.armeria.client.ClientOptions;
 import com.linecorp.armeria.client.ClientOptionsBuilder;
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
@@ -126,7 +127,33 @@ public final class ArmeriaRetrofitBuilder {
     }
 
     /**
-     * Sets the {@link BiFunction} that is applied to the underlying {@link HttpClient}.
+     * Sets the {@link ClientOptions} that customizes the underlying {@link HttpClient}.
+     * This method can be useful if you already have an Armeria client and want to reuse its configuration,
+     * such as using the same decorators.
+     * <pre>{@code
+     * HttpClient myClient = ...;
+     * // Use the same settings and decorators with `myClient` when sending requests.
+     * builder.clientOptions(myClient.options());
+     * }</pre>
+     */
+    public ArmeriaRetrofitBuilder clientOptions(ClientOptions clientOptions) {
+        requireNonNull(clientOptions, "clientOptions");
+        return withClientOptions((uri, b) -> b.options(clientOptions));
+    }
+
+    /**
+     * Sets the {@link BiFunction} that customizes the underlying {@link HttpClient}.
+     * <pre>{@code
+     * builder.withClientOptions((uri, b) -> {
+     *     if (uri.startsWith("https://foo.com/")) {
+     *         return b.setHttpHeader(HttpHeaders.AUTHORIZATION,
+     *                                "bearer my-access-token")
+     *                 .responseTimeout(Duration.ofSeconds(3));
+     *     } else {
+     *         return b;
+     *     }
+     * });
+     * }</pre>
      *
      * @param configurator a {@link BiFunction} whose first argument is the the URI of the server endpoint and
      *                     whose second argument is the {@link ClientOptionsBuilder} with default options of

--- a/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/metric/RetrofitMeterIdPrefixFunctionTest.java
+++ b/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/metric/RetrofitMeterIdPrefixFunctionTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.ClientFactoryBuilder;
+import com.linecorp.armeria.client.ClientOptionsBuilder;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.metric.MetricCollectingClient;
 import com.linecorp.armeria.client.retrofit2.ArmeriaRetrofitBuilder;
@@ -82,11 +83,10 @@ public class RetrofitMeterIdPrefixFunctionTest {
     public void metrics() {
         final Example example = new ArmeriaRetrofitBuilder(clientFactory)
                 .baseUrl("h1c://127.0.0.1:" + server.httpPort())
-                .withClientOptions((s, clientOptionsBuilder) -> {
-                    return clientOptionsBuilder.decorator(
-                            MetricCollectingClient.newDecorator(
-                                    RetrofitMeterIdPrefixFunction.builder("foo").build()));
-                })
+                .clientOptions(new ClientOptionsBuilder()
+                                       .decorator(MetricCollectingClient.newDecorator(
+                                               RetrofitMeterIdPrefixFunction.builder("foo").build()))
+                                       .build())
                 .build()
                 .create(Example.class);
 


### PR DESCRIPTION
Related: #1913
Motivation:

By adding a builder method that accepts `ClientOptions` directly instead
of the function that mutates `ClientOptions`, a user can easily reuse
his or her `ClientOptions` instance:

    HttpClient myClient = ...;
    // Before:
    builder.withClientOptions((uri, b) -> b.options(myClient.options()));
    // After:
    builder.clientOptions(myClient.options());

Modifications:

- Add `clientOptions(ClientOptions)` method to `ArmeriaRetrofitBuilder`.

Result:

- User friendliness.