### PR TITLE
Add `Unwrappable` and `ClientFactory.unwrap()`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/Client.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Client.java
@@ -58,8 +58,8 @@ public interface Client<I extends Request, O extends Response> extends Unwrappab
      * HttpClient client = new HttpClientBuilder()
      *     .decorator(LoggingClient.newDecorator())
      *     .build();
-     * LoggingClient unwrapped1 = client.as(LoggingClient.class);
-     * LoggingClient unwrapped2 = ClientFactory.DEFAULT.unwrap(client, LoggingClient.class);
+     * LoggingClient unwrapped1 = client.as(LoggingClient.class).get();
+     * LoggingClient unwrapped2 = ClientFactory.DEFAULT.unwrap(client, LoggingClient.class).get();
      * assert unwrapped1 == unwrapped2;
      * }</pre>
      *

--- a/core/src/main/java/com/linecorp/armeria/client/Client.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Client.java
@@ -59,12 +59,15 @@ public interface Client<I extends Request, O extends Response> extends Unwrappab
      *     .decorator(LoggingClient.newDecorator())
      *     .build();
      * LoggingClient unwrapped1 = client.as(LoggingClient.class).get();
-     * LoggingClient unwrapped2 = ClientFactory.DEFAULT.unwrap(client, LoggingClient.class).get();
+     * LoggingClient unwrapped2 = Clients.unwrap(client, LoggingClient.class).get();
      * assert unwrapped1 == unwrapped2;
      * }</pre>
      *
      * @param type the type of the object to return
      * @return the object of the specified {@code type} if found. {@link Optional#empty()} if not found.
+     *
+     * @see Clients#unwrap(Object, Class)
+     * @see ClientFactory#unwrap(Object, Class)
      */
     @Override
     default <T> Optional<T> as(Class<T> type) {

--- a/core/src/main/java/com/linecorp/armeria/client/Client.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Client.java
@@ -58,9 +58,12 @@ public interface Client<I extends Request, O extends Response> extends Unwrappab
      * HttpClient client = new HttpClientBuilder()
      *     .decorator(LoggingClient.newDecorator())
      *     .build();
-     * LoggingClient unwrapped1 = client.as(LoggingClient.class).get();
+     *
+     * LoggingClient unwrapped = client.as(LoggingClient.class).get();
+     *
+     * // You can also use Clients.unwrap(), which is useful especially for
+     * // Thrift and gRPC where the client object does not implement the 'as()' method.
      * LoggingClient unwrapped2 = Clients.unwrap(client, LoggingClient.class).get();
-     * assert unwrapped1 == unwrapped2;
      * }</pre>
      *
      * @param type the type of the object to return
@@ -68,6 +71,7 @@ public interface Client<I extends Request, O extends Response> extends Unwrappab
      *
      * @see Clients#unwrap(Object, Class)
      * @see ClientFactory#unwrap(Object, Class)
+     * @see Unwrappable
      */
     @Override
     default <T> Optional<T> as(Class<T> type) {

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactory.java
@@ -229,7 +229,6 @@ public interface ClientFactory extends AutoCloseable {
         requireNonNull(client, "client");
         requireNonNull(type, "type");
 
-
         if (type.isInstance(client)) {
             return Optional.of(type.cast(client));
         }

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactory.java
@@ -213,12 +213,16 @@ public interface ClientFactory extends AutoCloseable {
     /**
      * Unwraps the specified {@code client} object into the object of the specified {@code type}. For example,
      * <pre>{@code
+     * ClientFactory clientFactory = ...;
      * HttpClient client = new HttpClientBuilder()
+     *     .factory(clientFactory)
      *     .decorator(LoggingClient.newDecorator())
      *     .build();
-     * LoggingClient unwrapped1 = client.as(LoggingClient.class);
-     * LoggingClient unwrapped2 = Clients.unwrap(client, LoggingClient.class);
-     * assert unwrapped1 == unwrapped2;
+     *
+     * LoggingClient unwrapped = clientFactory.unwrap(client, LoggingClient.class).get();
+     *
+     * // If the client implements Unwrappable, you can just use the 'as()' method.
+     * LoggingClient unwrapped2 = client.as(LoggingClient.class).get();
      * }</pre>
      *
      * @param client the client object
@@ -227,6 +231,7 @@ public interface ClientFactory extends AutoCloseable {
      *
      * @see Client#as(Class)
      * @see Clients#unwrap(Object, Class)
+     * @see Unwrappable
      */
     default <T> Optional<T> unwrap(Object client, Class<T> type) {
         requireNonNull(client, "client");

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactory.java
@@ -217,13 +217,16 @@ public interface ClientFactory extends AutoCloseable {
      *     .decorator(LoggingClient.newDecorator())
      *     .build();
      * LoggingClient unwrapped1 = client.as(LoggingClient.class);
-     * LoggingClient unwrapped2 = ClientFactory.DEFAULT.unwrap(client, LoggingClient.class);
+     * LoggingClient unwrapped2 = Clients.unwrap(client, LoggingClient.class);
      * assert unwrapped1 == unwrapped2;
      * }</pre>
      *
      * @param client the client object
      * @param type the type of the object to return
      * @return the object of the specified {@code type} if found. {@link Optional#empty()} if not found.
+     *
+     * @see Client#as(Class)
+     * @see Clients#unwrap(Object, Class)
      */
     default <T> Optional<T> unwrap(Object client, Class<T> type) {
         requireNonNull(client, "client");

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactory.java
@@ -16,6 +16,10 @@
 
 package com.linecorp.armeria.client;
 
+import static java.util.Objects.requireNonNull;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
 import java.net.URI;
 import java.util.Optional;
 import java.util.Set;
@@ -27,6 +31,7 @@ import org.slf4j.LoggerFactory;
 
 import com.linecorp.armeria.common.Scheme;
 import com.linecorp.armeria.common.util.ReleasableHolder;
+import com.linecorp.armeria.common.util.Unwrappable;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.netty.channel.EventLoop;
@@ -201,7 +206,51 @@ public interface ClientFactory extends AutoCloseable {
      * {@link ClientFactory} does not know how to handle the {@link ClientBuilderParams} for the provided
      * {@code client}, it should return {@link Optional#empty()}.
      */
-    <T> Optional<ClientBuilderParams> clientBuilderParams(T client);
+    default <T> Optional<ClientBuilderParams> clientBuilderParams(T client) {
+        return unwrap(client, ClientBuilderParams.class);
+    }
+
+    /**
+     * Unwraps the specified {@code client} object into the object of the specified {@code type}. For example,
+     * <pre>{@code
+     * HttpClient client = new HttpClientBuilder()
+     *     .decorator(LoggingClient.newDecorator())
+     *     .build();
+     * LoggingClient unwrapped1 = client.as(LoggingClient.class);
+     * LoggingClient unwrapped2 = ClientFactory.DEFAULT.unwrap(client, LoggingClient.class);
+     * assert unwrapped1 == unwrapped2;
+     * }</pre>
+     *
+     * @param client the client object
+     * @param type the type of the object to return
+     * @return the object of the specified {@code type} if found. {@link Optional#empty()} if not found.
+     */
+    default <T> Optional<T> unwrap(Object client, Class<T> type) {
+        requireNonNull(client, "client");
+        requireNonNull(type, "type");
+
+
+        if (type.isInstance(client)) {
+            return Optional.of(type.cast(client));
+        }
+
+        if (client instanceof Unwrappable) {
+            return ((Unwrappable) client).as(type);
+        }
+
+        if (Proxy.isProxyClass(client.getClass())) {
+            final InvocationHandler handler = Proxy.getInvocationHandler(client);
+            if (type.isInstance(handler)) {
+                return Optional.of(type.cast(handler));
+            }
+
+            if (handler instanceof Unwrappable) {
+                return ((Unwrappable) handler).as(type);
+            }
+        }
+
+        return Optional.empty();
+    }
 
     /**
      * Closes all clients managed by this factory and shuts down the {@link EventLoopGroup}

--- a/core/src/main/java/com/linecorp/armeria/client/Clients.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Clients.java
@@ -18,8 +18,6 @@ package com.linecorp.armeria.client;
 import static com.linecorp.armeria.client.DefaultClientRequestContext.THREAD_LOCAL_CONTEXT_CUSTOMIZER;
 import static java.util.Objects.requireNonNull;
 
-import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.Proxy;
 import java.net.URI;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -390,17 +388,6 @@ public final class Clients {
 
     private static ClientBuilderParams builderParams(Object client) {
         requireNonNull(client, "client");
-        if (client instanceof ClientBuilderParams) {
-            return (ClientBuilderParams) client;
-        }
-
-        if (Proxy.isProxyClass(client.getClass())) {
-            final InvocationHandler handler = Proxy.getInvocationHandler(client);
-            if (handler instanceof ClientBuilderParams) {
-                return (ClientBuilderParams) handler;
-            }
-        }
-
         final Optional<ClientBuilderParams> params = ClientFactory.DEFAULT.clientBuilderParams(client);
         if (params.isPresent()) {
             return params.get();

--- a/core/src/main/java/com/linecorp/armeria/client/Clients.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Clients.java
@@ -397,6 +397,33 @@ public final class Clients {
     }
 
     /**
+     * Unwraps the specified client into the object of the specified {@code type}.
+     * Use this method instead of an explicit downcast. For example:
+     * <pre>{@code
+     * HttpClient client = new HttpClientBuilder()
+     *     .decorator(LoggingClient.newDecorator())
+     *     .build();
+     * LoggingClient unwrapped1 = client.as(LoggingClient.class).get();
+     * LoggingClient unwrapped2 = Clients.unwrap(client, LoggingClient.class).get();
+     * assert unwrapped1 == unwrapped2;
+     * }</pre>
+     *
+     * @param type the type of the object to return
+     * @return the object of the specified {@code type} if found. {@link Optional#empty()} if not found.
+     *
+     * @see Client#as(Class)
+     * @see ClientFactory#unwrap(Object, Class)
+     */
+    public static <T> Optional<T> unwrap(Object client, Class<T> type) {
+        final Optional<ClientBuilderParams> params = ClientFactory.DEFAULT.clientBuilderParams(client);
+        if (!params.isPresent()) {
+            return Optional.empty();
+        }
+
+        return params.get().factory().unwrap(client, type);
+    }
+
+    /**
      * Sets the specified HTTP header in a thread-local variable so that the header is sent by the client call
      * made from the current thread. Use the {@code try-with-resources} block with the returned
      * {@link SafeCloseable} to unset the thread-local variable automatically:

--- a/core/src/main/java/com/linecorp/armeria/client/Clients.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Clients.java
@@ -29,6 +29,7 @@ import com.linecorp.armeria.common.Scheme;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.util.SafeCloseable;
+import com.linecorp.armeria.common.util.Unwrappable;
 
 /**
  * Creates a new client that connects to a specified {@link URI}.
@@ -403,9 +404,11 @@ public final class Clients {
      * HttpClient client = new HttpClientBuilder()
      *     .decorator(LoggingClient.newDecorator())
      *     .build();
-     * LoggingClient unwrapped1 = client.as(LoggingClient.class).get();
-     * LoggingClient unwrapped2 = Clients.unwrap(client, LoggingClient.class).get();
-     * assert unwrapped1 == unwrapped2;
+     *
+     * LoggingClient unwrapped = Clients.unwrap(client, LoggingClient.class).get();
+     *
+     * // If the client implements Unwrappable, you can just use the 'as()' method.
+     * LoggingClient unwrapped2 = client.as(LoggingClient.class).get();
      * }</pre>
      *
      * @param type the type of the object to return
@@ -413,6 +416,7 @@ public final class Clients {
      *
      * @see Client#as(Class)
      * @see ClientFactory#unwrap(Object, Class)
+     * @see Unwrappable
      */
     public static <T> Optional<T> unwrap(Object client, Class<T> type) {
         final Optional<ClientBuilderParams> params = ClientFactory.DEFAULT.clientBuilderParams(client);

--- a/core/src/main/java/com/linecorp/armeria/client/DecoratingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DecoratingClient.java
@@ -16,12 +16,9 @@
 
 package com.linecorp.armeria.client;
 
-import static java.util.Objects.requireNonNull;
-
-import java.util.Optional;
-
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
+import com.linecorp.armeria.common.util.AbstractUnwrappable;
 
 /**
  * Decorates a {@link Client}. Use {@link SimpleDecoratingClient},
@@ -35,35 +32,14 @@ import com.linecorp.armeria.common.Response;
  * @param <R_O> the {@link Response} type of this {@link Client}
  */
 public abstract class DecoratingClient<T_I extends Request, T_O extends Response,
-                                       R_I extends Request, R_O extends Response> implements Client<R_I, R_O> {
-
-    private final Client<T_I, T_O> delegate;
+                                       R_I extends Request, R_O extends Response>
+        extends AbstractUnwrappable<Client<T_I, T_O>>
+        implements Client<R_I, R_O> {
 
     /**
      * Creates a new instance that decorates the specified {@link Client}.
      */
     protected DecoratingClient(Client<T_I, T_O> delegate) {
-        this.delegate = requireNonNull(delegate, "delegate");
-    }
-
-    /**
-     * Returns the {@link Client} being decorated.
-     */
-    @SuppressWarnings("unchecked")
-    protected final <T extends Client<T_I, T_O>> T delegate() {
-        return (T) delegate;
-    }
-
-    @Override
-    public final <T> Optional<T> as(Class<T> clientType) {
-        final Optional<T> result = Client.super.as(clientType);
-        return result.isPresent() ? result : delegate.as(clientType);
-    }
-
-    @Override
-    public String toString() {
-        final String simpleName = getClass().getSimpleName();
-        final String name = simpleName.isEmpty() ? getClass().getName() : simpleName;
-        return name + '(' + delegate + ')';
+        super(delegate);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/DecoratingClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DecoratingClientFactory.java
@@ -100,6 +100,11 @@ public class DecoratingClientFactory extends AbstractClientFactory {
     }
 
     @Override
+    public <T> Optional<T> unwrap(Object client, Class<T> type) {
+        return delegate().unwrap(client, type);
+    }
+
+    @Override
     public void close() {
         delegate().close();
     }

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientFactory.java
@@ -139,13 +139,19 @@ final class DefaultClientFactory extends AbstractClientFactory {
     }
 
     @Override
-    public <T> Optional<ClientBuilderParams> clientBuilderParams(T client) {
+    public <T> Optional<T> unwrap(Object client, Class<T> type) {
+        final Optional<T> params = super.unwrap(client, type);
+        if (params.isPresent()) {
+            return params;
+        }
+
         for (ClientFactory factory : clientFactories.values()) {
-            final Optional<ClientBuilderParams> params = factory.clientBuilderParams(client);
-            if (params.isPresent()) {
-                return params;
+            final Optional<T> p = factory.unwrap(client, type);
+            if (p.isPresent()) {
+                return p;
             }
         }
+
         return Optional.empty();
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClient.java
@@ -26,11 +26,12 @@ import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.util.Unwrappable;
 
 /**
  * An HTTP client.
  */
-public interface HttpClient extends ClientBuilderParams {
+public interface HttpClient extends ClientBuilderParams, Unwrappable {
 
     /**
      * Creates a new HTTP client using the {@link ClientFactory#DEFAULT} and the {@link ClientOptions#DEFAULT}.

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientFactory.java
@@ -24,7 +24,6 @@ import java.net.URI;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Consumer;
@@ -258,11 +257,6 @@ final class HttpClientFactory extends AbstractClientFactory {
         } else {
             throw new IllegalArgumentException("unsupported client type: " + clientType.getName());
         }
-    }
-
-    @Override
-    public <T> Optional<ClientBuilderParams> clientBuilderParams(T client) {
-        return Optional.empty();
     }
 
     private DefaultHttpClient newHttpClient(URI uri, Scheme scheme, Endpoint endpoint, ClientOptions options,

--- a/core/src/main/java/com/linecorp/armeria/client/UserClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/UserClient.java
@@ -28,6 +28,7 @@ import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.logging.RequestLogAvailability;
+import com.linecorp.armeria.common.util.AbstractUnwrappable;
 import com.linecorp.armeria.common.util.ReleasableHolder;
 
 import io.micrometer.core.instrument.MeterRegistry;
@@ -43,10 +44,11 @@ import io.netty.channel.EventLoop;
  * @param <I> the request type
  * @param <O> the response type
  */
-public abstract class UserClient<I extends Request, O extends Response> implements ClientBuilderParams {
+public abstract class UserClient<I extends Request, O extends Response>
+        extends AbstractUnwrappable<Client<I, O>>
+        implements ClientBuilderParams {
 
     private final ClientBuilderParams params;
-    private final Client<I, O> delegate;
     private final MeterRegistry meterRegistry;
     private final SessionProtocol sessionProtocol;
     private final Endpoint endpoint;
@@ -62,8 +64,8 @@ public abstract class UserClient<I extends Request, O extends Response> implemen
      */
     protected UserClient(ClientBuilderParams params, Client<I, O> delegate, MeterRegistry meterRegistry,
                          SessionProtocol sessionProtocol, Endpoint endpoint) {
+        super(delegate);
         this.params = params;
-        this.delegate = delegate;
         this.meterRegistry = meterRegistry;
         this.sessionProtocol = sessionProtocol;
         this.endpoint = endpoint;
@@ -87,14 +89,6 @@ public abstract class UserClient<I extends Request, O extends Response> implemen
     @Override
     public final ClientOptions options() {
         return params.options();
-    }
-
-    /**
-     * Returns the {@link Client} that will process {@link Request}s.
-     */
-    @SuppressWarnings("unchecked")
-    protected final <U extends Client<I, O>> U delegate() {
-        return (U) delegate;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/retry/Backoff.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/Backoff.java
@@ -18,18 +18,19 @@ package com.linecorp.armeria.client.retry;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.linecorp.armeria.client.retry.DefaultBackoffHolder.defaultBackoff;
 import static com.linecorp.armeria.client.retry.FixedBackoff.NO_DELAY;
-import static java.util.Objects.requireNonNull;
 
 import java.util.Optional;
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Supplier;
 
+import com.linecorp.armeria.common.util.Unwrappable;
+
 /**
  * Controls back off between attempts in a single retry operation.
  */
 @FunctionalInterface
-public interface Backoff {
+public interface Backoff extends Unwrappable {
 
     /**
      * Returns the default {@link Backoff}.
@@ -142,16 +143,15 @@ public interface Backoff {
 
     /**
      * Undecorates this {@link Backoff} to find the {@link Backoff} which is an instance of the specified
-     * {@code backoffType}.
+     * {@code type}.
      *
-     * @param backoffType the type of the desired {@link Backoff}
-     * @return the {@link Backoff} which is an instance of {@code backoffType} if this {@link Backoff}
+     * @param type the type of the desired {@link Backoff}
+     * @return the {@link Backoff} which is an instance of {@code type} if this {@link Backoff}
      *         decorated such a {@link Backoff}. {@link Optional#empty()} otherwise.
      */
-    default <T> Optional<T> as(Class<T> backoffType) {
-        requireNonNull(backoffType, "backoffType");
-        return backoffType.isInstance(this) ? Optional.of(backoffType.cast(this))
-                                            : Optional.empty();
+    @Override
+    default <T> Optional<T> as(Class<T> type) {
+        return Unwrappable.super.as(type);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/retry/Backoff.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/Backoff.java
@@ -148,6 +148,8 @@ public interface Backoff extends Unwrappable {
      * @param type the type of the desired {@link Backoff}
      * @return the {@link Backoff} which is an instance of {@code type} if this {@link Backoff}
      *         decorated such a {@link Backoff}. {@link Optional#empty()} otherwise.
+     *
+     * @see Unwrappable
      */
     @Override
     default <T> Optional<T> as(Class<T> type) {

--- a/core/src/main/java/com/linecorp/armeria/client/retry/BackoffWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/BackoffWrapper.java
@@ -15,39 +15,19 @@
  */
 package com.linecorp.armeria.client.retry;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
-import java.util.Optional;
-
-import com.google.common.base.MoreObjects;
+import com.linecorp.armeria.common.util.AbstractUnwrappable;
 
 /**
  * Wraps an existing {@link Backoff}.
  */
-public class BackoffWrapper implements Backoff {
-    private final Backoff delegate;
+public class BackoffWrapper extends AbstractUnwrappable<Backoff> implements Backoff {
 
     protected BackoffWrapper(Backoff delegate) {
-        this.delegate = checkNotNull(delegate, "delegate");
+        super(delegate);
     }
 
     @Override
     public long nextDelayMillis(int numAttemptsSoFar) {
-        return delegate.nextDelayMillis(numAttemptsSoFar);
-    }
-
-    protected Backoff delegate() {
-        return delegate;
-    }
-
-    @Override
-    public final <T> Optional<T> as(Class<T> backoffType) {
-        final Optional<T> result = Backoff.super.as(backoffType);
-        return result.isPresent() ? result : delegate.as(backoffType);
-    }
-
-    @Override
-    public String toString() {
-        return MoreObjects.toStringHelper(this).add("delegate", delegate).toString();
+        return delegate().nextDelayMillis(numAttemptsSoFar);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/util/AbstractUnwrappable.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/AbstractUnwrappable.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common.util;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Optional;
+
+/**
+ * Skeletal {@link Unwrappable} imlementation.
+ *
+ * @param <T> the type of the object being decorated
+ */
+public abstract class AbstractUnwrappable<T extends Unwrappable> implements Unwrappable {
+
+    private final T delegate;
+
+    /**
+     * Creates a new decorator with the specified delegate.
+     */
+    protected AbstractUnwrappable(T delegate) {
+        this.delegate = requireNonNull(delegate, "delegate");
+    }
+
+    /**
+     * Returns the object being decorated.
+     */
+    @SuppressWarnings("unchecked")
+    protected final <U extends T> U delegate() {
+        return (U) delegate;
+    }
+
+    @Override
+    public final <U> Optional<U> as(Class<U> type) {
+        final Optional<U> result = Unwrappable.super.as(type);
+        return result.isPresent() ? result : delegate.as(type);
+    }
+
+    @Override
+    public String toString() {
+        final String simpleName = getClass().getSimpleName();
+        final String name = simpleName.isEmpty() ? getClass().getName() : simpleName;
+        return name + '(' + delegate + ')';
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/common/util/Unwrappable.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/Unwrappable.java
@@ -42,8 +42,8 @@ public interface Unwrappable {
      * }
      *
      * Qux qux = new Qux(new Bar(new Foo()));
-     * Foo foo = qux.as(Foo.class);
-     * Bar bar = qux.as(Bar.class);
+     * Foo foo = qux.as(Foo.class).get();
+     * Bar bar = qux.as(Bar.class).get();
      * }</pre>
      *
      * @param type the type of the object to return

--- a/core/src/main/java/com/linecorp/armeria/common/util/Unwrappable.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/Unwrappable.java
@@ -20,7 +20,7 @@ import static java.util.Objects.requireNonNull;
 import java.util.Optional;
 
 /**
- * Provides a way to unwrap an object in decorator pattern, as an alternative to down-casting.
+ * Provides a way to unwrap an object in decorator pattern, similar to down-casting in an inheritance pattern.
  */
 public interface Unwrappable {
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/util/Unwrappable.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/Unwrappable.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common.util;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Optional;
+
+/**
+ * Provides a way to unwrap an object in decorator pattern, as an alternative to down-casting.
+ */
+public interface Unwrappable {
+    /**
+     * Unwraps this object into the object of the specified {@code type}.
+     * Use this method instead of an explicit downcast. For example:
+     * <pre>{@code
+     * class Foo {}
+     *
+     * class Bar<T> extends AbstractWrapper<T> {
+     *     Bar(T delegate) {
+     *         super(delegate);
+     *     }
+     * }
+     *
+     * class Qux<T> extends AbstractWrapper<T> {
+     *     Qux(T delegate) {
+     *         super(delegate);
+     *     }
+     * }
+     *
+     * Qux qux = new Qux(new Bar(new Foo()));
+     * Foo foo = qux.as(Foo.class);
+     * Bar bar = qux.as(Bar.class);
+     * }</pre>
+     *
+     * @param type the type of the object to return
+     * @return the object of the specified {@code type} if found. {@link Optional#empty()} if not found.
+     */
+    default <T> Optional<T> as(Class<T> type) {
+        requireNonNull(type, "type");
+        return type.isInstance(this) ? Optional.of(type.cast(this)) : Optional.empty();
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/DecoratingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DecoratingService.java
@@ -16,14 +16,11 @@
 
 package com.linecorp.armeria.server;
 
-import static java.util.Objects.requireNonNull;
-
-import java.util.Optional;
-
 import javax.annotation.Nullable;
 
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
+import com.linecorp.armeria.common.util.AbstractUnwrappable;
 
 /**
  * A {@link Service} that decorates another {@link Service}. Use {@link SimpleDecoratingService} or
@@ -37,45 +34,23 @@ import com.linecorp.armeria.common.Response;
  */
 public abstract class DecoratingService<T_I extends Request, T_O extends Response,
                                         R_I extends Request, R_O extends Response>
+        extends AbstractUnwrappable<Service<T_I, T_O>>
         implements Service<R_I, R_O> {
-
-    private final Service<T_I, T_O> delegate;
 
     /**
      * Creates a new instance that decorates the specified {@link Service}.
      */
     protected DecoratingService(Service<T_I, T_O> delegate) {
-        this.delegate = requireNonNull(delegate, "delegate");
-    }
-
-    /**
-     * Returns the {@link Service} being decorated.
-     */
-    @SuppressWarnings("unchecked")
-    protected final <T extends Service<T_I, T_O>> T delegate() {
-        return (T) delegate;
+        super(delegate);
     }
 
     @Override
     public void serviceAdded(ServiceConfig cfg) throws Exception {
-        ServiceCallbackInvoker.invokeServiceAdded(cfg, delegate);
-    }
-
-    @Override
-    public final <T> Optional<T> as(Class<T> serviceType) {
-        final Optional<T> result = Service.super.as(serviceType);
-        return result.isPresent() ? result : delegate.as(serviceType);
+        ServiceCallbackInvoker.invokeServiceAdded(cfg, delegate());
     }
 
     @Override
     public boolean shouldCachePath(String path, @Nullable String query, Route route) {
-        return delegate.shouldCachePath(path, query, route);
-    }
-
-    @Override
-    public String toString() {
-        final String simpleName = getClass().getSimpleName();
-        final String name = simpleName.isEmpty() ? getClass().getName() : simpleName;
-        return name + '(' + delegate + ')';
+        return delegate().shouldCachePath(path, query, route);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/Service.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Service.java
@@ -71,6 +71,8 @@ public interface Service<I extends Request, O extends Response> extends Unwrappa
      *
      * @param type the type of the object to return
      * @return the object of the specified {@code type} if found. {@link Optional#empty()} if not found.
+     *
+     * @see Unwrappable
      */
     @Override
     default <T> Optional<T> as(Class<T> type) {

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientUnwrapTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientUnwrapTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 
+import com.linecorp.armeria.client.encoding.HttpDecodingClient;
 import com.linecorp.armeria.client.logging.LoggingClient;
 import com.linecorp.armeria.client.retry.RetryStrategy;
 import com.linecorp.armeria.client.retry.RetryingHttpClient;
@@ -54,6 +55,6 @@ class HttpClientUnwrapTest {
         assertThat(factory.unwrap(client, Unwrappable.class)).containsSame(client);
         assertThat(factory.unwrap(client, Client.class)).containsInstanceOf(RetryingHttpClient.class);
 
-        assertThat(factory.unwrap(client, String.class)).isEmpty();
+        assertThat(factory.unwrap(client, HttpDecodingClient.class)).isEmpty();
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientUnwrapTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientUnwrapTest.java
@@ -39,6 +39,10 @@ class HttpClientUnwrapTest {
         assertThat(client.as(RetryingHttpClient.class)).containsInstanceOf(RetryingHttpClient.class);
         assertThat(client.as(LoggingClient.class)).containsInstanceOf(LoggingClient.class);
 
+        // The outermost decorator of the client must be returned,
+        // because the search begins from outside to inside.
+        // In the current setup, the outermost `Unwrappable` and `Client` are
+        // `client` and `RetryingHttpClient` respectively.
         assertThat(client.as(Unwrappable.class)).containsSame(client);
         assertThat(client.as(Client.class)).containsInstanceOf(RetryingHttpClient.class);
 

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientUnwrapTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientUnwrapTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.client.logging.LoggingClient;
+import com.linecorp.armeria.client.retry.RetryStrategy;
+import com.linecorp.armeria.client.retry.RetryingHttpClient;
+import com.linecorp.armeria.common.util.Unwrappable;
+
+class HttpClientUnwrapTest {
+
+    @Test
+    void test() {
+        final HttpClient client = new HttpClientBuilder()
+                .decorator(LoggingClient.newDecorator())
+                .decorator(RetryingHttpClient.newDecorator(RetryStrategy.never()))
+                .build();
+
+        assertThat(client.as(HttpClient.class)).containsSame(client);
+
+        assertThat(client.as(RetryingHttpClient.class)).containsInstanceOf(RetryingHttpClient.class);
+        assertThat(client.as(LoggingClient.class)).containsInstanceOf(LoggingClient.class);
+
+        assertThat(client.as(Unwrappable.class)).containsSame(client);
+        assertThat(client.as(Client.class)).containsInstanceOf(RetryingHttpClient.class);
+
+        assertThat(client.as(String.class)).isEmpty();
+
+        final ClientFactory factory = client.factory();
+
+        assertThat(factory.unwrap(client, HttpClient.class)).containsSame(client);
+
+        assertThat(factory.unwrap(client, RetryingHttpClient.class))
+                .containsInstanceOf(RetryingHttpClient.class);
+        assertThat(factory.unwrap(client, LoggingClient.class)).containsInstanceOf(LoggingClient.class);
+
+        assertThat(factory.unwrap(client, Unwrappable.class)).containsSame(client);
+        assertThat(factory.unwrap(client, Client.class)).containsInstanceOf(RetryingHttpClient.class);
+
+        assertThat(factory.unwrap(client, String.class)).isEmpty();
+    }
+}

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaChannel.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/ArmeriaChannel.java
@@ -17,6 +17,7 @@
 package com.linecorp.armeria.client.grpc;
 
 import java.net.URI;
+import java.util.Optional;
 
 import javax.annotation.Nullable;
 
@@ -40,6 +41,7 @@ import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.grpc.protocol.ArmeriaMessageFramer;
 import com.linecorp.armeria.common.logging.RequestLogAvailability;
 import com.linecorp.armeria.common.util.ReleasableHolder;
+import com.linecorp.armeria.common.util.Unwrappable;
 
 import io.grpc.CallOptions;
 import io.grpc.Channel;
@@ -56,7 +58,7 @@ import io.netty.handler.codec.http.HttpHeaderValues;
  * A {@link Channel} backed by an armeria {@link Client}. Stores the {@link ClientBuilderParams} and other
  * {@link Client} params for the associated gRPC stub.
  */
-class ArmeriaChannel extends Channel implements ClientBuilderParams {
+class ArmeriaChannel extends Channel implements ClientBuilderParams, Unwrappable {
 
     /**
      * See {@link ManagedChannelBuilder} for default setting.
@@ -149,6 +151,16 @@ class ArmeriaChannel extends Channel implements ClientBuilderParams {
     @Override
     public ClientOptions options() {
         return params.options();
+    }
+
+    @Override
+    public <T> Optional<T> as(Class<T> type) {
+        final Optional<T> unwrapped = Unwrappable.super.as(type);
+        if (unwrapped.isPresent()) {
+            return unwrapped;
+        }
+
+        return httpClient.as(type);
     }
 
     private DefaultClientRequestContext newContext(HttpMethod method, HttpRequest req) {

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientUnwrapTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientUnwrapTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client.grpc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.client.Client;
+import com.linecorp.armeria.client.ClientBuilder;
+import com.linecorp.armeria.client.Clients;
+import com.linecorp.armeria.client.logging.LoggingClient;
+import com.linecorp.armeria.client.retry.RetryStrategy;
+import com.linecorp.armeria.client.retry.RetryingHttpClient;
+import com.linecorp.armeria.common.util.Unwrappable;
+import com.linecorp.armeria.grpc.testing.TestServiceGrpc.TestServiceBlockingStub;
+
+class GrpcClientUnwrapTest {
+
+    @Test
+    void test() {
+        final TestServiceBlockingStub client = new ClientBuilder("gproto+http://127.0.0.1:1/")
+                .decorator(LoggingClient.newDecorator())
+                .decorator(RetryingHttpClient.newDecorator(RetryStrategy.never()))
+                .build(TestServiceBlockingStub.class);
+
+        assertThat(Clients.unwrap(client, TestServiceBlockingStub.class)).containsSame(client);
+
+        assertThat(Clients.unwrap(client, RetryingHttpClient.class))
+                .containsInstanceOf(RetryingHttpClient.class);
+        assertThat(Clients.unwrap(client, LoggingClient.class)).containsInstanceOf(LoggingClient.class);
+
+        assertThat(Clients.unwrap(client, Unwrappable.class)).containsInstanceOf(ArmeriaChannel.class);
+        assertThat(Clients.unwrap(client, Client.class)).containsInstanceOf(RetryingHttpClient.class);
+
+        assertThat(Clients.unwrap(client, String.class)).isEmpty();
+    }
+}

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientUnwrapTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientUnwrapTest.java
@@ -44,6 +44,10 @@ class GrpcClientUnwrapTest {
                 .containsInstanceOf(RetryingHttpClient.class);
         assertThat(Clients.unwrap(client, LoggingClient.class)).containsInstanceOf(LoggingClient.class);
 
+        // The outermost decorator of the client must be returned,
+        // because the search begins from outside to inside.
+        // In the current setup, the outermost `Unwrappable` and `Client` are
+        // `ArmeriaChannel` and `RetryingHttpClient` respectively.
         assertThat(Clients.unwrap(client, Unwrappable.class)).containsInstanceOf(ArmeriaChannel.class);
         assertThat(Clients.unwrap(client, Client.class)).containsInstanceOf(RetryingHttpClient.class);
 

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientUnwrapTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientUnwrapTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.client.ClientBuilder;
 import com.linecorp.armeria.client.Clients;
+import com.linecorp.armeria.client.encoding.HttpDecodingClient;
 import com.linecorp.armeria.client.logging.LoggingClient;
 import com.linecorp.armeria.client.retry.RetryStrategy;
 import com.linecorp.armeria.client.retry.RetryingHttpClient;
@@ -46,6 +47,6 @@ class GrpcClientUnwrapTest {
         assertThat(Clients.unwrap(client, Unwrappable.class)).containsInstanceOf(ArmeriaChannel.class);
         assertThat(Clients.unwrap(client, Client.class)).containsInstanceOf(RetryingHttpClient.class);
 
-        assertThat(Clients.unwrap(client, String.class)).isEmpty();
+        assertThat(Clients.unwrap(client, HttpDecodingClient.class)).isEmpty();
     }
 }

--- a/thrift/src/main/java/com/linecorp/armeria/client/thrift/THttpClient.java
+++ b/thrift/src/main/java/com/linecorp/armeria/client/thrift/THttpClient.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.client.thrift;
 
 import com.linecorp.armeria.client.ClientBuilderParams;
 import com.linecorp.armeria.common.RpcResponse;
+import com.linecorp.armeria.common.util.Unwrappable;
 
 /**
  * A generic Thrift-over-HTTP client.
@@ -36,7 +37,7 @@ import com.linecorp.armeria.common.RpcResponse;
  * client.execute("/foo", FooService.Iface.class, "foo", "arg1", "arg2", ...);
  * }</pre>
  */
-public interface THttpClient extends ClientBuilderParams {
+public interface THttpClient extends Unwrappable, ClientBuilderParams {
     /**
      * Executes the specified Thrift call.
      *

--- a/thrift/src/main/java/com/linecorp/armeria/client/thrift/THttpClientDelegate.java
+++ b/thrift/src/main/java/com/linecorp/armeria/client/thrift/THttpClientDelegate.java
@@ -58,6 +58,7 @@ import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.thrift.ThriftCall;
 import com.linecorp.armeria.common.thrift.ThriftProtocolFactories;
 import com.linecorp.armeria.common.thrift.ThriftReply;
+import com.linecorp.armeria.common.util.AbstractUnwrappable;
 import com.linecorp.armeria.common.util.CompletionActions;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.internal.thrift.TApplicationExceptions;
@@ -71,11 +72,12 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
 import io.netty.util.ReferenceCountUtil;
 
-final class THttpClientDelegate implements Client<RpcRequest, RpcResponse> {
+final class THttpClientDelegate
+        extends AbstractUnwrappable<Client<HttpRequest, HttpResponse>>
+        implements Client<RpcRequest, RpcResponse> {
 
     private final AtomicInteger nextSeqId = new AtomicInteger();
 
-    private final Client<HttpRequest, HttpResponse> httpClient;
     private final SerializationFormat serializationFormat;
     private final TProtocolFactory protocolFactory;
     private final MediaType mediaType;
@@ -83,7 +85,7 @@ final class THttpClientDelegate implements Client<RpcRequest, RpcResponse> {
 
     THttpClientDelegate(Client<HttpRequest, HttpResponse> httpClient,
                         SerializationFormat serializationFormat) {
-        this.httpClient = httpClient;
+        super(httpClient);
         this.serializationFormat = serializationFormat;
         protocolFactory = ThriftProtocolFactories.get(serializationFormat);
         mediaType = serializationFormat.mediaType();
@@ -137,7 +139,7 @@ final class THttpClientDelegate implements Client<RpcRequest, RpcResponse> {
             ctx.logBuilder().deferResponseContent();
 
             final CompletableFuture<AggregatedHttpResponse> future =
-                    httpClient.execute(ctx, httpReq).aggregateWithPooledObjects(ctx.eventLoop(), ctx.alloc());
+                    delegate().execute(ctx, httpReq).aggregateWithPooledObjects(ctx.eventLoop(), ctx.alloc());
 
             future.handle((res, cause) -> {
                 if (cause != null) {

--- a/thrift/src/main/java/com/linecorp/armeria/client/thrift/THttpClientInvocationHandler.java
+++ b/thrift/src/main/java/com/linecorp/armeria/client/thrift/THttpClientInvocationHandler.java
@@ -31,22 +31,23 @@ import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.ClientOptions;
 import com.linecorp.armeria.common.RpcResponse;
 import com.linecorp.armeria.common.thrift.AsyncMethodCallbacks;
+import com.linecorp.armeria.common.util.AbstractUnwrappable;
 import com.linecorp.armeria.common.util.Exceptions;
 
-final class THttpClientInvocationHandler implements InvocationHandler, ClientBuilderParams {
+final class THttpClientInvocationHandler
+        extends AbstractUnwrappable<THttpClient> implements InvocationHandler, ClientBuilderParams {
 
     private static final Object[] NO_ARGS = new Object[0];
 
     private final ClientBuilderParams params;
-    private final THttpClient thriftClient;
     private final String path;
     @Nullable
     private final String fragment;
 
     THttpClientInvocationHandler(ClientBuilderParams params,
                                  THttpClient thriftClient, String path, @Nullable String fragment) {
+        super(thriftClient);
         this.params = params;
-        this.thriftClient = thriftClient;
         this.path = path;
         this.fragment = fragment;
     }
@@ -121,10 +122,10 @@ final class THttpClientInvocationHandler implements InvocationHandler, ClientBui
         try {
             final RpcResponse reply;
             if (fragment != null) {
-                reply = thriftClient.executeMultiplexed(
+                reply = delegate().executeMultiplexed(
                         path, params.clientType(), fragment, method.getName(), args);
             } else {
-                reply = thriftClient.execute(path, params.clientType(), method.getName(), args);
+                reply = delegate().execute(path, params.clientType(), method.getName(), args);
             }
 
             if (callback != null) {

--- a/thrift/src/test/java/com/linecorp/armeria/client/thrift/THttpClientUnwrapTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/client/thrift/THttpClientUnwrapTest.java
@@ -45,6 +45,10 @@ class THttpClientUnwrapTest {
         assertThat(Clients.unwrap(client, RetryingRpcClient.class)).containsInstanceOf(RetryingRpcClient.class);
         assertThat(Clients.unwrap(client, LoggingClient.class)).containsInstanceOf(LoggingClient.class);
 
+        // The outermost decorator of the client must be returned,
+        // because the search begins from outside to inside.
+        // In the current setup, the outermost `Unwrappable` and `Client` are
+        // `THttpClientInvocationHandler` and `RetryingRpcClient` respectively.
         assertThat(Clients.unwrap(client, Unwrappable.class))
                 .containsInstanceOf(THttpClientInvocationHandler.class);
         assertThat(Clients.unwrap(client, Client.class)).containsInstanceOf(RetryingRpcClient.class);

--- a/thrift/src/test/java/com/linecorp/armeria/client/thrift/THttpClientUnwrapTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/client/thrift/THttpClientUnwrapTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.client.ClientBuilder;
 import com.linecorp.armeria.client.Clients;
+import com.linecorp.armeria.client.circuitbreaker.CircuitBreakerRpcClient;
 import com.linecorp.armeria.client.logging.LoggingClient;
 import com.linecorp.armeria.client.retry.RetryingRpcClient;
 import com.linecorp.armeria.common.util.Unwrappable;
@@ -48,6 +49,6 @@ class THttpClientUnwrapTest {
                 .containsInstanceOf(THttpClientInvocationHandler.class);
         assertThat(Clients.unwrap(client, Client.class)).containsInstanceOf(RetryingRpcClient.class);
 
-        assertThat(Clients.unwrap(client, String.class)).isEmpty();
+        assertThat(Clients.unwrap(client, CircuitBreakerRpcClient.class)).isEmpty();
     }
 }

--- a/thrift/src/test/java/com/linecorp/armeria/client/thrift/THttpClientUnwrapTest.java
+++ b/thrift/src/test/java/com/linecorp/armeria/client/thrift/THttpClientUnwrapTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client.thrift;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.client.Client;
+import com.linecorp.armeria.client.ClientBuilder;
+import com.linecorp.armeria.client.Clients;
+import com.linecorp.armeria.client.logging.LoggingClient;
+import com.linecorp.armeria.client.retry.RetryingRpcClient;
+import com.linecorp.armeria.common.util.Unwrappable;
+import com.linecorp.armeria.service.test.thrift.main.HelloService;
+
+class THttpClientUnwrapTest {
+
+    @Test
+    void test() {
+        final HelloService.Iface client = new ClientBuilder("tbinary+http://127.0.0.1:1/")
+                .decorator(LoggingClient.newDecorator())
+                .rpcDecorator(RetryingRpcClient.newDecorator(
+                        (ctx, response) -> CompletableFuture.completedFuture(null)))
+                .build(HelloService.Iface.class);
+
+        assertThat(Clients.unwrap(client, HelloService.Iface.class)).containsSame(client);
+
+        assertThat(Clients.unwrap(client, RetryingRpcClient.class)).containsInstanceOf(RetryingRpcClient.class);
+        assertThat(Clients.unwrap(client, LoggingClient.class)).containsInstanceOf(LoggingClient.class);
+
+        assertThat(Clients.unwrap(client, Unwrappable.class))
+                .containsInstanceOf(THttpClientInvocationHandler.class);
+        assertThat(Clients.unwrap(client, Client.class)).containsInstanceOf(RetryingRpcClient.class);
+
+        assertThat(Clients.unwrap(client, String.class)).isEmpty();
+    }
+}


### PR DESCRIPTION
Related: #2018
Motivation:

- `Client.as()` and `Service.as()` have the same logic which can be
  deduplicated.
- `Client.as()` is useless when a user tries to unwrap `HttpClient`,
  gRPC client or Thrift client, because they do not implement `Client`.

Modifications:

- Add `Unwrappable` and make `Client`, `Service` and `Backoff` extend it.
- Make `HttpClient` implement `Unwrappable`.
- Add `ClientFactory.unwrap(client, type)` so that a user can unwrap a
  gRPC or Thrift client.
- `ClientFactory.clientBuilderParam()` now delegates to `unwrap()`.
- Revise the Javadoc of `as()`.

Result:

- A non-`Client` client object can be unwrapped via `ClientFactory.unwrap()`.
- A user can implement his or her `Unwrappable`.