### PR TITLE
Provide a way to decorate multiple services by `Route`

### DIFF
--- a/brave/src/test/java/com/linecorp/armeria/server/brave/ServerRequestContextAdapterTest.java
+++ b/brave/src/test/java/com/linecorp/armeria/server/brave/ServerRequestContextAdapterTest.java
@@ -170,13 +170,13 @@ class ServerRequestContextAdapterTest {
 
     @Test
     void route_pathWithPrefix_glob() {
-        when(ctx.route()).thenReturn(Route.builder().pathWithPrefix("/foo/", "glob:bar").build());
+        when(ctx.route()).thenReturn(Route.builder().path("/foo/", "glob:bar").build());
         assertThat(response.route()).isEqualTo("/foo/**/bar");
     }
 
     @Test
     void route_pathWithPrefix_regex() {
-        when(ctx.route()).thenReturn(Route.builder().pathWithPrefix("/foo/", "regex:(bar|baz)").build());
+        when(ctx.route()).thenReturn(Route.builder().path("/foo/", "regex:(bar|baz)").build());
         assertThat(response.route()).isEqualTo("/foo/(bar|baz)");
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -33,7 +33,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.CaffeineSpec;
 import com.google.common.base.Ascii;
 import com.google.common.base.CharMatcher;
@@ -49,6 +48,7 @@ import com.linecorp.armeria.common.util.Sampler;
 import com.linecorp.armeria.internal.SslContextUtil;
 import com.linecorp.armeria.server.RoutingContext;
 import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceConfig;
 import com.linecorp.armeria.server.annotation.ExceptionHandler;
 import com.linecorp.armeria.server.annotation.ExceptionVerbosity;
@@ -265,6 +265,10 @@ public final class Flags {
     private static final String DEFAULT_ROUTE_CACHE_SPEC = "maximumSize=4096";
     private static final Optional<String> ROUTE_CACHE_SPEC =
             caffeineSpec("routeCache", DEFAULT_ROUTE_CACHE_SPEC);
+
+    private static final String DEFAULT_ROUTE_DECORATOR_CACHE_SPEC = "maximumSize=4096";
+    private static final Optional<String> ROUTE_DECORATOR_CACHE_SPEC =
+            caffeineSpec("routeDecoratorCache", DEFAULT_ROUTE_DECORATOR_CACHE_SPEC);
 
     private static final String DEFAULT_COMPOSITE_SERVICE_CACHE_SPEC = "maximumSize=256";
     private static final Optional<String> COMPOSITE_SERVICE_CACHE_SPEC =
@@ -712,12 +716,13 @@ public final class Flags {
 
     /**
      * Returns the value of the {@code routeCache} parameter. It would be used to create a Caffeine
-     * {@link Cache} instance using {@link Caffeine#from(String)} for routing a request. The {@link Cache}
+     * {@link Cache} instance using {@link CaffeineSpec} for routing a request. The {@link Cache}
      * would hold the mappings of {@link RoutingContext} and the designated {@link ServiceConfig}
      * for a request to improve server performance.
      *
      * <p>The default value of this flag is {@value DEFAULT_ROUTE_CACHE_SPEC}. Specify the
      * {@code -Dcom.linecorp.armeria.routeCache=<spec>} JVM option to override the default value.
+     * For example, {@code -Dcom.linecorp.armeria.routeCache=maximumSize=4096,expireAfterAccess=600s}.
      * Also, specify {@code -Dcom.linecorp.armeria.routeCache=off} JVM option to disable it.
      */
     public static Optional<String> routeCacheSpec() {
@@ -725,12 +730,28 @@ public final class Flags {
     }
 
     /**
+     * Returns the value of the {@code routeDecoratorCache} parameter. It would be used to create a Caffeine
+     * {@link Cache} instance using {@link CaffeineSpec} for mapping a route to decorator.
+     * The {@link Cache} would hold the mappings of {@link RoutingContext} and the designated
+     * dispatcher {@link Service}s for a request to improve server performance.
+     *
+     * <p>The default value of this flag is {@value DEFAULT_ROUTE_DECORATOR_CACHE_SPEC}. Specify the
+     * {@code -Dcom.linecorp.armeria.routeDecoratorCache=<spec>} JVM option to override the default value.
+     * For example, {@code -Dcom.linecorp.armeria.routeDecoratorCache=maximumSize=4096,expireAfterAccess=600s}.
+     * Also, specify {@code -Dcom.linecorp.armeria.routeDecoratorCache=off} JVM option to disable it.
+     */
+    public static Optional<String> routeDecoratorCacheSpec() {
+        return ROUTE_DECORATOR_CACHE_SPEC;
+    }
+
+    /**
      * Returns the value of the {@code parsedPathCache} parameter. It would be used to create a Caffeine
-     * {@link Cache} instance using {@link Caffeine#from(String)} mapping raw HTTP paths to parsed pair of
+     * {@link Cache} instance using {@link CaffeineSpec} for mapping raw HTTP paths to parsed pair of
      * path and query, after validation.
      *
      * <p>The default value of this flag is {@value DEFAULT_PARSED_PATH_CACHE_SPEC}. Specify the
      * {@code -Dcom.linecorp.armeria.parsedPathCache=<spec>} JVM option to override the default value.
+     * For example, {@code -Dcom.linecorp.armeria.parsedPathCache=maximumSize=4096,expireAfterAccess=600s}.
      * Also, specify {@code -Dcom.linecorp.armeria.parsedPathCache=off} JVM option to disable it.
      */
     public static Optional<String> parsedPathCacheSpec() {
@@ -739,11 +760,12 @@ public final class Flags {
 
     /**
      * Returns the value of the {@code headerValueCache} parameter. It would be used to create a Caffeine
-     * {@link Cache} instance using {@link Caffeine#from(String)} mapping raw HTTP ascii header values to
+     * {@link Cache} instance using {@link CaffeineSpec} for mapping raw HTTP ASCII header values to
      * {@link String}.
      *
      * <p>The default value of this flag is {@value DEFAULT_HEADER_VALUE_CACHE_SPEC}. Specify the
      * {@code -Dcom.linecorp.armeria.headerValueCache=<spec>} JVM option to override the default value.
+     * For example, {@code -Dcom.linecorp.armeria.headerValueCache=maximumSize=4096,expireAfterAccess=600s}.
      * Also, specify {@code -Dcom.linecorp.armeria.headerValueCache=off} JVM option to disable it.
      */
     public static Optional<String> headerValueCacheSpec() {
@@ -763,12 +785,13 @@ public final class Flags {
 
     /**
      * Returns the value of the {@code compositeServiceCache} parameter. It would be used to create a
-     * Caffeine {@link Cache} instance using {@link Caffeine#from(String)} for routing a request.
+     * Caffeine {@link Cache} instance using {@link CaffeineSpec} for routing a request.
      * The {@link Cache} would hold the mappings of {@link RoutingContext} and the designated
      * {@link ServiceConfig} for a request to improve server performance.
      *
      * <p>The default value of this flag is {@value DEFAULT_COMPOSITE_SERVICE_CACHE_SPEC}. Specify the
      * {@code -Dcom.linecorp.armeria.compositeServiceCache=<spec>} JVM option to override the default value.
+     * For example, {@code -Dcom.linecorp.armeria.compositeServiceCache=maximumSize=256,expireAfterAccess=600s}.
      * Also, specify {@code -Dcom.linecorp.armeria.compositeServiceCache=off} JVM option to disable it.
      */
     public static Optional<String> compositeServiceCacheSpec() {

--- a/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpServiceFactory.java
@@ -279,7 +279,7 @@ public final class AnnotatedHttpServiceFactory {
         final String computedPathPrefix = computePathPrefix(clazz, pathPrefix);
 
         final Route route = Route.builder()
-                                 .pathWithPrefix(computedPathPrefix, pattern)
+                                 .path(computedPathPrefix, pattern)
                                  .methods(methods)
                                  .consumes(consumableMediaTypes(method, clazz))
                                  .produces(producibleMediaTypes(method, clazz))

--- a/core/src/main/java/com/linecorp/armeria/server/AbstractBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AbstractBindingBuilder.java
@@ -1,0 +1,320 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.linecorp.armeria.common.HttpMethod.CONNECT;
+import static com.linecorp.armeria.common.HttpMethod.DELETE;
+import static com.linecorp.armeria.common.HttpMethod.GET;
+import static com.linecorp.armeria.common.HttpMethod.HEAD;
+import static com.linecorp.armeria.common.HttpMethod.OPTIONS;
+import static com.linecorp.armeria.common.HttpMethod.PATCH;
+import static com.linecorp.armeria.common.HttpMethod.POST;
+import static com.linecorp.armeria.common.HttpMethod.PUT;
+import static com.linecorp.armeria.common.HttpMethod.TRACE;
+import static com.linecorp.armeria.server.HttpHeaderUtil.ensureUniqueMediaTypes;
+import static java.util.Objects.requireNonNull;
+
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableList.Builder;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
+
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.MediaType;
+
+/**
+ * An abstract builder class for binding something to a {@link Route} fluently.
+ */
+abstract class AbstractBindingBuilder {
+
+    private Set<HttpMethod> methods = ImmutableSet.of();
+    private Set<MediaType> consumeTypes = ImmutableSet.of();
+    private Set<MediaType> produceTypes = ImmutableSet.of();
+    private final Map<RouteBuilder, Set<HttpMethod>> routeBuilders = new LinkedHashMap<>();
+    private final Set<RouteBuilder> pathBuilders = new LinkedHashSet<>();
+
+    /**
+     * Sets the path pattern that a {@link Service} will be bound to.
+     * Please refer to the <a href="https://line.github.io/armeria/server-basics.html#path-patterns">Path patterns</a>
+     * in order to learn how to specify a path pattern.
+     *
+     * @throws IllegalArgumentException if the specified path pattern is invalid
+     */
+    public AbstractBindingBuilder path(String pathPattern) {
+        pathBuilders.add(Route.builder().path(requireNonNull(pathPattern, "pathPattern")));
+        return this;
+    }
+
+    /**
+     * Sets the specified prefix which is a directory that a {@link Service} will be bound under.
+     * {@code pathUnder("/my/path")} is identical to {@code path("prefix:/my/path")}.
+     *
+     * @throws IllegalArgumentException if the specified path pattern is invalid
+     * @deprecated Use {@link #pathPrefix(String)}.
+     */
+    @Deprecated
+    public AbstractBindingBuilder pathUnder(String prefix) {
+        return pathPrefix(prefix);
+    }
+
+    /**
+     * Sets the specified prefix which is a directory that a {@link Service} will be bound under.
+     * {@code pathPrefix("/my/path")} is identical to {@code path("prefix:/my/path")}.
+     *
+     * @throws IllegalArgumentException if the specified path pattern is invalid
+     */
+    public AbstractBindingBuilder pathPrefix(String prefix) {
+        pathBuilders.add(Route.builder().pathPrefix(requireNonNull(prefix, "prefix")));
+        return this;
+    }
+
+    /**
+     * Sets the path pattern that a {@link Service} will be bound to, only supporting {@link HttpMethod#GET}
+     * requests.
+     * Please refer to the <a href="https://line.github.io/armeria/server-basics.html#path-patterns">Path patterns</a>
+     * in order to learn how to specify a path pattern.
+     *
+     * @throws IllegalArgumentException if the specified path pattern is invalid
+     */
+    public AbstractBindingBuilder get(String pathPattern) {
+        addRouteBuilder(pathPattern, GET);
+        return this;
+    }
+
+    /**
+     * Sets the path pattern that a {@link Service} will be bound to, only supporting {@link HttpMethod#POST}
+     * requests.
+     * Please refer to the <a href="https://line.github.io/armeria/server-basics.html#path-patterns">Path patterns</a>
+     * in order to learn how to specify a path pattern.
+     *
+     * @throws IllegalArgumentException if the specified path pattern is invalid
+     */
+    public AbstractBindingBuilder post(String pathPattern) {
+        addRouteBuilder(pathPattern, POST);
+        return this;
+    }
+
+    /**
+     * Sets the path pattern that a {@link Service} will be bound to, only supporting {@link HttpMethod#PUT}
+     * requests.
+     * Please refer to the <a href="https://line.github.io/armeria/server-basics.html#path-patterns">Path patterns</a>
+     * in order to learn how to specify a path pattern.
+     *
+     * @throws IllegalArgumentException if the specified path pattern is invalid
+     */
+    public AbstractBindingBuilder put(String pathPattern) {
+        addRouteBuilder(pathPattern, PUT);
+        return this;
+    }
+
+    /**
+     * Sets the path pattern that a {@link Service} will be bound to, only supporting {@link HttpMethod#PATCH}
+     * requests.
+     * Please refer to the <a href="https://line.github.io/armeria/server-basics.html#path-patterns">Path patterns</a>
+     * in order to learn how to specify a path pattern.
+     *
+     * @throws IllegalArgumentException if the specified path pattern is invalid
+     */
+    public AbstractBindingBuilder patch(String pathPattern) {
+        addRouteBuilder(pathPattern, PATCH);
+        return this;
+    }
+
+    /**
+     * Sets the path pattern that a {@link Service} will be bound to, only supporting {@link HttpMethod#DELETE}
+     * requests.
+     * Please refer to the <a href="https://line.github.io/armeria/server-basics.html#path-patterns">Path patterns</a>
+     * in order to learn how to specify a path pattern.
+     *
+     * @throws IllegalArgumentException if the specified path pattern is invalid
+     */
+    public AbstractBindingBuilder delete(String pathPattern) {
+        addRouteBuilder(pathPattern, DELETE);
+        return this;
+    }
+
+    /**
+     * Sets the path pattern that a {@link Service} will be bound to, only supporting {@link HttpMethod#OPTIONS}
+     * requests.
+     * Please refer to the <a href="https://line.github.io/armeria/server-basics.html#path-patterns">Path patterns</a>
+     * in order to learn how to specify a path pattern.
+     *
+     * @throws IllegalArgumentException if the specified path pattern is invalid
+     */
+    public AbstractBindingBuilder options(String pathPattern) {
+        addRouteBuilder(pathPattern, OPTIONS);
+        return this;
+    }
+
+    /**
+     * Sets the path pattern that a {@link Service} will be bound to, only supporting {@link HttpMethod#HEAD}
+     * requests.
+     * Please refer to the <a href="https://line.github.io/armeria/server-basics.html#path-patterns">Path patterns</a>
+     * in order to learn how to specify a path pattern.
+     *
+     * @throws IllegalArgumentException if the specified path pattern is invalid
+     */
+    public AbstractBindingBuilder head(String pathPattern) {
+        addRouteBuilder(pathPattern, HEAD);
+        return this;
+    }
+
+    /**
+     * Sets the path pattern that a {@link Service} will be bound to, only supporting {@link HttpMethod#TRACE}
+     * requests.
+     * Please refer to the <a href="https://line.github.io/armeria/server-basics.html#path-patterns">Path patterns</a>
+     * in order to learn how to specify a path pattern.
+     *
+     * @throws IllegalArgumentException if the specified path pattern is invalid
+     */
+    public AbstractBindingBuilder trace(String pathPattern) {
+        addRouteBuilder(pathPattern, TRACE);
+        return this;
+    }
+
+    /**
+     * Sets the path pattern that a {@link Service} will be bound to, only supporting {@link HttpMethod#CONNECT}
+     * requests.
+     * Please refer to the <a href="https://line.github.io/armeria/server-basics.html#path-patterns">Path patterns</a>
+     * in order to learn how to specify a path pattern.
+     *
+     * @throws IllegalArgumentException if the specified path pattern is invalid
+     */
+    public AbstractBindingBuilder connect(String pathPattern) {
+        addRouteBuilder(pathPattern, CONNECT);
+        return this;
+    }
+
+    private void addRouteBuilder(String pathPattern, HttpMethod method) {
+        addRouteBuilder(Route.builder().path(requireNonNull(pathPattern, "pathPattern")), EnumSet.of(method));
+    }
+
+    private void addRouteBuilder(RouteBuilder routeBuilder, Set<HttpMethod> methods) {
+        final Set<HttpMethod> methodSet = routeBuilders.computeIfAbsent(
+                routeBuilder, key -> EnumSet.noneOf(HttpMethod.class));
+
+        for (HttpMethod method : methods) {
+            if (!methodSet.add(method)) {
+                throw new IllegalArgumentException("duplicate HTTP method: " + method +
+                                                   ", for: " + routeBuilder);
+            }
+        }
+    }
+
+    /**
+     * Sets the {@link HttpMethod}s that a {@link Service} will support. If not set,
+     * {@link HttpMethod#knownMethods()}s are set.
+     *
+     * @see #path(String)
+     * @see #pathPrefix(String)
+     */
+    public AbstractBindingBuilder methods(HttpMethod... methods) {
+        return methods(ImmutableSet.copyOf(requireNonNull(methods, "methods")));
+    }
+
+    /**
+     * Sets the {@link HttpMethod}s that a {@link Service} will support. If not set,
+     * {@link HttpMethod#knownMethods()}s are set.
+     *
+     * @see #path(String)
+     * @see #pathPrefix(String)
+     */
+    public AbstractBindingBuilder methods(Iterable<HttpMethod> methods) {
+        requireNonNull(methods, "methods");
+        checkArgument(!Iterables.isEmpty(methods), "methods can't be empty");
+        this.methods = Sets.immutableEnumSet(methods);
+        return this;
+    }
+
+    /**
+     * Sets {@link MediaType}s that a {@link Service} will consume. If not set, the {@link Service}
+     * will accept all media types.
+     */
+    public AbstractBindingBuilder consumes(MediaType... consumeTypes) {
+        consumes(ImmutableSet.copyOf(requireNonNull(consumeTypes, "consumeTypes")));
+        return this;
+    }
+
+    /**
+     * Sets {@link MediaType}s that a {@link Service} will consume. If not set, the {@link Service}
+     * will accept all media types.
+     */
+    public AbstractBindingBuilder consumes(Iterable<MediaType> consumeTypes) {
+        ensureUniqueMediaTypes(consumeTypes, "consumeTypes");
+        this.consumeTypes = ImmutableSet.copyOf(consumeTypes);
+        return this;
+    }
+
+    /**
+     * Sets {@link MediaType}s that a {@link Service} will produce to be used in
+     * content negotiation. See <a href="https://tools.ietf.org/html/rfc7231#section-5.3.2">Accept header</a>
+     * for more information.
+     */
+    public AbstractBindingBuilder produces(MediaType... produceTypes) {
+        produces(ImmutableSet.copyOf(requireNonNull(produceTypes, "produceTypes")));
+        return this;
+    }
+
+    /**
+     * Sets {@link MediaType}s that a {@link Service} will produce to be used in
+     * content negotiation. See <a href="https://tools.ietf.org/html/rfc7231#section-5.3.2">Accept header</a>
+     * for more information.
+     */
+    public AbstractBindingBuilder produces(Iterable<MediaType> produceTypes) {
+        ensureUniqueMediaTypes(produceTypes, "produceTypes");
+        this.produceTypes = ImmutableSet.copyOf(produceTypes);
+        return this;
+    }
+
+    /**
+     * Returns a newly-created {@link Route}s based on the properties of this builder.
+     */
+    final List<Route> buildRouteList() {
+        final Builder<Route> builder = ImmutableList.builder();
+
+        if (pathBuilders.isEmpty() && routeBuilders.isEmpty()) {
+            throw new IllegalStateException(
+                    "Should set at least one path that the service is bound to before calling this.");
+        }
+        if (pathBuilders.isEmpty() && !methods.isEmpty()) {
+            throw new IllegalStateException("Should set a path when the methods are set: " + methods);
+        }
+
+        if (!pathBuilders.isEmpty()) {
+            final Set<HttpMethod> pathMethods = methods.isEmpty() ? HttpMethod.knownMethods() : methods;
+            pathBuilders.forEach(pathBuilder -> addRouteBuilder(pathBuilder, pathMethods));
+        }
+        routeBuilders.forEach((routeBuilder, routeMethods) -> {
+            builder.add(routeBuilder.methods(routeMethods)
+                                    .consumes(consumeTypes)
+                                    .produces(produceTypes)
+                                    .build());
+        });
+
+        return builder.build();
+    }
+}
+

--- a/core/src/main/java/com/linecorp/armeria/server/CompositeRouter.java
+++ b/core/src/main/java/com/linecorp/armeria/server/CompositeRouter.java
@@ -21,6 +21,7 @@ import static java.util.Objects.requireNonNull;
 import java.io.OutputStream;
 import java.util.List;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 import com.google.common.collect.ImmutableList;
 
@@ -62,6 +63,14 @@ final class CompositeRouter<I, O> implements Router<O> {
         routingCtx.delayedThrowable().ifPresent(Exceptions::throwUnsafely);
 
         return Routed.empty();
+    }
+
+    @Override
+    public Stream<Routed<O>> findAll(RoutingContext routingContext) {
+        return delegates.stream()
+                        .flatMap(delegate -> delegate.findAll(routingContext))
+                        .map(resultMapper)
+                        .distinct();
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/DecoratingServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DecoratingServiceBindingBuilder.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.function.Function;
+
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.MediaType;
+
+/**
+ * A builder class for binding a {@code decorator} with {@link Route} fluently.
+ * This class can be instantiated through {@link ServerBuilder#routeDecorator()}.
+ *
+ * <p>Call {@link #build(Function)} or {@link #build(DecoratingServiceFunction)}
+ * to build the {@code decorator} and return to the {@link ServerBuilder}.
+ *
+ * <pre>{@code
+ * ServerBuilder sb = new ServerBuilder();
+ *
+ * sb.routeDecorator()                                // Configure a decorator with route.
+ *   .pathPrefix("/api/users")
+ *   .build((delegate, ctx, req) -> {
+ *       if (!"bearer my_token".equals(req.headers().get(HttpHeaderNames.AUTHORIZATION))) {
+ *           return HttpResponse.of(HttpStatus.UNAUTHORIZED);
+ *       }
+ *       return delegate.serve(ctx, req);
+ *   });                                              // Return to the ServerBuilder.
+ * }</pre>
+ *
+ * @see VirtualHostDecoratingServiceBindingBuilder
+ */
+public final class DecoratingServiceBindingBuilder extends AbstractBindingBuilder {
+
+    private final ServerBuilder serverBuilder;
+
+    DecoratingServiceBindingBuilder(ServerBuilder serverBuilder) {
+        this.serverBuilder = requireNonNull(serverBuilder, "serverBuilder");
+    }
+
+    @Override
+    public DecoratingServiceBindingBuilder path(String pathPattern) {
+        return (DecoratingServiceBindingBuilder) super.path(pathPattern);
+    }
+
+    /**
+     * {@inheritDoc}
+     * @deprecated Use {@link #pathPrefix(String)}.
+     */
+    @Override
+    @Deprecated
+    public DecoratingServiceBindingBuilder pathUnder(String prefix) {
+        return (DecoratingServiceBindingBuilder) super.pathPrefix(prefix);
+    }
+
+    @Override
+    public DecoratingServiceBindingBuilder pathPrefix(String prefix) {
+        return (DecoratingServiceBindingBuilder) super.pathPrefix(prefix);
+    }
+
+    @Override
+    public DecoratingServiceBindingBuilder methods(HttpMethod... methods) {
+        return (DecoratingServiceBindingBuilder) super.methods(methods);
+    }
+
+    @Override
+    public DecoratingServiceBindingBuilder methods(Iterable<HttpMethod> methods) {
+        return (DecoratingServiceBindingBuilder) super.methods(methods);
+    }
+
+    @Override
+    public DecoratingServiceBindingBuilder get(String pathPattern) {
+        return (DecoratingServiceBindingBuilder) super.get(pathPattern);
+    }
+
+    @Override
+    public DecoratingServiceBindingBuilder post(String pathPattern) {
+        return (DecoratingServiceBindingBuilder) super.post(pathPattern);
+    }
+
+    @Override
+    public DecoratingServiceBindingBuilder put(String pathPattern) {
+        return (DecoratingServiceBindingBuilder) super.put(pathPattern);
+    }
+
+    @Override
+    public DecoratingServiceBindingBuilder patch(String pathPattern) {
+        return (DecoratingServiceBindingBuilder) super.patch(pathPattern);
+    }
+
+    @Override
+    public DecoratingServiceBindingBuilder delete(String pathPattern) {
+        return (DecoratingServiceBindingBuilder) super.delete(pathPattern);
+    }
+
+    @Override
+    public DecoratingServiceBindingBuilder options(String pathPattern) {
+        return (DecoratingServiceBindingBuilder) super.delete(pathPattern);
+    }
+
+    @Override
+    public DecoratingServiceBindingBuilder head(String pathPattern) {
+        return (DecoratingServiceBindingBuilder) super.head(pathPattern);
+    }
+
+    @Override
+    public DecoratingServiceBindingBuilder trace(String pathPattern) {
+        return (DecoratingServiceBindingBuilder) super.trace(pathPattern);
+    }
+
+    @Override
+    public DecoratingServiceBindingBuilder connect(String pathPattern) {
+        return (DecoratingServiceBindingBuilder) super.connect(pathPattern);
+    }
+
+    @Override
+    public DecoratingServiceBindingBuilder consumes(MediaType... consumeTypes) {
+        return (DecoratingServiceBindingBuilder) super.consumes(consumeTypes);
+    }
+
+    @Override
+    public DecoratingServiceBindingBuilder consumes(Iterable<MediaType> consumeTypes) {
+        return (DecoratingServiceBindingBuilder) super.consumes(consumeTypes);
+    }
+
+    @Override
+    public DecoratingServiceBindingBuilder produces(MediaType... produceTypes) {
+        return (DecoratingServiceBindingBuilder) super.produces(produceTypes);
+    }
+
+    @Override
+    public DecoratingServiceBindingBuilder produces(Iterable<MediaType> produceTypes) {
+        return (DecoratingServiceBindingBuilder) super.produces(produceTypes);
+    }
+
+    /**
+     * Sets the {@code decorator} and returns {@link ServerBuilder} that this
+     * {@link DecoratingServiceBindingBuilder} was created from.
+     *
+     * @param decorator the {@link Function} that decorates {@link Service}
+     * @param <T> the type of the {@link Service} being decorated
+     * @param <R> the type of the {@link Service} {@code decorator} will produce
+     */
+    public <T extends Service<HttpRequest, HttpResponse>, R extends Service<HttpRequest, HttpResponse>>
+    ServerBuilder build(Function<T, R> decorator) {
+        requireNonNull(decorator, "decorator");
+        @SuppressWarnings("unchecked")
+        final Function<Service<HttpRequest, HttpResponse>, Service<HttpRequest, HttpResponse>> castDecorator =
+                (Function<Service<HttpRequest, HttpResponse>, Service<HttpRequest, HttpResponse>>) decorator;
+
+        buildRouteList().forEach(
+                route -> serverBuilder.routingDecorator(new RouteDecoratingService(route, castDecorator)));
+        return serverBuilder;
+    }
+
+    /**
+     * Sets the {@link DecoratingServiceFunction} and returns {@link ServerBuilder} that this
+     * {@link DecoratingServiceBindingBuilder} was created from.
+     *
+     * @param decoratingServiceFunction the {@link DecoratingServiceFunction} that decorates {@link Service}
+     */
+    public ServerBuilder build(
+            DecoratingServiceFunction<HttpRequest, HttpResponse> decoratingServiceFunction) {
+        requireNonNull(decoratingServiceFunction, "decoratingServiceFunction");
+        return build(delegate -> new FunctionalDecoratingService<>(delegate, decoratingServiceFunction));
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/RouteBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RouteBuilder.java
@@ -73,6 +73,48 @@ public class RouteBuilder {
         return pathMapping(getPathMapping(pathPattern));
     }
 
+    /**
+     * Sets the {@link Route} to match the specified {@code prefix} and {@code pathPattern}. The mapped
+     * {@link Service} is found when a {@linkplain ServiceRequestContext#path() path} is under
+     * the specified {@code prefix} and the rest of the path matches the specified {@code pathPattern}.
+     *
+     * @see #path(String)
+     */
+    public RouteBuilder path(String prefix, String pathPattern) {
+        prefix = ensureAbsolutePath(prefix, "prefix");
+        if (!prefix.endsWith("/")) {
+            prefix += '/';
+        }
+
+        if ("/".equals(prefix)) {
+            // pathPrefix is not specified or "/".
+            return path(pathPattern);
+        }
+
+        if (pathPattern.startsWith("/")) {
+            return path(concatPaths(prefix, pathPattern));
+        }
+
+        if (pathPattern.startsWith(EXACT)) {
+            return exact(concatPaths(prefix, pathPattern.substring(EXACT.length())));
+        }
+
+        if (pathPattern.startsWith(PREFIX)) {
+            return pathPrefix(concatPaths(prefix, pathPattern.substring(PREFIX.length())));
+        }
+
+        if (pathPattern.startsWith(GLOB)) {
+            final String glob = pathPattern.substring(GLOB.length());
+            if (glob.startsWith("/")) {
+                return glob(concatPaths(prefix, glob));
+            } else {
+                return glob(concatPaths(prefix + "**/", glob), 1);
+            }
+        }
+
+        return pathMapping(new RegexPathMappingWithPrefix(prefix, getPathMapping(pathPattern)));
+    }
+
     private static PathMapping globPathMapping(String glob, int numGroupsToSkip) {
         if (glob.startsWith("/") && !glob.contains("*")) {
             // Does not have a pattern matcher.
@@ -104,10 +146,13 @@ public class RouteBuilder {
      *   <li>{@code "/foo/bar"} translates to  {@code "/bar"}</li>
      *   <li>{@code "/foo/bar/baz"} translates to {@code "/bar/baz"}</li>
      * </ul>
-     * This method is a shortcut to {@linkplain #prefix(String, boolean) prefix(prefix, true)}.
+     * This method is a shortcut to {@linkplain #pathPrefix(String, boolean) pathPrefix(prefix, true)}.
+     *
+     * @deprecated Use {@link #pathPrefix(String)}
      */
+    @Deprecated
     public RouteBuilder prefix(String prefix) {
-        return prefix(prefix, true);
+        return pathPrefix(prefix, true);
     }
 
     /**
@@ -120,8 +165,42 @@ public class RouteBuilder {
      *   <li>{@code "/foo/bar"} translates to  {@code "/bar"}</li>
      *   <li>{@code "/foo/bar/baz"} translates to {@code "/bar/baz"}</li>
      * </ul>
+     *
+     * @deprecated Use {@link #pathPrefix(String, boolean)}
      */
+    @Deprecated
     public RouteBuilder prefix(String prefix, boolean stripPrefix) {
+        return pathPrefix(prefix, stripPrefix);
+    }
+
+    /**
+     * Sets the {@link Route} to match when a {@linkplain ServiceRequestContext#path() path} is under the
+     * specified {@code prefix}. It also removes the specified {@code prefix} from the matched path so that
+     * {@linkplain ServiceRequestContext#mappedPath() mappedPath} does not have the specified {@code prefix}.
+     * For example, when {@code prefix} is {@code "/foo/"}:
+     * <ul>
+     *   <li>{@code "/foo/"} translates to {@code "/"}</li>
+     *   <li>{@code "/foo/bar"} translates to {@code "/bar"}</li>
+     *   <li>{@code "/foo/bar/baz"} translates to {@code "/bar/baz"}</li>
+     * </ul>
+     * This method is a shortcut to {@linkplain #pathPrefix(String, boolean) pathPrefix(prefix, true)}.
+     */
+    public RouteBuilder pathPrefix(String prefix) {
+        return pathPrefix(prefix, true);
+    }
+
+    /**
+     * Sets the {@link Route} to match when a {@linkplain ServiceRequestContext#path() path} is under the
+     * specified {@code prefix}. When {@code stripPrefix} is {@code true}, it also removes the specified
+     * {@code prefix} from the matched path so that {@linkplain ServiceRequestContext#path() mappedPath}
+     * does not have the specified {@code prefix}. For example, when {@code prefix} is {@code "/foo/"}:
+     * <ul>
+     *   <li>{@code "/foo/"} translates to {@code "/"}</li>
+     *   <li>{@code "/foo/bar"} translates to {@code "/bar"}</li>
+     *   <li>{@code "/foo/bar/baz"} translates to {@code "/bar/baz"}</li>
+     * </ul>
+     */
+    public RouteBuilder pathPrefix(String prefix, boolean stripPrefix) {
         return pathMapping(prefixPathMapping(requireNonNull(prefix, "prefix"), stripPrefix));
     }
 
@@ -170,41 +249,11 @@ public class RouteBuilder {
      * {@link Service} is found when a {@linkplain ServiceRequestContext#path() path} is under
      * the specified {@code prefix} and the rest of the path matches the specified {@code pathPattern}.
      *
-     * @see #path(String)
+     * @deprecated Use {@linkplain #path(String, String) path(prefix, pathPattern)}
      */
+    @Deprecated
     public RouteBuilder pathWithPrefix(String prefix, String pathPattern) {
-        prefix = ensureAbsolutePath(prefix, "prefix");
-        if (!prefix.endsWith("/")) {
-            prefix += '/';
-        }
-
-        if ("/".equals(prefix)) {
-            // pathPrefix is not specified or "/".
-            return path(pathPattern);
-        }
-
-        if (pathPattern.startsWith("/")) {
-            return path(concatPaths(prefix, pathPattern));
-        }
-
-        if (pathPattern.startsWith(EXACT)) {
-            return exact(concatPaths(prefix, pathPattern.substring(EXACT.length())));
-        }
-
-        if (pathPattern.startsWith(PREFIX)) {
-            return prefix(concatPaths(prefix, pathPattern.substring(PREFIX.length())));
-        }
-
-        if (pathPattern.startsWith(GLOB)) {
-            final String glob = pathPattern.substring(GLOB.length());
-            if (glob.startsWith("/")) {
-                return glob(concatPaths(prefix, glob));
-            } else {
-                return glob(concatPaths(prefix + "**/", glob), 1);
-            }
-        }
-
-        return pathMapping(new RegexPathMappingWithPrefix(prefix, getPathMapping(pathPattern)));
+        return path(prefix, pathPattern);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/RouteDecoratingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RouteDecoratingService.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.ArrayDeque;
+import java.util.Queue;
+import java.util.function.Function;
+
+import com.google.common.base.MoreObjects;
+
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+
+import io.netty.util.AttributeKey;
+
+/**
+ * Decorates a {@link Service} whose {@link Route} matches the {@link #route}.
+ *
+ * {@link RouteDecoratingService} is used for binding your {@link Service} to multiple {@code decorator}s
+ * with {@link Route}s. e.g.
+ * <pre>{@code
+ * > Server server = new ServerBuilder()
+ * >     .service("/api/users",  userService)
+ * >     .decoratorUnder("/", loggingDecorator)
+ * >     .decoratorUnder("/api", authDecorator)
+ * >     .decoratorUnder("/api/users", traceDecorator)
+ * >     .build();
+ * }</pre>
+ *
+ * {@link VirtualHostBuilder} wraps each specified {@code decorator} with {@link RouteDecoratingService} and
+ * merges them into a {@link Router}. When a client requests to {@code /api/users/1},
+ * {@link InitialDispatcherService} will work the following steps for building decorators
+ * being matched to the given request:
+ *
+ * <ul>
+ *   <li>Finds all matched decorators from {@link InitialDispatcherService#router}
+ *       using {@link RoutingContext}</li>
+ *   <li>Put them into {@code pendingDecorators} with keeping the finding order</li>
+ *   <li>Finally, put the original {@link Service} at the end of {@code pendingDecorators}</li>
+ * </ul>
+ *
+ * <p>The request will go through the below decorators to reach the {@code userService}.
+ * <pre>{@code
+ *  request -> initialDispatcherService
+ *          -> loggingDecorator         -> routeDecoratingService
+ *          -> authDecorator            -> routeDecoratingService
+ *          -> traceDecorator           -> routeDecoratingService
+ *          -> userService
+ * }</pre>
+ */
+final class RouteDecoratingService implements HttpService {
+
+    private static final AttributeKey<Queue<Service<HttpRequest, HttpResponse>>> DECORATOR_KEY =
+            AttributeKey.valueOf(RouteDecoratingService.class, "SERVICE_CHAIN");
+
+    static Function<Service<HttpRequest, HttpResponse>,
+            Service<HttpRequest, HttpResponse>> newDecorator(Router<RouteDecoratingService> router) {
+        return delegate -> new InitialDispatcherService(delegate, router);
+    }
+
+    private final Route route;
+    private final Service<HttpRequest, HttpResponse> decorator;
+
+    RouteDecoratingService(Route route,
+                           Function<Service<HttpRequest, HttpResponse>,
+                                   ? extends Service<HttpRequest, HttpResponse>> decoratorFunction) {
+        this.route = requireNonNull(route, "route");
+        decorator = requireNonNull(decoratorFunction, "decoratorFunction").apply(this);
+    }
+
+    @Override
+    public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+        final Queue<Service<HttpRequest, HttpResponse>> delegates = ctx.attr(DECORATOR_KEY).get();
+        final Service<HttpRequest, HttpResponse> delegate = delegates.poll();
+        return delegate.serve(ctx, req);
+    }
+
+    Route route() {
+        return route;
+    }
+
+    private Service<HttpRequest, HttpResponse> decorator() {
+        return decorator;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("route", route)
+                          .add("decorator", decorator).toString();
+    }
+
+    private static class InitialDispatcherService extends SimpleDecoratingHttpService {
+
+        private final Router<RouteDecoratingService> router;
+
+        InitialDispatcherService(Service<HttpRequest, HttpResponse> delegate,
+                                 Router<RouteDecoratingService> router) {
+            super(delegate);
+            this.router = router;
+        }
+
+        @Override
+        public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+            final Queue<Service<HttpRequest, HttpResponse>> serviceChain = new ArrayDeque<>(4);
+            router.findAll(ctx.routingContext()).forEach(routed -> {
+                if (routed.isPresent()) {
+                    serviceChain.add(routed.value().decorator());
+                }
+            });
+
+            if (serviceChain.isEmpty()) {
+                return delegate().serve(ctx, req);
+            }
+            serviceChain.add(delegate());
+            final Service<HttpRequest, HttpResponse> service = serviceChain.poll();
+            ctx.attr(DECORATOR_KEY).set(serviceChain);
+            return service.serve(ctx, req);
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(this)
+                              .add("router", router)
+                              .add("delegate", delegate()).toString();
+        }
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/RoutePathType.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RoutePathType.java
@@ -48,7 +48,7 @@ public enum RoutePathType {
     /**
      * The path which has the prefix and the regex.
      *
-     * @see RouteBuilder#pathWithPrefix(String, String)
+     * @see RouteBuilder#path(String, String)
      */
     REGEX_WITH_PREFIX(false);
 

--- a/core/src/main/java/com/linecorp/armeria/server/Router.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Router.java
@@ -17,6 +17,7 @@
 package com.linecorp.armeria.server;
 
 import java.io.OutputStream;
+import java.util.stream.Stream;
 
 import com.linecorp.armeria.common.metric.MeterIdPrefix;
 
@@ -36,9 +37,16 @@ public interface Router<V> {
     Routed<V> find(RoutingContext routingCtx);
 
     /**
+     * Finds all values of mapping that match the specified {@link RoutingContext}.
+     *
+     * @return a stream of {@link Routed} that wraps the matching value.
+     */
+    Stream<Routed<V>> findAll(RoutingContext routingCtx);
+
+    /**
      * Registers the stats of this {@link Router} to the specified {@link MeterRegistry}.
      *
-     * @return whether the stats of this {@link Router} has been registered
+     * @return whether the stats of this {@link Router} has been registered.
      */
     default boolean registerMetrics(MeterRegistry registry, MeterIdPrefix idPrefix) {
         return false;

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceBindingBuilder.java
@@ -71,9 +71,19 @@ public final class ServiceBindingBuilder extends AbstractServiceBindingBuilder {
         return (ServiceBindingBuilder) super.path(pathPattern);
     }
 
+    /**
+     * {@inheritDoc}
+     * @deprecated Use {@link #pathPrefix(String)}.
+     */
     @Override
+    @Deprecated
     public ServiceBindingBuilder pathUnder(String prefix) {
-        return (ServiceBindingBuilder) super.pathUnder(prefix);
+        return (ServiceBindingBuilder) super.pathPrefix(prefix);
+    }
+
+    @Override
+    public ServiceBindingBuilder pathPrefix(String prefix) {
+        return (ServiceBindingBuilder) super.pathPrefix(prefix);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceConfigBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceConfigBuilder.java
@@ -29,6 +29,28 @@ import com.linecorp.armeria.server.logging.AccessLogWriter;
 
 final class ServiceConfigBuilder {
 
+    static ServiceConfigBuilder copyOf(ServiceConfigBuilder original) {
+        final ServiceConfigBuilder builder = new ServiceConfigBuilder(original.route, original.service)
+                .requestContentPreviewerFactory(original.requestContentPreviewerFactory)
+                .responseContentPreviewerFactory(original.requestContentPreviewerFactory);
+        if (original.accessLogWriter != null) {
+            builder.accessLogWriter(original.accessLogWriter, original.shutdownAccessLogWriterOnStop);
+        }
+        if (original.loggerName != null) {
+            builder.loggerName(original.loggerName);
+        }
+        if (original.requestTimeoutMillis != null) {
+            builder.requestTimeoutMillis(original.requestTimeoutMillis);
+        }
+        if (original.maxRequestLength != null) {
+            builder.maxRequestLength(original.maxRequestLength);
+        }
+        if (original.verboseResponses != null) {
+            builder.verboseResponses(original.verboseResponses);
+        }
+        return builder;
+    }
+
     private final Route route;
     private final Service<HttpRequest, HttpResponse> service;
     @Nullable

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostDecoratingServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostDecoratingServiceBindingBuilder.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.function.Function;
+
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.MediaType;
+
+/**
+ * A builder class for binding a {@code decorator} to a {@link Route} fluently.
+ * This class can be instantiated through {@link VirtualHostBuilder#routeDecorator()}.
+ *
+ * <p>Call {@link #build(Function)} or {@link #build(DecoratingServiceFunction)}
+ * to build the {@code decorator} and return to the {@link VirtualHostBuilder}.
+ *
+ * <pre>{@code
+ * ServerBuilder sb = new ServerBuilder();
+ *
+ * sb.virtualHost("example.com")
+ *   .routeDecorator()                                // Configure a decorator with route.
+ *   .pathPrefix("/api/users")
+ *   .build((delegate, ctx, req) -> {
+ *       if (!"bearer my_token".equals(req.headers().get(HttpHeaderNames.AUTHORIZATION))) {
+ *           return HttpResponse.of(HttpStatus.UNAUTHORIZED);
+ *       }
+ *       return delegate.serve(ctx, req);
+ *   });                                              // Return to the VirtualHostBuilder.
+ * }</pre>
+ *
+ * @see VirtualHostServiceBindingBuilder
+ */
+public final class VirtualHostDecoratingServiceBindingBuilder extends AbstractBindingBuilder {
+
+    private final VirtualHostBuilder virtualHostBuilder;
+
+    VirtualHostDecoratingServiceBindingBuilder(VirtualHostBuilder virtualHostBuilder) {
+        this.virtualHostBuilder = requireNonNull(virtualHostBuilder, "virtualHostBuilder");
+    }
+
+    @Override
+    public VirtualHostDecoratingServiceBindingBuilder path(String pathPattern) {
+        return (VirtualHostDecoratingServiceBindingBuilder) super.path(pathPattern);
+    }
+
+    /**
+     * {@inheritDoc}
+     * @deprecated Use {@link #pathPrefix(String)}.
+     */
+    @Override
+    @Deprecated
+    public VirtualHostDecoratingServiceBindingBuilder pathUnder(String prefix) {
+        return (VirtualHostDecoratingServiceBindingBuilder) super.pathPrefix(prefix);
+    }
+
+    @Override
+    public VirtualHostDecoratingServiceBindingBuilder pathPrefix(String prefix) {
+        return (VirtualHostDecoratingServiceBindingBuilder) super.pathPrefix(prefix);
+    }
+
+    @Override
+    public VirtualHostDecoratingServiceBindingBuilder methods(HttpMethod... methods) {
+        return (VirtualHostDecoratingServiceBindingBuilder) super.methods(methods);
+    }
+
+    @Override
+    public VirtualHostDecoratingServiceBindingBuilder methods(Iterable<HttpMethod> methods) {
+        return (VirtualHostDecoratingServiceBindingBuilder) super.methods(methods);
+    }
+
+    @Override
+    public VirtualHostDecoratingServiceBindingBuilder get(String pathPattern) {
+        return (VirtualHostDecoratingServiceBindingBuilder) super.get(pathPattern);
+    }
+
+    @Override
+    public VirtualHostDecoratingServiceBindingBuilder post(String pathPattern) {
+        return (VirtualHostDecoratingServiceBindingBuilder) super.post(pathPattern);
+    }
+
+    @Override
+    public VirtualHostDecoratingServiceBindingBuilder put(String pathPattern) {
+        return (VirtualHostDecoratingServiceBindingBuilder) super.put(pathPattern);
+    }
+
+    @Override
+    public VirtualHostDecoratingServiceBindingBuilder patch(String pathPattern) {
+        return (VirtualHostDecoratingServiceBindingBuilder) super.patch(pathPattern);
+    }
+
+    @Override
+    public VirtualHostDecoratingServiceBindingBuilder delete(String pathPattern) {
+        return (VirtualHostDecoratingServiceBindingBuilder) super.delete(pathPattern);
+    }
+
+    @Override
+    public VirtualHostDecoratingServiceBindingBuilder options(String pathPattern) {
+        return (VirtualHostDecoratingServiceBindingBuilder) super.delete(pathPattern);
+    }
+
+    @Override
+    public VirtualHostDecoratingServiceBindingBuilder head(String pathPattern) {
+        return (VirtualHostDecoratingServiceBindingBuilder) super.head(pathPattern);
+    }
+
+    @Override
+    public VirtualHostDecoratingServiceBindingBuilder trace(String pathPattern) {
+        return (VirtualHostDecoratingServiceBindingBuilder) super.trace(pathPattern);
+    }
+
+    @Override
+    public VirtualHostDecoratingServiceBindingBuilder connect(String pathPattern) {
+        return (VirtualHostDecoratingServiceBindingBuilder) super.connect(pathPattern);
+    }
+
+    @Override
+    public VirtualHostDecoratingServiceBindingBuilder consumes(MediaType... consumeTypes) {
+        return (VirtualHostDecoratingServiceBindingBuilder) super.consumes(consumeTypes);
+    }
+
+    @Override
+    public VirtualHostDecoratingServiceBindingBuilder consumes(Iterable<MediaType> consumeTypes) {
+        return (VirtualHostDecoratingServiceBindingBuilder) super.consumes(consumeTypes);
+    }
+
+    @Override
+    public VirtualHostDecoratingServiceBindingBuilder produces(MediaType... produceTypes) {
+        return (VirtualHostDecoratingServiceBindingBuilder) super.produces(produceTypes);
+    }
+
+    @Override
+    public VirtualHostDecoratingServiceBindingBuilder produces(Iterable<MediaType> produceTypes) {
+        return (VirtualHostDecoratingServiceBindingBuilder) super.produces(produceTypes);
+    }
+
+    /**
+     * Sets the {@code decorator} and returns {@link VirtualHostBuilder} that this
+     * {@link VirtualHostDecoratingServiceBindingBuilder} was created from.
+     *
+     * @param decorator the {@link Function} that decorates {@link Service}
+     * @param <T> the type of the {@link Service} being decorated
+     * @param <R> the type of the {@link Service} {@code decorator} will produce
+     */
+    public <T extends Service<HttpRequest, HttpResponse>, R extends Service<HttpRequest, HttpResponse>>
+    VirtualHostBuilder build(Function<T, R> decorator) {
+        requireNonNull(decorator, "decorator");
+        @SuppressWarnings("unchecked")
+        final Function<Service<HttpRequest, HttpResponse>, Service<HttpRequest, HttpResponse>> castDecorator =
+                (Function<Service<HttpRequest, HttpResponse>, Service<HttpRequest, HttpResponse>>) decorator;
+
+        buildRouteList().forEach(
+                route -> virtualHostBuilder.routeDecoratingService(
+                        new RouteDecoratingService(route, castDecorator)));
+        return virtualHostBuilder;
+    }
+
+    /**
+     * Sets the {@link DecoratingServiceFunction} and returns {@link VirtualHostBuilder} that this
+     * {@link VirtualHostDecoratingServiceBindingBuilder} was created from.
+     *
+     * @param decoratingServiceFunction the {@link DecoratingServiceFunction} that decorates {@link Service}
+     */
+    public VirtualHostBuilder build(
+            DecoratingServiceFunction<HttpRequest, HttpResponse> decoratingServiceFunction) {
+        requireNonNull(decoratingServiceFunction, "decoratingServiceFunction");
+        return build(delegate -> new FunctionalDecoratingService<>(delegate, decoratingServiceFunction));
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostServiceBindingBuilder.java
@@ -71,9 +71,19 @@ public final class VirtualHostServiceBindingBuilder extends AbstractServiceBindi
         return (VirtualHostServiceBindingBuilder) super.path(pathPattern);
     }
 
+    /**
+     * {@inheritDoc}
+     * @deprecated Use {@link #pathPrefix(String)}.
+     */
     @Override
+    @Deprecated
     public VirtualHostServiceBindingBuilder pathUnder(String prefix) {
-        return (VirtualHostServiceBindingBuilder) super.pathUnder(prefix);
+        return (VirtualHostServiceBindingBuilder) super.pathPrefix(prefix);
+    }
+
+    @Override
+    public VirtualHostServiceBindingBuilder pathPrefix(String prefix) {
+        return (VirtualHostServiceBindingBuilder) super.pathPrefix(prefix);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/composition/AbstractCompositeService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/composition/AbstractCompositeService.java
@@ -155,8 +155,9 @@ public abstract class AbstractCompositeService<I extends Request, O extends Resp
 
         if (result.route().pathType() == RoutePathType.PREFIX) {
             assert ctx.route().pathType() == RoutePathType.PREFIX;
-            final Route newRoute = Route.builder().prefix(ctx.route().paths().get(0) +
-                                                          result.route().paths().get(0).substring(1)).build();
+            final Route newRoute = Route.builder()
+                                        .pathPrefix(ctx.route().paths().get(0) +
+                                                    result.route().paths().get(0).substring(1)).build();
 
             final ServiceRequestContext newCtx = new CompositeServiceRequestContext(
                     ctx, newRoute, result.routingResult().path());

--- a/core/src/main/java/com/linecorp/armeria/server/composition/CompositeServiceEntry.java
+++ b/core/src/main/java/com/linecorp/armeria/server/composition/CompositeServiceEntry.java
@@ -60,11 +60,11 @@ public final class CompositeServiceEntry<I extends Request, O extends Response> 
      * Creates a new {@link CompositeServiceEntry} whose {@link Service} is bound under the specified
      * directory.
      *
-     * @see RouteBuilder#prefix(String)
+     * @see RouteBuilder#pathPrefix(String)
      */
     public static <I extends Request, O extends Response>
     CompositeServiceEntry<I, O> ofPrefix(String pathPrefix, Service<I, O> service) {
-        return new CompositeServiceEntry<>(Route.builder().prefix(pathPrefix).build(), service);
+        return new CompositeServiceEntry<>(Route.builder().pathPrefix(pathPrefix).build(), service);
     }
 
     /**

--- a/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpDocServicePluginTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/annotation/AnnotatedHttpDocServicePluginTest.java
@@ -192,7 +192,7 @@ public class AnnotatedHttpDocServicePluginTest {
                         .availableMimeTypes(MediaType.PLAIN_TEXT_UTF_8, MediaType.JSON_UTF_8)
                         .build());
 
-        route = withMethodAndTypes(Route.builder().pathWithPrefix("/glob/", "glob:/home/*/files/**"));
+        route = withMethodAndTypes(Route.builder().path("/glob/", "glob:/home/*/files/**"));
         endpointInfo = endpointInfo(route, hostnamePattern);
         assertThat(endpointInfo).isEqualTo(
                 new EndpointInfoBuilder("*", "regex:^/glob/home/([^/]+)/files/(.*)$")
@@ -200,7 +200,7 @@ public class AnnotatedHttpDocServicePluginTest {
                         .build());
 
         route = withMethodAndTypes(Route.builder()
-                                        .pathWithPrefix("/prefix: regex:/", "regex:^/files/(?<filePath>.*)$"));
+                                        .path("/prefix: regex:/", "regex:^/files/(?<filePath>.*)$"));
         endpointInfo = endpointInfo(route, hostnamePattern);
         assertThat(endpointInfo).isEqualTo(
                 new EndpointInfoBuilder("*", "regex:^/files/(?<filePath>.*)$")

--- a/core/src/test/java/com/linecorp/armeria/server/AbstractBindingBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/AbstractBindingBuilderTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.MediaType;
+
+class AbstractBindingBuilderTest {
+
+    @Test
+    void multiRouteBuilder() {
+        final List<Route> routes = new AbstractBindingBuilder() {}
+                .path("/foo")
+                .pathPrefix("/bar")
+                .get("/baz")
+                .post("/qux")
+                .methods(HttpMethod.GET, HttpMethod.POST)
+                .consumes(MediaType.JSON_UTF_8, MediaType.HTML_UTF_8)
+                .produces(MediaType.JAVASCRIPT_UTF_8)
+                .buildRouteList();
+
+        assertThat(routes.size()).isEqualTo(4);
+        assertThat(routes).contains(
+                Route.builder()
+                     .path("/foo")
+                     .methods(HttpMethod.GET, HttpMethod.POST)
+                     .consumes(MediaType.JSON_UTF_8, MediaType.HTML_UTF_8)
+                     .produces(MediaType.JAVASCRIPT_UTF_8)
+                     .build(),
+                Route.builder()
+                     .pathPrefix("/bar")
+                     .methods(HttpMethod.GET, HttpMethod.POST)
+                     .consumes(MediaType.JSON_UTF_8, MediaType.HTML_UTF_8)
+                     .produces(MediaType.JAVASCRIPT_UTF_8)
+                     .build(),
+                Route.builder()
+                     .path("/baz")
+                     .methods(HttpMethod.GET)
+                     .consumes(MediaType.JSON_UTF_8, MediaType.HTML_UTF_8)
+                     .produces(MediaType.JAVASCRIPT_UTF_8)
+                     .build(),
+                Route.builder()
+                     .path("/qux")
+                     .methods(HttpMethod.POST)
+                     .consumes(MediaType.JSON_UTF_8, MediaType.HTML_UTF_8)
+                     .produces(MediaType.JAVASCRIPT_UTF_8)
+                     .build()
+        );
+    }
+
+    @Test
+    void shouldSetPath() {
+        assertThatThrownBy(() -> new AbstractBindingBuilder() {}.buildRouteList())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Should set at least");
+    }
+
+    @Test
+    void shouldHaveKnownMethods() {
+        final List<Route> routes = new AbstractBindingBuilder() {}.path("/foo")
+                                                                  .buildRouteList();
+        assertThat(routes.size()).isEqualTo(1);
+        assertThat(routes.get(0).methods()).isEqualTo(HttpMethod.knownMethods());
+    }
+
+    @Test
+    void shouldFailOnMethodWithoutPath() {
+        // empty route path
+        assertThatThrownBy(() -> new AbstractBindingBuilder() {}.methods(HttpMethod.GET)
+                                                                .buildRouteList())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Should set at least");
+
+        // only method without calling path
+        assertThatThrownBy(() -> new AbstractBindingBuilder() {}.get("/foo")
+                                                                .methods(HttpMethod.POST)
+                                                                .buildRouteList())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Should set a path");
+    }
+
+    @Test
+    void shouldFailOnDuplicatedMethod() {
+        assertThatThrownBy(() -> new AbstractBindingBuilder() {}.get("/foo")
+                                                                .get("/foo"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("duplicate HTTP method");
+    }
+
+    @Test
+    void nonEmptyMethod() {
+        assertThatThrownBy(() -> new AbstractBindingBuilder() {}.methods(ImmutableList.of()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("methods can't be empty");
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/PathWithPrefixTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/PathWithPrefixTest.java
@@ -24,36 +24,36 @@ class PathWithPrefixTest {
 
     @Test
     void prefix() {
-        Route route = Route.builder().pathWithPrefix("/foo/", "glob:/bar/**").build();
+        Route route = Route.builder().path("/foo/", "glob:/bar/**").build();
         assertThat(route.pathType()).isSameAs(RoutePathType.REGEX);
         assertThat(route.paths()).containsExactly("^/foo/bar/(.*)$", "/foo/bar/**");
 
-        route = Route.builder().pathWithPrefix("/foo/", "glob:bar").build();
+        route = Route.builder().path("/foo/", "glob:bar").build();
         assertThat(route.pathType()).isSameAs(RoutePathType.REGEX);
         assertThat(route.paths()).containsExactly("^/foo/(?:.+/)?bar$", "/foo/**/bar");
     }
 
     @Test
     void testLoggerName() {
-        Route route = Route.builder().pathWithPrefix("/foo/", "glob:/bar/**").build();
+        Route route = Route.builder().path("/foo/", "glob:/bar/**").build();
         assertThat(route.loggerName()).isEqualTo("foo.bar.__");
 
-        route = Route.builder().pathWithPrefix("/foo/", "glob:bar").build();
+        route = Route.builder().path("/foo/", "glob:bar").build();
         assertThat(route.loggerName()).isEqualTo("foo.__.bar");
 
-        route = Route.builder().pathWithPrefix("/foo/", "regex:/(foo|bar)").build();
+        route = Route.builder().path("/foo/", "regex:/(foo|bar)").build();
         assertThat(route.loggerName()).isEqualTo("foo.regex.__foo_bar_");
     }
 
     @Test
     void testMetricName() {
-        Route route = Route.builder().pathWithPrefix("/foo/", "glob:/bar/**").build();
+        Route route = Route.builder().path("/foo/", "glob:/bar/**").build();
         assertThat(route.meterTag()).isEqualTo("glob:/foo/bar/**");
 
-        route = Route.builder().pathWithPrefix("/foo/", "glob:bar").build();
+        route = Route.builder().path("/foo/", "glob:bar").build();
         assertThat(route.meterTag()).isEqualTo("glob:/foo/**/bar");
 
-        route = Route.builder().pathWithPrefix("/foo/", "regex:/(foo|bar)").build();
+        route = Route.builder().path("/foo/", "regex:/(foo|bar)").build();
         assertThat(route.meterTag()).isEqualTo("prefix:/foo/,regex:/(foo|bar)");
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/RouteDecoratingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/RouteDecoratingTest.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.ArrayDeque;
+import java.util.List;
+import java.util.Queue;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import javax.annotation.Nullable;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.client.ClientFactory;
+import com.linecorp.armeria.client.ClientFactoryBuilder;
+import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.server.annotation.Get;
+import com.linecorp.armeria.server.annotation.Param;
+import com.linecorp.armeria.testing.internal.MockAddressResolverGroup;
+import com.linecorp.armeria.testing.junit.server.ServerExtension;
+
+class RouteDecoratingTest {
+
+    static Queue<Integer> queue = new ArrayDeque<>();
+    private static final String ACCESS_TOKEN = "bearer: access-token";
+
+    @BeforeEach
+    void init() {
+        queue = new ArrayDeque<>();
+    }
+
+    static DecoratingServiceFunction<HttpRequest, HttpResponse> newDecorator(int id) {
+        return (delegate, ctx, req) -> {
+            queue.add(id);
+            return delegate.serve(ctx, req);
+        };
+    }
+
+    @RegisterExtension
+    static ServerExtension decoratingServer = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.service("/abc", (ctx, req) -> HttpResponse.of(HttpStatus.OK))
+              .service("/abc/def", (ctx, req) -> HttpResponse.of(HttpStatus.OK))
+              .service("/abc/def/ghi", (ctx, req) -> HttpResponse.of(HttpStatus.OK))
+              .routeDecorator().pathPrefix("/").build(newDecorator(1))
+              .routeDecorator().path("/abc").build(newDecorator(2))
+              .routeDecorator().pathPrefix("/abc").build(newDecorator(3))
+              .routeDecorator().pathPrefix("/abc/def").build(newDecorator(4))
+              .routeDecorator().path("glob:**def").build(newDecorator(5));
+        }
+    };
+
+    @RegisterExtension
+    static ServerExtension authServer = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.service("/api/users/{id}", (ctx, req) -> HttpResponse.of(HttpStatus.OK))
+              .annotatedService("/api/admin", new Object() {
+                  @Get("/{id}")
+                  public String getRole(@Param("id") Integer id) {
+                      return "ADMIN";
+                  }
+              })
+              .serviceUnder("/assets", (ctx, req) -> HttpResponse.of(HttpStatus.OK))
+              .decorator(Route.builder().pathPrefix("/api").build(), (delegate, ctx, req) -> {
+                  if (!ACCESS_TOKEN.equals(req.headers().get(HttpHeaderNames.AUTHORIZATION))) {
+                      return HttpResponse.of(HttpStatus.UNAUTHORIZED);
+                  }
+                  return delegate.serve(ctx, req);
+              })
+              .routeDecorator()
+              .pathPrefix("/assets/resources")
+              .build((delegate, ctx, req) -> {
+                  final HttpResponse response = delegate.serve(ctx, req);
+                  ctx.addAdditionalResponseHeader(HttpHeaderNames.CACHE_CONTROL, "public");
+                  return response;
+              })
+              .routeDecorator()
+              .pathPrefix("/assets/resources/private")
+              .build((delegate, ctx, req) -> {
+                  final HttpResponse response = delegate.serve(ctx, req);
+                  ctx.removeAdditionalResponseHeader(HttpHeaderNames.CACHE_CONTROL);
+                  ctx.addAdditionalResponseHeader(HttpHeaderNames.CACHE_CONTROL, "private");
+                  return response;
+              });
+        }
+    };
+
+    @RegisterExtension
+    static ServerExtension virtualHostServer = new ServerExtension() {
+        @Override
+        protected void configure(final ServerBuilder sb) throws Exception {
+            sb.virtualHost("foo.com")
+              .routeDecorator()
+              .pathPrefix("/foo")
+              .build((delegate, ctx, req) -> {
+                  if (!ACCESS_TOKEN.equals(req.headers().get(HttpHeaderNames.AUTHORIZATION))) {
+                      return HttpResponse.of(HttpStatus.UNAUTHORIZED);
+                  }
+                  return delegate.serve(ctx, req);
+              })
+              .serviceUnder("/foo", (ctx, req) -> HttpResponse.of(HttpStatus.OK))
+              .and()
+              .virtualHost("bar.com")
+              .serviceUnder("/bar", (ctx, req) -> HttpResponse.of(HttpStatus.OK));
+        }
+    };
+
+    @ParameterizedTest
+    @MethodSource("generateDecorateInOrder")
+    void decorateInOrder(String path, List<Integer> orders) {
+        final HttpClient client = HttpClient.of(decoratingServer.uri("/"));
+        client.get(path).aggregate().join();
+        assertThat(queue).containsExactlyElementsOf(orders);
+    }
+
+    static Stream<Arguments> generateDecorateInOrder() {
+        return Stream.of(
+                Arguments.of("/abc", ImmutableList.of(1, 2)),
+                Arguments.of("/abc/def", ImmutableList.of(1, 3, 5)),
+                Arguments.of("/abc/def/ghi", ImmutableList.of(1, 3, 4)));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "/api/users/1, " + ACCESS_TOKEN + ", 200, ",
+            "/api/users/2, " + ACCESS_TOKEN + ", 200, ",
+            "/api/users/1, , 401, ",
+            "/api/users/2, , 401, ",
+            "/api/admin/1, " + ACCESS_TOKEN + ", 200, ",
+            "/api/admin/1, , 401, ",
+            "/assets/index.html, , 200, ",
+            "/assets/resources/index.html, , 200, public",
+            "/assets/resources/private/profile.jpg, , 200, private",
+    })
+    void secured(String path, @Nullable String authorization, int status, String cacheControl) {
+        final HttpClient client = HttpClient.of(authServer.uri("/"));
+        final RequestHeaders headers;
+        if (authorization != null) {
+            headers = RequestHeaders.of(HttpMethod.GET, path, HttpHeaderNames.AUTHORIZATION, authorization);
+        } else {
+            headers = RequestHeaders.of(HttpMethod.GET, path);
+        }
+        final AggregatedHttpResponse res = client.execute(headers).aggregate().join();
+        assertThat(res.status().code()).isEqualTo(status);
+        assertThat(res.headers().get(HttpHeaderNames.CACHE_CONTROL)).isEqualTo(cacheControl);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "foo.com, /foo/1, " + ACCESS_TOKEN + ", 200",
+            "foo.com, /foo/1, , 401",
+            "bar.com, /bar/1, , 200"
+    })
+    void virtualHost(String host, String path, @Nullable String authorization, int status) {
+        final ClientFactory factory = new ClientFactoryBuilder()
+                .addressResolverGroupFactory(eventLoop -> MockAddressResolverGroup.localhost())
+                .build();
+        final HttpClient client = HttpClient.of(factory, "http://" + host + ':' + virtualHostServer.httpPort());
+        final RequestHeaders headers;
+        if (authorization != null) {
+            headers = RequestHeaders.of(HttpMethod.GET, path, HttpHeaderNames.AUTHORIZATION, authorization);
+        } else {
+            headers = RequestHeaders.of(HttpMethod.GET, path);
+        }
+        final AggregatedHttpResponse res = client.execute(headers).aggregate().join();
+        assertThat(res.status().code()).isEqualTo(status);
+    }
+
+    @Test
+    void shouldSetPath() {
+        assertThatThrownBy(() -> new ServerBuilder()
+                .routeDecorator().build(Function.identity())
+        ).isInstanceOf(IllegalStateException.class)
+         .hasMessageContaining("Should set at least one");
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/RouteTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/RouteTest.java
@@ -83,43 +83,43 @@ class RouteTest {
     void routePathWithPrefix() {
         Route route;
 
-        route = Route.builder().pathWithPrefix("/foo", "/bar").build();
+        route = Route.builder().path("/foo", "/bar").build();
         assertThat(route.pathType()).isSameAs(RoutePathType.EXACT);
         assertThat(route.paths()).containsExactly("/foo/bar", "/foo/bar");
 
-        route = Route.builder().pathWithPrefix("/foo", "/bar/{baz}").build();
+        route = Route.builder().path("/foo", "/bar/{baz}").build();
         assertThat(route.pathType()).isSameAs(RoutePathType.PARAMETERIZED);
         assertThat(route.paths()).containsExactly("/foo/bar/:", "/foo/bar/:");
 
-        route = Route.builder().pathWithPrefix("/bar", "/baz/:qux").build();
+        route = Route.builder().path("/bar", "/baz/:qux").build();
         assertThat(route.pathType()).isSameAs(RoutePathType.PARAMETERIZED);
         assertThat(route.paths()).containsExactly("/bar/baz/:", "/bar/baz/:");
 
-        route = Route.builder().pathWithPrefix("/foo", "exact:/:bar/baz").build();
+        route = Route.builder().path("/foo", "exact:/:bar/baz").build();
         assertThat(route.pathType()).isSameAs(RoutePathType.EXACT);
         assertThat(route.paths()).containsExactly("/foo/:bar/baz", "/foo/:bar/baz");
 
-        route = Route.builder().pathWithPrefix("/foo", "prefix:/").build();
+        route = Route.builder().path("/foo", "prefix:/").build();
         assertThat(route.pathType()).isSameAs(RoutePathType.PREFIX);
         assertThat(route.paths()).containsExactly("/foo/", "/foo/*");
 
-        route = Route.builder().pathWithPrefix("/foo", "prefix:/bar/baz").build();
+        route = Route.builder().path("/foo", "prefix:/bar/baz").build();
         assertThat(route.pathType()).isSameAs(RoutePathType.PREFIX);
         assertThat(route.paths()).containsExactly("/foo/bar/baz/", "/foo/bar/baz/*");
 
-        route = Route.builder().pathWithPrefix("/foo", "glob:/bar/baz").build();
+        route = Route.builder().path("/foo", "glob:/bar/baz").build();
         assertThat(route.pathType()).isSameAs(RoutePathType.EXACT);
         assertThat(route.paths()).containsExactly("/foo/bar/baz", "/foo/bar/baz");
 
-        route = Route.builder().pathWithPrefix("/foo", "glob:/home/*/files/**").build();
+        route = Route.builder().path("/foo", "glob:/home/*/files/**").build();
         assertThat(route.pathType()).isSameAs(RoutePathType.REGEX);
         assertThat(route.paths()).containsExactly("^/foo/home/([^/]+)/files/(.*)$", "/foo/home/*/files/**");
 
-        route = Route.builder().pathWithPrefix("/foo", "glob:bar").build();
+        route = Route.builder().path("/foo", "glob:bar").build();
         assertThat(route.pathType()).isSameAs(RoutePathType.REGEX);
         assertThat(route.paths()).containsExactly("^/foo/(?:.+/)?bar$", "/foo/**/bar");
 
-        route = Route.builder().pathWithPrefix("/foo", "regex:^/files/(?<filePath>.*)$").build();
+        route = Route.builder().path("/foo", "regex:^/files/(?<filePath>.*)$").build();
         assertThat(route.pathType()).isSameAs(RoutePathType.REGEX_WITH_PREFIX);
         assertThat(route.paths()).containsExactly("^/files/(?<filePath>.*)$", "/foo/");
     }

--- a/core/src/test/java/com/linecorp/armeria/server/RouterTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/RouterTest.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.server;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
@@ -25,9 +26,13 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 import org.assertj.core.util.Lists;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,7 +42,7 @@ import com.google.common.collect.Maps;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.MediaType;
 
-public class RouterTest {
+class RouterTest {
     private static final Logger logger = LoggerFactory.getLogger(RouterTest.class);
 
     private static final BiConsumer<Route, Route> REJECT = (a, b) -> {
@@ -45,7 +50,7 @@ public class RouterTest {
     };
 
     @Test
-    public void testRouters() {
+    void testRouters() {
         final List<Route> routes = Lists.newArrayList(
                 Route.builder().path("exact:/a").build(),         // router 1
                 Route.builder().path("/b/{var}").build(),
@@ -84,8 +89,43 @@ public class RouterTest {
         });
     }
 
+    @ParameterizedTest
+    @MethodSource("generateRouteMatchData")
+    void testFindAllMatchedRouters(String path, int expectForFind, List<Integer> expectForFindAll) {
+        final List<Route> routes = Lists.newArrayList(
+                Route.builder().path("prefix:/a").build(),
+                Route.builder().path("/a/{var}").build(),
+                Route.builder().path("prefix:/c").build(),
+                Route.builder().path("regex:/d/([^/]+)").build(),
+                Route.builder().path("glob:/d/**").build(),
+                Route.builder().path("exact:/e").build(),
+                Route.builder().path("glob:/h/**/z").build(),
+                Route.builder().path("prefix:/h").build()
+        );
+        final List<Router<Route>> routers = Routers.routers(routes, Function.identity(), REJECT);
+        final CompositeRouter<Route, Route> router = new CompositeRouter<>(routers, Function.identity());
+        final RoutingContext mock = mock(RoutingContext.class);
+
+        when(mock.path()).thenReturn(path);
+        assertThat(router.find(mock).route()).isEqualTo(routes.get(expectForFind));
+
+        final List<Route> matched = router.findAll(mock).map(Routed::route).collect(toImmutableList());
+        final List<Route> expected = expectForFindAll.stream().map(routes::get).collect(toImmutableList());
+        assertThat(matched).containsAll(expected);
+    }
+
+    static Stream<Arguments> generateRouteMatchData() {
+        return Stream.of(
+                Arguments.of("/a/1", 1, ImmutableList.of(0, 1)),
+                Arguments.of("/c/1", 2, ImmutableList.of(2)),
+                Arguments.of("/d/12", 3, ImmutableList.of(3, 4)),
+                Arguments.of("/e", 5, ImmutableList.of(5)),
+                Arguments.of("/h/1/2/3/z", 6, ImmutableList.of(6, 7))
+        );
+    }
+
     @Test
-    public void duplicateRoutes() {
+    void duplicateRoutes() {
         // Simple cases
         testDuplicateRoutes(Route.builder().path("exact:/a").build(),
                             Route.builder().path("exact:/a").build());
@@ -99,7 +139,7 @@ public class RouterTest {
      * Should detect the duplicates even if the mappings are split into more than one router.
      */
     @Test
-    public void duplicateMappingsWithRegex() {
+    void duplicateMappingsWithRegex() {
         // Ensure that 3 routers are created first really.
         assertThat(Routers.routers(ImmutableList.of(Route.builder().path("/foo/:bar").build(),
                                                     Route.builder().regex("not-trie-compatible").build(),
@@ -112,7 +152,7 @@ public class RouterTest {
     }
 
     @Test
-    public void duplicatePathWithHeaders() {
+    void duplicatePathWithHeaders() {
         // Not a duplicate if complexity is different.
         testNonDuplicateRoutes(Route.builder().path("/foo").build(),
                                Route.builder().path("/foo").methods(HttpMethod.GET).build());

--- a/core/src/test/java/com/linecorp/armeria/server/ServerBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerBuilderTest.java
@@ -18,12 +18,13 @@ package com.linecorp.armeria.server;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.time.Duration;
 import java.util.List;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,13 +36,14 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.testing.internal.MockAddressResolverGroup;
-import com.linecorp.armeria.testing.junit4.server.ServerRule;
+import com.linecorp.armeria.testing.junit.server.ServerExtension;
 
-public class ServerBuilderTest {
+class ServerBuilderTest {
 
     private static ClientFactory clientFactory;
-    @ClassRule
-    public static final ServerRule server = new ServerRule() {
+
+    @RegisterExtension
+    static final ServerExtension server = new ServerExtension() {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
             sb.service("/", (ctx, req) -> HttpResponse.of(HttpStatus.OK))
@@ -60,20 +62,20 @@ public class ServerBuilderTest {
         }
     };
 
-    @BeforeClass
-    public static void init() {
+    @BeforeAll
+    static void init() {
         clientFactory = new ClientFactoryBuilder()
                 .addressResolverGroupFactory(eventLoopGroup -> MockAddressResolverGroup.localhost())
                 .build();
     }
 
-    @AfterClass
-    public static void destroy() {
+    @AfterAll
+    static void destroy() {
         clientFactory.close();
     }
 
     @Test
-    public void acceptDuplicatePort() throws Exception {
+    void acceptDuplicatePort() throws Exception {
         final Server server = new ServerBuilder()
                 .http(8080)
                 .https(8080)
@@ -88,7 +90,7 @@ public class ServerBuilderTest {
     }
 
     @Test
-    public void treatAsSeparatePortIfZeroIsSpecifiedManyTimes() throws Exception {
+    void treatAsSeparatePortIfZeroIsSpecifiedManyTimes() throws Exception {
         final Server server = new ServerBuilder()
                 .http(0)
                 .http(0)
@@ -105,7 +107,7 @@ public class ServerBuilderTest {
     }
 
     @Test
-    public void numMaxConnections() {
+    void numMaxConnections() {
         final ServerBuilder sb = new ServerBuilder();
         assertThat(sb.maxNumConnections()).isEqualTo(Integer.MAX_VALUE);
     }
@@ -114,7 +116,7 @@ public class ServerBuilderTest {
      * Makes sure each virtual host can have its custom logger name.
      */
     @Test
-    public void setAccessLoggerTest1() {
+    void setAccessLoggerTest1() {
         final Server sb = new ServerBuilder()
                 .service("/", (ctx, req) -> HttpResponse.of(HttpStatus.OK))
                 .accessLogger(LoggerFactory.getLogger("default"))
@@ -156,7 +158,7 @@ public class ServerBuilderTest {
      * when a user specifies the default access logger via {@link ServerBuilder#accessLogger(String)}.
      */
     @Test
-    public void setAccessLoggerTest2() {
+    void setAccessLoggerTest2() {
         final Server sb = new ServerBuilder()
                 .service("/", (ctx, req) -> HttpResponse.of(HttpStatus.OK))
                 .accessLogger("test.default")
@@ -174,7 +176,7 @@ public class ServerBuilderTest {
      * when a user doesn't specify it.
      */
     @Test
-    public void defaultAccessLoggerTest() {
+    void defaultAccessLoggerTest() {
         final Server sb = new ServerBuilder()
                 .service("/", (ctx, req) -> HttpResponse.of(HttpStatus.OK))
                 .virtualHost("*.example.com")
@@ -193,7 +195,7 @@ public class ServerBuilderTest {
      * when the access logger of a {@link VirtualHost} set by a user is {@code null}.
      */
     @Test
-    public void buildIllegalExceptionTest() {
+    void buildIllegalExceptionTest() {
         final ServerBuilder sb = new ServerBuilder()
                 .service("/", (ctx, req) -> HttpResponse.of(HttpStatus.OK))
                 .accessLogger(host -> null);
@@ -216,7 +218,7 @@ public class ServerBuilderTest {
      * its own services.
      */
     @Test
-    public void decoratorTest() throws Exception {
+    void decoratorTest() throws Exception {
         final HttpClient client = HttpClient.of(server.uri("/"));
         final AggregatedHttpResponse res = client.get("/").aggregate().get();
         assertThat(res.headers().get("global_decorator")).isEqualTo("true");
@@ -230,5 +232,67 @@ public class ServerBuilderTest {
         final AggregatedHttpResponse res3 = vhostClient.get("/").aggregate().get();
         assertThat(res3.headers().get("global_decorator")).isEqualTo("true");
         assertThat(res3.headers().get("virtualhost_decorator")).isEqualTo("true");
+    }
+
+    @Test
+    void serveWithDefaultVirtualHostServiceIfNotExists() {
+        final Server server = new ServerBuilder()
+                .serviceUnder("/", (ctx, req) -> HttpResponse.of("default"))
+                .service("/abc", (ctx, req) -> HttpResponse.of("default_abc"))
+                .virtualHost("foo.com")
+                .service("/", (ctx, req) -> HttpResponse.of("foo"))
+                .service("/abc", (ctx, req) -> HttpResponse.of("foo_abc"))
+                .and().build();
+        server.start().join();
+
+        final HttpClient client = HttpClient.of(clientFactory, "http://127.0.0.1:" + server.activeLocalPort());
+        final HttpClient fooClient = HttpClient.of(clientFactory, "http://foo.com:" + server.activeLocalPort());
+
+        assertThat(client.get("/").aggregate().join().contentUtf8()).isEqualTo("default");
+        assertThat(client.get("/abc").aggregate().join().contentUtf8()).isEqualTo("default_abc");
+
+        assertThat(fooClient.get("/").aggregate().join().contentUtf8()).isEqualTo("foo");
+        assertThat(fooClient.get("/abc").aggregate().join().contentUtf8()).isEqualTo("foo_abc");
+
+        // should route to a service of default virtual host
+        assertThat(fooClient.get("/unknown").aggregate().join().contentUtf8()).isEqualTo("default");
+    }
+
+    @Test
+    void serviceConfigurationPriority() {
+        final Server server = new ServerBuilder()
+                .requestTimeoutMillis(100)     // for default virtual host
+                .service("/default_virtual_host",
+                         (ctx, req) -> HttpResponse.delayed(
+                                 HttpResponse.of(HttpStatus.OK), Duration.ofMillis(200))
+                )
+                .route().get("/service_config")
+                .requestTimeoutMillis(200)     // for service
+                .build((ctx, req) -> HttpResponse
+                        .delayed(HttpResponse.of(HttpStatus.OK), Duration.ofMillis(250)))
+                .virtualHost("foo.com")
+                .service("/custom_virtual_host", (ctx, req) -> HttpResponse.delayed(
+                        HttpResponse.of(HttpStatus.OK), Duration.ofMillis(150)))
+                .requestTimeoutMillis(300)    // for custom virtual host
+                .and().build();
+        server.start().join();
+
+        final HttpClient client = HttpClient.of(clientFactory, "http://127.0.0.1:" + server.activeLocalPort());
+        final HttpClient fooClient = HttpClient.of(clientFactory, "http://foo.com:" + server.activeLocalPort());
+
+        assertThat(client.get("/default_virtual_host").aggregate().join().status())
+                .isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+        assertThat(client.get("/service_config").aggregate().join().status())
+                .isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+
+        // choose from 'foo.com' virtual host
+        assertThat(fooClient.get("/default_virtual_host").aggregate().join().status())
+                .isEqualTo(HttpStatus.OK);
+        // choose from service config
+        assertThat(fooClient.get("/service_config").aggregate().join().status())
+                .isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+        // choose from 'foo.com' virtual host
+        assertThat(fooClient.get("/custom_virtual_host").aggregate().join().status())
+                .isEqualTo(HttpStatus.OK);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/ServiceBindingBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServiceBindingBuilderTest.java
@@ -65,7 +65,7 @@ public class ServiceBindingBuilderTest {
         assertThat(route.paths()).containsExactly("/foo/bar", "/foo/bar");
         assertThat(route.consumes()).containsExactly(JSON, PLAIN_TEXT_UTF_8);
         assertThat(route.produces()).containsExactly(JSON_UTF_8,
-                                                               PLAIN_TEXT_UTF_8);
+                                                     PLAIN_TEXT_UTF_8);
         assertThat(serviceConfig.requestTimeoutMillis()).isEqualTo(10);
         assertThat(serviceConfig.maxRequestLength()).isEqualTo(8192);
         assertThat(serviceConfig.verboseResponses()).isEqualTo(true);
@@ -94,7 +94,7 @@ public class ServiceBindingBuilderTest {
         assertThat(route.paths()).containsExactly("/foo/bar", "/foo/bar");
         assertThat(route.consumes()).containsExactly(JSON, PLAIN_TEXT_UTF_8);
         assertThat(route.produces()).containsExactly(JSON_UTF_8,
-                                                               PLAIN_TEXT_UTF_8);
+                                                     PLAIN_TEXT_UTF_8);
         assertThat(serviceConfig.requestTimeoutMillis()).isEqualTo(10);
         assertThat(serviceConfig.maxRequestLength()).isEqualTo(8192);
         assertThat(serviceConfig.verboseResponses()).isEqualTo(true);

--- a/core/src/test/java/com/linecorp/armeria/server/ServiceConfigBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServiceConfigBuilderTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.logging.ContentPreviewerFactory;
+import com.linecorp.armeria.server.logging.AccessLogWriter;
+
+class ServiceConfigBuilderTest {
+
+    @ParameterizedTest
+    @CsvSource({
+            "testLogger, 10, 50, true",
+            ",,,"
+    })
+    void copyOf(String loggerName, Long maxRequestLength, Long requestTimeoutMillis, Boolean verboseResponse) {
+        final Service<HttpRequest, HttpResponse> service = (ctx, req) -> HttpResponse.of(HttpStatus.OK);
+        final Route route = Route.builder().path("/foo").build();
+        final AccessLogWriter accessLogWriter = AccessLogWriter.disabled();
+        final ServiceConfigBuilder original = new ServiceConfigBuilder(route, service)
+                .accessLogWriter(accessLogWriter, true)
+                .requestContentPreviewerFactory(ContentPreviewerFactory.disabled())
+                .responseContentPreviewerFactory(ContentPreviewerFactory.disabled());
+        if (loggerName != null) {
+            original.loggerName(loggerName);
+        }
+        if (maxRequestLength != null) {
+            original.maxRequestLength(maxRequestLength);
+        }
+        if (verboseResponse != null) {
+            original.verboseResponses(verboseResponse);
+        }
+        if (requestTimeoutMillis != null) {
+            original.requestTimeoutMillis(requestTimeoutMillis);
+        }
+
+        final ServiceConfigBuilder copied = ServiceConfigBuilder.copyOf(original);
+        assertThat(copied.maxRequestLength()).isEqualTo(maxRequestLength);
+        assertThat(copied.accessLogWriter()).isEqualTo(accessLogWriter);
+        assertThat(copied.requestContentPreviewerFactory()).isEqualTo(ContentPreviewerFactory.disabled());
+        assertThat(copied.responseContentPreviewerFactory()).isEqualTo(ContentPreviewerFactory.disabled());
+        assertThat(copied.verboseResponses()).isEqualTo(verboseResponse);
+        assertThat(copied.requestTimeoutMillis()).isEqualTo(requestTimeoutMillis);
+
+        // build config to verify route, service and loggerName
+        if (maxRequestLength != null && requestTimeoutMillis != null && verboseResponse != null) {
+            final ServiceConfig serviceConfig = copied.build();
+            assertThat(serviceConfig.route()).isEqualTo(route);
+            assertThat((Service<?, ?>) serviceConfig.service()).isEqualTo(service);
+            if (loggerName == null) {
+                assertThat(serviceConfig.loggerName()).isEmpty();
+            } else {
+                assertThat(serviceConfig.loggerName()).contains(loggerName);
+            }
+            assertThat(serviceConfig.shutdownAccessLogWriterOnStop()).isEqualTo(true);
+        }
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/VirtualHostServiceBindingBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/VirtualHostServiceBindingBuilderTest.java
@@ -40,7 +40,7 @@ class VirtualHostServiceBindingBuilderTest {
         final ContentPreviewerFactory responseFactory = mock(ContentPreviewerFactory.class);
 
         sb.virtualHost("example.com")
-          .route().pathUnder("/foo/bar")
+          .route().pathPrefix("/foo/bar")
           .methods(HttpMethod.GET)
           .consumes(JSON, PLAIN_TEXT_UTF_8)
           .produces(JSON_UTF_8, PLAIN_TEXT_UTF_8)
@@ -60,7 +60,7 @@ class VirtualHostServiceBindingBuilderTest {
         assertThat(route.paths()).containsExactly("/foo/bar/", "/foo/bar/*");
         assertThat(route.consumes()).containsExactly(JSON, PLAIN_TEXT_UTF_8);
         assertThat(route.produces()).containsExactly(JSON_UTF_8,
-                                                               PLAIN_TEXT_UTF_8);
+                                                     PLAIN_TEXT_UTF_8);
         assertThat(serviceConfig.requestTimeoutMillis()).isEqualTo(10);
         assertThat(serviceConfig.maxRequestLength()).isEqualTo(8192);
         assertThat(serviceConfig.verboseResponses()).isEqualTo(true);
@@ -73,7 +73,7 @@ class VirtualHostServiceBindingBuilderTest {
         final ServerBuilder sb = new ServerBuilder();
 
         sb.virtualHost("example.com").withRoute(builder -> {
-            builder.pathUnder("/foo/bar")
+            builder.pathPrefix("/foo/bar")
                    .methods(HttpMethod.GET)
                    .consumes(JSON, PLAIN_TEXT_UTF_8)
                    .produces(JSON_UTF_8, PLAIN_TEXT_UTF_8)
@@ -92,7 +92,7 @@ class VirtualHostServiceBindingBuilderTest {
         assertThat(route.paths()).containsExactly("/foo/bar/", "/foo/bar/*");
         assertThat(route.consumes()).containsExactly(JSON, PLAIN_TEXT_UTF_8);
         assertThat(route.produces()).containsExactly(JSON_UTF_8,
-                                                               PLAIN_TEXT_UTF_8);
+                                                     PLAIN_TEXT_UTF_8);
         assertThat(serviceConfig.requestTimeoutMillis()).isEqualTo(10);
         assertThat(serviceConfig.maxRequestLength()).isEqualTo(8192);
         assertThat(serviceConfig.verboseResponses()).isEqualTo(true);

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcService.java
@@ -236,7 +236,7 @@ public final class GrpcService extends AbstractHttpService
         }
 
         if (protoReflectionService != null) {
-            Map<String, ServerServiceDefinition> grpcServices =
+            final Map<String, ServerServiceDefinition> grpcServices =
                     cfg.server().config().virtualHosts().stream()
                        .flatMap(host -> host.serviceConfigs().stream())
                        .map(serviceConfig -> serviceConfig.service().as(GrpcService.class))

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcDocServicePluginTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcDocServicePluginTest.java
@@ -181,12 +181,12 @@ public class GrpcDocServicePluginTest {
 
         // The case where a GrpcService is added to ServerBuilder with a prefix.
         serverBuilder.service(
-                Route.builder().prefix("/test").build(),
+                Route.builder().pathPrefix("/test").build(),
                 new GrpcServiceBuilder().addService(mock(UnitTestServiceImplBase.class)).build());
 
         // Another GrpcService with a different prefix.
         serverBuilder.service(
-                Route.builder().prefix("/reconnect").build(),
+                Route.builder().pathPrefix("/reconnect").build(),
                 new GrpcServiceBuilder().addService(mock(ReconnectServiceImplBase.class)).build());
 
         // Make sure all services and their endpoints exist in the specification.

--- a/site/src/sphinx/server-basics.rst
+++ b/site/src/sphinx/server-basics.rst
@@ -143,6 +143,27 @@ You might be interested in decorating a service using other decorators, for exam
 
 You can also use an arbitrary object that's annotated by the ``@Path`` annotation using ``annotatedService()``.
 
+Path patterns
+-------------
+
+You can use the following path patterns to map an HTTP request path to a service or a decorator.
+
++------------------------------------------+---------------------------------------+
+| Pattern                                  | Example                               |
++==========================================+=======================================+
+| Exact match                              | ``/foo/bar`` or ``exact:/foo/bar``    |
++------------------------------------------+---------------------------------------+
+| Curly-brace style path variables         | ``/users/{userId}``                   |
++------------------------------------------+---------------------------------------+
+| Colon style path variables               | ``/list/:productType/by/:ordering``   |
++------------------------------------------+---------------------------------------+
+| Prefix match                             | ``prefix:/files``                     |
++------------------------------------------+---------------------------------------+
+| Glob pattern                             | ``glob:/*/downloads/**``              |
++------------------------------------------+---------------------------------------+
+| Regular expression                       | ``regex:^/files/(?<filePath>.\*)$``   |
++------------------------------------------+---------------------------------------+
+
 Per service configuration
 -------------------------
 


### PR DESCRIPTION
Motivation:
A decorator has to decorate all services or some services which were statically bound to server configuration.
It is difficult to decorate services under a specific directory.
This PR is able to bind a decorator to multiple services whose `Route` match the given `route` dynamically.

Modifications:
* Additions
  * Add `findAll(RoutingContext)` to `Router` and its implementation for finding all matched `Route`
  * Add `findAll` method to `RoutingTrie` for finding all matched values
  * Add `routeDecoratorCache()` to `Flags` for caching the matched result
  * Add `wrapRouteDecoratingServiceRouter(Router<RouteDecoratingService>)` to `RouteCache` for wrapping with `CacheRouter`
  * Add `ofRouteDecoratingService(List<RouteDecoratingService>)` to `Routers`
  * Add `routeDecorator()` to `VirtualHost` and `ServerBuilder` for returning `DecoratingServiceBindingBuilder`.
  * Add class `RouteDecoratingService` for decorating a `Service` whose `Route` matches the given `route`.
  * Add new builder class `AbstractBindingBuilder` for binding something to a `Route` fluently.
* Deprecations
  * Deprecate `AbstractBindingBuilder#pathUnder(String prefix)`, use `AbstractBindingBuilder#pathPrefix(String prefix)`
  * Deprecate `RouteBuilder#prefix(String prefix)`, use `RouteBuilder#pathPrefix(String prefix)`
  * Deprecate `RouteBuilder#prefix(String prefix, boolean stripPrefix)`, use `RouteBuilder#pathPrefix(String prefix, boolean stripPrefix)`
  * Deprecate `RouteBuilder#pathWithPrefix(String prefix, String pathPattern)`, use `RouteBuilder#path(String prefix, String pathPattern)`
* Break Changes
  * A default virtual host **service** could serve a custom virtual host **request**. Please see #2057 for more information.
    * Before: if a custom virtual host fails to find a service being matched to the given request it returns `NOT_FOUND`.
    * After: if a custom virtual host fails to find a service being matched to the given request, try to route to a default virtual host to find a fallback service.  
* Write documentation for `Decorating a service by path mapping`

Result:

A user could decorate multiple services whose `Route` match the specified `route`.

```java
sb.routeDecorator()
  .pathPrefix("/api/users")
  .build((delegate, ctx, req) -> {
      if (!AUTHORIZATION.equals(req.headers().get("Authorization"))) {
          return HttpResponse.of(HttpStatus.UNAUTHORIZED);
      }
      return delegate.serve(ctx, req);
  });   
```

Fixes: #582 #2057 