### PR TITLE
Fix resource leak in `DefaultHttpClient.execute()`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerBuilder.java
@@ -25,7 +25,8 @@ import java.util.List;
 import java.util.Optional;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Ticker;
+
+import com.linecorp.armeria.common.util.Ticker;
 
 /**
  * Builds a {@link CircuitBreaker} instance using builder pattern.

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/NonBlockingCircuitBreaker.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/NonBlockingCircuitBreaker.java
@@ -30,7 +30,8 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Ticker;
+
+import com.linecorp.armeria.common.util.Ticker;
 
 /**
  * A non-blocking implementation of circuit breaker pattern.

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/SlidingWindowCounter.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/SlidingWindowCounter.java
@@ -26,7 +26,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.LongAdder;
 
-import com.google.common.base.Ticker;
+import com.linecorp.armeria.common.util.Ticker;
 
 /**
  * An {@link EventCounter} that accumulates the count of events within a time window.

--- a/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerHttpClientIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerHttpClientIntegrationTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client.circuitbreaker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+
+import java.net.ConnectException;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.client.HttpClientBuilder;
+import com.linecorp.armeria.client.UnprocessedRequestException;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpRequestWriter;
+import com.linecorp.armeria.common.stream.AbortedStreamException;
+import com.linecorp.armeria.unsafe.ByteBufHttpData;
+
+import io.netty.buffer.Unpooled;
+
+class CircuitBreakerHttpClientIntegrationTest {
+    @Test
+    void abortOnFailFast() throws Exception {
+        final AtomicLong tickerValue = new AtomicLong();
+        final CircuitBreaker circuitBreaker = new CircuitBreakerBuilder()
+                .ticker(tickerValue::get)
+                .counterUpdateInterval(Duration.ofSeconds(1))
+                .minimumRequestThreshold(0)
+                .build();
+
+        final HttpClient client = new HttpClientBuilder()
+                .decorator(CircuitBreakerHttpClient.newDecorator(
+                        circuitBreaker,
+                        (ctx, cause) -> CompletableFuture.completedFuture(false)))
+                .build();
+
+        for (int i = 0; i < 3; i++) {
+            final HttpRequestWriter req = HttpRequest.streaming(HttpMethod.POST, "h2c://127.0.0.1:1");
+            final ByteBufHttpData data = new ByteBufHttpData(Unpooled.wrappedBuffer(new byte[] { 0 }), true);
+            req.write(data);
+
+            switch (i) {
+                case 0:
+                case 1:
+                    assertThat(circuitBreaker.canRequest()).isTrue();
+                    assertThatThrownBy(() -> client.execute(req).aggregate().join())
+                            .isInstanceOfSatisfying(CompletionException.class, cause -> {
+                                assertThat(cause.getCause()).isInstanceOf(UnprocessedRequestException.class)
+                                                            .hasCauseInstanceOf(ConnectException.class);
+                            });
+                    break;
+                default:
+                    await().until(() -> !circuitBreaker.canRequest());
+                    assertThatThrownBy(() -> client.execute(req).aggregate().join())
+                            .isInstanceOf(CompletionException.class)
+                            .hasCauseInstanceOf(FailFastException.class);
+            }
+
+            await().untilAsserted(() -> {
+                assertThat(req.completionFuture()).hasFailedWithThrowableThat()
+                                                  .isInstanceOf(AbortedStreamException.class);
+            });
+
+            assertThat(data.refCnt()).isZero();
+
+            tickerValue.addAndGet(TimeUnit.SECONDS.toNanos(1));
+        }
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerRpcClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerRpcClientTest.java
@@ -21,25 +21,26 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.Duration;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 
-import org.junit.Test;
-
-import com.google.common.testing.FakeTicker;
+import org.junit.jupiter.api.Test;
 
 import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.RpcResponse;
 import com.linecorp.armeria.common.util.Exceptions;
+import com.linecorp.armeria.common.util.Ticker;
 import com.linecorp.armeria.testing.internal.AnticipatedException;
 
-public class CircuitBreakerRpcClientTest {
+class CircuitBreakerRpcClientTest {
 
     private static final String remoteServiceName = "testService";
 
@@ -60,7 +61,7 @@ public class CircuitBreakerRpcClientTest {
     private static final int minimumRequestThreshold = 2;
 
     @Test
-    public void testSingletonDecorator() {
+    void testSingletonDecorator() {
         final CircuitBreaker circuitBreaker = mock(CircuitBreaker.class);
         when(circuitBreaker.canRequest()).thenReturn(false);
 
@@ -70,7 +71,7 @@ public class CircuitBreakerRpcClientTest {
     }
 
     @Test
-    public void testPerMethodDecorator() {
+    void testPerMethodDecorator() {
         final CircuitBreaker circuitBreaker = mock(CircuitBreaker.class);
         when(circuitBreaker.canRequest()).thenReturn(false);
 
@@ -86,7 +87,7 @@ public class CircuitBreakerRpcClientTest {
     }
 
     @Test
-    public void testPerHostDecorator() {
+    void testPerHostDecorator() {
         final CircuitBreaker circuitBreaker = mock(CircuitBreaker.class);
         when(circuitBreaker.canRequest()).thenReturn(false);
 
@@ -102,7 +103,7 @@ public class CircuitBreakerRpcClientTest {
     }
 
     @Test
-    public void testPerHostAndMethodDecorator() {
+    void testPerHostAndMethodDecorator() {
         final CircuitBreaker circuitBreaker = mock(CircuitBreaker.class);
         when(circuitBreaker.canRequest()).thenReturn(false);
 
@@ -118,9 +119,8 @@ public class CircuitBreakerRpcClientTest {
     }
 
     @Test
-    public void testDelegate() throws Exception {
-        final FakeTicker ticker = new FakeTicker();
-        final CircuitBreaker circuitBreaker = new CircuitBreakerBuilder(remoteServiceName).ticker(ticker)
+    void testDelegate() throws Exception {
+        final CircuitBreaker circuitBreaker = new CircuitBreakerBuilder(remoteServiceName).ticker(() -> 0)
                                                                                           .build();
 
         @SuppressWarnings("unchecked")
@@ -136,7 +136,7 @@ public class CircuitBreakerRpcClientTest {
     }
 
     @Test
-    public void testDelegateIfFailToGetCircuitBreaker() throws Exception {
+    void testDelegateIfFailToGetCircuitBreaker() throws Exception {
         @SuppressWarnings("unchecked")
         final Client<RpcRequest, RpcResponse> delegate = mock(Client.class);
         when(delegate.execute(any(), any())).thenReturn(successRes);
@@ -153,9 +153,9 @@ public class CircuitBreakerRpcClientTest {
     }
 
     @Test
-    public void testStateTransition() throws Exception {
-        final FakeTicker ticker = new FakeTicker();
-        final CircuitBreaker circuitBreaker = buildCircuitBreaker(ticker);
+    void testStateTransition() throws Exception {
+        final AtomicLong ticker = new AtomicLong();
+        final CircuitBreaker circuitBreaker = buildCircuitBreaker(ticker::get);
 
         @SuppressWarnings("unchecked")
         final Client<RpcRequest, RpcResponse> delegate = mock(Client.class);
@@ -170,13 +170,13 @@ public class CircuitBreakerRpcClientTest {
             // Need to call execute() one more to change the state of the circuit breaker.
 
             assertThat(stub.execute(ctxA, reqA).cause()).isInstanceOf(AnticipatedException.class);
-            ticker.advance(Duration.ofMillis(1).toNanos());
+            ticker.addAndGet(Duration.ofMillis(1).toNanos());
         }
 
         // OPEN
         assertThatThrownBy(() -> stub.execute(ctxA, reqA)).isInstanceOf(FailFastException.class);
 
-        ticker.advance(circuitOpenWindow.toNanos());
+        ticker.addAndGet(circuitOpenWindow.toNanos());
 
         // return success future
         when(delegate.execute(ctxA, reqA)).thenReturn(successRes);
@@ -189,16 +189,14 @@ public class CircuitBreakerRpcClientTest {
     }
 
     @Test
-    public void testServiceScope() throws Exception {
-        final FakeTicker ticker = new FakeTicker();
-        final CircuitBreaker circuitBreaker = buildCircuitBreaker(ticker);
+    void testServiceScope() throws Exception {
+        final AtomicLong ticker = new AtomicLong();
+        final CircuitBreaker circuitBreaker = buildCircuitBreaker(ticker::get);
 
         @SuppressWarnings("unchecked")
         final Client<RpcRequest, RpcResponse> delegate = mock(Client.class);
         // Always return failed future for methodA
         when(delegate.execute(ctxA, reqA)).thenReturn(failureRes);
-        // Always return success future for methodB
-        when(delegate.execute(ctxB, reqB)).thenReturn(successRes);
 
         final CircuitBreakerRpcClient stub =
                 new CircuitBreakerRpcClient(delegate, (ctx, req) -> circuitBreaker, strategy());
@@ -209,7 +207,7 @@ public class CircuitBreakerRpcClientTest {
 
             assertThatThrownBy(() -> stub.execute(ctxA, reqA).join())
                     .hasCauseInstanceOf(AnticipatedException.class);
-            ticker.advance(Duration.ofMillis(1).toNanos());
+            ticker.addAndGet(Duration.ofMillis(1).toNanos());
         }
 
         // OPEN (methodA)
@@ -217,12 +215,15 @@ public class CircuitBreakerRpcClientTest {
 
         // OPEN (methodB)
         assertThatThrownBy(() -> stub.execute(ctxB, reqB)).isInstanceOf(FailFastException.class);
+
+        // methodB must not be invoked.
+        verify(delegate, never()).execute(ctxB, reqB);
     }
 
     @Test
-    public void testPerMethodScope() throws Exception {
-        final FakeTicker ticker = new FakeTicker();
-        final Function<String, CircuitBreaker> factory = method -> buildCircuitBreaker(ticker);
+    void testPerMethodScope() throws Exception {
+        final AtomicLong ticker = new AtomicLong();
+        final Function<String, CircuitBreaker> factory = method -> buildCircuitBreaker(ticker::get);
 
         @SuppressWarnings("unchecked")
         final Client<RpcRequest, RpcResponse> delegate = mock(Client.class);
@@ -240,7 +241,7 @@ public class CircuitBreakerRpcClientTest {
 
             assertThatThrownBy(() -> stub.execute(ctxA, reqA).join())
                     .hasCauseInstanceOf(AnticipatedException.class);
-            ticker.advance(Duration.ofMillis(1).toNanos());
+            ticker.addAndGet(Duration.ofMillis(1).toNanos());
         }
 
         // OPEN (methodA)
@@ -250,7 +251,7 @@ public class CircuitBreakerRpcClientTest {
         assertThat(stub.execute(ctxB, reqB).join()).isNull();
     }
 
-    private static CircuitBreaker buildCircuitBreaker(FakeTicker ticker) {
+    private static CircuitBreaker buildCircuitBreaker(Ticker ticker) {
         return new CircuitBreakerBuilder(remoteServiceName)
                 .minimumRequestThreshold(minimumRequestThreshold)
                 .circuitOpenWindow(circuitOpenWindow)

--- a/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/NonBlockingCircuitBreakerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/NonBlockingCircuitBreakerTest.java
@@ -23,16 +23,15 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.time.Duration;
+import java.util.concurrent.atomic.AtomicLong;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import com.google.common.testing.FakeTicker;
-
-public class NonBlockingCircuitBreakerTest {
+class NonBlockingCircuitBreakerTest {
 
     private static final String remoteServiceName = "testService";
 
-    private static final FakeTicker ticker = new FakeTicker();
+    private static final AtomicLong ticker = new AtomicLong();
 
     private static final Duration circuitOpenWindow = Duration.ofSeconds(1);
 
@@ -51,7 +50,7 @@ public class NonBlockingCircuitBreakerTest {
                 .counterSlidingWindow(Duration.ofSeconds(10))
                 .counterUpdateInterval(counterUpdateInterval)
                 .listener(listener)
-                .ticker(ticker)
+                .ticker(ticker::get)
                 .build();
     }
 
@@ -68,7 +67,7 @@ public class NonBlockingCircuitBreakerTest {
         cb.onSuccess();
         cb.onFailure();
         cb.onFailure();
-        ticker.advance(counterUpdateInterval.toNanos());
+        ticker.addAndGet(counterUpdateInterval.toNanos());
         cb.onFailure();
         assertThat(cb.state().isOpen()).isTrue();
         assertThat(cb.canRequest()).isFalse();
@@ -79,7 +78,7 @@ public class NonBlockingCircuitBreakerTest {
                                                            double failureRateThreshold) {
         final NonBlockingCircuitBreaker cb = openState(minimumRequestThreshold, failureRateThreshold);
 
-        ticker.advance(circuitOpenWindow.toNanos());
+        ticker.addAndGet(circuitOpenWindow.toNanos());
 
         assertThat(cb.state().isHalfOpen()).isFalse();
         assertThat(cb.canRequest()).isTrue(); // first request is allowed
@@ -89,24 +88,24 @@ public class NonBlockingCircuitBreakerTest {
     }
 
     @Test
-    public void testClosed() {
+    void testClosed() {
         closedState(2, 0.5);
     }
 
     @Test
-    public void testMinimumRequestThreshold() {
+    void testMinimumRequestThreshold() {
         final NonBlockingCircuitBreaker cb = create(4, 0.5);
         assertThat(cb.state().isClosed() && cb.canRequest()).isTrue();
 
         cb.onFailure();
-        ticker.advance(counterUpdateInterval.toNanos());
+        ticker.addAndGet(counterUpdateInterval.toNanos());
         cb.onFailure();
         assertThat(cb.state().isClosed()).isTrue();
         assertThat(cb.canRequest()).isTrue();
 
         cb.onFailure();
         cb.onFailure();
-        ticker.advance(counterUpdateInterval.toNanos());
+        ticker.addAndGet(counterUpdateInterval.toNanos());
         cb.onFailure();
 
         assertThat(cb.state().isOpen()).isTrue();
@@ -114,7 +113,7 @@ public class NonBlockingCircuitBreakerTest {
     }
 
     @Test
-    public void testFailureRateThreshold() {
+    void testFailureRateThreshold() {
         final NonBlockingCircuitBreaker cb = create(10, 0.5);
 
         for (int i = 0; i < 10; i++) {
@@ -124,19 +123,19 @@ public class NonBlockingCircuitBreakerTest {
             cb.onFailure();
         }
 
-        ticker.advance(counterUpdateInterval.toNanos());
+        ticker.addAndGet(counterUpdateInterval.toNanos());
         cb.onFailure();
 
         assertThat(cb.state().isClosed()).isTrue(); // 10 vs 9 (0.47)
         assertThat(cb.canRequest()).isTrue();
 
-        ticker.advance(counterUpdateInterval.toNanos());
+        ticker.addAndGet(counterUpdateInterval.toNanos());
         cb.onFailure();
 
         assertThat(cb.state().isClosed()).isTrue(); // 10 vs 10 (0.5)
         assertThat(cb.canRequest()).isTrue();
 
-        ticker.advance(counterUpdateInterval.toNanos());
+        ticker.addAndGet(counterUpdateInterval.toNanos());
         cb.onFailure();
 
         assertThat(cb.state().isOpen()).isTrue(); // 10 vs 11 (0.52)
@@ -144,17 +143,17 @@ public class NonBlockingCircuitBreakerTest {
     }
 
     @Test
-    public void testClosedToOpen() {
+    void testClosedToOpen() {
         openState(2, 0.5);
     }
 
     @Test
-    public void testOpenToHalfOpen() {
+    void testOpenToHalfOpen() {
         halfOpenState(2, 0.5);
     }
 
     @Test
-    public void testHalfOpenToClosed() {
+    void testHalfOpenToClosed() {
         final NonBlockingCircuitBreaker cb = halfOpenState(2, 0.5);
 
         cb.onSuccess();
@@ -164,7 +163,7 @@ public class NonBlockingCircuitBreakerTest {
     }
 
     @Test
-    public void testHalfOpenToOpen() {
+    void testHalfOpenToOpen() {
         final NonBlockingCircuitBreaker cb = halfOpenState(2, 0.5);
 
         cb.onFailure();
@@ -174,10 +173,10 @@ public class NonBlockingCircuitBreakerTest {
     }
 
     @Test
-    public void testHalfOpenRetryRequest() {
+    void testHalfOpenRetryRequest() {
         final NonBlockingCircuitBreaker cb = halfOpenState(2, 0.5);
 
-        ticker.advance(trialRequestInterval.toNanos());
+        ticker.addAndGet(trialRequestInterval.toNanos());
 
         assertThat(cb.state().isHalfOpen()).isTrue();
         assertThat(cb.canRequest()).isTrue(); // first request is allowed
@@ -186,7 +185,7 @@ public class NonBlockingCircuitBreakerTest {
     }
 
     @Test
-    public void testNotification() throws Exception {
+    void testNotification() throws Exception {
         reset(listener);
 
         final NonBlockingCircuitBreaker cb = create(4, 0.5);
@@ -198,7 +197,7 @@ public class NonBlockingCircuitBreakerTest {
         reset(listener);
 
         cb.onFailure();
-        ticker.advance(counterUpdateInterval.toNanos());
+        ticker.addAndGet(counterUpdateInterval.toNanos());
         cb.onFailure();
 
         // Notify updated event count
@@ -209,7 +208,7 @@ public class NonBlockingCircuitBreakerTest {
 
         cb.onFailure();
         cb.onFailure();
-        ticker.advance(counterUpdateInterval.toNanos());
+        ticker.addAndGet(counterUpdateInterval.toNanos());
         cb.onFailure();
 
         verify(listener, times(1)).onEventCountUpdated(name, EventCount.ZERO);
@@ -221,7 +220,7 @@ public class NonBlockingCircuitBreakerTest {
         cb.canRequest();
         verify(listener, times(1)).onRequestRejected(name);
 
-        ticker.advance(circuitOpenWindow.toNanos());
+        ticker.addAndGet(circuitOpenWindow.toNanos());
 
         // Notify half open
 


### PR DESCRIPTION
Motivation:

The `HttpRequest` given to `DefaultHttpClient.execute()` must be aborted
or consumed completely at any circumstances. However, it currently does
not. For example, when a circuit is open and `CircuitBreakerClient`
raises an exception, the request will be left open forever.

Modifications:

- Abort the request when request failed unexpectedly.
- Miscellaneous:
  - Replace Guava `Tickers` with ours.

Result:

- `ByteBufHttpData` does not leak anymore.